### PR TITLE
Refactor cli/test_ping for pytest

### DIFF
--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -12,57 +12,47 @@
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 :Upstream: No
 """
 import pytest
 
 from robottelo import ssh
-from robottelo.test import CLITestCase
 
 
-class PingTestCase(CLITestCase):
-    """Tests related to the hammer ping command"""
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_ping():
+    """hammer ping return code
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_ping(self):
-        """hammer ping return code
+    :id: dfa3ab4f-a64f-4a96-8c7f-d940df22b8bf
 
-        :id: dfa3ab4f-a64f-4a96-8c7f-d940df22b8bf
+    :steps:
+        1. Execute hammer ping
+        2. Check its return code, should be 0 if all services are ok else
+           != 0
 
-        :steps:
-            1. Execute hammer ping
-            2. Check its return code, should be 0 if all services are ok else
-               != 0
+    :expectedresults: hammer ping returns a right return code
+    """
+    result = ssh.command('hammer ping')
+    assert result.stderr.decode() == ''
 
-        :expectedresults: hammer ping returns a right return code
+    status_count = 0
+    ok_count = 0
+    # Exclude message from stdout for services candlepin_events and katello_events
+    result.stdout = [line for line in result.stdout if 'message' not in line]
 
-        :CaseImportance: Critical
-        """
-        result = ssh.command(f'hammer -u {self.foreman_user} -p {self.foreman_password} ping')
-        self.assertEqual(len(result.stderr), 0)
+    # iterate over the lines grouping every 3 lines
+    # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]
+    # only the status line is relevant for this test
+    for _, status, _ in zip(*[iter(result.stdout)] * 3):
+        status_count += 1
 
-        status_count = 0
-        ok_count = 0
-        # Exclude message from stdout for services candlepin_events and katello_events
-        result.stdout = [line for line in result.stdout if "message" not in line]
+        if status.split(':')[1].strip().lower() == 'ok':
+            ok_count += 1
 
-        # iterate over the lines grouping every 3 lines
-        # example [1, 2, 3, 4, 5, 6] will return [(1, 2, 3), (4, 5, 6)]
-        # only the status line is relevant for this test
-        for _, status, _ in zip(*[iter(result.stdout)] * 3):
-            status_count += 1
-
-            if status.split(':')[1].strip().lower() == 'ok':
-                ok_count += 1
-
-        if status_count == ok_count:
-            self.assertEqual(
-                result.return_code, 0, 'Return code should be 0 if all services are ok'
-            )
-        else:
-            self.assertNotEqual(
-                result.return_code, 0, 'Return code should not be 0 if any service is not ok'
-            )
+    if status_count == ok_count:
+        assert result.return_code == 0, 'Return code should be 0 if all services are ok'
+    else:
+        assert result.return_code != 0, 'Return code should not be 0 if any service is not ok'


### PR DESCRIPTION
```
setup@localhost:~/repos/robottelo (pytest-ping-13989$%<>) % pytest -vx tests/foreman/cli/test_ping.py
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 1 item                                                                                                                                                                                     

tests/foreman/cli/test_ping.py::test_positive_ping PASSED                                                                                                                                      [100%]

========================================================================================= 1 passed in 17.40s =========================================================================================

```