### PR TITLE
Add codecov.yml for configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+github_checks:
+  annotations: false
+
+# https://docs.codecov.io/docs/github-checks-beta
+# Annotations are shown for unchanged files on the diff
+# Turn off all annotations until this is more configurable
+# The codecov comment will still be made on the PR

--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -1,8 +1,7 @@
-name: Robottelo - CI
+# CI stages to execute against master branch on PR merge
+name: update_robottelo_image
 
-on:
-  pull_request:
-    types: ["opened", "synchronize", "reopened"]
+on: [push]
 
 env:
     PYCURL_SSL_LIBRARY: openssl
@@ -14,6 +13,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9]
+    env:
+      SATELLITE_VERSION: 6.9
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v2
@@ -25,7 +26,6 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          sudo apt update
           sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
           wget https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example
           # link vs compile time ssl implementations can break the environment when installing requirements
@@ -48,9 +48,6 @@ jobs:
           pytest -n 8 --setup-plan --disable-pytest-warnings -m pre_upgrade tests/upgrades/
           pytest -n 8 --setup-plan --disable-pytest-warnings -m post_upgrade tests/upgrades/
 
-      - name: Test Robottelo Coverage
-        run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo
-
       - name: Make Docs
         run: |
           make test-docstrings
@@ -65,3 +62,44 @@ jobs:
         with:
           file: coverage.xml
           name: ${{ github.run_id }}-py-${{ matrix.python-version }}
+
+
+  robottelo_container:
+    needs: codechecks
+    name: Update Robottelo container image on Quay.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get image tag
+        id: image_tag
+        run: |
+          echo -n ::set-output name=IMAGE_TAG::
+          TAG="${GITHUB_REF##*/}"
+          if [ "${TAG}" == "master" ]; then
+              TAG="latest"
+          fi
+          echo "${TAG}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Quay Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ secrets.QUAY_SERVER }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Build and push image to Quay
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.QUAY_SERVER }}/${{ secrets.QUAY_NAMESPACE }}/robottelo:${{ steps.image_tag.outputs.IMAGE_TAG }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,12 @@
-name: update_robottelo_image
+# CI stages to execute against Pull Requests
+name: Robottelo - CI
 
-on: [push]
+on:
+  pull_request:
+    types: ["opened", "synchronize", "reopened"]
+
+env:
+    PYCURL_SSL_LIBRARY: openssl
 
 jobs:
   codechecks:
@@ -9,9 +15,6 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9]
-    env:
-      PYCURL_SSL_LIBRARY: openssl
-      SATELLITE_VERSION: 6.9
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v2
@@ -23,6 +26,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
           wget https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example
           # link vs compile time ssl implementations can break the environment when installing requirements
@@ -45,6 +49,9 @@ jobs:
           pytest -n 8 --setup-plan --disable-pytest-warnings -m pre_upgrade tests/upgrades/
           pytest -n 8 --setup-plan --disable-pytest-warnings -m post_upgrade tests/upgrades/
 
+      - name: Test Robottelo Coverage
+        run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo
+
       - name: Make Docs
         run: |
           make test-docstrings
@@ -54,42 +61,8 @@ jobs:
         if: failure()
         run: git diff
 
-  robottelo_container:
-    needs: codechecks
-    name: Update Robottelo container image on Quay.
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Get image tag
-        id: image_tag
-        run: |
-          echo -n ::set-output name=IMAGE_TAG::
-          TAG="${GITHUB_REF##*/}"
-          if [ "${TAG}" == "master" ]; then
-              TAG="latest"
-          fi
-          echo "${TAG}"
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-
-      - name: Login to Quay Container Registry
-        uses: docker/login-action@v1
+      - name: Upload Codecov Coverage
+        uses: codecov/codecov-action@v1.0.13
         with:
-          registry: ${{ secrets.QUAY_SERVER }}
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Build and push image to Quay
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          tags: ${{ secrets.QUAY_SERVER }}/${{ secrets.QUAY_NAMESPACE }}/robottelo:${{ steps.image_tag.outputs.IMAGE_TAG }}
+          file: coverage.xml
+          name: ${{ github.run_id }}-py-${{ matrix.python-version }}


### PR DESCRIPTION
Just disable annotations for now as they're more bothersome than valuable.

It is making annotation notes for `patch` on code that isn't included in a PR, for example:
https://github.com/SatelliteQE/robottelo/pull/8278/files 

`Unchanged files with check annotations`  -> this is not helpful to reviewers, and pollutes the diff view.

Annotations can be individually controlled on files within the diff view, but not on a PR as a whole.  I did not find any configuration fields that would allow for disabling _only_ the unchecked files annotations, so I'm disabling them all until the feature is more rounded.

We'll continue to get coverage reports as comments on PRs, which does include specific listing of changes to any files included in the PR.

Additionally, I added the codecov upload to the master branch github action (and renamed the files appropriately).  We were not uploading codecov for master, and thus our comparison reports are out of date.

For example, the comment on this PR for codecov is pointing to `feff56e` as the reference, which is a commit from Dec 1, 2020:
![image](https://user-images.githubusercontent.com/21315076/105082804-16c16500-5a62-11eb-8496-f44712a40307.png)
