### PR TITLE
test coverage for katello-cert-check invalid/valid input

### DIFF
--- a/tests/foreman/data/certs.sh
+++ b/tests/foreman/data/certs.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+CERTS_DIR=certs
+
+THIRDPARTY_CA_CERT_NAME=ca-thirdparty
+if [[ ! -f "$CERTS_DIR/$THIRDPARTY_CA_CERT_NAME.key" || ! -f "$CERTS_DIR/$THIRDPARTY_CA_CERT_NAME.crt" ]]; then
+  echo "Generating CA"
+  openssl genrsa -out $CERTS_DIR/$THIRDPARTY_CA_CERT_NAME.key 2048
+  openssl req -x509 -new -nodes -key $CERTS_DIR/$THIRDPARTY_CA_CERT_NAME.key -sha256 -days 3650 -out $CERTS_DIR/$THIRDPARTY_CA_CERT_NAME.crt -subj "/CN=Thirdparty CA"
+else
+  echo "Thirdparty CA certificate exists. Skipping."
+fi
+
+CA_CERT_NAME=ca
+if [[ ! -f "$CERTS_DIR/$CA_CERT_NAME.key" || ! -f "$CERTS_DIR/$CA_CERT_NAME.crt" ]]; then
+  echo "Generating CA"
+  openssl genrsa -out $CERTS_DIR/$CA_CERT_NAME.key 2048
+  openssl req -x509 -new -nodes -key $CERTS_DIR/$CA_CERT_NAME.key -sha256 -days 3650 -out $CERTS_DIR/$CA_CERT_NAME.crt -subj "/CN=Test Self-Signed CA"
+else
+  echo "CA certificate exists. Skipping."
+fi
+
+CA_BUNDLE=ca-bundle
+if [[ ! -f "$CERTS_DIR/$CA_BUNDLE.crt" ]]; then
+  echo "Generating CA bundle"
+  cat $CERTS_DIR/$THIRDPARTY_CA_CERT_NAME.crt $CERTS_DIR/$CA_CERT_NAME.crt > $CERTS_DIR/$CA_BUNDLE.crt
+else
+  echo "CA certificate bundle exists. Skipping."
+fi
+
+CERT_NAME=foreman.example.com
+if [[ ! -f "$CERTS_DIR/$CERT_NAME.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
+  echo "Generating server certificate"
+  openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
+  openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj "/CN=foreman.example.com"
+  openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions extensions
+else
+  echo "Server certificate exists. Skipping."
+fi
+
+CERT_NAME=invalid
+if [[ ! -f "$CERTS_DIR/$CERT_NAME.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
+  echo "Generating invalid server certificate"
+  openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
+  openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj "/CN=foreman.example.com"
+  openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions client_extensions
+else
+  echo "Invalid server certificate exists. Skipping."
+fi
+
+CERT_NAME=wildcard
+if [[ ! -f "$CERTS_DIR/$CERT_NAME.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
+  echo "Generating server certificate"
+  openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
+  openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj "/CN=*.example.com"
+  openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions wildcard_extensions
+else
+  echo "Wildcard server certificate exists. Skipping."
+fi
+
+CERT_NAME=shortname
+if [[ ! -f "$CERTS_DIR/$CERT_NAME.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
+  echo "Generating shortname server certificate"
+  openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
+  openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj "/CN=foreman"
+  openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions shortname_extensions
+else
+  echo "Shortname server certificate exists. Skipping."
+fi

--- a/tests/foreman/data/certs.sh
+++ b/tests/foreman/data/certs.sh
@@ -2,6 +2,19 @@
 
 CERTS_DIR=certs
 
+function generate_certs(){
+   CERT_NAME=$1
+   SUBJ=$2
+   if [[ ! -f "$CERTS_DIR/${CERT_NAME}.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
+        echo "Generating server certificate"
+        openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
+        openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj $SUBJ
+        openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions extensions
+    else
+        echo "Server certificate exists. Skipping."
+   fi
+}
+
 THIRDPARTY_CA_CERT_NAME=ca-thirdparty
 if [[ ! -f "$CERTS_DIR/$THIRDPARTY_CA_CERT_NAME.key" || ! -f "$CERTS_DIR/$THIRDPARTY_CA_CERT_NAME.crt" ]]; then
   echo "Generating CA"
@@ -28,42 +41,14 @@ else
   echo "CA certificate bundle exists. Skipping."
 fi
 
-CERT_NAME=foreman.example.com
-if [[ ! -f "$CERTS_DIR/$CERT_NAME.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
-  echo "Generating server certificate"
-  openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
-  openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj "/CN=foreman.example.com"
-  openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions extensions
-else
-  echo "Server certificate exists. Skipping."
-fi
+# generate certs with hostname 'foreman.example.com'
+generate_certs "foreman.example.com" "/CN=foreman.example.com"
 
-CERT_NAME=invalid
-if [[ ! -f "$CERTS_DIR/$CERT_NAME.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
-  echo "Generating invalid server certificate"
-  openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
-  openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj "/CN=foreman.example.com"
-  openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions client_extensions
-else
-  echo "Invalid server certificate exists. Skipping."
-fi
+# generate invalid certs with hostname as 'foreman.example.com'
+generate_certs "invalid" "/CN=foreman.example.com"
 
-CERT_NAME=wildcard
-if [[ ! -f "$CERTS_DIR/$CERT_NAME.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
-  echo "Generating server certificate"
-  openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
-  openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj "/CN=*.example.com"
-  openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions wildcard_extensions
-else
-  echo "Wildcard server certificate exists. Skipping."
-fi
+# generate certs with wildcard
+generate_certs "wildcard" "/CN=*.example.com"
 
-CERT_NAME=shortname
-if [[ ! -f "$CERTS_DIR/$CERT_NAME.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
-  echo "Generating shortname server certificate"
-  openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
-  openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj "/CN=foreman"
-  openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions shortname_extensions
-else
-  echo "Shortname server certificate exists. Skipping."
-fi
+# generate certs with short hostname
+generate_certs "shortname" "/CN=foreman"

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -123,7 +123,8 @@ class TestKatelloCertsCheck:
             settings.server.hostname,
         ]
         with get_connection(timeout=300) as connection:
-            result = connection.run("rm -rf {}".format(" ".join(files)))
+            files = " ".join(files)
+            result = connection.run(f"rm -rf {files}")
             assert result.return_code == 0
 
     @pytest.fixture(scope="module")
@@ -265,7 +266,7 @@ class TestKatelloCertsCheck:
                     assert error['message'] in " ".join([result.stdout, result.stderr])
                     break
             else:
-                assert 0, "Failed to receive the error for invalid katello-cert-check"
+                pytest.fail("Failed to receive the error for invalid katello-cert-check")
 
     @pytest.mark.destructive
     def test_positive_update_katello_certs(self, cert_setup, cert_data, certs_cleanup):


### PR DESCRIPTION
### Description
This PR will be responsible to add new checks for invalid/valid conditions in katello-cert-check command. Add cleanup for certs so any modification can be done on the certs to check more invalid test cases, that will be introduced in further PR's.

If we dont have the cleanup, usually tests can not be re-run and failing with existing files.     

### Test Result 
```
(env) /home/okhatavk/Satellite/robottelo (master) $ pytest --picked --mode=onlychanged

Changed test files... 1. ['tests/foreman/sys/test_katello_certs_check.py::TestKatelloCertsCheck']
Changed test folders... 0. []
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-1.13, cov-2.10.1, xdist-2.2.0, mock-3.5.1, forked-1.3.0, picked-0.4.6
collected 13 items                                                                                                                                                                           

tests/foreman/sys/test_katello_certs_check.py .......ssssss                                                                                                                            [100%]

====================================================================================== warnings summary ======================================================================================
env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1
env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, MutableMapping

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================================================================== 7 passed, 6 skipped, 2 warnings in 720.43s (0:12:00) ====================================================================
(
```