### PR TITLE
Errata UI test fixes

### DIFF
--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -597,15 +597,22 @@ class GenericRHRepository(BaseRepository):
             raise ValueError('Can not handle Custom repository with url not supplied')
         if self.cdn:
             data = self.data
-            RepositorySet.enable(
+            if not Repository.list(
                 {
                     'organization-id': organization_id,
+                    'name': data['repository'],
                     'product': data['product'],
-                    'name': data['repository-set'],
-                    'basearch': data.get('arch', DEFAULT_ARCHITECTURE),
-                    'releasever': data.get('releasever'),
                 }
-            )
+            ):
+                RepositorySet.enable(
+                    {
+                        'organization-id': organization_id,
+                        'product': data['product'],
+                        'name': data['repository-set'],
+                        'basearch': data.get('arch', DEFAULT_ARCHITECTURE),
+                        'releasever': data.get('releasever'),
+                    }
+                )
             repo_info = Repository.info(
                 {
                     'organization-id': organization_id,


### PR DESCRIPTION
This PR fixes some errata UI tests. Changes include:

- Add a call to `session.organization.select(org_name=org.name)` in `test_content_host_errata_page_pagination`, so that the content host can be found in the correct org.
- Add an `__init__()` method to `ContentHost` so that it initializes the `subscribed` attribute to `False`.
- In `GenericRHRepository.create()`, add a check on whether the repository is already enabled before attempting to enable it, because `hammer repository-set enable` will return an error code if you run it a second time:

```
# hammer repository-set enable --organization yKrawjiiAaLi --id 3327 --releasever 7Server --basearch x86_64
Repository enabled.

# hammer repository-set enable --organization yKrawjiiAaLi --id 3327 --releasever 7Server --basearch x86_64
Could not enable repository:
  Error: 409 Conflict
```

This was causing errors in `tests/foreman/ui/test_errata.py` because both the `module_repos_col` and `module_erratatype_repos_col` fixtures enable `RHELAnsibleEngineRepository(cdn=True)`.

- Convert content host provisioning in `tests/foreman/ui/test_errata.py` to use `VMBroker`. Because we don't currently have rhel6 templates available, the `rhva_vm` fixture has been removed, and tests that used it now use `erratatype_vm`.


```
# pytest tests/foreman/ui/test_errata.py 
[...]
collected 15 items

tests/foreman/ui/test_errata.py ..........s.... [100%]
[...]
=== 14 passed, 1 skipped, 45 warnings in 23521.54s (6:32:01) ===
```