### PR TITLE
PR #8579 follow-up

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -641,7 +641,9 @@ def setting_update(request):
     restore their default value
     """
     setting_object = entities.Setting().search(query={'search': f'name={request.param}'})[0]
-    default_setting_value = setting_object.value or ''
+    default_setting_value = setting_object.value
+    if default_setting_value is None:
+        default_setting_value = ''
     yield setting_object
     setting_object.value = default_setting_value
     setting_object.update({'value'})


### PR DESCRIPTION
This is a follow-up to https://github.com/SatelliteQE/robottelo/pull/8579.
In that PR, I applied the suggestion by @mshriver, with which that PR was merged. While the suggestion remains a really cool python feature, I've now found out it's not equivalent in this case. That is `0 or ''` will result in `''`. And `0` is a valid value for `default_setting_value` so I need it to pass through this "filter". Therefore, the first 2-line solution, which catches only `None` values, will be necessary. Since that PR was merged, I opened this one.