### PR TITLE
GCE clean up

### DIFF
--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -266,7 +266,7 @@ class TestGCEHostProvisioningTestCase:
         request.cls.mtype = 'g1-small'
         request.cls.network = 'default'
         request.cls.volsize = '13'
-        request.cls.hostname = gen_string('alpha')
+        request.cls.hostname = f'test{gen_string("alpha")}'
 
         request.cls.fullhostname = f'{self.hostname}.{gce_domain.name}'.lower()
 
@@ -338,7 +338,7 @@ class TestGCEHostProvisioningTestCase:
             3. The host should show Installed status for provisioned host
         """
         assert class_host.name == self.fullhostname
-        assert class_host.build_status_label == "Installed"
+        assert class_host.build_status_label == 'Installed clear'
 
     @pytest.mark.tier3
     def test_positive_gce_host_ip(self, class_host, google_host):

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1878,7 +1878,6 @@ def gce_hostgroup(
 
 
 @pytest.mark.tier4
-@skip_if_not_set('gce')
 def test_positive_gce_provision_end_to_end(
     session, module_org, module_loc, module_os, gce_domain, gce_hostgroup, gce_client
 ):
@@ -1890,7 +1889,7 @@ def test_positive_gce_provision_end_to_end(
 
     :CaseLevel: System
     """
-    name = gen_string('alpha').lower()
+    name = f'test{gen_string("alpha").lower()}'
     hostname = f'{name}.{gce_domain.name}'
     gceapi_vmname = hostname.replace('.', '-')
     root_pwd = gen_string('alpha', 15)
@@ -1928,7 +1927,7 @@ def test_positive_gce_provision_end_to_end(
             # 1.1 UI based Assertions
             host_info = session.host.get_details(hostname)
             assert session.host.search(hostname)[0]['Name'] == hostname
-            assert host_info['properties']['properties_table']['Build'] == 'Installed'
+            assert host_info['properties']['properties_table']['Build'] == 'Installed clear'
             # 1.2 GCE Backend Assertions
             gceapi_vm = gce_client.get_vm(gceapi_vmname)
             assert gceapi_vm.is_running
@@ -1961,7 +1960,6 @@ def test_positive_gce_provision_end_to_end(
 
 @pytest.mark.tier4
 @pytest.mark.upgrade
-@skip_if_not_set('gce')
 def test_positive_gce_cloudinit_provision_end_to_end(
     session, module_org, module_loc, module_os, gce_domain, gce_hostgroup, gce_client
 ):
@@ -1973,7 +1971,7 @@ def test_positive_gce_cloudinit_provision_end_to_end(
 
     :CaseLevel: System
     """
-    name = gen_string('alpha').lower()
+    name = f'test{gen_string("alpha").lower()}'
     hostname = f'{name}.{gce_domain.name}'
     gceapi_vmname = hostname.replace('.', '-')
     storage = [{'size': 20}]
@@ -2001,7 +1999,10 @@ def test_positive_gce_cloudinit_provision_end_to_end(
             # 1.1 UI based Assertions
             host_info = session.host.get_details(hostname)
             assert session.host.search(hostname)[0]['Name'] == hostname
-            assert host_info['properties']['properties_table']['Build'] == 'Pending installation'
+            assert (
+                host_info['properties']['properties_table']['Build']
+                == 'Pending installation clear'
+            )
             # 1.2 GCE Backend Assertions
             gceapi_vm = gce_client.get_vm(gceapi_vmname)
             assert gceapi_vm


### PR DESCRIPTION
add 'test' prefix for VMs created on GCE so they can be cleaned up with CR clean up script

also fix failing asserts

```
$ pytest tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lvrtelov/PycharmProjects/lvrtelov/robottelo-lvrtelov, configfile: pyproject.toml
plugins: services-2.2.1, xdist-2.2.1, forked-1.3.0, cov-2.11.1, mock-3.5.1, ibutsu-1.14.1, reportportal-5.0.8
collected 6 items                                                                                                                                                        

tests/foreman/api/test_computeresource_gce.py .s....                                                                                                               [100%]

============================================================================ warnings summary ============================================================================
tests/foreman/api/test_computeresource_gce.py: 25 warnings
  /home/lvrtelov/PycharmProjects/lvrtelov/robottelo-lvrtelov/venv38/lib64/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-3-49.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
========================================================== 5 passed, 1 skipped, 25 warnings in 63.23s (0:01:03) ==========================================================
```
```

$ pytest tests/foreman/ui/test_host.py -k 'test_positive_gce_cloudinit_provision_end_to_end or test_positive_gce_provision_end_to_end'
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.8.6, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lvrtelov/PycharmProjects/lvrtelov/robottelo-lvrtelov, configfile: pyproject.toml
plugins: services-2.2.1, xdist-2.2.1, forked-1.3.0, cov-2.11.1, mock-3.5.1, ibutsu-1.14.1, reportportal-5.0.8
collected 32 items / 30 deselected / 2 selected                                                                                                                          

tests/foreman/ui/test_host.py ..                                                                                                                                   [100%]

============================================================================ warnings summary ============================================================================
tests/foreman/ui/test_host.py: 112 warnings
  /home/lvrtelov/PycharmProjects/lvrtelov/robottelo-lvrtelov/venv38/lib64/python3.8/site-packages/urllib3/connectionpool.py:1013: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-3-49.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================================= 2 passed, 30 deselected, 112 warnings in 921.63s (0:15:21) =======================================================
```