### PR TITLE
Prevented setting_update from attempting to (re)set null values

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -636,7 +636,7 @@ def setting_update(request):
     restore their default value
     """
     setting_object = entities.Setting().search(query={'search': f'name={request.param}'})[0]
-    default_setting_value = setting_object.value
+    default_setting_value = setting_object.value or ''
     yield setting_object
     setting_object.value = default_setting_value
     setting_object.update({'value'})


### PR DESCRIPTION
If a setting's default value is `null` and we want to restore its default value (after a test changed it) we have to use an empty string instead of `null` as Satellite doesn't allow users to set null values and requires users to instead set an empty value. This, according to devs, is so we can differentiate between default values that have never been changed and default values that have been changed by the user.
This was causing some tests to fail on fresh Satellites where the fixture -> test -> fixture flow caused `null -> [some value] -> null` change to be attempted. In automation, the first tests to try this and fail because of this would be `test_positive_update_login_page_footer_text` and `test_positive_update_login_page_footer_text_without_value`. Now, if the setting's default value is `null`, the change will be `null -> [some value] -> ""`.
Tests affected by this are either passing (especially the two mentioned on a fresh Satellite) or already failing in the main branch.