### PR TITLE
Fix docker repository tests, use quay.io instead of Docker Hub.

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -676,8 +676,8 @@ REP_TEM_APPLIED_ERRATA_INPUT = {
     },
     'Include Last Reboot': {'yes': 'yes', 'no': 'no'},
 }
-DOCKER_REGISTRY_HUB = 'https://registry-1.docker.io'
-DOCKER_UPSTREAM_NAME = 'busybox'
+DOCKER_REGISTRY_HUB = 'https://quay.io'
+DOCKER_UPSTREAM_NAME = 'quay/busybox'
 DOCKER_RH_REGISTRY_UPSTREAM_NAME = 'openshift3/ose-metrics-hawkular-openshift-agent'
 CUSTOM_LOCAL_FOLDER = '/var/www/html/myrepo/'
 CUSTOM_LOCAL_FILE = '/var/www/html/myrepo/test.txt'

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1752,8 +1752,8 @@ class TestDockerRepository:
         :CaseLevel: Integration
         """
         msg = (
-            f'DKR1007: Could not fetch repository {repo_options["docker_upstream_name"]} from'
-            f' registry {repo_options["url"]} - Unauthorized or Not Found'
+            f'DKR1007.*Could not fetch repository {repo_options["docker_upstream_name"]} from'
+            f' registry {repo_options["url"]}.*Unauthorized or Not Found'
         )
         with pytest.raises(TaskFailedError, match=msg):
             repo.sync()
@@ -1895,20 +1895,20 @@ class TestDockerRepository:
 
         :expectedresults: Non-whitelisted tags are not removed
         """
-        # TODO: add timeout support to sync(). This repo needs more than the default 300 seconds.
-        repo.sync()
+        repo.sync(timeout=600)
         repo = repo.read()
+        tag_count = repo.content_counts['docker_tag']
         assert len(repo.docker_tags_whitelist) == 0
-        assert repo.content_counts['docker_tag'] >= 2
+        assert tag_count > 0
 
-        tags = ['latest']
+        tags = ['no_such_tag']
         repo.docker_tags_whitelist = tags
         repo.update(['docker_tags_whitelist'])
         repo.sync()
-        repo = repo.read()
 
+        repo = repo.read()
         assert repo.docker_tags_whitelist == tags
-        assert repo.content_counts['docker_tag'] >= 2
+        assert repo.content_counts['docker_tag'] == tag_count
 
     @pytest.mark.tier2
     @pytest.mark.parametrize(

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -28,6 +28,7 @@ from robottelo.config import settings
 from robottelo.constants import CHECKSUM_TYPE
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import DOCKER_REGISTRY_HUB
+from robottelo.constants import DOCKER_UPSTREAM_NAME
 from robottelo.constants import DOWNLOAD_POLICIES
 from robottelo.constants import INVALID_URL
 from robottelo.constants import REPO_TYPE
@@ -394,7 +395,10 @@ def test_positive_sync_custom_repo_docker(session, module_org):
     """
     product = entities.Product(organization=module_org).create()
     repo = entities.Repository(
-        url=DOCKER_REGISTRY_HUB, product=product, content_type=REPO_TYPE['docker']
+        url=DOCKER_REGISTRY_HUB,
+        product=product,
+        content_type=REPO_TYPE['docker'],
+        docker_upstream_name=DOCKER_UPSTREAM_NAME,
     ).create()
     with session:
         result = session.repository.synchronize(product.name, repo.name)


### PR DESCRIPTION
This PR fixes docker repository tests that are failing with errors like this:

```
PLP0000: 'HTTPSConnectionPool(host='registry-1.docker.io', port=443):
 Max retries exceeded with url: /v2/library/busybox/manifests/latest
 (Caused by ResponseError('too many 429 error responses',))'
 for url https://registry-1.docker.io/v2/library/busybox/manifests/latest
```

These errors are due to rate limits imposed by Docker Hub:

https://docs.docker.com/docker-hub/download-rate-limit/

This PR changes the default for upstream docker repos from `registry-1.docker.io` to Red Hat's own `quay.io`, which doesn't impose any limits on download rate.

I've also moved docker-related tests in `tests/foreman/cli/test_repository.py` from the `TestRepository` class into the new class `TestDockerRepository`, to match `tests/foreman/api/test_repository.py` more closely. In the future we'll probably end up splitting the classes out into separate modules.

Test results:

```
# pytest -k TestDockerRepository tests/foreman/api/test_repository.py
[...]
collected 229 items / 212 deselected / 17 selected

tests/foreman/api/test_repository.py .................                   [100%]
[...]
========= 17 passed, 212 deselected, 65 warnings in 143.68s (0:02:23) ==========

# pytest -k TestDockerRepository tests/foreman/cli/test_repository.py
[...]
collected 276 items / 262 deselected / 14 selected

tests/foreman/cli/test_repository.py ..............                      [100%]
[...]
========== 14 passed, 262 deselected, 5 warnings in 274.77s (0:04:34) ==========

# pytest -k docker tests/foreman/ui/test_repository.py
[...]
collected 21 items / 19 deselected / 2 selected

tests/foreman/ui/test_repository.py ..                                   [100%]
[...]
========== 2 passed, 19 deselected, 18 warnings in 588.21s (0:09:48) ===========
```