### PR TITLE
Pull GHA workflow yamls from master branch

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -1,6 +1,10 @@
+# CI stages to execute against master branch on PR merge
 name: update_robottelo_image
 
 on: [push]
+
+env:
+    PYCURL_SSL_LIBRARY: openssl
 
 jobs:
   codechecks:
@@ -10,7 +14,6 @@ jobs:
       matrix:
         python-version: [3.8, 3.9]
     env:
-      PYCURL_SSL_LIBRARY: gnutls
       SATELLITE_VERSION: 6.8
     steps:
       - name: Checkout Robottelo
@@ -25,7 +28,13 @@ jobs:
         run: |
           sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
           wget https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example
-          pip install -U --no-binary=pycurl -r requirements.txt -r requirements-optional.txt
+          # link vs compile time ssl implementations can break the environment when installing requirements
+          # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
+          # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
+          pip install -U pip
+          pip uninstall -y pycurl
+          pip install --compile --no-cache-dir pycurl
+          pip install -U -r requirements.txt -r requirements-optional.txt
           cp robottelo.properties.sample robottelo.properties
           cp broker_settings.yaml.example broker_settings.yaml
           cp virtwho.properties.sample virtwho.properties
@@ -47,6 +56,13 @@ jobs:
       - name: Analysis (git diff)
         if: failure()
         run: git diff
+
+      - name: Upload Codecov Coverage
+        uses: codecov/codecov-action@v1.0.13
+        with:
+          file: coverage.xml
+          name: ${{ github.run_id }}-py-${{ matrix.python-version }}
+
 
   robottelo_container:
     needs: codechecks

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,3 +1,4 @@
+# CI stages to execute against Pull Requests
 name: Robottelo - CI
 
 on:
@@ -5,7 +6,7 @@ on:
     types: ["opened", "synchronize", "reopened"]
 
 env:
-    PYCURL_SSL_LIBRARY: gnutls
+    PYCURL_SSL_LIBRARY: openssl
 
 jobs:
   codechecks:
@@ -25,9 +26,16 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          sudo apt update
           sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
           wget https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example
-          pip install -U --no-binary=pycurl -r requirements.txt -r requirements-optional.txt
+          # link vs compile time ssl implementations can break the environment when installing requirements
+          # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
+          # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
+          pip install -U pip
+          pip uninstall -y pycurl
+          pip install --compile --no-cache-dir pycurl
+          pip install -U -r requirements.txt -r requirements-optional.txt
           cp robottelo.properties.sample robottelo.properties
           cp broker_settings.yaml.example broker_settings.yaml
           cp virtwho.properties.sample virtwho.properties


### PR DESCRIPTION
There are a few commits involving GHA changes in master branch from when
these files were created, but those commits include extraneous content.

I don't think there is any need to preserve specific commit history for
these files and cherry-pick those specific commits from master to 6.y.z
branches. The GHA configuration should be consistent across our actively
developed branches.
