### PR TITLE
Fix xdist worker logging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,4 @@ exclude = '''
 
 [tool.pytest.ini_options]
 junit_logging = 'all'
+addopts = '--show-capture=no'


### PR DESCRIPTION
Validated against xdist and single worker session, logs are now correctly written, and capture all of the nailgun/airgun client logging.

Default show-capture=no, because everything is written to logs. This was causing absurdly verbose logging to the console at the end of the test session.