### PR TITLE
[RFE] Upgrade Scenarios sharing workers between pre and post part

### DIFF
--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -97,6 +97,8 @@ from robottelo.decorators.func_locker import lock_function
 from robottelo.logging import logger
 
 
+pytest_plugins = 'tests.upgrades.scenario_workers'
+
 pre_upgrade_failed_tests = []
 
 

--- a/tests/upgrades/scenario_workers.py
+++ b/tests/upgrades/scenario_workers.py
@@ -1,0 +1,58 @@
+import json
+import os
+
+import pytest
+from automation_tools.satellite6.hammer import set_hammer_config
+from fabric.api import env
+
+import robottelo
+from robottelo.config import settings
+
+
+_json_file = 'upgrade_workers.json'
+
+
+def save_worker_id(test_name, worker_id):
+    data = {}
+    if os.path.exists(_json_file):
+        with open(_json_file) as rjson:
+            data = json.load(rjson)
+    with open(_json_file, 'w') as wjson:
+        # Removing the parameter name from test name before save
+        test_name = test_name.split('[')[0] if '[' in test_name else test_name
+        data.update({test_name: worker_id})
+        wjson.seek(0)
+        json.dump(data, wjson)
+
+
+def get_worker_id(test_name):
+    with open(_json_file) as rjson:
+        data = json.load(rjson)
+        return data.get(test_name)
+
+
+@pytest.fixture(autouse=True)
+def save_pretest_worker_id(request, worker_id):
+    """Saves the worker id of pre_upgrade test in json"""
+    if request.node.get_closest_marker('pre_upgrade'):
+        save_worker_id(request.node.name, worker_id)
+
+
+@pytest.fixture(autouse=True)
+def set_posttest_worker_id(request):
+    """Retrieves worker_id of pre_upgrade and sets the same to run post_upgrade"""
+    post_upgrade = request.node.get_closest_marker('post_upgrade')
+    if post_upgrade:
+        depend_test = post_upgrade.kwargs.get('depend_on')
+        if depend_test:
+            pre_test_name = depend_test.__name__
+            # settings.configure()
+            cache_proxy = robottelo.config.settings_proxy._cache
+            # Read the worker id of pre test name
+            worker_int = int(get_worker_id(pre_test_name).replace('gw', ''))
+            cache_proxy['server.hostname'] = settings.server.hostnames[worker_int]
+            settings.configure_nailgun()
+            settings.configure_airgun()
+            env.host_string = settings.server.hostname
+            env.user = 'root'
+            set_hammer_config()

--- a/tests/upgrades/scenario_workers.py
+++ b/tests/upgrades/scenario_workers.py
@@ -1,5 +1,5 @@
 import json
-import os
+from pathlib import Path
 
 import pytest
 from automation_tools.satellite6.hammer import set_hammer_config
@@ -12,47 +12,52 @@ from robottelo.config import settings
 _json_file = 'upgrade_workers.json'
 
 
-def save_worker_id(test_name, worker_id):
+def save_worker_hostname(test_name):
     data = {}
-    if os.path.exists(_json_file):
-        with open(_json_file) as rjson:
-            data = json.load(rjson)
-    with open(_json_file, 'w') as wjson:
-        # Removing the parameter name from test name before save
-        test_name = test_name.split('[')[0] if '[' in test_name else test_name
-        data.update({test_name: worker_id})
-        wjson.seek(0)
-        json.dump(data, wjson)
+    json_file = Path(_json_file)
+    if json_file.exists():
+        data = json.loads(json_file.read_text())
+    # Removing the parameter name from test name before save
+    test_name = test_name.split('[')[0] if '[' in test_name else test_name
+    data.update({test_name: settings.server.hostname})
+    json_file.write_text(json.dumps(data))
 
 
-def get_worker_id(test_name):
+def get_worker_hostname(test_name):
     with open(_json_file) as rjson:
         data = json.load(rjson)
         return data.get(test_name)
 
 
 @pytest.fixture(autouse=True)
-def save_pretest_worker_id(request, worker_id):
+def save_pre_upgrade_worker_hostname(request):
     """Saves the worker id of pre_upgrade test in json"""
     if request.node.get_closest_marker('pre_upgrade'):
-        save_worker_id(request.node.name, worker_id)
+        save_worker_hostname(request.node.name)
 
 
 @pytest.fixture(autouse=True)
-def set_posttest_worker_id(request):
-    """Retrieves worker_id of pre_upgrade and sets the same to run post_upgrade"""
+def set_post_upgrade_hostname(request):
+    """Retrieves worker hostname of pre_upgrade and sets the same to run post_upgrade
+
+    The limitation of this implementation is that the XDIST_BEHAVIOR won't be observed,
+    and tests running under xdist will not be isolated.
+    """
     post_upgrade = request.node.get_closest_marker('post_upgrade')
     if post_upgrade:
         depend_test = post_upgrade.kwargs.get('depend_on')
         if depend_test:
             pre_test_name = depend_test.__name__
-            # settings.configure()
+            settings.configure()
             cache_proxy = robottelo.config.settings_proxy._cache
+            pre_hostname = get_worker_hostname(pre_test_name)
+            if (pre_hostname is None) or (pre_hostname not in settings.server.hostnames):
+                pytest.skip(
+                    'Skipping the post_upgrade test as the pre_upgrade hostname is not found!'
+                )
             # Read the worker id of pre test name
-            worker_int = int(get_worker_id(pre_test_name).replace('gw', ''))
-            cache_proxy['server.hostname'] = settings.server.hostnames[worker_int]
+            cache_proxy['server.hostname'] = env.host_string = pre_hostname
+            env.user = 'root'
             settings.configure_nailgun()
             settings.configure_airgun()
-            env.host_string = settings.server.hostname
-            env.user = 'root'
             set_hammer_config()


### PR DESCRIPTION
-- This is an RFE/request to share the same worker/satellite between the pre and post part of upgrade scenario:

- Due to which the entities created before the upgrade will be accessible on the same satellite post upgrade.

-- This PR adds a plugin to the tests/upgrades/conftest.py
-- This removes the dependency of universal Configuration from __init__.py and configures it as per worker hostname in plugin itself.
