### PR TITLE
Remove unused ostree settings

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -277,10 +277,6 @@ ssh_key=
 # REQ_FILE=~/certs/server.csr
 # CA_BUNDLE_FILE=~/certs/rootCA.pem
 
-# Atomic Ostree Kickstart Installer
-# [ostree]
-# ostree_installer=OSTREE_INSTALLER
-
 # Section for performance tests parameters.
 # [performance]
 # Control whether or not to time on hammer commands in robottelo/cli/base.py

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -1009,25 +1009,6 @@ class OSPSettings(FeatureSettings):
         return validation_errors
 
 
-class OstreeSettings(FeatureSettings):
-    """Ostree settings definitions."""
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.ostree_installer = None
-
-    def read(self, reader):
-        """Read Ostree settings."""
-        self.ostree_installer = reader.get('ostree', 'ostree_installer')
-
-    def validate(self):
-        """Validate Ostree settings."""
-        validation_errors = []
-        if self.ostree_installer is None:
-            validation_errors.append('[ostree] ostree_installer option must be provided.')
-        return validation_errors
-
-
 class PerformanceSettings(FeatureSettings):
     """Performance settings definitions."""
 
@@ -1410,7 +1391,6 @@ class Settings:
         self.ipa = LDAPIPASettings()
         self.open_ldap = OpenLDAPSettings()
         self.oscap = OscapSettings()
-        self.ostree = OstreeSettings()
         self.osp = OSPSettings()
         self.performance = PerformanceSettings()
         self.rhev = RHEVSettings()

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -175,7 +175,6 @@ validators = dict(
             must_exist=True,
         )
     ],
-    ostree=[Validator("ostree.ostree_installer", must_exist=True)],
     performance=[
         Validator(
             "performance.cdn_address",


### PR DESCRIPTION
This PR is part of the conversion dynaconf. Because the `ostree` section of `robottelo.properties` is no longer used in any tests, this PR simply removes it instead of converting it.
