### PR TITLE
Convert cli/test_fact.py to pytest

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -12,7 +12,7 @@
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 :Upstream: No
 """
@@ -20,41 +20,33 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.fact import Fact
-from robottelo.test import CLITestCase
 
 
-class FactTestCase(CLITestCase):
-    """Fact related tests."""
-
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_list_by_name(self):
-        """Test Fact List
-
-        :id: 83794d97-d21b-4482-9522-9b41053e595f
-
-        :expectedresults: Fact List is displayed
+pytestmark = [pytest.mark.tier1]
 
 
-        :CaseImportance: Critical
-        """
-        for fact in ('uptime', 'uptime_days', 'uptime_seconds', 'memoryfree', 'ipaddress'):
-            with self.subTest(fact):
-                args = {'search': f"fact={fact}"}
-                facts = Fact().list(args)
-                self.assertEqual(facts[0]['fact'], fact)
+@pytest.mark.upgrade
+@pytest.mark.parametrize(
+    'fact', ['uptime', 'uptime_days', 'uptime_seconds', 'memoryfree', 'ipaddress']
+)
+def test_positive_list_by_name(fact):
+    """Test Fact List
 
-    @pytest.mark.tier1
-    def test_negative_list_by_name(self):
-        """Test Fact List failure
+    :id: 83794d97-d21b-4482-9522-9b41053e595f
 
-        :id: bd56d27e-59c0-4f35-bd53-2999af7c6946
+    :expectedresults: Fact List is displayed
 
-        :expectedresults: Fact List is not displayed
+    :parametrized: yes
+    """
+    facts = Fact().list(options={'search': f'fact={fact}'})
+    assert facts[0]['fact'] == fact
 
 
-        :CaseImportance: Critical
-        """
-        fact = gen_string('alpha')
-        args = {'search': f"fact={fact}"}
-        self.assertEqual(Fact().list(args), [], 'No records should be returned')
+def test_negative_list_by_name():
+    """Test Fact List failure
+
+    :id: bd56d27e-59c0-4f35-bd53-2999af7c6946
+
+    :expectedresults: Fact List is not displayed
+    """
+    assert Fact().list(options={'search': f'fact={gen_string("alpha")}'}) == []


### PR DESCRIPTION
```
setup@localhost:~/repos/robottelo (pytest-test-fact-13982$%<>) % pytest -vx tests/foreman/cli/test_fact.py 
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 6 items                                                                                                                                                                                    

tests/foreman/cli/test_fact.py::test_positive_list_by_name[uptime] PASSED                                                                                                                      [ 16%]
tests/foreman/cli/test_fact.py::test_positive_list_by_name[uptime_days] PASSED                                                                                                                 [ 33%]
tests/foreman/cli/test_fact.py::test_positive_list_by_name[uptime_seconds] PASSED                                                                                                              [ 50%]
tests/foreman/cli/test_fact.py::test_positive_list_by_name[memoryfree] PASSED                                                                                                                  [ 66%]
tests/foreman/cli/test_fact.py::test_positive_list_by_name[ipaddress] PASSED                                                                                                                   [ 83%]
tests/foreman/cli/test_fact.py::test_negative_list_by_name PASSED                                                                                                                              [100%]

========================================================================================= 6 passed in 51.87s =========================================================================================
```