### PR TITLE
Add temporary reportportal-client requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@ pytest==6.2.2
 pytest-services==2.2.1
 pytest-mock==3.5.1
 pytest-reportportal==5.0.7
+# TODO remove rp-client requirement
+# https://github.com/reportportal/agent-python-pytest/pull/247
+reportportal-client==5.0.8
 pytest-xdist==2.2.0
 pytest-ibutsu==1.13
 PyYAML==5.4.1


### PR DESCRIPTION
enum34 broke package installs in py38 when pytest-reportportal was added
reportportal-client 5.0.8 fixes enum issue

our direct dependency is pytest-reportportal, reportportal-client should
be installed through it.

This works around pytest-reportportal not yet updating its dependencies
or merging the following PR:
https://github.com/reportportal/agent-python-pytest/pull/247/files