### PR TITLE
VM->Broker conversion for api/test_errata.py

### DIFF
--- a/pytest_fixtures/broker.py
+++ b/pytest_fixtures/broker.py
@@ -78,6 +78,13 @@ def rhel8_contenthost():
         yield host
 
 
+@pytest.fixture
+def rhel6_contenthost():
+    """A function-level fixture that provides a content host object based on the rhel6 nick"""
+    with VMBroker(nick='rhel6', host_classes={'host': ContentHost}) as host:
+        yield host
+
+
 @pytest.fixture(scope="module")
 def rhel77_host_module():
     """A module-level fixture that provides a RHEL7.7 host object"""

--- a/pytest_fixtures/xdist.py
+++ b/pytest_fixtures/xdist.py
@@ -3,7 +3,7 @@ import logging
 import random
 
 import pytest
-from broker.broker import VMBroker
+from broker import VMBroker
 
 import robottelo
 from robottelo.config import settings

--- a/robottelo/config/facade.py
+++ b/robottelo/config/facade.py
@@ -27,6 +27,7 @@ WRAPPER_EXCEPTIONS = (
     'server.scheme',
     'server.admin_username',
     'server.admin_password',
+    'server.inventory_filter',
     'server.deploy_workflow',
     'azurerm.azure_region',
     'azurerm.client_id',


### PR DESCRIPTION
Converted api/test_errata.py
Also included some new fixtures and enhancements to the ContentHost
class
RHEL6 and RHEL8 tests can't be run due to needed template enhancements.

All non-rhel6/8 tests pass locally at the same percentage as before.