### PR TITLE
remove the skip_setting_if_not_set for auth tests

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -36,7 +36,6 @@ from robottelo.constants import CERT_PATH
 from robottelo.constants import LDAP_ATTR
 from robottelo.constants import PERMISSIONS
 from robottelo.datafactory import gen_string
-from robottelo.decorators import setting_is_set
 from robottelo.helpers import file_downloader
 from robottelo.rhsso_utils import create_group
 from robottelo.rhsso_utils import create_new_rhsso_user
@@ -51,9 +50,6 @@ from robottelo.utils.issue_handlers import is_open
 pytestmark = [pytest.mark.run_in_one_thread]
 
 EXTERNAL_GROUP_NAME = 'foobargroup'
-
-if not setting_is_set('ldap'):
-    pytest.skip('skipping tests due to missing ldap settings', allow_module_level=True)
 
 
 def set_certificate_in_satellite(server_type):


### PR DESCRIPTION
## PR Details 

Because of setting_is_set check tests are not able to get collected using pytest as it is using the older validator underneath. when we are moving to dynaconf the function is absolute. Removing the dependency as auth properties are already moved to Dynaconf and this validation is no more required 

Before Fix:

```
(env) /home/okhatavk/Satellite/robottelo (master) $ pytest tests/foreman/ui/test_ldap_authentication.py --collect-only 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, ibutsu-1.14.1, picked-0.4.6
collected 0 items / 1 skipped                                                                                                                                                                

================================================================================ no tests collected in 0.14s =================================================================================
(env) /home/okhatavk/Satellite/robottelo (master)

```

After Fix:

```
(env) /home/okhatavk/Satellite/robottelo (remove_the_skip_settings) $ pytest tests/foreman/ui/test_ldap_authentication.py --collect-only 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, ibutsu-1.14.1, picked-0.4.6
collected 69 items / 2 deselected / 67 selected                                                                                                                                              

<Package ui>
  <Module test_ldap_authentication.py>
    <Function test_positive_end_to_end[AD]>
    <Function test_positive_end_to_end[IPA]>
    <Function test_positive_end_to_end[OPENLDAP]>
    <Function test_positive_create_org_and_loc[AD]>
    <Function test_positive_create_org_and_loc[IPA]>
    <Function test_positive_create_org_and_loc[OPENLDAP]>
    <Function test_positive_create_with_https[AD]>
```





