### PR TITLE
Small test fix for reporttemplates

### DIFF
--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -740,7 +740,7 @@ def test_positive_generate_ansible_template():
     )
 
     report_data = ReportTemplate.with_user(username=user['login'], password=password).report_data(
-        {'id': template_name, 'job-id': schedule[0].split('Job ID: ', 1)[1]}
+        {'name': template_name, 'job-id': schedule[0].split('Job ID: ', 1)[1]}
     )
 
     assert host['name'] in [item.split(',')[1] for item in report_data if len(item) > 0]


### PR DESCRIPTION
Followup to 8441 that didn't get committed before merge

This was failing in master branch too, but I was debugging the branch for PR 8441 yesterday and figured out what was wrong with the test.

## Failure mode in master branch
```
> /home/setup/repos/robottelo/tests/foreman/cli/test_reporttemplates.py(743)test_positive_generate_ansible_template()
-> report_data = ReportTemplate.with_user(username=user['login'], password=password).report_data(
(Pdb) n
robottelo.cli.base.CLIReturnCodeError: CLIReturnCodeError(return_code=128, stderr="Resource report_template not found by id 'Ansible+-+Ansible+Inventory'\n", msg='Command "report-template report-data" finished with return_code 128\nstderr contains:\nResource report_template not found by id \'Ansible+-+Ansible+Inventory\'\n'

```