### PR TITLE
Ignore pytest-reportportal client errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,4 +18,5 @@ exclude = '''
 
 [tool.pytest.ini_options]
 junit_logging = 'all'
+rp_ignore_errors = 'True'
 addopts = '--show-capture=no'


### PR DESCRIPTION
https://github.com/reportportal/agent-python-pytest#troubleshooting

Mitigates connectivity issues of the RP server during a test session.
Currently any exceptions from pytest-reportportal result in an
INTERNALERROR that kills the session.