### PR TITLE
fixing selection in global registration tests

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1332,8 +1332,8 @@ def test_positive_global_registration_form(
     with session:
         cmd = session.host.get_register_command(
             {
-                'setup_insights': 'Yes' if insights_value else 'No',
-                'remote_execution': 'Yes' if rex_value else 'No',
+                'setup_insights': 'Yes (enforce)' if insights_value else 'No (enforce)',
+                'remote_execution': 'Yes (enforce)' if rex_value else 'No (enforce)',
                 'insecure': True,
                 'hostgroup': hostgroup.name,
                 'operatingsystem': module_os.title,


### PR DESCRIPTION
reacting to recent ui change in global registration dialog

```
pytest tests/foreman/ui/test_host.py -k test_positive_global_registration_form
                                          

tests/foreman/ui/test_host.py .                                                                               [100%]


============================= 1 passed, 31 deselected, 23 warnings in 89.10s (0:01:29) ==============================
```