### PR TITLE
Remove xdist from collect-only in GHA

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -48,9 +48,9 @@ jobs:
 
       - name: Collect Tests
         run: |
-          pytest -n 8 --setup-plan --disable-pytest-warnings tests/foreman/ tests/robottelo/
-          pytest -n 8 --setup-plan --disable-pytest-warnings -m pre_upgrade tests/upgrades/
-          pytest -n 8 --setup-plan --disable-pytest-warnings -m post_upgrade tests/upgrades/
+          pytest --collect-only --disable-pytest-warnings tests/foreman/ tests/robottelo/
+          pytest --collect-only --disable-pytest-warnings -m pre_upgrade tests/upgrades/
+          pytest --collect-only --disable-pytest-warnings -m post_upgrade tests/upgrades/
 
       - name: Test Robottelo Coverage
         run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,9 +46,9 @@ jobs:
 
       - name: Collect Tests
         run: |
-          pytest -n 8 --setup-plan --disable-pytest-warnings tests/foreman/ tests/robottelo/
-          pytest -n 8 --setup-plan --disable-pytest-warnings -m pre_upgrade tests/upgrades/
-          pytest -n 8 --setup-plan --disable-pytest-warnings -m post_upgrade tests/upgrades/
+          pytest --collect-only --disable-pytest-warnings tests/foreman/ tests/robottelo/
+          pytest --collect-only --disable-pytest-warnings -m pre_upgrade tests/upgrades/
+          pytest --collect-only --disable-pytest-warnings -m post_upgrade tests/upgrades/
 
       - name: Test Robottelo Coverage
         run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo


### PR DESCRIPTION
Due to randomization of parameter values in robottelo, xdist collection
comparison sometimes fails.

This is causing GHA workflow failures on PRs that should otherwise pass,
causing maintainers to have to re-run workflows frequently