### PR TITLE
updated the fix for missed test

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -522,6 +522,8 @@ def test_positive_update_external_roles(
             with pytest.raises(NavigationTriesExceeded):
                 ldapsession.architecture.search('')
             ldapsession.location.create({'name': location_name})
+            if is_open('BZ:1851905'):
+                ldapsession.browser.execute_script("window.history.go(-1)")
             assert ldapsession.location.search(location_name)[0]['Name'] == location_name
             current_user = ldapsession.location.read(location_name, 'current_user')['current_user']
             assert ad_data['ldap_user_name'] in current_user


### PR DESCRIPTION
```
(env) /home/okhatavk/Satellite/robottelo (master) $ pytest --picked --mode=onlychanged

Changed test files... 1. ['tests/foreman/ui/test_ldap_authentication.py::test_positive_update_external_roles']
Changed test folders... 0. []
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-1.13, cov-2.10.1, xdist-2.2.0, mock-3.5.1, forked-1.3.0, picked-0.4.6
collected 1 item                                                                                                                                                                             

tests/foreman/ui/test_ldap_authentication.py .                                                                                                                                         [100%]

====================================================================================== warnings summary ======================================================================================
env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1
env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, MutableMapping

tests/foreman/ui/test_ldap_authentication.py: 19 warnings
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-2-138.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================================================== 1 passed, 21 warnings in 1334.30s (0:22:14) =========================================================================

```

Note:
Along with this PR, we are also in process of testing PRT tool  