### PR TITLE
Add manual BZ test coverage

### DIFF
--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -316,3 +316,51 @@ def test_negative_delete_by_id():
     entity_id = invalid_id_list()[0]
     with pytest.raises(CLIReturnCodeError):
         HostGroup.delete({'id': entity_id})
+
+
+@pytest.mark.stubbed
+def test_positive_nested_hostgroup_info():
+    """`hammer hostgroup info` for a nested host group shows the assigned puppet classes.
+
+    :id: b49bad08-d93c-4b30-b7f0-504dbf4d9ba2
+
+    :BZ: 1859712
+
+    :customerscenario: true
+
+    :Steps:
+
+        1. Create parent hostgroup and nested hostgroup, with puppet environment, classes, and
+           parameters on each.
+        2. Use hammer to get the parent hostgroup info, and verify that its puppet environment,
+           classes, and parameters are visible.
+           # hammer hostgroup info --id 1
+           Id:                    1
+           Name:                  parent_hostgroup
+           [...]
+           Puppet Environment:    common
+           [...]
+           Puppetclasses:
+           .  my_class_1
+           .  my_class_2
+           Parameters:
+           [...]
+        3. Use hammer to get the nested hostgroup info, and verify that the puppet environment,
+           classes, and parameters are visible.
+           # hammer hostgroup info --id 2
+           Id:                    2
+           Name:                  nested_hostgroup
+           [...]
+           Parent:                parent_hostgroup
+           [...]
+           Puppetclasses:
+           .  my_class_1
+           .  my_class_2
+           .  my_class_3
+           [...]
+
+    expectedresults: Puppet environment, classes, and parameters visible for both parent and
+        nested hostgroups.
+
+    """
+    pass

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -6,6 +6,8 @@
 
 :CaseComponent: HostGroup
 
+:CaseLevel: Integration
+
 :Assignee: tpapaioa
 
 :TestType: Functional
@@ -42,8 +44,6 @@ def test_positive_end_to_end(session, module_org, module_loc):
     :id: 537d95f2-fe32-4e06-a2cb-21c80fe8e2e2
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -96,8 +96,6 @@ def test_negative_delete_with_discovery_rule(session, module_org, module_loc):
         was shown
 
     :CaseImportance: High
-
-    :CaseLevel: Integration
     """
     hostgroup = entities.HostGroup(organization=[module_org], location=[module_loc]).create()
     entities.DiscoveryRule(
@@ -119,8 +117,6 @@ def test_create_with_config_group(session, module_org, module_loc):
     :id: 05a64d6b-113b-4652-86bf-19bc65b70131
 
     :expectedresults: Host group created and contains proper config group
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     environment = entities.Environment(organization=[module_org], location=[module_loc]).create()
@@ -149,8 +145,6 @@ def test_create_with_puppet_class(session, module_org, module_loc):
     :id: 166ca6a6-c0f7-4fa0-a3f2-b0d6980cf50d
 
     :expectedresults: Host group created and contains proper puppet class
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     pc_name = 'generic_1'
@@ -179,3 +173,25 @@ def test_create_with_puppet_class(session, module_org, module_loc):
         hostgroup_values = session.hostgroup.read(name, widget_names='puppet_classes')
         assert len(hostgroup_values['puppet_classes']['classes']['assigned']) == 1
         assert hostgroup_values['puppet_classes']['classes']['assigned'][0] == pc_name
+
+
+@pytest.mark.stubbed
+def test_positive_create_new_host():
+    """Verify that content source field automatically populates when creating new host from host
+    group.
+
+    :id: 49704437-5ca1-46cb-b74e-de58396add37
+
+    :Steps:
+
+        1. Create hostgroup with the Content Source field populated.
+        2. Create host from Hosts > Create Host, selecting the hostgroup in the Host Group field.
+
+    :expectedresults: The host's Content source field is automatically populated from the selected
+        hostgroup.
+
+    :BZ: 1866746
+
+    :customerscenario: true
+    """
+    pass

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1,4 +1,4 @@
-"""Test class for Repository UI
+"""Test module for Repository UI
 
 :Requirement: Repository
 
@@ -324,15 +324,22 @@ def test_positive_discover_repo_via_new_product(session, module_org):
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_discover_module_stream_repo_via_existing_product(session, module_org):
-    """Create repository with having module streams via repo-discovery under existing product
+    """Create repository with module streams via repo-discovery under an existing product.
 
     :id: e7b9e2c4-7ecd-4cde-8f74-961fbac8919c
-
-    :expectedresults: Repository is discovered and created
 
     :CaseLevel: Integration
 
     :BZ: 1676642
+
+    :Steps:
+        1. Create a product.
+        2. From Content > Products, click on the Repo Discovery button.
+        3. Enter a url containing a yum repository with module streams, e.g.,
+           CUSTOM_MODULE_STREAM_REPO_1.
+        4. Click the Discover button.
+
+    :expectedresults: Repositories are discovered.
     """
 
 
@@ -877,3 +884,51 @@ def test_positive_recommended_repos(session, module_org):
         rrepos_off = session.redhatrepository.read(recommended_repo='off')
         assert REPOSET['rhae2'] in [repo['name'] for repo in rrepos_off]
         assert len(rrepos_off) > len(rrepos_on)
+
+
+@pytest.mark.stubbed
+def test_positive_upload_resigned_rpm():
+    """Re-sign and re-upload an rpm that already exists in a repository.
+
+    :id: 75416e72-701a-471c-a0ba-846cf881a1e4
+
+    :expectedresults: New rpm is displayed, old rpm is not displayed in web UI.
+
+    :BZ: 1883722
+
+    :customerscenario: true
+
+    :Steps:
+        1. Buld or prepare an unsigned rpm.
+        2. Create a gpg key.
+        3. Use the gpg key to sign the rpm with sha1.
+        4. Create an rpm repository in the Satellite.
+        5. Upload the sha1 signed rpm to the repository.
+        6. Use the gpg key to re-sign the rpm with sha2 again.
+        7. Upload the sha2 signed rpm to the repository.
+
+    :expectedresults: New rpm is displayed, old rpm is not displayed in web UI.
+    """
+    pass
+
+
+@pytest.mark.stubbed
+def test_positive_remove_srpm_change_checksum():
+    """Re-sync a repository that has had an srpm removed and repodata checksum type changed from
+    sha1 to sha256.
+
+    :id: 8bd50cd6-34ac-452d-8654-2792a2613921
+
+    :customerscenario: true
+
+    :BZ: 1850914
+
+    :Steps:
+        1. Sync a repository that contains rpms and srpms and uses sha1 repodata.
+        2. Re-sync the repository after an srpm has been removed and its repodata regenerated
+           using sha256.
+
+    :expectedresults: Repository re-syncs successfully, and the removed srpm is no longer visible
+        in the UI.
+    """
+    pass


### PR DESCRIPTION
This PR adds some manual/stubbed tests for BZ coverage.
```
<Package cli>
  <Module test_hostgroup.py>
    <Function test_positive_nested_hostgroup_info>
<Package ui>
  <Module test_hostgroup.py>
    <Function test_positive_create_new_host>
  <Module test_repository.py>
    <Function test_positive_discover_module_stream_repo_via_existing_product>
    <Function test_positive_upload_resigned_rpm>
    <Function test_positive_remove_srpm_change_checksum>
```