### PR TITLE
Add pytest to create coverage report on master

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -48,6 +48,9 @@ jobs:
           pytest -n 8 --setup-plan --disable-pytest-warnings -m pre_upgrade tests/upgrades/
           pytest -n 8 --setup-plan --disable-pytest-warnings -m post_upgrade tests/upgrades/
 
+      - name: Test Robottelo Coverage
+        run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo
+
       - name: Make Docs
         run: |
           make test-docstrings


### PR DESCRIPTION
Grabbed the coverage upload in #8289, but missed adding the pytest run that generates the report.

The pull request and merge workflows have an effectively identical job definition, but GHA doesn't provide a great way of reducing that duplication. The `on` attribute of the workflow only applies to the workflow itself, not any specific jobs within the workflow. It does not appear that this `on` attribute is accessible through any of the available contextual metadata within the job, so that they can be dynamically executed.  