### PR TITLE
vm2br cli/test_host

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -210,7 +210,7 @@ class ContentHost(Host):
         self,
         org='Default_Organization',
         activation_key=None,
-        lce=None,
+        lce='Library',
         consumerid=None,
         force=True,
         releasever=None,

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -210,7 +210,7 @@ class ContentHost(Host):
         self,
         org='Default_Organization',
         activation_key=None,
-        lce='Library',
+        lce=None,
         consumerid=None,
         force=True,
         releasever=None,

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1999,6 +1999,7 @@ def test_negative_without_attach(request, module_host_subscription, host_subscri
     host = Host.info({'name': module_host_subscription.client.hostname})
     module_host_subscription.client.register_contenthost(
         module_host_subscription.org.name,
+        lce=None,  # required, to jump into right branch in register_contenthost method
         consumerid=host['subscription-information']['uuid'],
         force=False,
     )
@@ -2031,8 +2032,6 @@ def test_negative_without_attach_with_lce(module_host_subscription, host_subscri
         environment=lce,
         organization=org,
     ).create()
-    # entities.ContentView().search(
-    #     query={'search': f'name={DEFAULT_CV}', 'organization_id': f'{module_org.id}'}
     setup_org_for_a_rh_repo(
         {
             'product': PRDS['rhel'],

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -18,6 +18,7 @@
 """
 import time
 from datetime import datetime
+from datetime import timedelta
 from random import choice
 
 import pytest
@@ -1515,18 +1516,17 @@ def katello_host_tools_repos():
 @pytest.mark.skip_if_not_set('clients')
 @pytest.fixture(scope="function")
 def katello_host_tools_client(katello_host_tools_repos, rhel7_contenthost):
-    client = rhel7_contenthost
-    client.install_katello_ca()
+    rhel7_contenthost.install_katello_ca()
     # Register content host and install katello-host-tools
-    client.register_contenthost(
+    rhel7_contenthost.register_contenthost(
         katello_host_tools_repos['org'].label,
         katello_host_tools_repos['ak'].name,
     )
-    assert client.subscribed
-    host_info = Host.info({'name': client.hostname})
-    client.enable_repo(REPOS['rhst7']['id'])
-    client.install_katello_host_tools()
-    yield {'client': client, 'host_info': host_info}
+    assert rhel7_contenthost.subscribed
+    host_info = Host.info({'name': rhel7_contenthost.hostname})
+    rhel7_contenthost.enable_repo(REPOS['rhst7']['id'])
+    rhel7_contenthost.install_katello_host_tools()
+    yield {'client': rhel7_contenthost, 'host_info': host_info}
 
 
 @pytest.mark.katello_host_tools
@@ -1849,6 +1849,10 @@ class HostSubscription:
                 in Host.info({'name': self.client.hostname})['subscription-information'][
                     'registered-at'
                 ]
+                or (datetime.utcnow() - timedelta(days=1)).strftime("%Y-%m-%d")
+                in Host.info({'name': self.client.hostname})['subscription-information'][
+                    'registered-at'
+                ]
             ):
                 Host.subscription_unregister({'host': self.client.hostname})
 
@@ -1941,7 +1945,7 @@ def test_positive_attach(request, module_host_subscription, host_subscription_cl
     try:
         module_host_subscription.client.install_katello_agent()
     except ContentHostError:
-        pytest.fail("ContentHostError raised unexpectedly!")
+        pytest.fail('ContentHostError raised unexpectedly!')
 
 
 @pytest.mark.host_subscription
@@ -1974,7 +1978,7 @@ def test_positive_attach_with_lce(module_host_subscription, host_subscription_cl
     try:
         module_host_subscription.client.install_katello_agent()
     except ContentHostError:
-        pytest.fail("ContentHostError raised unexpectedly!")
+        pytest.fail('ContentHostError raised unexpectedly!')
 
 
 @pytest.mark.host_subscription
@@ -2155,7 +2159,7 @@ def test_positive_auto_attach(request, module_host_subscription, host_subscripti
     try:
         module_host_subscription.client.install_katello_agent()
     except ContentHostError:
-        pytest.fail("ContentHostError raised unexpectedly!")
+        pytest.fail('ContentHostError raised unexpectedly!')
 
 
 @pytest.mark.host_subscription


### PR DESCRIPTION
cleanup with request object was added to `register_contenthost`.
Cleanup is preventing from possible organization mismatch error. This was discussed previously in automation chat. 
This would require other people to change their name definitions and method definitions when register_contenthost is called. 

Note: I am component owner