### PR TITLE
Replace old custom kickstarter repo

### DIFF
--- a/robottelo/constants/repos.py
+++ b/robottelo/constants/repos.py
@@ -7,7 +7,7 @@ if not settings.configured:
 REPOS_URL = settings.repos_hosting_url
 
 CUSTOM_FILE_REPO = 'https://fixtures.pulpproject.org/file/'
-CUSTOM_KICKSTART_REPO = 'http://mirror.linux.duke.edu/pub/centos/8/BaseOS/x86_64/kickstart/'
+CUSTOM_KICKSTART_REPO = 'http://ftp.cvut.cz/centos/8/BaseOS/x86_64/kickstart/'
 CUSTOM_RPM_REPO = 'https://fixtures.pulpproject.org/rpm-signed/'
 CUSTOM_RPM_SHA_512 = 'https://fixtures.pulpproject.org/rpm-with-sha-512/'
 CUSTOM_MODULE_STREAM_REPO_1 = f'{REPOS_URL}/module_stream1'


### PR DESCRIPTION
Old kickstarter repo is pointing to something out of date.  Replacing with something that is working.  `test_positive_sync_kickstart_repo` is using that repo.

```
pytest tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_repo
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.8.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, cov-2.11.1, ibutsu-1.14.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1
collected 1 item                                                                                                                                                                                                                         

tests/foreman/api/test_contentmanagement.py .                                                                                                                                                                                      [100%]

=== warnings summary ====
tests/foreman/api/test_contentmanagement.py: 52 warnings
  /home/ltran/Projects/venv/my_robo_env/lib64/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-2-51.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
===================== 1 passed, 52 warnings in 248.29s (0:04:08) ========================