### PR TITLE
Rewrite RHEV CLI test to Pytest

### DIFF
--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -53,7 +53,7 @@ def test_positive_create_rhev_with_valid_name(rhev):
     """
     ComputeResource.create(
         {
-            'name': 'cr {}'.format(gen_string(str_type='alpha')),
+            'name': f'cr {gen_string(str_type="alpha")}',
             'provider': 'Ovirt',
             'user': rhev.username,
             'password': rhev.password,
@@ -271,7 +271,7 @@ def test_positive_add_image_rhev_with_name(rhev):
     ComputeResource.image_create(
         {
             'compute-resource': comp_res['name'],
-            'name': 'img {}'.format(gen_string(str_type='alpha')),
+            'name': f'img {gen_string(str_type="alpha")}',
             'uuid': rhev.image_uuid,
             'operatingsystem': rhev.os['title'],
             'architecture': rhev.image_arch,
@@ -316,8 +316,8 @@ def test_negative_add_image_rhev_with_invalid_uuid(rhev):
         ComputeResource.image_create(
             {
                 'compute-resource': comp_res['name'],
-                'name': 'img {}'.format(gen_string(str_type='alpha')),
-                'uuid': 'invalidimguuid {}'.format(gen_string(str_type='alpha')),
+                'name': f'img {gen_string(str_type="alpha")}',
+                'uuid': f'invalidimguuid {gen_string(str_type="alpha")}',
                 'operatingsystem': rhev.os['title'],
                 'architecture': rhev.image_arch,
                 'username': "root",
@@ -362,7 +362,7 @@ def test_negative_add_image_rhev_with_invalid_name(rhev):
             {
                 'compute-resource': comp_res['name'],
                 # too long string (>255 chars)
-                'name': 'img {}'.format(gen_string(str_type='alphanumeric', length=256)),
+                'name': f'img {gen_string(str_type="alphanumeric", length=256)}',
                 'uuid': rhev.image_uuid,
                 'operatingsystem': rhev.os['title'],
                 'architecture': rhev.image_arch,

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -24,369 +24,375 @@ from robottelo.cli.factory import CLIReturnCodeError
 from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.factory import make_os
 from robottelo.config import settings
-from robottelo.decorators import skip_if_not_set
-from robottelo.test import CLITestCase
 
 
-class RHEVComputeResourceTestCase(CLITestCase):
-    """RHEVComputeResource CLI tests."""
+@pytest.fixture(scope='module')
+def rhev():
+    rhev = type('rhev', (object,), {})()
+    rhev.current_rhev_url = settings.rhev.hostname
+    rhev.username = settings.rhev.username
+    rhev.password = settings.rhev.password
+    rhev.datacenter = settings.rhev.datacenter
+    rhev.image_arch = settings.rhev.image_arch
+    rhev.image_uuid = settings.rhev.image_uuid
+    rhev.os = make_os()
+    return rhev
 
-    @classmethod
-    @skip_if_not_set('rhev')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.current_rhev_url = settings.rhev.hostname
-        cls.username = settings.rhev.username
-        cls.password = settings.rhev.password
-        cls.datacenter = settings.rhev.datacenter
-        cls.image_arch = settings.rhev.image_arch
-        cls.image_uuid = settings.rhev.image_uuid
-        cls.os = make_os()
 
-    @pytest.mark.tier1
-    def test_positive_create_rhev_with_valid_name(self):
-        """Create Compute Resource of type Rhev with valid name
+@pytest.mark.tier1
+def test_positive_create_rhev_with_valid_name(rhev):
+    """Create Compute Resource of type Rhev with valid name
 
-        :id: 92a577db-144e-4761-a52e-e83887464986
+    :id: 92a577db-144e-4761-a52e-e83887464986
 
-        :expectedresults: Compute resource is created
+    :expectedresults: Compute resource is created
 
-        :CaseImportance: Critical
+    :CaseImportance: Critical
 
-        :BZ: 1602835
-        """
+    :BZ: 1602835
+    """
+    ComputeResource.create(
+        {
+            'name': 'cr {}'.format(gen_string(str_type='alpha')),
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+
+
+@pytest.mark.tier1
+def test_positive_rhev_info(rhev):
+    """List the info of RHEV compute resource
+
+    :id: 1b18f6e8-c431-41ab-ae49-a2bbb74712f2
+
+    :expectedresults: RHEV Compute resource Info is displayed
+
+    :CaseImportance: Critical
+
+    :BZ: 1602835
+    """
+    name = gen_string('utf8')
+    compute_resource = make_compute_resource(
+        {
+            'name': name,
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+    assert compute_resource['name'] == name
+
+
+@pytest.mark.tier
+def test_positive_delete_by_name(rhev):
+    """Delete the RHEV compute resource by name
+
+    :id: ac84acbe-3e02-4f49-9695-b668df28b353
+
+    :expectedresults: Compute resource is deleted
+
+    :CaseImportance: Critical
+
+    :BZ: 1602835
+    """
+    comp_res = make_compute_resource(
+        {
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+    assert comp_res['name']
+    ComputeResource.delete({'name': comp_res['name']})
+    result = ComputeResource.exists(search=('name', comp_res['name']))
+    assert not result
+
+
+@pytest.mark.tier1
+def test_positive_delete_by_id(rhev):
+    """Delete the RHEV compute resource by id
+
+    :id: 4bcd4fa3-df8b-4773-b142-e47458116552
+
+    :expectedresults: Compute resource is deleted
+
+    :CaseImportance: Critical
+
+    :BZ: 1602835
+    """
+    comp_res = make_compute_resource(
+        {
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+    assert comp_res['name']
+    ComputeResource.delete({'id': comp_res['id']})
+    result = ComputeResource.exists(search=('name', comp_res['name']))
+    assert not result
+
+
+@pytest.mark.tier2
+def test_negative_create_rhev_with_url(rhev):
+    """RHEV compute resource negative create with invalid values
+
+    :id: 1f318a4b-8dca-491b-b56d-cff773ed624e
+
+    :expectedresults: Compute resource is not created
+
+    :CaseImportance: High
+    """
+    with pytest.raises(CLIReturnCodeError):
         ComputeResource.create(
             {
-                'name': 'cr {}'.format(gen_string(str_type='alpha')),
                 'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
+                'user': rhev.username,
+                'password': rhev.password,
+                'datacenter': rhev.datacenter,
+                'url': 'invalid url',
             }
         )
 
-    @pytest.mark.tier1
-    def test_positive_rhev_info(self):
-        """List the info of RHEV compute resource
 
-        :id: 1b18f6e8-c431-41ab-ae49-a2bbb74712f2
+@pytest.mark.tier2
+def test_negative_create_with_same_name(rhev):
+    """RHEV compute resource negative create with the same name
 
-        :expectedresults: RHEV Compute resource Info is displayed
+    :id: f00813ef-df31-462c-aa87-479b8272aea3
 
-        :CaseImportance: Critical
+    :steps:
 
-        :BZ: 1602835
-        """
-        name = gen_string('utf8')
-        compute_resource = make_compute_resource(
+        1. Create a RHEV compute resource.
+        2. Create another RHEV compute resource with same name.
+
+    :expectedresults: Compute resource is not created
+
+    :CaseImportance: High
+    """
+    name = gen_string('alpha')
+    compute_resource = make_compute_resource(
+        {
+            'name': name,
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+    assert compute_resource['name'] == name
+    with pytest.raises(CLIFactoryError):
+        make_compute_resource(
             {
                 'name': name,
                 'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
+                'user': rhev.username,
+                'password': rhev.password,
+                'datacenter': rhev.datacenter,
+                'url': rhev.current_rhev_url,
             }
         )
-        self.assertEquals(compute_resource['name'], name)
 
-    @pytest.mark.tier1
-    def test_positive_delete_by_name(self):
-        """Delete the RHEV compute resource by name
 
-        :id: ac84acbe-3e02-4f49-9695-b668df28b353
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_update_name(rhev):
+    """RHEV compute resource positive update
 
-        :expectedresults: Compute resource is deleted
+    :id: 5ca29b81-d1f0-409f-843d-aa5daf957d7f
 
-        :CaseImportance: Critical
+    :steps:
 
-        :BZ: 1602835
-        """
-        comp_res = make_compute_resource(
-            {
-                'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
-            }
-        )
-        self.assertTrue(comp_res['name'])
-        ComputeResource.delete({'name': comp_res['name']})
-        result = ComputeResource.exists(search=('name', comp_res['name']))
-        self.assertFalse(result)
+        1. Create a RHEV compute resource
+        2. Update the name of the created compute resource
 
-    @pytest.mark.tier1
-    def test_positive_delete_by_id(self):
-        """Delete the RHEV compute resource by id
+    :expectedresults: Compute Resource is successfully updated
 
-        :id: 4bcd4fa3-df8b-4773-b142-e47458116552
+    :CaseImportance: Critical
 
-        :expectedresults: Compute resource is deleted
+    :BZ: 1602835
+    """
+    new_name = gen_string('alpha')
+    comp_res = make_compute_resource(
+        {
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+    assert comp_res['name']
+    ComputeResource.update({'name': comp_res['name'], 'new-name': new_name})
+    assert new_name == ComputeResource.info({'id': comp_res['id']})['name']
 
-        :CaseImportance: Critical
 
-        :BZ: 1602835
-        """
-        comp_res = make_compute_resource(
-            {
-                'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
-            }
-        )
-        self.assertTrue(comp_res['name'])
-        ComputeResource.delete({'id': comp_res['id']})
-        result = ComputeResource.exists(search=('name', comp_res['name']))
-        self.assertFalse(result)
+@pytest.mark.tier2
+def test_positive_add_image_rhev_with_name(rhev):
+    """Add images to the RHEV compute resource
 
-    @pytest.mark.tier2
-    def test_negative_create_rhev_with_url(self):
-        """RHEV compute resource negative create with invalid values
+    :id: 2da84165-a56f-4282-9343-94828fa69c13
 
-        :id: 1f318a4b-8dca-491b-b56d-cff773ed624e
+    :setup: Images/templates should be present in RHEV-M itself,
+        so that satellite can use them.
 
-        :expectedresults: Compute resource is not created
+    :steps:
 
-        :CaseImportance: High
-        """
-        with self.assertRaises(CLIReturnCodeError):
-            ComputeResource.create(
-                {
-                    'provider': 'Ovirt',
-                    'user': self.username,
-                    'password': self.password,
-                    'datacenter': self.datacenter,
-                    'url': 'invalid url',
-                }
-            )
+        1. Create a compute resource of type rhev.
+        2. Create a image for the compute resource with valid parameter,
+           compute-resource image create
 
-    @pytest.mark.tier2
-    def test_negative_create_with_same_name(self):
-        """RHEV compute resource negative create with the same name
+    :expectedresults: The image is added to the CR successfully
+    """
+    if rhev.image_uuid is None:
+        pytest.skip('Missing configuration for rhev.image_uuid')
 
-        :id: f00813ef-df31-462c-aa87-479b8272aea3
+    comp_res = make_compute_resource(
+        {
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+    assert comp_res['name']
+    ComputeResource.image_create(
+        {
+            'compute-resource': comp_res['name'],
+            'name': 'img {}'.format(gen_string(str_type='alpha')),
+            'uuid': rhev.image_uuid,
+            'operatingsystem': rhev.os['title'],
+            'architecture': rhev.image_arch,
+            'username': "root",
+        }
+    )
+    result = ComputeResource.image_list({'compute-resource': comp_res['name']})
+    assert result[0]['uuid'] == rhev.image_uuid
 
-        :steps:
 
-            1. Create a RHEV compute resource.
-            2. Create another RHEV compute resource with same name.
+@pytest.mark.skip_if_open("BZ:1829239")
+@pytest.mark.tier2
+def test_negative_add_image_rhev_with_invalid_uuid(rhev):
+    """Attempt to add invalid image to the RHEV compute resource
 
-        :expectedresults: Compute resource is not created
+    :id: e8a653f9-9749-4c76-95ed-2411a7c0a117
 
-        :CaseImportance: High
-        """
-        name = gen_string('alpha')
-        compute_resource = make_compute_resource(
-            {
-                'name': name,
-                'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
-            }
-        )
-        self.assertEquals(compute_resource['name'], name)
-        with self.assertRaises(CLIFactoryError):
-            make_compute_resource(
-                {
-                    'name': name,
-                    'provider': 'Ovirt',
-                    'user': self.username,
-                    'password': self.password,
-                    'datacenter': self.datacenter,
-                    'url': self.current_rhev_url,
-                }
-            )
+    :setup: Images/templates should be present in RHEV-M itself,
+        so that satellite can use them.
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_update_name(self):
-        """RHEV compute resource positive update
+    :steps:
 
-        :id: 5ca29b81-d1f0-409f-843d-aa5daf957d7f
+        1. Create a compute resource of type rhev.
+        2. Create a image for the compute resource with invalid value for
+           uuid parameter, compute-resource image create.
 
-        :steps:
+    :expectedresults: The image should not be added to the CR
 
-            1. Create a RHEV compute resource
-            2. Update the name of the created compute resource
-
-        :expectedresults: Compute Resource is successfully updated
-
-        :CaseImportance: Critical
-
-        :BZ: 1602835
-        """
-        new_name = gen_string('alpha')
-        comp_res = make_compute_resource(
-            {
-                'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
-            }
-        )
-        self.assertTrue(comp_res['name'])
-        ComputeResource.update({'name': comp_res['name'], 'new-name': new_name})
-        self.assertEqual(new_name, ComputeResource.info({'id': comp_res['id']})['name'])
-
-    @pytest.mark.tier2
-    def test_positive_add_image_rhev_with_name(self):
-        """Add images to the RHEV compute resource
-
-        :id: 2da84165-a56f-4282-9343-94828fa69c13
-
-        :setup: Images/templates should be present in RHEV-M itself,
-            so that satellite can use them.
-
-        :steps:
-
-            1. Create a compute resource of type rhev.
-            2. Create a image for the compute resource with valid parameter,
-               compute-resource image create
-
-        :expectedresults: The image is added to the CR successfully
-        """
-        if self.image_uuid is None:
-            self.skipTest('Missing configuration for rhev.image_uuid')
-
-        comp_res = make_compute_resource(
-            {
-                'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
-            }
-        )
-        self.assertTrue(comp_res['name'])
+    :BZ: 1829239
+    """
+    comp_res = make_compute_resource(
+        {
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+    assert comp_res['name']
+    with pytest.raises(CLIReturnCodeError):
         ComputeResource.image_create(
             {
                 'compute-resource': comp_res['name'],
                 'name': 'img {}'.format(gen_string(str_type='alpha')),
-                'uuid': self.image_uuid,
-                'operatingsystem': self.os['title'],
-                'architecture': self.image_arch,
+                'uuid': 'invalidimguuid {}'.format(gen_string(str_type='alpha')),
+                'operatingsystem': rhev.os['title'],
+                'architecture': rhev.image_arch,
                 'username': "root",
             }
         )
-        result = ComputeResource.image_list({'compute-resource': comp_res['name']})
-        self.assertEqual(result[0]['uuid'], self.image_uuid)
 
-    @pytest.mark.skip_if_open("BZ:1829239")
-    @pytest.mark.tier2
-    def test_negative_add_image_rhev_with_invalid_uuid(self):
-        """Attempt to add invalid image to the RHEV compute resource
 
-        :id: e8a653f9-9749-4c76-95ed-2411a7c0a117
+@pytest.mark.tier2
+def test_negative_add_image_rhev_with_invalid_name(rhev):
+    """Attempt to add invalid image name to the RHEV compute resource
 
-        :setup: Images/templates should be present in RHEV-M itself,
-            so that satellite can use them.
+    :id: 873a7d79-1e89-4e4f-81ca-b6db1e0246da
 
-        :steps:
+    :setup: Images/templates should be present in RHEV-M itself,
+        so that satellite can use them.
 
-            1. Create a compute resource of type rhev.
-            2. Create a image for the compute resource with invalid value for
-               uuid parameter, compute-resource image create.
+    :steps:
 
-        :expectedresults: The image should not be added to the CR
+        1. Create a compute resource of type rhev.
+        2. Create a image for the compute resource with invalid value for
+           name parameter, compute-resource image create.
 
-        :BZ: 1829239
-        """
-        comp_res = make_compute_resource(
+    :expectedresults: The image should not be added to the CR
+
+    """
+    if rhev.image_uuid is None:
+        pytest.skip('Missing configuration for rhev.image_uuid')
+
+    comp_res = make_compute_resource(
+        {
+            'provider': 'Ovirt',
+            'user': rhev.username,
+            'password': rhev.password,
+            'datacenter': rhev.datacenter,
+            'url': rhev.current_rhev_url,
+        }
+    )
+
+    assert comp_res['name']
+    with pytest.raises(CLIReturnCodeError):
+        ComputeResource.image_create(
             {
-                'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
-            }
-        )
-        self.assertTrue(comp_res['name'])
-        with self.assertRaises(CLIReturnCodeError):
-            ComputeResource.image_create(
-                {
-                    'compute-resource': comp_res['name'],
-                    'name': 'img {}'.format(gen_string(str_type='alpha')),
-                    'uuid': 'invalidimguuid {}'.format(gen_string(str_type='alpha')),
-                    'operatingsystem': self.os['title'],
-                    'architecture': self.image_arch,
-                    'username': "root",
-                }
-            )
-
-    @pytest.mark.tier2
-    def test_negative_add_image_rhev_with_invalid_name(self):
-        """Attempt to add invalid image name to the RHEV compute resource
-
-        :id: 873a7d79-1e89-4e4f-81ca-b6db1e0246da
-
-        :setup: Images/templates should be present in RHEV-M itself,
-            so that satellite can use them.
-
-        :steps:
-
-            1. Create a compute resource of type rhev.
-            2. Create a image for the compute resource with invalid value for
-               name parameter, compute-resource image create.
-
-        :expectedresults: The image should not be added to the CR
-
-        """
-        if self.image_uuid is None:
-            self.skipTest('Missing configuration for rhev.image_uuid')
-
-        comp_res = make_compute_resource(
-            {
-                'provider': 'Ovirt',
-                'user': self.username,
-                'password': self.password,
-                'datacenter': self.datacenter,
-                'url': self.current_rhev_url,
+                'compute-resource': comp_res['name'],
+                # too long string (>255 chars)
+                'name': 'img {}'.format(gen_string(str_type='alphanumeric', length=256)),
+                'uuid': rhev.image_uuid,
+                'operatingsystem': rhev.os['title'],
+                'architecture': rhev.image_arch,
+                'username': "root",
             }
         )
 
-        self.assertTrue(comp_res['name'])
-        with self.assertRaises(CLIReturnCodeError):
-            ComputeResource.image_create(
-                {
-                    'compute-resource': comp_res['name'],
-                    # too long string (>255 chars)
-                    'name': 'img {}'.format(gen_string(str_type='alphanumeric', length=256)),
-                    'uuid': self.image_uuid,
-                    'operatingsystem': self.os['title'],
-                    'architecture': self.image_arch,
-                    'username': "root",
-                }
-            )
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
-    @pytest.mark.upgrade
-    def test_positive_provision_rhev_without_host_group(self):
-        """Provision a host on RHEV compute resource without
-        the help of hostgroup.
+@pytest.mark.stubbed
+@pytest.mark.tier3
+@pytest.mark.upgrade
+def test_positive_provision_rhev_without_host_group(rhev):
+    """Provision a host on RHEV compute resource without
+    the help of hostgroup.
 
-        :id: 861940cb-1550-4f00-9df2-5a45683635b1
+    :id: 861940cb-1550-4f00-9df2-5a45683635b1
 
-        :setup: Provisioning setup like domain, subnet etc.
+    :setup: Provisioning setup like domain, subnet etc.
 
-        :steps:
+    :steps:
 
-            1. Create a RHEV compute resource.
-            2. Create a host on RHEV compute resource.
-            3. Use compute-attributes parameter to specify key-value parameters
-               regarding the virtual machine.
-            4. Provision the host.
+        1. Create a RHEV compute resource.
+        2. Create a host on RHEV compute resource.
+        3. Use compute-attributes parameter to specify key-value parameters
+           regarding the virtual machine.
+        4. Provision the host.
 
-        :expectedresults: The host should be provisioned successfully
+    :expectedresults: The host should be provisioned successfully
 
-        :CaseAutomation: NotAutomated
+    :CaseAutomation: NotAutomated
 
-        :CaseLevel: Integration
-        """
+    :CaseLevel: Integration
+    """


### PR DESCRIPTION
```
$ pytest tests/foreman/cli/test_computeresource_rhev.py --verbose -n2
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.7, pytest-6.2.2, py-1.9.0, pluggy-0.13.1 -- /home/lhellebr/git/robottelo/venv3/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo, configfile: pyproject.toml
plugins: xdist-2.2.1, ibutsu-1.14.1, services-2.2.1, mock-3.5.1, cov-2.10.0, reportportal-5.0.8, forked-1.2.0
[gw0] linux Python 3.8.7 cwd: /home/lhellebr/git/robottelo
[gw1] linux Python 3.8.7 cwd: /home/lhellebr/git/robottelo
[gw1] Python 3.8.7 (default, Jan 20 2021, 00:00:00)  -- [GCC 10.2.1 20201125 (Red Hat 10.2.1-9)]
[gw0] Python 3.8.7 (default, Jan 20 2021, 00:00:00)  -- [GCC 10.2.1 20201125 (Red Hat 10.2.1-9)]
gw0 [10] / gw1 [10]
scheduling tests via LoadScheduling

tests/foreman/cli/test_computeresource_rhev.py::test_positive_rhev_info 
tests/foreman/cli/test_computeresource_rhev.py::test_positive_create_rhev_with_valid_name 
[gw1] [ 10%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_positive_create_rhev_with_valid_name 
[gw0] [ 20%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_positive_rhev_info 
tests/foreman/cli/test_computeresource_rhev.py::test_positive_delete_by_name 
tests/foreman/cli/test_computeresource_rhev.py::test_positive_delete_by_id 
[gw0] [ 30%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_positive_delete_by_id 
[gw1] [ 40%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_positive_delete_by_name 
tests/foreman/cli/test_computeresource_rhev.py::test_negative_create_rhev_with_url 
tests/foreman/cli/test_computeresource_rhev.py::test_negative_create_with_same_name 
[gw1] [ 50%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_negative_create_rhev_with_url 
tests/foreman/cli/test_computeresource_rhev.py::test_positive_update_name 
[gw0] [ 60%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_negative_create_with_same_name 
tests/foreman/cli/test_computeresource_rhev.py::test_positive_add_image_rhev_with_name 
[gw1] [ 70%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_positive_update_name 
tests/foreman/cli/test_computeresource_rhev.py::test_negative_add_image_rhev_with_invalid_uuid 
[gw1] [ 80%] SKIPPED tests/foreman/cli/test_computeresource_rhev.py::test_negative_add_image_rhev_with_invalid_uuid 
[gw0] [ 90%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_positive_add_image_rhev_with_name 
tests/foreman/cli/test_computeresource_rhev.py::test_negative_add_image_rhev_with_invalid_name 
[gw0] [100%] PASSED tests/foreman/cli/test_computeresource_rhev.py::test_negative_add_image_rhev_with_invalid_name 

====================================================================================== warnings summary ======================================================================================
tests/foreman/cli/test_computeresource_rhev.py:92
tests/foreman/cli/test_computeresource_rhev.py:92
  /home/lhellebr/git/robottelo/tests/foreman/cli/test_computeresource_rhev.py:92: PytestUnknownMarkWarning: Unknown pytest.mark.tier - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.tier

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================================================================== 9 passed, 1 skipped, 2 warnings in 110.32s (0:01:50) ====================================================================
2021-03-23 16:14:47 - py.warnings - WARNING - /home/lhellebr/git/robottelo/venv3/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Mapping, MutableMapping

2021-03-23 16:14:47 - py.warnings - WARNING - /home/lhellebr/git/robottelo/venv3/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Mapping, MutableMapping

2021-03-23 16:14:47 - py.warnings - WARNING - /home/lhellebr/git/robottelo/venv3/lib/python3.8/site-packages/cinderclient/client.py:23: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp

WARNING:robottelo.config:Legacy Robottelo settings configure() failed, most likely required configuration option is not provided. Continuing for the sake of unit tests
WARNING:robottelo.config:Dynaconf validation failed, continuing for the sake of unit tests
```