### PR TITLE
Reassigning the LBA test cases to Akhil

### DIFF
--- a/tests/foreman/longrun/test_capsule_loadbalancer.py
+++ b/tests/foreman/longrun/test_capsule_loadbalancer.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Capsule
 
-:Assignee: vsedmik
+:Assignee: akjha
 
 :TestType: Functional
 


### PR DESCRIPTION
As per discussion with Vijay earlier in February, the capsule load balance test cases are owned by Akhil. Please confirm and approve if you agree.