### PR TITLE
Add the ability for Robottelo to dynamically request test targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ logs/**
 /.tox
 /.coverage
 /htmlcov/
+/robottelo_collection.log
 
 # Varies per-deployment.
 /robottelo.properties
@@ -59,7 +60,6 @@ tests/foreman/pytest.ini
 
 # For pytest --bz-cache generated file
 **/bz_cache.json
-
 
 # For `coverage xml` generated file.
 **/coverage.xml

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -1,6 +1,31 @@
 SERVER:
-  # Server hostname
-  # HOSTNAME: replace-with-satellite-hostname
+  # Server hostnames, a list of one or more dns-resolvable hostnames
+  HOSTNAMES:
+    - null
+  #  - replace.with.satellite.hostname
+  #  - replace.with.satellite.hostname
+  VERSION:
+    # The full release version (6.9.2)
+    # RELEASE: populate with satellite version
+    # The snap version currently testing (if applicable)
+    # SNAP:
+    # The source of Satellite packages. Can be one of:
+    # internal, ga, beta
+    SOURCE: "internal"
+  # run-on-one - All xdist runners default to the first satellite
+  # balance - xdist runners will be split between available satellites
+  # on-demand - any xdist runner without a satellite will have a new one provisioned.
+  # if a new satellite is required, test execution will wait until one is received.
+  XDIST_BEHAVIOR: "run-on-one"
+  # Before attempting a new broker checkout, check the local inventory
+  FROM_INVENTORY: False
+  # A broker filter specifying which hosts can be used
+  INVENTORY_FILTER: "name<sat"
+  # If one or more Satellites are provisioned,
+  # this setting determines if they will be automatically checked in
+  AUTO_CHECKIN: False
+  # The Ansible Tower workflow used to deploy a satellite
+  DEPLOY_WORKFLOW: "deploy-sat-jenkins"
   # HTTP scheme when building the server URL
   # Suggested values for "scheme" are "http" and "https".
   SCHEME: https

--- a/pytest_fixtures/xdist.py
+++ b/pytest_fixtures/xdist.py
@@ -1,13 +1,52 @@
 """Fixtures specific to or relating to pytest's xdist plugin"""
-import pytest
+import logging
+import random
 
+import pytest
+from broker.broker import VMBroker
+
+import robottelo
 from robottelo.config import settings
+
+logger = logging.getLogger('robottelo')
 
 
 @pytest.fixture(scope="session", autouse=True)
-def align_xdist_satellites(worker_id):
-    """Set a different Satellite per worker when available in robottelo's config"""
-    settings.configure()
-    settings.server.hostname = settings.server.get_hostname(worker_id)
-    settings.configure_nailgun()
+def align_to_satellite(worker_id, satellite_factory):
+    """Attempt to align a Satellite to the current xdist worker"""
+    cache_proxy = robottelo.config.settings_proxy._cache
+    # clear any hostname that may have been previously set
+    cache_proxy['server.hostname'] = on_demand_sat = None
+
+    if worker_id in ['master', 'local']:
+        worker_pos = 0
+    else:
+        worker_pos = int(worker_id.replace('gw', ''))
+
+    # attempt to add potential satellites from the broker inventory file
+    if settings.server.inventory_filter:
+        settings.server.hostnames  # need to prime the cache
+        hosts = VMBroker().from_inventory(filter=settings.server.inventory_filter)
+        cache_proxy['server.hostnames'].extend([host.hostname for host in hosts])
+
+    # attempt to align a worker to a satellite
+    if settings.server.xdist_behavior == 'run-on-one' and settings.server.hostnames:
+        cache_proxy['server.hostname'] = settings.server.hostnames[0]
+    elif settings.server.hostnames and worker_pos < len(settings.server.hostnames):
+        cache_proxy['server.hostname'] = settings.server.hostnames[worker_pos]
+    elif settings.server.xdist_behavior == 'balance' and settings.server.hostnames:
+        cache_proxy['server.hostname'] = random.choice(settings.server.hostnames)
+    # get current satellite information
+    elif settings.server.xdist_behavior == "on-demand":
+        on_demand_sat = satellite_factory()
+        if on_demand_sat.hostname:
+            cache_proxy['server.hostname'] = on_demand_sat.hostname
+        # if no satellite was received, fallback to balance
+        if not settings.server.hostname:
+            cache_proxy['server.hostname'] = random.choice(settings.server.hostnames)
+    logger.info(f"xdist worker {worker_id} " f"was assigned hostname {settings.server.hostname}")
     settings.configure_airgun()
+    settings.configure_nailgun()
+    yield
+    if on_demand_sat and settings.server.auto_checkin:
+        VMBroker().checkin(host=on_demand_sat)

--- a/robottelo/config/facade.py
+++ b/robottelo/config/facade.py
@@ -19,6 +19,7 @@ logger = logging.getLogger('robottelo.config.facade')
 
 WRAPPER_EXCEPTIONS = (
     'server.hostname',
+    # 'server.hostnames',
     'server.ssh_key',
     'server.ssh_key_string',
     'server.ssh_password',
@@ -376,11 +377,11 @@ class SettingsFacade:
         elif key == "server.get_credentials":
             value = self._cached_function(self.__server_get_credentials)
         elif key == "server.get_url":
-            value = self._cached_function(self.__server_get_url)
+            value = self.__server_get_url
         elif key == "server.get_pub_url":
-            value = self._cached_function(self.__server_get_pub_url)
+            value = self.__server_get_pub_url
         elif key == "server.get_cert_rpm_url":
-            value = self._cached_function(self.__server_get_cert_rpm_url)
+            value = self.__server_get_cert_rpm_url
         elif key == 'server.get_hostname':
             value = self.__server_get_hostname
         elif key == "server.version":

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -6,7 +6,14 @@ from robottelo.constants import VALID_GCE_ZONES
 
 validators = dict(
     server=[
-        Validator("server.hostname", must_exist=True),
+        Validator("server.hostname", must_exist=False),
+        Validator("server.hostnames", must_exist=True, is_type_of=list),
+        Validator("server.version.release", must_exist=True),
+        Validator("server.version.source", must_exist=True),
+        Validator(
+            "server.xdist_behavior", must_exist=True, is_in=['run-on-one', 'balance', 'on-demand']
+        ),
+        Validator("server.auto_checkin", default=False, is_type_of=bool),
         (
             Validator("server.ssh_key", must_exist=True)
             | Validator("server.ssh_password", must_exist=True)
@@ -14,6 +21,7 @@ validators = dict(
         ),
         Validator("server.admin_password", default="changeme"),
         Validator("server.admin_username", default="admin"),
+        Validator("server.deploy_workflow", must_exist=True),
         Validator("server.scheme", default="https"),
         Validator("server.ssh_username", default="root"),
     ],

--- a/robottelo/utils/issue_handlers/bugzilla.py
+++ b/robottelo/utils/issue_handlers/bugzilla.py
@@ -47,7 +47,10 @@ def is_open_bz(issue, data=None):
     # BZ is CLOSED with a resolution in (ERRATA, CURRENT_RELEASE, ...)
     # server.version is higher or equal than BZ version
     # Consider fixed,  BZ is not open
-    if settings.server.version >= extract_min_version(bz):
+    if hasattr(settings.server.version, 'release'):
+        if settings.server.version.release >= extract_min_version(bz).release:
+            return False
+    elif settings.server.version >= extract_min_version(bz):
         return False
 
     # Not in OPEN_STATUSES

--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -259,7 +259,10 @@ def __initiate(config):
         for upgrade_mark in (PRE_UPGRADE_MARK, POST_UPGRADE_MARK)
         if upgrade_mark in config.option.markexpr
     ]:
-        raise OptionMarksError('options error: pre_upgrade or post_upgrade marks must be selected')
+        pytest.skip(
+            'options error: pre_upgrade or post_upgrade marks must be selected',
+            allow_module_level=True,
+        )
     if PRE_UPGRADE_MARK in config.option.markexpr:
         pre_upgrade_failed_tests = []
         PRE_UPGRADE = True


### PR DESCRIPTION
This change introduces the ability for robottelo to fill Satellite test
target requirements based on criteria defined in the new server settings
file.
One notable configuration change is that hostname is now hostnames,
which requires a list of one or more hostnames.
If one or more Satellites are required to meet xdist worker demands,
then the additional settings will control on-demand behavior.