### PR TITLE
Convert tests/upgrades/test_yum_plugins.py to pytest

### DIFF
--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -1,4 +1,4 @@
-"""Test for Loaded yum plugins count related Upgrade Scenario's
+"""Test for Loaded yum plugins count related Upgrade Scenarios
 
 :Requirement: Upgraded Satellite
 
@@ -16,6 +16,8 @@
 
 :Upstream: No
 """
+import logging
+
 from fabric.api import execute
 from nailgun import entities
 from upgrade.helpers.docker import docker_execute_command
@@ -28,18 +30,20 @@ from wait_for import wait_for
 
 from robottelo.api.utils import attach_custom_product_subscription
 from robottelo.api.utils import call_entity_method_with_timeout
-from robottelo.constants import DEFAULT_LOC
-from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import REPOS
-from robottelo.test import APITestCase
 from robottelo.test import settings
 from robottelo.upgrade_utility import install_or_update_package
 from robottelo.upgrade_utility import publish_content_view
 from robottelo.upgrade_utility import run_goferd
 
 
-class TestScenarioYumPluginsCount(APITestCase):
+LOGGER = logging.getLogger('robottelo')
+DOCKER_VM = settings.upgrade.docker_vm
+CLIENT_OS = DISTRO_RHEL7
+
+
+class TestScenarioYumPluginsCount:
     """The test class contains pre and post upgrade scenarios to test the
     loaded yum plugins count on content host.
 
@@ -60,27 +64,19 @@ class TestScenarioYumPluginsCount(APITestCase):
 
     """
 
-    @classmethod
-    def setUpClass(cls):
-        cls.docker_vm = settings.upgrade.docker_vm
-        cls.client_os = DISTRO_RHEL7
-        cls.org = entities.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})[0]
-        cls.loc = entities.Location().search(query={'search': f'name="{DEFAULT_LOC}"'})[0]
-
     def _check_yum_plugins_count(self, client_container_id):
         """Check yum loaded plugins counts """
 
-        kwargs = {'host': self.docker_vm}
-        execute(docker_execute_command, client_container_id, 'yum clean all', **kwargs)[
-            self.docker_vm
-        ]
+        kwargs = {'host': DOCKER_VM}
+        execute(docker_execute_command, client_container_id, 'yum clean all', **kwargs)[DOCKER_VM]
         plugins_count = execute(
             docker_execute_command,
             client_container_id,
-            'yum repolist|grep "Loaded plugins"|wc -l',
+            'yum repolist | grep "Loaded plugins" | wc -l',
             **kwargs,
-        )[self.docker_vm]
-        self.assertEqual(int(plugins_count), 2)
+        )[DOCKER_VM]
+        # The 'Loaded plugins' can happen once or (in the case of enabled repository upload) twice.
+        assert int(plugins_count) <= 2
 
     def _create_custom_tools_repos(self, product):
         """Create custom tools repo and sync it"""
@@ -95,7 +91,7 @@ class TestScenarioYumPluginsCount(APITestCase):
         call_entity_method_with_timeout(tools_repo.sync, timeout=1400)
         return tools_repo
 
-    def _get_rh_rhel_tools_repos(self):
+    def _get_rh_rhel_tools_repos(self, org):
         """Get list of RHEL7 and tools repos
 
         :return: nailgun.entities.Repository: repository
@@ -105,12 +101,12 @@ class TestScenarioYumPluginsCount(APITestCase):
         repo2_name = 'rhst7_{}'.format(str(from_version).replace('.', ''))
 
         repo1_id = (
-            entities.Repository(organization=self.org)
+            entities.Repository(organization=org)
             .search(query={'search': '{}'.format(REPOS['rhel7']['id'])})[0]
             .id
         )
         repo2_id = (
-            entities.Repository(organization=self.org)
+            entities.Repository(organization=org)
             .search(query={'search': '{}'.format(REPOS[repo2_name]['id'])})[0]
             .id
         )
@@ -118,7 +114,7 @@ class TestScenarioYumPluginsCount(APITestCase):
         return [entities.Repository(id=repo_id) for repo_id in [repo1_id, repo2_id]]
 
     @pre_upgrade
-    def test_pre_scenario_yum_plugins_count(self):
+    def test_pre_scenario_yum_plugins_count(self, default_org):
         """Create content host and register with Satellite.
 
         :id: preupgrade-45241ada-c2c4-409e-a6e2-92c2cf0ac16c
@@ -129,45 +125,48 @@ class TestScenarioYumPluginsCount(APITestCase):
             2. Create LifecycleEnvironment.
             3. Enable/sync 'base os RHEL7' and tools repos.
             4. Create 'Content View' and activation key.
-            5. Create a content host, register and install katello-agent on it.
+            5. Create a content host, register and install katello-host-tools and katello-agent.
 
         :expectedresults:
 
             1. The content host is created.
             2. katello-agent install and goferd run.
         """
-        environment = entities.LifecycleEnvironment(organization=self.org).search(
+        environment = entities.LifecycleEnvironment(organization=default_org).search(
             query={'search': 'name=Library'}
         )[0]
-        repos = self._get_rh_rhel_tools_repos()
-        content_view = publish_content_view(org=self.org, repolist=repos)
+        repos = self._get_rh_rhel_tools_repos(default_org)
+        content_view = publish_content_view(org=default_org, repolist=repos)
         ak = entities.ActivationKey(
-            content_view=content_view, organization=self.org.id, environment=environment
+            content_view=content_view, organization=default_org.id, environment=environment
         ).create()
 
-        rhel7_client = dockerize(ak_name=ak.name, distro='rhel7', org_label=self.org.label)
+        rhel7_client = dockerize(ak_name=ak.name, distro='rhel7', org_label=default_org.label)
         client_container_id = [value for value in rhel7_client.values()][0]
         wait_for(
-            lambda: self.org.label
+            lambda: default_org.label
             in execute(
                 docker_execute_command,
                 client_container_id,
                 'subscription-manager identity',
-                host=self.docker_vm,
-            )[self.docker_vm],
+                host=DOCKER_VM,
+            )[DOCKER_VM],
             timeout=800,
             delay=2,
-            logger=self.logger,
+            logger=LOGGER,
         )
         status = execute(
             docker_execute_command,
             client_container_id,
             'subscription-manager identity',
-            host=self.docker_vm,
-        )[self.docker_vm]
-        self.assertIn(self.org.label, status)
+            host=DOCKER_VM,
+        )[DOCKER_VM]
+        assert default_org.label in status
 
-        install_or_update_package(client_hostname=client_container_id, package="katello-agent")
+        install_or_update_package(
+            client_hostname=client_container_id, package='katello-host-tools'
+        )
+        install_or_update_package(client_hostname=client_container_id, package='katello-agent')
         run_goferd(client_hostname=client_container_id)
 
         scenario_dict = {
@@ -176,7 +175,7 @@ class TestScenarioYumPluginsCount(APITestCase):
         create_dict(scenario_dict)
 
     @post_upgrade(depend_on=test_pre_scenario_yum_plugins_count)
-    def test_post_scenario_yum_plugins_count(self):
+    def test_post_scenario_yum_plugins_count(self, default_org):
         """Upgrade katello agent on pre-upgrade content host registered
         with Satellite.
 
@@ -186,6 +185,7 @@ class TestScenarioYumPluginsCount(APITestCase):
             1. Create Product, custom tools repo and sync them.
             2. Add in content-view and publish it.
             3. Attach custom subscription to content host.
+            4. Install katello-host-tools, so enabled_repos_upload yum plugin is enabled.
             4. Update katello-agent and Restart goferd.
             5. Check yum plugins count.
 
@@ -198,7 +198,7 @@ class TestScenarioYumPluginsCount(APITestCase):
         client_container_id = list(client.values())[0]
         client_container_name = list(client.keys())[0]
         cv = entities.ContentView(id=entity_data.get('cv_id')).read()
-        product = entities.Product(organization=self.org).create()
+        product = entities.Product(organization=default_org).create()
 
         tools_repo = self._create_custom_tools_repos(product)
         product.sync()
@@ -210,7 +210,10 @@ class TestScenarioYumPluginsCount(APITestCase):
 
         attach_custom_product_subscription(prod_name=product.name, host_name=client_container_name)
         install_or_update_package(
-            client_hostname=client_container_id, update=True, package="katello-agent"
+            client_hostname=client_container_id, update=True, package='katello-host-tools'
+        )
+        install_or_update_package(
+            client_hostname=client_container_id, update=True, package='katello-agent'
         )
         run_goferd(client_hostname=client_container_id)
         self._check_yum_plugins_count(client_container_id)


### PR DESCRIPTION
Pre-upgrade test, on a 6.8.5 Satellite w/ rhel7 server and satellite tools repos enabled and synced:

```
# rm -f /var/tmp/robottelo_pre_upgrade_failed_tests.json
# rm -f ~/.config/nailgun/*.json
# source ../jenkins-configs/compute_resources.conf
# source ../jenkins-configs/sat6_upgrade.conf
# export SATELLITE_HOSTNAME=XXX
# export RHEV_SAT_HOST=$SATELLITE_HOSTNAME
# FROM_VERSION=6.8 TO_VERSION=6.9 pytest -m pre_upgrade -s tests/upgrades/test_yum_plugins.py
[...]
collected 2 items / 1 deselected / 1 selected

tests/upgrades/test_yum_plugins.py .
[...]
=== 1 passed, 1 deselected, 61 warnings in 479.07s (0:07:59) ===
```

Post-upgrade (6.9) test:
```
# FROM_VERSION=6.8 TO_VERSION=6.9 pytest -m post_upgrade -s tests/upgrades/test_yum_plugins.py 
[...]
collected 2 items / 1 deselected / 1 selected
[...]
tests/upgrades/test_yum_plugins.py .
[...]
=== 1 passed, 1 deselected, 57 warnings in 439.75s (0:07:19) ===
```