### PR TITLE
Pytest conversion for tests/foreman/cli/test_report.py

### DIFF
--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -23,67 +23,50 @@ import pytest
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.report import Report
-from robottelo.test import CLITestCase
 
 
-class ReportTestCase(CLITestCase):
-    """Test class for Reports CLI. """
+@pytest.fixture(scope='module', autouse=True)
+def run_puppet_agent():
+    """Retrieves the client configuration from the puppet master and
+    applies it to the local host. This is required to make sure
+    that we have reports available.
+    """
+    ssh.command('puppet agent -t')
 
-    def setUp(self):
-        super().setUp()
-        self.run_puppet_agent()
 
-    def run_puppet_agent(self):
-        """Retrieves the client configuration from the puppet master and
-        applies it to the local host. This is required to make sure
-        that we have reports available.
-        """
-        ssh.command('puppet agent -t')
+@pytest.mark.tier1
+def test_positive_info():
+    """Test Info for Puppet report
 
-    @pytest.mark.tier1
-    def test_positive_list(self):
-        """Test list for Puppet report
+    :id: 32646d4b-7101-421a-85e0-777d3c6b71ec
 
-        :id: 8325e18f-58a4-49b8-a5f3-eebbe1d568b5
+    :expectedresults: Puppet Report Info is displayed
 
-        :expectedresults: Puppert Report List is displayed
+    :CaseImportance: Critical
+    """
+    result = Report.list()
+    assert len(result) > 0
+    # Grab a random report
+    report = random.choice(result)
+    result = Report.info({'id': report['id']})
+    assert report['id'] == result['id']
 
-        :CaseImportance: Critical
-        """
-        Report.list()
 
-    @pytest.mark.tier1
-    def test_positive_info(self):
-        """Test Info for Puppet report
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_delete_by_id():
+    """Check if Puppet Report can be deleted by its ID
 
-        :id: 32646d4b-7101-421a-85e0-777d3c6b71ec
+    :id: bf918ec9-e2d4-45d0-b913-ab939b5d5e6a
 
-        :expectedresults: Puppet Report Info is displayed
+    :expectedresults: Puppet Report is deleted
 
-        :CaseImportance: Critical
-        """
-        result = Report.list()
-        self.assertGreater(len(result), 0)
-        # Grab a random report
-        report = random.choice(result)
-        result = Report.info({'id': report['id']})
-        self.assertEqual(report['id'], result['id'])
-
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_delete_by_id(self):
-        """Check if Puppet Report can be deleted by its ID
-
-        :id: bf918ec9-e2d4-45d0-b913-ab939b5d5e6a
-
-        :expectedresults: Puppet Report is deleted
-
-        :CaseImportance: Critical
-        """
-        result = Report.list()
-        self.assertGreater(len(result), 0)
-        # Grab a random report
-        report = random.choice(result)
-        Report.delete({'id': report['id']})
-        with self.assertRaises(CLIReturnCodeError):
-            Report.info({'id': report['id']})
+    :CaseImportance: Critical
+    """
+    result = Report.list()
+    assert len(result) > 0
+    # Grab a random report
+    report = random.choice(result)
+    Report.delete({'id': report['id']})
+    with pytest.raises(CLIReturnCodeError):
+        Report.info({'id': report['id']})


### PR DESCRIPTION
Test result:
```
$ pytest tests/foreman/cli/test_report.py 
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.13, services-2.2.1, mock-3.5.1, reportportal-5.0.7, xdist-2.2.1, forked-1.3.0
collected 3 items

tests/foreman/cli/test_report.py ...                                     [100%]

========================= 3 passed in 69.63s (0:01:09) =========================
 ```
