### PR TITLE
convert test_virtwho upgrade cases to pytest

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -96,7 +96,7 @@ class TestScenarioPositiveVirtWho:
         )
         virt_who_instance = (
             entities.VirtWhoConfig(organization_id=org.id)
-            .search(query={'search': f"name={FORM_DATA['name']}"})[0]
+            .search(query={'search': f'name={FORM_DATA["name"]}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
@@ -158,11 +158,11 @@ class TestScenarioPositiveVirtWho:
             2. the config and guest connection have the same status.
             3. virt-who config should update and delete successfully.
         """
-        org = entities.Organization().search(query={'search': f"name={ORG_DATA['name']}"})[0]
+        org = entities.Organization().search(query={'search': f'name={ORG_DATA["name"]}'})[0]
 
         # Post upgrade, Verify virt-who exists and has same status.
         vhd = entities.VirtWhoConfig(organization_id=org.id).search(
-            query={'search': f"name={FORM_DATA['name']}"}
+            query={'search': f'name={FORM_DATA["name"]}'}
         )[0]
         if not is_open('BZ:1802395'):
             assert vhd.status == 'ok'

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -92,7 +92,7 @@ class TestScenarioPositiveVirtWho:
         assert vhd.status == 'unknown'
         command = get_configure_command(vhd.id, org=org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, FORM_DATA['hypervisor_type'], debug=True, org=org.name
+            command, FORM_DATA['hypervisor_type'], debug=True, org=org.label
         )
         virt_who_instance = (
             entities.VirtWhoConfig(organization_id=org.id)
@@ -168,7 +168,7 @@ class TestScenarioPositiveVirtWho:
             assert vhd.status == 'ok'
         # Verify virt-who status via CLI as we cannot check it via API now
         vhd_cli = VirtWhoConfig.exists(search=('name', FORM_DATA['name']))
-        assert VirtWhoConfig.info({'id': vhd_cli['id']})['general-information']['status'] == 'ok'
+        assert VirtWhoConfig.info({'id': vhd_cli['id']})['general-information']['status'] == 'OK'
 
         # Vefify the connection of the guest on Content host
         entity_data = get_entity_data(self.__class__.__name__)


### PR DESCRIPTION
**Description**
convert test_virtwho upgrade cases to pytest

**Test Result**
```
(3.8_env) [hkx303@kuhuang robottelo]$ pytest -m "pre_upgrade" tests/upgrades/test_virtwho.py
2021-04-15 20:54:36 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
==================================== test session starts =====================================
platform linux -- Python 3.8.7, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, reportportal-5.0.7, xdist-2.2.0, cov-2.11.1, ibutsu-1.13, mock-3.5.1, forked-1.3.0
collecting ... 2021-04-15 20:54:36 - robottelo - DEBUG - Selected 2 and deselected 0 tests based on new infra markers.
2021-04-15 20:54:36 - robottelo - DEBUG - Calling Bugzilla API for {'1802395'}
collected 2 items / 1 deselected / 1 selected  
================== 1 passed, 1 deselected, 15 warnings in 153.18s (0:02:33) ==================


(3.8_env) [hkx303@kuhuang robottelo]$ pytest -m "post_upgrade" tests/upgrades/test_virtwho.py
2021-04-15 21:07:09 - robottelo - INFO - Started setUpClass: robottelo.test/TestCase
==================================== test session starts =====================================
platform linux -- Python 3.8.7, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, reportportal-5.0.7, xdist-2.2.0, cov-2.11.1, ibutsu-1.13, mock-3.5.1, forked-1.3.0
collecting ... 2021-04-15 21:07:09 - robottelo - DEBUG - Selected 2 and deselected 0 tests based on new infra markers.
2021-04-15 21:07:09 - robottelo - DEBUG - Calling Bugzilla API for {'1802395'}
collected 2 items / 1 deselected / 1 selected       
======================= 1 passed, 1 deselected, 11 warnings in 24.39s ========================
```