### PR TITLE
Rename module_ak to module_ak_cv_lce

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -425,16 +425,16 @@ def default_contentview(module_org):
 
 
 @pytest.fixture(scope='module')
-def module_ak(module_org, module_lce, module_published_cv):
-    """Module Activation key"""
+def module_ak_cv_lce(module_org, module_lce, module_published_cv):
+    """Module Activation key with CV promoted to LCE"""
     promote(module_published_cv.version[0], module_lce.id)
     module_published_cv = module_published_cv.read()
-    module_ak = entities.ActivationKey(
+    module_ak_cv_lce = entities.ActivationKey(
         content_view=module_published_cv,
         environment=module_lce,
         organization=module_org,
     ).create()
-    return module_ak
+    return module_ak_cv_lce
 
 
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -24,7 +24,7 @@ from robottelo.test import settings
 
 @pytest.mark.tier1
 def test_positive_register(
-    module_org, module_location, module_lce, module_ak, module_published_cv
+    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv
 ):
     """System is registered
 
@@ -55,7 +55,7 @@ def test_positive_register(
         )
         assert vm.execute(
             f'python /root/bootstrap.py -s {settings.server.hostname} -o {module_org.name}'
-            f' -L {module_location.name} -a {module_ak.name} --hostgroup={hg.name}'
+            f' -L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             ' --skip puppet --skip foreman'
         )
         # assure system is registered
@@ -65,7 +65,7 @@ def test_positive_register(
         # register system once again
         assert vm.execute(
             f'python /root/bootstrap.py -s "{settings.server.hostname}" -o {module_org.name} '
-            f'-L {module_location.name} -a {module_ak.name} --hostgroup={hg.name}'
+            f'-L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             '--skip puppet --skip foreman '
         )
         # assure system is registered


### PR DESCRIPTION
As pointed out by @tstrych, we are likely to need more than two versions of default and module activation keys, so better names are required.





