### PR TITLE
add flynt, the f-string convertor

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,10 @@ repos:
   hooks:
   - id: pyupgrade
     args: [--py38-plus]
+- repo: https://github.com/ikamensh/flynt/
+  rev: '0.58'
+  hooks:
+  - id: flynt
 - repo: https://github.com/psf/black
   rev: 20.8b1
   hooks:

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -943,7 +943,7 @@ def set_hammer_api_timeout(timeout=-1, reverse=False):
     :param bool reverse: Reverses the request timeout
     :return: ssh.command
     """
-    default_timeout = ':request_timeout: {}'.format(120)
+    default_timeout = f':request_timeout: {120}'
     new_timeout = f':request_timeout: {timeout}'
     if not reverse:
         return ssh.command(

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -268,7 +268,7 @@ class Base:
             options = {}
 
         if search is not None and 'search' not in options:
-            options.update({'search': '{}=\\"{}\\"'.format(search[0], search[1])})
+            options.update({'search': f'{search[0]}=\\"{search[1]}\\"'})
 
         result = cls.list(options)
         if result:

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1084,7 +1084,7 @@ def make_user(options=None):
         'password': gen_alphanumeric(),
     }
     logger.debug(
-        'User "{}" password not provided {} was generated'.format(args['login'], args['password'])
+        f"User \"{args['login']}\" password not provided {args['password']} was generated"
     )
 
     return create_object(User, args, options)
@@ -1484,7 +1484,7 @@ def make_medium(options=None):
         'organization-ids': None,
         'organizations': None,
         'os-family': None,
-        'path': 'http://{}'.format(gen_string('alpha', 6)),
+        'path': f"http://{gen_string('alpha', 6)}",
     }
 
     return create_object(Medium, args, options)
@@ -1689,9 +1689,7 @@ def activationkey_add_subscription_to_repo(options=None):
     )
     # Add subscription to activation-key
     if options['subscription'] not in (sub['name'] for sub in subscriptions):
-        raise CLIFactoryError(
-            'Subscription {} not found in the given org'.format(options['subscription'])
-        )
+        raise CLIFactoryError(f"Subscription {options['subscription']} not found in the given org")
     for subscription in subscriptions:
         if subscription['name'] == options['subscription']:
             if subscription['quantity'] != 'Unlimited' and int(subscription['quantity']) == 0:
@@ -2166,7 +2164,7 @@ def configure_env_for_provision(org=None, loc=None):
         }
     )
     for template in (provisioning_template, pxe_template):
-        if '{} ({})'.format(template['name'], template['type']) not in os['templates']:
+        if f"{template['name']} ({template['type']})" not in os['templates']:
             OperatingSys.update(
                 {
                     'id': os['id'],
@@ -2682,7 +2680,7 @@ def virt_who_hypervisor_config(
     )
     # configure manually RHEL custom repo url as sync time is very big
     # (more than 2 hours for RHEL 7Server) and not critical in this context.
-    rhel_repo_option_name = 'rhel{}_repo'.format(DISTROS_MAJOR_VERSION[DISTRO_RHEL7])
+    rhel_repo_option_name = f'rhel{DISTROS_MAJOR_VERSION[DISTRO_RHEL7]}_repo'
     rhel_repo_url = getattr(settings, rhel_repo_option_name, None)
     if not rhel_repo_url:
         raise ValueError(
@@ -2693,7 +2691,7 @@ def virt_who_hypervisor_config(
     virt_who_vm.configure_rhel_repo(rhel_repo_url)
     if hypervisor_hostname and configure_ssh:
         # configure ssh access of hypervisor from virt_who_vm
-        hypervisor_ssh_key_name = 'hypervisor-{}.key'.format(gen_string('alpha').lower())
+        hypervisor_ssh_key_name = f"hypervisor-{gen_string('alpha').lower()}.key"
         # upload the ssh key
         vm_upload_ssh_key(virt_who_vm, settings.server.ssh_key, hypervisor_ssh_key_name)
         # setup the ssh config and known_hosts files
@@ -2745,7 +2743,7 @@ def virt_who_hypervisor_config(
     # first report when started or with one shot command
     # the virt-who hypervisor will be registered to satellite with host name
     # like "virt-who-{hypervisor_hostname}-{organization_id}"
-    virt_who_hypervisor_hostname = 'virt-who-{}-{}'.format(hypervisor_hostname, org['id'])
+    virt_who_hypervisor_hostname = f"virt-who-{hypervisor_hostname}-{org['id']}"
     # find the registered virt-who hypervisor host
     org_hosts = Host.list(
         {'organization-id': org['id'], 'search': f'name={virt_who_hypervisor_hostname}'}
@@ -2814,7 +2812,7 @@ def make_http_proxy(options=None):
         'organization-ids': None,
         'organization-titles': None,
         'password': None,
-        'url': '{}:{}'.format(gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999)),
+        'url': f"{gen_url(scheme='https')}:{gen_integer(min_value=10, max_value=9999)}",
         'username': None,
     }
 

--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -120,7 +120,7 @@ def parse_help(output):
             if match is None:  # pragma: no cover
                 continue
             if match.group('name') is None:
-                contents['options'][-1]['help'] += ' {}'.format(match.group('help'))
+                contents['options'][-1]['help'] += f" {match.group('help')}"
             else:
                 contents['options'].append(
                     {

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -452,7 +452,7 @@ class DistroSettings(FeatureSettings):
         validation_errors = []
         if not all(self.__dict__.values()):
             validation_errors.append(
-                'All [distro] %s options must be provided.' % list(self.__dict__.keys())
+                f'All [distro] {list(self.__dict__.keys())} options must be provided.'
             )
         return validation_errors
 
@@ -1558,11 +1558,11 @@ class Settings:
         webdrivers = ('chrome', 'edge', 'firefox', 'ie', 'phantomjs')
         if self.browser not in browsers:
             validation_errors.append(
-                '[robottelo] browser should be one of {}.'.format(', '.join(browsers))
+                f"[robottelo] browser should be one of {', '.join(browsers)}."
             )
         if self.webdriver not in webdrivers:
             validation_errors.append(
-                '[robottelo] webdriver should be one of {}.'.format(', '.join(webdrivers))
+                f"[robottelo] webdriver should be one of {', '.join(webdrivers)}."
             )
         if self.browser == 'saucelabs':
             if self.saucelabs_user is None:

--- a/robottelo/config/casts.py
+++ b/robottelo/config/casts.py
@@ -63,9 +63,7 @@ class LoggingLevel:
     def __call__(self, value):
         value = value.lower()
         if value not in self._logging_levels:
-            raise ValueError(
-                '{} should one of {}.'.format(value, ', '.join(self._logging_levels.keys()))
-            )
+            raise ValueError(f"{value} should one of {', '.join(self._logging_levels.keys())}.")
         return self._logging_levels[value]
 
 

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -579,8 +579,8 @@ def invalid_docker_upstream_names():
             gen_string('alphanumeric', random.randint(3, 6)).lower(),
             gen_string('alphanumeric', random.randint(3, 6)).lower(),
         ),
-        '{}-_-_/-_.'.format(gen_string('alphanumeric', 1).lower()),
-        '-_-_/{}-_.'.format(gen_string('alphanumeric', 1).lower()),
+        f"{gen_string('alphanumeric', 1).lower()}-_-_/-_.",
+        f"-_-_/{gen_string('alphanumeric', 1).lower()}-_.",
     ]
 
 

--- a/robottelo/decorators/__init__.py
+++ b/robottelo/decorators/__init__.py
@@ -91,7 +91,7 @@ def skip_if_not_set(*options):
                     missing.append(option)
             if not missing:
                 return func(*args, **kwargs)
-            raise unittest2.SkipTest('Missing configuration for: {}.'.format(', '.join(missing)))
+            raise unittest2.SkipTest(f"Missing configuration for: {', '.join(missing)}.")
 
         return wrapper
 

--- a/robottelo/decorators/func_shared/shared.py
+++ b/robottelo/decorators/func_shared/shared.py
@@ -418,7 +418,7 @@ def _get_kwargs_md5(**kwargs):
     """Create an md5 hexdigest from kwargs"""
     hd = None
     if kwargs:
-        text = '{}'.format(tuple(sorted(kwargs.items())))
+        text = f'{tuple(sorted(kwargs.items()))}'
         md = hashlib.md5(text.encode())
         hd = md.hexdigest()
     return hd

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -321,7 +321,7 @@ def add_remote_execution_ssh_key(hostname, key_path=None, proxy_hostname=None, *
     key_path = key_path or '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
     # This connection defaults to settings.server
     server_key = ssh.command(
-        cmd='cat %s' % key_path, output_format='base', hostname=proxy_hostname
+        cmd=f'cat {key_path}', output_format='base', hostname=proxy_hostname
     ).stdout
     # Sometimes stdout contains extra empty string. Skipping it
     if isinstance(server_key, list):

--- a/robottelo/libvirt_discovery.py
+++ b/robottelo/libvirt_discovery.py
@@ -101,7 +101,7 @@ class LibvirtGuest:
         self.ip_addr = None
         self._domain = None
         self._created = False
-        self.guest_name = 'mac{}'.format(self.mac.replace(':', ""))
+        self.guest_name = f"mac{self.mac.replace(':', '')}"
 
     def create(self):
         """Creates a virtual machine on the libvirt server using
@@ -179,7 +179,7 @@ class LibvirtGuest:
         ssh.command(f'virsh undefine {self.hostname}', hostname=self.libvirt_server)
         image_name = f'{self.hostname}.img'
         ssh.command(
-            'rm {}'.format(os.path.join(self.image_dir, image_name)),
+            f'rm {os.path.join(self.image_dir, image_name)}',
             hostname=self.libvirt_server,
         )
 

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -582,7 +582,7 @@ class GenericRHRepository(BaseRepository):
                 self.data['repository'], self.distro, hex(id(self))
             )
         else:
-            return '<RH custom Repo url: {} object: {}>'.format(self.url, hex(id(self)))
+            return f'<RH custom Repo url: {self.url} object: {hex(id(self))}>'
 
     def create(
         self,
@@ -988,7 +988,7 @@ class RepositoryCollection:
             install_katello_agent=install_katello_agent,
         )
         if configure_rhel_repo:
-            rhel_repo_option_name = 'rhel{}_repo'.format(DISTROS_MAJOR_VERSION[self.distro])
+            rhel_repo_option_name = f'rhel{DISTROS_MAJOR_VERSION[self.distro]}_repo'
             rhel_repo_url = getattr(settings, rhel_repo_option_name, None)
             if not rhel_repo_url:
                 raise ValueError(

--- a/robottelo/rhsso_utils.py
+++ b/robottelo/rhsso_utils.py
@@ -61,7 +61,7 @@ def get_rhsso_client_id():
         cmd=f"{KEY_CLOAK_CLI} get clients --fields id,clientId",
         hostname=rhsso_host,
     )
-    result_json = json.loads("[{{{0}".format("".join(result)))
+    result_json = json.loads(f"[{{{''.join(result)}")
     client_id = None
     for client in result_json:
         if client_name in client['clientId']:
@@ -76,7 +76,7 @@ def get_rhsso_user_details(username):
         cmd=f"{KEY_CLOAK_CLI} get users -r {realm} -q username={username}",
         hostname=rhsso_host,
     )
-    result_json = json.loads("[{{{0}".format("".join(result)))
+    result_json = json.loads(f"[{{{''.join(result)}")
     return result_json[0]
 
 
@@ -86,7 +86,7 @@ def get_rhsso_groups_details(group_name):
         cmd=f"{KEY_CLOAK_CLI} get groups -r {realm} -q group_name={group_name}",
         hostname=rhsso_host,
     )
-    result_json = json.loads("[{{{0}".format("".join(result)))
+    result_json = json.loads(f"[{{{''.join(result)}")
     return result_json[0]
 
 

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -245,7 +245,7 @@ def add_authorized_key(
     ) as con:
 
         # ensure ssh directory exists
-        execute_command('mkdir -p %s' % ssh_path, con)
+        execute_command(f'mkdir -p {ssh_path}', con)
 
         # append the key if doesn't exists
         add_key = "grep -q '{key}' {dest} || echo '{key}' >> {dest}".format(
@@ -254,13 +254,13 @@ def add_authorized_key(
         execute_command(add_key, con)
 
         # set proper permissions
-        execute_command('chmod 700 %s' % ssh_path, con)
-        execute_command('chmod 600 %s' % auth_file, con)
+        execute_command(f'chmod 700 {ssh_path}', con)
+        execute_command(f'chmod 600 {auth_file}', con)
         ssh_user = username or settings.server.ssh_username
         execute_command(f'chown -R {ssh_user} {ssh_path}', con)
 
         # Restore SELinux context with restorecon, if it's available:
-        cmd = 'command -v restorecon && restorecon -RvF %s || true' % ssh_path
+        cmd = f'command -v restorecon && restorecon -RvF {ssh_path} || true'
         execute_command(cmd, con)
 
 
@@ -449,7 +449,7 @@ def is_ssh_pub_key(key):
     """
 
     if not isinstance(key, str):
-        raise ValueError("Key should be a string type, received: {}".format(type(key)))
+        raise ValueError(f"Key should be a string type, received: {type(key)}")
 
     # 1) a valid pub key has 3 parts separated by space
     try:

--- a/robottelo/system_facts.py
+++ b/robottelo/system_facts.py
@@ -40,33 +40,33 @@ DISTRO_IDS = [
     },
     {
         'id': 'Santiago',
-        'version': '6.{}'.format(gen_integer(1, 5)),
+        'version': f'6.{gen_integer(1, 5)}',
         'architecture': gen_choice(ARCHITECTURES),
         'kernel': '2.6.32-431.el6',
     },
     {
         'id': 'Tikanga',
-        'version': '5.{}'.format(gen_integer(1, 10)),
+        'version': f'5.{gen_integer(1, 10)}',
         'architecture': gen_choice(ARCHITECTURES),
         'kernel': '2.6.18-371.el5',
     },
     {
         'id': 'Nahant',
-        'version': '4.{}'.format(gen_integer(1, 9)),
+        'version': f'4.{gen_integer(1, 9)}',
         # Assuming only 'i386' and 'x86_64'
         'architecture': gen_choice(ARCHITECTURES[:2]),
         'kernel': '2.6.9-100.el4',
     },
     {
         'id': 'Taroon',
-        'version': '3.{}'.format(gen_integer(1, 9)),
+        'version': f'3.{gen_integer(1, 9)}',
         # Assuming only 'i386' and 'x86_64'
         'architecture': gen_choice(ARCHITECTURES[:2]),
         'kernel': '2.4.21-50.el3',
     },
     {
         'id': 'Pensacola',
-        'version': '2.{}'.format(gen_integer(1, 7)),
+        'version': f'2.{gen_integer(1, 7)}',
         # Assuming only 'i386' and 'x86_64'
         'architecture': gen_choice(ARCHITECTURES[:2]),
         'kernel': '2.4.9-e.57.el2',

--- a/robottelo/upgrade_utility.py
+++ b/robottelo/upgrade_utility.py
@@ -73,7 +73,7 @@ def create_repo(rpm_name, repo_path, post_upgrade=False, other_rpm=None):
     """
     if post_upgrade:
         run(f'wget {rpm_name} -P {repo_path}')
-        run('rm -rf {}'.format(repo_path + other_rpm))
+        run(f'rm -rf {repo_path + other_rpm}')
         run(f'createrepo --update {repo_path}')
     else:
         run(f'rm -rf {repo_path}')

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -140,7 +140,7 @@ class VirtualMachine:
         self._domain = domain
         self._created = False
         self._subscribed = False
-        self._source_image = source_image or '{}-base'.format(image_map.get(self.distro))
+        self._source_image = source_image or f'{image_map.get(self.distro)}-base'
         self._target_image = target_image or gen_string('alphanumeric', 16).lower()
         if tag:
             self._target_image = tag + self._target_image
@@ -344,7 +344,7 @@ class VirtualMachine:
         )
         image_name = f'{self.target_image}.img'
         ssh.command(
-            'rm {}'.format(os.path.join(self.image_dir, image_name)),
+            f'rm {os.path.join(self.image_dir, image_name)}',
             hostname=self.provisioning_server,
             connection_timeout=30,
         )

--- a/scripts/hammer_command_tree.py
+++ b/scripts/hammer_command_tree.py
@@ -18,7 +18,7 @@ def generate_command_tree(command):
     contents = hammer.parse_help(output)
     if len(contents['subcommands']) > 0:
         for subcommand in contents['subcommands']:
-            subcommand.update(generate_command_tree('{} {}'.format(command, subcommand['name'])))
+            subcommand.update(generate_command_tree(f"{command} {subcommand['name']}"))
     return contents
 
 

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -311,7 +311,7 @@ class TestGCEHostProvisioningTestCase:
     @pytest.fixture(scope='class')
     def google_host(self, googleclient):
         """Returns the Google Client Host object to perform the assertions"""
-        return googleclient.get_vm(name='{}'.format(self.fullhostname.replace('.', '-')))
+        return googleclient.get_vm(name=f"{self.fullhostname.replace('.', '-')}")
 
     @pytest.mark.tier1
     def test_positive_gce_host_provisioned(self, class_host):

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -800,9 +800,7 @@ class TestContentViewFilterRule:
             content_view=content_view,
             inclusion=False,
         ).create()
-        module_streams = entities.ModuleStream().search(
-            query={'search': 'name="{}"'.format('duck')}
-        )
+        module_streams = entities.ModuleStream().search(query={'search': "name=\"duck\""})
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter, module_stream=module_streams
         ).create()
@@ -910,9 +908,7 @@ class TestContentViewFilterRule:
             content_view=content_view,
             inclusion=False,
         ).create()
-        module_streams = entities.ModuleStream().search(
-            query={'search': 'name="{}"'.format('walrus')}
-        )
+        module_streams = entities.ModuleStream().search(query={'search': "name=\"walrus\""})
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter, module_stream=module_streams
         ).create()
@@ -948,7 +944,7 @@ class TestContentViewFilterRule:
             inclusion=False,
         ).create()
         module_streams = entities.ModuleStream().search(
-            query={'search': 'name="{}" and version="{}'.format('kangaroo', '20180730223407')}
+            query={'search': "name=\"kangaroo\" and version=\"20180730223407"}
         )
         entities.ContentViewFilterRule(
             content_view_filter=cv_filter, module_stream=module_streams

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -311,7 +311,7 @@ def test_positive_upload_facts():
     name = gen_choice(list(valid_data_list().values()))
     result = _create_discovered_host(name)
     discovered_host = entities.DiscoveredHost(id=result['id']).read_json()
-    host_name = 'mac{}'.format(discovered_host['mac'].replace(':', ''))
+    host_name = f"mac{discovered_host['mac'].replace(':', '')}"
     assert discovered_host['name'] == host_name
 
 
@@ -411,9 +411,7 @@ def test_positive_delete_pxe_host():
     result = _create_discovered_host(name)
 
     entities.DiscoveredHost(id=result['id']).delete()
-    search = entities.DiscoveredHost().search(
-        query={'search': 'name == {}'.format(result['name'])}
-    )
+    search = entities.DiscoveredHost().search(query={'search': f"name == {result['name']}"})
     assert len(search) == 0
 
 

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -110,7 +110,7 @@ class TestLocation:
 
         :expectedresults: Location created successfully and has expected name
         """
-        name = '{}, {}'.format(gen_string('alpha'), gen_string('alpha'))
+        name = f"{gen_string('alpha')}, {gen_string('alpha')}"
         location = entities.Location(name=name).create()
         assert location.name == name
         location.delete()

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -112,7 +112,7 @@ def tftpboot(module_org):
     kinds = entities.TemplateKind().search(query={"search": "name ~ PXE"})
 
     # clean the already-deployed default pxe configs
-    ssh.command('rm {}'.format(' '.join([i['path'] for i in default_templates.values()])))
+    ssh.command(f"rm {' '.join([i['path'] for i in default_templates.values()])}")
 
     # create custom Templates per kind
     for template in default_templates.values():
@@ -133,7 +133,7 @@ def tftpboot(module_org):
     yield default_templates
 
     # delete the deployed tftp files
-    ssh.command('rm {}'.format(' '.join([i['path'] for i in default_templates.values()])))
+    ssh.command(f"rm {' '.join([i['path'] for i in default_templates.values()])}")
     # set the settings back to defaults
     for setting in default_settings:
         if setting.value is None:

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -461,7 +461,7 @@ class TestSshKeyInUser:
 
         :return: string type well formatted RSA key
         """
-        return 'ssh-rsa {}'.format(paramiko.RSAKey.generate(2048).get_base64())
+        return f'ssh-rsa {paramiko.RSAKey.generate(2048).get_base64()}'
 
     @pytest.fixture(scope='class')
     def create_user(self):
@@ -749,9 +749,9 @@ class TestActiveDirectoryUser:
         )
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
-        user = entities.User().search(
-            query={'search': 'login={}'.format(create_ldap['ldap_user_name'])}
-        )[0]
+        user = entities.User().search(query={'search': f"login={create_ldap['ldap_user_name']}"})[
+            0
+        ]
         user.role = [entities.Role(id=org_admin['id']).read()]
         user.update(['role'])
         for entity in [
@@ -873,9 +873,7 @@ class TestFreeIPAUser:
         )
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
-        user = entities.User().search(
-            query={'search': 'login={}'.format(create_ldap['username'])}
-        )[0]
+        user = entities.User().search(query={'search': f"login={create_ldap['username']}"})[0]
         user.role = [entities.Role(id=org_admin['id']).read()]
         user.update(['role'])
         for entity in [

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1443,7 +1443,7 @@ class ActivationKeyTestCase(CLITestCase):
                 content = ActivationKey.product_content(
                     {'id': result['activationkey-id'], 'organization-id': self.org['id']}
                 )
-                self.assertEqual(content[0]['override'], 'enabled:{}'.format(int(override_value)))
+                self.assertEqual(content[0]['override'], f'enabled:{int(override_value)}')
 
     @pytest.mark.tier2
     def test_positive_remove_user(self):
@@ -1504,12 +1504,12 @@ class ActivationKeyTestCase(CLITestCase):
         """
         user_name = gen_alphanumeric()
         user_password = gen_alphanumeric()
-        ak_name_like = 'ak_{}'.format(gen_string('alpha'))
+        ak_name_like = f"ak_{gen_string('alpha')}"
         hc_names_like = (
-            'Test_*_{}'.format(gen_string('alpha')),
-            'Test_*_{}'.format(gen_string('alpha')),
+            f"Test_*_{gen_string('alpha')}",
+            f"Test_*_{gen_string('alpha')}",
         )
-        ak_name = '{}_{}'.format(ak_name_like, gen_string('alpha'))
+        ak_name = f"{ak_name_like}_{gen_string('alpha')}"
         org = make_org()
         self.upload_manifest(org['id'], manifests.clone())
         available_subscriptions = Subscription.list({'organization-id': org['id']}, per_page=False)

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -58,9 +58,7 @@ def test_negative_create_with_url():
     """
     # Create a random proxy
     with pytest.raises(CLIFactoryError, match='Could not create the proxy:'):
-        make_proxy(
-            {'url': 'http://{}:{}'.format(gen_string('alpha', 6), gen_string('numeric', 4))}
-        )
+        make_proxy({'url': f"http://{gen_string('alpha', 6)}:{gen_string('numeric', 4)}"})
 
 
 @skip_if_not_set('fake_capsules')

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -326,7 +326,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
         )
         nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
         request.cls.interfaces_attributes = (
-            "compute_network={},compute_public_ip=Static," "compute_private_ip=false".format(nw_id)
+            f"compute_network={nw_id},compute_public_ip=Static,compute_private_ip=false"
         )
 
     @pytest.fixture(scope='class')

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -56,8 +56,8 @@ def valid_name_desc_data():
         {'name': gen_string('alphanumeric'), 'description': gen_string('alphanumeric', 255)},
         {'name': gen_string('utf8'), 'description': gen_string('utf8')},
         {
-            'name': '<html>{}</html>'.format(gen_string('alpha')),
-            'description': '<html>{}</html>'.format(gen_string('alpha')),
+            'name': f"<html>{gen_string('alpha')}</html>",
+            'description': f"<html>{gen_string('alpha')}</html>",
         },
         {
             'name': "{0}[]@#$%^&*(),./?\\\"{{}}><|''".format(gen_string('utf8')),
@@ -81,7 +81,7 @@ def valid_update_data():
     return (
         {'new-name': gen_string('utf8', 255)},
         {'new-name': gen_string('alphanumeric')},
-        {'new-name': 'white spaces %s' % gen_string(str_type='alphanumeric')},
+        {'new-name': f"white spaces {gen_string(str_type='alphanumeric')}"},
         {'description': gen_string('utf8', 255)},
         {'description': gen_string('alphanumeric')},
         {'url': gen_url()},
@@ -124,7 +124,7 @@ class ComputeResourceTestCase(CLITestCase):
         """
         ComputeResource.create(
             {
-                'name': 'cr {}'.format(gen_string(str_type='alpha')),
+                'name': f"cr {gen_string(str_type='alpha')}",
                 'provider': 'Libvirt',
                 'url': self.current_libvirt_url,
             }
@@ -169,7 +169,7 @@ class ComputeResourceTestCase(CLITestCase):
             {'provider': FOREMAN_PROVIDERS['libvirt'], 'url': self.current_libvirt_url}
         )
         self.assertTrue(comp_res['name'])
-        result_list = ComputeResource.list({'search': 'name=%s' % comp_res['name']})
+        result_list = ComputeResource.list({'search': f"name={comp_res['name']}"})
         self.assertTrue(len(result_list) > 0)
         result = ComputeResource.exists(search=('name', comp_res['name']))
         self.assertTrue(result)

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -55,7 +55,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
         """
         ComputeResource.create(
             {
-                'name': 'cr {}'.format(gen_string(str_type='alpha')),
+                'name': f"cr {gen_string(str_type='alpha')}",
                 'provider': 'Ovirt',
                 'user': self.username,
                 'password': self.password,
@@ -266,7 +266,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
         ComputeResource.image_create(
             {
                 'compute-resource': comp_res['name'],
-                'name': 'img {}'.format(gen_string(str_type='alpha')),
+                'name': f"img {gen_string(str_type='alpha')}",
                 'uuid': self.image_uuid,
                 'operatingsystem': self.os['title'],
                 'architecture': self.image_arch,
@@ -310,8 +310,8 @@ class RHEVComputeResourceTestCase(CLITestCase):
             ComputeResource.image_create(
                 {
                     'compute-resource': comp_res['name'],
-                    'name': 'img {}'.format(gen_string(str_type='alpha')),
-                    'uuid': 'invalidimguuid {}'.format(gen_string(str_type='alpha')),
+                    'name': f"img {gen_string(str_type='alpha')}",
+                    'uuid': f"invalidimguuid {gen_string(str_type='alpha')}",
                     'operatingsystem': self.os['title'],
                     'architecture': self.image_arch,
                     'username': "root",
@@ -355,7 +355,7 @@ class RHEVComputeResourceTestCase(CLITestCase):
                 {
                     'compute-resource': comp_res['name'],
                     # too long string (>255 chars)
-                    'name': 'img {}'.format(gen_string(str_type='alphanumeric', length=256)),
+                    'name': f"img {gen_string(str_type='alphanumeric', length=256)}",
                     'uuid': self.image_uuid,
                     'operatingsystem': self.os['title'],
                     'architecture': self.image_arch,

--- a/tests/foreman/cli/test_content_credentials.py
+++ b/tests/foreman/cli/test_content_credentials.py
@@ -288,7 +288,7 @@ def test_positive_update_key(name, module_org):
     assert gpg_key['content'] != content
     local_key = create_gpg_key_file(content)
     assert gpg_key, 'GPG Key file must be created'
-    key = '/tmp/%s' % gen_alphanumeric()
+    key = f'/tmp/{gen_alphanumeric()}'
     ssh.upload_file(local_file=local_key, remote_file=key)
     ContentCredential.update(
         {'key': key, 'name': gpg_key['name'], 'organization-id': module_org.id}

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -255,9 +255,7 @@ class ContentViewTestCase(CLITestCase):
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
         # Check content view files presence before deletion
-        result = ssh.command(
-            'find /var/lib/pulp/published -name "*{}*"'.format(content_view['name'])
-        )
+        result = ssh.command(f"find /var/lib/pulp/published -name \"*{content_view['name']}*\"")
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stdout), 0)
         self.assertEqual(len(content_view['versions']), 1)
@@ -416,7 +414,7 @@ class ContentViewTestCase(CLITestCase):
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
         # Check content view files presence before deletion
-        result = ssh.command('find /var/lib/pulp -name "*{}*"'.format(content_view['name']))
+        result = ssh.command(f"find /var/lib/pulp -name \"*{content_view['name']}*\"")
         self.assertEqual(result.return_code, 0)
         self.assertNotEqual(len(result.stdout), 0)
         self.assertEqual(len(content_view['versions']), 1)
@@ -436,7 +434,7 @@ class ContentViewTestCase(CLITestCase):
         )
         ContentView.delete({'id': content_view['id']})
         # Check content view files presence after deletion
-        result = ssh.command('find /var/lib/pulp -name "*{}*"'.format(content_view['name']))
+        result = ssh.command(f"find /var/lib/pulp -name \"*{content_view['name']}*\"")
         self.assertEqual(result.return_code, 0)
         self.assertEqual(len(result.stdout), 0)
 
@@ -3081,7 +3079,7 @@ class ContentViewTestCase(CLITestCase):
             host_client.install_katello_ca()
             host_client.register_contenthost(
                 org['label'],
-                lce='{}/{}'.format(env['name'], content_view['name']),
+                lce=f"{env['name']}/{content_view['name']}",
                 username=user_name,
                 password=user_password,
             )
@@ -4884,7 +4882,7 @@ class ContentViewFileRepoTestCase(CLITestCase):
         if 'multi_upload' not in options or not options['multi_upload']:
             ssh.upload_file(local_file=get_data_file(RPM_TO_UPLOAD), remote_file=remote_path)
         else:
-            remote_path = "/tmp/{}/".format(gen_string('alpha'))
+            remote_path = f"/tmp/{gen_string('alpha')}/"
             ssh.upload_files(local_dir=os.getcwd() + "/../data/", remote_dir=remote_path)
 
         Repository.upload_content(

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -856,7 +856,7 @@ class DockerContentViewTestCase(CLITestCase):
         Product.update({'name': new_prod_name, 'id': prod['id']})
         repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
 
-        expected_pattern = "{}/{}".format(content_view['label'], old_prod_name).lower()
+        expected_pattern = f"{content_view['label']}/{old_prod_name}".lower()
         self.assertEqual(lce['registry-name-pattern'], new_pattern)
         self.assertEqual(
             Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
@@ -869,7 +869,7 @@ class DockerContentViewTestCase(CLITestCase):
         )
         repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
 
-        expected_pattern = "{}/{}".format(content_view['label'], new_prod_name).lower()
+        expected_pattern = f"{content_view['label']}/{new_prod_name}".lower()
         self.assertEqual(
             Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
         )
@@ -910,7 +910,7 @@ class DockerContentViewTestCase(CLITestCase):
         Repository.update({'name': new_repo_name, 'id': repo['id'], 'product-id': prod['id']})
         repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
 
-        expected_pattern = "{}/{}".format(content_view['label'], old_repo_name).lower()
+        expected_pattern = f"{content_view['label']}/{old_repo_name}".lower()
         self.assertEqual(
             Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
         )
@@ -922,7 +922,7 @@ class DockerContentViewTestCase(CLITestCase):
         )
         repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
 
-        expected_pattern = "{}/{}".format(content_view['label'], new_repo_name).lower()
+        expected_pattern = f"{content_view['label']}/{new_repo_name}".lower()
         self.assertEqual(
             Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
         )
@@ -1256,14 +1256,14 @@ class DockerClientTestCase(CLITestCase):
             self.assertEqual(result.return_code, 0)
             try:
                 result = ssh.command(
-                    'docker run {}'.format(repo['published-at']),
+                    f"docker run {repo['published-at']}",
                     hostname=self.docker_host.ip_addr,
                 )
                 self.assertEqual(result.return_code, 0)
             finally:
                 # Stop and remove the container
                 result = ssh.command(
-                    'docker ps -a | grep {}'.format(repo['published-at']),
+                    f"docker ps -a | grep {repo['published-at']}",
                     hostname=self.docker_host.ip_addr,
                 )
                 container_id = result.stdout[0].split()[0]
@@ -1271,9 +1271,7 @@ class DockerClientTestCase(CLITestCase):
                 ssh.command(f'docker rm {container_id}', hostname=self.docker_host.ip_addr)
         finally:
             # Remove docker image
-            ssh.command(
-                'docker rmi {}'.format(repo['published-at']), hostname=self.docker_host.ip_addr
-            )
+            ssh.command(f"docker rmi {repo['published-at']}", hostname=self.docker_host.ip_addr)
 
     @skip_if_not_set('docker')
     @pytest.mark.tier3

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -33,7 +33,7 @@ def valid_create_params():
     """Returns a list of valid domain create parameters"""
     return [
         {
-            'name': 'white spaces {}'.format(gen_string(str_type='utf8')),
+            'name': f"white spaces {gen_string(str_type='utf8')}",
             'description': gen_string(str_type='alpha'),
         },
         {'name': gen_string(str_type='utf8'), 'description': gen_string(str_type='utf8')},
@@ -57,7 +57,7 @@ def valid_update_params():
     """Returns a list of valid domain update parameters"""
     return [
         {
-            'name': 'white spaces {}'.format(gen_string(str_type='utf8')),
+            'name': f"white spaces {gen_string(str_type='utf8')}",
             'description': gen_string(str_type='alpha'),
         },
         {'name': gen_string(str_type='utf8'), 'description': gen_string(str_type='utf8')},
@@ -92,7 +92,7 @@ def invalid_set_params():
     """Returns a list of invalid domain set parameters"""
     return [
         {
-            'name': 'white spaces {}'.format(gen_string(str_type='utf8')),
+            'name': f"white spaces {gen_string(str_type='utf8')}",
             'value': gen_string(str_type='utf8'),
         },
         {'name': '', 'value': gen_string(str_type='utf8')},

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -35,8 +35,8 @@ class GlobalParameterTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        name = 'opt-%s' % gen_string('alpha', 10)
-        value = 'val-{} {}'.format(gen_string('alpha', 10), gen_string('alpha', 10))
+        name = f"opt-{gen_string('alpha', 10)}"
+        value = f"val-{gen_string('alpha', 10)} {gen_string('alpha', 10)}"
         GlobalParameter().set({'name': name, 'value': value})
 
     @pytest.mark.tier1
@@ -50,8 +50,8 @@ class GlobalParameterTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        name = 'opt-%s' % gen_string('alpha', 10)
-        value = 'val-{} {}'.format(gen_string('alpha', 10), gen_string('alpha', 10))
+        name = f"opt-{gen_string('alpha', 10)}"
+        value = f"val-{gen_string('alpha', 10)} {gen_string('alpha', 10)}"
         GlobalParameter().set({'name': name, 'value': value})
         result = GlobalParameter().list({'search': name})
         self.assertEqual(len(result), 1)
@@ -69,8 +69,8 @@ class GlobalParameterTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        name = 'opt-%s' % gen_string('alpha', 10)
-        value = 'val-{} {}'.format(gen_string('alpha', 10), gen_string('alpha', 10))
+        name = f"opt-{gen_string('alpha', 10)}"
+        value = f"val-{gen_string('alpha', 10)} {gen_string('alpha', 10)}"
         GlobalParameter().set({'name': name, 'value': value})
         GlobalParameter().delete({'name': name})
         result = GlobalParameter().list({'search': name})

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -58,7 +58,7 @@ def _format_commands_diff(commands_diff):
     for key, value in sorted(commands_diff.items()):
         if key == 'hammer':
             continue
-        output.write('{}{}\n'.format(key, ' (new command)' if value['added_command'] else ''))
+        output.write(f"{key}{' (new command)' if value['added_command'] else ''}\n")
         if value.get('added_subcommands'):
             output.write('  Added subcommands:\n')
             for subcommand in value.get('added_subcommands'):

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -127,9 +127,9 @@ class HostCreateTestCase(CLITestCase):
         cls.puppet_cv = publish_puppet_module(
             puppet_modules, CUSTOM_PUPPET_REPO, cls.new_org['id']
         )
-        cls.puppet_env = Environment.list(
-            {'search': 'content_view="{}"'.format(cls.puppet_cv['name'])}
-        )[0]
+        cls.puppet_env = Environment.list({'search': f"content_view=\"{cls.puppet_cv['name']}\""})[
+            0
+        ]
         cls.puppet_class = Puppet.info(
             {'name': puppet_modules[0]['name'], 'puppet-environment': cls.puppet_env['name']}
         )
@@ -482,7 +482,7 @@ class HostCreateTestCase(CLITestCase):
             client.install_katello_ca()
             client.register_contenthost(
                 self.new_org['label'],
-                lce='{}/{}'.format(self.new_lce['label'], self.promoted_cv['label']),
+                lce=f"{self.new_lce['label']}/{self.promoted_cv['label']}",
             )
             self.assertTrue(client.subscribed)
 
@@ -540,7 +540,7 @@ class HostCreateTestCase(CLITestCase):
         sc_params_list = SmartClassParameter.list(
             {
                 'environment': self.puppet_env['name'],
-                'search': 'puppetclass="{}"'.format(self.puppet_class['name']),
+                'search': f"puppetclass=\"{self.puppet_class['name']}\"",
             }
         )
         scp_id = choice(sc_params_list)['id']
@@ -594,7 +594,7 @@ class HostCreateTestCase(CLITestCase):
             client.install_katello_ca()
             client.register_contenthost(
                 self.new_org['label'],
-                lce='{}/{}'.format(self.new_lce['label'], self.promoted_cv['label']),
+                lce=f"{self.new_lce['label']}/{self.promoted_cv['label']}",
             )
             self.assertTrue(client.subscribed)
             hosts = Host.list({'search': 'last_checkin = "Today" or last_checkin = "Yesterday"'})
@@ -929,9 +929,7 @@ class HostUpdateTestCase(CLITestCase):
             }
         )
         self.host = Host.info({'id': self.host['id']})
-        self.assertEqual(
-            '{}.{}'.format(new_name, self.host['network']['domain']), self.host['name']
-        )
+        self.assertEqual(f"{new_name}.{self.host['network']['domain']}", self.host['name'])
         self.assertEqual(self.host['location'], new_loc['name'])
         self.assertEqual(self.host['network']['mac'], new_mac)
         self.assertEqual(self.host['network']['domain'], new_domain['name'])
@@ -956,7 +954,7 @@ class HostUpdateTestCase(CLITestCase):
                     Host.update({'id': self.host['id'], 'new-name': new_name})
                 self.host = Host.info({'id': self.host['id']})
                 self.assertNotEqual(
-                    '{}.{}'.format(new_name, self.host['network']['domain']).lower(),
+                    f"{new_name}.{self.host['network']['domain']}".lower(),
                     self.host['name'],
                 )
 
@@ -1860,7 +1858,7 @@ class HostSubscriptionTestCase(CLITestCase):
         if lce:
             result = self.client.register_contenthost(
                 self.org['name'],
-                lce='{}/{}'.format(self.hosts_env['name'], self.content_view['name']),
+                lce=f"{self.hosts_env['name']}/{self.content_view['name']}",
                 auto_attach=auto_attach,
             )
         else:
@@ -2068,7 +2066,7 @@ class HostSubscriptionTestCase(CLITestCase):
         # register client
         self.client.register_contenthost(
             org['name'],
-            lce='{}/{}'.format(hosts_env['name'], content_view['name']),
+            lce=f"{hosts_env['name']}/{content_view['name']}",
             auto_attach=False,
         )
 
@@ -2107,7 +2105,7 @@ class HostSubscriptionTestCase(CLITestCase):
         )
         pool_id = subscriptions.stdout[0]
         # attach to plain RHEL subsctiption
-        self.client.run('subscription-manager attach --pool "%s"' % pool_id)
+        self.client.run(f'subscription-manager attach --pool "{pool_id}"')
         self.assertTrue(self.client.subscribed)
         result = self._client_enable_repo()
         self.assertNotEqual(result.return_code, 0)

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -65,7 +65,7 @@ def cv(module_org):
 @pytest.fixture(scope='module')
 def env(cv):
     """Return the puppet environment."""
-    return Environment.list({'search': 'content_view="{}"'.format(cv['name'])})[0]
+    return Environment.list({'search': f"content_view=\"{cv['name']}\""})[0]
 
 
 @pytest.fixture(scope='module')
@@ -145,7 +145,7 @@ def test_positive_create_with_multiple_entities_and_delete(
     arch = make_architecture()
     ptable = make_partition_table({'location-ids': loc['id'], 'organization-ids': org_2.id})
     os = make_os({'architecture-ids': arch['id'], 'partition-table-ids': ptable['id']})
-    os_full_name = "{} {}.{}".format(os['name'], os['major-version'], os['minor-version'])
+    os_full_name = f"{os['name']} {os['major-version']}.{os['minor-version']}"
     media = make_medium(
         {
             'operatingsystem-ids': os['id'],

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -56,7 +56,7 @@ class HttpProxyTestCase(CLITestCase):
         self.addCleanup(org_cleanup, org['id'])
         # Create http proxy
         name = gen_string('alpha', 15)
-        url = '{}:{}'.format(gen_url(scheme='https'), gen_integer(min_value=10, max_value=9999))
+        url = f"{gen_url(scheme='https')}:{gen_integer(min_value=10, max_value=9999)}"
         password = gen_string('alpha', 15)
         username = gen_string('alpha', 15)
         updated_name = gen_string('alpha', 15)

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -239,7 +239,7 @@ class SimpleLoggingTestCase(CLITestCase):
             line_count_start = line_count(source_log, connection)
             # command for this test
             new_repo = self._make_repository({'name': gen_string('alpha')})
-            self.logger.info('Created Repo {} for dynflow log test'.format(new_repo['name']))
+            self.logger.info(f"Created Repo {new_repo['name']} for dynflow log test")
             # get the number of lines in the source log after the test
             line_count_end = line_count(source_log, connection)
             # get the log lines of interest, put them in test_logfile

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -134,7 +134,7 @@ class MyAccountTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        email = '{}@example.com'.format(gen_string('alphanumeric'))
+        email = f"{gen_string('alphanumeric')}@example.com"
         self.update_user({'mail': email})
         result = self.user_info()
         self.assertEqual(result['email'], email)

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -54,7 +54,7 @@ class TestOperatingSystem:
         """
         os_list_before = OperatingSys.list()
         os = make_os()
-        os_list = OperatingSys.list({'search': 'name=%s' % os['name']})
+        os_list = OperatingSys.list({'search': f"name={os['name']}"})
         os_info = OperatingSys.info({'id': os_list[0]['id']})
         assert os['id'] == os_info['id']
         os_list_after = OperatingSys.list()
@@ -91,7 +91,7 @@ class TestOperatingSystem:
         os_list_before = OperatingSys.list()
         name = gen_string('alpha')
         os = make_os({'name': name})
-        os_list = OperatingSys.list({'search': 'name=%s' % name})
+        os_list = OperatingSys.list({'search': f'name={name}'})
         os_info = OperatingSys.info({'id': os_list[0]['id']})
         assert os['id'] == os_info['id']
         os_list_after = OperatingSys.list()

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -922,7 +922,7 @@ class TestOpenScap:
         )
         host_name = host.name + "." + host.domain.name
         Scappolicy.update({'id': scap_policy['id'], 'hosts': host_name})
-        hosts = Host.list({'search': 'compliance_policy_id = {}'.format(scap_policy['id'])})
+        hosts = Host.list({'search': f"compliance_policy_id = {scap_policy['id']}"})
         assert host_name in [host['name'] for host in hosts]
 
     @pytest.mark.stubbed

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -102,7 +102,7 @@ class TestRemoteExecution:
                 'value': 'True',
             }
         )
-        command = "echo {}".format(gen_string('alpha'))
+        command = f"echo {gen_string('alpha')}"
         invocation_command = make_job_invocation(
             {
                 'job-template': 'Run Command - SSH Default',
@@ -124,7 +124,7 @@ class TestRemoteExecution:
             raise AssertionError(result)
 
         task = Task.list_tasks({"search": command})[0]
-        search = Task.list_tasks({"search": 'id={}'.format(task["id"])})
+        search = Task.list_tasks({"search": f"id={task['id']}"})
         assert search[0]["action"] == task["action"]
 
     @pytest.mark.skip_if_open('BZ:1804685')
@@ -358,7 +358,7 @@ class TestRemoteExecution:
                 )
             )
             raise AssertionError(result)
-        result = ssh.command("rpm -q {}".format(" ".join(packages)), hostname=self.client.ip_addr)
+        result = ssh.command(f"rpm -q {' '.join(packages)}", hostname=self.client.ip_addr)
         assert result.return_code == 0
 
     @pytest.mark.tier3

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -230,9 +230,7 @@ class ReportTemplateTestCase(CLITestCase):
             {
                 'name': rt_host_statuses['name'],
                 'inputs': (
-                    rt_host_statuses['template-inputs'][0]['name']
-                    + "="
-                    + 'name={}'.format(host1['name'])
+                    rt_host_statuses['template-inputs'][0]['name'] + "=" + f"name={host1['name']}"
                 ),
             }
         )
@@ -388,9 +386,7 @@ class ReportTemplateTestCase(CLITestCase):
 
         result = ReportTemplate.generate({'name': report_template['name']})
         assert 'Name,Operating System' in result  # verify header of custom template
-        assert (
-            '{},"{}"'.format(host['name'], host['operating-system']['operating-system']) in result
-        )
+        assert f"{host['name']},\"{host['operating-system']['operating-system']}\"" in result
 
     @pytest.mark.tier3
     @pytest.mark.stubbed

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -235,7 +235,7 @@ class TestRole:
         :CaseImportance: Critical
 
         """
-        role_list = Role.list({'search': 'name=\\"{}\\"'.format(choice(ROLES))})
+        role_list = Role.list({'search': f'name=\\"{choice(ROLES)}\\"'})
         assert len(role_list) == 1
         cloned_role = Role.clone(
             {'id': role_list[0]['id'], 'new-name': gen_string('alphanumeric')}
@@ -1277,7 +1277,7 @@ class TestSystemAdmin:
                 'firstname': gen_string('alpha'),
                 'lastname': gen_string('alpha'),
                 'login': gen_string('alpha'),
-                'mail': '{}@example.com'.format(gen_string('alpha')),
+                'mail': f"{gen_string('alpha')}@example.com",
                 'password': common_pass,
                 'organizations': org['name'],
                 'role-ids': role['id'],
@@ -1299,7 +1299,7 @@ class TestSystemAdmin:
                 'firstname': gen_string('alpha'),
                 'lastname': gen_string('alpha'),
                 'login': gen_string('alpha'),
-                'mail': '{}@example.com'.format(gen_string('alpha')),
+                'mail': f"{gen_string('alpha')}@example.com",
                 'password': common_pass,
                 'organizations': org['name'],
                 'role-ids': org_role['id'],

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -372,7 +372,7 @@ class ContentViewSync(CLITestCase):
     def setUp(self):
         """Create Directory for CV export"""
         super().setUp()
-        self.export_dir = "{}/{}".format(self.export_base, gen_string('alpha'))
+        self.export_dir = f"{self.export_base}/{gen_string('alpha')}"
         ssh.command(f'mkdir {self.export_dir}')
 
     def tearDown(self):

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -186,7 +186,7 @@ class SubscriptionTestCase(CLITestCase):
         self._upload_manifest(self.org['id'])
         Subscription.list({'organization-id': self.org['id']}, per_page=None)
         history = Subscription.manifest_history({'organization-id': self.org['id']})
-        assert '{} file imported successfully.'.format(self.org['name']) in ''.join(history)
+        assert f"{self.org['name']} file imported successfully." in ''.join(history)
 
     @pytest.mark.tier1
     @pytest.mark.upgrade

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -548,14 +548,14 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org):
     for product in products:
         Product.set_sync_plan({'id': product['id'], 'sync-plan-id': sync_plan['id']})
     # Wait quarter of expected time
-    logger.info('Waiting {} seconds to check products were not synced'.format(delay / 4))
+    logger.info(f'Waiting {delay / 4} seconds to check products were not synced')
     sleep(delay / 4)
     # Verify products has not been synced yet
     for repo in repos:
         with pytest.raises(AssertionError):
             validate_task_status(repo['id'], max_tries=1)
     # Wait the rest of expected time
-    logger.info('Waiting {} seconds to check products were synced'.format(delay * 3 / 4))
+    logger.info(f'Waiting {delay * 3 / 4} seconds to check products were synced')
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
     for repo in repos:

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -106,13 +106,13 @@ class UserTestCase(CLITestCase):
                 )
 
         # list by firstname and lastname
-        result = User.list({'search': 'firstname = {}'.format(user_params['firstname'])})
+        result = User.list({'search': f"firstname = {user_params['firstname']}"})
         # make sure user is in list result
         self.assertEqual(
             {user['id'], user['login'], user['name']},
             {result[0]['id'], result[0]['login'], result[0]['name']},
         )
-        result = User.list({'search': 'lastname = {}'.format(user_params['lastname'])})
+        result = User.list({'search': f"lastname = {user_params['lastname']}"})
         # make sure user is in list result
         self.assertEqual(
             {user['id'], user['login'], user['name']},
@@ -336,7 +336,7 @@ class SshKeyInUserTestCase(CLITestCase):
 
         :return: string type well formatted RSA key
         """
-        return 'ssh-rsa {}'.format(paramiko.RSAKey.generate(2048).get_base64())
+        return f'ssh-rsa {paramiko.RSAKey.generate(2048).get_base64()}'
 
     @classmethod
     def setUpClass(cls):

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -76,7 +76,7 @@ class UserGroupTestCase(CLITestCase):
         self.assertEqual(user_group['user-groups'][0]['usergroup'], sub_user_group['name'])
 
         # List
-        result_list = UserGroup.list({'search': 'name={}'.format(user_group['name'])})
+        result_list = UserGroup.list({'search': f"name={user_group['name']}"})
         self.assertTrue(len(result_list) > 0)
         self.assertTrue(UserGroup.exists(search=('name', user_group['name'])))
 

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -178,7 +178,7 @@ class TestComputeResourceHost:
                 'provision-method': 'build',
             }
         )
-        hostname = '{}.{}'.format(host_name, provisioning['config_env']['domain'])
+        hostname = f"{host_name}.{provisioning['config_env']['domain']}"
         assert hostname == host['name']
         host_info = Host.info({'name': hostname})
         host_ip = host_info.get('network').get('ipv4-address')
@@ -266,7 +266,7 @@ class TestComputeResourceHost:
                 'provision-method': 'build',
             }
         )
-        hostname = '{}.{}'.format(host_name, provisioning['config_env']['domain'])
+        hostname = f"{host_name}.{provisioning['config_env']['domain']}"
         assert hostname == host['name']
         # Check on Vmware, if VM exists
         assert vmware['vmware_api'].does_vm_exist(hostname)

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -40,7 +40,7 @@ NAV_ITEMS = [
 
 @pytest.fixture(scope="module")
 def module_org():
-    org = entities.Organization(name="insights_{}".format(gen_string("alpha", 6))).create()
+    org = entities.Organization(name=f"insights_{gen_string('alpha', 6)}").create()
     with manifests.clone() as manifest:
         up_man(org.id, manifest.content)
     yield org

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -85,9 +85,9 @@ class TestKatelloCertsCheck:
     def cert_setup(self, cert_data):
         # Need a subdirectory under ssl-build with same name as Capsule name
         with get_connection(timeout=100) as connection:
-            connection.run('mkdir ssl-build/{}'.format(cert_data['capsule_hostname']))
+            connection.run(f"mkdir ssl-build/{cert_data['capsule_hostname']}")
             # Ignore creation error, but assert directory exists
-            assert connection.run('test -e ssl-build/{}'.format(cert_data['capsule_hostname']))
+            assert connection.run(f"test -e ssl-build/{cert_data['capsule_hostname']}")
         upload_file(
             local_file=get_data_file('generate-ca.sh'),
             remote_file="generate-ca.sh",
@@ -104,9 +104,7 @@ class TestKatelloCertsCheck:
             assert result.return_code == 0
         # create the Satellite's cert
         with get_connection(timeout=300) as connection:
-            result = connection.run(
-                "yes | bash {} {}".format('generate-crt.sh', cert_data['sat6_hostname'])
-            )
+            result = connection.run(f"yes | bash generate-crt.sh {cert_data['sat6_hostname']}")
             assert result.return_code == 0
 
     @pytest.fixture()
@@ -350,7 +348,7 @@ class TestKatelloCertsCheck:
                 )
             )
             connection.run(
-                'cp "{}" /root/capsule_cert/capsule_cert.pem'.format(cert_data['cert_file_name'])
+                f"cp \"{cert_data['cert_file_name']}\" /root/capsule_cert/capsule_cert.pem"
             )
             connection.run(
                 'cp "{}" /root/capsule_cert/capsule_cert_key.pem'.format(
@@ -401,7 +399,7 @@ class TestKatelloCertsCheck:
                 )
             )
             connection.run(
-                'cp "{}" /root/capsule_cert/capsule_cert.pem'.format(cert_data['cert_file_name'])
+                f"cp \"{cert_data['cert_file_name']}\" /root/capsule_cert/capsule_cert.pem"
             )
             connection.run(
                 'cp "{}" /root/capsule_cert/capsule_cert_key.pem'.format(
@@ -542,7 +540,7 @@ class TestCapsuleCertsCheckTestCase:
     def file_setup(self):
         """Create working directory and file."""
         capsule_hostname = 'capsule.example.com'
-        tmp_dir = '/var/tmp/{}'.format(gen_string('alpha', 6))
+        tmp_dir = f"/var/tmp/{gen_string('alpha', 6)}"
         caps_cert_file = f'{tmp_dir}/ssl-build/capsule.example.com/cert-data'
         # Use same path locally as on remote for storing files
         Path(f'{tmp_dir}/ssl-build/capsule.example.com/').mkdir(parents=True, exist_ok=True)

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -71,7 +71,7 @@ class TestRenameHost:
             old_hostname = connection.run('hostname').stdout[0]
             new_hostname = f'new-{old_hostname}'
             # create installation medium with hostname in path
-            medium_path = 'http://{}/testpath-{}/os/'.format(old_hostname, gen_string('alpha'))
+            medium_path = f"http://{old_hostname}/testpath-{gen_string('alpha')}/os/"
             medium = entities.Media(organization=[module_org], path_=medium_path).create()
             repo = entities.Repository(product=module_product, name='testrepo').create()
             result = connection.run(

--- a/tests/foreman/ui/conftest.py
+++ b/tests/foreman/ui/conftest.py
@@ -48,7 +48,7 @@ def module_user(request, module_org, module_loc):
     """
     # take only "module" from "tests.ui.test_module"
     test_module_name = request.module.__name__.split('.')[-1].split('_', 1)[-1]
-    login = '{}_{}'.format(test_module_name, gen_string('alphanumeric'))
+    login = f"{test_module_name}_{gen_string('alphanumeric')}"
     password = gen_string('alphanumeric')
     LOGGER.debug('Creating session user %r', login)
     user = nailgun.entities.User(

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -385,9 +385,7 @@ def test_positive_VM_import(session, module_ca_cert, module_org, module_loc, rhe
         )
         assert session.host.search(rhev_data['vm_name']) is not None
     # disassociate the host so the corresponding VM doesn't get removed from the CR on host delete
-    entities.Host().search(query={'search': 'name~{}'.format(rhev_data['vm_name'])})[
-        0
-    ].disassociate()
+    entities.Host().search(query={'search': f"name~{rhev_data['vm_name']}"})[0].disassociate()
     entities.Host(name=rhev_data['vm_name']).search()[0].delete()
 
 
@@ -616,7 +614,7 @@ def test_positive_associate_with_custom_profile_with_template(session, rhev_data
     cr_name = gen_string('alpha')
     cr_profile_data = dict(
         cluster=rhev_data['datacenter'],
-        template='{} (base version)'.format(rhev_data['image_name']),
+        template=f"{rhev_data['image_name']} (base version)",
         cores='2',
         memory='1 GB',
     )

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -104,7 +104,7 @@ def test_positive_end_to_end(session, module_org, module_loc, module_libvirt_url
         # check that the compute resource is listed in one of the default compute profiles
         profile_cr_values = session.computeprofile.list_resources(COMPUTE_PROFILE_SMALL)
         profile_cr_names = [cr['Compute Resource'] for cr in profile_cr_values]
-        assert '{} ({})'.format(new_cr_name, FOREMAN_PROVIDERS['libvirt']) in profile_cr_names
+        assert f"{new_cr_name} ({FOREMAN_PROVIDERS['libvirt']})" in profile_cr_names
         session.computeresource.update_computeprofile(
             new_cr_name,
             COMPUTE_PROFILE_SMALL,

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -54,7 +54,7 @@ def _get_normalized_size(size):
         size = round(size, 2)
     if size == int(size):
         size = int(size)
-    return '{} {}'.format(size, suffixes[suffix_index])
+    return f'{size} {suffixes[suffix_index]}'
 
 
 def _get_vmware_datastore_summary_string(data_store_name=VMWARE_CONSTANTS['datastore']):
@@ -174,7 +174,7 @@ def test_positive_end_to_end(session, module_org, module_loc, module_vmware_sett
         # check that the compute resource is listed in one of the default compute profiles
         profile_cr_values = session.computeprofile.list_resources(COMPUTE_PROFILE_LARGE)
         profile_cr_names = [cr['Compute Resource'] for cr in profile_cr_values]
-        assert '{} ({})'.format(new_cr_name, FOREMAN_PROVIDERS['vmware']) in profile_cr_names
+        assert f"{new_cr_name} ({FOREMAN_PROVIDERS['vmware']})" in profile_cr_names
         session.computeresource.delete(new_cr_name)
         assert not session.computeresource.search(new_cr_name)
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -583,7 +583,7 @@ def test_positive_host_re_registion_with_host_rename(session, module_org, repos_
     result = vm.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
     assert result.return_code == 0
     vm.unregister()
-    updated_hostname = '{}.{}'.format(gen_string('alpha'), vm.hostname).lower()
+    updated_hostname = f"{gen_string('alpha')}.{vm.hostname}".lower()
     vm.run(f'hostnamectl set-hostname {updated_hostname}')
     assert result.return_code == 0
     vm.register_contenthost(

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -619,7 +619,7 @@ def test_positive_publish_multiple_with_docker_repo(session, module_org, module_
     with session:
         for version in range(randint(2, 5)):
             result = session.contentview.publish(content_view.name)
-            assert result['Version'] == 'Version {}.0'.format(version + 1)
+            assert result['Version'] == f'Version {version + 1}.0'
 
 
 @pytest.mark.tier2
@@ -647,7 +647,7 @@ def test_positive_publish_multiple_with_docker_repo_composite(session, module_or
         session.contentview.add_cv(composite_cv.name, content_view.name)
         for version in range(randint(2, 5)):
             result = session.contentview.publish(composite_cv.name)
-            assert result['Version'] == 'Version {}.0'.format(version + 1)
+            assert result['Version'] == f'Version {version + 1}.0'
 
 
 @pytest.mark.tier2
@@ -1193,7 +1193,7 @@ def test_positive_publish_version_changes_in_target_env(session, module_org):
     cv_name = gen_string('alpha')
     # will promote environment to 3 versions
     versions_count = 3
-    versions = ('Version {}.0'.format(ver + 1) for ver in range(versions_count))
+    versions = (f'Version {ver + 1}.0' for ver in range(versions_count))
     # create environment lifecycle
     lce = entities.LifecycleEnvironment(organization=module_org).create()
     repo_names = [gen_string('alphanumeric') for _ in range(versions_count)]
@@ -2163,12 +2163,12 @@ def test_positive_update_inclusive_filter_package_version(session, module_org):
         result = session.contentview.publish(cv.name)
         assert result['Version'] == VERSION
         packages = session.contentview.search_version_package(
-            cv.name, VERSION, 'name = "{}" and version = "{}"'.format(package_name, '0.71')
+            cv.name, VERSION, f"name = \"{package_name}\" and version = \"0.71\""
         )
         assert len(packages) == 1
         assert packages[0]['Name'] == package_name and packages[0]['Version'] == '0.71'
         packages = session.contentview.search_version_package(
-            cv.name, VERSION, 'name = "{}" and version = "{}"'.format(package_name, '5.21')
+            cv.name, VERSION, f"name = \"{package_name}\" and version = \"5.21\""
         )
         assert not packages[0]['Name']
         session.contentviewfilter.update_package_rule(
@@ -2180,11 +2180,11 @@ def test_positive_update_inclusive_filter_package_version(session, module_org):
         )
         new_version = session.contentview.publish(cv.name)['Version']
         packages = session.contentview.search_version_package(
-            cv.name, new_version, 'name = "{}" and version = "{}"'.format(package_name, '0.71')
+            cv.name, new_version, f"name = \"{package_name}\" and version = \"0.71\""
         )
         assert not packages[0]['Name']
         packages = session.contentview.search_version_package(
-            cv.name, new_version, 'name = "{}" and version = "{}"'.format(package_name, '5.21')
+            cv.name, new_version, f"name = \"{package_name}\" and version = \"5.21\""
         )
         assert len(packages) == 1
         assert packages[0]['Name'] == package_name and packages[0]['Version'] == '5.21'
@@ -2224,12 +2224,12 @@ def test_positive_update_exclusive_filter_package_version(session, module_org):
         result = session.contentview.publish(cv.name)
         assert result['Version'] == VERSION
         packages = session.contentview.search_version_package(
-            cv.name, VERSION, 'name = "{}" and version = "{}"'.format(package_name, '5.21')
+            cv.name, VERSION, f"name = \"{package_name}\" and version = \"5.21\""
         )
         assert len(packages) == 1
         assert packages[0]['Name'] == package_name and packages[0]['Version'] == '5.21'
         packages = session.contentview.search_version_package(
-            cv.name, VERSION, 'name = "{}" and version = "{}"'.format(package_name, '0.71')
+            cv.name, VERSION, f"name = \"{package_name}\" and version = \"0.71\""
         )
         assert not packages[0]['Name']
         session.contentviewfilter.update_package_rule(
@@ -2241,11 +2241,11 @@ def test_positive_update_exclusive_filter_package_version(session, module_org):
         )
         new_version = session.contentview.publish(cv.name)['Version']
         packages = session.contentview.search_version_package(
-            cv.name, new_version, 'name = "{}" and version = "{}"'.format(package_name, '5.21')
+            cv.name, new_version, f"name = \"{package_name}\" and version = \"5.21\""
         )
         assert not packages[0]['Name']
         packages = session.contentview.search_version_package(
-            cv.name, new_version, 'name = "{}" and version = "{}"'.format(package_name, '0.71')
+            cv.name, new_version, f"name = \"{package_name}\" and version = \"0.71\""
         )
         assert len(packages) == 1
         assert packages[0]['Name'] == package_name and packages[0]['Version'] == '0.71'
@@ -2609,18 +2609,18 @@ def test_positive_update_filter_affected_repos(session, module_org):
         cv.publish()
         # Verify filter affected repo1
         packages = session.contentview.search_version_package(
-            cv.name, VERSION, 'name = "{}" and version = "{}"'.format(repo1_package_name, '0.71')
+            cv.name, VERSION, f"name = \"{repo1_package_name}\" and version = \"0.71\""
         )
         assert len(packages) == 1
         assert packages[0]['Name'] == repo1_package_name and packages[0]['Version'] == '0.71'
         packages = session.contentview.search_version_package(
-            cv.name, VERSION, 'name = "{}" and version = "{}"'.format(repo1_package_name, '5.21')
+            cv.name, VERSION, f"name = \"{repo1_package_name}\" and version = \"5.21\""
         )
         # checking search showing empty result
         assert not packages[0]['Name']
         # Verify repo2 was not affected and repo2 packages are present
         packages = session.contentview.search_version_package(
-            cv.name, VERSION, 'name = "{}" and version = "{}"'.format(repo2_package_name, '5.6.6')
+            cv.name, VERSION, f"name = \"{repo2_package_name}\" and version = \"5.6.6\""
         )
         assert len(packages) == 1
         assert packages[0]['Name'] == repo2_package_name and packages[0]['Version'] == '5.6.6'
@@ -2941,9 +2941,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(session):
                 'host_group.puppet_ca': sat_hostname,
                 'host_group.puppet_master': sat_hostname,
                 'operating_system.architecture': arch.name,
-                'operating_system.operating_system': '{} {}.{}'.format(
-                    os.name, os.major, os.minor
-                ),
+                'operating_system.operating_system': f'{os.name} {os.major}.{os.minor}',
                 'operating_system.ptable': ptable.name,
                 'operating_system.media_type': 'Synced Content',
                 'operating_system.media_content.synced_content': repo.name,
@@ -3325,7 +3323,7 @@ def test_positive_composite_child_inc_update(session):
     ).update(['content_view'])
     with VirtualMachine(distro=DISTRO_RHEL7) as vm:
         repos_collection.setup_virtual_machine(vm)
-        result = vm.run('yum -y install {}'.format(FAKE_0_INC_UPD_OLD_PACKAGE.rstrip('.rpm')))
+        result = vm.run(f"yum -y install {FAKE_0_INC_UPD_OLD_PACKAGE.rstrip('.rpm')}")
         assert result.return_code == 0
         create_repo(
             repo_name, FAKE_0_INC_UPD_URL, [FAKE_0_INC_UPD_NEW_PACKAGE], wipe_repodata=True

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -60,7 +60,7 @@ def provisioning_env(module_org, module_loc):
     return configure_provisioning(
         org=module_org,
         loc=module_loc,
-        os='Redhat {}'.format(RHELRepository().repo_data['version']),
+        os=f"Redhat {RHELRepository().repo_data['version']}",
     )
 
 

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -234,7 +234,7 @@ def test_positive_list_host_based_on_rule_search_query(
     )
     # create an other discovered host with an other cpu count
     create_discovered_host(options={'physicalprocessorcount': cpu_count + 1})
-    provisioned_host_name = '{}.{}'.format(discovered_host['name'], host.domain.read().name)
+    provisioned_host_name = f"{discovered_host['name']}.{host.domain.read().name}"
     with session:
         session.organization.select(org_name=module_org.name)
         session.location.select(loc_name=module_loc.name)
@@ -247,7 +247,7 @@ def test_positive_list_host_based_on_rule_search_query(
         assert values['table'][0]['CPUs'] == str(cpu_count)
         # auto provision the discovered host
         session.discoveredhosts.apply_action('Auto Provision', [discovered_host['name']])
-        assert not session.discoveredhosts.search('name = "{}"'.format(discovered_host['name']))
+        assert not session.discoveredhosts.search(f"name = \"{discovered_host['name']}\"")
         values = session.discoveryrule.read_associated_hosts(discovery_rule.name)
         assert values['searchbox'] == f'discovery_rule = "{discovery_rule.name}"'
         assert len(values['table']) == 1
@@ -268,13 +268,13 @@ def test_positive_end_to_end(session, module_org, module_loc):
     :CaseImportance: Critical
     """
     rule_name = gen_string('alpha')
-    search = 'cpu_count = {}'.format(gen_integer(1, 5))
+    search = f'cpu_count = {gen_integer(1, 5)}'
     hg_name = gen_string('alpha')
     hostname = gen_string('alpha')
     hosts_limit = str(gen_integer(0, 100))
     priority = str(gen_integer(1, 100))
     new_rule_name = gen_string('alpha')
-    new_search = 'cpu_count = {}'.format(gen_integer(6, 10))
+    new_search = f'cpu_count = {gen_integer(6, 10)}'
     new_hg_name = gen_string('alpha')
     new_hostname = gen_string('alpha')
     new_hosts_limit = str(gen_integer(101, 200))

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -399,7 +399,7 @@ def test_positive_list_permission(test_name, module_org, module_repos_col, modul
             query={'search': 'resource_type="Katello::Product"'}
         ),
         role=role,
-        search='name = "{}"'.format(PRDS['rhel']),
+        search=f"name = \"{PRDS['rhel']}\"",
     ).create()
     user_password = gen_string('alphanumeric')
     user = entities.User(

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -406,7 +406,7 @@ def test_positive_end_to_end(session, module_host_template, module_org, module_g
             global_param['overridden'] = False
 
     config_group = entities.ConfigGroup().create()
-    new_name = 'new{}'.format(gen_string("alpha").lower())
+    new_name = f"new{gen_string('alpha').lower()}"
     new_host_name = f'{new_name}.{module_host_template.domain.name}'
     with session:
         host_name = create_fake_host(

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -153,7 +153,7 @@ def test_positive_run_custom_job_template_by_ip(session, module_org, module_vm_c
                 'template_content.command': 'ls',
             }
         )
-        job_description = '{} with inputs command="ls"'.format(camelize(job_template_name.lower()))
+        job_description = f'{camelize(job_template_name.lower())} with inputs command="ls"'
         session.jobinvocation.wait_job_invocation_state(
             entity_name=job_description, host_name=hostname
         )

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -169,7 +169,7 @@ def test_positive_search_scoped(session):
         session.organization.create({'name': org_name, 'label': label})
         for query in [
             f'label = {label}',
-            'label ~ {}'.format(label[:-5]),
+            f'label ~ {label[:-5]}',
             f'label ^ "{label}"',
         ]:
             assert session.organization.search(query)[0]['Name'] == org_name

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -127,7 +127,7 @@ def test_positive_end_to_end(
 
     :CaseImportance: High
     """
-    name = '{} {}'.format(gen_string('alpha'), gen_string('alpha'))
+    name = f"{gen_string('alpha')} {gen_string('alpha')}"
     new_name = gen_string('alpha')
     description = gen_string('alpha')
     oscap_content_title = gen_string('alpha')

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -210,12 +210,12 @@ def test_positive_rh_repo_search_and_check_file_list(session, module_org, module
     """
     with session:
         session.organization.select(org_name=module_org.name)
-        assert session.package.search(
-            'name = {}'.format('puppet-agent'), repository=module_rh_repo.name
-        )[0]['RPM'].startswith('puppet-agent')
-        assert session.package.search(
-            'name = {}'.format('katello-host-tools'), repository=module_rh_repo.name
-        )[0]['RPM'].startswith('katello-host-tools')
+        assert session.package.search("name = puppet-agent", repository=module_rh_repo.name)[0][
+            'RPM'
+        ].startswith('puppet-agent')
+        assert session.package.search("name = katello-host-tools", repository=module_rh_repo.name)[
+            0
+        ]['RPM'].startswith('katello-host-tools')
         package_details = session.package.read('tracer-common', repository=module_rh_repo.name)
         assert {
             '/etc/bash_completion.d/tracer',

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -415,7 +415,7 @@ def test_positive_schedule_generation_and_get_mail(session, module_org, module_l
                 'email_to': 'root@localhost',
             },
         )
-    file_path = '/tmp/{}.json'.format(gen_string('alpha'))
+    file_path = f"/tmp/{gen_string('alpha')}.json"
     gzip_path = f'{file_path}.gz'
     expect_script = (
         f'#!/usr/bin/env expect\n'

--- a/tests/robottelo/test_func_shared.py
+++ b/tests/robottelo/test_func_shared.py
@@ -137,7 +137,7 @@ def basic_shared_counter_string(prefix='', suffix='', counter=0, increment_by=1)
     """basic function that increment a counter and return a string with
     prefix
     """
-    return '{}_{}_{}'.format(prefix, counter + increment_by, suffix)
+    return f'{prefix}_{counter + increment_by}_{suffix}'
 
 
 class NotRestorableException(Exception):

--- a/tests/robottelo/test_host_info.py
+++ b/tests/robottelo/test_host_info.py
@@ -78,7 +78,7 @@ class TestGetHostOsVersion:
         os_version = host_info.get_host_os_version.__wrapped__()
         assert 'Not Available' == os_version
         ssh_result.assert_called_once_with('cat /etc/redhat-release')
-        logger.warning.assert_called_once_with('Host version not available: %r' % cmd)
+        logger.warning.assert_called_once_with(f'Host version not available: {cmd!r}')
 
     @mock.patch('robottelo.host_info.LOGGER')
     def test_command_parsing_error(self, logger, ssh_result):
@@ -90,7 +90,7 @@ class TestGetHostOsVersion:
         os_version = host_info.get_host_os_version.__wrapped__()
         assert 'Not Available' == os_version
         ssh_result.assert_called_once_with('cat /etc/redhat-release')
-        logger.warning.assert_called_once_with('Host version not available: %r' % cmd)
+        logger.warning.assert_called_once_with(f'Host version not available: {cmd!r}')
 
 
 class TestGetHostSatVersion:
@@ -157,7 +157,7 @@ class TestGetHostSatVersion:
         ]
         ssh_result.assert_has_calls(calls)
         logger.warning.assert_called_once_with(
-            'Host Satellite version not available: %r' % self.SSH_RESULT_ERROR
+            f'Host Satellite version not available: {self.SSH_RESULT_ERROR!r}'
         )
 
 

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -225,7 +225,7 @@ class TestCapsuleSyncNewRepo:
         cap_host = settings.upgrade.rhev_cap_host or settings.upgrade.capsule_hostname
         org = entities.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})[0]
         lc_env = entities.LifecycleEnvironment(organization=org).search(
-            query={'search': 'name="{}"'.format('Dev')}
+            query={'search': "name=\"Dev\""}
         )[0]
 
         product = entities.Product(organization=org).create()

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -46,7 +46,7 @@ def create_activation_key_for_client_registration(ak_name, client_os, org, envir
     """
     client_os = client_os.upper()
     from_ver = settings.upgrade.from_version
-    rhel_prod_name = 'scenarios_rhel{}_prod'.format(client_os[-1])
+    rhel_prod_name = f'scenarios_rhel{client_os[-1]}_prod'
     rhel_repo_name = f'{rhel_prod_name}_repo'
     rhel_url = settings.rhel7_os
     if rhel_url is None:
@@ -116,7 +116,7 @@ def create_activation_key_for_client_registration(ak_name, client_os, org, envir
     ).create()
     if sat_state == 'pre':
         tools_sub = 'Red Hat Satellite Employee Subscription'
-        tools_content = 'rhel-{}-server-satellite-tools-{}-rpms'.format(client_os[-1], from_ver)
+        tools_content = f'rhel-{client_os[-1]}-server-satellite-tools-{from_ver}-rpms'
     else:
         tools_sub = tools_prod.name
     tools_subscription = entities.Subscription(organization=org.id).search(

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -78,16 +78,16 @@ class ScenarioErrataAbstract:
         """
 
         from_version = settings.upgrade.from_version
-        repo2_name = 'rhst7_{}'.format(str(from_version).replace('.', ''))
+        repo2_name = f"rhst7_{str(from_version).replace('.', '')}"
 
         repo1_id = (
             entities.Repository(organization=self.org)
-            .search(query={'search': '{}'.format(REPOS['rhel7']['id'])})[0]
+            .search(query={'search': f"{REPOS['rhel7']['id']}"})[0]
             .id
         )
         repo2_id = (
             entities.Repository(organization=self.org)
-            .search(query={'search': '{}'.format(REPOS[repo2_name]['id'])})[0]
+            .search(query={'search': f"{REPOS[repo2_name]['id']}"})[0]
             .id
         )
 

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -117,12 +117,10 @@ class scenario_positive_gce_host_compute_resource(APITestCase):
         self.__class__.fullhost = f'{hostname}.{self.domain_name}'.lower()
         preentities = get_entity_data(self.__class__.__name__)
         gce_cr = entities.GCEComputeResource().search(
-            query={'search': 'name={}'.format(preentities['cr_name'])}
+            query={'search': f"name={preentities['cr_name']}"}
         )[0]
-        org = entities.Organization().search(
-            query={'search': 'name={}'.format(preentities['org'])}
-        )[0]
-        loc = entities.Location().search(query={'search': 'name={}'.format(preentities['loc'])})[0]
+        org = entities.Organization().search(query={'search': f"name={preentities['org']}"})[0]
+        loc = entities.Location().search(query={'search': f"name={preentities['loc']}"})[0]
         compute_attrs = {
             'machine_type': 'g1-small',
             'network': 'default',

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -130,7 +130,7 @@ class Scenario_custom_repo_check(APITestCase):
         cls.sat_host = settings.server.hostname
         cls.docker_vm = settings.upgrade.docker_vm
         cls.file_path = '/var/www/html/pub/custom_repo/'
-        cls.custom_repo = 'https://{}{}'.format(cls.sat_host, '/pub/custom_repo/')
+        cls.custom_repo = f"https://{cls.sat_host}/pub/custom_repo/"
         _, cls.rpm1_name = os.path.split(rpm1)
         _, cls.rpm2_name = os.path.split(rpm2)
 

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -100,16 +100,16 @@ class Scenario_yum_plugins_count(APITestCase):
         """
 
         from_version = settings.upgrade.from_version
-        repo2_name = 'rhst7_{}'.format(str(from_version).replace('.', ''))
+        repo2_name = f"rhst7_{str(from_version).replace('.', '')}"
 
         repo1_id = (
             entities.Repository(organization=self.org)
-            .search(query={'search': '{}'.format(REPOS['rhel7']['id'])})[0]
+            .search(query={'search': f"{REPOS['rhel7']['id']}"})[0]
             .id
         )
         repo2_id = (
             entities.Repository(organization=self.org)
-            .search(query={'search': '{}'.format(REPOS[repo2_name]['id'])})[0]
+            .search(query={'search': f"{REPOS[repo2_name]['id']}"})[0]
             .id
         )
 


### PR DESCRIPTION
adding flynt[1] to pre-commit hooks

We do not currently use pyupgrades[2] option `--py36-plus` to format -f-strings.

[1] https://github.com/ikamensh/flynt
[2] https://github.com/asottile/pyupgrade