### PR TITLE
Convert EC2 CLI test to pytest

### DIFF
--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -23,61 +23,57 @@ from robottelo.cli.org import Org
 from robottelo.config import settings
 from robottelo.constants import EC2_REGION_CA_CENTRAL_1
 from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.decorators import skip_if_not_set
-from robottelo.test import CLITestCase
 
 
-class EC2ComputeResourceTestCase(CLITestCase):
-    """EC2 ComputeResource CLI tests."""
+@pytest.fixture(scope='module')
+def aws():
+    aws = type('rhev', (object,), {})()
+    aws.org = make_org()
+    aws.loc = make_location()
+    Org.add_location({'id': aws.org['id'], 'location-id': aws.loc['id']})
+    aws.aws_access_key = settings.ec2.access_key
+    aws.aws_secret_key = settings.ec2.secret_key
+    aws.aws_region = settings.ec2.region
+    aws.aws_image = settings.ec2.image
+    aws.aws_availability_zone = settings.ec2.availability_zone
+    aws.aws_subnet = settings.ec2.subnet
+    aws.aws_security_groups = settings.ec2.security_groups
+    aws.aws_managed_ip = settings.ec2.managed_ip
+    return aws
 
-    @classmethod
-    @skip_if_not_set('ec2')
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.org = make_org()
-        cls.loc = make_location()
-        Org.add_location({'id': cls.org['id'], 'location-id': cls.loc['id']})
-        cls.aws_access_key = settings.ec2.access_key
-        cls.aws_secret_key = settings.ec2.secret_key
-        cls.aws_region = settings.ec2.region
-        cls.aws_image = settings.ec2.image
-        cls.aws_availability_zone = settings.ec2.availability_zone
-        cls.aws_subnet = settings.ec2.subnet
-        cls.aws_security_groups = settings.ec2.security_groups
-        cls.aws_managed_ip = settings.ec2.managed_ip
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_create_ec2_with_custom_region(self):
-        """Create a new ec2 compute resource with custom region
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_create_ec2_with_custom_region(aws):
+    """Create a new ec2 compute resource with custom region
 
-        :id: 28eb592d-ebf0-4659-900a-87112b3b2ad7
+    :id: 28eb592d-ebf0-4659-900a-87112b3b2ad7
 
-        :customerscenario: true
+    :customerscenario: true
 
-        :expectedresults: ec2 compute resource is created successfully.
+    :expectedresults: ec2 compute resource is created successfully.
 
-        :BZ: 1456942
+    :BZ: 1456942
 
-        :CaseAutomation: Automated
+    :CaseAutomation: Automated
 
-        :CaseImportance: Critical
+    :CaseImportance: Critical
 
-        :CaseLevel: Component
-        """
-        cr_name = gen_string(str_type='alpha')
-        cr_description = gen_string(str_type='alpha')
-        cr = make_compute_resource(
-            {
-                'name': cr_name,
-                'description': cr_description,
-                'provider': FOREMAN_PROVIDERS['ec2'],
-                'user': self.aws_access_key,
-                'password': self.aws_secret_key,
-                'region': EC2_REGION_CA_CENTRAL_1,
-                'organizations': self.org['name'],
-                'locations': self.loc['name'],
-            }
-        )
-        self.assertEquals(cr['name'], cr_name)
-        self.assertEquals(cr['region'], EC2_REGION_CA_CENTRAL_1)
+    :CaseLevel: Component
+    """
+    cr_name = gen_string(str_type='alpha')
+    cr_description = gen_string(str_type='alpha')
+    cr = make_compute_resource(
+        {
+            'name': cr_name,
+            'description': cr_description,
+            'provider': FOREMAN_PROVIDERS['ec2'],
+            'user': aws.aws_access_key,
+            'password': aws.aws_secret_key,
+            'region': EC2_REGION_CA_CENTRAL_1,
+            'organizations': aws.org['name'],
+            'locations': aws.loc['name'],
+        }
+    )
+    assert cr['name'] == cr_name
+    assert cr['region'] == EC2_REGION_CA_CENTRAL_1


### PR DESCRIPTION
```
$ pytest -n2 --verbose tests/foreman/cli/test_computeresource_ec2.py 
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.7, pytest-6.2.2, py-1.9.0, pluggy-0.13.1 -- /home/lhellebr/git/robottelo/venv3/bin/python3
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo, configfile: pyproject.toml
plugins: xdist-2.2.1, ibutsu-1.14.1, services-2.2.1, mock-3.5.1, cov-2.10.0, reportportal-5.0.8, forked-1.2.0
[gw0] linux Python 3.8.7 cwd: /home/lhellebr/git/robottelo
[gw1] linux Python 3.8.7 cwd: /home/lhellebr/git/robottelo
[gw0] Python 3.8.7 (default, Jan 20 2021, 00:00:00)  -- [GCC 10.2.1 20201125 (Red Hat 10.2.1-9)]
[gw1] Python 3.8.7 (default, Jan 20 2021, 00:00:00)  -- [GCC 10.2.1 20201125 (Red Hat 10.2.1-9)]
gw0 [1] / gw1 [1]
scheduling tests via LoadScheduling

tests/foreman/cli/test_computeresource_ec2.py::test_positive_create_ec2_with_custom_region 
[gw0] [100%] PASSED tests/foreman/cli/test_computeresource_ec2.py::test_positive_create_ec2_with_custom_region 

===================================================================================== 1 passed in 52.55s =====================================================================================
2021-03-23 16:52:58 - py.warnings - WARNING - /home/lhellebr/git/robottelo/venv3/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Mapping, MutableMapping

2021-03-23 16:52:58 - py.warnings - WARNING - /home/lhellebr/git/robottelo/venv3/lib/python3.8/site-packages/botocore/vendored/requests/packages/urllib3/_collections.py:1: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
  from collections import Mapping, MutableMapping

2021-03-23 16:52:59 - py.warnings - WARNING - /home/lhellebr/git/robottelo/venv3/lib/python3.8/site-packages/cinderclient/client.py:23: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp

WARNING:robottelo.config:Legacy Robottelo settings configure() failed, most likely required configuration option is not provided. Continuing for the sake of unit tests
WARNING:robottelo.config:Dynaconf validation failed, continuing for the sake of unit tests
```