### PR TITLE
Restrict GHA workflow to only run on merge to master

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -1,7 +1,10 @@
 # CI stages to execute against master branch on PR merge
 name: update_robottelo_image
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 env:
     PYCURL_SSL_LIBRARY: openssl


### PR DESCRIPTION
This is the workflow that updates robottelo quay image, we're doubling our GHA actions on PRs right now by running this on generic 'push'.