### PR TITLE
Refactor test_globalparam to pytest, condense tests

### DIFF
--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -12,68 +12,42 @@
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 :Upstream: No
 """
+from functools import partial
+
 import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.globalparam import GlobalParameter
-from robottelo.test import CLITestCase
 
 
-class GlobalParameterTestCase(CLITestCase):
-    """GlobalParameter related CLI tests."""
-
-    @pytest.mark.tier1
-    def test_positive_set(self):
-        """Check if Global Param can be set
-
-        :id: af0d3338-d7a1-41e5-959a-289ebc326c5b
-
-        :expectedresults: Global Param is set
+pytestmark = [pytest.mark.tier1]
 
 
-        :CaseImportance: Critical
-        """
-        name = 'opt-%s' % gen_string('alpha', 10)
-        value = 'val-{} {}'.format(gen_string('alpha', 10), gen_string('alpha', 10))
-        GlobalParameter().set({'name': name, 'value': value})
+@pytest.mark.upgrade
+def test_positive_list_delete_by_name():
+    """Test Global Param List
 
-    @pytest.mark.tier1
-    def test_positive_list_by_name(self):
-        """Test Global Param List
+    :id: 8dd6c4e8-4ec9-4bee-8a04-f5788960973a
 
-        :id: 8dd6c4e8-4ec9-4bee-8a04-f5788960973a
+    :expectedresults: Global Param is set, listed, and deleted by name
+    """
+    alphastring = partial(gen_string, 'alpha', 10)
 
-        :expectedresults: Global Param List is displayed
+    name = f'opt-{alphastring()}'
+    value = f'val-{alphastring()} {alphastring()}'
 
+    # Create
+    GlobalParameter().set({'name': name, 'value': value})
 
-        :CaseImportance: Critical
-        """
-        name = 'opt-%s' % gen_string('alpha', 10)
-        value = 'val-{} {}'.format(gen_string('alpha', 10), gen_string('alpha', 10))
-        GlobalParameter().set({'name': name, 'value': value})
-        result = GlobalParameter().list({'search': name})
-        self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['value'], value)
+    # List by name
+    result = GlobalParameter().list({'search': name})
+    assert len(result) == 1
+    assert result[0]['value'] == value
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_delete_by_name(self):
-        """Check if Global Param can be deleted
-
-        :id: 2c44d9c9-2a21-4415-8e89-cfd3d963891b
-
-        :expectedresults: Global Param is deleted
-
-
-        :CaseImportance: Critical
-        """
-        name = 'opt-%s' % gen_string('alpha', 10)
-        value = 'val-{} {}'.format(gen_string('alpha', 10), gen_string('alpha', 10))
-        GlobalParameter().set({'name': name, 'value': value})
-        GlobalParameter().delete({'name': name})
-        result = GlobalParameter().list({'search': name})
-        self.assertEqual(len(result), 0)
+    # Delete
+    GlobalParameter().delete({'name': name})
+    assert len(GlobalParameter().list({'search': name})) == 0


### PR DESCRIPTION
```
setup@localhost:~/repos/robottelo (pytest-globalparam-13983$%=) % pytest -vx tests/foreman/cli/test_globalparam.py 
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo68z/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, reportportal-5.0.7, ibutsu-1.15, xdist-2.1.0, mock-3.3.1, services-2.2.1
collected 1 item                                                                                                                                                                                     

tests/foreman/cli/test_globalparam.py::test_positive_list_delete_by_name PASSED
 ```