### PR TITLE
Fix capsule upgrade playbook test

### DIFF
--- a/robottelo/vm_capsule.py
+++ b/robottelo/vm_capsule.py
@@ -226,7 +226,9 @@ class CapsuleVirtualMachine(VirtualMachine):
         )
         self.configure_rhel_repo(getattr(settings, f"{self.distro}_repo"))
         self.run('yum repolist')
-        self.run('yum -y update')
+        self.run('yum -y update', timeout=1800)
+        self.run('firewall-cmd --add-service RH-Satellite-6-capsule')
+        self.run('firewall-cmd --runtime-to-permanent')
         self.run('yum -y install satellite-capsule', timeout=1200)
         result = self.run('rpm -q satellite-capsule')
         if result.return_code != 0:


### PR DESCRIPTION
To fix the `test_positive_run_capsule_upgrade_playbook` I needed to fix `vm_capsule` too as several things were failing:
1. capsule installer timeouted during yum update
2. capsule installer failed due to not configured firewalld (after update)
3. capsule upgrade playbook id changed
4. different set of features listed for 6.9 capsule

Test result:
```
(venv38) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_remoteexecution.py::test_positive_run_capsule_upgrade_playbook
========================================== test session starts ==========================================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, mock-3.4.0, ibutsu-1.13, xdist-2.2.0
collected 1 item                                                                                                                                                                                                                         

tests/foreman/api/test_remoteexecution.py .                                                       [100%]

=========================================== warnings summary ============================================
...
============================== 1 passed, 56 warnings in 1819.56s (0:30:19) ==============================
```