### PR TITLE
Add test to check 'insights-client --test-connection' for rhel8 host.

### DIFF
--- a/pytest_fixtures/broker.py
+++ b/pytest_fixtures/broker.py
@@ -21,6 +21,13 @@ def rhel7_contenthost():
         yield host
 
 
+@pytest.fixture
+def rhel8_contenthost():
+    """A fixture that provides a content host object based on the rhel8 nick"""
+    with VMBroker(nick='rhel8', host_classes={'host': ContentHost}) as host:
+        yield host
+
+
 @pytest.fixture(scope="module")
 def rhel77_host_module():
     """A module-level fixture that provides a host object"""

--- a/tests/foreman/rhai/test_rhai_client.py
+++ b/tests/foreman/rhai/test_rhai_client.py
@@ -19,9 +19,10 @@
 import pytest
 
 from robottelo.constants import DISTRO_RHEL7
+from robottelo.constants import DISTRO_RHEL8
 
 
-@pytest.mark.skip_if_open('BZ:1892405')
+@pytest.mark.tier4
 @pytest.mark.run_in_one_thread
 def test_positive_connection_option(rhel7_contenthost, module_org, activation_key):
     """Verify that 'insights-client --test-connection' successfully tests the proxy connection via
@@ -41,8 +42,9 @@ def test_positive_connection_option(rhel7_contenthost, module_org, activation_ke
     )
 
 
-@pytest.mark.stubbed
-def test_positive_connection_option_non_rhel7():
+@pytest.mark.tier4
+@pytest.mark.run_in_one_thread
+def test_positive_connection_option_non_rhel7(rhel8_contenthost, module_org, activation_key):
     """Verify that 'insights-client --test-connection' successfully tests the proxy connection via
     the Satellite.
 
@@ -56,4 +58,11 @@ def test_positive_connection_option_non_rhel7():
 
     :expectedresults: 'insights-client --test-connection' should return 0.
     """
-    pass
+    rhel8_contenthost.configure_rhai_client(activation_key.name, module_org.label, DISTRO_RHEL8)
+    result = rhel8_contenthost.execute('insights-client --test-connection')
+    assert result.status == 0, (
+        'insights-client --test-connection failed.\n'
+        f'status: {result.status}\n'
+        f'stdout: {result.stdout}\n'
+        f'stderr: {result.stderr}'
+    )


### PR DESCRIPTION
Test result:
```
$ pytest tests/foreman/rhai/test_rhai_client.py 
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.13, services-2.2.1, mock-3.5.1, reportportal-5.0.7, xdist-2.2.1, forked-1.3.0
collected 2 items

tests/foreman/rhai/test_rhai_client.py ..                                [100%]
================== 2 passed, 19 warnings in 922.26s (0:15:22) ==================
```
