### PR TITLE
change to environment_ids

### DIFF
--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -110,7 +110,7 @@ def create_activation_key_for_client_registration(ak_name, client_os, org, envir
     tools_cv = tools_cv.read()  # Published CV with new version
     # Promote CV
     cvv = entities.ContentViewVersion(id=max([cvv.id for cvv in tools_cv.version])).read()
-    cvv.promote(data={'environment_id': environment.id, 'force': False})
+    cvv.promote(data={'environment_ids': environment.id, 'force': False})
     tools_ak = entities.ActivationKey(
         name=ak_name, content_view=tools_cv, organization=org.id, environment=environment
     ).create()
@@ -173,7 +173,7 @@ def update_product_subscription_in_ak(product, yum_repo, ak, org):
         .environment
     )
     cvv = entities.ContentViewVersion(id=max([cvv.id for cvv in cv.version])).read()
-    cvv.promote(data={'environment_id': environment.id, 'force': False})
+    cvv.promote(data={'environment_ids': environment.id, 'force': False})
     subscription = entities.Subscription(organization=org).search(
         query={'search': 'name={}'.format(product.name)}
     )[0]


### PR DESCRIPTION
 due to API change

Hi, while testing I found this change had not been made when API changed a few months ago.

