### PR TITLE
Add missing fixture to errata cli test

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1096,7 +1096,7 @@ def test_positive_list_filter_by_org(products_with_repos, filter_by_org):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_list_filter_by_cve(module_org):
+def test_positive_list_filter_by_cve(module_org, rh_repo):
     """Filter errata by CVE
 
     :id: 7791137c-95a7-4518-a56b-766a5680c5fb


### PR DESCRIPTION
The `test_positive_list_filter_by_cve` test was not explicitly calling the `rh_repo` fixture to import the manifest and enable red hat repos. The test might accidentally pass if another test in the module happened to run first and enable those repos, but the test fails if run alone.

Test results:
```
# pytest -s -k test_positive_list_filter_by_cve tests/foreman/cli/test_errata.py
[...]
collected 37 items / 36 deselected / 1 selected                                                                                                                                                                                              
[...]
=== 1 passed, 36 deselected, 14 warnings in 195.06s (0:03:15) ===
```
