### PR TITLE
Add new broker settings file for robottelo

### DIFF
--- a/conf/broker.yaml.template
+++ b/conf/broker.yaml.template
@@ -1,0 +1,3 @@
+BROKER:
+    # The path where your broker settings and inventory are located
+    BROKER_DIRECTORY: "."


### PR DESCRIPTION
Currently just the single value as all other config values reside
in broker's own settings file.