### PR TITLE
Fix test_positive_search_in_multiple_repos

### DIFF
--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -114,16 +114,16 @@ def test_positive_search_in_multiple_repos(session, module_org, module_yum_repo,
     with session:
         session.organization.select(org_name=module_org.name)
         assert session.package.search('name = tiger')[0]['RPM'].startswith('tiger')
-        assert session.package.search('name = Lizard')[0]['RPM'].startswith('Lizard')
+        assert session.package.search('name = ant')[0]['RPM'].startswith('ant')
         # First repository
         assert session.package.search('name = tiger', repository=module_yum_repo.name)[0][
             'RPM'
         ].startswith('tiger')
-        assert not session.package.search('name = Lizard', repository=module_yum_repo.name)
+        assert not session.package.search('name = ant', repository=module_yum_repo.name)
         # Second repository
-        assert session.package.search('name = Lizard', repository=module_yum_repo2.name)[0][
+        assert session.package.search('name = ant', repository=module_yum_repo2.name)[0][
             'RPM'
-        ].startswith('Lizard')
+        ].startswith('ant')
         assert not session.package.search('name = tiger', repository=module_yum_repo2.name)
 
 


### PR DESCRIPTION
There's a failure due to the custom repo changes that doesn't have the specific rpms mentioned.

results:
```
================================= test session starts =====
platform linux -- Python 3.8.2, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ltran/Projects/robottelo, configfile: pyproject.toml
plugins: mock-3.6.0, forked-1.3.0, services-2.2.1, cov-2.11.1, ibutsu-1.14.1, xdist-2.2.1, reportportal-5.0.8
collected 1 item                                                                                                                                                                                                                         

tests/foreman/ui/test_package.py .                                                                                                                                                                                                 [100%]

====================================== 1 passed in 123.99s (0:02:03) ================
```