### PR TITLE
Convert sys/test_dynflow to pytest

### DIFF
--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -19,30 +19,24 @@
 import pytest
 
 from robottelo import ssh
-from robottelo.test import TestCase
 
 
-class DynflowTestCase(TestCase):
-    """Dynflow tests"""
+@pytest.mark.tier2
+def test_positive_setup_dynflow():
+    """Set dynflow parameters, restart it and check it adheres to them
 
-    @pytest.mark.tier2
-    def test_positive_setup_dynflow(self):
-        """Set dynflow parameters, restart it and check it adheres to them
+    :id: a5aaab5e-bc18-453e-a284-64aef752ec88
 
-        :id: a5aaab5e-bc18-453e-a284-64aef752ec88
-
-        :expectedresults: Correct dynflow processes are running, respecting settings
-
-        :CaseImportance: High
-        """
-        commands = [
-            "cd /etc/foreman/dynflow/",
-            "cp worker-hosts-queue.yml test.yml",
-            "sed -i s/5/6/ test.yml",
-            "systemctl restart 'dynflow-sidekiq@test'",
-            "while ! systemctl status 'dynflow-sidekiq@test' -l | "  # no comma here
-            "grep -q ' of 6 busy' ; do sleep 0.5 ; done",
-        ]
-        # if thread count is not respected or the process is not running, this should timeout
-        ssh.command(" && ".join(commands))
-        ssh.command("systemctl stop 'dynflow-sidekiq@test'; rm /etc/foreman/dynflow/test.yml")
+    :expectedresults: Correct dynflow processes are running, respecting settings
+    """
+    commands = [
+        'cd /etc/foreman/dynflow/',
+        'cp worker-hosts-queue.yml test.yml',
+        'sed -i s/5/6/ test.yml',
+        "systemctl restart 'dynflow-sidekiq@test'",
+        "while ! systemctl status 'dynflow-sidekiq@test' -l | "  # no comma here
+        "grep -q ' of 6 busy' ; do sleep 0.5 ; done",
+    ]
+    # if thread count is not respected or the process is not running, this should timeout
+    ssh.command(' && '.join(commands))
+    ssh.command("systemctl stop 'dynflow-sidekiq@test'; rm /etc/foreman/dynflow/test.yml")


### PR DESCRIPTION
```
setup@localhost:~/repos/robottelo (pytest-dynflow-14000$%=) % pytest -v tests/foreman/sys/test_dynflow.py 
========================================================================================== test session starts ==========================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 1 item                                                                                                                                                                                        

tests/foreman/sys/test_dynflow.py::test_positive_setup_dynflow PASSED                                                                                                                             [100%]

===================================================================================== 1 passed in 65.83s (0:01:05) ======================================================================================
```