### PR TITLE
Add assignee testimony tokens

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -1,3 +1,5 @@
+Assignee:
+    required: true
 BZ: {}
 CaseAutomation:
     casesensitive: true

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ActivationKeys
 
+:Assignee: chiggins
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High
@@ -37,6 +39,8 @@ def test_positive_create_by_type():
     :CaseImportance: Medium
 
     :CaseComponent: AuditLog
+
+    :Assignee: rplevka
     """
     for entity_item in [
         {'entity': entities.Architecture()},
@@ -118,6 +122,8 @@ def test_positive_update_by_type():
     :CaseImportance: Medium
 
     :CaseComponent: AuditLog
+
+    :Assignee: rplevka
     """
     for entity in [
         entities.Architecture(),
@@ -158,6 +164,8 @@ def test_positive_delete_by_type():
     :CaseImportance: Medium
 
     :CaseComponent: AuditLog
+
+    :Assignee: rplevka
     """
     for entity in [
         entities.Architecture(),

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Search
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources-Azure
 
+:Assignee: jyejare
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -9,7 +9,9 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 :CaseLevel: Acceptance
 
-:CaseComponent:  ComputeResources-GCE
+:CaseComponent: ComputeResources-GCE
+
+:Assignee: lvrtelov
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -12,6 +12,8 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_content_credentials.py
+++ b/tests/foreman/api/test_content_credentials.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentCredentials
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High
@@ -148,6 +150,8 @@ class TestSatelliteContentManagement:
 
         :CaseComponent: Pulp
 
+        :Assignee: ltran
+
         :BZ: 1687801
         """
         org = entities.Organization().create()
@@ -191,6 +195,8 @@ class TestCapsuleContentManagement:
         :id: a31b0e21-aa5d-44e2-a408-5e01b79db3a1
 
         :CaseComponent: RHCloud-Insights
+
+        :Assignee: jpathan
 
         :customerscenario: true
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentViews
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High
@@ -306,6 +308,8 @@ class TestContentView:
         :CaseLevel: Integration
 
         :CaseComponent: Pulp
+
+        :Assignee: ltran
 
         :CaseImportance: Medium
 
@@ -877,6 +881,8 @@ class TestContentViewPublishPromote:
         :CaseLevel: Integration
 
         :CaseComponent: Pulp
+
+        :Assignee: ltran
 
         :CaseImportance: Medium
 

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -12,6 +12,8 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 :CaseComponent: ContentViews
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentViews
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -4,6 +4,8 @@
 
 :CaseComponent: DiscoveryPlugin
 
+:Assignee: rplevka
+
 :CaseAutomation: Automated
 
 :CaseLevel: System

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: DiscoveryPlugin
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseLevel: Acceptance

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -61,6 +61,8 @@ class DockerRepositoryTestCase(APITestCase):
     repositories.
 
     :CaseComponent: Repositories
+
+    :Assignee: tpapaioa
     """
 
     @classmethod
@@ -289,6 +291,8 @@ class DockerContentViewTestCase(APITestCase):
     """Tests specific to using ``Docker`` repositories with Content Views.
 
     :CaseComponent: ContentViews
+
+    :Assignee: ltran
 
     :CaseLevel: Integration
     """
@@ -883,6 +887,8 @@ class DockerActivationKeyTestCase(APITestCase):
     """Tests specific to adding ``Docker`` repositories to Activation Keys.
 
     :CaseComponent: ActivationKeys
+
+    :Assignee: chiggins
 
     :CaseLevel: Integration
     """

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -12,6 +12,8 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ErrataManagement
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -12,6 +12,8 @@ http://theforeman.org/api/apidoc/v2/filters.html
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: TasksPlugin
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -12,6 +12,8 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High
@@ -1234,6 +1236,8 @@ def test_positive_verify_files_with_pxegrub_uefi_secureboot():
 
     :CaseComponent: TFTP
 
+    :Assignee: rdrazny
+
     :CaseLevel: Integration
     """
 
@@ -1267,6 +1271,8 @@ def test_positive_verify_files_with_pxegrub2_uefi():
     :CaseAutomation: NotAutomated
 
     :CaseComponent: TFTP
+
+    :Assignee: rdrazny
 
     :CaseLevel: Integration
     """
@@ -1303,6 +1309,8 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
     :CaseLevel: Integration
 
     :CaseComponent: TFTP
+
+    :Assignee: rdrazny
     """
 
 

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: HostCollections
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: HostGroup
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_ldapauthsource.py
+++ b/tests/foreman/api/test_ldapauthsource.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: LDAP
 
+:Assignee: okhatavk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -12,6 +12,8 @@ http://www.katello.org/docs/api/apidoc/lifecycle_environments.html
 
 :CaseComponent: LifecycleEnvironments
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -11,6 +11,8 @@ http://theforeman.org/api/apidoc/v2/locations.html
 
 :CaseComponent: OrganizationsLocations
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -14,6 +14,8 @@ References for the relevant paths can be found on your Satellite:
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -13,6 +13,8 @@ http://theforeman.org/api/apidoc/v2/organizations.html
 
 :CaseComponent: OrganizationsLocations
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -12,6 +12,8 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -12,6 +12,8 @@ tested can be found here: http://theforeman.org/api/apidoc/v2/permissions.html
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -11,6 +11,8 @@ http://<sat6>/apidoc/v2/products.html
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_puppet.py
+++ b/tests/foreman/api/test_puppet.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_puppetmodule.py
+++ b/tests/foreman/api/test_puppetmodule.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Reporting
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High
@@ -2269,6 +2271,8 @@ class TestSRPMRepositoryIgnoreContent:
 
     :CaseComponent: Pulp
 
+    :Assignee: ltran
+
     :BZ: 1673215
     """
 
@@ -2485,6 +2489,8 @@ class TestTokenAuthContainerRepository:
     container_repo section of robottelo.yaml
 
     :CaseComponent: ContainerManagement-Content
+
+    :Assignee: mzalewsk
     """
 
     @pytest.mark.skipif(

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -12,6 +12,8 @@ http://www.katello.org/docs/api/apidoc/repository_sets.html
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -12,6 +12,8 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 
 :CaseComponent: Candlepin
 
+:Assignee: chiggins
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -12,6 +12,8 @@ http://theforeman.org/api/apidoc/v2/roles.html
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Settings
 
+:Assignee: desingh
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Capsule
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: Critical

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -13,6 +13,8 @@ http://theforeman.org/api/apidoc/v2/1.15.html
 
 :CaseComponent: Networking
 
+:Assignee: rdrazny
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -12,6 +12,8 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 
 :CaseComponent: SubscriptionManagement
 
+:Assignee: chiggins
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -12,6 +12,8 @@ API reference for sync plans can be found on your Satellite:
 
 :CaseComponent: SyncPlans
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -9,6 +9,8 @@ http://theforeman.org/api/apidoc/v2/provisioning_templates.html
 
 :CaseComponent: ProvisioningTemplates
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseLevel: Integration
@@ -143,8 +145,6 @@ def tftpboot(module_org):
 
 class TestProvisioningTemplate:
     """Tests for provisioning templates
-
-    :CaseComponent: ProvisioningTemplates
 
     :CaseLevel: Acceptance
     """

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ProvisioningTemplates
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: TemplatesPlugin
 
+:Assignee: ogajduse
+
 :TestType: Functional
 
 :Upstream: No
@@ -29,8 +31,6 @@ from robottelo.constants import FOREMAN_TEMPLATES_COMMUNITY_URL
 
 class TestTemplateSyncTestCase:
     """Implements TemplateSync tests from API
-
-    :CaseComponent: TemplatesPlugin
 
     :CaseLevel: Acceptance
     """

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -12,6 +12,8 @@ tested can be found here: http://theforeman.org/api/apidoc/v2/users.html
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/api/test_usergroup.py
+++ b/tests/foreman/api/test_usergroup.py
@@ -11,6 +11,8 @@ https://theforeman.org/api/2.0/apidoc/v2/usergroups.html
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Infrastructure
 
+:Assignee: lpramuk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ActivationKeys
 
+:Assignee: chiggins
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Authentication
 
+:Assignee: okhatavk
+
 :TestType: Functional
 
 :CaseImportance: Critical

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Bootstrap
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Capsule
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: Critical

--- a/tests/foreman/cli/test_capsule_installer.py
+++ b/tests/foreman/cli/test_capsule_installer.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Capsule
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources-Azure
 
+:Assignee: jyejare
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -5,6 +5,8 @@
 
 :CaseComponent: ComputeResources-EC2
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -25,6 +25,8 @@ Subcommands::
 
 :CaseComponent: ComputeResources-libvirt
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -7,6 +7,8 @@
 
 :CaseComponent: ComputeResources-OpenStack
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -7,6 +7,8 @@
 
 :CaseComponent: ComputeResources-RHEV
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -5,6 +5,8 @@
 
 :CaseComponent: ComputeResources-VMWare
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_content_credentials.py
+++ b/tests/foreman/cli/test_content_credentials.py
@@ -10,6 +10,7 @@ Satellite 6.8
 
 :CaseComponent: ContentCredentials
 
+:Assignee: swadeley
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: Hosts-Content
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentViews
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentViews
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: DiscoveryPlugin
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseLevel: System

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: DiscoveryPlugin
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -76,7 +76,9 @@ def _make_docker_repo(product_id, name=None, upstream_name=None, url=None):
 class DockerManifestTestCase(CLITestCase):
     """Tests related to docker manifest command
 
-    :CaseComponent: Hammer-Content
+    :CaseComponent: Repositories
+
+    :Assignee: tpapaioa
     """
 
     @pytest.mark.tier2
@@ -124,6 +126,8 @@ class DockerRepositoryTestCase(CLITestCase):
     repositories.
 
     :CaseComponent: Repositories
+
+    :Assignee: tpapaioa
     """
 
     @classmethod
@@ -391,6 +395,8 @@ class DockerContentViewTestCase(CLITestCase):
     """Tests specific to using ``Docker`` repositories with Content Views.
 
     :CaseComponent: ContentViews
+
+    :Assignee: ltran
 
     :CaseLevel: Integration
     """
@@ -999,6 +1005,8 @@ class DockerActivationKeyTestCase(CLITestCase):
 
     :CaseComponent: ActivationKeys
 
+    :Assignee: chiggins
+
     :CaseLevel: Integration
     """
 
@@ -1198,6 +1206,8 @@ class DockerClientTestCase(CLITestCase):
     from a Satellite 6 instance.
 
     :CaseComponent: ContentManagement
+
+    :Assignee: ltran
 
     :CaseLevel: System
 

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ErrataManagement
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Fact
 
+:Assignee: rdrazny
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Parameters
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hammer
 
+:Assignee: gtalreja
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: HostCollections
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: HostGroup
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Installer
 
+:Assignee: desingh
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: RemoteExecution
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Katello-agent
 
+:Assignee: gtalreja
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: LDAP
 
+:Assignee: okhatavk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: LifecycleEnvironments
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: OrganizationsLocations
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Logging
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: Medium

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_myaccount.py
+++ b/tests/foreman/cli/test_myaccount.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: OrganizationsLocations
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hammer
 
+:Assignee: gtalreja
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Provisioning
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseImportance: Critical

--- a/tests/foreman/cli/test_puppet.py
+++ b/tests/foreman/cli/test_puppet.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_puppetmodule.py
+++ b/tests/foreman/cli/test_puppetmodule.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Realm
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: RemoteExecution
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High
@@ -468,6 +470,8 @@ class TestRemoteExecution:
         """Run Receptor installer ("Configure Cloud Connector")
 
         :CaseComponent: RHCloud-CloudConnector
+
+        :Assignee: lhellebr
 
         :id: 811c7747-bec6-1a2d-8e5c-b5045d3fbc0d
 

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -7,6 +7,8 @@
 
 :CaseComponent: Reporting
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: InterSatelliteSync
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High
@@ -224,6 +226,8 @@ class ContentViewSync(CLITestCase):
     """Implements Content View Export Import tests in CLI
 
     :CaseComponent: ContentViews
+
+    :Assignee: ltran
     """
 
     export_base = '/var/lib/pulp/katello-export'
@@ -418,6 +422,8 @@ class ContentViewSync(CLITestCase):
 
         :CaseComponent: ContentViews
 
+        :Assignee: ltran
+
         :CaseImportance: High
 
         :CaseLevel: System
@@ -554,6 +560,8 @@ class ContentViewSync(CLITestCase):
 
         :CaseComponent: ContentViews
 
+        :Assignee: ltran
+
         :CaseImportance: High
 
         :CaseLevel: System
@@ -606,6 +614,8 @@ class ContentViewSync(CLITestCase):
         :CaseAutomation: Automated
 
         :CaseComponent: ContentViews
+
+        :Assignee: ltran
 
         :CaseImportance: High
 
@@ -670,6 +680,8 @@ class ContentViewSync(CLITestCase):
         :CaseAutomation: Automated
 
         :CaseComponent: ContentViews
+
+        :Assignee: ltran
 
         :CaseImportance: Critical
 

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Settings
 
+:Assignee: desingh
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: LDAP
 
+:Assignee: okhatavk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Networking
 
+:Assignee: rdrazny
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SubscriptionManagement
 
+:Assignee: chiggins
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SyncPlans
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_template.py
+++ b/tests/foreman/cli/test_template.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ProvisioningTemplates
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: TemplatesPlugin
 
+:Assignee: ogajduse
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -14,6 +14,8 @@ When testing email validation [1] and [2] should be taken into consideration.
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hammer
 
+:Assignee: gtalreja
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: Infobloxintegration
 
+:Assignee: rdrazny
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Installer
 
+:Assignee: desingh
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/longrun/test_capsule_loadbalancer.py
+++ b/tests/foreman/longrun/test_capsule_loadbalancer.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Capsule
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts-Content
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/longrun/test_n_1_upgrade.py
+++ b/tests/foreman/longrun/test_n_1_upgrade.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Capsule
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: Critical

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: Critical

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -3,6 +3,8 @@
 
 :CaseComponent: ComputeResources
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: Critical
@@ -135,6 +137,8 @@ def test_positive_provision_rhev_with_host_group(rhev, provisioning, tear_down):
 
     :CaseComponent: ComputeResources-RHEV
 
+    :Assignee: lhellebr
+
     :id: ba78868f-5cff-462f-a55d-f6aa4d11db52
 
     :setup: Hostgroup and provisioning setup like domain, subnet etc.
@@ -209,6 +213,8 @@ def test_positive_provision_vmware_with_host_group(vmware, provisioning, tear_do
     :Requirement: Computeresource Vmware
 
     :CaseComponent: ComputeResources-VMWare
+
+    :Assignee: lhellebr
 
     :id: ae4d5949-f0e6-44ca-93b6-c5241a02b64b
 

--- a/tests/foreman/longrun/test_remote_DB.py
+++ b/tests/foreman/longrun/test_remote_DB.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ForemanMaintain
 
+:Assignee: gtalreja
+
 :TestType: Functional
 
 :CaseImportance: Medium
@@ -34,6 +36,8 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: Integration
 
         :CaseComponent: Installer
+
+        :Assignee: desingh
         """
 
     @pytest.mark.stubbed
@@ -50,6 +54,8 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: Integration
 
         :CaseComponent: Installer
+
+        :Assignee: desingh
         """
 
     @pytest.mark.stubbed
@@ -66,6 +72,8 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: Integration
 
         :CaseComponent: Installer
+
+        :Assignee: desingh
         """
 
     @pytest.mark.stubbed
@@ -82,6 +90,8 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: System
 
         :CaseComponent: Installer
+
+        :Assignee: desingh
         """
 
     @pytest.mark.stubbed
@@ -104,6 +114,8 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: System
 
         :CaseComponent: Installer
+
+        :Assignee: desingh
         """
 
     @pytest.mark.stubbed
@@ -205,6 +217,8 @@ class RemoteDBTestCase(TestCase):
         :CaseLevel: Integration
 
         :CaseComponent: Installer
+
+        :Assignee: desingh
         """
 
     @pytest.mark.stubbed

--- a/tests/foreman/rhai/test_rhai.py
+++ b/tests/foreman/rhai/test_rhai.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: RHCloud-Insights
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: RHCloud-Insights
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: Dynflow
 
+:Assignee: lhellebr
+
 :Requirement: Dynflow
 
 :TestType: Functional

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -26,6 +26,8 @@ def test_positive_ansible_modules_installation():
 
     :CaseComponent: Ansible
 
+    :Assignee: lpramuk
+
     :id: 553a927e-2665-4227-8542-0258d7b1ccc4
 
     :expectedresults: ansible-collection-redhat-satellite package is

--- a/tests/foreman/sys/test_foreman_rake.py
+++ b/tests/foreman/sys/test_foreman_rake.py
@@ -26,6 +26,8 @@ def test_positive_katello_reimport():
 
     :CaseComponent: ContentManagement
 
+    :Assignee: ltran
+
     :id: b4119265-1bf0-4b0b-8b96-43f68af39708
 
     :Steps: Have satellite up and run 'foreman-rake katello:reimport'

--- a/tests/foreman/sys/test_foreman_service.py
+++ b/tests/foreman/sys/test_foreman_service.py
@@ -28,6 +28,8 @@ def test_positive_foreman_service_auto_restart(foreman_service_teardown):
 
     :CaseComponent: Infrastructure
 
+    :Assignee: lpramuk
+
     :id: 766560b8-30bb-11eb-8dae-d46d6dd3b5b2
 
     :Steps:

--- a/tests/foreman/sys/test_hooks.py
+++ b/tests/foreman/sys/test_hooks.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: HooksPlugin
 
+:Assignee: rdrazny
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Certificates
 
+:Assignee: okhatavk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: satellite-change-hostname
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/sys/test_sat_clone.py
+++ b/tests/foreman/sys/test_sat_clone.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SatelliteClone
 
+:Assignee: vsedmik
+
 :TestType: functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ActivationKeys
 
+:Assignee: chiggins
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: Low

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: AuditLog
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Search
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources-Azure
 
+:Assignee: jyejare
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources-EC2
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources-GCE
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ComputeResources-libvirt
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: ComputeResources-VMWare
 
+:Assignee: lhellebr
+
 :CaseLevel: Acceptance
 
 :TestType: Functional

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: Low

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContainerManagement-Content
 
+:Assignee: mzalewsk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentCredentials
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts-Content
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High
@@ -1401,6 +1403,8 @@ def test_content_access_after_stopped_foreman(session, vm, foreman_service_teard
     :CaseImportance: Medium
 
     :CaseComponent: Infrastructure
+
+    :Assignee: lpramuk
     """
     result = vm.run(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.return_code == 0

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -11,6 +11,8 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 
 :CaseComponent: ContentViews
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Dashboard
 
+:Assignee: ogajduse
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: DiscoveryPlugin
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseLevel: System

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: DiscoveryPlugin
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ErrataManagement
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: HostCollections
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: HostGroup
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: RemoteExecution
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: RemoteExecution
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: LDAP
 
+:Assignee: okhatavk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: LifecycleEnvironments
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: OrganizationsLocations
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_media.py
+++ b/tests/foreman/ui/test_media.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: Low

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: OrganizationsLocations
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SCAPPlugin
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentManagement
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ProvisioningTemplates
 
+:Assignee: rplevka
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: Low

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: Low

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: RemoteExecution
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Reporting
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: RHCloud-Inventory
 
+:Assignee: jpathan
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Settings
 
+:Assignee: desingh
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:Assignee: vsedmik
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Networking
 
+:Assignee: rdrazny
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SubscriptionManagement
 
+:Assignee: chiggins
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Repositories
 
+:Assignee: tpapaioa
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: SyncPlans
 
+:Assignee: swadeley
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: TemplatesPlugin
 
+:Assignee: ogajduse
+
 :TestType: Functional
 
 :Upstream: No

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: UsersRoles
 
+:Assignee: pondrejk
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/api/test_rhevm.py
+++ b/tests/foreman/virtwho/api/test_rhevm.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/api/test_xen.py
+++ b/tests/foreman/virtwho/api/test_xen.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/cli/test_rhevm.py
+++ b/tests/foreman/virtwho/cli/test_rhevm.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/cli/test_xen.py
+++ b/tests/foreman/virtwho/cli/test_xen.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/ui/test_rhevm.py
+++ b/tests/foreman/virtwho/ui/test_rhevm.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/foreman/virtwho/ui/test_xen.py
+++ b/tests/foreman/virtwho/ui/test_xen.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
+:Assignee: kuhuang
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_bookmarks.py
+++ b/tests/upgrades/test_bookmarks.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Search
 
+:Assignee: lvrtelov
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -6,7 +6,9 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Capsule
+
+:Assignee: vsedmik
 
 :TestType: Functional
 

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -6,7 +6,9 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: Hosts-Content
+
+:Assignee: swadeley
 
 :TestType: Functional
 

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: ContentViews
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: Critical

--- a/tests/upgrades/test_foreman_maintain.py
+++ b/tests/upgrades/test_foreman_maintain.py
@@ -6,7 +6,9 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: ForemanMaintain
+
+:Assignee: gtalreja
 
 :TestType: Functional
 

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Hosts
 
+:Assignee: tstrych
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_hostgroup.py
+++ b/tests/upgrades/test_hostgroup.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Performance
 
+:Assignee: psuriset
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_satellitesync.py
+++ b/tests/upgrades/test_satellitesync.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: InterSatelliteSync
 
+:Assignee: ltran
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_subnet.py
+++ b/tests/upgrades/test_subnet.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -6,7 +6,9 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: CLI
+:CaseComponent: SubscriptionManagement
+
+:Assignee: chiggins
 
 :TestType: Functional
 

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_user.py
+++ b/tests/upgrades/test_user.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: High

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: API
 
+:Assignee: lhellebr
+
 :TestType: Functional
 
 :CaseImportance: Critical


### PR DESCRIPTION
This PR adds a new testimony token, `Assignee`, to all tests with ` CaseComponent`. The ability to filter on test assignee has also been added as a pytest option, alongside the existing importance and component filters.

```
  --assignee=ASSIGNEE   Comma separated list of assignees to include in test
                        collection
```

