### PR TITLE
Add requirements-optional to pyup

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,3 +1,9 @@
 pin: False
+
 requirements:
   - requirements.txt
+  - requirements-optional.txt
+
+label_prs: dependencies
+
+close_prs: True

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Version updates managed by pyup.io
 
 attrdict==2.0.1
-broker>=0.1.3
+broker==0.1.8
 cryptography==3.3.1
 deepdiff==5.2.2
 dynaconf==3.1.2


### PR DESCRIPTION
Pin broker to 0.1.8, pyup should provide regular updates on release

I added a configuration field to pyupbot to apply a label for us, but it requires private key permissions even on public repos.  I'm not sure who currently owns the API key used by pyup-bot, but we may need to update that for the configuration to take effect.

Also thought it was worthwhile to have our 'optional' requirements installed as well.