### PR TITLE
Dynaconf conversion / remove unused rhai settings

### DIFF
--- a/robottelo.properties.sample
+++ b/robottelo.properties.sample
@@ -234,12 +234,6 @@ ssh_key=
 # private_registry_password=
 
 
-# For testing Red Hat Access Insights
-# [rhai]
-# Provide link to el6/el7 repo to fetch the redhat-access-insights client rpm
-# insights_client_el6repo=https://www.example.com/insights-client/repo/insights-client-6.repo
-# insights_client_el7repo=https://www.example.com/insights-client/repo/insights-client-7.repo
-
 # VLAN Networking details
 # These settings are required for compute resources testing, for example
 # host provisioning on CR's, discovery e.t.c.


### PR DESCRIPTION
This PR is part of the dynaconf conversion project, for the `[rhai]` section of `robottelo.properties`. Those settings are not used (the insights client configuration in `ContentHost.configure_rhai_client()` uses the base server repositories `settings.rhel<X>_repo` to install the `insights-client` rpm), so this PR simply removes those settings from `robottelo.properties.sample`.