### PR TITLE
Add fixture to disable BFA

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,15 +10,15 @@ pytest_plugins = [
     "pytest_plugins.disable_rp_params",
     # Fixtures
     "pytest_fixtures.api_fixtures",
-    "pytest_fixtures.xdist",
     "pytest_fixtures.broker",
+    "pytest_fixtures.xdist",
     # Component Fixtures
-    "pytest_fixtures.satellite_auth",
-    "pytest_fixtures.sys_fixtures",
-    "pytest_fixtures.templatesync_fixtures",
     "pytest_fixtures.ansible_fixtures",
     "pytest_fixtures.oscap_fixtures",
+    "pytest_fixtures.satellite_auth",
+    "pytest_fixtures.sys_fixtures",
     "pytest_fixtures.smartproxy_fixtures",
+    "pytest_fixtures.templatesync_fixtures",
     "pytest_fixtures.user_fixtures",
     "pytest_fixtures.upgrade_fixtures",
 ]

--- a/pytest_fixtures/sys_fixtures.py
+++ b/pytest_fixtures/sys_fixtures.py
@@ -1,6 +1,8 @@
 import pytest
 
+from robottelo.config import settings
 from robottelo.rhsso_utils import run_command
+from robottelo.ssh import command as ssh_command
 
 
 @pytest.fixture
@@ -8,3 +10,16 @@ def foreman_service_teardown():
     """stop and restart of foreman service"""
     yield
     run_command('foreman-maintain service start --only=foreman')
+
+
+@pytest.fixture(autouse=True, scope="session")
+def relax_bfa():
+    """Relax BFA protection against failed login attempts
+
+    The robottelo.ssh.command should resolve the hostname for the current xdist worker
+    """
+    if settings.server.hostname:
+        ssh_command(
+            f'hammer -u admin -p {settings.server.admin_password} '
+            'settings set --name "failed_login_attempts_limit" --value 0'
+        )

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -109,7 +109,6 @@ def test_name(request):
 
         tests.foreman.ui.test_activationkey::test_positive_create
         tests.foreman.api.test_errata::TestErrata::test_positive_list
-
     """
     return request.node._nodeid
 


### PR DESCRIPTION
Remove unused test_name fixture as well.

This used to be done via automation_tools against test targets before robottelo was executed.

Its necessary for robottelo to run effectively, and should be accomplished within the test session.

The scope on this blew up, the more I dug, the more I saw that should be changed.