### PR TITLE
Dynaconf conversion for docker settings

### DIFF
--- a/conf/docker.yaml.template
+++ b/conf/docker.yaml.template
@@ -1,0 +1,11 @@
+DOCKER:
+  # External docker registry URL in the format http[s]://<server>[:<port>]
+  # EXTERNAL_REGISTRY_1:
+  # Private docker registry URL in the format http[s]://<server>[:<port>]
+  PRIVATE_REGISTRY_URL: https://registry.hub.docker.com
+  # Private docker registry name
+  # PRIVATE_REGISTRY_NAME: username/imagename
+  # Private docker registry username
+  # PRIVATE_REGISTRY_USERNAME:
+  # Private docker registry password
+  # PRIVATE_REGISTRY_PASSWORD:

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -458,7 +458,6 @@ class DockerSettings(FeatureSettings):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.docker_image = None
         self.external_registry_1 = None
         self.private_registry_url = None
         self.private_registry_name = None
@@ -467,7 +466,6 @@ class DockerSettings(FeatureSettings):
 
     def read(self, reader):
         """Read docker settings."""
-        self.docker_image = reader.get('docker', 'docker_image')
         self.external_registry_1 = reader.get('docker', 'external_registry_1')
         self.private_registry_url = reader.get('docker', 'private_registry_url')
         self.private_registry_name = reader.get('docker', 'private_registry_name')
@@ -477,8 +475,6 @@ class DockerSettings(FeatureSettings):
     def validate(self):
         """Validate docker settings."""
         validation_errors = []
-        if not self.docker_image:
-            validation_errors.append('[docker] docker_image option must be provided or enabled.')
         if not self.external_registry_1:
             validation_errors.append('[docker] external_registry_1 option must be provided.')
         return validation_errors

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -72,7 +72,16 @@ validators = dict(
             must_exist=True,
         )
     ],
-    docker=[Validator('docker.docker_image', 'docker.external_registry_1', must_exist=True)],
+    docker=[
+        Validator(
+            'docker.external_registry_1',
+            'docker.private_registry_url',
+            'docker.private_registry_name',
+            'docker.private_registry_username',
+            'docker.private_registry_password',
+            must_exist=True,
+        )
+    ],
     ec2=[
         Validator(
             'ec2.access_key',
@@ -210,6 +219,8 @@ validators = dict(
             'repos.rhel7_os',
             'repos.rhel8_os.baseos',
             'repos.rhel8_os.appstream',
+            'repos.rhel7_optional',
+            'repos.rhel7_extras',
             'repos.sattools_repo.rhel6',
             'repos.sattools_repo.rhel7',
             'repos.sattools_repo.rhel8',

--- a/robottelo/vm.py
+++ b/robottelo/vm.py
@@ -83,7 +83,6 @@ class VirtualMachine:
             DISTRO_RHEL8: settings.distro.image_el8,
             DISTRO_SLES11: settings.distro.image_sles11,
             DISTRO_SLES12: settings.distro.image_sles12,
-            'image_docker': settings.docker.docker_image,
         }
         self.cpu = cpu
         self.mac = None


### PR DESCRIPTION
This PR converts the `docker` section of `robottelo.properties` to `dynaconf` settings.

The `docker_image` setting has been removed, and new repo settings `settings.repos.rhel7_optional` and `settings.repos.rhel7_extras` have been added. With the recent pytest conversion, the `docker_host` fixture now installs the `docker` rpm on a rhel7 vm deployed with `broker`, instead of deploying the RHV snapshot previously stored in `docker_image`.