### PR TITLE
Pin pytest-ibutsu to 1.14.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ navmazing==1.1.6
 paramiko==2.5.0
 productmd==1.26
 pytest==5.4.3
+pytest-ibutsu==1.14.1
 pytest-services==1.3.1
 pytest-mock==1.10.4
 pytest-reportportal==5.0.7
@@ -31,7 +32,6 @@ PyYAML==5.1.2
 tenacity==6.0.0
 pyotp==2.3.0
 pexpect==4.7.0
-pytest-ibutsu==1.1.1
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git@6.8.z#egg=airgun


### PR DESCRIPTION
pytest-ibutsu 1.1.1 doesn't freeze the ibutsu-client.

pytest-ibutsu 1.14.1 does freeze the ibutsu-client.

ibtusu-client 2.0 released on March 9th, breaking pytest-ibutsu 1.1.1 install.


https://github.com/ibutsu/pytest-ibutsu/blob/v1.14.1/setup.cfg#L38