### PR TITLE
Fix test_positive_last_checkin_status test case

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -688,7 +688,7 @@ class TestVirtwhoConfigforEsx:
             # 10 mins margin to check the Last Checkin time
             assert (
                 abs(
-                    datetime.strptime(checkin_time, "%b %d, %I:%M %p")
+                    datetime.strptime(checkin_time, "%B %d, %Y, %I:%M %p")
                     .replace(year=datetime.utcnow().year)
                     .timestamp()
                     - time_now.timestamp()


### PR DESCRIPTION
**Description**
Now, the time format for the Last Checkin in the contest host page has been changed from `Jan 19, 11:42 PM` to `January 20, 2021, 12:32 PM`. Need to update the test case to fix the format error.