### PR TITLE
Fix selection by testimony marker

### DIFF
--- a/pytest_plugins/testimony_markers.py
+++ b/pytest_plugins/testimony_markers.py
@@ -127,5 +127,5 @@ def pytest_collection_modifyitems(session, items, config):
             selected.append(item)
 
     # selected will be empty if no filter option was passed, defaulting to full items list
-    items[:] = selected or items
+    items[:] = selected if deselected else items
     config.hook.pytest_deselected(items=deselected)


### PR DESCRIPTION
This PR fixes an issue with test collection by component, importance, and assignee. If no tests match the given values, then all tests should be marked as deselected, and no tests should run. Without this fix, all tests are still being collected and run, even though they are marked for deselection.

Before the fix:

```
$ pytest --collect-only --importance BADVALUE tests/foreman/ui/test_organization.py 
[...]
collected 6 items / 6 deselected                                                                                                                                                                                                             

<Package ui>
  <Module test_organization.py>
    <Function test_positive_end_to_end>
    <Function test_positive_search_scoped>
    <Function test_positive_create_with_all_users>
    <Function test_positive_update_compresource>
    <Function test_positive_delete_with_manifest_lces>
    <Function test_positive_download_debug_cert_after_refresh>

=== no tests collected (6 deselected) in 1.40s ======

# pytest --importance BADVALUE tests/foreman/ui/test_organization.py 
[...]
collected 6 items / 6 deselected                                                                                                                                                                                                             

tests/foreman/ui/test_organization.py EEsEEE      [100%]

[...]
```

After the fix:
```
# pytest --collect-only --importance BADVALUE tests/foreman/ui/test_organization.py 
[...]
collected 6 items / 6 deselected                                                                                                                                                                                                             
=== no tests collected (6 deselected) in 0.01s ===

# pytest --importance BADVALUE tests/foreman/ui/test_organization.py 
[...]
collected 6 items / 6 deselected                                                                                                                                                                                                             

=== 6 deselected in 0.02s ===
```