### PR TITLE
fix cert tests, missed the files to add earlier commit

### DIFF
--- a/tests/foreman/data/certs.sh
+++ b/tests/foreman/data/certs.sh
@@ -5,11 +5,12 @@ CERTS_DIR=certs
 function generate_certs(){
    CERT_NAME=$1
    SUBJ=$2
+   extensions=$3
    if [[ ! -f "$CERTS_DIR/${CERT_NAME}.key" || ! -f "$CERTS_DIR/$CERT_NAME.crt" ]]; then
         echo "Generating server certificate"
         openssl genrsa -out $CERTS_DIR/$CERT_NAME.key 2048
         openssl req -new -key $CERTS_DIR/$CERT_NAME.key -out $CERTS_DIR/$CERT_NAME.csr -subj $SUBJ
-        openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions extensions
+        openssl x509 -req -in $CERTS_DIR/$CERT_NAME.csr -CA $CERTS_DIR/$CA_CERT_NAME.crt -CAkey $CERTS_DIR/$CA_CERT_NAME.key -CAcreateserial -out $CERTS_DIR/$CERT_NAME.crt -days 3650 -sha256 -extfile extensions.txt -extensions $extensions
     else
         echo "Server certificate exists. Skipping."
    fi
@@ -42,13 +43,13 @@ else
 fi
 
 # generate certs with hostname 'foreman.example.com'
-generate_certs "foreman.example.com" "/CN=foreman.example.com"
+generate_certs "foreman.example.com" "/CN=foreman.example.com" "extensions"
 
 # generate invalid certs with hostname as 'foreman.example.com'
-generate_certs "invalid" "/CN=foreman.example.com"
+generate_certs "invalid" "/CN=foreman.example.com" "client_extensions"
 
 # generate certs with wildcard
-generate_certs "wildcard" "/CN=*.example.com"
+generate_certs "wildcard" "/CN=*.example.com" "wildcard_extensions"
 
 # generate certs with short hostname
-generate_certs "shortname" "/CN=foreman"
+generate_certs "shortname" "/CN=foreman" "shortname_extensions"

--- a/tests/foreman/data/extensions.txt
+++ b/tests/foreman/data/extensions.txt
@@ -1,0 +1,24 @@
+[extensions]
+keyUsage = keyEncipherment
+subjectAltName = @alt_names
+
+[client_extensions]
+keyUsage = keyEncipherment
+extendedKeyUsage = clientAuth
+
+[wildcard_extensions]
+keyUsage = keyEncipherment
+subjectAltName = @wildcard_alt_names
+
+[shortname_extensions]
+keyUsage = keyEncipherment
+subjectAltName = @shortname_alt_names
+
+[alt_names]
+DNS.1 = foreman.example.com
+
+[wildcard_alt_names]
+DNS.1 = *.example.com
+
+[shortname_alt_names]
+DNS.1 = foreman

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -130,7 +130,7 @@ class TestKatelloCertsCheck:
             result = connection.run(f"rm -rf {files}")
             assert result.return_code == 0
 
-    @pytest.fixture(scope="module")
+    @pytest.fixture()
     def generate_certs(self):
         upload_file(
             local_file=get_data_file('certs.sh'),


### PR DESCRIPTION
Thanks, @swadeley, 

Earlier PR missed adding the extension.txt file causing failures, some modification required which missed earlier. while I was testing locally the file was exist I missed push it. 

```
=========================== short test summary info ============================
FAILED test_katello_certs_check.py::TestKatelloCertsCheck::test_positive_update_katello_certs
============  7 passed, 6 deselected in 639.43s (0:10:39) =============     
```