### PR TITLE
Refactor sys/test_hooks for pytest

### DIFF
--- a/tests/foreman/sys/test_hooks.py
+++ b/tests/foreman/sys/test_hooks.py
@@ -15,7 +15,6 @@
 :CaseImportance: High
 
 :Upstream: No
-
 """
 import pytest
 from fauxfactory import gen_ipaddr
@@ -25,137 +24,130 @@ from requests.exceptions import HTTPError
 from robottelo import ssh
 from robottelo.datafactory import valid_hostgroups_list
 from robottelo.datafactory import valid_hosts_list
-from robottelo.test import TestCase
 
 HOOKS_DIR = '/usr/share/foreman/config/hooks'
 LOGS_DIR = '/usr/share/foreman/tmp/hooks.log'
+SCRIPT_PATH = f'{HOOKS_DIR}/logger.sh'
 
 
-@pytest.mark.run_in_one_thread
-class ForemanHooksTestCase(TestCase):
-    """Test class for testing foreman hooks"""
+pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.destructive]
 
-    @classmethod
-    def setUpClass(cls):
-        """Create logger script to be executed via hooks"""
-        super().setUpClass()
-        cls.org = 1  # using Default_Organization
-        cls.script_path = f"{HOOKS_DIR}/logger.sh"
-        ssh.command(
-            '''printf '#!/bin/sh\necho "$(date): Executed $1 hook'''
-            + f''' on object $2" > {LOGS_DIR}' > {cls.script_path}'''
-        )
-        ssh.command(f"chmod 774 {cls.script_path}")
-        ssh.command(f"chown foreman:foreman {cls.script_path}")
-        ssh.command(f"restorecon -RvF {HOOKS_DIR}")
 
-    @classmethod
-    def tearDownClass(cls):
-        """clean up hook files"""
-        super().tearDownClass()
-        ssh.command(f"rm -rf {HOOKS_DIR}/*")
+@pytest.fixture(scope='function')
+def logger_hook(default_org):
+    """Create logger script to be executed via hooks"""
+    ssh.command(
+        '''printf '#!/bin/sh\necho "$(date): Executed $1 hook'''
+        + f''' on object $2" > {LOGS_DIR}' > {SCRIPT_PATH}'''
+    )
+    ssh.command(f'chmod 774 {SCRIPT_PATH}')
+    ssh.command(f'chown foreman:foreman {SCRIPT_PATH}')
+    ssh.command(f'restorecon -RvF {HOOKS_DIR}')
+    yield
 
-    @pytest.mark.destructive
-    def test_positive_host_hooks(self):
-        """Create hooks to be executed on host create, update and destroy
+    ssh.command(f'rm -rf {HOOKS_DIR}/*')
 
-        :id: 4fe35fda-1524-44f7-9221-96d1aeafc75c
 
-        :Steps:
-            1. Create hook directories with symlinks to logger script
-            for subset of supported events: create, update, destroy
-            2. Perform trigger actions (create, update and delete host)
-            3. Observe custom logs created by hook script
+def test_positive_host_hooks(logger_hook):
+    """Create hooks to be executed on host create, update and destroy
 
-        :expectedresults: hook scripts are executed at proper time
-        """
-        host_name = valid_hosts_list()[0]
-        expected_msg = "Executed {0} hook on object {1}"
+    :id: 4fe35fda-1524-44f7-9221-96d1aeafc75c
 
-        # create hook destination directories with logger script
-        create_event = "create"
-        update_event = "update"
-        destroy_event = "destroy"
-        for event in [create_event, destroy_event, update_event]:
-            hook_dir = f"{HOOKS_DIR}/host/managed/{event}"
-            ssh.command(f'''mkdir -p {hook_dir}''')
-            ssh.command(f'''ln -sf {self.script_path} {hook_dir}/''')
-        result = ssh.command("systemctl restart httpd")
-        self.assertEqual(result.return_code, 0)
+    :Steps:
+        1. Create hook directories with symlinks to logger script
+        for subset of supported events: create, update, destroy
+        2. Perform trigger actions (create, update and delete host)
+        3. Observe custom logs created by hook script
 
-        # delete host, check logs for hook activity
-        host = entities.Host(name=host_name).create()
-        self.assertEqual(host.name, f'{host_name}.{host.domain.read().name}')
-        result = ssh.command(f'cat {LOGS_DIR}')
-        self.assertEqual(result.return_code, 0)
-        self.assertIn(expected_msg.format(create_event, host_name), result.stdout[0])
+    :expectedresults: hook scripts are executed at proper time
+    """
+    host_name = valid_hosts_list()[0]
+    expected_msg = 'Executed {0} hook on object {1}'
 
-        # update host, check logs for hook activity
-        new_ip = gen_ipaddr()
-        host.ip = new_ip
-        host = host.update(['ip'])
-        self.assertEqual(host.ip, new_ip)
-        result = ssh.command(f'cat {LOGS_DIR}')
-        self.assertEqual(result.return_code, 0)
-        self.assertIn(expected_msg.format(update_event, host_name), result.stdout[0])
+    # create hook destination directories with logger script
+    create_event = 'create'
+    update_event = 'update'
+    destroy_event = 'destroy'
+    for event in [create_event, destroy_event, update_event]:
+        hook_dir = f'{HOOKS_DIR}/host/managed/{event}'
+        ssh.command(f'mkdir -p {hook_dir}')
+        ssh.command(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
+    result = ssh.command('systemctl restart httpd')
+    assert result.return_code == 0
 
-        # delete host, check logs for hook activity
-        host.delete()
-        with self.assertRaises(HTTPError):
-            host.read()
-        result = ssh.command(f'cat {LOGS_DIR}')
-        self.assertEqual(result.return_code, 0)
-        self.assertIn(expected_msg.format(destroy_event, host_name), result.stdout[0])
+    # delete host, check logs for hook activity
+    host = entities.Host(name=host_name).create()
+    assert host.name == f'{host_name}.{host.domain.read().name}'
+    result = ssh.command(f'cat {LOGS_DIR}')
+    assert result.return_code == 0
+    assert expected_msg.format(create_event, host_name) in result.stdout[0]
 
-    @pytest.mark.destructive
-    def test_positive_hostgroup_hooks(self):
-        """Create hooks to be executed on hostgroup create, udpdate and destroy
+    # update host, check logs for hook activity
+    new_ip = gen_ipaddr()
+    host.ip = new_ip
+    host = host.update(['ip'])
+    assert host.ip == new_ip
+    result = ssh.command(f'cat {LOGS_DIR}')
+    assert result.return_code == 0
+    assert expected_msg.format(update_event, host_name) in result.stdout[0]
 
-        :id: 7e935dec-e4fe-47d8-be02-8c687a99ae7a
+    # delete host, check logs for hook activity
+    host.delete()
+    with pytest.raises(HTTPError):
+        host.read()
+    result = ssh.command(f'cat {LOGS_DIR}')
+    assert result.return_code == 0
+    assert expected_msg.format(destroy_event, host_name) in result.stdout[0]
 
-        :steps:
-            1. Create hook directories with symlinks to logger script
-            for subset of supported events: before_create, before_update,
-            before_destroy
-            2. Perform trigger actions (create, update and delete host group)
-            3. Observe custom logs created by hook script
 
-        :expectedresults: hook scripts are executed at proper time
-        """
-        hg_name = valid_hostgroups_list()[0]
-        expected_msg = "Executed {0} hook on object {1}"
+def test_positive_hostgroup_hooks(logger_hook, default_org):
+    """Create hooks to be executed on hostgroup create, udpdate and destroy
 
-        # create hook destination directories with logger script
-        create_event = "before_create"
-        update_event = "before_update"
-        destroy_event = "before_destroy"
-        for event in [create_event, update_event, destroy_event]:
-            hook_dir = f"{HOOKS_DIR}/hostgroup/{event}"
-            ssh.command(f'''mkdir -p {hook_dir}''')
-            ssh.command(f'''ln -sf {self.script_path} {hook_dir}/''')
-        result = ssh.command("systemctl restart httpd")
-        self.assertEqual(result.return_code, 0)
+    :id: 7e935dec-e4fe-47d8-be02-8c687a99ae7a
 
-        # create hg, check logs for hook activity
-        hg = entities.HostGroup(name=hg_name, organization=[self.org]).create()
-        self.assertEqual(hg.name, hg_name)
-        result = ssh.command(f'cat {LOGS_DIR}')
-        self.assertEqual(result.return_code, 0)
-        self.assertIn(expected_msg.format(create_event, hg_name), result.stdout[0])
+    :steps:
+        1. Create hook directories with symlinks to logger script
+        for subset of supported events: before_create, before_update,
+        before_destroy
+        2. Perform trigger actions (create, update and delete host group)
+        3. Observe custom logs created by hook script
 
-        # update hg, check logs for hook activity
-        new_arch = entities.Architecture().create()
-        hg.architecture = new_arch
-        hg = hg.update(['architecture'])
-        self.assertEqual(hg.architecture.read().name, new_arch.name)
-        result = ssh.command(f'cat {LOGS_DIR}')
-        self.assertEqual(result.return_code, 0)
-        self.assertIn(expected_msg.format(update_event, hg_name), result.stdout[0])
+    :expectedresults: hook scripts are executed at proper time
+    """
+    hg_name = valid_hostgroups_list()[0]
+    expected_msg = 'Executed {0} hook on object {1}'
 
-        # delete hg, check logs for hook activity
-        hg.delete()
-        with self.assertRaises(HTTPError):
-            hg.read()
-        result = ssh.command(f'cat {LOGS_DIR}')
-        self.assertEqual(result.return_code, 0)
-        self.assertIn(expected_msg.format(destroy_event, hg_name), result.stdout[0])
+    # create hook destination directories with logger script
+    create_event = 'before_create'
+    update_event = 'before_update'
+    destroy_event = 'before_destroy'
+    for event in [create_event, update_event, destroy_event]:
+        hook_dir = f'{HOOKS_DIR}/hostgroup/{event}'
+        ssh.command(f'mkdir -p {hook_dir}')
+        ssh.command(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
+    result = ssh.command('systemctl restart httpd')
+    assert result.return_code == 0
+
+    # create hg, check logs for hook activity
+    hg = entities.HostGroup(name=hg_name, organization=[default_org.id]).create()
+    assert hg.name == hg_name
+    result = ssh.command(f'cat {LOGS_DIR}')
+    assert result.return_code == 0
+    assert expected_msg.format(create_event, hg_name) in result.stdout[0]
+
+    # update hg, check logs for hook activity
+    new_arch = entities.Architecture().create()
+    hg.architecture = new_arch
+    hg = hg.update(['architecture'])
+    assert hg.architecture.read().name == new_arch.name
+    result = ssh.command(f'cat {LOGS_DIR}')
+    assert result.return_code == 0
+    assert expected_msg.format(update_event, hg_name) in result.stdout[0]
+
+    # delete hg, check logs for hook activity
+    hg.delete()
+    with pytest.raises(HTTPError):
+        hg.read()
+    result = ssh.command(f'cat {LOGS_DIR}')
+    assert result.return_code == 0
+    assert expected_msg.format(destroy_event, hg_name) in result.stdout[0]


### PR DESCRIPTION
Tests are currently failing in master at the same point they're failing in this branch.

If that level of risk is not acceptable for the conversion, I'd like to get @rdrazny input on why this is failing on 6.9.

## Master branch test failures
```
setup@localhost:~/repos/robottelo (master$%>) % pytest -v tests/foreman/sys/test_hooks.py 
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 2 items                                                                                                                                                                                    

tests/foreman/sys/test_hooks.py::ForemanHooksTestCase::test_positive_host_hooks FAILED                                                                                                         [ 50%]
tests/foreman/sys/test_hooks.py::ForemanHooksTestCase::test_positive_hostgroup_hooks FAILED                                                                                                    [100%]
====================================================================================== short test summary info =======================================================================================
FAILED tests/foreman/sys/test_hooks.py::ForemanHooksTestCase::test_positive_host_hooks - AssertionError: 1 != 0
FAILED tests/foreman/sys/test_hooks.py::ForemanHooksTestCase::test_positive_hostgroup_hooks - AssertionError: 1 != 0
============================================================================= 2 failed, 17 warnings in 72.65s (0:01:12) ==============================================================================

```

## This branch
```
setup@localhost:~/repos/robottelo (pytest-hooks-14001$%=) % pytest -v tests/foreman/sys/test_hooks.py 
========================================================================================== test session starts ==========================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 2 items                                                                                                                                                                                       

tests/foreman/sys/test_hooks.py::test_positive_host_hooks FAILED                                                                                                                                  [ 50%]
tests/foreman/sys/test_hooks.py::test_positive_hostgroup_hooks FAILED                                                                                                                             [100%]
======================================================================================== short test summary info ========================================================================================
FAILED tests/foreman/sys/test_hooks.py::test_positive_host_hooks - assert 1 == 0
FAILED tests/foreman/sys/test_hooks.py::test_positive_hostgroup_hooks - assert 1 == 0


```