### PR TITLE
Disable Report Portal parameter logging

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -7,6 +7,7 @@ pytest_plugins = [
     "pytest_plugins.issue_handlers",
     "pytest_plugins.testimony_markers",
     "pytest_plugins.manual_skipped",
+    "pytest_plugins.disable_rp_params",
     # Fixtures
     "pytest_fixtures.api_fixtures",
     "pytest_fixtures.xdist",

--- a/pytest_plugins/disable_rp_params.py
+++ b/pytest_plugins/disable_rp_params.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_configure(config):
+    """Override Report Portal (RP) service objects attribute
+    to prevent it from posting the parameter values of the tests.
+    This is to make RP to correctly match and handle the test re-runs.
+
+    We can remove this once we implement a compatible parametrization
+    """
+    if hasattr(config, 'py_test_service'):
+        config.py_test_service.rp_supports_parameters = False


### PR DESCRIPTION
Due the way the parametrization of some robottelo tests is implemented, we have to apply a workaround to change the report portal logger plugin behavior, so it doesn't log the used parameter in the metadata.

This used to result in various parameters to be logged across reruns and was causing RP not to match some tests and not marking them as re-runs.

![rp_scrshot](https://i.imgur.com/hyUCsjy.png)