### PR TITLE
Fix typeerror in test_hostcollection

### DIFF
--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -221,7 +221,7 @@ def test_positive_add_hosts(module_org, fake_hosts):
     :BZ: 1325989
     """
     host_collection = entities.HostCollection(organization=module_org).create()
-    host_ids = {str(host.id) for host in fake_hosts}
+    host_ids = [str(host.id) for host in fake_hosts]
     host_collection.host_ids = host_ids
     host_collection = host_collection.update(['host_ids'])
     assert len(host_collection.host) == len(fake_hosts)


### PR DESCRIPTION

This has been failing with a TypeError for quite some time.

`E TypeError: Object of type set is not JSON serializable `

```setup@localhost:~/repos/robottelo (fix-type-error-test-host$%) % pytest -vx tests/foreman/api/test_hostcollection.py -k test_positive_add_hosts
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.9, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, reportportal-5.0.8, mock-3.6.0, cov-2.11.1, services-2.2.1
collected 54 items / 53 deselected / 1 selected                                                                                                                                              

tests/foreman/api/test_hostcollection.py::test_positive_add_hosts PASSED   ```