### PR TITLE
Move robottelo.satellite_version_undr to repos

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -1,4 +1,5 @@
 REPOS:
+  SATELLITE_VERSION_UNDR: "@jinja {{this.robottelo.satellite_version | replace('.', '_')}}"
   # Provide link to rhel6/7/8 repo here, as puppet rpm would require packages from
   # RHEL 6/7/8 repo and syncing the entire repo on the fly would take longer for
   # tests to run Specify the *.repo link to an internal repo for tests to execute properly

--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -63,4 +63,3 @@ ROBOTTELO:
   # Satellite version supported by this branch
   # UNDR version is used for some URL composition
   SATELLITE_VERSION: "6.9"
-  SATELLITE_VERSION_UNDR: "@jinja {{this.robottelo.satellite_version | replace('.', '_')}}"


### PR DESCRIPTION
dynaconf limitation on dynamic variables
the variable defined in the same file is not correctly updated with its
env var override before beign formatted into the string

Thanks @devendra104 for bringing this to my attention