### PR TITLE
Scenario rename to TestScenario

### DIFF
--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -299,7 +299,7 @@ class TestAzureRMHostProvisioningTestCase:
 
 
 @pytest.mark.run_in_one_thread
-class TestAzureRM_UserData_Provisioning:
+class TestAzureRMUserDataProvisioning:
     """AzureRM UserData Host Provisioning Tests"""
 
     @pytest.fixture(scope='class', autouse=True)
@@ -453,7 +453,7 @@ class TestAzureRM_UserData_Provisioning:
 
 
 @pytest.mark.run_in_one_thread
-class TestAzureRm_Shared_Gallery_FinishTemplate_Provisioning:
+class TestAzureRMSharedGalleryFinishTemplateProvisioning:
     """AzureRM Host Provisioning Tests with Shared Image Gallery"""
 
     @pytest.fixture(scope='class', autouse=True)
@@ -579,7 +579,7 @@ class TestAzureRm_Shared_Gallery_FinishTemplate_Provisioning:
 
 
 @pytest.mark.run_in_one_thread
-class TestAzureRm_Custom_Image_FinishTemplate_Provisioning:
+class TestAzureRMCustomImageFinishTemplateProvisioning:
     """AzureRM Host Provisioning Tests with Custom Image"""
 
     @pytest.fixture(scope='class', autouse=True)

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -296,7 +296,7 @@ class TestAzureRMComputeResourceTestCase:
 
 
 @pytest.mark.run_in_one_thread
-class TestAzureRm_FinishTemplate_Provisioning:
+class TestAzureRMFinishTemplateProvisioning:
     """AzureRM Host Provisioning Tests"""
 
     @pytest.fixture(scope='class', autouse=True)
@@ -419,7 +419,7 @@ class TestAzureRm_FinishTemplate_Provisioning:
 
 
 @pytest.mark.run_in_one_thread
-class TestAzureRm_UserData_Provisioning:
+class TestAzureRMUserDataProvisioning:
     """AzureRM Host Provisioning Tests"""
 
     @pytest.fixture(scope='class', autouse=True)
@@ -546,7 +546,7 @@ class TestAzureRm_UserData_Provisioning:
 
 
 @pytest.mark.run_in_one_thread
-class TestAzureRm_BYOS_FinishTemplate_Provisioning:
+class TestAzureRMBYOSFinishTemplateProvisioning:
     """AzureRM Host Provisioning Test with BYOS Image"""
 
     @pytest.fixture(scope='class', autouse=True)

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -45,7 +45,7 @@ def _valid_sc_parameters_data():
     ]
 
 
-class scenario_positive_puppet_parameter_and_datatype_intact(APITestCase):
+class Test_scenario_positive_puppet_parameter_and_datatype_intact(APITestCase):
     """Puppet Class Parameters value and type is intact post upgrade
 
     :id: 08012f39-240b-40df-b893-2ee767129737

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -45,7 +45,7 @@ def _valid_sc_parameters_data():
     ]
 
 
-class Test_scenario_positive_puppet_parameter_and_datatype_intact(APITestCase):
+class TestScenarioPositivePuppetParameterAndDatatypeIntact(APITestCase):
     """Puppet Class Parameters value and type is intact post upgrade
 
     :id: 08012f39-240b-40df-b893-2ee767129737

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -182,7 +182,7 @@ def update_product_subscription_in_ak(product, yum_repo, ak, org):
     ak.add_subscriptions(data={'subscription_id': subscription.id})
 
 
-class Scenario_upgrade_old_client_and_package_installation(APITestCase):
+class Test_scenario_upgrade_old_client_and_package_installation(APITestCase):
     """The test class contains pre and post upgrade scenarios to test if the
     package can be installed on preupgrade client remotely
 
@@ -299,7 +299,7 @@ class Scenario_upgrade_old_client_and_package_installation(APITestCase):
         self.assertIn(self.package_name, installed_package)
 
 
-class Scenario_upgrade_new_client_and_package_installation(APITestCase):
+class Test_scenario_upgrade_new_client_and_package_installation(APITestCase):
     """The test class contains post-upgrade scenarios to test if the package
     can be installed on postupgrade client remotely
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -182,7 +182,7 @@ def update_product_subscription_in_ak(product, yum_repo, ak, org):
     ak.add_subscriptions(data={'subscription_id': subscription.id})
 
 
-class Test_scenario_upgrade_old_client_and_package_installation(APITestCase):
+class TestScenarioUpgradeOldClientAndPackageInstallation(APITestCase):
     """The test class contains pre and post upgrade scenarios to test if the
     package can be installed on preupgrade client remotely
 
@@ -299,7 +299,7 @@ class Test_scenario_upgrade_old_client_and_package_installation(APITestCase):
         self.assertIn(self.package_name, installed_package)
 
 
-class Test_scenario_upgrade_new_client_and_package_installation(APITestCase):
+class TestScenarioUpgradeNewClientAndPackageInstallation(APITestCase):
     """The test class contains post-upgrade scenarios to test if the package
     can be installed on postupgrade client remotely
 

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -44,7 +44,7 @@ from robottelo.upgrade_utility import publish_content_view
 from robottelo.upgrade_utility import run_goferd
 
 
-class ScenarioErrataAbstract:
+class Test_scenarioErrataAbstract:
     """This is an Abstract Class whose methods are inherited by others errata
     scenarios"""
 
@@ -96,7 +96,7 @@ class ScenarioErrataAbstract:
         return [entities.Repository(id=repo_id) for repo_id in [repo1_id, repo2_id]]
 
 
-class Scenario_errata_count(APITestCase, ScenarioErrataAbstract):
+class Test_scenario_errata_count(APITestCase, Test_scenarioErrataAbstract):
     """The test class contains pre and post upgrade scenarios to test if the
     errata count for satellite client/content host.
 
@@ -277,8 +277,8 @@ class Scenario_errata_count(APITestCase, ScenarioErrataAbstract):
             install_or_update_package(client_hostname=client_container_id, package=package)
 
 
-class Scenario_errata_count_with_previous_version_katello_agent(
-    APITestCase, ScenarioErrataAbstract
+class Test_scenario_errata_count_with_previous_version_katello_agent(
+    APITestCase, Test_scenarioErrataAbstract
 ):
     """The test class contains pre and post upgrade scenarios to test erratas count
     and remotely install using n-1 'katello-agent' on content host.

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -44,7 +44,7 @@ from robottelo.upgrade_utility import publish_content_view
 from robottelo.upgrade_utility import run_goferd
 
 
-class Test_scenarioErrataAbstract:
+class TestScenarioErrataAbstract:
     """This is an Abstract Class whose methods are inherited by others errata
     scenarios"""
 
@@ -96,7 +96,7 @@ class Test_scenarioErrataAbstract:
         return [entities.Repository(id=repo_id) for repo_id in [repo1_id, repo2_id]]
 
 
-class Test_scenario_errata_count(APITestCase, Test_scenarioErrataAbstract):
+class TestScenarioErrataCount(APITestCase, TestScenarioErrataAbstract):
     """The test class contains pre and post upgrade scenarios to test if the
     errata count for satellite client/content host.
 
@@ -277,8 +277,8 @@ class Test_scenario_errata_count(APITestCase, Test_scenarioErrataAbstract):
             install_or_update_package(client_hostname=client_container_id, package=package)
 
 
-class Test_scenario_errata_count_with_previous_version_katello_agent(
-    APITestCase, Test_scenarioErrataAbstract
+class TestScenarioErrataCountWithPreviousVersionKatelloAgent(
+    APITestCase, TestScenarioErrataAbstract
 ):
     """The test class contains pre and post upgrade scenarios to test erratas count
     and remotely install using n-1 'katello-agent' on content host.

--- a/tests/upgrades/test_foreman_maintain.py
+++ b/tests/upgrades/test_foreman_maintain.py
@@ -23,7 +23,7 @@ from upgrade_tests import pre_upgrade
 from robottelo import ssh
 
 
-class ScenarioForemanMaintain(TestCase):
+class Test_scenarioForemanMaintain(TestCase):
     """The test class contains pre-upgrade and post-upgrade scenarios to test
     foreman-maintain utility
 

--- a/tests/upgrades/test_foreman_maintain.py
+++ b/tests/upgrades/test_foreman_maintain.py
@@ -23,7 +23,7 @@ from upgrade_tests import pre_upgrade
 from robottelo import ssh
 
 
-class Test_scenarioForemanMaintain(TestCase):
+class TestScenarioForemanMaintain(TestCase):
     """The test class contains pre-upgrade and post-upgrade scenarios to test
     foreman-maintain utility
 

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -44,7 +44,7 @@ GCE_SETTINGS = dict(
 )
 
 
-class Test_scenario_positive_gce_host_compute_resource(APITestCase):
+class TestScenarioPositiveGCEHostComputeResource(APITestCase):
     """The host can be provisioned on GCE CR created in previous version
 
     :steps:

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -44,7 +44,7 @@ GCE_SETTINGS = dict(
 )
 
 
-class scenario_positive_gce_host_compute_resource(APITestCase):
+class Test_scenario_positive_gce_host_compute_resource(APITestCase):
     """The host can be provisioned on GCE CR created in previous version
 
     :steps:

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -32,7 +32,7 @@ from robottelo.test import settings
 from robottelo.vm import VirtualMachine
 
 
-class Test_scenario_remoteexecution_external_capsule(APITestCase):
+class TestScenarioRemoteexecutionExternalCapsule(APITestCase):
     """Test Remote Execution job created before migration runs successfully
     post migration on a client registered with external capsule.
 
@@ -154,7 +154,7 @@ class Test_scenario_remoteexecution_external_capsule(APITestCase):
         )
 
 
-class Test_scenario_remoteexecution_satellite(APITestCase):
+class TestScenarioRemoteexecutionSatellite(APITestCase):
     """Test Remote Execution job created before migration runs successfully
     post migration on a client registered with Satellite.
 

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -32,7 +32,7 @@ from robottelo.test import settings
 from robottelo.vm import VirtualMachine
 
 
-class Scenario_remoteexecution_external_capsule(APITestCase):
+class Test_scenario_remoteexecution_external_capsule(APITestCase):
     """Test Remote Execution job created before migration runs successfully
     post migration on a client registered with external capsule.
 
@@ -154,7 +154,7 @@ class Scenario_remoteexecution_external_capsule(APITestCase):
         )
 
 
-class Scenario_remoteexecution_satellite(APITestCase):
+class Test_scenario_remoteexecution_satellite(APITestCase):
     """Test Remote Execution job created before migration runs successfully
     post migration on a client registered with Satellite.
 

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -41,7 +41,7 @@ from robottelo.upgrade_utility import install_or_update_package
 from robottelo.upgrade_utility import publish_content_view
 
 
-class Test_scenario_repository_upstream_authorization_check(APITestCase):
+class TestScenarioRepositoryUpstreamAuthorizationCheck(APITestCase):
     """This test scenario is to verify the upstream username in post-upgrade for a custom
     repository which does have a upstream username but not password set on it in pre-upgrade.
 
@@ -107,7 +107,7 @@ class Test_scenario_repository_upstream_authorization_check(APITestCase):
         self.assertNotIn(self.upstream_username, result)
 
 
-class Test_scenario_custom_repo_check(APITestCase):
+class TestScenarioCustomRepoCheck(APITestCase):
     """Scenario test to verify if we can create a custom repository and consume it
     via client then we alter the created custom repository and satellite will be able
     to sync back the repo.

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -41,7 +41,7 @@ from robottelo.upgrade_utility import install_or_update_package
 from robottelo.upgrade_utility import publish_content_view
 
 
-class Scenario_repository_upstream_authorization_check(APITestCase):
+class Test_scenario_repository_upstream_authorization_check(APITestCase):
     """This test scenario is to verify the upstream username in post-upgrade for a custom
     repository which does have a upstream username but not password set on it in pre-upgrade.
 
@@ -107,7 +107,7 @@ class Scenario_repository_upstream_authorization_check(APITestCase):
         self.assertNotIn(self.upstream_username, result)
 
 
-class Scenario_custom_repo_check(APITestCase):
+class Test_scenario_custom_repo_check(APITestCase):
     """Scenario test to verify if we can create a custom repository and consume it
     via client then we alter the created custom repository and satellite will be able
     to sync back the repo.

--- a/tests/upgrades/test_user.py
+++ b/tests/upgrades/test_user.py
@@ -20,7 +20,7 @@ from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
 
 
-class Test_scenario_positive_create_sshkey_in_existing_users:
+class TestScenarioPositiveCreateSSHKeyInExistingUsers:
     """SSH Key can be created in existing user post upgrade
 
     :id: e4338daa-272a-42e3-be45-77e1caea607f
@@ -57,7 +57,7 @@ class Test_scenario_positive_create_sshkey_in_existing_users:
         """
 
 
-class Test_scenario_positive_existing_user_passwordless_access_to_host:
+class TestScenarioPositiveExistingUserPasswordlessAccessToHost:
     """Existing user can password-less access to provisioned host
 
     :id: d2d94447-5fc7-49cc-840e-06568d8a5141

--- a/tests/upgrades/test_user.py
+++ b/tests/upgrades/test_user.py
@@ -20,7 +20,7 @@ from upgrade_tests import post_upgrade
 from upgrade_tests import pre_upgrade
 
 
-class scenario_positive_create_sshkey_in_existing_users:
+class Test_scenario_positive_create_sshkey_in_existing_users:
     """SSH Key can be created in existing user post upgrade
 
     :id: e4338daa-272a-42e3-be45-77e1caea607f
@@ -57,7 +57,7 @@ class scenario_positive_create_sshkey_in_existing_users:
         """
 
 
-class scenario_positive_existing_user_passwordless_access_to_host:
+class Test_scenario_positive_existing_user_passwordless_access_to_host:
     """Existing user can password-less access to provisioned host
 
     :id: d2d94447-5fc7-49cc-840e-06568d8a5141

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -38,7 +38,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-class scenario_positive_virt_who(APITestCase):
+class Test_scenario_positive_virt_who(APITestCase):
     """Virt-who config is intact post upgrade and verify the config can be updated and deleted.
     :steps:
 

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -38,7 +38,7 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import virtwho
 
 
-class Test_scenario_positive_virt_who(APITestCase):
+class TestScenarioPositiveVirtWho(APITestCase):
     """Virt-who config is intact post upgrade and verify the config can be updated and deleted.
     :steps:
 

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -39,7 +39,7 @@ from robottelo.upgrade_utility import publish_content_view
 from robottelo.upgrade_utility import run_goferd
 
 
-class Scenario_yum_plugins_count(APITestCase):
+class Test_scenario_yum_plugins_count(APITestCase):
     """The test class contains pre and post upgrade scenarios to test the
     loaded yum plugins count on content host.
 

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -39,7 +39,7 @@ from robottelo.upgrade_utility import publish_content_view
 from robottelo.upgrade_utility import run_goferd
 
 
-class Test_scenario_yum_plugins_count(APITestCase):
+class TestScenarioYumPluginsCount(APITestCase):
     """The test class contains pre and post upgrade scenarios to test the
     loaded yum plugins count on content host.
 


### PR DESCRIPTION
Scenario -> `TestScenario`
class names to Camel case in the whole robottelo.

results:
```
pytest --collect-only tests/foreman/api/test_computeresource_azurerm.py
=========================================== 10 tests collected in 0.03s ===========================================


 pytest --collect-only tests/foreman/cli/test_computeresource_azurerm.py
 =========================================== 11 tests collected in 0.03s ===========================================

 pytest --collect-only -m pre_upgrade tests/upgrades/
================================= 28/65 tests collected (37 deselected) in 0.21s ==================================

pytest --collect-only -m post_upgrade tests/upgrades/ 
 ================================= 31/65 tests collected (34 deselected) in 0.24s ==================================

 ```
 btw `28 + 31 -> 59 != 65 `, don't know what is not collected :D 
