### PR TITLE
Update pre-commit flake8 to 3.8.4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   hooks:
   - id: black
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.9
+  rev: 3.8.4
   hooks:
   - id: flake8
 - repo: local

--- a/pytest_fixtures/satellite_auth.py
+++ b/pytest_fixtures/satellite_auth.py
@@ -282,7 +282,7 @@ def rhsso_setting_setup(request):
 @pytest.fixture()
 def rhsso_setting_setup_with_timeout(rhsso_setting_setup, request):
     """Update the RHSSO setting with timeout setting and revert it in cleanup"""
-    setting_entity = entities.Setting().search(query={'search': f'name=idle_timeout'})[0]
+    setting_entity = entities.Setting().search(query={'search': 'name=idle_timeout'})[0]
     setting_entity.value = 1
     setting_entity.update({'value'})
     yield

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -418,7 +418,7 @@ def test_positive_provision_pxe_host_dhcp_change(discovery_settings, provisionin
             subnet.from_ = old_sub_from
             subnet.update(['from_'])
             ssh_client.exec_command(
-                f'mv /etc/dhcp/dhcpd_backup.conf /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf'
+                'mv /etc/dhcp/dhcpd_backup.conf /etc/dhcp/dhcpd.conf /etc/dhcp/dhcpd.conf'
             )
 
 

--- a/tests/robottelo/test_vm.py
+++ b/tests/robottelo/test_vm.py
@@ -83,7 +83,7 @@ class TestVirtualMachine:
         with patch('robottelo.ssh.command') as ssh_mock:
             ssh_mock.side_effect = exception_type({('127.0.0.1', 22): None})
             with pytest.raises(
-                VirtualMachineError, match=f'Exception connecting via ssh to get host os version'
+                VirtualMachineError, match='Exception connecting via ssh to get host os version'
             ):
                 VirtualMachine()
 

--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -327,9 +327,8 @@ def pytest_collection_modifyitems(items, config):
                 for depend_on_node_id in depend_on_node_ids:
                     if depend_on_node_id in pre_upgrade_failed_tests:
                         log(
-                            'Deselected (because of dependant test failed): {}'.format(
-                                item.nodeid, 'INFO'
-                            )
+                            f'Deselected (because of dependant test failed): {item.nodeid}',
+                            'INFO',
                         )
                         deselected_items.append(item)
 


### PR DESCRIPTION
This PR updates the pre-commit config to use flake8 3.8.4.

Also made a few small fixes reported by pre-commit.