### PR TITLE
[Dynaconf] - migrated the auth servers properties

### DIFF
--- a/conf/ipa.yaml.template
+++ b/conf/ipa.yaml.template
@@ -1,0 +1,17 @@
+# For LDAP freeIPA Authentication.
+IPA:
+  # HOSTNAME_IPA: replace with hostname
+  # USERNAME_IPA: replace with username
+  # PASSWORD_IPA: update the password
+  # BASEDN_IPA: replace with basedn
+  # GROUPBASEDN_IPA: replace with group basedn
+  USER_IPA: foreman
+  OTP_USER: otp_user
+  # TIME_BASED_SECRET: update the time based token secret
+  DISABLED_IPA_USER: disabled_user
+  GROUP_USERS:
+    - satadmin_01
+    - satuser_01
+  GROUPS:
+    - satadmins
+    - satusers

--- a/conf/ldap.yaml.template
+++ b/conf/ldap.yaml.template
@@ -1,0 +1,9 @@
+# For Active Directory LDAP Authentication.
+LDAP:
+  # HOSTNAME: replace with AD ldap server name
+  USERNAME: foobar
+  # PASSWORD: update with password
+  # BASEDN: update base dn
+  # GRPBASEDN: update with group base dn
+  # REALM: update with realm address
+  # NAMESERVER: update with the ip of the ad ldap server name

--- a/conf/openldap.yaml.template
+++ b/conf/openldap.yaml.template
@@ -1,0 +1,8 @@
+# For Open Ldap Authentication
+OPEN_LDAP:
+  # HOSTNAME: replace with env openldap server
+  USERNAME: cn=ldapadmin,dc=example,dc=com
+  OPEN_LDAP_USER: foreman
+  # PASSWORD: replace with actual password
+  BASE_DN: dc=example,dc=com
+  GROUP_BASE_DN: ou=foobargroup,ou=users,dc=example,dc=com

--- a/conf/rhsso.yaml.template
+++ b/conf/rhsso.yaml.template
@@ -1,0 +1,13 @@
+# section for RH-SSO integration
+RHSSO:
+# RH-SSO Hostname
+  # HOST_NAME: update with rhsso host name
+# RH-SSO Host Url
+  # HOST_URL: update with rhsso environment url
+# RH-SSO Host Admin of Realm
+  RHSSO_USER: sat_admin
+# RH-SSO Host Admin Password
+  # USER_PASSWORD: update with password
+# RH-SSO Host Realm
+  REALM: satqe
+  # TOTP_SECRET: update with the totp secret token


### PR DESCRIPTION
### Gitlab PR
148

### AD and IPA
```
(env) /home/okhatavk/Satellite/robottelo (auth_server_dynaconf) $ pytest -k 'test_login_failure_if_internal_user_exist_ipa_ad' tests/foreman/ui/test_ldap_authentication.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-1.13, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, picked-0.4.6
collected 44 items / 42 deselected / 2 selected                                                                                                                                              

tests/foreman/ui/test_ldap_authentication.py ..                                                                                                                                        [100%]

====================================================================================== warnings summary ======================================================================================
tests/foreman/ui/test_ldap_authentication.py: 20 warnings
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-3-116.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================= 2 passed, 42 deselected, 20 warnings in 171.12s (0:02:51) ==================================================================
(env) /home/okhatavk/Satellite/robottelo (auth_server_dynaconf) $ 

```
### OpenLdap
```

(env) /home/okhatavk/Satellite/robottelo (auth_server_dynaconf) $ pytest -k 'test_positive_end_to_end_open_ldap_authsource' tests/foreman/ui/test_ldap_authentication.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-1.13, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, picked-0.4.6
collected 44 items / 43 deselected / 1 selected                                                                                                                                              

tests/foreman/ui/test_ldap_authentication.py .                                                                                                                                         [100%]

====================================================================================== warnings summary ======================================================================================
tests/foreman/ui/test_ldap_authentication.py: 10 warnings
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-3-116.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================= 1 passed, 43 deselected, 10 warnings in 245.63s (0:04:05) ==================================================================

```
### RHSSO

```
(env) /home/okhatavk/Satellite/robottelo (auth_server_dynaconf) $ pytest -k 'test_totp_user_login' tests/foreman/ui/test_ldap_authentication.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-6.2.1, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-1.13, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, picked-0.4.6
collected 44 items / 43 deselected / 1 selected                                                                                                                                              

tests/foreman/ui/test_ldap_authentication.py .                                                                                                                                         [100%]

====================================================================================== warnings summary ======================================================================================
tests/foreman/ui/test_ldap_authentication.py: 22 warnings
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-2-149.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================= 1 passed, 43 deselected, 22 warnings in 201.88s (0:03:21) ==================================================================

```
