### PR TITLE
Fix test_positive_crud_scap_policy

### DIFF
--- a/pytest_fixtures/oscap_fixtures.py
+++ b/pytest_fixtures/oscap_fixtures.py
@@ -61,6 +61,6 @@ def tailoring_file(module_org, module_location, tailoring_file_path):
     ).create()
     return {
         "name": tailoring_file_name,
-        "tailoring_file_id": tf_info['id'],
+        "tailoring_file_id": tf_info.id,
         "tailoring_file_profile_id": tf_info.tailoring_file_profiles[0]['id'],
     }

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -76,14 +76,14 @@ class TestOscapPolicy:
         assert policy.deploy_by == 'puppet'
         assert policy.name == name
         assert policy.description == description
-        assert policy.scap_content_id == scap_content["scap_id"]
-        assert policy.scap_content_profile_id == scap_content["scap_profile_id"]
-        assert policy.tailoring_file_id == tailoring_file["tailoring_file_id"]
+        assert str(policy.scap_content_id) == str(scap_content["scap_id"])
+        assert str(policy.scap_content_profile_id) == str(scap_content["scap_profile_id"])
+        assert str(policy.tailoring_file_id) == str(tailoring_file["tailoring_file_id"])
         assert policy.period == "monthly"
-        assert policy.day_of_month == 5
-        assert policy.hostgroup[0].id == hostgroup.id
-        assert policy.organization[0].id == module_org.id
-        assert policy.location[0].id == module_location.id
+        assert int(policy.day_of_month) == 5
+        assert str(policy.hostgroup[0].id) == str(hostgroup.id)
+        assert str(policy.organization[0].id) == str(module_org.id)
+        assert str(policy.location[0].id) == str(module_location.id)
         # Update oscap policy with new name
         policy = entities.CompliancePolicies(id=policy.id, name=new_name).update()
         assert policy.name == new_name


### PR DESCRIPTION
There was a typeerror in the oscap_fixtures

Fixing that, I found assertion failures due to int/string comparisons

```
setup@localhost:~/repos/robottelo (fix-type-error-test-oscap$*%) % pytest -vx tests/foreman/api/test_oscappolicy.py -k test_positive_crud_scap_policy
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.8.9, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/setup/repos/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/setup/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, ibutsu-1.14.1, xdist-2.2.1, reportportal-5.0.8, mock-3.6.0, cov-2.11.1, services-2.2.1
collected 1 item                                                                                                                                                                             

tests/foreman/api/test_oscappolicy.py::TestOscapPolicy::test_positive_crud_scap_policy PASSED
```