### PR TITLE
Removed redundant for cycle (iterating already done in parametrization)

### DIFF
--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -121,8 +121,7 @@ def test_positive_delete(new_name):
 
     :parametrized: yes
     """
-    for new_name in valid_data_list():
-        profile = entities.ComputeProfile(name=new_name).create()
-        profile.delete()
-        with pytest.raises(HTTPError):
-            entities.ComputeProfile(id=profile.id).read()
+    profile = entities.ComputeProfile(name=new_name).create()
+    profile.delete()
+    with pytest.raises(HTTPError):
+        entities.ComputeProfile(id=profile.id).read()


### PR DESCRIPTION
I removed the `for` cycle which did exactly what the parametrization does.
```
$ pytest tests/foreman/api/test_computeprofile.py::test_positive_delete
============================= test session starts ==============================
collected 7 items                                                              

tests/foreman/api/test_computeprofile.py .......                         [100%]
======================= 7 passed, 18 warnings in 31.44s ========================
```
