### PR TITLE
Fix unique names of test for each value

### DIFF
--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -70,13 +70,12 @@ def valid_name_desc_data():
 
 def invalid_create_data():
     """Random data for invalid name and url"""
-    items = [
+    return (
         {'name': gen_string('alphanumeric', 256)},
         {'name': ''},
         {'url': 'invalid url'},
         {'url': ''},
-    ]
-    return {f'{list(item.keys())[0]}=>{list(item.values())[0][0:10]}': item for item in items}
+    )
 
 
 def valid_update_data():
@@ -94,13 +93,12 @@ def valid_update_data():
 
 def invalid_update_data():
     """Random data for invalid update"""
-    items = [
+    return (
         {'new-name': gen_string('utf8', 256)},
         {'new-name': ''},
         {'url': 'invalid url'},
         {'url': ''},
-    ]
-    return {f'{list(item.keys())[0]}=>{list(item.values())[0][0:10]}': item for item in items}
+    )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/pull/8388#issuecomment-797502793

```
$ pytest tests/foreman/cli/test_computeresource_libvirt.py --verbose
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.8.7, pytest-5.4.3, py-1.9.0, pluggy-0.13.1 -- /home/lhellebr/git/robottelo/venv3/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
plugins: services-1.3.1, ibutsu-1.1.1, xdist-1.34.0, cov-2.10.0, mock-3.3.1, forked-1.2.0
collected 32 items                                                                                                                                                                                                                           

tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_name PASSED                                                                                                                                               [  3%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_info PASSED                                                                                                                                                           [  6%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_list PASSED                                                                                                                                                           [  9%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_delete_by_name PASSED                                                                                                                                                 [ 12%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_libvirt[0] PASSED                                                                                                                                         [ 15%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_libvirt[1] PASSED                                                                                                                                         [ 18%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_libvirt[2] PASSED                                                                                                                                         [ 21%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_libvirt[3] PASSED                                                                                                                                         [ 25%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_libvirt[4] PASSED                                                                                                                                         [ 28%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_libvirt[5] PASSED                                                                                                                                         [ 31%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_loc PASSED                                                                                                                                                [ 34%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_locs PASSED                                                                                                                                               [ 37%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_create_with_name_url[0] PASSED                                                                                                                                        [ 40%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_create_with_name_url[1] PASSED                                                                                                                                        [ 43%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_create_with_name_url[2] PASSED                                                                                                                                        [ 46%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_create_with_name_url[3] PASSED                                                                                                                                        [ 50%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_create_with_same_name PASSED                                                                                                                                          [ 53%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_name[0] PASSED                                                                                                                                                 [ 56%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_name[1] PASSED                                                                                                                                                 [ 59%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_name[2] PASSED                                                                                                                                                 [ 62%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_name[3] PASSED                                                                                                                                                 [ 65%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_name[4] PASSED                                                                                                                                                 [ 68%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_name[5] PASSED                                                                                                                                                 [ 71%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_name[6] PASSED                                                                                                                                                 [ 75%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_update[0] PASSED                                                                                                                                                      [ 78%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_update[1] PASSED                                                                                                                                                      [ 81%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_update[2] PASSED                                                                                                                                                      [ 84%]
tests/foreman/cli/test_computeresource_libvirt.py::test_negative_update[3] PASSED                                                                                                                                                      [ 87%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_console_password_and_name[true] PASSED                                                                                                                    [ 90%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_create_with_console_password_and_name[false] PASSED                                                                                                                   [ 93%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_console_password[true] PASSED                                                                                                                                  [ 96%]
tests/foreman/cli/test_computeresource_libvirt.py::test_positive_update_console_password[false] PASSED                                                                                                                                 [100%]

======================================================================================================= 32 passed in 545.66s (0:09:05) =======================================================================================================
```