### PR TITLE
Update expected API endpoints for 6.9

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -232,6 +232,20 @@ API_PATHS = {
         '/katello/api/content_credentials/:id/content',
         '/katello/api/content_credentials/:id/content',
     ),
+    'content_export_incrementals': (
+        '/katello/api/content_export_incrementals/version',
+        '/katello/api/content_export_incrementals/library',
+    ),
+    'content_exports': (
+        '/katello/api/content_exports',
+        '/katello/api/content_exports/api_status',
+        '/katello/api/content_exports/version',
+        '/katello/api/content_exports/library',
+    ),
+    'content_imports': (
+        '/katello/api/content_imports/version',
+        '/katello/api/content_imports/library',
+    ),
     'content_uploads': (
         '/katello/api/repositories/:repository_id/content_uploads',
         '/katello/api/repositories/:repository_id/content_uploads/:id',
@@ -287,8 +301,6 @@ API_PATHS = {
         '/katello/api/content_view_versions/:id/export',
         '/katello/api/content_view_versions/:id/promote',
         '/katello/api/content_view_versions/:id/republish_repositories',
-        '/katello/api/content_view_versions/export_histories',
-        '/katello/api/content_view_versions/export_api_status',
         '/katello/api/content_view_versions/import',
         '/katello/api/content_view_versions/incremental_update',
     ),
@@ -529,6 +541,7 @@ API_PATHS = {
         '/api/job_invocations/:id/hosts/:host_id',
         '/api/job_invocations/:id/hosts/:host_id/raw',
         '/api/job_invocations/:id/rerun',
+        '/api/job_invocations/:id/outputs',
     ),
     'job_templates': (
         '/api/job_templates',
@@ -674,6 +687,7 @@ API_PATHS = {
         '/api/provisioning_templates/build_pxe_default',
         '/api/provisioning_templates/import',
     ),
+    'puppet_hosts': ('/api/hosts/:id/puppetrun',),
     'ptables': (
         '/api/ptables',
         '/api/ptables',
@@ -802,6 +816,7 @@ API_PATHS = {
         '/api/users/:user_id/ssh_keys/:id',
         '/api/users/:user_id/ssh_keys/:id',
     ),
+    'statistics': ('/api/statistics',),
     'subnet_disks': ('/bootdisk/api', '/bootdisk/api/subnets/:subnet_id'),
     'subnets': (
         '/api/subnets',
@@ -864,6 +879,7 @@ API_PATHS = {
     ),
     'template_invocations': ('/api/job_invocations/:job_invocation_id/template_invocations',),
     'template_kinds': ('/api/template_kinds',),
+    'trends': ('/api/trends', '/api/trends/:id', '/api/trends', '/api/trends/:id'),
     'upstream_subscriptions': (
         '/katello/api/organizations/:organization_id/upstream_subscriptions',
         '/katello/api/organizations/:organization_id/upstream_subscriptions',


### PR DESCRIPTION
content-import: https://github.com/Katello/hammer-cli-katello/pull/760
content-export: https://github.com/Katello/hammer-cli-katello/pull/753
puppet_hosts: reverting change in commit 6e3c3de8bb4a34e98c2d46f816a7e7b76dd28d3d which removed the endpoint prematurely, it should me marked as deprecated in 6.9 and removed in 6.10
statistics, trends: reverting change in commit 6f5299a6a8119bf4c0efd94e813de0dbeec081ee which removed the endpoint prematurely, it should me marked as deprecated in 6.9 and removed in 6.10
job_invocations/outputs: https://github.com/theforeman/foreman_remote_execution/pull/543/files
content_export_histories, export_api_status: a19435a3757c80371a29408a9a04e131b6576ec2 in Katello git, replaced by content-export endpoint