### PR TITLE
Add option to control stubbed case collection

### DIFF
--- a/pytest_plugins/manual_skipped.py
+++ b/pytest_plugins/manual_skipped.py
@@ -17,7 +17,7 @@ def pytest_collection_modifyitems(session, config, items):
     opt_passed = config.getvalue('mark_manuals_passed')
     opt_skipped = config.getvalue('mark_manuals_skipped')
     # TODO turn this into a flag or a choice option, this logic is just silly.
-    mark_skipped = opt_skipped and (not opt_passed)
+    mark_skipped = opt_skipped and not opt_passed
     include_stubbed = config.getvalue('include_stubbed')
     selected = []
     deselected = []

--- a/pytest_plugins/manual_skipped.py
+++ b/pytest_plugins/manual_skipped.py
@@ -9,33 +9,56 @@ LOGGER = logging.getLogger('robottelo')
 
 def pytest_configure(config):
     """Register custom marker for stubbed test cases."""
-    marker = "stubbed: Tests that are not automated yet or manual only."
-    config.addinivalue_line("markers", marker)
+    config.addinivalue_line('markers', 'stubbed: Tests that are not automated yet or manual only.')
 
 
 def pytest_collection_modifyitems(session, config, items):
-    """
-    Collects tests based on pytest option to select tests marked as failed on Report Portal
-    """
-    mark_passed = config.getvalue('mark_manuals_passed')
-    mark_skipped = config.getvalue('mark_manuals_skipped')
-    if mark_passed or (not mark_skipped):
-        return
+    """Remove/Include stubbed tests from collection based on CLI option"""
+    opt_passed = config.getvalue('mark_manuals_passed')
+    opt_skipped = config.getvalue('mark_manuals_skipped')
+    # TODO turn this into a flag or a choice option, this logic is just silly.
+    mark_skipped = opt_skipped and (not opt_passed)
+    include_stubbed = config.getvalue('include_stubbed')
+    selected = []
+    deselected = []
     for item in items:
-        if item.get_closest_marker(name='stubbed'):
-            item.add_marker(marker=pytest.mark.skip(reason=NOT_IMPLEMENTED))
+        stub_marked = item.get_closest_marker(name='stubbed')
+        # The test case is stubbed, and --include-stubbed was passed, include in collection
+        if stub_marked and include_stubbed:
+            selected.append(item)
+            # enforce skip/pass behavior by marking skip
+            if mark_skipped:
+                item.add_marker(marker=pytest.mark.skip(reason=NOT_IMPLEMENTED))
+            continue
+
+        # The test case is stubbed, but --include-stubbed was NOT passed, deselect the item
+        if stub_marked and not include_stubbed:
+            deselected.append(item)
+            continue
+
+        # Its a non-stubbed item, this hook doesn't apply
+        selected.append(item)
+
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected
 
 
 def pytest_addoption(parser):
-    """Add options to pytest to modify manual tests as skipped"""
+    """Add options to pytest to modify manual tests as skipped and control collection"""
     parser.addoption(
-        "--mark-manuals-skipped",
+        '--include-stubbed',
+        action='store_true',
+        default=False,
+        help='Include stubbed tests in collection, by default they are deselected',
+    )
+    parser.addoption(
+        '--mark-manuals-skipped',
         action='store_true',
         default=True,
         help='Mark stubbed tests as skipped tests.',
     )
     parser.addoption(
-        "--mark-manuals-passed",
+        '--mark-manuals-passed',
         action='store_true',
         default=False,
         help='Mark stubbed tests as passed tests.',


### PR DESCRIPTION
Update the manual_skipped module to add a `--include-stubbed` option

Default test collection to exclude stubbed test cases

Included stubbed cases only when `--include-stubbed` is passed

## Collection with --include-stubbed, cases are skipped by default
```
setup@localhost:~/repos/robottelo (stubbed-tests-deselected$*%=) % pytest --disable-pytest-warnings --include-stubbed tests/foreman/api/test_discoveryrule.py
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.13, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 5 items                                                                                                                                                                                                   

tests/foreman/api/test_discoveryrule.py ..sss                                                                                                                                                                 [100%]

==================================================================================== 2 passed, 3 skipped, 27 warnings in 23.75s =====================================================================================
```

## Collection without --include-stubbed
```
setup@localhost:~/repos/robottelo (stubbed-tests-deselected$*%=) % pytest --disable-pytest-warnings tests/foreman/api/test_discoveryrule.py 
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.13, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 5 items / 3 deselected / 2 selected                                                                                                                                                                       

tests/foreman/api/test_discoveryrule.py ..                                                                                                                                                                    [100%]

=================================================================================== 2 passed, 3 deselected, 27 warnings in 24.54s ===================================================================================
```


## Collection with --include-stubbed and --mark-manuals-passed
```
setup@localhost:~/repos/robottelo (stubbed-tests-deselected$*%=) % pytest --disable-pytest-warnings --include-stubbed --mark-manuals-passed tests/foreman/api/test_discoveryrule.py
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.13, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 5 items                                                                                                                                                                                                   

tests/foreman/api/test_discoveryrule.py .....                                                                                                                                                                 [100%]

========================================================================================== 5 passed, 27 warnings in 24.61s ==========================================================================================

```


This robottelo-ci PR should go in with this behavioral change.
https://github.com/SatelliteQE/robottelo-ci/pull/1913