### PR TITLE
Remove the rp client requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,9 +17,6 @@ pytest==6.2.2
 pytest-services==2.2.1
 pytest-mock==3.5.1
 pytest-reportportal==5.0.7
-# TODO remove rp-client requirement
-# https://github.com/reportportal/agent-python-pytest/pull/247
-reportportal-client==5.0.8
 pytest-xdist==2.2.1
 pytest-ibutsu==1.13
 PyYAML==5.4.1


### PR DESCRIPTION
it was not a direct requirement, and was to deal with some version
updates. It can now be removed, pytest-reportportal will pull in the
correct version