### PR TITLE
Removed parametrization causing errors in cli/test_repository.py

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -533,11 +533,6 @@ class TestRepository:
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': list(valid_data_list().values())[0]}]),
-        indirect=True,
-    )
     def test_positive_create_with_gpg_key_by_id(self, repo_options, gpg_key):
         """Check if repository can be created with gpg key ID
 
@@ -555,11 +550,6 @@ class TestRepository:
         assert repo['gpg-key']['name'] == gpg_key['name']
 
     @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': list(valid_data_list().values())[0]}]),
-        indirect=True,
-    )
     def test_positive_create_with_gpg_key_by_name(
         self, repo_options, module_org, module_product, gpg_key
     ):
@@ -1415,11 +1405,6 @@ class TestRepository:
 
     @pytest.mark.tier1
     @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': list(valid_data_list().values())[0]}]),
-        indirect=True,
-    )
-    @pytest.mark.parametrize(
         'new_repo_options',
         **parametrized(
             [
@@ -1450,11 +1435,6 @@ class TestRepository:
 
     @pytest.mark.tier1
     @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': list(valid_data_list().values())[0]}]),
-        indirect=True,
-    )
-    @pytest.mark.parametrize(
         'new_repo_options',
         **parametrized(
             [
@@ -1482,11 +1462,6 @@ class TestRepository:
         assert result['url'] == repo['url']
 
     @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': list(valid_data_list().values())[0]}]),
-        indirect=True,
-    )
     def test_positive_update_gpg_key(self, repo_options, module_org, repo, gpg_key):
         """Update the original gpg key
 
@@ -1813,11 +1788,6 @@ class TestRepository:
         assert repo['content-counts']['puppet-modules'] == '0'
 
     @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': list(valid_data_list().values())[0]}]),
-        indirect=True,
-    )
     def test_positive_upload_content(self, repo):
         """Create repository and upload content
 
@@ -2045,11 +2015,6 @@ class TestRepository:
         assert len(repos) == 0
 
     @pytest.mark.tier2
-    @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': list(valid_data_list().values())[0]}]),
-        indirect=True,
-    )
     def test_positive_upload_remove_srpm_content(self, repo):
         """Create repository, upload and remove an SRPM content
 
@@ -2091,11 +2056,6 @@ class TestRepository:
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
-    @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': list(valid_data_list().values())[0]}]),
-        indirect=True,
-    )
     def test_positive_srpm_list_end_to_end(self, repo):
         """Create repository,  upload, list and remove an SRPM content
 


### PR DESCRIPTION
For `test_negative_update_auth_url_with_special_characters` and `test_negative_update_auth_url_too_long`, the removed parametrization in conjunction with the others caused only the first configuration of the test to pass, while the following failed on errors during the setup of the test.

That was because it tried to create a new repository with an already existing name. Without the explicit parametrization, a random name gets generated by default. Because the parametrization is therefore unnecessary, I took the liberty of removing all of its instances in the file.
```
pytest \
> tests/foreman/cli/test_repository.py::TestRepository::test_positive_create_with_gpg_key_by_id \
> tests/foreman/cli/test_repository.py::TestRepository::test_positive_create_with_gpg_key_by_name \
> tests/foreman/cli/test_repository.py::TestRepository::test_negative_update_auth_url_with_special_characters \
> tests/foreman/cli/test_repository.py::TestRepository::test_negative_update_auth_url_too_long \
> tests/foreman/cli/test_repository.py::TestRepository::test_positive_update_gpg_key \
> tests/foreman/cli/test_repository.py::TestRepository::test_positive_upload_content \
> tests/foreman/cli/test_repository.py::TestRepository::test_positive_upload_remove_srpm_content \
> tests/foreman/cli/test_repository.py::TestRepository::test_positive_srpm_list_end_to_end
============================ test session starts =============================                                                    

tests/foreman/cli/test_repository.py ......................            [100%]

================= 22 passed, 3 warnings in 564.17s (0:09:24) =================
```
