### PR TITLE
Convert cli/test_discoveryrule to pytest

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -1,7 +1,11 @@
 # Module-wide Nailgun Entity Fixtures to be used by API, CLI and UI Tests
+import logging
+
 import pytest
+from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_string
 from nailgun import entities
+from requests.exceptions import HTTPError
 from wrapanapi import AzureSystem
 from wrapanapi import GoogleCloudSystem
 
@@ -35,6 +39,8 @@ from robottelo.test import settings
 if not settings.configured:
     settings.configure()
 
+logger = logging.getLogger('robottelo')
+
 
 @pytest.fixture(scope='session')
 def default_org():
@@ -51,6 +57,13 @@ def module_org():
     return entities.Organization().create()
 
 
+@pytest.fixture(scope='class')
+def class_org():
+    org = entities.Organization().create()
+    yield org
+    org.delete()
+
+
 @pytest.fixture(scope='module')
 def module_manifest_org():
     org = entities.Organization().create()
@@ -62,6 +75,13 @@ def module_manifest_org():
 @pytest.fixture(scope='module')
 def module_location(module_org):
     return entities.Location(organization=[module_org]).create()
+
+
+@pytest.fixture(scope='class')
+def class_location(class_org):
+    loc = entities.Location(organization=[class_org]).create()
+    yield loc
+    loc.delete()
 
 
 @pytest.fixture(scope='session')
@@ -82,6 +102,17 @@ def module_host():
 @pytest.fixture(scope='module')
 def module_hostgroup():
     return entities.HostGroup().create()
+
+
+@pytest.fixture(scope='class')
+def class_hostgroup(class_org, class_location):
+    """Create a hostgroup linked to specific org and location created at the class scope"""
+    hostgroup = entities.HostGroup(organization=[class_org], location=[class_location]).create()
+    yield hostgroup
+    try:
+        hostgroup.delete()
+    except HTTPError:
+        logger.exception('Exception while deleting class scope hostgroup entity in teardown')
 
 
 @pytest.fixture(scope='module')
@@ -253,6 +284,12 @@ def module_puppet_environment(module_org, module_location):
 @pytest.fixture(scope='module')
 def module_user(module_org, module_location):
     return entities.User(organization=[module_org], location=[module_location]).create()
+
+
+@pytest.fixture(scope='class')
+def class_user_password():
+    """Generate a random password for a user, and capture it so a test has access to it"""
+    return gen_alphanumeric()
 
 
 # Compute resource - Libvirt entities

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -16,12 +16,17 @@
 
 :Upstream: No
 """
+import logging
 import random
+from functools import partial
 
 import pytest
-from fauxfactory import gen_alphanumeric
+from attrdict import AttrDict
 from fauxfactory import gen_choice
 from fauxfactory import gen_string
+from nailgun.entities import Role as RoleEntity
+from nailgun.entities import User as UserEntity
+from requests import HTTPError
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.discoveryrule import DiscoveryRule
@@ -30,72 +35,72 @@ from robottelo.cli.factory import make_discoveryrule
 from robottelo.cli.factory import make_hostgroup
 from robottelo.cli.factory import make_location
 from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_user
-from robottelo.cli.user import User
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
+from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
-from robottelo.test import CLITestCase
 
 
-class DiscoveryRuleTestCase(CLITestCase):
+logger = logging.getLogger('robottelo')
+
+
+@filtered_datapoint
+def invalid_hostnames_list():
+    """Generates a list of invalid host names.
+
+    :return: Returns the invalid host names list
+    """
+    return {
+        'cjk': gen_string('cjk'),
+        'latin': gen_string('latin1'),
+        'numeric': gen_string('numeric'),
+        'utf8': gen_string('utf8'),
+        'special': '$#@!*',
+        'whitespace': '" "',
+        'negative': '-1',
+    }
+
+
+class TestDiscoveryRule:
     """Implements Foreman discovery Rules tests in CLI."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Tests for discovery rules via Hammer CLI"""
-        super().setUpClass()
-        cls.org = make_org()
-        cls.loc = make_location()
-        cls.hostgroup = make_hostgroup(
-            {'organization-ids': cls.org['id'], 'location-ids': cls.loc['id']}
+    @pytest.fixture(scope='function')
+    def discoveryrule_factory(self, class_org, class_location, class_hostgroup):
+        def _create_discoveryrule(org, loc, hostgroup, options=None):
+            """Makes a new discovery rule and asserts its success"""
+            options = options or {}
+
+            searches = [
+                'cpu_count = 1',
+                'disk_count < 5',
+                'memory > 500',
+                'model = KVM',
+                'Organization = Default_Organization',
+                'last_report = Today',
+                'subnet =  192.168.100.0',
+                'facts.architecture != x86_64',
+            ]
+
+            if not any(options.get(key) for key in ['organizations', 'organization-ids']):
+                options['organization-ids'] = org.id
+            if not any(options.get(key) for key in ['locations', 'locations-ids']):
+                options['location-ids'] = loc.id
+            if not any(options.get(key) for key in ['hostgroup', 'hostgroup-ids']):
+                options['hostgroup-id'] = hostgroup.id
+            if options.get('search') is None:
+                options['search'] = gen_choice(searches)
+
+            # create a simple object from the dictionary that the CLI factory provides
+            # This allows for consistent attributized access of all fixture entities in the tests
+            return AttrDict(make_discoveryrule(options))
+
+        return partial(
+            _create_discoveryrule, org=class_org, loc=class_location, hostgroup=class_hostgroup
         )
 
-    def _make_discoveryrule(self, options=None):
-        """Makes a new discovery rule and asserts its success"""
-        if options is None:
-            options = {}
-
-        searches = [
-            'cpu_count = 1',
-            'disk_count < 5',
-            'memory > 500',
-            'model = KVM',
-            'Organization = Default_Organization',
-            'last_report = Today',
-            'subnet =  192.168.100.0',
-            'facts.architecture != x86_64',
-        ]
-
-        if not any(options.get(key) for key in ['organizations', 'organization-ids']):
-            options['organization-ids'] = self.org['id']
-        if not any(options.get(key) for key in ['locations', 'locations-ids']):
-            options['location-ids'] = self.loc['id']
-        if not any(options.get(key) for key in ['hostgroup', 'hostgroup-ids']):
-            options['hostgroup-id'] = self.hostgroup['id']
-        if options.get('search') is None:
-            options['search'] = gen_choice(searches)
-
-        return make_discoveryrule(options)
-
-    @filtered_datapoint
-    def invalid_hostnames_list(self):
-        """Generates a list of invalid host names.
-
-        :return: Returns the invalid host names list
-        """
-        return [
-            {'name': gen_string('cjk')},
-            {'name': gen_string('latin1')},
-            {'name': gen_string('numeric')},
-            {'name': gen_string('utf8')},
-            {'name': '$#@!*'},
-            {'name': '" "'},
-            {'name': '-1'},
-        ]
-
     @pytest.mark.tier1
-    def test_positive_create_with_name(self):
+    @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
+    def test_positive_create_with_name(self, name, discoveryrule_factory):
         """Create Discovery Rule using different names
 
         :id: 066e66bc-c572-4ae9-b458-90daf83bab54
@@ -103,14 +108,14 @@ class DiscoveryRuleTestCase(CLITestCase):
         :expectedresults: Rule should be successfully created
 
         :CaseImportance: Critical
+
+        :parametrized: yes
         """
-        for name in valid_data_list():
-            with self.subTest(name):
-                rule = self._make_discoveryrule({'name': name})
-                self.assertEqual(rule['name'], name)
+        rule = discoveryrule_factory(options={'name': name})
+        assert rule.name == name
 
     @pytest.mark.tier1
-    def test_positive_create_with_search(self):
+    def test_positive_create_with_search(self, discoveryrule_factory):
         """Create Discovery Rule using different search queries
 
         :id: 2383e898-a968-4183-a270-55e9350e0596
@@ -121,11 +126,11 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseImportance: Critical
         """
         search_query = 'cpu_count = 2'
-        rule = self._make_discoveryrule({'search': search_query})
-        self.assertEqual(rule['search'], search_query)
+        rule = discoveryrule_factory(options={'search': search_query})
+        assert rule.search == search_query
 
     @pytest.mark.tier2
-    def test_positive_create_with_hostname(self):
+    def test_positive_create_with_hostname(self, discoveryrule_factory):
         """Create Discovery Rule using valid hostname
 
         :id: deee22c3-dcfd-4940-b27c-cca137ec9a92
@@ -136,11 +141,13 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseLevel: Component
         """
         host_name = 'myhost'
-        rule = self._make_discoveryrule({'hostname': host_name})
-        self.assertEqual(rule['hostname-template'], host_name)
+        rule = discoveryrule_factory(options={'hostname': host_name})
+        assert rule['hostname-template'] == host_name
 
     @pytest.mark.tier1
-    def test_positive_create_with_org_loc_id(self):
+    def test_positive_create_with_org_loc_id(
+        self, discoveryrule_factory, class_org, class_location, class_hostgroup
+    ):
         """Create discovery rule by associating org and location ids
 
         :id: bdb4c581-d27a-4d1a-920b-89689e68a57f
@@ -151,18 +158,20 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        rule = self._make_discoveryrule(
-            {
-                'hostgroup-id': self.hostgroup['id'],
-                'organization-ids': self.org['id'],
-                'location-ids': self.loc['id'],
+        rule = discoveryrule_factory(
+            options={
+                'hostgroup-id': class_hostgroup.id,
+                'organization-ids': class_org.id,
+                'location-ids': class_location.id,
             }
         )
-        self.assertIn(self.org['name'], rule['organizations'])
-        self.assertIn(self.loc['name'], rule['locations'])
+        assert class_org.name in rule.organizations
+        assert class_location.name in rule.locations
 
     @pytest.mark.tier2
-    def test_positive_create_with_org_loc_name(self):
+    def test_positive_create_with_org_loc_name(
+        self, discoveryrule_factory, class_org, class_location, class_hostgroup
+    ):
         """Create discovery rule by associating org and location names
 
         :id: f0d550ae-16d8-48ec-817e-d2e5b7405b46
@@ -171,18 +180,18 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :BZ: 1377990
         """
-        rule = self._make_discoveryrule(
-            {
-                'hostgroup-id': self.hostgroup['id'],
-                'organizations': self.org['name'],
-                'locations': self.loc['name'],
+        rule = discoveryrule_factory(
+            options={
+                'hostgroup-id': class_hostgroup.id,
+                'organizations': class_org.name,
+                'locations': class_location.name,
             }
         )
-        self.assertIn(self.org['name'], rule['organizations'])
-        self.assertIn(self.loc['name'], rule['locations'])
+        assert class_org.name in rule.organizations
+        assert class_location.name in rule.locations
 
     @pytest.mark.tier2
-    def test_positive_create_with_hosts_limit(self):
+    def test_positive_create_with_hosts_limit(self, discoveryrule_factory):
         """Create Discovery Rule providing any number from range 1..100 for
         hosts limit option
 
@@ -194,11 +203,11 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseLevel: Component
         """
         hosts_limit = '5'
-        rule = self._make_discoveryrule({'hosts-limit': hosts_limit})
-        self.assertEqual(rule['hosts-limit'], hosts_limit)
+        rule = discoveryrule_factory(options={'hosts-limit': hosts_limit})
+        assert rule['hosts-limit'] == hosts_limit
 
     @pytest.mark.tier1
-    def test_positive_create_with_max_count(self):
+    def test_positive_create_with_max_count(self, discoveryrule_factory):
         """Create Discovery Rule providing any number from range 1..100 for
         max count option
 
@@ -210,11 +219,11 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseLevel: Component
         """
         max_count = '10'
-        rule = self._make_discoveryrule({'max-count': max_count})
-        self.assertEqual(rule['hosts-limit'], max_count)
+        rule = discoveryrule_factory(options={'max-count': max_count})
+        assert rule['hosts-limit'] == max_count
 
     @pytest.mark.tier1
-    def test_positive_create_with_priority(self):
+    def test_positive_create_with_priority(self, discoveryrule_factory):
         """Create Discovery Rule providing any number from range 1..100 for
         priority option
 
@@ -225,13 +234,13 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        available = set(range(1, 1000)) - {r['priority'] for r in DiscoveryRule.list()}
+        available = set(range(1, 1000)) - {AttrDict(r).priority for r in DiscoveryRule.list()}
         rule_priority = random.sample(available, 1)
-        rule = self._make_discoveryrule({'priority': rule_priority[0]})
-        self.assertEqual(rule['priority'], str(rule_priority[0]))
+        rule = discoveryrule_factory(options={'priority': rule_priority[0]})
+        assert rule.priority == str(rule_priority[0])
 
     @pytest.mark.tier2
-    def test_positive_create_disabled_rule(self):
+    def test_positive_create_disabled_rule(self, discoveryrule_factory):
         """Create Discovery Rule in disabled state
 
         :id: 8837a0c6-e19a-4c33-8b87-07b6f69dbb0f
@@ -240,11 +249,12 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseLevel: Component
         """
-        rule = self._make_discoveryrule({'enabled': 'false'})
-        self.assertEqual(rule['enabled'], 'false')
+        rule = discoveryrule_factory(options={'enabled': 'false'})
+        assert rule.enabled == 'false'
 
     @pytest.mark.tier3
-    def test_negative_create_with_invalid_name(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+    def test_negative_create_with_invalid_name(self, name, discoveryrule_factory):
         """Create Discovery Rule with invalid names
 
         :id: a0350dc9-8f5b-4673-be88-a5e35d1f8ca7
@@ -254,14 +264,15 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseImportance: Medium
 
         :CaseLevel: Component
+
+        :parametrized: yes
         """
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(CLIFactoryError):
-                    self._make_discoveryrule({'name': name})
+        with pytest.raises(CLIFactoryError):
+            discoveryrule_factory(options={'name': name})
 
     @pytest.mark.tier3
-    def test_negative_create_with_invalid_hostname(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_hostnames_list()))
+    def test_negative_create_with_invalid_hostname(self, name, discoveryrule_factory):
         """Create Discovery Rule with invalid hostname
 
         :id: 0ae51085-30d0-44f9-9e49-abe928a8a4b7
@@ -273,14 +284,14 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseLevel: Component
 
         :BZ: 1378427
+
+        :parametrized: yes
         """
-        for name in self.invalid_hostnames_list():
-            with self.subTest(name):
-                with self.assertRaises(CLIFactoryError):
-                    self._make_discoveryrule({'hostname': name})
+        with pytest.raises(CLIFactoryError):
+            discoveryrule_factory(options={'hostname': name})
 
     @pytest.mark.tier3
-    def test_negative_create_with_too_long_limit(self):
+    def test_negative_create_with_too_long_limit(self, discoveryrule_factory):
         """Create Discovery Rule with too long host limit value
 
         :id: 12dbb023-c963-4ead-a81e-ad53033de947
@@ -290,11 +301,11 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Medium
         """
-        with self.assertRaises(CLIFactoryError):
-            self._make_discoveryrule({'hosts-limit': '9999999999'})
+        with pytest.raises(CLIFactoryError):
+            discoveryrule_factory(options={'hosts-limit': '9999999999'})
 
     @pytest.mark.tier1
-    def test_negative_create_with_same_name(self):
+    def test_negative_create_with_same_name(self, discoveryrule_factory):
         """Create Discovery Rule with name that already exists
 
         :id: 0906cf64-ed0b-49af-844f-1af22f81ab94
@@ -304,12 +315,12 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseImportance: Medium
         """
         name = gen_string('alpha')
-        self._make_discoveryrule({'name': name})
-        with self.assertRaises(CLIFactoryError):
-            self._make_discoveryrule({'name': name})
+        discoveryrule_factory(options={'name': name})
+        with pytest.raises(CLIFactoryError):
+            discoveryrule_factory(options={'name': name})
 
     @pytest.mark.tier1
-    def test_positive_delete(self):
+    def test_positive_delete(self, discoveryrule_factory):
         """Delete existing Discovery Rule
 
         :id: c9b88a94-13c4-496f-a5c1-c088187250dc
@@ -318,13 +329,13 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        rule = self._make_discoveryrule()
-        DiscoveryRule.delete({'id': rule['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            DiscoveryRule.info({'id': rule['id']})
+        rule = discoveryrule_factory()
+        DiscoveryRule.delete({'id': rule.id})
+        with pytest.raises(CLIReturnCodeError):
+            DiscoveryRule.info({'id': rule.id})
 
     @pytest.mark.tier3
-    def test_positive_update_name(self):
+    def test_positive_update_name(self, discoveryrule_factory):
         """Update discovery rule name
 
         :id: 1045e2c4-e1f7-42c9-95f7-488fc79bf70b
@@ -335,14 +346,14 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Medium
         """
-        rule = self._make_discoveryrule()
+        rule = discoveryrule_factory()
         new_name = gen_string('numeric')
-        DiscoveryRule.update({'id': rule['id'], 'name': new_name})
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertEqual(rule['name'], new_name)
+        DiscoveryRule.update({'id': rule.id, 'name': new_name})
+        rule = AttrDict(DiscoveryRule.info({'id': rule.id}))
+        assert rule.name == new_name
 
     @pytest.mark.tier2
-    def test_positive_update_org_loc_by_id(self):
+    def test_positive_update_org_loc_by_id(self, discoveryrule_factory):
         """Update org and location of selected discovery rule using org/loc ids
 
         :id: 26da79aa-30e5-4052-98ae-141de071a68a
@@ -353,26 +364,26 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseLevel: Component
         """
-        new_org = make_org()
-        new_loc = make_location()
-        new_hostgroup = make_hostgroup(
-            {'organization-ids': new_org['id'], 'location-ids': new_loc['id']}
+        new_org = AttrDict(make_org())
+        new_loc = AttrDict(make_location())
+        new_hostgroup = AttrDict(
+            make_hostgroup({'organization-ids': new_org.id, 'location-ids': new_loc.id})
         )
-        rule = self._make_discoveryrule()
+        rule = discoveryrule_factory()
         DiscoveryRule.update(
             {
-                'id': rule['id'],
-                'organization-ids': new_org['id'],
-                'location-ids': new_loc['id'],
-                'hostgroup-id': new_hostgroup['id'],
+                'id': rule.id,
+                'organization-ids': new_org.id,
+                'location-ids': new_loc.id,
+                'hostgroup-id': new_hostgroup.id,
             }
         )
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertIn(new_org['name'], rule['organizations'])
-        self.assertIn(new_loc['name'], rule['locations'])
+        rule = AttrDict(DiscoveryRule.info({'id': rule.id}))
+        assert new_org.name in rule.organizations
+        assert new_loc.name in rule.locations
 
     @pytest.mark.tier3
-    def test_positive_update_org_loc_by_name(self):
+    def test_positive_update_org_loc_by_name(self, discoveryrule_factory):
         """Update org and location of selected discovery rule using org/loc
         names
 
@@ -386,26 +397,26 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Medium
         """
-        new_org = make_org()
-        new_loc = make_location()
-        new_hostgroup = make_hostgroup(
-            {'organization-ids': new_org['id'], 'location-ids': new_loc['id']}
+        new_org = AttrDict(make_org())
+        new_loc = AttrDict(make_location())
+        new_hostgroup = AttrDict(
+            make_hostgroup({'organization-ids': new_org.id, 'location-ids': new_loc.id})
         )
-        rule = self._make_discoveryrule()
+        rule = discoveryrule_factory()
         DiscoveryRule.update(
             {
-                'id': rule['id'],
-                'organizations': new_org['name'],
-                'locations': new_loc['name'],
-                'hostgroup-id': new_hostgroup['id'],
+                'id': rule.id,
+                'organizations': new_org.name,
+                'locations': new_loc.name,
+                'hostgroup-id': new_hostgroup.id,
             }
         )
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertIn(new_org['name'], rule['organizations'])
-        self.assertIn(new_loc['name'], rule['locations'])
+        rule = AttrDict(DiscoveryRule.info({'id': rule.id}))
+        assert new_org.name in rule.organizations
+        assert new_loc.name in rule.locations
 
     @pytest.mark.tier2
-    def test_positive_update_query(self):
+    def test_positive_update_query(self, discoveryrule_factory):
         """Update discovery rule search query
 
         :id: 86943095-acc5-40ff-8e3c-88c76b36333d
@@ -414,14 +425,14 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseLevel: Component
         """
-        rule = self._make_discoveryrule()
+        rule = discoveryrule_factory()
         new_query = 'model = KVM'
-        DiscoveryRule.update({'id': rule['id'], 'search': new_query})
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertEqual(rule['search'], new_query)
+        DiscoveryRule.update({'id': rule.id, 'search': new_query})
+        rule = AttrDict(DiscoveryRule.info({'id': rule.id}))
+        assert rule.search == new_query
 
     @pytest.mark.tier2
-    def test_positive_update_hostgroup(self):
+    def test_positive_update_hostgroup(self, discoveryrule_factory, class_org):
         """Update discovery rule host group
 
         :id: 07992a3f-2aa9-4e45-b2e8-ef3d2f255292
@@ -430,14 +441,15 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseLevel: Component
         """
-        new_hostgroup = make_hostgroup({'organization-ids': self.org['id']})
-        rule = self._make_discoveryrule()
-        DiscoveryRule.update({'id': rule['id'], 'hostgroup': new_hostgroup['name']})
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertEqual(rule['host-group'], new_hostgroup['name'])
+        new_hostgroup = AttrDict(make_hostgroup({'organization-ids': class_org.id}))
+        rule = discoveryrule_factory()
+        DiscoveryRule.update({'id': rule.id, 'hostgroup': new_hostgroup.name})
+        rule = DiscoveryRule.info({'id': rule.id})
+        # AttrDict doesn't support attributized access on key with a hyphen
+        assert rule['host-group'] == new_hostgroup.name
 
     @pytest.mark.tier2
-    def test_positive_update_hostname(self):
+    def test_positive_update_hostname(self, discoveryrule_factory):
         """Update discovery rule hostname value
 
         :id: 4c123488-92df-42f6-afe3-8a88cd90ffc2
@@ -447,13 +459,13 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseLevel: Component
         """
         new_hostname = gen_string('alpha')
-        rule = self._make_discoveryrule()
-        DiscoveryRule.update({'id': rule['id'], 'hostname': new_hostname})
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertEqual(rule['hostname-template'], new_hostname)
+        rule = discoveryrule_factory()
+        DiscoveryRule.update({'id': rule.id, 'hostname': new_hostname})
+        rule = AttrDict(DiscoveryRule.info({'id': rule.id}))
+        assert rule['hostname-template'] == new_hostname
 
     @pytest.mark.tier2
-    def test_positive_update_limit(self):
+    def test_positive_update_limit(self, discoveryrule_factory):
         """Update discovery rule limit value
 
         :id: efa6f5bc-4d56-4449-90f5-330affbcfb09
@@ -462,14 +474,14 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseLevel: Component
         """
-        rule = self._make_discoveryrule({'hosts-limit': '5'})
+        rule = discoveryrule_factory(options={'hosts-limit': '5'})
         new_limit = '10'
-        DiscoveryRule.update({'id': rule['id'], 'hosts-limit': new_limit})
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertEqual(rule['hosts-limit'], new_limit)
+        DiscoveryRule.update({'id': rule.id, 'hosts-limit': new_limit})
+        rule = AttrDict(DiscoveryRule.info({'id': rule.id}))
+        assert rule['hosts-limit'] == new_limit
 
     @pytest.mark.tier1
-    def test_positive_update_priority(self):
+    def test_positive_update_priority(self, discoveryrule_factory):
         """Update discovery rule priority value
 
         :id: 0543cc73-c692-4bbf-818b-37353ec98986
@@ -478,18 +490,18 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        available = set(range(1, 1000)) - {r['priority'] for r in DiscoveryRule.list()}
+        available = set(range(1, 1000)) - {AttrDict(r).priority for r in DiscoveryRule.list()}
         rule_priority = random.sample(available, 1)
-        rule = self._make_discoveryrule({'priority': rule_priority[0]})
-        self.assertEqual(rule['priority'], str(rule_priority[0]))
-        available = set(range(1, 1000)) - {r['priority'] for r in DiscoveryRule.list()}
+        rule = discoveryrule_factory(options={'priority': rule_priority[0]})
+        assert rule.priority == str(rule_priority[0])
+        available = set(range(1, 1000)) - {AttrDict(r).priority for r in DiscoveryRule.list()}
         rule_priority = random.sample(available, 1)
-        DiscoveryRule.update({'id': rule['id'], 'priority': rule_priority[0]})
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertEqual(rule['priority'], str(rule_priority[0]))
+        DiscoveryRule.update({'id': rule.id, 'priority': rule_priority[0]})
+        rule = AttrDict(DiscoveryRule.info({'id': rule.id}))
+        assert rule.priority == str(rule_priority[0])
 
     @pytest.mark.tier1
-    def test_positive_update_disable_enable(self):
+    def test_positive_update_disable_enable(self, discoveryrule_factory):
         """Update discovery rule enabled state. (Disabled->Enabled)
 
         :id: 64e8b21b-2ab0-49c3-a12d-02dbdb36647a
@@ -498,14 +510,15 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Critical
         """
-        rule = self._make_discoveryrule({'enabled': 'false'})
-        self.assertEqual(rule['enabled'], 'false')
-        DiscoveryRule.update({'id': rule['id'], 'enabled': 'true'})
-        rule = DiscoveryRule.info({'id': rule['id']})
-        self.assertEqual(rule['enabled'], 'true')
+        rule = discoveryrule_factory(options={'enabled': 'false'})
+        assert rule.enabled == 'false'
+        DiscoveryRule.update({'id': rule.id, 'enabled': 'true'})
+        rule = AttrDict(DiscoveryRule.info({'id': rule.id}))
+        assert rule.enabled == 'true'
 
     @pytest.mark.tier3
-    def test_negative_update_name(self):
+    @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
+    def test_negative_update_name(self, name, discoveryrule_factory):
         """Update discovery rule name using invalid names only
 
         :id: 8293cc6a-d983-460a-b76e-221ad02b54b7
@@ -515,15 +528,15 @@ class DiscoveryRuleTestCase(CLITestCase):
         :CaseLevel: Component
 
         :CaseImportance: Medium
+
+        :parametrized: yes
         """
-        rule = self._make_discoveryrule()
-        for name in invalid_values_list():
-            with self.subTest(name):
-                with self.assertRaises(CLIReturnCodeError):
-                    DiscoveryRule.update({'id': rule['id'], 'name': name})
+        rule = discoveryrule_factory()
+        with pytest.raises(CLIReturnCodeError):
+            DiscoveryRule.update({'id': rule.id, 'name': name})
 
     @pytest.mark.tier3
-    def test_negative_update_hostname(self):
+    def test_negative_update_hostname(self, discoveryrule_factory):
         """Update discovery rule host name using number as a value
 
         :id: c382dbc7-9509-4060-9038-1617f7fef038
@@ -534,12 +547,12 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseLevel: Component
         """
-        rule = self._make_discoveryrule()
-        with self.assertRaises(CLIReturnCodeError):
-            DiscoveryRule.update({'id': rule['id'], 'hostname': '$#@!*'})
+        rule = discoveryrule_factory()
+        with pytest.raises(CLIReturnCodeError):
+            DiscoveryRule.update({'id': rule.id, 'hostname': '$#@!*'})
 
     @pytest.mark.tier3
-    def test_negative_update_limit(self):
+    def test_negative_update_limit(self, discoveryrule_factory):
         """Update discovery rule host limit using invalid values
 
         :id: e3257d8a-91b9-406f-bd74-0fd1fb05bb77
@@ -550,13 +563,13 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Medium
         """
-        rule = self._make_discoveryrule()
+        rule = discoveryrule_factory()
         host_limit = gen_string('alpha')
-        with self.assertRaises(CLIReturnCodeError):
-            DiscoveryRule.update({'id': rule['id'], 'hosts-limit': host_limit})
+        with pytest.raises(CLIReturnCodeError):
+            DiscoveryRule.update({'id': rule.id, 'hosts-limit': host_limit})
 
     @pytest.mark.tier3
-    def test_negative_update_priority(self):
+    def test_negative_update_priority(self, discoveryrule_factory):
         """Update discovery rule priority using invalid values
 
         :id: 0778dd00-aa19-4062-bdf3-752e1b546ec2
@@ -567,46 +580,55 @@ class DiscoveryRuleTestCase(CLITestCase):
 
         :CaseImportance: Medium
         """
-        rule = self._make_discoveryrule()
+        rule = discoveryrule_factory()
         priority = gen_string('alpha')
-        with self.assertRaises(CLIReturnCodeError):
-            DiscoveryRule.update({'id': rule['id'], 'priority': priority})
+        with pytest.raises(CLIReturnCodeError):
+            DiscoveryRule.update({'id': rule.id, 'priority': priority})
 
 
-class DiscoveryRuleRoleTestCase(CLITestCase):
+class TestDiscoveryRuleRole:
     """Implements Foreman discovery Rules tests along with roles from CLI."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Tests for discovery rules via Hammer CLI"""
-        super().setUpClass()
-        cls.org = make_org()
-        cls.loc = make_location()
-        cls.hostgroup = make_hostgroup(
-            {'organization-ids': cls.org['id'], 'location-ids': cls.loc['id']}
-        )
-        cls.password = gen_alphanumeric()
-        cls.user = make_user(
-            {
-                'organization-ids': cls.org['id'],
-                'location-ids': cls.loc['id'],
-                'password': cls.password,
-            }
-        )
-        cls.user['password'] = cls.password
-        User.add_role({'login': cls.user['login'], 'role': 'Discovery Manager'})
-        cls.user_reader = make_user(
-            {
-                'organization-ids': cls.org['id'],
-                'location-ids': cls.loc['id'],
-                'password': cls.password,
-            }
-        )
-        cls.user_reader['password'] = cls.password
-        User.add_role({'login': cls.user_reader['login'], 'role': 'Discovery Reader'})
+    @pytest.fixture(scope='class')
+    def class_user_manager(self, class_user_password, class_org, class_location):
+        try:
+            manager_role = RoleEntity().search(query={'search': 'name="Discovery Manager"'})[0]
+        except IndexError:
+            pytest.fail('Discovery Manager role was not found, setup cannot continue')
+        user = UserEntity(
+            organization=[class_org],
+            location=[class_location],
+            password=class_user_password,
+            role=[manager_role],
+        ).create()
+        yield user
+        try:
+            user.delete()
+        except HTTPError:
+            logger.exception('Exception while deleting class scope user entity in teardown')
+
+    @pytest.fixture(scope='class')
+    def class_user_reader(self, class_user_password, class_org, class_location):
+        try:
+            reader_role = RoleEntity().search(query={'search': 'name="Discovery Reader"'})[0]
+        except IndexError:
+            pytest.fail('Discovery Manager role was not found, setup cannot continue')
+        user = UserEntity(
+            organization=[class_org],
+            location=[class_location],
+            password=class_user_password,
+            role=[reader_role],
+        ).create()
+        yield user
+        try:
+            user.delete()
+        except HTTPError:
+            logger.exception('Exception while deleting class scope user entity in teardown')
 
     @pytest.mark.tier2
-    def test_positive_create_rule_with_non_admin_user(self):
+    def test_positive_create_rule_with_non_admin_user(
+        self, class_org, class_location, class_user_password, class_user_manager, class_hostgroup
+    ):
         """Create rule with non-admin user by associating discovery_manager role
 
         :id: 056535aa-3338-4c1e-8a4b-ebfc8bd6e456
@@ -616,22 +638,28 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
-        rule = DiscoveryRule.with_user(self.user['login'], self.user['password']).create(
-            {
-                'name': rule_name,
-                'search': 'cpu_count = 5',
-                'organizations': self.org['name'],
-                'locations': self.loc['name'],
-                'hostgroup-id': self.hostgroup['id'],
-            }
+        rule = AttrDict(
+            DiscoveryRule.with_user(class_user_manager.login, class_user_password).create(
+                {
+                    'name': rule_name,
+                    'search': 'cpu_count = 5',
+                    'organizations': class_org.name,
+                    'locations': class_location.name,
+                    'hostgroup-id': class_hostgroup.id,
+                }
+            )
         )
-        rule = DiscoveryRule.with_user(self.user['login'], self.user['password']).info(
-            {'id': rule['id']}
+        rule = AttrDict(
+            DiscoveryRule.with_user(class_user_manager.login, class_user_password).info(
+                {'id': rule.id}
+            )
         )
-        self.assertEqual(rule['name'], rule_name)
+        assert rule.name == rule_name
 
     @pytest.mark.tier2
-    def test_positive_delete_rule_with_non_admin_user(self):
+    def test_positive_delete_rule_with_non_admin_user(
+        self, class_org, class_location, class_user_manager, class_hostgroup, class_user_password
+    ):
         """Delete rule with non-admin user by associating discovery_manager role
 
         :id: 87ab969b-7d92-478d-a5c0-1c0d50e9bdd6
@@ -641,26 +669,33 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
-        rule = DiscoveryRule.with_user(self.user['login'], self.user['password']).create(
-            {
-                'name': rule_name,
-                'search': 'cpu_count = 5',
-                'organizations': self.org['name'],
-                'locations': self.loc['name'],
-                'hostgroup-id': self.hostgroup['id'],
-            }
+        rule = AttrDict(
+            DiscoveryRule.with_user(class_user_manager.login, class_user_password).create(
+                {
+                    'name': rule_name,
+                    'search': 'cpu_count = 5',
+                    'organizations': class_org.name,
+                    'locations': class_location.name,
+                    'hostgroup-id': class_hostgroup.id,
+                }
+            )
         )
-        rule = DiscoveryRule.with_user(self.user['login'], self.user['password']).info(
-            {'id': rule['id']}
+        rule = AttrDict(
+            DiscoveryRule.with_user(class_user_manager.login, class_user_password).info(
+                {'id': rule.id}
+            )
         )
-        DiscoveryRule.with_user(self.user['login'], self.user['password']).delete(
-            {'id': rule['id']}
+
+        DiscoveryRule.with_user(class_user_manager.login, class_user_password).delete(
+            {'id': rule.id}
         )
-        with self.assertRaises(CLIReturnCodeError):
-            DiscoveryRule.info({'id': rule['id']})
+        with pytest.raises(CLIReturnCodeError):
+            DiscoveryRule.info({'id': rule.id})
 
     @pytest.mark.tier2
-    def test_positive_view_existing_rule_with_non_admin_user(self):
+    def test_positive_view_existing_rule_with_non_admin_user(
+        self, class_org, class_location, class_user_password, class_user_reader, class_hostgroup
+    ):
         """Existing rule should be viewed to non-admin user by associating
         discovery_reader role.
 
@@ -677,23 +712,29 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
         :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
-        rule = make_discoveryrule(
-            {
-                'name': rule_name,
-                'enabled': 'false',
-                'search': "last_report = Today",
-                'organizations': self.org['name'],
-                'locations': self.loc['name'],
-                'hostgroup-id': self.hostgroup['id'],
-            }
+        rule = AttrDict(
+            make_discoveryrule(
+                {
+                    'name': rule_name,
+                    'enabled': 'false',
+                    'search': "last_report = Today",
+                    'organizations': class_org.name,
+                    'locations': class_location.name,
+                    'hostgroup-id': class_hostgroup.id,
+                }
+            )
         )
-        rule = DiscoveryRule.with_user(
-            self.user_reader['login'], self.user_reader['password']
-        ).info({'id': rule['id']})
-        self.assertEqual(rule['name'], rule_name)
+        rule = AttrDict(
+            DiscoveryRule.with_user(class_user_reader.login, class_user_password).info(
+                {'id': rule.id}
+            )
+        )
+        assert rule.name == rule_name
 
     @pytest.mark.tier2
-    def test_negative_delete_rule_with_non_admin_user(self):
+    def test_negative_delete_rule_with_non_admin_user(
+        self, class_org, class_location, class_user_password, class_user_reader, class_hostgroup
+    ):
         """Delete rule with non-admin user by associating discovery_reader role
 
         :id: f7f9569b-916e-46f3-bd89-a05e33483741
@@ -703,19 +744,23 @@ class DiscoveryRuleRoleTestCase(CLITestCase):
 
         :CaseLevel: Integration
         """
-        rule = make_discoveryrule(
-            {
-                'enabled': 'false',
-                'search': "last_report = Today",
-                'organizations': self.org['name'],
-                'locations': self.loc['name'],
-                'hostgroup-id': self.hostgroup['id'],
-            }
+        rule = AttrDict(
+            make_discoveryrule(
+                {
+                    'enabled': 'false',
+                    'search': "last_report = Today",
+                    'organizations': class_org.name,
+                    'locations': class_location.name,
+                    'hostgroup-id': class_hostgroup.id,
+                }
+            )
         )
-        rule = DiscoveryRule.with_user(
-            self.user_reader['login'], self.user_reader['password']
-        ).info({'id': rule['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            DiscoveryRule.with_user(
-                self.user_reader['login'], self.user_reader['password']
-            ).delete({'id': rule['id']})
+        rule = AttrDict(
+            DiscoveryRule.with_user(class_user_reader.login, class_user_password).info(
+                {'id': rule.id}
+            )
+        )
+        with pytest.raises(CLIReturnCodeError):
+            DiscoveryRule.with_user(class_user_reader.login, class_user_password).delete(
+                {'id': rule.id}
+            )


### PR DESCRIPTION
Use a fixture that yields a partial function to control scope of
org/location and reduce number of variables that have to be passed by
every test function's call to the fixture function.

Local testing passing fine, will run Robottelo Runner as well.

```
setup@localhost:~/repos/robottelo (pytest-cli-discrule-10988$*%<>) % pytest -vx tests/foreman/cli/test_discoveryrule.py                      
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.8, pytest-6.2.2, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, mock-3.5.1, reportportal-5.0.8, cov-2.11.1, services-2.2.1
collected 61 items                                                                                                                                                                           

tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_name[alpha] PASSED                                                                               [  1%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_name[numeric] PASSED                                                                             [  3%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_name[alphanumeric] PASSED                                                                        [  4%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_name[latin1] PASSED                                                                              [  6%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_name[utf8] PASSED                                                                                [  8%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_name[cjk] PASSED                                                                                 [  9%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_name[html] PASSED                                                                                [ 11%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_search PASSED                                                                                    [ 13%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_hostname PASSED                                                                                  [ 14%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_org_loc_id PASSED                                                                                [ 16%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_org_loc_name PASSED                                                                              [ 18%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_hosts_limit PASSED                                                                               [ 19%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_max_count PASSED                                                                                 [ 21%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_with_priority PASSED                                                                                  [ 22%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_create_disabled_rule PASSED                                                                                  [ 24%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[0] PASSED                                                                           [ 26%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[1] PASSED                                                                           [ 27%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[2] PASSED                                                                           [ 29%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[3] PASSED                                                                           [ 31%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[4] PASSED                                                                           [ 32%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[5] PASSED                                                                           [ 34%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[6] PASSED                                                                           [ 36%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[7] PASSED                                                                           [ 37%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[8] PASSED                                                                           [ 39%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_name[9] PASSED                                                                           [ 40%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_hostname[cjk] PASSED                                                                     [ 42%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_hostname[latin] PASSED                                                                   [ 44%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_hostname[numeric] PASSED                                                                 [ 45%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_hostname[utf8] PASSED                                                                    [ 47%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_hostname[special] PASSED                                                                 [ 49%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_hostname[whitespace] PASSED                                                              [ 50%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_invalid_hostname[negative] PASSED                                                                [ 52%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_too_long_limit PASSED                                                                            [ 54%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_create_with_same_name PASSED                                                                                 [ 55%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_delete PASSED                                                                                                [ 57%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_name PASSED                                                                                           [ 59%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_org_loc_by_id PASSED                                                                                  [ 60%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_org_loc_by_name PASSED                                                                                [ 62%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_query PASSED                                                                                          [ 63%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_hostgroup PASSED                                                                                      [ 65%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_hostname PASSED                                                                                       [ 67%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_limit PASSED                                                                                          [ 68%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_priority PASSED                                                                                       [ 70%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_positive_update_disable_enable PASSED                                                                                 [ 72%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[0] PASSED                                                                                        [ 73%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[1] PASSED                                                                                        [ 75%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[2] PASSED                                                                                        [ 77%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[3] PASSED                                                                                        [ 78%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[4] PASSED                                                                                        [ 80%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[5] PASSED                                                                                        [ 81%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[6] PASSED                                                                                        [ 83%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[7] PASSED                                                                                        [ 85%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[8] PASSED                                                                                        [ 86%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_name[9] PASSED                                                                                        [ 88%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_hostname PASSED                                                                                       [ 90%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_limit PASSED                                                                                          [ 91%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRule::test_negative_update_priority PASSED                                                                                       [ 93%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRuleRole::test_positive_create_rule_with_non_admin_user PASSED                                                                   [ 95%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRuleRole::test_positive_delete_rule_with_non_admin_user PASSED                                                                   [ 96%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRuleRole::test_positive_view_existing_rule_with_non_admin_user PASSED                                                            [ 98%]
tests/foreman/cli/test_discoveryrule.py::TestDiscoveryRuleRole::test_negative_delete_rule_with_non_admin_user PASSED  

```