### PR TITLE
Add manual insights test, small fixes

### DIFF
--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -1,4 +1,4 @@
-"""Tests for Red Hat Access Insights Client rpm
+"""Tests for Insights client rpm
 
 :Requirement: Rhai Client
 
@@ -15,24 +15,25 @@
 :Upstream: No
 """
 import pytest
-from broker.broker import VMBroker
 
 from robottelo.constants import DISTRO_RHEL7
-from robottelo.hosts import ContentHost
 
 
 @pytest.mark.skip_if_open('BZ:1892405')
-def test_positive_connection_option(module_org, activation_key):
-    """Verify that '--test-connection' option for insights-client
-    client rpm tests the connection with the satellite server connection
-    with satellite server
+@pytest.mark.run_in_one_thread
+def test_positive_connection_option(rhel7_contenthost, module_org, activation_key):
+    """Verify that 'insights-client --test-connection' successfully tests the proxy connection via
+    the Satellite.
 
     :id: 167758c9-cbfa-4a81-9a11-27f88aaf9118
 
-    :expectedresults: 'insights-client --test-connection' should
-        return zero on a successfully registered machine to RHAI service
+    :expectedresults: 'insights-client --test-connection' should return 0.
     """
-    with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
-        vm.configure_rhai_client(activation_key.name, module_org.label, DISTRO_RHEL7)
-        test_connection = vm.run('insights-client --test-connection')
-        assert test_connection.status == 0
+    rhel7_contenthost.configure_rhai_client(activation_key.name, module_org.label, DISTRO_RHEL7)
+    result = rhel7_contenthost.execute('insights-client --test-connection')
+    assert result.status == 0, (
+        'insights-client --test-connection failed.\n'
+        f'status: {result.status}\n'
+        f'stdout: {result.stdout}\n'
+        f'stderr: {result.stderr}'
+    )


### PR DESCRIPTION
This PR adds a manual test,  `test_positive_register_client_with_template`, to cover the new feature in Satellite 6.9.0 that allows insights client registration through a provisioning template.

I've also made a few small changes:
- Convert double-quote to single-quote strings, per style guide.
- Updated some comments, strings, and tests to refer to `Red Hat Insights` or `insights-client`, instead of the outdated `Red Hat Access Insights`, `RHAI`, or `redhat-access-insights`.
- Fix for ssh command output status checking: `not result.status` should be `results.status != 0` when checking for an error. 