### PR TITLE
Month format change

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -113,7 +113,7 @@ def test_positive_end_to_end(session, module_org):
         assert syncplan_values['details']['enabled'] == 'Yes'
         assert syncplan_values['details']['interval'] == SYNC_INTERVAL['day']
         time = syncplan_values['details']['date_time'].rpartition(':')[0]
-        assert time == startdate.strftime("%b %-d, %Y %-I:%M")
+        assert time == startdate.strftime("%B %-d, %Y, %-I")
         # Update sync plan with new description
         session.syncplan.update(plan_name, {'details.description': new_description})
         syncplan_values = session.syncplan.read(plan_name)
@@ -165,7 +165,7 @@ def test_positive_end_to_end_custom_cron(session):
         assert syncplan_values['details']['cron_expression'] == cron_expression
         assert syncplan_values['details']['recurring_logic'].isdigit()
         time = syncplan_values['details']['date_time'].rpartition(':')[0]
-        assert time == startdate.strftime("%b %-d, %Y %-I:%M")
+        assert time == startdate.strftime("%B %-d, %Y, %-I")
         # Update sync plan with new description
         session.syncplan.update(plan_name, {'details.interval': SYNC_INTERVAL['day']})
         syncplan_values = session.syncplan.read(plan_name)


### PR DESCRIPTION
Hello

The month part of the date and time format has changed:

```
>   ???
E   AssertionError: assert 'February 2, 2021, 12' == 'Feb 2, 2021 12:21'
E     - Feb 2, 2021 12:21
E     ?               ---
E     + February 2, 2021, 12
E     ?    +++++        +

tests/foreman/ui/test_syncplan.py:169: AssertionError
```

This PR fixes that in tow tests.



