### PR TITLE
Refactor test_api_endtoend and endtoend/utils for pytest

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -45,7 +45,6 @@ from robottelo.constants.repos import FAKE_0_PUPPET_REPO
 from robottelo.decorators import setting_is_set
 from robottelo.decorators import skip_if_not_set
 from robottelo.helpers import get_nailgun_config
-from robottelo.test import TestCase
 from robottelo.utils.issue_handlers import is_open
 
 API_PATHS = {
@@ -896,31 +895,34 @@ API_PATHS = {
 }
 
 
-class AvailableURLsTestCase(TestCase):
+@pytest.fixture(scope='module', autouse=True)
+def filtered_api_paths():
+    """Filter the API_PATHS dict based on BZs that impact various endpoints"""
+    missing = defaultdict(list)
+    if is_open('BZ:1887932'):
+        missing['subscriptions'].append(
+            '/katello/api/activation_keys/:activation_key_id/subscriptions'
+        )
+    filtered_paths = API_PATHS.copy()
+    for endpoint, missing_paths in missing.items():
+        filtered_paths[endpoint] = tuple(
+            path for path in filtered_paths[endpoint] if path not in missing_paths
+        )
+    return filtered_paths
+
+
+class TestAvailableURLs:
     """Tests for ``api/v2``."""
 
-    longMessage = True
-    maxDiff = None
+    pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
 
-    @classmethod
-    def setUpClass(cls):
-        """Define commonly-used variables."""
-        super().setUpClass()
-        cls.path = f'{settings.server.get_url()}/api/v2'
-        missing = defaultdict(list)
-        if is_open('BZ:1887932'):
-            missing['subscriptions'].append(
-                '/katello/api/activation_keys/:activation_key_id/subscriptions'
-            )
-        for endpoint, missing_paths in missing.items():
-            API_PATHS[endpoint] = tuple(
-                path for path in API_PATHS[endpoint] if path not in missing_paths
-            )
+    @pytest.fixture(scope='class')
+    def api_url(self):
+        """We want to delay referencing server.get_url() until test execution"""
+        return f'{settings.server.get_url()}/api/v2'
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
     @pytest.mark.build_sanity
-    def test_positive_get_status_code(self):
+    def test_positive_get_status_code(self, api_url):
         """GET ``api/v2`` and examine the response.
 
         :id: 9d9c1afd-9158-419e-9a6e-91e9888f0c04
@@ -929,13 +931,11 @@ class AvailableURLsTestCase(TestCase):
             content-type
 
         """
-        response = client.get(self.path, auth=settings.server.get_credentials(), verify=False)
-        self.assertEqual(response.status_code, http.client.OK)
-        self.assertIn('application/json', response.headers['content-type'])
+        response = client.get(api_url, auth=settings.server.get_credentials(), verify=False)
+        assert response.status_code == http.client.OK
+        assert 'application/json' in response.headers['content-type']
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_get_links(self):
+    def test_positive_get_links(self, api_url, filtered_api_paths):
         """GET ``api/v2`` and check the links returned.
 
         :id: 7b2dd77a-a821-485b-94db-b583f93c9a89
@@ -944,7 +944,7 @@ class AvailableURLsTestCase(TestCase):
 
         """
         # Did the server give us any paths at all?
-        response = client.get(self.path, auth=settings.server.get_credentials(), verify=False)
+        response = client.get(api_url, auth=settings.server.get_credentials(), verify=False)
         response.raise_for_status()
         # response.json()['links'] is a dict like this:
         #
@@ -964,10 +964,10 @@ class AvailableURLsTestCase(TestCase):
         #          '/katello/api/organizations/:organization_id/content_views',
         #          '/katello/api/organizations/:organization_id/content_views',
         #     ], …}
-        api_paths = response.json()['links']
-        transformed_paths = {ep: tuple(paths.values()) for ep, paths in api_paths.items()}
+        sat_api_paths = response.json()['links']
+        transformed_paths = {ep: tuple(paths.values()) for ep, paths in sat_api_paths.items()}
         api_diff = DeepDiff(
-            API_PATHS,
+            filtered_api_paths,
             transformed_paths,
             ignore_order=True,
             report_repetition=True,
@@ -976,16 +976,15 @@ class AvailableURLsTestCase(TestCase):
         assert api_diff == {}, f'API path mismatch (expected first): \n{pformat(api_diff)}'
 
 
-class EndToEndTestCase(TestCase, ClientProvisioningMixin):
+class TestEndToEnd(ClientProvisioningMixin):
     """End-to-end tests using the ``API`` path."""
 
-    @classmethod
-    def setUpClass(cls):  # noqa
-        super().setUpClass()
-        cls.fake_manifest_is_set = setting_is_set('fake_manifest')
+    pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
+    @pytest.fixture(scope='class')
+    def fake_manifest_is_set(self):
+        return setting_is_set('fake_manifest')
+
     @pytest.mark.build_sanity
     def test_positive_find_default_org(self):
         """Check if 'Default Organization' is present
@@ -993,14 +992,11 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         :id: c6e45b36-d8b6-4507-8dcd-0645668496b9
 
         :expectedresults: 'Default Organization' is found
-
         """
         results = entities.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].name, DEFAULT_ORG)
+        assert len(results) == 1
+        assert results[0].name == DEFAULT_ORG
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
     @pytest.mark.build_sanity
     def test_positive_find_default_loc(self):
         """Check if 'Default Location' is present
@@ -1008,14 +1004,11 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         :id: 1f40b3c6-488d-4037-a7ab-250a02bf919a
 
         :expectedresults: 'Default Location' is found
-
         """
         results = entities.Location().search(query={'search': f'name="{DEFAULT_LOC}"'})
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].name, DEFAULT_LOC)
+        assert len(results) == 1
+        assert results[0].name == DEFAULT_LOC
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
     @pytest.mark.build_sanity
     def test_positive_find_admin_user(self):
         """Check if Admin User is present
@@ -1023,14 +1016,11 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         :id: 892fdfcd-18c0-42ef-988b-f13a04097f5c
 
         :expectedresults: Admin User is found and has Admin role
-
         """
         results = entities.User().search(query={'search': 'login=admin'})
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].login, 'admin')
+        assert len(results) == 1
+        assert results[0].login == 'admin'
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
     @pytest.mark.build_sanity
     @pytest.mark.skip_if_open('BZ:1897360')
     def test_positive_ping(self):
@@ -1040,10 +1030,9 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
 
         :expectedresults: Overall and individual services status should be
             'ok'.
-
         """
         response = entities.Ping().search_json()
-        self.assertEqual(response['status'], 'ok')  # overall status
+        assert response['status'] == 'ok'  # overall status
 
         # Check that all services are OK. ['services'] is in this format:
         #
@@ -1053,17 +1042,16 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         #    …
         # }, 'status': 'ok'}
         services = response['services']
-        self.assertTrue(
-            all([service['status'] == 'ok' for service in services.values()]),
-            'Not all services seem to be up and running!',
-        )
+        assert all(
+            [service['status'] == 'ok' for service in services.values()]
+        ), 'Not all services seem to be up and running!'
 
     @skip_if_not_set('compute_resources')
     @pytest.mark.tier4
     @pytest.mark.on_premises_provisioning
     @pytest.mark.upgrade
     @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-    def test_positive_end_to_end(self):
+    def test_positive_end_to_end(self, fake_manifest_is_set):
         """Perform end to end smoke tests using RH and custom repos.
 
         1. Create a new user with admin permissions
@@ -1105,7 +1093,7 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         org = entities.Organization(server_config).create()
 
         # step 2.2: Clone and upload manifest
-        if self.fake_manifest_is_set:
+        if fake_manifest_is_set:
             with manifests.clone() as manifest:
                 upload_manifest(org.id, manifest.content)
 
@@ -1129,7 +1117,7 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
         repositories.append(repo2)
 
         # step 2.7: Enable a Red Hat repository
-        if self.fake_manifest_is_set:
+        if fake_manifest_is_set:
             repo3 = entities.Repository(
                 id=enable_rhrepo_and_fetchid(
                     basearch='x86_64',
@@ -1157,25 +1145,25 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
 
         # step 2.11: Add a PUPPET module to new content view
         puppet_mods = content_view.available_puppet_modules()
-        self.assertGreater(len(puppet_mods['results']), 0)
+        assert len(puppet_mods['results']), 'Available puppet modules should be greater than zero'
         puppet_module = random.choice(puppet_mods['results'])
         puppet = entities.ContentViewPuppetModule(
             author=puppet_module['author'], content_view=content_view, name=puppet_module['name']
         ).create()
-        self.assertEqual(puppet.name, puppet_module['name'])
+        assert puppet.name == puppet_module['name']
 
         # step 2.12: Publish content view
         content_view.publish()
 
         # step 2.13: Promote content view to the lifecycle environment
         content_view = content_view.read()
-        self.assertEqual(len(content_view.version), 1)
+        assert len(content_view.version) == 1
         cv_version = content_view.version[0].read()
-        self.assertEqual(len(cv_version.environment), 1)
+        assert len(cv_version.environment) == 1
         promote(cv_version, le1.id)
         # check that content view exists in lifecycle
         content_view = content_view.read()
-        self.assertEqual(len(content_view.version), 1)
+        assert len(content_view.version) == 1
         cv_version = cv_version.read()
 
         # step 2.14: Create a new activation key
@@ -1190,7 +1178,7 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
                 activation_key.add_subscriptions(data={'quantity': 1, 'subscription_id': sub.id})
                 break
         # step 2.15.1: Enable product content
-        if self.fake_manifest_is_set:
+        if fake_manifest_is_set:
             activation_key.content_override(
                 data={'content_overrides': [{'content_label': AK_CONTENT_LABEL, 'value': '1'}]}
             )
@@ -1205,9 +1193,9 @@ class EndToEndTestCase(TestCase, ClientProvisioningMixin):
             organization=org,
         ).create()
         # check that content view matches what we passed
-        self.assertEqual(content_host.content_facet_attributes['content_view_id'], content_view.id)
+        assert content_host.content_facet_attributes['content_view_id'] == content_view.id
         # check that lifecycle environment matches
-        self.assertEqual(content_host.content_facet_attributes['lifecycle_environment_id'], le1.id)
+        assert content_host.content_facet_attributes['lifecycle_environment_id'] == le1.id
 
         # step 2.16: Create a new libvirt compute resource
         entities.LibvirtComputeResource(


### PR DESCRIPTION
Running these locally still, not quite ready yet.

`tests/foreman/endtoend/test_api_endtoend.py::AvailableURLsTestCase::test_positive_get_links` Is failing in the master branch, I won't be addressing that failure here.  Some API endpoints have changed in recent snaps.

```
setup@localhost:~/repos/robottelo (pytest-api-endtoend-13994$%=) % pytest -v tests/foreman/endtoend/test_api_endtoend.py 
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 7 items                                                                                                                                                                                    

tests/foreman/endtoend/test_api_endtoend.py::TestAvailableURLs::test_positive_get_status_code PASSED                                                                                           [ 14%]
tests/foreman/endtoend/test_api_endtoend.py::TestAvailableURLs::test_positive_get_links FAILED                                                                                                 [ 28%]
tests/foreman/endtoend/test_api_endtoend.py::TestEndToEnd::test_positive_find_default_org PASSED                                                                                               [ 42%]
tests/foreman/endtoend/test_api_endtoend.py::TestEndToEnd::test_positive_find_default_loc PASSED                                                                                               [ 57%]
tests/foreman/endtoend/test_api_endtoend.py::TestEndToEnd::test_positive_find_admin_user PASSED                                                                                                [ 71%]
tests/foreman/endtoend/test_api_endtoend.py::TestEndToEnd::test_positive_ping SKIPPED (BZ:1897360)                                                                                             [ 85%]
tests/foreman/endtoend/test_api_endtoend.py::TestEndToEnd::test_positive_end_to_end PASSED                                                                                                     [100%]

============================================================================================== FAILURES ==============================================================================================
<KNOWN FAILURE ON MASTER BRANCH>
====================================================================================== short test summary info =======================================================================================
FAILED tests/foreman/endtoend/test_api_endtoend.py::TestAvailableURLs::test_positive_get_links - AssertionError: API path mismatch (expected first): 
================================================================== 1 failed, 5 passed, 1 skipped, 74 warnings in 126.76s (0:02:06) ===================================================================

```