### PR TITLE
changed assignee name for ContentVV

### DIFF
--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentViews
 
-:Assignee: chiggins
+:Assignee: ltran
 
 :TestType: Functional
 


### PR DESCRIPTION
The assignee's name was incorrect. Changed to the official owner. 