### PR TITLE
Automate test_positive_inventory_generate_upload_cli

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,7 @@ pytest_plugins = [
     # Component Fixtures
     'pytest_fixtures.ansible_fixtures',
     'pytest_fixtures.oscap_fixtures',
+    'pytest_fixtures.rh_cloud',
     'pytest_fixtures.satellite_auth',
     'pytest_fixtures.sys_fixtures',
     'pytest_fixtures.smartproxy_fixtures',

--- a/pytest_fixtures/broker.py
+++ b/pytest_fixtures/broker.py
@@ -109,3 +109,22 @@ def capsule_latest():
         host_classes={'host': Capsule}, workflow=settings.capsule.deploy_workflow
     ) as cap:
         yield cap
+
+
+@pytest.fixture(scope='module')
+def content_hosts():
+    """A module-level fixture that provides two content hosts object based on the rhel7 nick"""
+    with VMBroker(nick='rhel7', host_classes={'host': ContentHost}, _count=2) as hosts:
+        hosts[0].set_infrastructure_type('physical')
+        yield hosts
+
+
+@pytest.fixture(scope='module')
+def registered_hosts(organization_ak_setup, content_hosts):
+    """Fixture that registers content hosts to Satellite."""
+    org, ak = organization_ak_setup
+    for vm in content_hosts:
+        vm.install_katello_ca()
+        vm.register_contenthost(org.label, ak.name)
+        assert vm.subscribed
+    return content_hosts

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -1,0 +1,20 @@
+import pytest
+from nailgun import entities
+
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+
+
+@pytest.fixture(scope='module')
+def organization_ak_setup(module_manifest_org):
+    """A module-level fixture to create an Activation key in module_org"""
+    ak = entities.ActivationKey(
+        content_view=module_manifest_org.default_content_view,
+        organization=module_manifest_org,
+        environment=entities.LifecycleEnvironment(id=module_manifest_org.library.id),
+        auto_attach=True,
+    ).create()
+    subscription = entities.Subscription(organization=module_manifest_org).search(
+        query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
+    )[0]
+    ak.add_subscriptions(data={'quantity': 10, 'subscription_id': subscription.id})
+    return module_manifest_org, ak

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -1,0 +1,85 @@
+"""Utility module for RH cloud inventory tests"""
+import hashlib
+import json
+import os
+import tarfile
+
+from robottelo import ssh
+
+
+def get_host_counts(tarobj):
+    """
+    Returns hosts count from tarfile.
+    Args:
+        tarobj: tarfile to get host count from
+    """
+    metadata_counts = {}
+    slices_counts = {}
+    for file_ in tarobj.getmembers():
+        file_name = os.path.basename(file_.name)
+        if not file_name.endswith(".json"):
+            continue
+        json_data = json.load(tarobj.extractfile(file_))
+        if file_name == "metadata.json":
+            metadata_counts = {
+                f"{key}.json": value['number_hosts']
+                for key, value in json_data['report_slices'].items()
+            }
+        else:
+            slices_counts[file_name] = len(json_data['hosts'])
+
+    return {
+        "metadata_counts": metadata_counts,
+        "slices_counts": slices_counts,
+    }
+
+
+def get_local_file_data(path):
+    """Returs information about tarfile.
+    Args:
+        path: path to tarfile
+    """
+    size = os.path.getsize(path)
+
+    with open(path, 'rb') as fh:
+        file_content = fh.read()
+    checksum = hashlib.sha256(file_content).hexdigest()
+
+    try:
+        tarobj = tarfile.open(path, mode='r')
+        host_counts = get_host_counts(tarobj)
+        tarobj.close()
+        extractable = True
+        json_files_parsable = True
+    except (tarfile.TarError, json.JSONDecodeError):
+        host_counts = {}
+        extractable = False
+        json_files_parsable = False
+
+    return {
+        "size": size,
+        "checksum": checksum,
+        "extractable": extractable,
+        "json_files_parsable": json_files_parsable,
+        **host_counts,
+    }
+
+
+def get_remote_report_checksum(org_id):
+    """
+    Returns checksum of red_hat_inventory report present on satellite.
+    Args:
+        org_id: organization-id
+    """
+    remote_paths = [
+        f"/var/lib/foreman/red_hat_inventory/uploads/done/report_for_{org_id}.tar.gz",
+        f"/var/lib/foreman/red_hat_inventory/uploads/report_for_{org_id}.tar.gz",
+    ]
+
+    for path in remote_paths:
+        result = ssh.command(f"sha256sum {path}", output_format='plain')
+        if result.return_code != 0:
+            continue
+        checksum, _ = result.stdout.split(maxsplit=1)
+        return checksum
+    return ""

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -9,35 +9,35 @@ from robottelo import ssh
 
 def get_host_counts(tarobj):
     """
-    Returns hosts count from tarfile.
+    Returns hosts count from tar file.
     Args:
-        tarobj: tarfile to get host count from
+        tarobj: tar file to get host count from
     """
     metadata_counts = {}
     slices_counts = {}
     for file_ in tarobj.getmembers():
         file_name = os.path.basename(file_.name)
-        if not file_name.endswith(".json"):
+        if not file_name.endswith('.json'):
             continue
         json_data = json.load(tarobj.extractfile(file_))
-        if file_name == "metadata.json":
+        if file_name == 'metadata.json':
             metadata_counts = {
-                f"{key}.json": value['number_hosts']
+                f'{key}.json': value['number_hosts']
                 for key, value in json_data['report_slices'].items()
             }
         else:
             slices_counts[file_name] = len(json_data['hosts'])
 
     return {
-        "metadata_counts": metadata_counts,
-        "slices_counts": slices_counts,
+        'metadata_counts': metadata_counts,
+        'slices_counts': slices_counts,
     }
 
 
 def get_local_file_data(path):
-    """Returs information about tarfile.
+    """Returns information about tar file.
     Args:
-        path: path to tarfile
+        path: path to tar file
     """
     size = os.path.getsize(path)
 
@@ -57,10 +57,10 @@ def get_local_file_data(path):
         json_files_parsable = False
 
     return {
-        "size": size,
-        "checksum": checksum,
-        "extractable": extractable,
-        "json_files_parsable": json_files_parsable,
+        'size': size,
+        'checksum': checksum,
+        'extractable': extractable,
+        'json_files_parsable': json_files_parsable,
         **host_counts,
     }
 
@@ -72,14 +72,13 @@ def get_remote_report_checksum(org_id):
         org_id: organization-id
     """
     remote_paths = [
-        f"/var/lib/foreman/red_hat_inventory/uploads/done/report_for_{org_id}.tar.gz",
-        f"/var/lib/foreman/red_hat_inventory/uploads/report_for_{org_id}.tar.gz",
+        f'/var/lib/foreman/red_hat_inventory/uploads/done/report_for_{org_id}.tar.xz',
+        f'/var/lib/foreman/red_hat_inventory/uploads/report_for_{org_id}.tar.xz',
     ]
 
     for path in remote_paths:
-        result = ssh.command(f"sha256sum {path}", output_format='plain')
+        result = ssh.command(f'sha256sum {path}', output_format='plain')
         if result.return_code != 0:
             continue
         checksum, _ = result.stdout.split(maxsplit=1)
         return checksum
-    return ""

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -18,9 +18,13 @@
 """
 import pytest
 
+from robottelo import ssh
+from robottelo.rh_cloud_utils import get_local_file_data
+from robottelo.rh_cloud_utils import get_remote_report_checksum
 
-@pytest.mark.stubbed
-def test_positive_inventory_generate_upload_cli():
+
+@pytest.mark.tier3
+def test_positive_inventory_generate_upload_cli(organization_ak_setup, registered_hosts):
     """Tests Insights inventory generation and upload via foreman-rake commands:
     https://github.com/theforeman/foreman_rh_cloud/blob/master/README.md
 
@@ -51,8 +55,30 @@ def test_positive_inventory_generate_upload_cli():
 
     :expectedresults: Inventory is generated and uploaded to cloud.redhat.com.
 
-    :CaseAutomation: NotAutomated
+    :CaseAutomation: Automated
 
     :CaseLevel: System
     """
-    pass
+    org, ak = organization_ak_setup
+    cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:report:generate_upload'
+    upload_success_msg = f'Generated and uploaded inventory report for organization \'{org.name}\''
+    result = ssh.command(cmd)
+    assert result.return_code == 0
+    assert result.stdout[0] == upload_success_msg
+
+    local_report_path = f'/tmp/report_for_{org.id}.tar.xz'
+    remote_report_path = (
+        f'/var/lib/foreman/red_hat_inventory/uploads/done/report_for_{org.id}.tar.xz'
+    )
+    ssh.download_file(remote_report_path, local_report_path)
+    local_file_data = get_local_file_data(local_report_path)
+    assert local_file_data['checksum'] == get_remote_report_checksum(org.id)
+    assert local_file_data['size'] > 0
+    assert local_file_data['extractable']
+    assert local_file_data['json_files_parsable']
+
+    slices_in_metadata = set(local_file_data['metadata_counts'].keys())
+    slices_in_tar = set(local_file_data['slices_counts'].keys())
+    assert slices_in_metadata == slices_in_tar
+    for slice_name, hosts_count in local_file_data['metadata_counts'].items():
+        assert hosts_count == local_file_data['slices_counts'][slice_name]


### PR DESCRIPTION
Automated `test_positive_inventory_generate_upload_cli` test and moved rh_cloud inventory helper functions to `robottelo/rh_cloud_utils.py`. Also removed `VirtualMachine` and used `VMBroker` instead for content hosts.
Test result:
```
$ pytest tests/foreman/cli/test_rhcloud_inventory.py 
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.13, services-2.2.1, cov-2.11.1, mock-3.5.1, reportportal-5.0.7, xdist-2.2.1, forked-1.3.0
collected 1 item

tests/foreman/cli/test_rhcloud_inventory.py .                            [100%]
================== 1 passed, 8 warnings in 867.32s (0:14:27) ===================
```
Note: `test_rhcloud_inventory_e2e` doesn't work currently. 
