### PR TITLE
Convert the last uses of CLITestCase

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -56,6 +56,11 @@ def default_location():
     return entities.Location().search(query={'search': f'name="{DEFAULT_LOC}"'})[0]
 
 
+@pytest.fixture(scope='function')
+def function_org():
+    return entities.Organization().create()
+
+
 @pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()

--- a/robottelo/test.py
+++ b/robottelo/test.py
@@ -12,7 +12,6 @@ import unittest2
 from robottelo import manifests
 from robottelo.config import settings
 from robottelo.constants import INTERFACE_API
-from robottelo.constants import INTERFACE_CLI
 
 LOGGER = logging.getLogger('robottelo')
 
@@ -303,23 +302,3 @@ class APITestCase(TestCase):
     _default_interface = INTERFACE_API
     _default_notraises_value_handler = APINotRaisesValueHandler
     _multiprocess_can_split_ = True
-
-
-class CLITestCase(TestCase):
-    """Test case for CLI tests."""
-
-    _default_interface = INTERFACE_CLI
-    _default_notraises_value_handler = CLINotRaisesValueHandler
-    _multiprocess_can_split_ = True
-
-    def assert_error_msg(self, raise_ctx, *contents):
-        """Checking error msg present on Raise Context Exception
-        Raise assertion error if any of contents are not present on error msg
-
-        :param raise_ctx: Raise Context
-        :param contents: contents which must be present on message
-        """
-        exception = raise_ctx.exception
-        error_msg = getattr(exception, 'stderr', str(exception))
-        for content in contents:
-            self.assertIn(content, error_msg)

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -18,101 +18,97 @@
 """
 import pytest
 
-from robottelo.test import CLITestCase
+pytestmark = [pytest.mark.stubbed]
 
 
-class AbrtTestCase(CLITestCase):
-    """Test class for generating abrt report in CLI."""
+@pytest.mark.upgrade
+@pytest.mark.tier1
+def test_positive_create_report(self):
+    """a crashed program and abrt reports are send
 
-    @pytest.mark.stubbed
-    @pytest.mark.upgrade
-    @pytest.mark.tier1
-    def test_positive_create_report(self):
-        """a crashed program and abrt reports are send
+    :id: 6e6e7525-895a-4192-9e56-4a0df1ad41ff
 
-        :id: 6e6e7525-895a-4192-9e56-4a0df1ad41ff
+    :Setup: abrt
 
-        :Setup: abrt
+    :Steps: start a sleep process in background, kill it send the report
+        using smart-proxy-abrt-send
 
-        :Steps: start a sleep process in background, kill it send the report
-            using smart-proxy-abrt-send
+    :expectedresults: A abrt report with ccpp.* extension  created under
+        /var/tmp/abrt
 
-        :expectedresults: A abrt report with ccpp.* extension  created under
-            /var/tmp/abrt
+    :CaseAutomation: NotAutomated
 
-        :CaseAutomation: NotAutomated
+    :CaseImportance: Critical
 
-        :CaseImportance: Critical
+    """
 
-        """
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier2
-    def test_positive_create_reports(self):
-        """Counts are correct when abrt sends multiple reports
+@pytest.mark.tier2
+def test_positive_create_reports(self):
+    """Counts are correct when abrt sends multiple reports
 
-        :id: 13aed05c-b72d-4a35-aa0e-5ac2029300e7
+    :id: 13aed05c-b72d-4a35-aa0e-5ac2029300e7
 
-        :Setup: abrt
+    :Setup: abrt
 
-        :Steps:
+    :Steps:
 
-            1. Create multiple reports of abrt
-            2. Keep track of counts
+        1. Create multiple reports of abrt
+        2. Keep track of counts
 
-        :expectedresults: Count is updated in proper manner
+    :expectedresults: Count is updated in proper manner
 
-        :CaseAutomation: NotAutomated
+    :CaseAutomation: NotAutomated
 
-        """
+    """
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier2
-    def test_positive_update_timer(self):
-        """Edit the smart-proxy-abrt timer
 
-        :id: 8e62d8d4-9b1c-4eb7-9352-c001be09a4d9
+@pytest.mark.tier2
+def test_positive_update_timer(self):
+    """Edit the smart-proxy-abrt timer
 
-        :Setup: abrt
+    :id: 8e62d8d4-9b1c-4eb7-9352-c001be09a4d9
 
-        :Steps: edit the timer for /etc/cron.d/rubygem-smart_proxy_abrt
+    :Setup: abrt
 
-        :expectedresults: the timer file is edited
+    :Steps: edit the timer for /etc/cron.d/rubygem-smart_proxy_abrt
 
-        :CaseAutomation: NotAutomated
+    :expectedresults: the timer file is edited
 
-        """
+    :CaseAutomation: NotAutomated
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier2
-    def test_positive_identify_hostname(self):
-        """Identifying the hostnames
+    """
 
-        :id: d9ab279b-45cf-412e-bc0f-af31737cfa74
 
-        :Setup: abrt
+@pytest.mark.tier2
+def test_positive_identify_hostname(self):
+    """Identifying the hostnames
 
-        :Steps: UI => Settings => Abrt tab => edit hostnames
+    :id: d9ab279b-45cf-412e-bc0f-af31737cfa74
 
-        :expectedresults: Assertion of hostnames is possible
+    :Setup: abrt
 
-        :CaseAutomation: NotAutomated
+    :Steps: UI => Settings => Abrt tab => edit hostnames
 
-        """
+    :expectedresults: Assertion of hostnames is possible
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier2
-    def test_positive_search_report(self):
-        """Able to retrieve reports in CLI
+    :CaseAutomation: NotAutomated
 
-        :id: b0623309-1b76-466d-a026-496e117f2d04
+    """
 
-        :Setup: abrt
 
-        :Steps: access /var/tmp/abrt/ccpp-* files
+@pytest.mark.tier2
+def test_positive_search_report(self):
+    """Able to retrieve reports in CLI
 
-        :expectedresults: Assertion of parameters
+    :id: b0623309-1b76-466d-a026-496e117f2d04
 
-        :CaseAutomation: NotAutomated
+    :Setup: abrt
 
-        """
+    :Steps: access /var/tmp/abrt/ccpp-* files
+
+    :expectedresults: Assertion of parameters
+
+    :CaseAutomation: NotAutomated
+
+    """

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -30,14 +30,14 @@ from robottelo.cli.defaults import Defaults
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product
 from robottelo.helpers import read_data_file
-from robottelo.test import CLITestCase
-from robottelo.utils.issue_handlers import is_open
 
 
 HAMMER_COMMANDS = json.loads(read_data_file('hammer_commands.json'))
 
+pytestmark = [pytest.mark.tier1]
 
-def _fetch_command_info(command):
+
+def fetch_command_info(command):
     """Fetch command info from expected commands info dictionary."""
     info = HAMMER_COMMANDS
     if command != 'hammer':
@@ -54,7 +54,7 @@ def _fetch_command_info(command):
     return info
 
 
-def _format_commands_diff(commands_diff):
+def format_commands_diff(commands_diff):
     """Format the commands differences into a human readable format."""
     output = io.StringIO()
     for key, value in sorted(commands_diff.items()):
@@ -83,145 +83,125 @@ def _format_commands_diff(commands_diff):
     return output_value
 
 
-class HammerCommandsTestCase(CLITestCase):
-    """Tests for ensuring that  all expected hammer subcommands and its options
-    are present.
+def traverse_command_tree():
+    """Walk through the hammer commands tree and assert that the expected
+    options are present.
 
     """
+    differences = {}
+    raw_output = ssh.command('hammer full-help', output_format='plain').stdout
+    commands = re.split(r'.*\n(?=hammer.*\n^[-]+)', raw_output, flags=re.M)
+    commands.pop(0)  # remove "Hammer CLI help" line
+    for raw_command in commands:
+        raw_command = raw_command.splitlines()
+        command = raw_command.pop(0).replace(' >', '')
+        output = hammer.parse_help(raw_command)
+        command_options = {option['name'] for option in output['options']}
+        command_subcommands = {subcommand['name'] for subcommand in output['subcommands']}
+        expected = fetch_command_info(command)
+        expected_options = set()
+        expected_subcommands = set()
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.differences = {}
+        if expected is not None:
+            expected_options = {option['name'] for option in expected['options']}
+            expected_subcommands = {subcommand['name'] for subcommand in expected['subcommands']}
+        added_options = tuple(command_options - expected_options)
+        removed_options = tuple(expected_options - command_options)
+        added_subcommands = tuple(command_subcommands - expected_subcommands)
+        removed_subcommands = tuple(expected_subcommands - command_subcommands)
 
-    def _traverse_command_tree(self):
-        """Walk through the hammer commands tree and assert that the expected
-        options are present.
+        if added_options or added_subcommands or removed_options or removed_subcommands:
+            diff = {'added_command': expected is None}
+            if added_options:
+                diff['added_options'] = added_options
+            if removed_options:
+                diff['removed_options'] = removed_options
+            if added_subcommands:
+                diff['added_subcommands'] = added_subcommands
+            if removed_subcommands:
+                diff['removed_subcommands'] = removed_subcommands
+            differences[command] = diff
 
-        """
-        raw_output = ssh.command('hammer full-help', output_format='plain').stdout
-        commands = re.split('.*\n(?=hammer.*\n^[-]+)', raw_output, flags=re.M)
-        commands.pop(0)  # remove "Hammer CLI help" line
-        for raw_command in commands:
-            raw_command = raw_command.splitlines()
-            command = raw_command.pop(0).replace(' >', '')
-            output = hammer.parse_help(raw_command)
-            command_options = {option['name'] for option in output['options']}
-            command_subcommands = {subcommand['name'] for subcommand in output['subcommands']}
-            expected = _fetch_command_info(command)
-            expected_options = set()
-            expected_subcommands = set()
-
-            if expected is not None:
-                expected_options = {option['name'] for option in expected['options']}
-                expected_subcommands = {
-                    subcommand['name'] for subcommand in expected['subcommands']
-                }
-            if is_open('BZ:1666687'):
-                cmds = ['hammer report-template create', 'hammer report-template update']
-                if command in cmds:
-                    command_options.add('interactive')
-                if 'hammer virt-who-config fetch' in command:
-                    command_options.add('output')
-            added_options = tuple(command_options - expected_options)
-            removed_options = tuple(expected_options - command_options)
-            added_subcommands = tuple(command_subcommands - expected_subcommands)
-            removed_subcommands = tuple(expected_subcommands - command_subcommands)
-
-            if added_options or added_subcommands or removed_options or removed_subcommands:
-                diff = {'added_command': expected is None}
-                if added_options:
-                    diff['added_options'] = added_options
-                if removed_options:
-                    diff['removed_options'] = removed_options
-                if added_subcommands:
-                    diff['added_subcommands'] = added_subcommands
-                if removed_subcommands:
-                    diff['removed_subcommands'] = removed_subcommands
-                self.differences[command] = diff
-
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_all_options(self):
-        """check all provided options for every hammer command
-
-        :id: 1203ab9f-896d-4039-a166-9e2d36925b5b
-
-        :expectedresults: All expected options are present
-
-        :CaseImportance: Critical
-        """
-        self.maxDiff = None
-        self._traverse_command_tree()
-        if self.differences:
-            self.fail('\n' + _format_commands_diff(self.differences))
+    return differences
 
 
-class HammerTestCase(CLITestCase):
-    """Tests related to hammer sub options. """
+@pytest.mark.upgrade
+def test_positive_all_options():
+    """check all provided options for every hammer command
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    @pytest.mark.run_in_one_thread
-    def test_positive_disable_hammer_defaults(self):
-        """Verify hammer disable defaults command.
+    :id: 1203ab9f-896d-4039-a166-9e2d36925b5b
 
-        :id: d0b65f36-b91f-4f2f-aaf8-8afda3e23708
+    :expectedresults: All expected options are present
 
-        :steps:
-            1. Add hammer defaults as organization-id.
-            2. Verify hammer product list successful.
-            3. Run hammer --no-use-defaults product list.
+    :CaseImportance: Critical
+    """
+    diff = traverse_command_tree()
+    if diff:
+        pytest.fail(format_commands_diff(diff))
 
-        :expectedresults: Hammer --no-use-defaults product list should fail.
 
-        :CaseImportance: Critical
+@pytest.mark.upgrade
+@pytest.mark.run_in_one_thread
+def test_positive_disable_hammer_defaults():
+    """Verify hammer disable defaults command.
 
-        :BZ: 1640644, 1368173
-        """
-        default_org = make_org()
-        default_product_name = gen_string('alpha')
-        make_product({'name': default_product_name, 'organization-id': default_org['id']})
-        try:
-            Defaults.add({'param-name': 'organization_id', 'param-value': default_org['id']})
-            # list templates for BZ#1368173
-            result = ssh.command('hammer job-template list')
-            assert result.return_code == 0
-            # Verify --organization-id is not required to pass if defaults are set
-            result = ssh.command('hammer product list')
-            assert result.return_code == 0
-            # Verify product list fail without using defaults
-            result = ssh.command('hammer --no-use-defaults product list')
-            assert result.return_code != 0
-            assert default_product_name not in "".join(result.stdout)
-            # Verify --organization-id is not required to pass if defaults are set
-            result = ssh.command('hammer --use-defaults product list')
-            assert result.return_code == 0
-            assert default_product_name in "".join(result.stdout)
-        finally:
-            Defaults.delete({'param-name': 'organization_id'})
-            result = ssh.command('hammer defaults list')
-            assert default_org['id'] not in "".join(result.stdout)
+    :id: d0b65f36-b91f-4f2f-aaf8-8afda3e23708
 
-    @pytest.mark.tier1
-    def test_positive_check_debug_log_levels(self):
-        """Enabling debug log level in candlepin via hammer logging
+    :steps:
+        1. Add hammer defaults as organization-id.
+        2. Verify hammer product list successful.
+        3. Run hammer --no-use-defaults product list.
 
-        :id: 029c80f1-2bc5-494e-a04a-7d6beb0f769a
+    :expectedresults: Hammer --no-use-defaults product list should fail.
 
-        :expectedresults: Verify enabled debug log level
+    :CaseImportance: Critical
 
-        :CaseImportance: Medium
-
-        :BZ: 1760773
-        """
-        Admin.logging({"all": True, "level-debug": True})
-        # Verify value of `log4j.logger.org.candlepin` as `DEBUG`
-        result = ssh.command("grep DEBUG /etc/candlepin/candlepin.conf")
+    :BZ: 1640644, 1368173
+    """
+    default_org = make_org()
+    default_product_name = gen_string('alpha')
+    make_product({'name': default_product_name, 'organization-id': default_org['id']})
+    try:
+        Defaults.add({'param-name': 'organization_id', 'param-value': default_org['id']})
+        # list templates for BZ#1368173
+        result = ssh.command('hammer job-template list')
         assert result.return_code == 0
-        assert 'log4j.logger.org.candlepin = DEBUG' in result.stdout
-
-        Admin.logging({"all": True, "level-production": True})
-        # Verify value of `log4j.logger.org.candlepin` as `WARN`
-        result = ssh.command("grep WARN /etc/candlepin/candlepin.conf")
+        # Verify --organization-id is not required to pass if defaults are set
+        result = ssh.command('hammer product list')
         assert result.return_code == 0
-        assert 'log4j.logger.org.candlepin = WARN' in result.stdout
+        # Verify product list fail without using defaults
+        result = ssh.command('hammer --no-use-defaults product list')
+        assert result.return_code != 0
+        assert default_product_name not in "".join(result.stdout)
+        # Verify --organization-id is not required to pass if defaults are set
+        result = ssh.command('hammer --use-defaults product list')
+        assert result.return_code == 0
+        assert default_product_name in ''.join(result.stdout)
+    finally:
+        Defaults.delete({'param-name': 'organization_id'})
+        result = ssh.command('hammer defaults list')
+        assert default_org['id'] not in ''.join(result.stdout)
+
+
+def test_positive_check_debug_log_levels():
+    """Enabling debug log level in candlepin via hammer logging
+
+    :id: 029c80f1-2bc5-494e-a04a-7d6beb0f769a
+
+    :expectedresults: Verify enabled debug log level
+
+    :CaseImportance: Medium
+
+    :BZ: 1760773
+    """
+    Admin.logging({'all': True, 'level-debug': True})
+    # Verify value of `log4j.logger.org.candlepin` as `DEBUG`
+    result = ssh.command('grep DEBUG /etc/candlepin/candlepin.conf')
+    assert result.return_code == 0
+    assert 'log4j.logger.org.candlepin = DEBUG' in result.stdout
+
+    Admin.logging({"all": True, "level-production": True})
+    # Verify value of `log4j.logger.org.candlepin` as `WARN`
+    result = ssh.command('grep WARN /etc/candlepin/candlepin.conf')
+    assert result.return_code == 0
+    assert 'log4j.logger.org.candlepin = WARN' in result.stdout

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -18,128 +18,125 @@
 """
 import pytest
 
-from robottelo.test import CLITestCase
+pytestmark = [pytest.mark.stubbed]
 
 
-class InstallerTestCase(CLITestCase):
-    """Test class for installer"""
+# Notes for installer testing:
+# Perhaps there is a convenient log analyzer library out there
+# that can parse logs? It would be better (and possibly less
+# error-prone) than simply grepping for ERROR/FATAL
 
-    # Notes for installer testing:
-    # Perhaps there is a convenient log analyzer library out there
-    # that can parse logs? It would be better (and possibly less
-    # error-prone) than simply grepping for ERROR/FATAL
 
-    @pytest.mark.stubbed
-    @pytest.mark.upgrade
-    def test_positive_installer_check_services(self):
-        # devnote:
-        # maybe `hammer ping` command might be useful here to check
-        # the health status
-        """Services services start correctly
+@pytest.mark.upgrade
+def test_positive_installer_check_services():
+    # devnote:
+    # maybe `hammer ping` command might be useful here to check
+    # the health status
+    """Services services start correctly
 
-        :id: d3f99d2d-8e87-47c4-b80e-151edac5b0c3
+    :id: d3f99d2d-8e87-47c4-b80e-151edac5b0c3
 
-        :expectedresults: All services {katello-jobs, tomcat6, foreman, pulp,
-            passenger-analytics, httpd, foreman_proxy, elasticsearch,
-            postgresql, mongod} are started
+    :expectedresults: All services {katello-jobs, tomcat6, foreman, pulp,
+        passenger-analytics, httpd, foreman_proxy, elasticsearch,
+        postgresql, mongod} are started
 
-        :CaseAutomation: NotAutomated
-        """
+    :CaseAutomation: NotAutomated
+    """
 
-    @pytest.mark.stubbed
-    def test_positive_installer_logfile_check(self):
-        """Look for ERROR or FATAL references in logfiles
 
-        :id: fe29310d-7fe2-4563-bd4b-ecebc0a24f7f
+def test_positive_installer_logfile_check():
+    """Look for ERROR or FATAL references in logfiles
 
-        :steps: search all relevant logfiles for ERROR/FATAL
+    :id: fe29310d-7fe2-4563-bd4b-ecebc0a24f7f
 
-        :expectedresults: No ERROR/FATAL notifcations occur in {katello-jobs,
-            tomcat6, foreman, pulp, passenger-analytics,httpd, foreman_proxy,
-            elasticsearch, postgresql, mongod} logfiles.
+    :steps: search all relevant logfiles for ERROR/FATAL
 
-        :CaseAutomation: NotAutomated
-        """
+    :expectedresults: No ERROR/FATAL notifcations occur in {katello-jobs,
+        tomcat6, foreman, pulp, passenger-analytics,httpd, foreman_proxy,
+        elasticsearch, postgresql, mongod} logfiles.
 
-    @pytest.mark.stubbed
-    def test_positive_installer_check_progress_meter(self):
-        """Assure progress indicator/meter "works"
+    :CaseAutomation: NotAutomated
+    """
 
-        :id: c654be1b-d018-4eb4-9867-6ecbb0a8ae5a
 
-        :expectedresults: Progress indicator increases appropriately as install
-            commences, through to completion
+def test_positive_installer_check_progress_meter():
+    """Assure progress indicator/meter "works"
 
-        :CaseAutomation: NotAutomated
-        """
+    :id: c654be1b-d018-4eb4-9867-6ecbb0a8ae5a
 
-    @pytest.mark.stubbed
-    def test_positive_server_installer_from_iso(self):
-        """Can install product from ISO
+    :expectedresults: Progress indicator increases appropriately as install
+        commences, through to completion
 
-        :id: 38c08646-9f71-48d9-a9c2-66bd94c3e5bb
+    :CaseAutomation: NotAutomated
+    """
 
-        :expectedresults: Install from ISO is sucessful.
 
-        :CaseAutomation: NotAutomated
-        """
+def test_positive_server_installer_from_iso():
+    """Can install product from ISO
 
-    @pytest.mark.stubbed
-    def test_positive_server_installer_from_repository(self):
-        """Can install main satellite instance successfully via RPM
+    :id: 38c08646-9f71-48d9-a9c2-66bd94c3e5bb
 
-        :id: 4dac99c3-6334-43df-adc4-c26e19f762ce
+    :expectedresults: Install from ISO is sucessful.
 
-        :expectedresults: Install of main instance successful.
+    :CaseAutomation: NotAutomated
+    """
 
-        :CaseAutomation: NotAutomated
-        """
 
-    @pytest.mark.stubbed
-    def test_positive_capsule_installer_from_repository(self):
-        """Can install capsule successfully via RPM
+def test_positive_server_installer_from_repository():
+    """Can install main satellite instance successfully via RPM
 
-        :id: 07b0aaa3-651a-4103-904d-c8bcc632a3d1
+    :id: 4dac99c3-6334-43df-adc4-c26e19f762ce
 
-        :expectedresults: Install of capsule successful.
+    :expectedresults: Install of main instance successful.
 
-        :CaseAutomation: NotAutomated
-        """
+    :CaseAutomation: NotAutomated
+    """
 
-    @pytest.mark.stubbed
-    def test_positive_disconnected_util_installer(self):
-        """Can install  satellite disconnected utility successfully
-        via RPM
 
-        :id: b738cf2a-9c5f-4865-b134-102a4688534c
+def test_positive_capsule_installer_from_repository():
+    """Can install capsule successfully via RPM
 
-        :expectedresults: Install of disconnected utility successful.
+    :id: 07b0aaa3-651a-4103-904d-c8bcc632a3d1
 
-        :CaseAutomation: NotAutomated
-        """
+    :expectedresults: Install of capsule successful.
 
-    @pytest.mark.stubbed
-    def test_positive_capsule_installer_and_register(self):
-        """Upon installation, capsule instance self-registers
-        itself to parent instance
+    :CaseAutomation: NotAutomated
+    """
 
-        :id: efd03442-5a08-445d-b257-e4d346084379
 
-        :expectedresults: capsule is communicating properly with parent,
-            following install.
+def test_positive_disconnected_util_installer():
+    """Can install  satellite disconnected utility successfully
+    via RPM
 
-        :CaseAutomation: NotAutomated
-        """
+    :id: b738cf2a-9c5f-4865-b134-102a4688534c
 
-    @pytest.mark.stubbed
-    def test_positive_installer_clear_data(self):
-        """User can run installer to clear existing data
+    :expectedresults: Install of disconnected utility successful.
 
-        :id: 11ed1ed5-7f72-4310-80df-5cac6547b01a
+    :CaseAutomation: NotAutomated
+    """
 
-        :expectedresults: All data is cleared from satellite instance
 
-        :BZ: 1072780
+def test_positive_capsule_installer_and_register():
+    """Upon installation, capsule instance self-registers
+    itself to parent instance
 
-        :CaseAutomation: NotAutomated
-        """
+    :id: efd03442-5a08-445d-b257-e4d346084379
+
+    :expectedresults: capsule is communicating properly with parent,
+        following install.
+
+    :CaseAutomation: NotAutomated
+    """
+
+
+def test_positive_installer_clear_data():
+    """User can run installer to clear existing data
+
+    :id: 11ed1ed5-7f72-4310-80df-5cac6547b01a
+
+    :expectedresults: All data is cleared from satellite instance
+
+    :BZ: 1072780
+
+    :CaseAutomation: NotAutomated
+    """

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -18,60 +18,53 @@
 """
 import pytest
 
-from robottelo.test import CLITestCase
+pytestmark = [pytest.mark.stubbed, pytest.mark.upgrade]
+
+# Notes for SSO testing:
+# Of interest... In some testcases I've placed a few comments prefaced with
+# "devnote:" These are -- obviously -- notes from developers that might
+# help reiterate something important or a reminder of way(s) to test
+# something.
+
+# There may well be more cases that I have missed for this feature, and
+# possibly other LDAP types. These (in particular, the LDAP variations)
+# can be easily added later.
 
 
-class SingleSignOnTestCase(CLITestCase):
-    """Test Class for SSO CLI"""
+def test_positive_login_kerberos_user():
+    """kerberos user can login to CLI
 
-    # Notes for SSO testing:
-    # Of interest... In some testcases I've placed a few comments prefaced with
-    # "devnote:" These are -- obviously -- notes from developers that might
-    # help reiterate something important or a reminder of way(s) to test
-    # something.
+    :id: 59a1b463-67b3-4f18-b851-afaa3c65ccb6
 
-    # There may well be more cases that I have missed for this feature, and
-    # possibly other LDAP types. These (in particular, the LDAP variations)
-    # can be easily added later.
+    :setup: kerberos configured against foreman.
 
-    @pytest.mark.stubbed
-    @pytest.mark.upgrade
-    def test_positive_login_kerberos_user(self):
-        """kerberos user can login to CLI
+    :expectedresults: Log in to hammer cli successfully
 
-        :id: 59a1b463-67b3-4f18-b851-afaa3c65ccb6
+    :CaseAutomation: NotAutomated
+    """
 
-        :setup: kerberos configured against foreman.
 
-        :expectedresults: Log in to hammer cli successfully
+def test_positive_login_ipa_user():
+    """IPA user can login to CLI
 
-        :CaseAutomation: NotAutomated
-        """
+    :id: cbd0df84-6a4d-4c82-bf30-cecd51f40c03
 
-    @pytest.mark.stubbed
-    @pytest.mark.upgrade
-    def test_positive_login_ipa_user(self):
-        """IPA user can login to CLI
+    :setup: IPA configured against foreman.
 
-        :id: cbd0df84-6a4d-4c82-bf30-cecd51f40c03
+    :expectedresults: Log in to hammer cli successfully
 
-        :setup: IPA configured against foreman.
+    :CaseAutomation: NotAutomated
+    """
 
-        :expectedresults: Log in to hammer cli successfully
 
-        :CaseAutomation: NotAutomated
-        """
+def test_positive_login_openldap_user():
+    """OpenLDAP user can login to CLI
 
-    @pytest.mark.stubbed
-    @pytest.mark.upgrade
-    def test_positive_login_openldap_user(self):
-        """OpenLDAP user can login to CLI
+    :id: de31d5eb-4e0d-495e-bf31-bc49f9d50d68
 
-        :id: de31d5eb-4e0d-495e-bf31-bc49f9d50d68
+    :setup: OpenLDAP configured against foreman.
 
-        :setup: OpenLDAP configured against foreman.
+    :expectedresults: Log in to hammer cli successfully
 
-        :expectedresults: Log in to hammer cli successfully
-
-        :CaseAutomation: NotAutomated
-        """
+    :CaseAutomation: NotAutomated
+    """

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -16,8 +16,6 @@
 
 :Upstream: No
 """
-import csv
-
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
@@ -26,7 +24,6 @@ from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_activation_key
-from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product
 from robottelo.cli.factory import make_repository
 from robottelo.cli.host import Host
@@ -37,285 +34,249 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.ssh import upload_file
-from robottelo.test import CLITestCase
 
 
-@pytest.fixture(scope='class')
-def golden_ticket_host_setup(request):
-    org = make_org()
+pytestmark = [pytest.mark.run_in_one_thread]
+
+
+@pytest.fixture(scope='module')
+def golden_ticket_host_setup(request, module_org):
     with manifests.clone(name='golden_ticket') as manifest:
-        upload_manifest(org['id'], manifest.content)
-    new_product = make_product({'organization-id': org['id']})
+        upload_manifest(module_org.id, manifest.content)
+    new_product = make_product({'organization-id': module_org.id})
     new_repo = make_repository({'product-id': new_product['id']})
     Repository.synchronize({'id': new_repo['id']})
     new_ak = make_activation_key(
         {
             'lifecycle-environment': 'Library',
             'content-view': 'Default Organization View',
-            'organization-id': org['id'],
+            'organization-id': module_org.id,
             'auto-attach': False,
         }
     )
-    request.cls.org_setup = org
-    request.cls.ak_setup = new_ak
+    return new_ak
 
 
-@pytest.mark.run_in_one_thread
-class SubscriptionTestCase(CLITestCase):
-    """Manifest CLI tests"""
+@pytest.fixture(scope='function')
+def manifest_clone_upload(function_org):
+    with manifests.clone() as cloned_manifest:
+        upload_manifest(function_org.id, cloned_manifest.content)
+        yield
 
-    def setUp(self):
-        """Tests for content-view via Hammer CLI"""
-        super().setUp()
-        self.org = make_org()
 
-    def _upload_manifest(self, org_id, manifest=None):
-        """Uploads a manifest into an organization.
+@pytest.mark.tier1
+def test_positive_manifest_upload(function_org, manifest_clone_upload):
+    """upload manifest
 
-        A cloned manifest will be used if ``manifest`` is None.
-        """
-        if manifest is None:
-            manifest = manifests.clone()
-        self.upload_manifest(org_id, manifest)
+    :id: e5a0e4f8-fed9-4896-87a0-ac33f6baa227
 
-    @staticmethod
-    def _read_csv_file(file_path):
-        """Read a csv file as a dictionary
+    :expectedresults: Manifest are uploaded properly
 
-        :param str file_path: The file location path to read as csv
+    :CaseImportance: Critical
+    """
 
-        :returns a tuple (list, list[dict]) that represent field_names, data
-        """
-        csv_data = []
-        with open(file_path) as csv_file:
-            csv_reader = csv.DictReader(csv_file, delimiter=',')
-            field_names = csv_reader.fieldnames
-            for csv_row in csv_reader:
-                csv_data.append(csv_row)
-        return field_names, csv_data
+    Subscription.list({'organization-id': function_org.id}, per_page=False)
 
-    @staticmethod
-    def _write_csv_file(file_path, filed_names, csv_data):
-        """Write to csv file
 
-        :param str file_path: The file location path to write as csv
-        :param list filed_names: The field names to be written
-        :param list[dict] csv_data: the list dict data to be saved
-        """
-        with open(file_path, 'w') as csv_file:
-            csv_writer = csv.DictWriter(csv_file, filed_names, delimiter=',')
-            csv_writer.writeheader()
-            for csv_row in csv_data:
-                csv_writer.writerow(csv_row)
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_manifest_delete(function_org, manifest_clone_upload):
+    """Delete uploaded manifest
 
-    @pytest.mark.tier1
-    def test_positive_manifest_upload(self):
-        """upload manifest
+    :id: 01539c07-00d5-47e2-95eb-c0fd4f39090f
 
-        :id: e5a0e4f8-fed9-4896-87a0-ac33f6baa227
+    :expectedresults: Manifest are deleted properly
 
-        :expectedresults: Manifest are uploaded properly
+    :CaseImportance: Critical
+    """
+    Subscription.list({'organization-id': function_org.id}, per_page=False)
+    Subscription.delete_manifest({'organization-id': function_org.id})
+    Subscription.list({'organization-id': function_org.id}, per_page=False)
 
-        :CaseImportance: Critical
-        """
-        self._upload_manifest(self.org['id'])
-        Subscription.list({'organization-id': self.org['id']}, per_page=False)
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_manifest_delete(self):
-        """Delete uploaded manifest
+@pytest.mark.tier2
+@pytest.mark.upgrade
+def test_positive_enable_manifest_reposet(function_org, manifest_clone_upload):
+    """enable repository set
 
-        :id: 01539c07-00d5-47e2-95eb-c0fd4f39090f
+    :id: cc0f8f40-5ea6-4fa7-8154-acdc2cb56b45
 
-        :expectedresults: Manifest are deleted properly
+    :expectedresults: you are able to enable and synchronize repository
+        contained in a manifest
 
-        :CaseImportance: Critical
-        """
-        self._upload_manifest(self.org['id'])
-        Subscription.list({'organization-id': self.org['id']}, per_page=False)
-        Subscription.delete_manifest({'organization-id': self.org['id']})
-        Subscription.list({'organization-id': self.org['id']}, per_page=False)
+    :CaseLevel: Integration
 
-    @pytest.mark.tier2
-    @pytest.mark.upgrade
-    def test_positive_enable_manifest_reposet(self):
-        """enable repository set
+    :CaseImportance: Critical
+    """
+    Subscription.list({'organization-id': function_org.id}, per_page=False)
+    RepositorySet.enable(
+        {
+            'basearch': 'x86_64',
+            'name': REPOSET['rhva6'],
+            'organization-id': function_org.id,
+            'product': PRDS['rhel'],
+            'releasever': '6Server',
+        }
+    )
+    Repository.synchronize(
+        {
+            'name': REPOS['rhva6']['name'],
+            'organization-id': function_org.id,
+            'product': PRDS['rhel'],
+        }
+    )
 
-        :id: cc0f8f40-5ea6-4fa7-8154-acdc2cb56b45
 
-        :expectedresults: you are able to enable and synchronize repository
-            contained in a manifest
+@pytest.mark.tier3
+def test_positive_manifest_history(function_org, manifest_clone_upload):
+    """upload manifest and check history
 
-        :CaseLevel: Integration
+    :id: 000ab0a0-ec1b-497a-84ff-3969a965b52c
 
-        :CaseImportance: Critical
-        """
-        self._upload_manifest(self.org['id'])
-        Subscription.list({'organization-id': self.org['id']}, per_page=False)
-        RepositorySet.enable(
-            {
-                'basearch': 'x86_64',
-                'name': REPOSET['rhva6'],
-                'organization-id': self.org['id'],
-                'product': PRDS['rhel'],
-                'releasever': '6Server',
-            }
-        )
-        Repository.synchronize(
-            {
-                'name': REPOS['rhva6']['name'],
-                'organization-id': self.org['id'],
-                'product': PRDS['rhel'],
-            }
-        )
+    :expectedresults: Manifest history is shown properly
 
-    @pytest.mark.tier3
-    def test_positive_manifest_history(self):
-        """upload manifest and check history
+    :CaseImportance: Medium
+    """
+    Subscription.list({'organization-id': function_org.id}, per_page=None)
+    history = Subscription.manifest_history({'organization-id': function_org.id})
+    assert f'{function_org.name} file imported successfully.' in ''.join(history)
 
-        :id: 000ab0a0-ec1b-497a-84ff-3969a965b52c
 
-        :expectedresults: Manifest history is shown properly
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_manifest_refresh(function_org):
+    """upload manifest and refresh
 
-        :CaseImportance: Medium
-        """
-        self._upload_manifest(self.org['id'])
-        Subscription.list({'organization-id': self.org['id']}, per_page=None)
-        history = Subscription.manifest_history({'organization-id': self.org['id']})
-        assert '{} file imported successfully.'.format(self.org['name']) in ''.join(history)
+    :id: 579bbbf7-11cf-4d78-a3b1-16d73bd4ca57
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_manifest_refresh(self):
-        """upload manifest and refresh
+    :expectedresults: Manifests can be refreshed
 
-        :id: 579bbbf7-11cf-4d78-a3b1-16d73bd4ca57
+    :CaseImportance: Critical
+    """
+    upload_manifest(function_org.id, manifests.original_manifest().content)
+    Subscription.list({'organization-id': function_org.id}, per_page=False)
+    Subscription.refresh_manifest({'organization-id': function_org.id})
+    Subscription.delete_manifest({'organization-id': function_org.id})
 
-        :expectedresults: Manifests can be refreshed
 
-        :CaseImportance: Critical
-        """
-        self._upload_manifest(self.org['id'], manifests.original_manifest())
-        Subscription.list({'organization-id': self.org['id']}, per_page=False)
-        Subscription.refresh_manifest({'organization-id': self.org['id']})
-        Subscription.delete_manifest({'organization-id': self.org['id']})
+@pytest.mark.tier2
+def test_positive_subscription_list(function_org, manifest_clone_upload):
+    """Verify that subscription list contains start and end date
 
-    @pytest.mark.skip_if_open("BZ:1686916")
-    @pytest.mark.tier2
-    def test_positive_subscription_list(self):
-        """Verify that subscription list contains start and end date
+    :id: 4861bcbc-785a-436d-98ce-14cfef7d6907
 
-        :id: 4861bcbc-785a-436d-98ce-14cfef7d6907
+    :expectedresults: subscription list contains the start and end date
 
-        :expectedresults: subscription list contains the start and end date
+    :BZ: 1686916
 
-        :BZ: 1686916
+    :CaseImportance: Medium
+    """
+    subscription_list = Subscription.list({'organization-id': function_org.id}, per_page=False)
+    for column in ['start-date', 'end-date']:
+        assert column in subscription_list[0].keys()
 
-        :CaseImportance: Medium
-        """
-        self._upload_manifest(self.org['id'])
-        subscription_list = Subscription.list({'organization-id': self.org['id']}, per_page=False)
-        for column in ['start-date', 'end-date']:
-            assert column in subscription_list[0].keys()
 
-    @pytest.mark.tier2
-    def test_positive_delete_manifest_as_another_user(self):
-        """Verify that uploaded manifest if visible and deletable
-            by a different user than the one who uploaded it
+@pytest.mark.tier2
+def test_positive_delete_manifest_as_another_user():
+    """Verify that uploaded manifest if visible and deletable
+        by a different user than the one who uploaded it
 
-        :id: 4861bcbc-785a-436d-98cf-13cfef7d6907
+    :id: 4861bcbc-785a-436d-98cf-13cfef7d6907
 
-        :expectedresults: manifest is refreshed
+    :expectedresults: manifest is refreshed
 
-        :BZ: 1669241
+    :BZ: 1669241
 
-        :CaseImportance: Medium
-        """
-        org = entities.Organization().create()
-        user1_password = gen_string('alphanumeric')
-        user1 = entities.User(
-            admin=True, password=user1_password, organization=[org], default_organization=org
-        ).create()
-        user2_password = gen_string('alphanumeric')
-        user2 = entities.User(
-            admin=True, password=user2_password, organization=[org], default_organization=org
-        ).create()
-        # use the first admin to upload a manifest
-        with manifests.clone() as manifest:
-            upload_file(manifest.content, manifest.filename)
-        Subscription.with_user(username=user1.login, password=user1_password).upload(
-            {'file': manifest.filename, 'organization-id': org.id}
-        )
-        # try to search and delete the manifest with another admin
-        Subscription.with_user(username=user2.login, password=user2_password).delete_manifest(
-            {'organization-id': org.id}
-        )
-        assert len(Subscription.list({'organization-id': org.id})) == 0
+    :CaseImportance: Medium
+    """
+    org = entities.Organization().create()
+    user1_password = gen_string('alphanumeric')
+    user1 = entities.User(
+        admin=True, password=user1_password, organization=[org], default_organization=org
+    ).create()
+    user2_password = gen_string('alphanumeric')
+    user2 = entities.User(
+        admin=True, password=user2_password, organization=[org], default_organization=org
+    ).create()
+    # use the first admin to upload a manifest
+    with manifests.clone() as manifest:
+        upload_file(manifest.content, manifest.filename)
+    Subscription.with_user(username=user1.login, password=user1_password).upload(
+        {'file': manifest.filename, 'organization-id': org.id}
+    )
+    # try to search and delete the manifest with another admin
+    Subscription.with_user(username=user2.login, password=user2_password).delete_manifest(
+        {'organization-id': org.id}
+    )
+    assert len(Subscription.list({'organization-id': org.id})) == 0
 
-    @pytest.mark.tier2
-    @pytest.mark.stubbed
-    @pytest.mark.usefixtures("golden_ticket_host_setup")
-    def test_positive_subscription_status_disabled_golden_ticket(self):
-        """Verify that Content host Subscription status is set to 'Disabled'
-         for a golden ticket manifest
 
-        :id: 42e10499-3a0d-48cd-ab71-022421a74add
+@pytest.mark.tier2
+@pytest.mark.stubbed
+def test_positive_subscription_status_disabled_golden_ticket():
+    """Verify that Content host Subscription status is set to 'Disabled'
+     for a golden ticket manifest
 
-        :expectedresults: subscription status is 'Disabled'
+    :id: 42e10499-3a0d-48cd-ab71-022421a74add
 
-        :BZ: 1789924
+    :expectedresults: subscription status is 'Disabled'
 
-        :CaseImportance: Medium
-        """
+    :BZ: 1789924
 
-    @pytest.mark.stubbed
-    def test_positive_candlepin_events_processed_by_STOMP(self):
-        """Verify that Candlepin events are being read and processed by
-           attaching subscriptions, validating host subscriptions status,
-           and viewing processed and failed Candlepin events
+    :CaseImportance: Medium
+    """
 
-        :id: d54a7652-f87d-4277-a0ec-a153e27b4487
 
-        :steps:
+@pytest.mark.stubbed
+def test_positive_candlepin_events_processed_by_STOMP():
+    """Verify that Candlepin events are being read and processed by
+       attaching subscriptions, validating host subscriptions status,
+       and viewing processed and failed Candlepin events
 
-            1. Register Content Host without subscriptions attached
-            2. Verify subscriptions status is invalid
-            3. Import a Manifest
-            4. Attach subs to content host
-            5. Verify subscription status is green, "valid", with
-               "hammer subscription list --host-id x"
-            6. Check for processed and failed Candlepin events
+    :id: d54a7652-f87d-4277-a0ec-a153e27b4487
 
-        :expectedresults: Candlepin events are being read and processed
-                          correctly without any failures
-        :BZ: #1826515
+    :steps:
 
-        :CaseImportance: High
-        """
+        1. Register Content Host without subscriptions attached
+        2. Verify subscriptions status is invalid
+        3. Import a Manifest
+        4. Attach subs to content host
+        5. Verify subscription status is green, "valid", with
+           "hammer subscription list --host-id x"
+        6. Check for processed and failed Candlepin events
 
-    @pytest.mark.tier2
-    @pytest.mark.libvirt_content_host
-    @pytest.mark.usefixtures("golden_ticket_host_setup")
-    @pytest.mark.usefixtures("rhel77_contenthost_class")
-    def test_positive_auto_attach_disabled_golden_ticket(self):
-        """Verify that Auto-Attach is disabled or "Not Applicable"
-        when a host organization is in Simple Content Access mode (Golden Ticket)
+    :expectedresults: Candlepin events are being read and processed
+                      correctly without any failures
+    :BZ: #1826515
 
-        :id: 668fae4d-7364-4167-967f-6fc31ba52d26
+    :CaseImportance: High
+    """
 
-        :expectedresults: auto attaching a subscription is not allowed
-            and returns an error message
 
-        :BZ: 1718954
+@pytest.mark.tier2
+@pytest.mark.libvirt_content_host
+def test_positive_auto_attach_disabled_golden_ticket(
+    module_org, golden_ticket_host_setup, rhel77_contenthost_class
+):
+    """Verify that Auto-Attach is disabled or "Not Applicable"
+    when a host organization is in Simple Content Access mode (Golden Ticket)
 
-        :CaseImportance: Medium
-        """
-        self.content_host.install_katello_ca()
-        self.content_host.register_contenthost(self.org_setup['label'], self.ak_setup['name'])
-        assert self.content_host.subscribed
-        host = Host.list({'search': self.content_host.hostname})
-        host_id = host[0]['id']
-        with pytest.raises(CLIReturnCodeError) as context:
-            Host.subscription_auto_attach({'host-id': host_id})
-        assert "This host's organization is in Simple Content Access mode" in str(context.value)
+    :id: 668fae4d-7364-4167-967f-6fc31ba52d26
+
+    :expectedresults: auto attaching a subscription is not allowed
+        and returns an error message
+
+    :BZ: 1718954
+
+    :CaseImportance: Medium
+    """
+    rhel77_contenthost_class.install_katello_ca()
+    rhel77_contenthost_class.register_contenthost(
+        module_org.label, golden_ticket_host_setup['name']
+    )
+    assert rhel77_contenthost_class.subscribed
+    host = Host.list({'search': rhel77_contenthost_class.hostname})
+    host_id = host[0]['id']
+    with pytest.raises(CLIReturnCodeError) as context:
+        Host.subscription_auto_attach({'host-id': host_id})
+    assert "This host's organization is in Simple Content Access mode" in str(context.value)

--- a/tests/robottelo/test_assertions.py
+++ b/tests/robottelo/test_assertions.py
@@ -6,7 +6,6 @@ from requests import HTTPError
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.test import APITestCase
-from robottelo.test import CLITestCase
 
 
 def fake_128_return_code():
@@ -189,68 +188,6 @@ class APIAssertNotRaisesTestCase(APITestCase):
         with pytest.raises(HTTPError):
             with self.assertNotRaises(ZeroDivisionError, expected_value=404):
                 fake_404_response()
-
-
-class CLIAssertNotRaisesTestCase(CLITestCase):
-    """CLI specific tests for :meth:`robottelo.test.TestCase.assertNotRaises`."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Do not inherit and stub :meth:`setUpClass`."""
-        pass
-
-    @classmethod
-    def tearDownClass(cls):
-        """Do not inherit and stub :meth:`tearDownClass`."""
-        pass
-
-    def setUp(self):
-        """Do not inherit and stub :meth:`setUp`."""
-        pass
-
-    def tearDown(self):
-        """Do not inherit and stub :meth:`tearDown`."""
-        pass
-
-    def _set_worker_logger(self, worker_id):
-        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
-        with worker ids and logger.
-        """
-        pass
-
-    def test_positive_raised_callable_with_status_code(self):
-        """Assert that the test will fail (not marked as errored) in case
-        expected exception with expected cli_return_code code was risen inside
-        :meth:`robottelo.test.TestCase.assertNotRaises` call.
-        """
-        with pytest.raises(AssertionError):
-            self.assertNotRaises(CLIReturnCodeError, fake_128_return_code, expected_value=128)
-
-    def test_positive_raised_context_manager_with_status_code(self):
-        """Assert that the test will fail (not marked as errored) in case
-        expected exception with expected cli_return_code was risen inside
-        :meth:`robottelo.test.TestCase.assertNotRaises` block.
-        """
-        with pytest.raises(AssertionError):
-            with self.assertNotRaises(CLIReturnCodeError, expected_value=128):
-                fake_128_return_code()
-
-    def test_negative_wrong_status_code_callable(self):
-        """Assert that expected exception with unexpected cli_return_code
-        won't be handled and passed through to the test from
-        :meth:`robottelo.test.TestCase.assertNotRaises` call.
-        """
-        with pytest.raises(CLIReturnCodeError):
-            self.assertNotRaises(CLIReturnCodeError, fake_128_return_code, expected_value=129)
-
-    def test_negative_wrong_status_code_context_manager(self):
-        """Assert that expected exception with unexpected cli_return_code
-        status code won't be handled and passed through to the test from
-        :meth:`robottelo.test.TestCase.assertNotRaises` block.
-        """
-        with pytest.raises(CLIReturnCodeError):
-            with self.assertNotRaises(CLIReturnCodeError, expected_value=129):
-                fake_128_return_code()
 
 
 class APIAssertNotRaisesRegexTestCase(APITestCase):
@@ -463,75 +400,3 @@ class APIAssertNotRaisesRegexTestCase(APITestCase):
         with pytest.raises(HTTPError):
             with self.assertNotRaisesRegex(ZeroDivisionError, 'foo', expected_value=404):
                 fake_404_response()
-
-
-class CLIAssertNotRaisesRegexTestCase(CLITestCase):
-    """CLI specific tests for
-    :meth:`robottelo.test.TestCase.assertNotRaisesRegex`.
-    """
-
-    @classmethod
-    def setUpClass(cls):
-        """Do not inherit and stub :meth:`setUpClass`."""
-        pass
-
-    @classmethod
-    def tearDownClass(cls):
-        """Do not inherit and stub :meth:`tearDownClass`."""
-        pass
-
-    def setUp(self):
-        """Do not inherit and stub :meth:`setUp`."""
-        pass
-
-    def tearDown(self):
-        """Do not inherit and stub :meth:`tearDown`."""
-        pass
-
-    def _set_worker_logger(self, worker_id):
-        """Do not inherit and stub ``_get_worker_logger`` not to have to deal
-        with worker ids and logger.
-        """
-        pass
-
-    pattern = '404 Resource Not Found'
-
-    def test_positive_raised_callable_with_status_code(self):
-        """Assert that the test will fail (not marked as errored) in case
-        expected exception was risen inside
-        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call and
-        cli_return_code altogether with regex pattern match expected ones.
-        """
-        with pytest.raises(AssertionError):
-            self.assertNotRaisesRegex(
-                CLIReturnCodeError, self.pattern, fake_128_return_code, expected_value=128
-            )
-
-    def test_positive_raised_context_manager_with_status_code(self):
-        """Assert that the test will fail (not marked as errored) in case
-        expected exception was risen inside
-        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block and
-        cli_return_code altogether with regex pattern match expected ones.
-        """
-        with pytest.raises(AssertionError):
-            with self.assertNotRaisesRegex(CLIReturnCodeError, self.pattern, expected_value=128):
-                fake_128_return_code()
-
-    def test_negative_wrong_status_code_callable(self):
-        """Assert that expected exception with valid pattern but unexpected
-        cli_return_code won't be handled and passed through to the test from
-        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` call.
-        """
-        with pytest.raises(CLIReturnCodeError):
-            self.assertNotRaisesRegex(
-                CLIReturnCodeError, self.pattern, fake_128_return_code, expected_value=129
-            )
-
-    def test_negative_wrong_status_code_context_manager(self):
-        """Assert that expected exception with valid pattern but unexpected
-        cli_return_code won't be handled and passed through to the test from
-        :meth:`robottelo.test.TestCase.assertNotRaisesRegex` block.
-        """
-        with pytest.raises(CLIReturnCodeError):
-            with self.assertNotRaisesRegex(CLIReturnCodeError, self.pattern, expected_value=129):
-                fake_128_return_code()


### PR DESCRIPTION
@lpramuk , @ColeHiggins2  @devendra104 @Gauravtalreja1 @omkarkhatavkar I've requested your reviews because you own these test modules.

I've converted some test modules that were still using CLITestCase, and removed the no longer used test case.

Some of these tests were already not passing in master.  I tried to keep test functionality and coverage the same.

# Test Results

## test_abrt.py

All stubbed, module collects/runs without issue.

## test_hammer.py

`tests/foreman/cli/test_hammer.py::HammerCommandsTestCase::test_positive_all_options` is failing in master branch.

```
tests/foreman/cli/test_hammer.py::test_positive_all_options FAILED                                                                                                                                                [ 33%]
tests/foreman/cli/test_hammer.py::test_positive_disable_hammer_defaults PASSED                                                                                                                                    [ 66%]
tests/foreman/cli/test_hammer.py::test_positive_check_debug_log_levels PASSED                                                                                                                                     [100%]
```

## test_installer.py

All stubbed, module collects/runs without issue.

## test_sso.py

All stubbed, module collects/runs without issue.

## test_subscription.py

`tests/foreman/cli/test_subscription.py::SubscriptionTestCase::test_positive_manifest_refresh` is failing in master branch.

```
tests/foreman/cli/test_subscription.py::test_positive_manifest_upload PASSED                                                                                                                                      [ 14%]
tests/foreman/cli/test_subscription.py::test_positive_manifest_delete PASSED                                                                                                                                      [ 28%]
tests/foreman/cli/test_subscription.py::test_positive_enable_manifest_reposet PASSED                                                                                                                              [ 42%]
tests/foreman/cli/test_subscription.py::test_positive_manifest_history PASSED                                                                                                                                     [ 57%]
tests/foreman/cli/test_subscription.py::test_positive_manifest_refresh FAILED                                                                                                                                     [ 71%]
tests/foreman/cli/test_subscription.py::test_positive_subscription_list PASSED                                                                                                                                    [ 85%]
tests/foreman/cli/test_subscription.py::test_positive_delete_manifest_as_another_user PASSED                                                                                                                      [100%]
```