### PR TITLE
Use random name in repo create step

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -769,7 +769,10 @@ class TestRepository:
         'repo_options',
         **parametrized(
             [
-                {'url': repo.format(cred['login'], cred['pass'])}
+                {
+                    'url': repo.format(cred['login'], cred['pass']),
+                    'name': gen_string('alpha'),
+                }
                 for cred in valid_http_credentials()
                 if cred['quote']
                 for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
@@ -796,7 +799,10 @@ class TestRepository:
         'repo_options',
         **parametrized(
             [
-                {'url': repo.format(cred['login'], cred['pass'])}
+                {
+                    'url': repo.format(cred['login'], cred['pass']),
+                    'name': gen_string('alpha'),
+                }
                 for cred in invalid_http_credentials()
                 for repo in (FAKE_5_YUM_REPO, FAKE_7_PUPPET_REPO)
             ]


### PR DESCRIPTION
Hello

tests `test_negative_update_auth_url_with_special_characters` and `test_negative_create_with_auth_url_too_long` were failing [1]

This error was seen:
```

E           Could not create the repository:
E             Validation failed: Name has already been taken for this product.

robottelo/cli/factory.py:137: CLIFactoryError
```



[1] https://github.com/SatelliteQE/robottelo/pull/8318#issuecomment-770667185