### PR TITLE
removing unwanted cert-check test case

### DIFF
--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -495,45 +495,6 @@ class TestKatelloCertsCheck:
         :CaseAutomation: NotAutomated
         """
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier1
-    def test_negative_check_for_non_ascii_characters(self):
-        """Validate non ascii character in certs.
-
-        :id: c6a5e60d-e6d6-420c-b153-c6edb4ad7c99
-
-        :steps:
-
-            1. Create certs with ascii characters
-            2. Run katello-certs-check with the required arguments
-
-        :expectedresults: Check for non ascii character should fail gracefully
-                          e.g. no traces.
-
-        :CaseAutomation: NotAutomated
-        """
-
-    @pytest.mark.stubbed
-    @pytest.mark.tier1
-    def test_positive_validate_without_req_file_output(self):
-        """Check katello-certs-check without -r REQ_FILE generates correct command.
-
-        :id: b7d782eb-28ea-47e9-8661-1b5e5201c82f
-
-        :steps:
-
-            1. Generate custom certs
-            2. Run katello-certs-check with the required valid arguments and
-               without -r REQ_FILE option
-               katello-certs-check -c CERT_FILE -k KEY_FILE -b CA_BUNDLE_FILE
-            3. Assert the output has correct commands with options
-
-        :expectedresults: Katello-certs-check should generate correct commands
-            with options.
-
-        :CaseAutomation: NotAutomated
-        """
-
 
 class TestCapsuleCertsCheckTestCase:
     """Implements Capsule certs checks on Satellite Server.


### PR DESCRIPTION
No More Valid Test as per https://github.com/Katello/katello-installer/pull/552/files

1. latest code: https://github.com/theforeman/foreman-installer/blob/develop/bin/katello-certs-check there is not validation required 
2. https://github.com/theforeman/foreman-installer/commit/2a99269114b8f7e570a8371a08b074ca41315872#diff-38b8e9056bcc7d9c8f5fe13d40eb47ac3462fdc830dbd580ecf05b24fe0e3bdcR14
