### PR TITLE
Fix regular expression for test_negative_synchronize_private_registry_wrong_password

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1756,8 +1756,8 @@ class TestDockerRepository:
         :CaseLevel: Integration
         """
         msg = (
-            f'DKR1007: Could not fetch repository {repo_options["docker_upstream_name"]} from'
-            f' registry {repo_options["url"]} - Unauthorized or Not Found'
+            rf'DKR1007: Could not fetch repository {repo_options["docker_upstream_name"]} from'
+            rf' registry {repo_options["url"]}.*Unauthorized or Not Found'
         )
         with pytest.raises(TaskFailedError, match=msg):
             repo.sync()


### PR DESCRIPTION
Before fix:

```
collected 227 items / 226 deselected / 1 selected

tests/foreman/api/test_repository.py F [100%]

        with pytest.raises(TaskFailedError, match=msg):
>           repo.sync()
E           AssertionError: Regex pattern 'DKR1007: Could not fetch repository XXX/XXX from registry https://registry.example.com - Unauthorized or Not Found' does not match '[...] 
\'output\': "Could not fetch repository XXX/XXX from registry https://registry.example.com - 401 Client Error: \'Unauthorized or Not Found\' for url[...]

tests/foreman/api/test_repository.py:1761: AssertionError
[...]
=== 1 failed, 226 deselected in 101.73s (0:01:41) ===
```

After fix:

```
# pytest -k test_negative_synchronize_private_registry_wrong_password tests/foreman/api/test_repository.py
[...]
collected 227 items / 226 deselected / 1 selected
[...]
=== 1 passed, 226 deselected in 108.52s (0:01:48) ===
```