### PR TITLE
adding hammer defaults check

### DIFF
--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -176,13 +176,16 @@ class HammerTestCase(CLITestCase):
 
         :CaseImportance: Critical
 
-        :BZ: 1640644
+        :BZ: 1640644, 1368173
         """
         default_org = make_org()
         default_product_name = gen_string('alpha')
         make_product({'name': default_product_name, 'organization-id': default_org['id']})
         try:
             Defaults.add({'param-name': 'organization_id', 'param-value': default_org['id']})
+            # list templates for BZ#1368173
+            result = ssh.command('hammer job-template list')
+            assert result.return_code == 0
             # Verify --organization-id is not required to pass if defaults are set
             result = ssh.command('hammer product list')
             assert result.return_code == 0


### PR DESCRIPTION
Adding a check for bz#1368173 into an existing scenario, so that a separate test in cli/test_job_templates.py. Related to discussion in #8488

```
 pytest tests/foreman/cli/test_hammer.py -k test_positive_disable_hammer_defaults
================================================ test session starts ================================================

tests/foreman/cli/test_hammer.py .                                                                            [100%]

==================================== 1 passed, 2 deselected in 63.93s (0:01:03) =====================================
```