### PR TITLE
Markers to filter tests in new pipeline

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,8 @@
 pytest_plugins = [
     # Plugins
     'pytest_plugins.rerun_rp.rerun_rp',
+    'pytest_plugins.infra_dependent_markers',
+    'pytest_plugins.marker_deselection',
     'pytest_plugins.markers',
     'pytest_plugins.issue_handlers',
     'pytest_plugins.testimony_markers',

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -108,6 +108,7 @@ def module_domain(module_org, module_location):
     return entities.Domain(location=[module_location], organization=[module_org]).create()
 
 
+@pytest.mark.vlan_networking
 @pytest.fixture(scope='module')
 def module_subnet(module_org, module_location, default_domain, default_smart_proxy):
     network = settings.vlan_networking.subnet

--- a/pytest_fixtures/satellite_auth.py
+++ b/pytest_fixtures/satellite_auth.py
@@ -240,6 +240,7 @@ def enable_external_auth_rhsso(enroll_configure_rhsso_external_auth):
     set_the_redirect_uri()
 
 
+@pytest.mark.external_auth
 @pytest.fixture(scope='session')
 def enroll_idm_and_configure_external_auth():
     """Enroll the Satellite6 Server to an IDM Server."""
@@ -290,6 +291,7 @@ def rhsso_setting_setup_with_timeout(rhsso_setting_setup, request):
     setting_entity.update({'value'})
 
 
+@pytest.mark.external_auth
 @pytest.fixture(scope='session')
 def enroll_ad_and_configure_external_auth():
     """Enroll Satellite Server to an AD Server."""

--- a/pytest_plugins/infra_dependent_markers.py
+++ b/pytest_plugins/infra_dependent_markers.py
@@ -1,0 +1,14 @@
+# Custom infra dependent markers for selection and deselection of tests
+
+
+def pytest_configure(config):
+    """Register custom markers to avoid warnings."""
+    markers = [
+        "on_premises_provisioning: Tests that runs on on_premises Providers",
+        "libvirt_discovery: Tests depends on Libvirt Provider for discovery",
+        "libvirt_content_host: Tests depends on Libvirt Provider for content hosts",
+        "external_auth: External Authentication tests",
+        "vlan_networking: Tests depends on static predefined vlan networking etc",
+    ]
+    for marker in markers:
+        config.addinivalue_line("markers", marker)

--- a/pytest_plugins/marker_deselection.py
+++ b/pytest_plugins/marker_deselection.py
@@ -1,0 +1,62 @@
+import logging
+
+import pytest
+
+
+LOGGER = logging.getLogger('robottelo')
+
+
+def pytest_addoption(parser):
+    """Add options for pytest to collect tests than can run on SatLab infra"""
+    options = [
+        '--include-onprem-provisioning',
+        '--include-libvirt',
+        '--include-external-auth',
+        '--include-vlan-networking',
+    ]
+    for opt in options:
+        help_text = f'''Filter out tests depends on infra availability
+
+                        Usage: `pytest tests/foreman {opt}`
+                    '''
+        parser.addoption(opt, action='store_true', default=False, help=help_text)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items, config):
+    """
+    Collects and modifies tests collection based on pytest option to deselect tests for new infra
+    """
+    include_onprem_provision = config.getoption('include_onprem_provisioning', False)
+    include_libvirt = config.getoption('include_libvirt', False)
+    include_eauth = config.getoption('include_external_auth', False)
+    include_vlan = config.getoption('include_vlan_networking', False)
+    selected = []
+    deselected = []
+    # Cloud Provisioning Test can be run on new pipeline
+    for item in items:
+        item_marks = [m.name for m in item.iter_markers()]
+        # Include / Exclude On Premises Provisioning Tests
+        if 'on_premises_provisioning' in item_marks:
+            selected.append(item) if include_onprem_provision else deselected.append(item)
+            continue
+        # Include / Exclude External Libvirt based Tests
+        if any(marker in item_marks for marker in ['libvirt_discovery', 'libvirt_content_host']):
+            selected.append(item) if include_libvirt else deselected.append(item)
+            continue
+        # Include / Exclude External Auth based Tests
+        if 'external_auth' in item_marks:
+            selected.append(item) if include_eauth else deselected.append(item)
+            continue
+        # Include / Exclude VLAN networking based based Tests
+        if 'vlan_networking' in item_marks:
+            selected.append(item) if include_vlan else deselected.append(item)
+            continue
+        # This Plugin does not applies to this test
+        selected.append(item)
+    LOGGER.debug(
+        f'Selected {len(selected)} and deselected {len(deselected)} '
+        'tests based on new infra markers.'
+    )
+    items[:] = selected or items
+    config.hook.pytest_deselected(items=deselected)

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -28,6 +28,7 @@ from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import VALID_GCE_ZONES
 
+
 GCE_SETTINGS = dict(
     project_id=settings.gce.project_id,
     client_email=settings.gce.client_email,

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -34,6 +34,8 @@ from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.decorators import skip_if_not_set
 
+pytestmark = pytest.mark.on_premises_provisioning
+
 
 @pytest.fixture(scope="module")
 @skip_if_not_set('compute_resources')

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -184,6 +184,7 @@ class TestCapsuleContentManagement:
         proxy.download_policy = download_policy
         proxy.update(['download_policy'])
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_insights_puppet_package_availability(self, capsule_vm):
@@ -216,6 +217,7 @@ class TestCapsuleContentManagement:
             )
         assert result.return_code == 0
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_uploaded_content_library_sync(self, capsule_vm):
@@ -293,6 +295,7 @@ class TestCapsuleContentManagement:
         assert len(capsule_rpms) == 1
         assert capsule_rpms[0] == RPM_TO_UPLOAD
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_checksum_sync(self, capsule_vm):
@@ -419,6 +422,7 @@ class TestCapsuleContentManagement:
         assert result.return_code == 0
         assert len(result.stdout) > 0
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
@@ -617,6 +621,7 @@ class TestCapsuleContentManagement:
             cvv_repo_path
         )
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_iso_library_sync(self, capsule_vm):
@@ -687,6 +692,7 @@ class TestCapsuleContentManagement:
         assert len(result) > 0
         assert set(sat_isos) == set(capsule_isos)
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
@@ -816,6 +822,7 @@ class TestCapsuleContentManagement:
         # Assert checksums are matching
         assert package_md5 == published_package_md5
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_mirror_on_sync(self, capsule_vm):
@@ -957,6 +964,7 @@ class TestCapsuleContentManagement:
             assert result.return_code == 0
             assert package_name in result.stdout[0]
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_update_with_immediate_sync(self, request, capsule_vm):
@@ -1112,6 +1120,7 @@ class TestCapsuleContentManagement:
 
         assert len(broken_links) == 0
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
@@ -1233,6 +1242,7 @@ class TestCapsuleContentManagement:
         )
         assert next(matching_filenames, None)
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     @skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_capsule_pub_url_accessible(self, capsule_vm):

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -186,6 +186,7 @@ def _fetch_available_errata(module_org, host, expected_amount, timeout=120):
 
 
 @pytest.mark.upgrade
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_bulk_install_package(module_org, activation_key, custom_repo, rh_repo):
     """Bulk install package to a collection of hosts
@@ -218,6 +219,7 @@ def test_positive_bulk_install_package(module_org, activation_key, custom_repo, 
 
 
 @pytest.mark.upgrade
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_install_in_hc(module_org, activation_key, custom_repo, rh_repo):
     """Install errata in a host-collection
@@ -261,6 +263,7 @@ def test_positive_install_in_hc(module_org, activation_key, custom_repo, rh_repo
 
 
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 def test_positive_install_in_host(module_org, activation_key, custom_repo, rh_repo):
     """Install errata in a host
 
@@ -289,6 +292,7 @@ def test_positive_install_in_host(module_org, activation_key, custom_repo, rh_re
 
 
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 def test_positive_install_multiple_in_host(module_org, activation_key, custom_repo, rh_repo):
     """For a host with multiple applicable errata install one and ensure
     the rest of errata is still available
@@ -530,6 +534,7 @@ def test_positive_filter_by_envs(module_org):
 
 
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 def test_positive_get_count_for_host(module_org):
     """Available errata count when retrieving Host
 
@@ -606,6 +611,7 @@ def test_positive_get_count_for_host(module_org):
 
 
 @pytest.mark.upgrade
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_get_applicable_for_host(module_org):
     """Get applicable errata ids for a host
@@ -747,6 +753,7 @@ def test_positive_get_diff_for_cv_envs():
 
 
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 def test_positive_incremental_update_required(
     module_org, module_lce, activation_key, module_cv, custom_repo, rh_repo
 ):
@@ -857,6 +864,7 @@ def _validate_swid_tags_installed(module_org, vm, module_name):
 
 
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 def test_errata_installation_with_swidtags(module_org, module_lce, repos_collection):
     """Verify errata installation with swid_tags and swid tags get updated after

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -412,6 +412,7 @@ def test_positive_create_and_update_with_subnet(
 
 
 @pytest.mark.tier2
+@pytest.mark.on_premises_provisioning
 def test_positive_create_and_update_with_compresource(
     module_org, module_location, module_cr_libvirt
 ):
@@ -675,6 +676,7 @@ def test_positive_end_to_end_with_host_parameters(module_org, module_location):
 
 
 @pytest.mark.tier2
+@pytest.mark.on_premises_provisioning
 def test_positive_end_to_end_with_image(
     module_org, module_location, module_cr_libvirt, module_libvirt_image
 ):
@@ -706,6 +708,7 @@ def test_positive_end_to_end_with_image(
 
 
 @pytest.mark.tier1
+@pytest.mark.on_premises_provisioning
 @pytest.mark.parametrize('method', **parametrized(['build', 'image']))
 def test_positive_create_with_provision_method(
     method, module_org, module_location, module_cr_libvirt

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -396,6 +396,7 @@ def test_negative_create_with_invalid_name(module_org, name):
 
 
 @pytest.mark.tier1
+@pytest.mark.libvirt_content_host
 def test_positive_add_remove_subscription(
     module_org, module_lce, module_promoted_cv, module_ak_cv_lce
 ):

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -31,6 +31,7 @@ CAPSULE_TARGET_VERSION = '6.9.z'
 
 
 @pytest.mark.tier4
+@pytest.mark.libvirt_content_host
 def test_positive_run_capsule_upgrade_playbook():
     """Run Capsule Upgrade playbook against an External Capsule
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -224,6 +224,7 @@ class SubscriptionsTestCase(APITestCase):
         assert len(Subscription.list({'organization-id': org.id})) == 0
 
     @pytest.mark.tier2
+    @pytest.mark.libvirt_content_host
     @pytest.mark.usefixtures("golden_ticket_host_setup")
     def test_positive_subscription_status_disabled(self):
         """Verify that Content host Subscription status is set to 'Disabled'

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -591,6 +591,7 @@ def test_negative_update_usage_limit(module_org):
 @skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
+@pytest.mark.libvirt_content_host
 def test_positive_usage_limit(module_org):
     """Test that Usage limit actually limits usage
 
@@ -861,6 +862,7 @@ def test_positive_delete_subscription(module_manifest_org):
 @skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
+@pytest.mark.libvirt_content_host
 def test_positive_update_aks_to_chost(module_org):
     """Check if multiple Activation keys can be attached to a
     Content host
@@ -1571,6 +1573,7 @@ def test_positive_view_subscriptions_by_non_admin_user(module_manifest_org):
 
 @skip_if_not_set('clients')
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_subscription_quantity_attached(module_org):
     """Check the Quantity and Attached fields of 'hammer activation-key subscriptions'

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -49,6 +49,8 @@ from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import parametrized
 from robottelo.decorators import skip_if_not_set
 
+pytestmark = pytest.mark.libvirt_content_host
+
 
 def valid_name_desc_data():
     """Random data for valid name and description"""

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -25,6 +25,8 @@ from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.factory import make_os
 from robottelo.config import settings
 
+pytestmark = pytest.mark.on_premises_provisioning
+
 
 @pytest.fixture(scope='module')
 def rhev():

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -22,6 +22,8 @@ from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import VMWARE_CONSTANTS
 
+pytestmark = pytest.mark.on_premises_provisioning
+
 
 @pytest.fixture(scope='module')
 def vmware(module_org, module_location):

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -39,6 +39,7 @@ from robottelo.test import CLITestCase
 from robottelo.vm import VirtualMachine
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.run_in_one_thread
 class ContentAccessTestCase(CLITestCase):
     """Content Access CLI tests."""

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2707,6 +2707,7 @@ class TestContentView:
         assert content_view['content-host-count'] == '1'
 
     @pytest.mark.tier3
+    @pytest.mark.libvirt_content_host
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     def test_positive_sub_host_with_restricted_user_perm_at_custom_loc(self, module_org):
         """Attempt to subscribe a host with restricted user permissions and
@@ -2861,6 +2862,7 @@ class TestContentView:
             assert len(org_hosts) == 1
             assert org_hosts[0]['name'] == host_client.hostname
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     def test_positive_sub_host_with_restricted_user_perm_at_default_loc(self, module_org):
         """Attempt to subscribe a host with restricted user permissions and
@@ -3905,6 +3907,7 @@ class TestContentView:
 
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier3
+    @pytest.mark.libvirt_content_host
     @pytest.mark.upgrade
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     def test_positive_remove_cv_version_from_multi_env_capsule_scenario(self, module_org):

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -110,6 +110,7 @@ class DiscoveredTestCase(CLITestCase):
         Settings.set({'name': 'discovery_auto', 'value': cls.default_discovery_auto['value']})
         super().tearDownClass()
 
+    @pytest.mark.libvirt_discovery
     @pytest.mark.tier3
     def test_positive_pxe_based_discovery(self):
         """Discover a host via PXE boot by setting "proxy.type=proxy" in
@@ -133,6 +134,7 @@ class DiscoveredTestCase(CLITestCase):
             self.assertIsNotNone(host)
 
     @pytest.mark.tier3
+    @pytest.mark.libvirt_discovery
     @pytest.mark.upgrade
     def test_positive_provision_pxeless_bios_syslinux(self):
         """Provision and discover the pxe-less BIOS host from cli using SYSLINUX
@@ -208,6 +210,7 @@ class DiscoveredTestCase(CLITestCase):
                 DiscoveredHost.info({'id': discovered_host['id']})
 
     @pytest.mark.tier3
+    @pytest.mark.libvirt_discovery
     @pytest.mark.upgrade
     def test_positive_provision_pxe_host_with_bios_syslinux(self):
         """Provision the pxe-based BIOS discovered host from cli using SYSLINUX
@@ -348,6 +351,7 @@ class DiscoveredTestCase(CLITestCase):
         """
 
     @pytest.mark.tier3
+    @pytest.mark.libvirt_discovery
     def test_positive_delete(self):
         """Delete the selected discovered host
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -466,6 +466,7 @@ def test_positive_katello_and_openscap_loaded():
 
 @pytest.mark.host_create
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 def test_positive_register_with_no_ak(module_lce, module_org, module_promoted_cv):
     """Register host to satellite without activation key
@@ -486,6 +487,7 @@ def test_positive_register_with_no_ak(module_lce, module_org, module_promoted_cv
 
 
 @pytest.mark.host_create
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_negative_register_twice(module_ak_with_cv, module_org):
     """Attempt to register a host twice to Satellite
@@ -544,6 +546,7 @@ def test_positive_list_scparams(module_env_search, module_org, module_puppet_cla
 
 
 @pytest.mark.host_create
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_list(module_ak_with_cv, module_lce, module_org):
     """List hosts for a given org
@@ -564,6 +567,7 @@ def test_positive_list(module_ak_with_cv, module_lce, module_org):
 
 
 @pytest.mark.host_create
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_list_by_last_checkin(module_lce, module_org, module_promoted_cv):
     """List all content hosts using last checkin criteria
@@ -592,6 +596,7 @@ def test_positive_list_by_last_checkin(module_lce, module_org, module_promoted_c
 
 @pytest.mark.host_create
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 def test_positive_unregister(module_ak_with_cv, module_lce, module_org):
     """Unregister a host
@@ -619,6 +624,7 @@ def test_positive_unregister(module_ak_with_cv, module_lce, module_org):
 
 @skip_if_not_set('compute_resources')
 @pytest.mark.host_create
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier1
 def test_positive_create_using_libvirt_without_mac(
     module_location, module_org, module_default_proxy
@@ -1820,6 +1826,7 @@ class HostSubscription:
 
 # -------------------------- HOST SUBSCRIPTION SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.host_subscription
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_register(module_host_subscription, host_subscription_client):
     """Attempt to register a host

--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -60,6 +60,7 @@ class KatelloAgentTestCase(CLITestCase):
     activation_key = None
 
     @classmethod
+    @pytest.mark.libvirt_content_host
     @skip_if_not_set('clients', 'fake_manifest')
     def setUpClass(cls):
         """Create Org, Lifecycle Environment, Content View, Activation key"""
@@ -282,6 +283,7 @@ class KatelloAgentTestCase(CLITestCase):
         assert result.return_code != 0
 
     @pytest.mark.tier3
+    @pytest.mark.libvirt_content_host
     @pytest.mark.upgrade
     def test_positive_register_host_ak_with_host_collection(self):
         """Attempt to register a host using activation key with host collection

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -467,6 +467,7 @@ class TestRHSSOAuthSource:
 
         request.addfinalizer(rh_sso_hammer_auth_cleanup)
 
+    @pytest.mark.external_auth
     @pytest.mark.destructive
     def test_rhsso_login_using_hammer(
         self, enable_external_auth_rhsso, rhsso_setting_setup, rh_sso_hammer_auth_setup
@@ -505,6 +506,7 @@ class TestRHSSOAuthSource:
             ).list()
         assert 'Missing one of the required permissions' in error.value.message
 
+    @pytest.mark.external_auth
     @pytest.mark.destructive
     def test_rhsso_timeout_using_hammer(
         self,

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -284,6 +284,7 @@ def test_positive_add_and_remove_hostgroups(module_org):
 
 @skip_if_not_set('compute_resources')
 @pytest.mark.tier2
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 def test_positive_add_and_remove_compute_resources(module_org):
     """Add and remove a compute resource from organization

--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -20,6 +20,7 @@ import pytest
 
 
 @pytest.mark.stubbed
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 def test_rhel_pxe_provisioning_on_libvirt():
     """Provision RHEL system via PXE on libvirt and make sure it behaves

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -23,6 +23,7 @@ from robottelo.decorators import skip_if_not_set
 
 @pytest.mark.stubbed
 @pytest.mark.tier3
+@pytest.mark.on_premises_provisioning
 @pytest.mark.upgrade
 @skip_if_not_set('clients')
 def test_positive_puppet_scenario():
@@ -61,6 +62,7 @@ def test_positive_puppet_scenario():
 
 @pytest.mark.stubbed
 @pytest.mark.tier3
+@pytest.mark.on_premises_provisioning
 @pytest.mark.upgrade
 @skip_if_not_set('clients')
 def test_positive_puppet_capsule_scenario():

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -81,6 +81,7 @@ def fixture_vmsetup(request, fixture_org):
 class TestRemoteExecution:
     """Implements job execution tests in CLI."""
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     def test_positive_run_default_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Run default template on host connected by ip and list task
@@ -129,6 +130,7 @@ class TestRemoteExecution:
         search = Task.list_tasks({"search": 'id={}'.format(task["id"])})
         assert search[0]["action"] == task["action"]
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.skip_if_open('BZ:1804685')
     @pytest.mark.tier3
     def test_positive_run_job_effective_user_by_ip(self, fixture_vmsetup, fixture_org):
@@ -202,6 +204,7 @@ class TestRemoteExecution:
         # assert the file is owned by the effective user
         assert username == result.stdout[0]
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     def test_positive_run_custom_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Run custom template on host connected by ip
@@ -241,6 +244,7 @@ class TestRemoteExecution:
             )
             raise AssertionError(result)
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_run_default_job_template_multiple_hosts_by_ip(
@@ -298,6 +302,7 @@ class TestRemoteExecution:
                 )
             assert invocation_command['success'] == '2', output_msgs
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     def test_positive_install_multiple_packages_with_a_job_by_ip(
@@ -363,6 +368,7 @@ class TestRemoteExecution:
         result = ssh.command("rpm -q {}".format(" ".join(packages)), hostname=self.client.ip_addr)
         assert result.return_code == 0
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     def test_positive_run_recurring_job_with_max_iterations_by_ip(
         self, fixture_vmsetup, fixture_org
@@ -414,6 +420,7 @@ class TestRemoteExecution:
         assert rec_logic['state'] == 'finished'
         assert rec_logic['iteration'] == '2'
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     def test_positive_run_scheduled_job_template_by_ip(self, fixture_vmsetup, fixture_org):
         """Schedule a job to be ran against a host
@@ -523,6 +530,7 @@ class TestRemoteExecution:
 class TestAnsibleREX:
     """Test class for remote execution via Ansible"""
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_run_effective_user_job(self, fixture_vmsetup, fixture_org):
@@ -607,6 +615,7 @@ class TestAnsibleREX:
         # assert the file is owned by the effective user
         assert username == result.stdout[0], "file ownership mismatch"
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_run_reccuring_job(self, fixture_vmsetup, fixture_org):
@@ -666,6 +675,7 @@ class TestAnsibleREX:
         assert rec_logic['state'] == 'finished'
         assert rec_logic['iteration'] == '2'
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     @pytest.mark.upgrade
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -720,6 +720,7 @@ class ReportTemplateTestCase(CLITestCase):
 
         assert host['name'] in [item.split(',')[1] for item in report_data if len(item) > 0]
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     def test_positive_generate_entitlements_report_multiple_formats(self):
         """Generate an report using the Subscription - Entitlement Report template
@@ -780,6 +781,7 @@ class ReportTemplateTestCase(CLITestCase):
             # BZ 1830289
             assert 'Subscription Quantity' in result_csv[0]
 
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier3
     def test_positive_schedule_Entitlements_report(self):
         """Schedule an report using the Subscription - Entitlement Report template in csv format.

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -300,6 +300,7 @@ class SubscriptionTestCase(CLITestCase):
         """
 
     @pytest.mark.tier2
+    @pytest.mark.libvirt_content_host
     @pytest.mark.usefixtures("golden_ticket_host_setup")
     def test_positive_auto_attach_disabled_golden_ticket(self):
         """Verify that Auto-Attach is disabled or "Not Applicable"

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -56,6 +56,7 @@ def module_lce(module_org):
 
 
 @pytest.mark.tier4
+@pytest.mark.libvirt_content_host
 @pytest.mark.parametrize('value', **xdist_adapter(_distro_cdn_variants()))
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_vm_install_package(value, module_org, module_lce):

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1060,6 +1060,7 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
 
     @skip_if_not_set('compute_resources')
     @pytest.mark.tier4
+    @pytest.mark.on_premises_provisioning
     @pytest.mark.upgrade
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
     def test_positive_end_to_end(self):

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -103,6 +103,7 @@ def test_positive_cli_find_admin_user():
 
 @skip_if_not_set('compute_resources')
 @pytest.mark.tier4
+@pytest.mark.on_premises_provisioning
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_cli_end_to_end(fake_manifest_is_set):

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -46,6 +46,7 @@ from robottelo.test import TestCase
 from robottelo.vm import VirtualMachine
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.run_in_one_thread
 class IncrementalUpdateTestCase(TestCase):
     """Tests for the Incremental Update feature"""

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -166,6 +166,7 @@ class OpenScapTestCase(CLITestCase):
         }
 
     @pytest.mark.tier4
+    @pytest.mark.libvirt_content_host
     @pytest.mark.upgrade
     def test_positive_upload_to_satellite(self):
         """Perform end to end oscap test, and push the updated scap content via puppet
@@ -349,6 +350,7 @@ class OpenScapTestCase(CLITestCase):
                 assert result is not None
 
     @pytest.mark.upgrade
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     def test_positive_oscap_run_with_tailoring_file_and_capsule(self):
         """End-to-End Oscap run with tailoring files and default capsule via puppet
@@ -461,6 +463,7 @@ class OpenScapTestCase(CLITestCase):
             assert result is not None
 
     @pytest.mark.upgrade
+    @pytest.mark.libvirt_content_host
     @pytest.mark.tier4
     def test_positive_oscap_run_with_tailoring_file_with_ansible(self):
         """End-to-End Oscap run with tailoring files via ansible

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -128,6 +128,8 @@ def tear_down(provisioning):
         Host.delete({'id': host['id']})
 
 
+@pytest.mark.on_premises_provisioning
+@pytest.mark.vlan_networking
 @pytest.mark.tier3
 def test_positive_provision_rhev_with_host_group(rhev, provisioning, tear_down):
     """Provision a host on RHEV compute resource with
@@ -205,6 +207,8 @@ def test_positive_provision_rhev_with_host_group(rhev, provisioning, tear_down):
     host_provisioning_check(ip_addr=host_ip)
 
 
+@pytest.mark.on_premises_provisioning
+@pytest.mark.vlan_networking
 @pytest.mark.tier3
 def test_positive_provision_vmware_with_host_group(vmware, provisioning, tear_down, vmware_cr):
     """Provision a host on vmware compute resource with
@@ -278,6 +282,8 @@ def test_positive_provision_vmware_with_host_group(vmware, provisioning, tear_do
     host_provisioning_check(ip_addr=host_ip)
 
 
+@pytest.mark.on_premises_provisioning
+@pytest.mark.vlan_networking
 @pytest.mark.tier3
 def test_positive_provision_vmware_with_host_group_bootdisk(
     vmware, provisioning, tear_down, vmware_cr

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -37,6 +37,7 @@ NAV_ITEMS = [
 ]
 
 
+@pytest.mark.libvirt_content_host
 def test_positive_register_client_to_insights(vm, autosession):
     """Verify registration via insights-client.
 
@@ -88,6 +89,7 @@ def test_positive_register_client_with_template():
     pass
 
 
+@pytest.mark.libvirt_content_host
 def test_positive_unregister_client_from_insights(vm, autosession):
     """Verify unregistration via insights-client.
 
@@ -498,6 +500,7 @@ def test_positive_inventory_group_systems():
     pass
 
 
+@pytest.mark.libvirt_content_host
 def test_numeric_group(vm, autosession):
     """Check the rule appears when provoked and disappears on Satellite once applied.
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -95,6 +95,7 @@ def test_positive_end_to_end_crud(session, module_org):
 
 
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 def test_positive_end_to_end_register(session):
     """Create activation key and use it during content host registering
@@ -864,6 +865,7 @@ def test_positive_add_docker_repo_ccv(session, module_org):
 
 @skip_if_not_set('clients')
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 def test_positive_add_host(session, module_org):
     """Test that hosts can be associated to Activation Keys
 
@@ -896,6 +898,7 @@ def test_positive_add_host(session, module_org):
 
 
 @skip_if_not_set('clients')
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_delete_with_system(session):
     """Delete an Activation key which has registered systems
@@ -935,6 +938,7 @@ def test_positive_delete_with_system(session):
 
 
 @skip_if_not_set('clients')
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_negative_usage_limit(session, module_org):
     """Test that Usage limit actually limits usage
@@ -974,6 +978,7 @@ def test_negative_usage_limit(session, module_org):
 
 @skip_if_not_set('clients')
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_add_multiple_aks_to_system(session, module_org):
@@ -1030,6 +1035,7 @@ def test_positive_add_multiple_aks_to_system(session, module_org):
 
 @skip_if_not_set('clients')
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_host_associations(session):
@@ -1072,6 +1078,7 @@ def test_positive_host_associations(session):
 
 @skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_service_level_subscription_with_custom_product(session):
     """Subscribe a host to activation key with Premium service level and with

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -73,6 +73,7 @@ def module_loc():
     return entities.Location().create()
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 @pytest.mark.parametrize('version', [True, False])
 def test_positive_end_to_end(session, rhev_data, module_org, module_loc, module_ca_cert, version):
@@ -121,6 +122,7 @@ def test_positive_end_to_end(session, rhev_data, module_org, module_loc, module_
         assert not session.computeresource.search(new_name)
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 @pytest.mark.parametrize('version', [True, False])
 def test_positive_add_resource(session, module_ca_cert, rhev_data, version):
@@ -159,6 +161,7 @@ def test_positive_add_resource(session, module_ca_cert, rhev_data, version):
         assert resource_values['provider_content']['api4'] == version
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 @pytest.mark.parametrize('version', [True, False])
 def test_positive_edit_resource_description(session, module_ca_cert, rhev_data, version):
@@ -196,6 +199,7 @@ def test_positive_edit_resource_description(session, module_ca_cert, rhev_data, 
         assert resource_values['description'] == new_description
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 @pytest.mark.parametrize('version', [True, False])
 def test_positive_list_resource_vms(session, module_ca_cert, rhev_data, version):
@@ -227,6 +231,7 @@ def test_positive_list_resource_vms(session, module_ca_cert, rhev_data, version)
         assert vm['Name'].read() == rhev_data['vm_name']
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_edit_resource_version(session, module_ca_cert, rhev_data):
     """Edit RHEV Compute Resource with another protocol version
@@ -259,6 +264,7 @@ def test_positive_edit_resource_version(session, module_ca_cert, rhev_data):
         assert resource_values['provider_content']['api4']
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 @pytest.mark.parametrize('version', [True, False])
 @pytest.mark.run_in_one_thread
@@ -307,6 +313,7 @@ def test_positive_resource_vm_power_management(session, module_ca_cert, rhev_dat
         assert session.computeresource.vm_status(name, rhev_data['vm_name']) is not status
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 @pytest.mark.parametrize('version', [True, False])
 def test_positive_VM_import(session, module_ca_cert, module_org, module_loc, rhev_data, version):
@@ -393,6 +400,7 @@ def test_positive_VM_import(session, module_ca_cert, module_org, module_loc, rhe
     entities.Host(name=rhev_data['vm_name']).search()[0].delete()
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 @pytest.mark.parametrize('version', [True, False])
 def test_positive_update_organization(session, rhev_data, module_loc, module_ca_cert, version):
@@ -443,6 +451,7 @@ def test_positive_update_organization(session, rhev_data, module_loc, module_ca_
         assert new_organization.name in resource_values['organizations']['resources']['assigned']
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_image_end_to_end(session, rhev_data, module_loc, module_ca_cert):
     """Perform end to end testing for compute resource RHV component image.
@@ -504,6 +513,7 @@ def test_positive_image_end_to_end(session, rhev_data, module_loc, module_ca_cer
         )
 
 
+@pytest.mark.on_premises_provisioning
 @skip_if_not_set('vlan_networking')
 @pytest.mark.tier2
 def test_positive_associate_with_custom_profile(session, rhev_data, module_ca_cert):
@@ -590,6 +600,7 @@ def test_positive_associate_with_custom_profile(session, rhev_data, module_ca_ce
                 assert provided_value == expected_value
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 def test_positive_associate_with_custom_profile_with_template(session, rhev_data, module_ca_cert):
     """Associate custom default (3-Large) compute profile to rhev compute

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -39,6 +39,7 @@ def module_libvirt_url():
     return LIBVIRT_RESOURCE_URL % settings.compute_resources.libvirt_hostname
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_loc, module_libvirt_url):
     """Perform end to end testing for compute resource Libvirt component.

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -105,6 +105,7 @@ def module_vmware_settings():
     )
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier1
 def test_positive_end_to_end(session, module_org, module_loc, module_vmware_settings):
     """Perform end to end testing for compute resource VMware component.
@@ -181,6 +182,7 @@ def test_positive_end_to_end(session, module_org, module_loc, module_vmware_sett
         assert not session.computeresource.search(new_cr_name)
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_retrieve_virtual_machine_list(session, module_vmware_settings):
     """List the virtual machine list from vmware compute resource
@@ -217,6 +219,7 @@ def test_positive_retrieve_virtual_machine_list(session, module_vmware_settings)
         )
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_image_end_to_end(session, module_vmware_settings):
     """Perform end to end testing for compute resource VMware component image.
@@ -276,6 +279,7 @@ def test_positive_image_end_to_end(session, module_vmware_settings):
         )
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 @pytest.mark.run_in_one_thread
 def test_positive_resource_vm_power_management(session, module_vmware_settings):
@@ -311,6 +315,7 @@ def test_positive_resource_vm_power_management(session, module_vmware_settings):
             assert session.computeresource.vm_status(cr_name, vm_name) is power_status
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_select_vmware_custom_profile_guest_os_rhel7(session, module_vmware_settings):
     """Select custom default (3-Large) compute profile guest OS RHEL7.
@@ -357,6 +362,7 @@ def test_positive_select_vmware_custom_profile_guest_os_rhel7(session, module_vm
         assert values['provider_content']['guest_os'] == guest_os_name
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_access_vmware_with_custom_profile(session, module_vmware_settings):
     """Associate custom default (3-Large) compute profile

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -141,6 +141,7 @@ def set_ignore_facts_for_os(value=False):
 def run_remote_command_on_content_host(command, vm_module_streams):
     result = vm_module_streams.run(command)
     assert result.return_code == 0
+    return result
 
 
 def line_count(file, connection=None):
@@ -169,6 +170,7 @@ def module_host_template(module_org, module_loc):
     return host_template
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_end_to_end(session, repos_collection, vm):
     """Create all entities required for content host, set up host, register it
@@ -242,6 +244,7 @@ def test_positive_end_to_end(session, repos_collection, vm):
         assert not session.contenthost.search(vm.hostname)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_positive_end_to_end_bulk_update(session, vm):
@@ -298,6 +301,7 @@ def test_positive_end_to_end_bulk_update(session, vm):
         session.contenthost.delete(vm.hostname)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_search_by_subscription_status(session, vm):
     """Register host into the system and search for it afterwards by
@@ -331,6 +335,7 @@ def test_positive_search_by_subscription_status(session, vm):
         assert values['table'][0]['Name'] == vm.hostname
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_negative_install_package(session, vm):
     """Attempt to install non-existent package to a host remotely
@@ -352,6 +357,7 @@ def test_negative_install_package(session, vm):
         assert result['result'] == 'warning'
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_remove_package(session, vm):
@@ -373,6 +379,7 @@ def test_positive_remove_package(session, vm):
         assert not packages
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_upgrade_package(session, vm):
     """Upgrade a host package remotely
@@ -393,6 +400,7 @@ def test_positive_upgrade_package(session, vm):
         assert packages[0]['Installed Package'] == FAKE_2_CUSTOM_PACKAGE
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_package_group(session, vm):
@@ -414,6 +422,7 @@ def test_positive_install_package_group(session, vm):
             assert packages[0]['Installed Package'] == package
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_remove_package_group(session, vm):
     """Remove a package group from a host remotely
@@ -434,6 +443,7 @@ def test_positive_remove_package_group(session, vm):
             assert not session.contenthost.search_package(vm.hostname, package)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_actions_katello_host_package_update_timeout(session, vm):
     """Check that Actions::Katello::Host::Package::Update task will time
@@ -495,6 +505,7 @@ def test_actions_katello_host_package_update_timeout(session, vm):
     assert error_line_found, "The expected time out error was not found in logs."
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_search_errata_non_admin(session, vm, module_org, test_name, default_viewer_role):
     """Search for host's errata by non-admin user with enough permissions
@@ -518,6 +529,7 @@ def test_positive_search_errata_non_admin(session, vm, module_org, test_name, de
         assert FAKE_2_ERRATA_ID in {errata['Id'] for errata in chost['errata']['table']}
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_ensure_errata_applicability_with_host_reregistered(session, vm):
@@ -559,6 +571,7 @@ def test_positive_ensure_errata_applicability_with_host_reregistered(session, vm
         assert FAKE_2_ERRATA_ID in {errata['Id'] for errata in chost['errata']['table']}
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_host_re_registion_with_host_rename(session, module_org, repos_collection, vm):
     """Ensure that content host should get re-registered after change in the hostname
@@ -597,6 +610,7 @@ def test_positive_host_re_registion_with_host_rename(session, module_org, repos_
         assert session.contenthost.search(updated_hostname)[0]['Name'] == updated_hostname
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 @pytest.mark.upgrade
@@ -673,6 +687,7 @@ def test_positive_check_ignore_facts_os_setting(session, vm, module_org, request
 
 @skip_if_not_set('clients', 'fake_manifest', 'compute_resources')
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 def test_positive_virt_who_hypervisor_subscription_status(session):
     """Check that virt-who hypervisor shows the right subscription status
@@ -746,6 +761,7 @@ def test_positive_virt_who_hypervisor_subscription_status(session):
             assert chost['details']['subscription_status'] == 'Fully entitled'
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_module_stream_actions_on_content_host(session, vm_module_streams):
@@ -850,6 +866,7 @@ def test_module_stream_actions_on_content_host(session, vm_module_streams):
         assert module_stream[0]['Status'] == ""
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_module_streams_customize_action(session, vm_module_streams):
     """Check remote execution for customized module action is working on content host.
@@ -899,6 +916,7 @@ def test_module_streams_customize_action(session, vm_module_streams):
         assert module_stream[0]['Stream'] == install_stream_version
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_install_modular_errata(session, vm_module_streams):
@@ -964,6 +982,7 @@ def test_install_modular_errata(session, vm_module_streams):
         assert module_stream[0]['Name'] == module_name
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_module_status_update_from_content_host_to_satellite(session, vm_module_streams):
     """Verify dnf upload-profile updates the module stream status to Satellite.
@@ -1012,6 +1031,7 @@ def test_module_status_update_from_content_host_to_satellite(session, vm_module_
         )
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_module_status_update_without_force_upload_package_profile(session, vm, vm_module_streams):
     """Verify you do not have to run dnf upload-profile or restart rhsmcertd
@@ -1074,6 +1094,7 @@ def test_module_status_update_without_force_upload_package_profile(session, vm, 
         )
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_module_stream_update_from_satellite(session, vm_module_streams):
@@ -1134,6 +1155,7 @@ def test_module_stream_update_from_satellite(session, vm_module_streams):
         )
 
 
+@pytest.mark.libvirt_content_host
 @skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_syspurpose_attributes_empty(session, vm_module_streams):
@@ -1159,6 +1181,7 @@ def test_syspurpose_attributes_empty(session, vm_module_streams):
             assert details[spname] == ''
 
 
+@pytest.mark.libvirt_content_host
 @skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_set_syspurpose_attributes_cli(session, vm_module_streams):
@@ -1187,6 +1210,7 @@ def test_set_syspurpose_attributes_cli(session, vm_module_streams):
             assert details[spname] == spdata[1]
 
 
+@pytest.mark.libvirt_content_host
 @skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_unset_syspurpose_attributes_cli(session, vm_module_streams):
@@ -1221,6 +1245,7 @@ def test_unset_syspurpose_attributes_cli(session, vm_module_streams):
             assert details[spname] == ''
 
 
+@pytest.mark.libvirt_content_host
 @skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_syspurpose_matched(session, vm_module_streams):
@@ -1246,6 +1271,7 @@ def test_syspurpose_matched(session, vm_module_streams):
         assert details['system_purpose_status'] == "Matched"
 
 
+@pytest.mark.libvirt_content_host
 @skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_syspurpose_bulk_action(session, vm):
@@ -1276,6 +1302,7 @@ def test_syspurpose_bulk_action(session, vm):
             assert val in result.stdout
 
 
+@pytest.mark.libvirt_content_host
 @skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_syspurpose_mismatched(session, vm_module_streams):
@@ -1388,6 +1415,7 @@ def test_search_for_virt_who_hypervisors(session):
         assert hypervisor_display_name not in content_hosts
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.destructive
 @pytest.mark.run_in_one_thread
 @pytest.mark.upgrade

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2808,6 +2808,7 @@ def test_positive_publish_promote_with_custom_puppet_module(session, module_org)
 
 
 @pytest.mark.upgrade
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier2
 def test_positive_subscribe_system_with_custom_content(session):
     """Attempt to subscribe a host to content view with custom repository
@@ -2840,6 +2841,7 @@ def test_positive_subscribe_system_with_custom_content(session):
 
 @pytest.mark.upgrade
 @pytest.mark.tier3
+@pytest.mark.libvirt_content_host
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_subscribe_system_with_puppet_modules(session):
     """Attempt to subscribe a host to content view with puppet modules

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -190,6 +190,7 @@ def test_positive_task_status(session):
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @skip_if_not_set('clients')
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_user_access_with_host_filter(test_name, module_loc):

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -112,6 +112,8 @@ def _is_host_reachable(host, retries=12, iteration_sleep=5, expect_reachable=Tru
 
 @skip_if_not_set('compute_resources', 'vlan_networking')
 @pytest.mark.tier3
+@pytest.mark.vlan_networking
+@pytest.mark.libvirt_discovery
 @pytest.mark.upgrade
 def test_positive_pxe_based_discovery(session, provisioning_env):
     """Discover a host via PXE boot by setting "proxy.type=proxy" in
@@ -138,6 +140,8 @@ def test_positive_pxe_based_discovery(session, provisioning_env):
 
 @skip_if_not_set('compute_resources', 'discovery', 'vlan_networking')
 @pytest.mark.tier3
+@pytest.mark.vlan_networking
+@pytest.mark.libvirt_discovery
 @pytest.mark.upgrade
 def test_positive_pxe_less_with_dhcp_unattended(session, provisioning_env):
     """Discover a host with dhcp via bootable discovery ISO by setting
@@ -339,6 +343,8 @@ def test_positive_update_default_taxonomies(session, module_org, module_loc):
 
 
 @skip_if_not_set('compute_resources', 'vlan_networking')
+@pytest.mark.libvirt_discovery
+@pytest.mark.vlan_networking
 @pytest.mark.tier3
 def test_positive_reboot(session, provisioning_env):
     """Reboot a discovered host.

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -196,6 +196,7 @@ def errata_status_installable():
     _set_setting_value(errata_status_installable, original_value)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_end_to_end(session, module_repos_col, vm):
     """Create all entities required for errata, set up applicable host,
@@ -545,6 +546,7 @@ def test_positive_filter_by_environment(session, module_org, module_repos_col):
             )
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_content_host_previous_env(session, module_org, module_repos_col, vm):
@@ -589,6 +591,7 @@ def test_positive_content_host_previous_env(session, module_org, module_repos_co
         assert content_host_erratum[0]['Id'] == CUSTOM_REPO_ERRATA_ID
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_content_host_library(session, module_org, vm):
     """Check if the applicable errata are available from the content
@@ -616,6 +619,7 @@ def test_positive_content_host_library(session, module_org, vm):
         assert content_host_erratum[0]['Id'] == CUSTOM_REPO_ERRATA_ID
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_content_host_search_type(session, erratatype_vm):
     """Search for errata on a content host's errata tab by type.
@@ -673,6 +677,7 @@ def test_positive_content_host_search_type(session, erratatype_vm):
         assert errata_ids == sorted(FAKE_11_YUM_ENHANCEMENT_ERRATUM)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.skip_if_open("BZ:1655130")
 @pytest.mark.tier3
 def test_positive_content_host_errata_details(session, erratatype_vm, module_org, test_name):
@@ -718,6 +723,7 @@ def test_positive_content_host_errata_details(session, erratatype_vm, module_org
         assert erratum_details['type'] == 'security'
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_show_count_on_content_host_page(session, module_org, rhva_vm):
     """Available errata count displayed in Content hosts page
@@ -756,6 +762,7 @@ def test_positive_show_count_on_content_host_page(session, module_org, rhva_vm):
             assert int(installable_errata[errata_type]) == 1
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_show_count_on_content_host_details_page(session, module_org, rhva_vm):
     """Errata count on Content host Details page
@@ -793,6 +800,7 @@ def test_positive_show_count_on_content_host_details_page(session, module_org, r
             assert int(content_host_values['details'][errata_type]) == 1
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
@@ -887,6 +895,7 @@ def test_positive_filtered_errata_status_installable_param(session, errata_statu
                 assert expected_values[key] in actual_values[key], 'Expected text not found'
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_content_host_errata_search_commands(session, module_org, module_repos_col):
     """View a list of affected content hosts for security (RHSA) and bugfix (RHBA) errata,

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1634,6 +1634,7 @@ def test_positive_bulk_delete_host(session, module_loc):
         assert not values['table']
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier4
 def test_positive_provision_end_to_end(
     session,
@@ -1690,6 +1691,7 @@ def test_positive_provision_end_to_end(
         )
 
 
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier4
 def test_positive_delete_libvirt(
     session,

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -379,6 +379,7 @@ def test_positive_add_host(session):
         assert hc_values['hosts']['resources']['assigned'][0]['Name'] == host.name
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_package(session, module_org, vm_content_hosts, vm_host_collection):
@@ -399,6 +400,7 @@ def test_positive_install_package(session, module_org, vm_content_hosts, vm_host
         assert _is_package_installed(vm_content_hosts, FAKE_0_CUSTOM_PACKAGE_NAME)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_remove_package(session, module_org, vm_content_hosts, vm_host_collection):
@@ -422,6 +424,7 @@ def test_positive_remove_package(session, module_org, vm_content_hosts, vm_host_
         )
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_upgrade_package(session, module_org, vm_content_hosts, vm_host_collection):
     """Upgrade a package on hosts inside host collection remotely
@@ -442,6 +445,7 @@ def test_positive_upgrade_package(session, module_org, vm_content_hosts, vm_host
         assert _is_package_installed(vm_content_hosts, FAKE_2_CUSTOM_PACKAGE)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_package_group(session, module_org, vm_content_hosts, vm_host_collection):
@@ -466,6 +470,7 @@ def test_positive_install_package_group(session, module_org, vm_content_hosts, v
             assert _is_package_installed(vm_content_hosts, package)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_remove_package_group(session, module_org, vm_content_hosts, vm_host_collection):
     """Remove a package group from hosts inside host collection remotely
@@ -494,6 +499,7 @@ def test_positive_remove_package_group(session, module_org, vm_content_hosts, vm
             assert not _is_package_installed(vm_content_hosts, package, expect_installed=False)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_errata(session, module_org, vm_content_hosts, vm_host_collection):
@@ -516,6 +522,7 @@ def test_positive_install_errata(session, module_org, vm_content_hosts, vm_host_
         assert _is_package_installed(vm_content_hosts, FAKE_2_CUSTOM_PACKAGE)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_change_assigned_content(
     session, module_org, module_lce, vm_content_hosts, vm_host_collection, module_repos_collection
@@ -663,6 +670,7 @@ def test_negative_hosts_limit(session, module_org, module_loc):
         ) in str(context.value)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_module_stream(
@@ -700,6 +708,7 @@ def test_positive_install_module_stream(
         assert _is_package_installed(vm_content_hosts_module_stream, FAKE_3_CUSTOM_PACKAGE)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_modular_errata(

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -77,6 +77,7 @@ def module_vm_client_by_ip(module_org, module_loc):
         yield vm_client
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier4
 def test_positive_run_default_job_template_by_ip(session, module_org, module_vm_client_by_ip):
     """Run a job template on a host connected by ip
@@ -113,6 +114,7 @@ def test_positive_run_default_job_template_by_ip(session, module_org, module_vm_
         assert status['overview']['hosts_table'][0]['Status'] == 'success'
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier4
 def test_positive_run_custom_job_template_by_ip(session, module_org, module_vm_client_by_ip):
     """Run a job template on a host connected by ip

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1032,6 +1032,7 @@ def test_single_sign_on_using_rhsso(rhsso_setting_setup, session):
         assert settings.rhsso.rhsso_user in actual_user
 
 
+@pytest.mark.external_auth
 @pytest.mark.destructive
 def test_external_logout_rhsso(enable_external_auth_rhsso, rhsso_setting_setup, session):
     """Verify the external logout page navigation with external authentication RH-SSO
@@ -1060,6 +1061,7 @@ def test_external_logout_rhsso(enable_external_auth_rhsso, rhsso_setting_setup, 
         assert settings.rhsso.rhsso_user in actual_user
 
 
+@pytest.mark.external_auth
 @pytest.mark.destructive
 def test_session_expire_rhsso_idle_timeout(
     enable_external_auth_rhsso, rhsso_setting_setup_with_timeout, session
@@ -1085,6 +1087,7 @@ def test_session_expire_rhsso_idle_timeout(
         assert error.typename == "NavigationTriesExceeded"
 
 
+@pytest.mark.external_auth
 @pytest.mark.destructive
 def test_external_new_user_login_and_check_count_rhsso(
     enable_external_auth_rhsso, external_user_count, rhsso_setting_setup, session
@@ -1126,6 +1129,7 @@ def test_external_new_user_login_and_check_count_rhsso(
         assert error.typename == "NavigationTriesExceeded"
 
 
+@pytest.mark.external_auth
 @pytest.mark.skip_if_open("BZ:1873439")
 @pytest.mark.destructive
 def test_login_failure_rhsso_user_if_internal_user_exist(
@@ -1168,6 +1172,7 @@ def test_login_failure_rhsso_user_if_internal_user_exist(
         assert error.typename == "NavigationTriesExceeded"
 
 
+@pytest.mark.external_auth
 @pytest.mark.destructive
 def test_user_permissions_rhsso_user_after_group_delete(
     enable_external_auth_rhsso,
@@ -1232,6 +1237,7 @@ def test_user_permissions_rhsso_user_after_group_delete(
         assert error.typename == "NavigationTriesExceeded"
 
 
+@pytest.mark.external_auth
 @pytest.mark.destructive
 def test_user_permissions_rhsso_user_multiple_group(
     enable_external_auth_rhsso,

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -203,6 +203,7 @@ def test_positive_add_org_hostgroup_template(session):
 
 
 @skip_if_not_set('compute_resources')
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_update_compresource(session):
     """Add/Remove compute resource from/to location

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -207,6 +207,7 @@ def test_positive_create_with_all_users(session):
 
 
 @skip_if_not_set('compute_resources')
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_update_compresource(session):
     """Add/Remove compute resource from/to organization.

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -80,6 +80,7 @@ def module_vm_client_by_ip(module_org, module_loc):
         yield vm_client
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_run_default_job_template_by_ip(session, module_vm_client_by_ip):
     """Run a job template against a single host by ip
@@ -117,6 +118,7 @@ def test_positive_run_default_job_template_by_ip(session, module_vm_client_by_ip
         assert job_status['overview']['hosts_table'][0]['Status'] == 'success'
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_run_custom_job_template_by_ip(session, module_vm_client_by_ip):
     """Run a job template on a host connected by ip
@@ -166,6 +168,7 @@ def test_positive_run_custom_job_template_by_ip(session, module_vm_client_by_ip)
 
 
 @pytest.mark.upgrade
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_run_job_template_multiple_hosts_by_ip(session, module_org, module_loc):
     """Run a job template against multiple hosts by ip
@@ -218,6 +221,7 @@ def test_positive_run_job_template_multiple_hosts_by_ip(session, module_org, mod
             )
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_run_scheduled_job_template_by_ip(session, module_vm_client_by_ip):
     """Schedule a job to be ran against a host by ip

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -490,6 +490,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
     """
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_gen_entitlements_reports_multiple_formats(session, setup_content, module_org):
     """Generate reports using the Entitlements template in html, yaml, json, and csv format.

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -118,12 +118,14 @@ def organization_ak_setup(module_org):
     return module_org, ak
 
 
+@pytest.mark.libvirt_content_host
 @pytest.fixture(scope="module")
 def virtual_host():
     with VirtualMachine(distro=DISTRO_RHEL7) as vm:
         yield vm
 
 
+@pytest.mark.libvirt_content_host
 @pytest.fixture(scope="module")
 def baremetal_host():
     with VirtualMachine(distro=DISTRO_RHEL7) as vm:

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -257,6 +257,7 @@ def test_positive_access_manifest_as_another_admin_user(test_name):
         assert not session.subscription.has_manifest
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_view_vdc_subscription_products(session):
     """Ensure that Virtual Datacenters subscription provided products is
@@ -319,6 +320,7 @@ def test_positive_view_vdc_subscription_products(session):
 
 
 @skip_if_not_set('compute_resources')
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_view_vdc_guest_subscription_products(session):
     """Ensure that Virtual Data Centers guest subscription Provided
@@ -455,6 +457,7 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(session):
         assert set(col[1:]) == set(checkbox_dict)
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_subscription_status_disabled_golden_ticket(session, golden_ticket_host_setup):
     """Verify that Content host Subscription status is set to 'Disabled'
@@ -481,6 +484,7 @@ def test_positive_subscription_status_disabled_golden_ticket(session, golden_tic
             assert "Disabled" in host
 
 
+@pytest.mark.libvirt_content_host
 @pytest.mark.tier2
 def test_positive_candlepin_events_processed_by_STOMP(session):
     """Verify that Candlepin events are being read and processed by


### PR DESCRIPTION
This PR includes:

#### 1. Markers to filter following tests in robottelo:

- [x] API
- [x] CLI
- [x] UI
- [x] End To End
- [x] Longrun
- [x] RHAI

#### 2. Pytest Plugin that modifies the collection of these tests based on new following options to select the tests:

- [x] **--include-onprem-provisioning** => Selects on-premises provisioning tests 
- [x] **--include-libvirt** => Selects libvirt based content host tests 
- [x] **--include-external-auth** => Selects External Auth based tests 
- [x] **--include-vlan-networking** => Selects VLAN networking tests 

**Most IMP:** The tests of which inclusion is not selected using above option(s), then those tests will be deselected by default. That also means if the option(s) is not provided to pytest it will be considered as to deselect those tests by default.