### PR TITLE
Remove nitpicky and adjust makefiles for docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,11 +55,12 @@ help:
 	@echo "  clean-all                  to clean cache, pyc, logs and docs"
 
 docs:
-	@cd docs; $(MAKE) html
+	$(info "Copying broker_config.yaml to avoid warnings")
+	@cp ./broker_settings.yaml docs/; $(MAKE) -C docs html
 
 docs-clean:
 	$(info "Cleaning docs...")
-	@cd docs; $(MAKE) clean
+	$(MAKE) -C docs clean
 
 test-docstrings: uuid-check
 	$(info "Checking for errors in docstrings and testimony tags...")

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -14,10 +14,9 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean  html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
-
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  clean      to cleanup build directory and temp config files"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"
@@ -39,7 +38,8 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 
 clean:
-	-rm -rf $(BUILDDIR)/*
+	$(info "Removing build dir content and broker_settings.yaml")
+	@rm -rf $(BUILDDIR)/* broker_settings.yaml
 
 html:
 	$(SPHINXBUILD) -W -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,35 +41,7 @@ autoapi_dirs = ['../robottelo']
 source_suffix = '.rst'
 master_doc = 'index'
 exclude_patterns = ['_build', 'pytest/*']
-nitpicky = True
-nitpick_ignore = [
-    ('py:class', 'bool'),
-    ('py:class', 'callable'),
-    ('py:class', 'dict'),
-    ('py:class', 'Exception'),
-    ('py:class', 'int'),
-    ('py:class', 'list'),
-    ('py:class', 'object'),
-    ('py:class', 'set'),
-    ('py:class', 'str'),
-    ('py:class', 'tuple'),
-    ('py:class', 'broker.hosts.Host'),
-    ('py:class', 'json.JSONEncoder'),
-    ('py:class', 'nailgun.entities.ActivationKey'),
-    ('py:class', 'nailgun.entities.Organization'),
-    ('py:class', 'nailgun.entities.Environment'),
-    ('py:class', 'nailgun.entities.Product'),
-    ('py:class', 'nailgun.entities.Role'),
-    ('py:class', 'nailgun.entities.Repository'),
-    ('py:class', 'paramiko.SSHClient'),
-    ('py:mod', 'robottelo.cli.template_sync'),
-    ('py:class', 'unittest2.case.TestCase'),
-    ('py:class', 'unittest2.TestCase'),
-    ('py:class', 'wrapt.CallableObjectProxy'),
-    ('py:mod', 'tests'),
-    ('py:mod', 'tests.foreman'),
-    ('py:mod', 'tests.foreman.cli'),
-]
+nitpicky = False
 autodoc_default_options = {'members': None, 'undoc-members': None}
 
 # Format-Specific Options -----------------------------------------------------


### PR DESCRIPTION
nitpicky was causing more trouble than it was worth, and our exceptions
list continued to grow.

Adjust the makefile commands for docs, using the `-C` switch for working
directory