### PR TITLE
Convert {api, cli}/test_docker.py to pytest

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -13,6 +13,8 @@ REPOS:
   # RHEL8_OS:
       # BASEOS: replace-with-rhel8-os-baseos-http-link
       # APPSTREAM: replace-with-rhel8-os-appstream-http-link
+  # RHEL7_OPTIONAL: replace-with-rhel7-optional-url
+  # RHEL7_EXTRAS: replace-with-rhel7-extras-url
   # If capsule and satellite tools repositories available related packages will
   # be pulled from there instead of using the CDN channel. These information is
   # more suited to be used for downstream, downstream-iso and zstream builds.

--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -126,6 +126,10 @@ ssh_key=
 # RHEL 8 repos
 # rhel8_os=baseos=http://example.com/rhel-8/BaseOS/x86_64/os/,appstream=http://example.com/rhel-8/AppStream/x86_64/os/
 
+# Link to rhel7 optional repository
+# rhel7_optional=http://example.com/yum/rhel7-optional/
+# Link to rhel7 extras repository
+# rhel7_extras=http://example.com/yum/rhel7-extras/
 
 # If capsule and satellite tools repositories available related packages will
 # be pulled from there instead of using the CDN channel. These information is

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1349,6 +1349,8 @@ class Settings:
         self.rhel6_os = None
         self.rhel7_os = None
         self.rhel8_os = None
+        self.rhel7_optional = None
+        self.rhel7_extras = None
         self.capsule_repo = None
         self.rhscl_repo = None
         self.ansible_repo = None
@@ -1467,6 +1469,8 @@ class Settings:
         self.rhel6_os = self.reader.get('robottelo', 'rhel6_os', None)
         self.rhel7_os = self.reader.get('robottelo', 'rhel7_os', None)
         self.rhel8_os = self.reader.get('robottelo', 'rhel8_os', None, dict)
+        self.rhel7_optional = self.reader.get('robottelo', 'rhel7_optional', None)
+        self.rhel7_extras = self.reader.get('robottelo', 'rhel7_extras', None)
         self.capsule_repo = self.reader.get('robottelo', 'capsule_repo', None)
         self.rhscl_repo = self.reader.get('robottelo', 'rhscl_repo', None)
         self.ansible_repo = self.reader.get('robottelo', 'ansible_repo', None)

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1,4 +1,4 @@
-"""Unit tests for the Docker feature.
+"""Tests for the Docker feature.
 
 :Requirement: Docker
 
@@ -12,6 +12,7 @@
 
 :Upstream: No
 """
+import logging
 from random import choice
 from random import randint
 
@@ -28,7 +29,6 @@ from robottelo.cli.docker import Docker
 from robottelo.cli.factory import make_activation_key
 from robottelo.cli.factory import make_content_view
 from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product_wait
 from robottelo.cli.factory import make_repository
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
@@ -37,43 +37,93 @@ from robottelo.cli.repository import Repository
 from robottelo.config import settings
 from robottelo.constants import DOCKER_REGISTRY_HUB
 from robottelo.constants import DOCKER_RH_REGISTRY_UPSTREAM_NAME
-from robottelo.datafactory import generate_strings_list
+from robottelo.constants import DOCKER_UPSTREAM_NAME
+from robottelo.constants import REPO_TYPE
 from robottelo.datafactory import invalid_docker_upstream_names
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_docker_repository_names
 from robottelo.datafactory import valid_docker_upstream_names
 from robottelo.decorators import skip_if_not_set
-from robottelo.test import CLITestCase
-from robottelo.vm import VirtualMachine
 
-DOCKER_PROVIDER = 'Docker'
-REPO_CONTENT_TYPE = 'docker'
-REPO_UPSTREAM_NAME = 'busybox'
+logger = logging.getLogger('robottelo')
 
 
-def _make_docker_repo(product_id, name=None, upstream_name=None, url=None):
+def _repo(product_id, name=None, upstream_name=None, url=None):
     """Creates a Docker-based repository.
 
     :param product_id: ID of the ``Product``.
     :param str name: Name for the repository. If ``None`` then a random
         value will be generated.
     :param str upstream_name: A valid name of an existing upstream repository.
-        If ``None`` then defaults to ``busybox``.
+        If ``None`` then defaults to DOCKER_UPSTREAM_NAME constant.
     :param str url: URL of repository. If ``None`` then defaults to
         DOCKER_REGISTRY_HUB constant.
     :return: A ``Repository`` object.
     """
     return make_repository(
         {
-            'content-type': REPO_CONTENT_TYPE,
-            'docker-upstream-name': upstream_name or REPO_UPSTREAM_NAME,
-            'name': name or choice(generate_strings_list(15, ['numeric', 'html'])),
+            'content-type': REPO_TYPE['docker'],
+            'docker-upstream-name': upstream_name or DOCKER_UPSTREAM_NAME,
+            'name': name or gen_string('alpha', 5),
             'product-id': product_id,
             'url': url or DOCKER_REGISTRY_HUB,
         }
     )
 
 
-class DockerManifestTestCase(CLITestCase):
+def _content_view(repo_id, org_id):
+    """Create a content view and link it to the given repository."""
+    content_view = make_content_view({'composite': False, 'organization-id': org_id})
+    ContentView.add_repository({'id': content_view['id'], 'repository-id': repo_id})
+    return ContentView.info({'id': content_view['id']})
+
+
+@pytest.fixture
+def docker_host(rhel7_contenthost):
+    """Instantiate and set up a docker host VM. Destroy VM when done."""
+    logger.info('Installing katello-ca on the external docker host')
+    rhel7_contenthost.install_katello_ca()
+
+    repos = {
+        'server': settings.rhel7_os,
+        'optional': settings.rhel7_optional,
+        'extras': settings.rhel7_extras,
+    }
+    rhel7_contenthost.create_custom_repos(**repos)
+    rhel7_contenthost.execute('yum -y install docker')
+    rhel7_contenthost.execute('systemctl start docker')
+    return rhel7_contenthost
+
+
+@pytest.fixture
+def repo(module_product):
+    return _repo(module_product.id)
+
+
+@pytest.fixture
+def content_view(module_org, repo):
+    return _content_view(repo['id'], module_org.id)
+
+
+@pytest.fixture
+def content_view_publish(content_view):
+    ContentView.publish({'id': content_view['id']})
+    content_view = ContentView.info({'id': content_view['id']})
+    return ContentView.version_info({'id': content_view['versions'][0]['id']})
+
+
+@pytest.fixture
+def content_view_promote(content_view_publish, module_lce):
+    ContentView.version_promote(
+        {
+            'id': content_view_publish['id'],
+            'to-lifecycle-environment-id': module_lce.id,
+        }
+    )
+    return ContentView.version_info({'id': content_view_publish['id']})
+
+
+class TestDockerManifest:
     """Tests related to docker manifest command
 
     :CaseComponent: Repositories
@@ -82,7 +132,7 @@ class DockerManifestTestCase(CLITestCase):
     """
 
     @pytest.mark.tier2
-    def test_positive_read_docker_tags(self):
+    def test_positive_read_docker_tags(self, repo):
         """docker manifest displays tags information for a docker manifest
 
         :id: 59b605b5-ac2d-46e3-a85e-a259e78a07a8
@@ -94,70 +144,52 @@ class DockerManifestTestCase(CLITestCase):
 
         :BZ: 1658274
         """
-        organization = make_org()
-        product = make_product_wait({'organization-id': organization['id']})
-        repository = make_repository(
-            {
-                'content-type': REPO_CONTENT_TYPE,
-                'docker-upstream-name': REPO_UPSTREAM_NAME,
-                'product-id': product['id'],
-                'url': DOCKER_REGISTRY_HUB,
-            }
-        )
-        Repository.synchronize({'id': repository['id']})
+        Repository.synchronize({'id': repo['id']})
         # Grab all available manifests related to repository
-        manifests_list = Docker.manifest.list({'repository-id': repository['id']})
+        manifests_list = Docker.manifest.list({'repository-id': repo['id']})
         # Some manifests do not have tags associated with it, ignore those
         # because we want to check the tag information
         manifests = [m_iter for m_iter in manifests_list if not m_iter['tags'] == '']
-        self.assertTrue(manifests)
-        tags_list = Docker.tag.list({'repository-id': repository['id']})
+        assert manifests
+        tags_list = Docker.tag.list({'repository-id': repo['id']})
         # Extract tag names for the repository out of docker tag list
         repo_tag_names = [tag['tag'] for tag in tags_list]
         for manifest in manifests:
             manifest_info = Docker.manifest.info({'id': manifest['id']})
             # Check that manifest's tag is listed in tags for the repository
             for t_iter in manifest_info['tags']:
-                self.assertIn(t_iter['name'], repo_tag_names)
+                assert t_iter['name'] in repo_tag_names
 
 
-class DockerRepositoryTestCase(CLITestCase):
-    """Tests specific to performing CRUD methods against ``Docker``
-    repositories.
+class TestDockerRepository:
+    """Tests specific to performing CRUD methods against ``Docker`` repositories.
 
     :CaseComponent: Repositories
 
     :Assignee: tpapaioa
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Create an organization and product which can be re-used in tests."""
-        super().setUpClass()
-        cls.org_id = make_org()['id']
-
     @pytest.mark.tier1
-    def test_positive_create_with_name(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_docker_repository_names()))
+    def test_positive_create_with_name(self, module_org, module_product, name):
         """Create one Docker-type repository
 
         :id: e82a36c8-3265-4c10-bafe-c7e07db3be78
+
+        :parametrized: yes
 
         :expectedresults: A repository is created with a Docker upstream
          repository.
 
         :CaseImportance: Critical
         """
-        for name in valid_docker_repository_names():
-            with self.subTest(name):
-                repo = _make_docker_repo(
-                    make_product_wait({'organization-id': self.org_id})['id'], name
-                )
-                self.assertEqual(repo['name'], name)
-                self.assertEqual(repo['upstream-repository-name'], REPO_UPSTREAM_NAME)
-                self.assertEqual(repo['content-type'], REPO_CONTENT_TYPE)
+        repo = _repo(module_product.id, name)
+        assert repo['name'] == name
+        assert repo['upstream-repository-name'] == DOCKER_UPSTREAM_NAME
+        assert repo['content-type'] == REPO_TYPE['docker']
 
     @pytest.mark.tier2
-    def test_positive_create_repos_using_same_product(self):
+    def test_positive_create_repos_using_same_product(self, module_org, module_product):
         """Create multiple Docker-type repositories
 
         :id: 6dd25cf4-f8b6-4958-976a-c116daf27b44
@@ -167,16 +199,15 @@ class DockerRepositoryTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        product = make_product_wait({'organization-id': self.org_id})
         repo_names = set()
         for _ in range(randint(2, 5)):
-            repo = _make_docker_repo(product['id'])
+            repo = _repo(module_product.id)
             repo_names.add(repo['name'])
-        product = Product.info({'id': product['id'], 'organization-id': self.org_id})
-        self.assertEqual(repo_names, {repo_['repo-name'] for repo_ in product['content']})
+        product = Product.info({'id': module_product.id, 'organization-id': module_org.id})
+        assert repo_names.issubset({repo_['repo-name'] for repo_ in product['content']})
 
     @pytest.mark.tier2
-    def test_positive_create_repos_using_multiple_products(self):
+    def test_positive_create_repos_using_multiple_products(self, module_org):
         """Create multiple Docker-type repositories on multiple
         products.
 
@@ -189,16 +220,16 @@ class DockerRepositoryTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         for _ in range(randint(2, 5)):
-            product = make_product_wait({'organization-id': self.org_id})
+            product = make_product_wait({'organization-id': module_org.id})
             repo_names = set()
             for _ in range(randint(2, 3)):
-                repo = _make_docker_repo(product['id'])
+                repo = _repo(product['id'])
                 repo_names.add(repo['name'])
-            product = Product.info({'id': product['id'], 'organization-id': self.org_id})
-            self.assertEqual(repo_names, {repo_['repo-name'] for repo_ in product['content']})
+            product = Product.info({'id': product['id'], 'organization-id': module_org.id})
+            assert repo_names == {repo_['repo-name'] for repo_ in product['content']}
 
     @pytest.mark.tier1
-    def test_positive_sync(self):
+    def test_positive_sync(self, repo):
         """Create and sync a Docker-type repository
 
         :id: bff1d40e-181b-48b2-8141-8c86e0db62a2
@@ -208,60 +239,61 @@ class DockerRepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
-        self.assertEqual(int(repo['content-counts']['container-image-manifests']), 0)
+        assert int(repo['content-counts']['container-image-manifests']) == 0
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertGreaterEqual(int(repo['content-counts']['container-image-manifests']), 1)
+        assert int(repo['content-counts']['container-image-manifests']) > 0
 
     @pytest.mark.tier1
-    def test_positive_update_name(self):
+    @pytest.mark.parametrize('new_name', **parametrized(valid_docker_repository_names()))
+    def test_positive_update_name(self, repo, new_name):
         """Create a Docker-type repository and update its name.
 
         :id: 8b3a8496-e9bd-44f1-916f-6763a76b9b1b
+
+        :parametrized: yes
 
         :expectedresults: A repository is created with a Docker upstream
             repository and that its name can be updated.
 
         :CaseImportance: Critical
         """
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
-        for new_name in valid_docker_repository_names():
-            with self.subTest(new_name):
-                Repository.update({'id': repo['id'], 'new-name': new_name, 'url': repo['url']})
-                repo = Repository.info({'id': repo['id']})
-                self.assertEqual(repo['name'], new_name)
+        Repository.update({'id': repo['id'], 'new-name': new_name, 'url': repo['url']})
+        repo = Repository.info({'id': repo['id']})
+        assert repo['name'] == new_name
 
     @pytest.mark.tier1
-    def test_positive_update_upstream_name(self):
+    @pytest.mark.parametrize('new_upstream_name', **parametrized(valid_docker_upstream_names()))
+    def test_positive_update_upstream_name(self, repo, new_upstream_name):
         """Create a Docker-type repository and update its upstream name.
 
         :id: 1a6985ed-43ec-4ea6-ba27-e3870457ac56
+
+        :parametrized: yes
 
         :expectedresults: A repository is created with a Docker upstream
             repository and that its upstream name can be updated.
 
         :CaseImportance: Critical
         """
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
-
-        for new_upstream_name in valid_docker_upstream_names():
-            with self.subTest(new_upstream_name):
-                Repository.update(
-                    {
-                        'docker-upstream-name': new_upstream_name,
-                        'id': repo['id'],
-                        'url': repo['url'],
-                    }
-                )
-                repo = Repository.info({'id': repo['id']})
-                self.assertEqual(repo['upstream-repository-name'], new_upstream_name)
+        Repository.update(
+            {
+                'docker-upstream-name': new_upstream_name,
+                'id': repo['id'],
+                'url': repo['url'],
+            }
+        )
+        repo = Repository.info({'id': repo['id']})
+        assert repo['upstream-repository-name'] == new_upstream_name
 
     @pytest.mark.tier1
-    def test_negative_update_upstream_name(self):
+    @pytest.mark.parametrize('new_upstream_name', **parametrized(invalid_docker_upstream_names()))
+    def test_negative_update_upstream_name(self, repo, new_upstream_name):
         """Attempt to update upstream name for a Docker-type repository.
 
         :id: 798651af-28b2-4907-b3a7-7c560bf66c7c
+
+        :parametrized: yes
 
         :expectedresults: A repository is created with a Docker upstream
             repository and that its upstream name can not be updated with
@@ -269,23 +301,18 @@ class DockerRepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
-
-        for new_upstream_name in invalid_docker_upstream_names():
-            with self.subTest(new_upstream_name):
-                with self.assertRaises(CLIReturnCodeError) as context:
-                    Repository.update(
-                        {
-                            'docker-upstream-name': new_upstream_name,
-                            'id': repo['id'],
-                            'url': repo['url'],
-                        }
-                    )
-                self.assertIn('Validation failed: Docker upstream name', str(context.exception))
+        with pytest.raises(CLIReturnCodeError, match='Validation failed: Docker upstream name'):
+            Repository.update(
+                {
+                    'docker-upstream-name': new_upstream_name,
+                    'id': repo['id'],
+                    'url': repo['url'],
+                }
+            )
 
     @skip_if_not_set('docker')
     @pytest.mark.tier1
-    def test_positive_create_with_long_upstream_name(self):
+    def test_positive_create_with_long_upstream_name(self, module_product):
         """Create a docker repository with upstream name longer than 30
         characters
 
@@ -299,16 +326,16 @@ class DockerRepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        repo = _make_docker_repo(
-            make_product_wait({'organization-id': self.org_id})['id'],
+        repo = _repo(
+            module_product.id,
             upstream_name=DOCKER_RH_REGISTRY_UPSTREAM_NAME,
             url=settings.docker.external_registry_1,
         )
-        self.assertEqual(repo['upstream-repository-name'], DOCKER_RH_REGISTRY_UPSTREAM_NAME)
+        assert repo['upstream-repository-name'] == DOCKER_RH_REGISTRY_UPSTREAM_NAME
 
     @skip_if_not_set('docker')
     @pytest.mark.tier1
-    def test_positive_update_with_long_upstream_name(self):
+    def test_positive_update_with_long_upstream_name(self, repo):
         """Create a docker repository and update its upstream name with longer
         than 30 characters value
 
@@ -320,7 +347,6 @@ class DockerRepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
         Repository.update(
             {
                 'docker-upstream-name': DOCKER_RH_REGISTRY_UPSTREAM_NAME,
@@ -329,10 +355,10 @@ class DockerRepositoryTestCase(CLITestCase):
             }
         )
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['upstream-repository-name'], DOCKER_RH_REGISTRY_UPSTREAM_NAME)
+        assert repo['upstream-repository-name'] == DOCKER_RH_REGISTRY_UPSTREAM_NAME
 
     @pytest.mark.tier2
-    def test_positive_update_url(self):
+    def test_positive_update_url(self, repo):
         """Create a Docker-type repository and update its URL.
 
         :id: 73caacd4-7f17-42a7-8d93-3dee8b9341fa
@@ -341,13 +367,12 @@ class DockerRepositoryTestCase(CLITestCase):
             repository and that its URL can be updated.
         """
         new_url = gen_url()
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
         Repository.update({'id': repo['id'], 'url': new_url})
         repo = Repository.info({'id': repo['id']})
-        self.assertEqual(repo['url'], new_url)
+        assert repo['url'] == new_url
 
     @pytest.mark.tier1
-    def test_positive_delete_by_id(self):
+    def test_positive_delete_by_id(self, repo):
         """Create and delete a Docker-type repository
 
         :id: ab1e8228-92a8-45dc-a863-7181711f2745
@@ -357,13 +382,12 @@ class DockerRepositoryTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
         Repository.delete({'id': repo['id']})
-        with self.assertRaises(CLIReturnCodeError):
+        with pytest.raises(CLIReturnCodeError):
             Repository.info({'id': repo['id']})
 
     @pytest.mark.tier2
-    def test_positive_delete_random_repo_by_id(self):
+    def test_positive_delete_random_repo_by_id(self, module_org):
         """Create Docker-type repositories on multiple products and
         delete a random repository from a random product.
 
@@ -373,25 +397,26 @@ class DockerRepositoryTestCase(CLITestCase):
             without altering the other products.
         """
         products = [
-            make_product_wait({'organization-id': self.org_id}) for _ in range(randint(2, 5))
+            make_product_wait({'organization-id': module_org.id}) for _ in range(randint(2, 5))
         ]
         repos = []
         for product in products:
             for _ in range(randint(2, 3)):
-                repos.append(_make_docker_repo(product['id']))
+                repos.append(_repo(product['id']))
         # Select random repository and delete it
         repo = choice(repos)
         repos.remove(repo)
         Repository.delete({'id': repo['id']})
-        with self.assertRaises(CLIReturnCodeError):
+        with pytest.raises(CLIReturnCodeError):
             Repository.info({'id': repo['id']})
         # Verify other repositories were not touched
+        product_ids = [product['id'] for product in products]
         for repo in repos:
             result = Repository.info({'id': repo['id']})
-            self.assertIn(result['product']['id'], [product['id'] for product in products])
+            assert result['product']['id'] in product_ids
 
 
-class DockerContentViewTestCase(CLITestCase):
+class TestDockerContentView:
     """Tests specific to using ``Docker`` repositories with Content Views.
 
     :CaseComponent: ContentViews
@@ -401,29 +426,8 @@ class DockerContentViewTestCase(CLITestCase):
     :CaseLevel: Integration
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Create an organization which can be re-used in tests."""
-        super().setUpClass()
-        cls.org_id = make_org()['id']
-
-    def _create_and_associate_repo_with_cv(self):
-        """Create a Docker-based repository and content view and associate
-        them.
-        """
-        self.repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
-        self.content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
-        ContentView.add_repository(
-            {'id': self.content_view['id'], 'repository-id': self.repo['id']}
-        )
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertIn(
-            self.repo['id'],
-            [repo_['id'] for repo_ in self.content_view['container-image-repositories']],
-        )
-
     @pytest.mark.tier2
-    def test_positive_add_docker_repo_by_id(self):
+    def test_positive_add_docker_repo_by_id(self, module_org, repo):
         """Add one Docker-type repository to a non-composite content view
 
         :id: 87d6c7bb-92f8-4a32-8ad2-2a1af896500b
@@ -431,16 +435,15 @@ class DockerContentViewTestCase(CLITestCase):
         :expectedresults: A repository is created with a Docker repository and
             the product is added to a non-composite content view
         """
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
-        content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        self.assertIn(
-            repo['id'], [repo_['id'] for repo_ in content_view['container-image-repositories']]
-        )
+        assert repo['id'] in [
+            repo_['id'] for repo_ in content_view['container-image-repositories']
+        ]
 
     @pytest.mark.tier2
-    def test_positive_add_docker_repos_by_id(self):
+    def test_positive_add_docker_repos_by_id(self, module_org, module_product):
         """Add multiple Docker-type repositories to a non-composite CV.
 
         :id: 2eb19e28-a633-4c21-9469-75a686c83b34
@@ -449,19 +452,18 @@ class DockerContentViewTestCase(CLITestCase):
             repositories and the product is added to a non-composite content
             view.
         """
-        product = make_product_wait({'organization-id': self.org_id})
-        repos = [_make_docker_repo(product['id']) for _ in range(randint(2, 5))]
-        content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
+        repos = [_repo(module_product.id) for _ in range(randint(2, 5))]
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         for repo in repos:
             ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        self.assertEqual(
-            {repo['id'] for repo in repos},
-            {repo['id'] for repo in content_view['container-image-repositories']},
-        )
+
+        assert {repo['id'] for repo in repos} == {
+            repo['id'] for repo in content_view['container-image-repositories']
+        }
 
     @pytest.mark.tier2
-    def test_positive_add_synced_docker_repo_by_id(self):
+    def test_positive_add_synced_docker_repo_by_id(self, module_org, repo):
         """Create and sync a Docker-type repository
 
         :id: 6f51d268-ed23-48ab-9dea-cd3571daa647
@@ -469,19 +471,19 @@ class DockerContentViewTestCase(CLITestCase):
         :expectedresults: A repository is created with a Docker repository and
             it is synchronized.
         """
-        repo = _make_docker_repo(make_product_wait({'organization-id': self.org_id})['id'])
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
-        self.assertGreaterEqual(int(repo['content-counts']['container-image-manifests']), 1)
-        content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
+        assert int(repo['content-counts']['container-image-manifests']) > 0
+
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        self.assertIn(
-            repo['id'], [repo_['id'] for repo_ in content_view['container-image-repositories']]
-        )
+        assert repo['id'] in [
+            repo_['id'] for repo_ in content_view['container-image-repositories']
+        ]
 
     @pytest.mark.tier2
-    def test_positive_add_docker_repo_by_id_to_ccv(self):
+    def test_positive_add_docker_repo_by_id_to_ccv(self, module_org, content_view):
         """Add one Docker-type repository to a composite content view
 
         :id: 8e2ef5ba-3cdf-4ef9-a22a-f1701e20a5d5
@@ -492,25 +494,25 @@ class DockerContentViewTestCase(CLITestCase):
 
         :BZ: 1359665
         """
-        self._create_and_associate_repo_with_cv()
-        ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), 1)
-        comp_content_view = make_content_view({'composite': True, 'organization-id': self.org_id})
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
+        comp_content_view = make_content_view(
+            {'composite': True, 'organization-id': module_org.id}
+        )
         ContentView.update(
             {
                 'id': comp_content_view['id'],
-                'component-ids': self.content_view['versions'][0]['id'],
+                'component-ids': content_view['versions'][0]['id'],
             }
         )
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertIn(
-            self.content_view['versions'][0]['id'],
-            [component['id'] for component in comp_content_view['components']],
-        )
+        assert content_view['versions'][0]['id'] in [
+            component['id'] for component in comp_content_view['components']
+        ]
 
     @pytest.mark.tier2
-    def test_positive_add_docker_repos_by_id_to_ccv(self):
+    def test_positive_add_docker_repos_by_id_to_ccv(self, module_org, module_product):
         """Add multiple Docker-type repositories to a composite content view.
 
         :id: b79cbc97-3dba-4059-907d-19316684d569
@@ -522,16 +524,19 @@ class DockerContentViewTestCase(CLITestCase):
         :BZ: 1359665
         """
         cv_versions = []
-        product = make_product_wait({'organization-id': self.org_id})
         for _ in range(randint(2, 5)):
-            content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
-            repo = _make_docker_repo(product['id'])
+            content_view = make_content_view(
+                {'composite': False, 'organization-id': module_org.id}
+            )
+            repo = _repo(module_product.id)
             ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
             ContentView.publish({'id': content_view['id']})
             content_view = ContentView.info({'id': content_view['id']})
-            self.assertEqual(len(content_view['versions']), 1)
+            assert len(content_view['versions']) == 1
             cv_versions.append(content_view['versions'][0])
-        comp_content_view = make_content_view({'composite': True, 'organization-id': self.org_id})
+        comp_content_view = make_content_view(
+            {'composite': True, 'organization-id': module_org.id}
+        )
         ContentView.update(
             {
                 'component-ids': [cv_version['id'] for cv_version in cv_versions],
@@ -539,14 +544,12 @@ class DockerContentViewTestCase(CLITestCase):
             }
         )
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
+        comp_ids = [component['id'] for component in comp_content_view['components']]
         for cv_version in cv_versions:
-            self.assertIn(
-                cv_version['id'],
-                [component['id'] for component in comp_content_view['components']],
-            )
+            assert cv_version['id'] in comp_ids
 
     @pytest.mark.tier2
-    def test_positive_publish_with_docker_repo(self):
+    def test_positive_publish_with_docker_repo(self, content_view):
         """Add Docker-type repository to content view and publish it once.
 
         :id: 28480de3-ffb5-4b8e-8174-fffffeef6af4
@@ -555,14 +558,13 @@ class DockerContentViewTestCase(CLITestCase):
             repository and the product is added to a content view which is then
             published only once.
         """
-        self._create_and_associate_repo_with_cv()
-        self.assertEqual(len(self.content_view['versions']), 0)
-        ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), 1)
+        assert len(content_view['versions']) == 0
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
 
     @pytest.mark.tier2
-    def test_positive_publish_with_docker_repo_composite(self):
+    def test_positive_publish_with_docker_repo_composite(self, content_view, module_org):
         """Add Docker-type repository to composite CV and publish it once.
 
         :id: 2d75419b-73ed-4f29-ae0d-9af8d9624c87
@@ -574,29 +576,32 @@ class DockerContentViewTestCase(CLITestCase):
 
         :BZ: 1359665
         """
-        self._create_and_associate_repo_with_cv()
-        self.assertEqual(len(self.content_view['versions']), 0)
-        ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), 1)
-        comp_content_view = make_content_view({'composite': True, 'organization-id': self.org_id})
+        assert len(content_view['versions']) == 0
+
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
+
+        comp_content_view = make_content_view(
+            {'composite': True, 'organization-id': module_org.id}
+        )
         ContentView.update(
             {
-                'component-ids': self.content_view['versions'][0]['id'],
+                'component-ids': content_view['versions'][0]['id'],
                 'id': comp_content_view['id'],
             }
         )
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertIn(
-            self.content_view['versions'][0]['id'],
-            [component['id'] for component in comp_content_view['components']],
-        )
+        assert content_view['versions'][0]['id'] in [
+            component['id'] for component in comp_content_view['components']
+        ]
+
         ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertEqual(len(comp_content_view['versions']), 1)
+        assert len(comp_content_view['versions']) == 1
 
     @pytest.mark.tier2
-    def test_positive_publish_multiple_with_docker_repo(self):
+    def test_positive_publish_multiple_with_docker_repo(self, content_view):
         """Add Docker-type repository to content view and publish it multiple
         times.
 
@@ -606,16 +611,16 @@ class DockerContentViewTestCase(CLITestCase):
             repository and the product is added to a content view which is then
             published multiple times.
         """
-        self._create_and_associate_repo_with_cv()
-        self.assertEqual(len(self.content_view['versions']), 0)
+        assert len(content_view['versions']) == 0
+
         publish_amount = randint(2, 5)
         for _ in range(publish_amount):
-            ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), publish_amount)
+            ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == publish_amount
 
     @pytest.mark.tier2
-    def test_positive_publish_multiple_with_docker_repo_composite(self):
+    def test_positive_publish_multiple_with_docker_repo_composite(self, module_org, content_view):
         """Add Docker-type repository to content view and publish it multiple
         times.
 
@@ -628,31 +633,34 @@ class DockerContentViewTestCase(CLITestCase):
 
         :BZ: 1359665
         """
-        self._create_and_associate_repo_with_cv()
-        self.assertEqual(len(self.content_view['versions']), 0)
-        ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), 1)
-        comp_content_view = make_content_view({'composite': True, 'organization-id': self.org_id})
+        assert len(content_view['versions']) == 0
+
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
+
+        comp_content_view = make_content_view(
+            {'composite': True, 'organization-id': module_org.id}
+        )
         ContentView.update(
             {
-                'component-ids': self.content_view['versions'][0]['id'],
+                'component-ids': content_view['versions'][0]['id'],
                 'id': comp_content_view['id'],
             }
         )
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertIn(
-            self.content_view['versions'][0]['id'],
-            [component['id'] for component in comp_content_view['components']],
-        )
+        assert content_view['versions'][0]['id'] in [
+            component['id'] for component in comp_content_view['components']
+        ]
+
         publish_amount = randint(2, 5)
         for _ in range(publish_amount):
             ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertEqual(len(comp_content_view['versions']), publish_amount)
+        assert len(comp_content_view['versions']) == publish_amount
 
     @pytest.mark.tier2
-    def test_positive_promote_with_docker_repo(self):
+    def test_positive_promote_with_docker_repo(self, module_org, module_lce, content_view):
         """Add Docker-type repository to content view and publish it.
         Then promote it to the next available lifecycle-environment.
 
@@ -661,20 +669,22 @@ class DockerContentViewTestCase(CLITestCase):
         :expectedresults: Docker-type repository is promoted to content view
             found in the specific lifecycle-environment.
         """
-        lce = make_lifecycle_environment({'organization-id': self.org_id})
-        self._create_and_associate_repo_with_cv()
-        ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), 1)
-        cvv = ContentView.version_info({'id': self.content_view['versions'][0]['id']})
-        self.assertEqual(len(cvv['lifecycle-environments']), 1)
-        ContentView.version_promote({'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']})
-        cvv = ContentView.version_info({'id': self.content_view['versions'][0]['id']})
-        self.assertEqual(len(cvv['lifecycle-environments']), 2)
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
+
+        cvv = ContentView.version_info({'id': content_view['versions'][0]['id']})
+        assert len(cvv['lifecycle-environments']) == 1
+
+        ContentView.version_promote(
+            {'id': cvv['id'], 'to-lifecycle-environment-id': module_lce.id}
+        )
+        cvv = ContentView.version_info({'id': content_view['versions'][0]['id']})
+        assert len(cvv['lifecycle-environments']) == 2
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_promote_multiple_with_docker_repo(self):
+    def test_positive_promote_multiple_with_docker_repo(self, module_org, content_view):
         """Add Docker-type repository to content view and publish it.
         Then promote it to multiple available lifecycle-environments.
 
@@ -683,22 +693,29 @@ class DockerContentViewTestCase(CLITestCase):
         :expectedresults: Docker-type repository is promoted to content view
             found in the specific lifecycle-environments.
         """
-        self._create_and_associate_repo_with_cv()
-        ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), 1)
-        cvv = ContentView.version_info({'id': self.content_view['versions'][0]['id']})
-        self.assertEqual(len(cvv['lifecycle-environments']), 1)
-        for i in range(1, randint(3, 6)):
-            lce = make_lifecycle_environment({'organization-id': self.org_id})
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
+
+        cvv = ContentView.version_info({'id': content_view['versions'][0]['id']})
+        assert len(cvv['lifecycle-environments']) == 1
+
+        lces = [
+            make_lifecycle_environment({'organization-id': module_org.id})
+            for _ in range(1, randint(3, 6))
+        ]
+
+        for expected_lces, lce in enumerate(lces, start=2):
             ContentView.version_promote(
                 {'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']}
             )
-            cvv = ContentView.version_info({'id': self.content_view['versions'][0]['id']})
-            self.assertEqual(len(cvv['lifecycle-environments']), i + 1)
+            cvv = ContentView.version_info({'id': cvv['id']})
+            assert len(cvv['lifecycle-environments']) == expected_lces
 
     @pytest.mark.tier2
-    def test_positive_promote_with_docker_repo_composite(self):
+    def test_positive_promote_with_docker_repo_composite(
+        self, module_org, module_lce, content_view
+    ):
         """Add Docker-type repository to composite content view and publish it.
         Then promote it to the next available lifecycle-environment.
 
@@ -709,39 +726,41 @@ class DockerContentViewTestCase(CLITestCase):
 
         :BZ: 1359665
         """
-        self._create_and_associate_repo_with_cv()
-        ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), 1)
-        comp_content_view = make_content_view({'composite': True, 'organization-id': self.org_id})
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
+
+        comp_content_view = make_content_view(
+            {'composite': True, 'organization-id': module_org.id}
+        )
         ContentView.update(
             {
-                'component-ids': self.content_view['versions'][0]['id'],
+                'component-ids': content_view['versions'][0]['id'],
                 'id': comp_content_view['id'],
             }
         )
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertIn(
-            self.content_view['versions'][0]['id'],
-            [component['id'] for component in comp_content_view['components']],
-        )
+        assert content_view['versions'][0]['id'] in [
+            component['id'] for component in comp_content_view['components']
+        ]
+
         ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
         cvv = ContentView.version_info({'id': comp_content_view['versions'][0]['id']})
-        self.assertEqual(len(cvv['lifecycle-environments']), 1)
-        lce = make_lifecycle_environment({'organization-id': self.org_id})
+        assert len(cvv['lifecycle-environments']) == 1
+
         ContentView.version_promote(
             {
                 'id': comp_content_view['versions'][0]['id'],
-                'to-lifecycle-environment-id': lce['id'],
+                'to-lifecycle-environment-id': module_lce.id,
             }
         )
         cvv = ContentView.version_info({'id': comp_content_view['versions'][0]['id']})
-        self.assertEqual(len(cvv['lifecycle-environments']), 2)
+        assert len(cvv['lifecycle-environments']) == 2
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_promote_multiple_with_docker_repo_composite(self):
+    def test_positive_promote_multiple_with_docker_repo_composite(self, content_view, module_org):
         """Add Docker-type repository to composite content view and publish it.
         Then promote it to the multiple available lifecycle-environments.
 
@@ -752,40 +771,47 @@ class DockerContentViewTestCase(CLITestCase):
 
         :BZ: 1359665
         """
-        self._create_and_associate_repo_with_cv()
-        ContentView.publish({'id': self.content_view['id']})
-        self.content_view = ContentView.info({'id': self.content_view['id']})
-        self.assertEqual(len(self.content_view['versions']), 1)
-        comp_content_view = make_content_view({'composite': True, 'organization-id': self.org_id})
+        ContentView.publish({'id': content_view['id']})
+        content_view = ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
+
+        comp_content_view = make_content_view(
+            {'composite': True, 'organization-id': module_org.id}
+        )
         ContentView.update(
             {
-                'component-ids': self.content_view['versions'][0]['id'],
+                'component-ids': content_view['versions'][0]['id'],
                 'id': comp_content_view['id'],
             }
         )
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertIn(
-            self.content_view['versions'][0]['id'],
-            [component['id'] for component in comp_content_view['components']],
-        )
+        assert content_view['versions'][0]['id'] in [
+            component['id'] for component in comp_content_view['components']
+        ]
+
         ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
         cvv = ContentView.version_info({'id': comp_content_view['versions'][0]['id']})
-        self.assertEqual(len(cvv['lifecycle-environments']), 1)
-        for i in range(1, randint(3, 6)):
-            lce = make_lifecycle_environment({'organization-id': self.org_id})
+        assert len(cvv['lifecycle-environments']) == 1
+
+        lces = [
+            make_lifecycle_environment({'organization-id': module_org.id})
+            for _ in range(1, randint(3, 6))
+        ]
+
+        for expected_lces, lce in enumerate(lces, start=2):
             ContentView.version_promote(
                 {
-                    'id': comp_content_view['versions'][0]['id'],
+                    'id': cvv['id'],
                     'to-lifecycle-environment-id': lce['id'],
                 }
             )
-            cvv = ContentView.version_info({'id': comp_content_view['versions'][0]['id']})
-            self.assertEqual(len(cvv['lifecycle-environments']), i + 1)
+            cvv = ContentView.version_info({'id': cvv['id']})
+            assert len(cvv['lifecycle-environments']) == expected_lces
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_name_pattern_change(self):
+    def test_positive_name_pattern_change(self, module_org):
         """Promote content view with Docker repository to lifecycle environment.
         Change registry name pattern for that environment. Verify that repository
         name on product changed according to new pattern.
@@ -795,41 +821,45 @@ class DockerContentViewTestCase(CLITestCase):
         :expectedresults: Container repository name is changed
             according to new pattern.
         """
+        lce = make_lifecycle_environment({'organization-id': module_org.id})
         pattern_prefix = gen_string('alpha', 5)
         docker_upstream_name = 'hello-world'
         new_pattern = (
-            "{}-<%= content_view.label %>" + "/<%= repository.docker_upstream_name %>"
-        ).format(pattern_prefix)
+            f'{pattern_prefix}-<%= content_view.label %>/<%= repository.docker_upstream_name %>'
+        )
 
-        repo = _make_docker_repo(
-            make_product_wait({'organization-id': self.org_id})['id'],
+        repo = _repo(
+            make_product_wait({'organization-id': module_org.id})['id'],
+            name=gen_string('alpha', 5),
             upstream_name=docker_upstream_name,
         )
         Repository.synchronize({'id': repo['id']})
-        content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        lce = make_lifecycle_environment({'organization-id': self.org_id})
+
         ContentView.version_promote(
             {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
         )
         LifecycleEnvironment.update(
-            {'registry-name-pattern': new_pattern, 'id': lce['id'], 'organization-id': self.org_id}
+            {
+                'registry-name-pattern': new_pattern,
+                'id': lce['id'],
+                'organization-id': module_org.id,
+            }
         )
-        lce = LifecycleEnvironment.info({'id': lce['id'], 'organization-id': self.org_id})
-        repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
+        lce = LifecycleEnvironment.info({'id': lce['id'], 'organization-id': module_org.id})
+        assert lce['registry-name-pattern'] == new_pattern
 
-        expected_pattern = "{}-{}/{}".format(
-            pattern_prefix, content_view['label'], docker_upstream_name
-        ).lower()
-        self.assertEqual(lce['registry-name-pattern'], new_pattern)
-        self.assertEqual(
-            Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
-        )
+        repo = Repository.list(
+            {'name': repo['name'], 'environment-id': lce['id'], 'organization-id': module_org.id}
+        )[0]
+        expected_name = f'{pattern_prefix}-{content_view["label"]}/{docker_upstream_name}'.lower()
+        assert Repository.info({'id': repo['id']})['container-repository-name'] == expected_name
 
     @pytest.mark.tier2
-    def test_positive_product_name_change_after_promotion(self):
+    def test_positive_product_name_change_after_promotion(self, module_org):
         """Promote content view with Docker repository to lifecycle environment.
         Change product name. Verify that repository name on product changed
         according to new pattern.
@@ -842,46 +872,58 @@ class DockerContentViewTestCase(CLITestCase):
         old_prod_name = gen_string('alpha', 5)
         new_prod_name = gen_string('alpha', 5)
         docker_upstream_name = 'hello-world'
-        new_pattern = "<%= content_view.label %>/<%= product.name %>"
+        new_pattern = '<%= content_view.label %>/<%= product.name %>'
 
-        prod = make_product_wait({'organization-id': self.org_id, 'name': old_prod_name})
-        repo = _make_docker_repo(prod['id'], upstream_name=docker_upstream_name)
+        lce = make_lifecycle_environment({'organization-id': module_org.id})
+        prod = make_product_wait({'organization-id': module_org.id, 'name': old_prod_name})
+        repo = _repo(prod['id'], name=gen_string('alpha', 5), upstream_name=docker_upstream_name)
         Repository.synchronize({'id': repo['id']})
-        content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        lce = make_lifecycle_environment({'organization-id': self.org_id})
         LifecycleEnvironment.update(
-            {'registry-name-pattern': new_pattern, 'id': lce['id'], 'organization-id': self.org_id}
+            {
+                'registry-name-pattern': new_pattern,
+                'id': lce['id'],
+                'organization-id': module_org.id,
+            }
         )
-        lce = LifecycleEnvironment.info({'id': lce['id'], 'organization-id': self.org_id})
+        lce = LifecycleEnvironment.info({'id': lce['id'], 'organization-id': module_org.id})
+        assert lce['registry-name-pattern'] == new_pattern
+
         ContentView.version_promote(
             {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
         )
         Product.update({'name': new_prod_name, 'id': prod['id']})
-        repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
 
-        expected_pattern = "{}/{}".format(content_view['label'], old_prod_name).lower()
-        self.assertEqual(lce['registry-name-pattern'], new_pattern)
-        self.assertEqual(
-            Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
-        )
+        repo = Repository.list(
+            {'name': repo['name'], 'environment-id': lce['id'], 'organization-id': module_org.id}
+        )[0]
+        expected_name = f'{content_view["label"]}/{old_prod_name}'.lower()
+        assert Repository.info({'id': repo['id']})['container-repository-name'] == expected_name
 
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
         ContentView.version_promote(
-            {'id': content_view['versions'][-1]['id'], 'to-lifecycle-environment-id': lce['id']}
+            {
+                'id': content_view['versions'][-1]['id'],
+                'to-lifecycle-environment-id': lce['id'],
+            }
         )
-        repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
 
-        expected_pattern = "{}/{}".format(content_view['label'], new_prod_name).lower()
-        self.assertEqual(
-            Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
-        )
+        repo = Repository.list(
+            {
+                'name': repo['name'],
+                'environment-id': lce['id'],
+                'organization-id': module_org.id,
+            }
+        )[0]
+        expected_name = f'{content_view["label"]}/{new_prod_name}'.lower()
+        assert Repository.info({'id': repo['id']})['container-repository-name'] == expected_name
 
     @pytest.mark.tier2
-    def test_positive_repo_name_change_after_promotion(self):
+    def test_positive_repo_name_change_after_promotion(self, module_org):
         """Promote content view with Docker repository to lifecycle environment.
         Change repository name. Verify that Docker repository name on product
         changed according to new pattern.
@@ -894,47 +936,59 @@ class DockerContentViewTestCase(CLITestCase):
         old_repo_name = gen_string('alpha', 5)
         new_repo_name = gen_string('alpha', 5)
         docker_upstream_name = 'hello-world'
-        new_pattern = "<%= content_view.label %>/<%= repository.name %>"
+        new_pattern = '<%= content_view.label %>/<%= repository.name %>'
 
-        prod = make_product_wait({'organization-id': self.org_id})
-        repo = _make_docker_repo(
-            prod['id'], name=old_repo_name, upstream_name=docker_upstream_name
-        )
+        lce = make_lifecycle_environment({'organization-id': module_org.id})
+        prod = make_product_wait({'organization-id': module_org.id})
+        repo = _repo(prod['id'], name=old_repo_name, upstream_name=docker_upstream_name)
         Repository.synchronize({'id': repo['id']})
-        content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        lce = make_lifecycle_environment({'organization-id': self.org_id})
         LifecycleEnvironment.update(
-            {'registry-name-pattern': new_pattern, 'id': lce['id'], 'organization-id': self.org_id}
+            {
+                'registry-name-pattern': new_pattern,
+                'id': lce['id'],
+                'organization-id': module_org.id,
+            }
         )
-        lce = LifecycleEnvironment.info({'id': lce['id'], 'organization-id': self.org_id})
         ContentView.version_promote(
             {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
         )
         Repository.update({'name': new_repo_name, 'id': repo['id'], 'product-id': prod['id']})
-        repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
 
-        expected_pattern = "{}/{}".format(content_view['label'], old_repo_name).lower()
-        self.assertEqual(
-            Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
-        )
+        repo = Repository.list(
+            {
+                'name': new_repo_name,
+                'environment-id': lce['id'],
+                'organization-id': module_org.id,
+            }
+        )[0]
+        expected_name = f'{content_view["label"]}/{old_repo_name}'.lower()
+        assert Repository.info({'id': repo['id']})['container-repository-name'] == expected_name
 
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
         ContentView.version_promote(
-            {'id': content_view['versions'][-1]['id'], 'to-lifecycle-environment-id': lce['id']}
+            {
+                'id': content_view['versions'][-1]['id'],
+                'to-lifecycle-environment-id': lce['id'],
+            }
         )
-        repos = Repository.list({'environment-id': lce['id'], 'organization-id': self.org_id})
 
-        expected_pattern = "{}/{}".format(content_view['label'], new_repo_name).lower()
-        self.assertEqual(
-            Repository.info({'id': repos[0]['id']})['container-repository-name'], expected_pattern
-        )
+        repo = Repository.list(
+            {
+                'name': new_repo_name,
+                'environment-id': lce['id'],
+                'organization-id': module_org.id,
+            }
+        )[0]
+        expected_name = f'{content_view["label"]}/{new_repo_name}'.lower()
+        assert Repository.info({'id': repo['id']})['container-repository-name'] == expected_name
 
     @pytest.mark.tier2
-    def test_negative_set_non_unique_name_pattern_and_promote(self):
+    def test_negative_set_non_unique_name_pattern_and_promote(self, module_org):
         """Set registry name pattern to one that does not guarantee uniqueness.
         Try to promote content view with multiple Docker repositories to
         lifecycle environment. Verify that content has not been promoted.
@@ -944,27 +998,28 @@ class DockerContentViewTestCase(CLITestCase):
         :expectedresults: Content view is not promoted
         """
         docker_upstream_names = ['hello-world', 'alpine']
-        new_pattern = "<%= organization.label %>"
+        new_pattern = '<%= organization.label %>'
 
         lce = make_lifecycle_environment(
-            {'organization-id': self.org_id, 'registry-name-pattern': new_pattern}
+            {'organization-id': module_org.id, 'registry-name-pattern': new_pattern}
         )
 
-        prod = make_product_wait({'organization-id': self.org_id})
-        content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
+        prod = make_product_wait({'organization-id': module_org.id})
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         for docker_name in docker_upstream_names:
-            repo = _make_docker_repo(prod['id'], upstream_name=docker_name)
+            repo = _repo(prod['id'], upstream_name=docker_name)
             Repository.synchronize({'id': repo['id']})
             ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        with self.assertRaises(CLIReturnCodeError):
+
+        with pytest.raises(CLIReturnCodeError):
             ContentView.version_promote(
                 {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
             )
 
     @pytest.mark.tier2
-    def test_negative_promote_and_set_non_unique_name_pattern(self):
+    def test_negative_promote_and_set_non_unique_name_pattern(self, module_org, module_product):
         """Promote content view with multiple Docker repositories to
         lifecycle environment. Set registry name pattern to one that
         does not guarantee uniqueness. Verify that pattern has not been
@@ -975,32 +1030,31 @@ class DockerContentViewTestCase(CLITestCase):
         :expectedresults: Registry name pattern is not changed
         """
         docker_upstream_names = ['hello-world', 'alpine']
-        new_pattern = "<%= organization.label %>"
+        new_pattern = '<%= organization.label %>'
 
-        prod = make_product_wait({'organization-id': self.org_id})
-        content_view = make_content_view({'composite': False, 'organization-id': self.org_id})
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         for docker_name in docker_upstream_names:
-            repo = _make_docker_repo(prod['id'], upstream_name=docker_name)
+            repo = _repo(module_product.id, upstream_name=docker_name)
             Repository.synchronize({'id': repo['id']})
             ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        lce = make_lifecycle_environment({'organization-id': self.org_id})
+        lce = make_lifecycle_environment({'organization-id': module_org.id})
         ContentView.version_promote(
             {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
         )
 
-        with self.assertRaises(CLIReturnCodeError):
+        with pytest.raises(CLIReturnCodeError):
             LifecycleEnvironment.update(
                 {
                     'registry-name-pattern': new_pattern,
                     'id': lce['id'],
-                    'organization-id': self.org_id,
+                    'organization-id': module_org.id,
                 }
             )
 
 
-class DockerActivationKeyTestCase(CLITestCase):
+class TestDockerActivationKey:
     """Tests specific to adding ``Docker`` repositories to Activation Keys.
 
     :CaseComponent: ActivationKeys
@@ -1010,32 +1064,8 @@ class DockerActivationKeyTestCase(CLITestCase):
     :CaseLevel: Integration
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Create necessary objects which can be re-used in tests."""
-        super().setUpClass()
-        cls.org = make_org()
-        cls.lce = make_lifecycle_environment({'organization-id': cls.org['id']})
-        cls.product = make_product_wait({'organization-id': cls.org['id']})
-        cls.repo = _make_docker_repo(cls.product['id'])
-        cls.content_view = make_content_view(
-            {'composite': False, 'organization-id': cls.org['id']}
-        )
-        ContentView.add_repository({'id': cls.content_view['id'], 'repository-id': cls.repo['id']})
-        cls.content_view = ContentView.info({'id': cls.content_view['id']})
-        ContentView.publish({'id': cls.content_view['id']})
-        cls.content_view = ContentView.info({'id': cls.content_view['id']})
-        cls.cvv = ContentView.version_info({'id': cls.content_view['versions'][0]['id']})
-        ContentView.version_promote(
-            {
-                'id': cls.content_view['versions'][0]['id'],
-                'to-lifecycle-environment-id': cls.lce['id'],
-            }
-        )
-        cls.cvv = ContentView.version_info({'id': cls.content_view['versions'][0]['id']})
-
     @pytest.mark.tier2
-    def test_positive_add_docker_repo_cv(self):
+    def test_positive_add_docker_repo_cv(self, module_org, module_lce, content_view_promote):
         """Add Docker-type repository to a non-composite content view
         and publish it. Then create an activation key and associate it with the
         Docker content view.
@@ -1047,15 +1077,15 @@ class DockerActivationKeyTestCase(CLITestCase):
         """
         activation_key = make_activation_key(
             {
-                'content-view-id': self.content_view['id'],
-                'lifecycle-environment-id': self.lce['id'],
-                'organization-id': self.org['id'],
+                'content-view-id': content_view_promote['content-view-id'],
+                'lifecycle-environment-id': module_lce.id,
+                'organization-id': module_org.id,
             }
         )
-        self.assertEqual(activation_key['content-view'], self.content_view['name'])
+        assert activation_key['content-view'] == content_view_promote['content-view-name']
 
     @pytest.mark.tier2
-    def test_positive_remove_docker_repo_cv(self):
+    def test_positive_remove_docker_repo_cv(self, module_org, module_lce, content_view_promote):
         """Add Docker-type repository to a non-composite content view
         and publish it. Create an activation key and associate it with the
         Docker content view. Then remove this content view from the activation
@@ -1068,34 +1098,34 @@ class DockerActivationKeyTestCase(CLITestCase):
         """
         activation_key = make_activation_key(
             {
-                'content-view-id': self.content_view['id'],
-                'lifecycle-environment-id': self.lce['id'],
-                'organization-id': self.org['id'],
+                'content-view-id': content_view_promote['content-view-id'],
+                'lifecycle-environment-id': module_lce.id,
+                'organization-id': module_org.id,
             }
         )
-        self.assertEqual(activation_key['content-view'], self.content_view['name'])
+        assert activation_key['content-view'] == content_view_promote['content-view-name']
 
         # Create another content view replace with
-        another_cv = make_content_view({'composite': False, 'organization-id': self.org['id']})
+        another_cv = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.publish({'id': another_cv['id']})
         another_cv = ContentView.info({'id': another_cv['id']})
         ContentView.version_promote(
-            {'id': another_cv['versions'][0]['id'], 'to-lifecycle-environment-id': self.lce['id']}
+            {'id': another_cv['versions'][0]['id'], 'to-lifecycle-environment-id': module_lce.id}
         )
 
         ActivationKey.update(
             {
                 'id': activation_key['id'],
-                'organization-id': self.org['id'],
+                'organization-id': module_org.id,
                 'content-view-id': another_cv['id'],
-                'lifecycle-environment-id': self.lce['id'],
+                'lifecycle-environment-id': module_lce.id,
             }
         )
         activation_key = ActivationKey.info({'id': activation_key['id']})
-        self.assertNotEqual(activation_key['content-view'], self.content_view['name'])
+        assert activation_key['content-view'] != content_view_promote['content-view-name']
 
     @pytest.mark.tier2
-    def test_positive_add_docker_repo_ccv(self):
+    def test_positive_add_docker_repo_ccv(self, module_org, module_lce, content_view_publish):
         """Add Docker-type repository to a non-composite content view
         and publish it. Then add this content view to a composite content view
         and publish it. Create an activation key and associate it with the
@@ -1109,36 +1139,36 @@ class DockerActivationKeyTestCase(CLITestCase):
         :BZ: 1359665
         """
         comp_content_view = make_content_view(
-            {'composite': True, 'organization-id': self.org['id']}
+            {'composite': True, 'organization-id': module_org.id}
         )
         ContentView.update(
             {
-                'component-ids': self.content_view['versions'][0]['id'],
+                'component-ids': content_view_publish['id'],
                 'id': comp_content_view['id'],
             }
         )
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertIn(
-            self.content_view['versions'][0]['id'],
-            [component['id'] for component in comp_content_view['components']],
-        )
+        assert content_view_publish['id'] in [
+            component['id'] for component in comp_content_view['components']
+        ]
+
         ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
         comp_cvv = ContentView.version_info({'id': comp_content_view['versions'][0]['id']})
         ContentView.version_promote(
-            {'id': comp_cvv['id'], 'to-lifecycle-environment-id': self.lce['id']}
+            {'id': comp_cvv['id'], 'to-lifecycle-environment-id': module_lce.id}
         )
         activation_key = make_activation_key(
             {
                 'content-view-id': comp_content_view['id'],
-                'lifecycle-environment-id': self.lce['id'],
-                'organization-id': self.org['id'],
+                'lifecycle-environment-id': module_lce.id,
+                'organization-id': module_org.id,
             }
         )
-        self.assertEqual(activation_key['content-view'], comp_content_view['name'])
+        assert activation_key['content-view'] == comp_content_view['name']
 
     @pytest.mark.tier2
-    def test_positive_remove_docker_repo_ccv(self):
+    def test_positive_remove_docker_repo_ccv(self, module_org, module_lce, content_view_publish):
         """Add Docker-type repository to a non-composite content view
         and publish it. Then add this content view to a composite content view
         and publish it. Create an activation key and associate it with the
@@ -1153,55 +1183,55 @@ class DockerActivationKeyTestCase(CLITestCase):
         :BZ: 1359665
         """
         comp_content_view = make_content_view(
-            {'composite': True, 'organization-id': self.org['id']}
+            {'composite': True, 'organization-id': module_org.id}
         )
         ContentView.update(
             {
-                'component-ids': self.content_view['versions'][0]['id'],
+                'component-ids': content_view_publish['id'],
                 'id': comp_content_view['id'],
             }
         )
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
-        self.assertIn(
-            self.content_view['versions'][0]['id'],
-            [component['id'] for component in comp_content_view['components']],
-        )
+        assert content_view_publish['id'] in [
+            component['id'] for component in comp_content_view['components']
+        ]
+
         ContentView.publish({'id': comp_content_view['id']})
         comp_content_view = ContentView.info({'id': comp_content_view['id']})
         comp_cvv = ContentView.version_info({'id': comp_content_view['versions'][0]['id']})
         ContentView.version_promote(
-            {'id': comp_cvv['id'], 'to-lifecycle-environment-id': self.lce['id']}
+            {'id': comp_cvv['id'], 'to-lifecycle-environment-id': module_lce.id}
         )
         activation_key = make_activation_key(
             {
                 'content-view-id': comp_content_view['id'],
-                'lifecycle-environment-id': self.lce['id'],
-                'organization-id': self.org['id'],
+                'lifecycle-environment-id': module_lce.id,
+                'organization-id': module_org.id,
             }
         )
-        self.assertEqual(activation_key['content-view'], comp_content_view['name'])
+        assert activation_key['content-view'] == comp_content_view['name']
 
         # Create another content view replace with
-        another_cv = make_content_view({'composite': False, 'organization-id': self.org['id']})
+        another_cv = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.publish({'id': another_cv['id']})
         another_cv = ContentView.info({'id': another_cv['id']})
         ContentView.version_promote(
-            {'id': another_cv['versions'][0]['id'], 'to-lifecycle-environment-id': self.lce['id']}
+            {'id': another_cv['versions'][0]['id'], 'to-lifecycle-environment-id': module_lce.id}
         )
 
         ActivationKey.update(
             {
                 'id': activation_key['id'],
-                'organization-id': self.org['id'],
+                'organization-id': module_org.id,
                 'content-view-id': another_cv['id'],
-                'lifecycle-environment-id': self.lce['id'],
+                'lifecycle-environment-id': module_lce.id,
             }
         )
         activation_key = ActivationKey.info({'id': activation_key['id']})
-        self.assertNotEqual(activation_key['content-view'], comp_content_view['name'])
+        assert activation_key['content-view'] != comp_content_view['name']
 
 
-class DockerClientTestCase(CLITestCase):
+class TestDockerClient:
     """Tests specific to using ``Docker`` as a client to pull Docker images
     from a Satellite 6 instance.
 
@@ -1214,26 +1244,8 @@ class DockerClientTestCase(CLITestCase):
     :CaseImportance: Medium
     """
 
-    @classmethod
-    def setUpClass(cls):
-        """Create an organization and product which can be re-used in tests."""
-        super().setUpClass()
-        cls.org = make_org()
-        """Instantiate and setup a docker host VM"""
-        cls.logger.info('Creating an external docker host')
-        docker_image = settings.docker.docker_image
-        cls.docker_host = VirtualMachine(source_image=docker_image, tag='docker')
-        cls.docker_host.create()
-        cls.logger.info('Installing katello-ca on the external docker host')
-        cls.docker_host.install_katello_ca()
-
-    @classmethod
-    def tearDownClass(cls):
-        """Destroy the docker host VM"""
-        cls.docker_host.destroy()
-
     @pytest.mark.tier3
-    def test_positive_pull_image(self):
+    def test_positive_pull_image(self, module_org, docker_host):
         """A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
 
@@ -1246,48 +1258,42 @@ class DockerClientTestCase(CLITestCase):
 
         :expectedresults: Client can pull Docker images from server and run it.
         """
-
-        product = make_product_wait({'organization-id': self.org['id']})
-        repo = _make_docker_repo(product['id'])
+        product = make_product_wait({'organization-id': module_org.id})
+        repo = _repo(product['id'])
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
         try:
+            result = docker_host.execute(
+                f'docker login -u {settings.server.admin_username}'
+                f' -p {settings.server.admin_password} {settings.server.hostname}'
+            )
+            assert result.status == 0
+
             # publishing takes few seconds sometimes
             result, _ = wait_for(
-                lambda: ssh.command(
-                    f'docker pull {repo["published-at"]}',
-                    hostname=self.docker_host.ip_addr,
-                ),
+                lambda: docker_host.execute(f'docker pull {repo["published-at"]}'),
                 num_sec=60,
                 delay=2,
-                fail_condition=lambda out: out.return_code != 0,
-                logger=self.logger,
+                fail_condition=lambda out: out.status != 0,
+                logger=logger,
             )
-            self.assertEqual(result.return_code, 0)
+            assert result.status == 0
             try:
-                result = ssh.command(
-                    'docker run {}'.format(repo['published-at']),
-                    hostname=self.docker_host.ip_addr,
-                )
-                self.assertEqual(result.return_code, 0)
+                result = docker_host.execute(f'docker run {repo["published-at"]}')
+                assert result.status == 0
             finally:
                 # Stop and remove the container
-                result = ssh.command(
-                    'docker ps -a | grep {}'.format(repo['published-at']),
-                    hostname=self.docker_host.ip_addr,
-                )
+                result = docker_host.execute(f'docker ps -a | grep {repo["published-at"]}')
                 container_id = result.stdout[0].split()[0]
-                ssh.command(f'docker stop {container_id}', hostname=self.docker_host.ip_addr)
-                ssh.command(f'docker rm {container_id}', hostname=self.docker_host.ip_addr)
+                docker_host.execute(f'docker stop {container_id}')
+                docker_host.execute(f'docker rm {container_id}')
         finally:
             # Remove docker image
-            ssh.command(
-                'docker rmi {}'.format(repo['published-at']), hostname=self.docker_host.ip_addr
-            )
+            docker_host.execute(f'docker rmi {repo["published-at"]}')
 
     @skip_if_not_set('docker')
     @pytest.mark.tier3
-    def test_positive_container_admin_end_to_end_search(self):
+    def test_positive_container_admin_end_to_end_search(self, module_org, docker_host):
         """Verify that docker command line can be used against
         Satellite server to search for container images stored
         on Satellite instance.
@@ -1297,36 +1303,35 @@ class DockerClientTestCase(CLITestCase):
         :steps:
 
             1. Publish and promote content view with Docker content
-            2. Set "Unauthenticated Pull" option to false
+            2. Set 'Unauthenticated Pull' option to false
             3. Try to search for docker images on Satellite
             4. Use Docker client to login to Satellite docker hub
             5. Search for docker images
             6. Use Docker client to log out of Satellite docker hub
             7. Try to search for docker images (ensure last search result
                is caused by change of Satellite option and not login/logout)
-            8. Set "Unauthenticated Pull" option to true
+            8. Set 'Unauthenticated Pull' option to true
             9. Search for docker images
 
         :expectedresults: Client can search for docker images stored
             on Satellite instance
         """
         pattern_prefix = gen_string('alpha', 5)
-        docker_upstream_name = 'alpine'
         registry_name_pattern = (
-            "{}-<%= content_view.label %>/<%= repository.docker_upstream_name %>"
-        ).format(pattern_prefix)
+            f'{pattern_prefix}-<%= content_view.label %>/<%= repository.docker_upstream_name %>'
+        )
 
         # Satellite setup: create product and add Docker repository;
         # create content view and add Docker repository;
         # create lifecycle environment and promote content view to it
-        product = make_product_wait({'organization-id': self.org['id']})
-        repo = _make_docker_repo(product['id'], upstream_name=docker_upstream_name)
+        lce = make_lifecycle_environment({'organization-id': module_org.id})
+        product = make_product_wait({'organization-id': module_org.id})
+        repo = _repo(product['id'], upstream_name=DOCKER_UPSTREAM_NAME)
         Repository.synchronize({'id': repo['id']})
-        content_view = make_content_view({'composite': False, 'organization-id': self.org['id']})
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        lce = make_lifecycle_environment({'organization-id': self.org['id']})
         ContentView.version_promote(
             {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
         )
@@ -1335,65 +1340,58 @@ class DockerClientTestCase(CLITestCase):
                 'registry-name-pattern': registry_name_pattern,
                 'registry-unauthenticated-pull': 'false',
                 'id': lce['id'],
-                'organization-id': self.org['id'],
+                'organization-id': module_org.id,
             }
         )
-        docker_repo_uri = " {}/{}-{}/{} ".format(
-            settings.server.hostname, pattern_prefix, content_view['label'], docker_upstream_name
+        docker_repo_uri = (
+            f' {settings.server.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f'{DOCKER_UPSTREAM_NAME} '
         ).lower()
 
         # 3. Try to search for docker images on Satellite
-        remote_search_command = 'docker search {}/{}'.format(
-            settings.server.hostname, docker_upstream_name
-        )
-        result = ssh.command(remote_search_command, hostname=self.docker_host.ip_addr)
-        self.assertEqual(result.return_code, 0)
-        self.assertNotIn(docker_repo_uri, "\n".join(result.stdout))
+        remote_search_command = f'docker search {settings.server.hostname}/{DOCKER_UPSTREAM_NAME}'
+        result = docker_host.execute(remote_search_command)
+        assert result.status == 0
+        assert docker_repo_uri not in result.stdout
 
         # 4. Use Docker client to login to Satellite docker hub
-        result = ssh.command(
-            'docker login -u {} -p {} {}'.format(
-                settings.server.admin_username,
-                settings.server.admin_password,
-                settings.server.hostname,
-            ),
-            hostname=self.docker_host.ip_addr,
+        result = docker_host.execute(
+            f'docker login -u {settings.server.admin_username}'
+            f' -p {settings.server.admin_password} {settings.server.hostname}'
         )
-        self.assertEqual(result.return_code, 0)
+        assert result.status == 0
 
         # 5. Search for docker images
-        result = ssh.command(remote_search_command, hostname=self.docker_host.ip_addr)
-        self.assertEqual(result.return_code, 0)
-        self.assertIn(docker_repo_uri, "\n".join(result.stdout))
+        result = docker_host.execute(remote_search_command)
+        assert result.status == 0
+        assert docker_repo_uri in result.stdout
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = ssh.command(
-            f'docker logout {settings.server.hostname}', hostname=self.docker_host.ip_addr
-        )
-        self.assertEqual(result.return_code, 0)
+        result = docker_host.execute(f'docker logout {settings.server.hostname}')
+        assert result.status == 0
 
         # 7. Try to search for docker images
-        result = ssh.command(remote_search_command, hostname=self.docker_host.ip_addr)
-        self.assertEqual(result.return_code, 0)
-        self.assertNotIn(docker_repo_uri, "\n".join(result.stdout))
+        result = docker_host.execute(remote_search_command)
+        assert result.status == 0
+        assert docker_repo_uri not in result.stdout
 
-        # 8. Set "Unauthenticated Pull" option to true
+        # 8. Set 'Unauthenticated Pull' option to true
         LifecycleEnvironment.update(
             {
                 'registry-unauthenticated-pull': 'true',
                 'id': lce['id'],
-                'organization-id': self.org['id'],
+                'organization-id': module_org.id,
             }
         )
 
         # 9. Search for docker images
-        result = ssh.command(remote_search_command, hostname=self.docker_host.ip_addr)
-        self.assertEqual(result.return_code, 0)
-        self.assertIn(docker_repo_uri, "\n".join(result.stdout))
+        result = docker_host.execute(remote_search_command)
+        assert result.status == 0
+        assert docker_repo_uri in result.stdout
 
     @skip_if_not_set('docker')
     @pytest.mark.tier3
-    def test_positive_container_admin_end_to_end_pull(self):
+    def test_positive_container_admin_end_to_end_pull(self, module_org, docker_host):
         """Verify that docker command line can be used against
         Satellite server to pull in container images stored
         on Satellite instance.
@@ -1403,36 +1401,36 @@ class DockerClientTestCase(CLITestCase):
         :steps:
 
             1. Publish and promote content view with Docker content
-            2. Set "Unauthenticated Pull" option to false
+            2. Set 'Unauthenticated Pull' option to false
             3. Try to pull in docker image from Satellite
             4. Use Docker client to login to Satellite container registry
             5. Pull in docker image
             6. Use Docker client to log out of Satellite container registry
             7. Try to pull in docker image (ensure next pull result
                is caused by change of Satellite option and not login/logout)
-            8. Set "Unauthenticated Pull" option to true
+            8. Set 'Unauthenticated Pull' option to true
             9. Pull in docker image
 
         :expectedresults: Client can pull in docker images stored
             on Satellite instance
         """
         pattern_prefix = gen_string('alpha', 5)
-        docker_upstream_name = 'alpine'
+        docker_upstream_name = DOCKER_UPSTREAM_NAME
         registry_name_pattern = (
-            "{}-<%= content_view.label %>/<%= repository.docker_upstream_name %>"
-        ).format(pattern_prefix)
+            f'{pattern_prefix}-<%= content_view.label %>/<%= repository.docker_upstream_name %>'
+        )
 
         # Satellite setup: create product and add Docker repository;
         # create content view and add Docker repository;
         # create lifecycle environment and promote content view to it
-        product = make_product_wait({'organization-id': self.org['id']})
-        repo = _make_docker_repo(product['id'], upstream_name=docker_upstream_name)
+        lce = make_lifecycle_environment({'organization-id': module_org.id})
+        product = make_product_wait({'organization-id': module_org.id})
+        repo = _repo(product['id'], upstream_name=docker_upstream_name)
         Repository.synchronize({'id': repo['id']})
-        content_view = make_content_view({'composite': False, 'organization-id': self.org['id']})
+        content_view = make_content_view({'composite': False, 'organization-id': module_org.id})
         ContentView.add_repository({'id': content_view['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': content_view['id']})
         content_view = ContentView.info({'id': content_view['id']})
-        lce = make_lifecycle_environment({'organization-id': self.org['id']})
         ContentView.version_promote(
             {'id': content_view['versions'][0]['id'], 'to-lifecycle-environment-id': lce['id']}
         )
@@ -1441,68 +1439,63 @@ class DockerClientTestCase(CLITestCase):
                 'registry-name-pattern': registry_name_pattern,
                 'registry-unauthenticated-pull': 'false',
                 'id': lce['id'],
-                'organization-id': self.org['id'],
+                'organization-id': module_org.id,
             }
         )
-        docker_repo_uri = "{}/{}-{}/{}".format(
-            settings.server.hostname, pattern_prefix, content_view['label'], docker_upstream_name
+        docker_repo_uri = (
+            f'{settings.server.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f'{docker_upstream_name}'
         ).lower()
 
         # 3. Try to pull in docker image from Satellite
         docker_pull_command = f'docker pull {docker_repo_uri}'
-        result = ssh.command(docker_pull_command, hostname=self.docker_host.ip_addr)
-        self.assertEqual(result.return_code, 1)
+        result = docker_host.execute(docker_pull_command)
+        assert result.status == 1
 
         # 4. Use Docker client to login to Satellite docker hub
-        result = ssh.command(
-            'docker login -u {} -p {} {}'.format(
-                settings.server.admin_username,
-                settings.server.admin_password,
-                settings.server.hostname,
-            ),
-            hostname=self.docker_host.ip_addr,
+        result = docker_host.execute(
+            f'docker login -u {settings.server.admin_username}'
+            f' -p {settings.server.admin_password} {settings.server.hostname}'
         )
-        self.assertEqual(result.return_code, 0)
+        assert result.status == 0
 
         # 5. Pull in docker image
         # publishing takes few seconds sometimes
         result, _ = wait_for(
-            lambda: ssh.command(docker_pull_command, hostname=self.docker_host.ip_addr),
+            lambda: docker_host.execute(docker_pull_command),
             num_sec=60,
             delay=2,
-            fail_condition=lambda out: out.return_code != 0,
-            logger=self.logger,
+            fail_condition=lambda out: out.status != 0,
+            logger=logger,
         )
-        self.assertEqual(result.return_code, 0)
+        assert result.status == 0
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = ssh.command(
-            f'docker logout {settings.server.hostname}', hostname=self.docker_host.ip_addr
-        )
-        self.assertEqual(result.return_code, 0)
+        result = docker_host.execute(f'docker logout {settings.server.hostname}')
+        assert result.status == 0
 
         # 7. Try to pull in docker image
-        result = ssh.command(docker_pull_command, hostname=self.docker_host.ip_addr)
-        self.assertEqual(result.return_code, 1)
+        result = docker_host.execute(docker_pull_command)
+        assert result.status == 1
 
-        # 8. Set "Unauthenticated Pull" option to true
+        # 8. Set 'Unauthenticated Pull' option to true
         LifecycleEnvironment.update(
             {
                 'registry-unauthenticated-pull': 'true',
                 'id': lce['id'],
-                'organization-id': self.org['id'],
+                'organization-id': module_org.id,
             }
         )
 
         # 9. Pull in docker image
-        result = ssh.command(docker_pull_command, hostname=self.docker_host.ip_addr)
-        self.assertEqual(result.return_code, 0)
+        result = docker_host.execute(docker_pull_command)
+        assert result.status == 0
 
     @pytest.mark.stubbed
     @skip_if_not_set('docker')
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_upload_image(self):
+    def test_positive_upload_image(self, module_org):
         """A Docker-enabled client can create a new ``Dockerfile``
         pointing to an existing Docker image from a Satellite 6 and modify it.
         Then, using ``docker build`` generate a new image which can then be
@@ -1531,54 +1524,50 @@ class DockerClientTestCase(CLITestCase):
             is eventually implemented
 
             compute_resource = make_compute_resource({
-                'organization-ids': [self.org['id']],
-                'provider': DOCKER_PROVIDER,
-                'url': 'http://{0}:2375'.format(self.docker_host.ip_addr),
+                'organization-ids': [module_org.id],
+                'provider': 'Docker',
+                'url': f'http://{docker_host.ip_addr}:2375',
             })
             container = make_container({
                 'compute-resource-id': compute_resource['id'],
-                'organization-ids': [self.org['id']],
+                'organization-ids': [module_org.id],
             })
             Docker.container.start({'id': container['id']})
             """
             container = {'uuid': 'stubbed test'}
             repo_name = gen_string('alphanumeric').lower()
-            # Commit a new docker image and verify image was created
-            result = ssh.command(
-                'docker commit {0} {1}/{2}:latest && '
-                'docker images --all | grep {1}/{2}'.format(
-                    container['uuid'], repo_name, REPO_UPSTREAM_NAME
-                ),
-                self.docker_host.ip_addr,
-            )
-            self.assertEqual(result.return_code, 0)
-            # Save the image to a tar archive
-            result = ssh.command(
-                'docker save -o {0}.tar {0}/{1}'.format(repo_name, REPO_UPSTREAM_NAME),
-                self.docker_host.ip_addr,
-            )
-            self.assertEqual(result.return_code, 0)
-            tar_file = f'{repo_name}.tar'
-            ssh.download_file(tar_file, hostname=self.docker_host.ip_addr)
 
+            # Commit a new docker image and verify image was created
+            image_name = f'{repo_name}/{DOCKER_UPSTREAM_NAME}'
+            result = docker_host.execute(
+                f'docker commit {container["uuid"]} {image_name}:latest && '
+                f'docker images --all | grep {image_name}'
+            )
+            assert result.status == 0
+
+            # Save the image to a tar archive
+            result = docker_host.execute(f'docker save -o {repo_name}.tar {image_name}')
+            assert result.status == 0
+
+            tar_file = f'{repo_name}.tar'
+            ssh.download_file(tar_file, hostname=docker_host.ip_addr)
             ssh.upload_file(
                 local_file=tar_file,
                 remote_file=f'/tmp/{tar_file}',
                 hostname=settings.server.hostname,
             )
+
             # Upload tarred repository
-            product = make_product_wait({'organization-id': self.org['id']})
-            repo = _make_docker_repo(product['id'])
+            product = make_product_wait({'organization-id': module_org.id})
+            repo = _repo(product['id'])
             Repository.upload_content({'id': repo['id'], 'path': f'/tmp/{repo_name}.tar'})
+
             # Verify repository was uploaded successfully
             repo = Repository.info({'id': repo['id']})
-            self.assertIn(settings.server.hostname, repo['published-at'])
-            self.assertIn(
-                '{}-{}-{}'.format(
-                    self.org['label'].lower(), product['label'].lower(), repo['label'].lower()
-                ),
-                repo['published-at'],
-            )
+            assert settings.server.hostname == repo['published-at']
+
+            repo_name = '-'.join((module_org.label, product['label'], repo['label'])).lower()
+            assert repo_name in repo['published-at']
         finally:
             # Remove the archive
             ssh.command(f'rm -f /tmp/{repo_name}.tar')


### PR DESCRIPTION
This PR converts the `test_docker` modules to pytest.

```
# pytest tests/foreman/api/test_docker.py
[...]
collected 59 items

tests/foreman/api/test_docker.py ....................................... [ 66%]
....................                                                     [100%]
[...]


# pytest tests/foreman/cli/test_docker.py
[...]
collected 65 items

tests/foreman/cli/test_docker.py ....................................... [ 60%]
.........................s                                               [100%]
[...]
```

I've also updated the `docker_host` fixture/method to use `broker` to provision a RHEL 7 vm and install `docker`. Installing the rpm requires access to the RHEL 7 optional and extras repositories, so those new settings have been added to `robottelo.properties.sample`.