### PR TITLE
Add logging config for airgun, widgetastic, and navmazing.

### DIFF
--- a/logging.conf
+++ b/logging.conf
@@ -1,5 +1,5 @@
 [loggers]
-keys=nailgun,root,robottelo,robozilla,robottelo_config,robottelo_collection
+keys=nailgun,root,robottelo,robozilla,robottelo_config,robottelo_collection,widgetastic_null,navmazing_null,airgun
 
 [handlers]
 keys=consoleHandler,fileHandler,fileHandlerCollection
@@ -35,6 +35,21 @@ qualname=robottelo.collection
 level=DEBUG
 handlers=fileHandler
 qualname=robozilla
+
+[logger_widgetastic_null]
+level=DEBUG
+handlers=fileHandler
+qualname=widgetastic_null
+
+[logger_navmazing_null]
+level=DEBUG
+handlers=fileHandler
+qualname=navmazing_null
+
+[logger_airgun]
+level=DEBUG
+handlers=fileHandler
+qualname=airgun
 
 [handler_consoleHandler]
 class=StreamHandler


### PR DESCRIPTION
To aid in troubleshooting UI tests, this PR adds logging handlers for airgun, widgetastic, and navmazing. They are all `DEBUG` level, to match the other handlers, and they all log to `robottelo.log`. Sample log output with this change:

```
2021-04-06 14:25:07 - widgetastic_null - INFO - [LoginView/submit]: click (elapsed 3025 ms)
2021-04-06 14:25:07 - navmazing_null - INFO - NAVIGATE: Checking if already at All
2021-04-06 14:25:07 - navmazing_null - INFO - NAVIGATE: Already at All
2021-04-06 14:25:30 - widgetastic_null - DEBUG - [SubscriptionListView]: Started 'lambda defined as `lambda: self.am_i_here(*args, **kwargs),`' at 19169.23
2021-04-06 14:25:30 - widgetastic_null - DEBUG - [SubscriptionListView]: Took 0.11 to do 'lambda defined as `lambda: self.am_i_here(*args, **kwargs),`'
2021-04-06 14:25:30 - widgetastic_null - DEBUG - [SubscriptionListView]: Finished 'lambda defined as `lambda: self.am_i_here(*args, **kwargs),`' at 19169.23, 1 tries
2021-04-06 14:25:30 - widgetastic_null - DEBUG - [SubscriptionListView/add_button]: wait_displayed started
2021-04-06 14:25:30 - widgetastic_null - DEBUG - move_to_element: Button(href='subscriptions/add')
2021-04-06 14:25:30 - widgetastic_null - DEBUG - move_to_element: <selenium.webdriver.remote.webelement.WebElement (session="8a7296e29baddaaaad459b592ad50384", element="0c70c70c-3ab7-4a93-bea2-a5036e353b32")>
2021-04-06 14:25:32 - widgetastic_null - INFO - [SubscriptionListView/add_button]: wait_displayed (elapsed 1803 ms)
2021-04-06 14:25:32 - widgetastic_null - DEBUG - move_to_element: <selenium.webdriver.remote.webelement.WebElement (session="8a7296e29baddaaaad459b592ad50384", element="0c70c70c-3ab7-4a93-bea2-a5036e353b32")>
2021-04-06 14:25:33 - widgetastic_null - DEBUG - css classes for Button(href='subscriptions/add') => {'btn-primary', 'btn', 'disabled'}
2021-04-06 14:25:33 - airgun.session - INFO - Stopping UI session 'tests/foreman/ui/test_subscription.py::test_positive_access_manifest_as_another_admin_user' for user 'trUGpu'
2021-04-06 14:25:33 - airgun.session - DEBUG - Saving screenshot /tmp/robottelo/screenshots/2021-04-06/tests/foreman/ui/test_subscription.py::test_positive_access_manifest_as_another_admin_user-screenshot-2021-04-06_14_25_33.png
2021-04-06 14:25:34 - robottelo - DEBUG - Finished Test: tests/foreman/ui/test_subscription.py::test_positive_access_manifest_as_another_admin_user
2021-04-06 14:47:16 - robottelo - DEBUG - Selected 5 and deselected 4 tests based on new infra markers.
2021-04-06 18:47:16 - conftest - DEBUG - Collected 5 test cases
```