### PR TITLE
Add stubbed tests for Inventory upload settings

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -232,3 +232,83 @@ def test_hosts_synchronization():
 
     :CaseAutomation: NotAutomated
     """
+
+
+@pytest.mark.stubbed
+def test_obfuscate_host_names():
+    """Test whether `Obfuscate host names` setting works as expected.
+
+    :id: 3c3a36b6-6566-446b-b803-3f8f9aab2511
+
+    :Steps:
+
+        1. Prepare machine and upload its data to Insights
+        2. Add Cloud API key in Satellite
+        3. Go to Configure > Inventory upload > enable “Obfuscate host names” setting.
+        4. Generate report after enabling the setting.
+        5. Check if host names are obfuscated in generated reports.
+        6. Disable previous setting.
+        7. Go to Administer > Settings > RH Cloud and enable "Obfuscate host names" setting.
+        8. Generate report after enabling the setting.
+        9. Check if host names are obfuscated in generated reports.
+
+    :expectedresults:
+        1. Obfuscated host names in reports generated.
+
+    :CaseAutomation: NotAutomated
+    """
+
+
+@pytest.mark.stubbed
+def test_obfuscate_host_ipv4_addresses():
+    """Test whether `Obfuscate host ipv4 addresses` setting works as expected.
+
+    :id: c0fc4ee9-a6a1-42c0-83f0-0f131ca9ab41
+
+    :Steps:
+
+        1. Prepare machine and upload its data to Insights
+        2. Add Cloud API key in Satellite
+        3. Go to Configure > Inventory upload > enable “Obfuscate host ipv4 addresses” setting.
+        4. Generate report after enabling the setting.
+        5. Check if hosts ipv4 addresses are obfuscated in generated reports.
+        6. Disable previous setting.
+        7. Go to Administer > Settings > RH Cloud and enable "Obfuscate IPs" setting.
+        8. Generate report after enabling the setting.
+        9. Check if hosts ipv4 addresses are obfuscated in generated reports.
+
+    :expectedresults:
+        1. Obfuscated host ipv4 addresses in generated reports.
+
+    :BZ: 1852594
+
+    :CaseAutomation: NotAutomated
+    """
+
+
+@pytest.mark.stubbed
+def test_exclude_packages_setting():
+    """Test whether `Exclude Packages` setting works as expected.
+
+    :id: 646093fa-fdd6-4f70-82aa-725e31fa3f12
+
+    :Steps:
+
+        1. Prepare machine and upload its data to Insights
+        2. Add Cloud API key in Satellite
+        3. Go to Configure > Inventory upload > enable “Exclude Packages” setting.
+        4. Generate report after enabling the setting.
+        5. Check if packages are excluded from generated reports.
+        6. Disable previous setting.
+        7. Go to Administer > Settings > RH Cloud and enable
+            "Don't upload installed packages" setting.
+        8. Generate report after enabling the setting.
+        9. Check if packages are excluded from generated reports.
+
+    :expectedresults:
+        1. Packages are excluded from reports generated.
+
+    :BZ: 1852594
+
+    :CaseAutomation: NotAutomated
+    """


### PR DESCRIPTION
Stubbed tests for “Exclude Packages”, “Obfuscate host ipv4 addresses”, and “Obfuscate host names” settings of Inventory upload plugin.