### PR TITLE
Errata test fixes

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2276,11 +2276,11 @@ def setup_virtual_machine(
             result = vm.run(
                 f'yum-config-manager --enable {org_label}_{product_label}_{repo_label}'
             )
-            if result.return_code != 0:
+            # Check for either status or return_code attribute, depending on ssh implementation
+            status = getattr(result, 'status', getattr(result, 'return_code', None))
+            if status != 0:
                 raise CLIFactoryError(
-                    'Failed to enable custom repository "{}"\n{}'.format(
-                        repos_label, result.stderr
-                    )
+                    f'Failed to enable custom repository {repo_label!s}\n{result.stderr}'
                 )
     if install_katello_agent:
         vm.install_katello_agent()

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -333,6 +333,7 @@ PRDS = {
     'rhdt': 'Red Hat Developer Tools for RHEL Server',
     'rhscl': 'Red Hat Software Collections (for RHEL Server)',
     'rhae': 'Red Hat Ansible Engine',
+    'rhel8': 'Red Hat Enterprise Linux for x86_64',
 }
 
 REPOSET = {
@@ -355,6 +356,7 @@ REPOSET = {
     'rhdt7': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7 Server'),
     'rhscl7': ('Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server'),
     'rhae2': 'Red Hat Ansible Engine 2.7 RPMs for Red Hat Enterprise Linux 7 Server',
+    'rhst8': 'Red Hat Satellite Tools 6.9 for RHEL 8 x86_64 (RPMs)',
 }
 
 NO_REPOS_AVAILABLE = "This system has no repositories available through subscriptions."
@@ -543,6 +545,15 @@ REPOS = {
         'product': PRDS['rhae'],
         'distro': DISTRO_RHEL7,
         'key': 'rhae2',
+    },
+    'rhst8': {
+        'id': 'satellite-tools-6.9-for-rhel-8-x86_64-rpms',
+        'name': 'Red Hat Satellite Tools 6.9 for RHEL 8 x86_64 RPMs',
+        'version': '6.9',
+        'reposet': REPOSET['rhst8'],
+        'product': PRDS['rhel8'],
+        'distro': DISTRO_RHEL8,
+        'key': 'rhst',
     },
 }
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -101,6 +101,8 @@ class ContentHost(Host):
             downstream_repo = settings.sattools_repo['rhel6']
         elif repo == REPOS['rhst7']['id']:
             downstream_repo = settings.sattools_repo['rhel7']
+        elif repo == REPOS['rhst8']['id']:
+            downstream_repo = settings.sattools_repo['rhel8']
         elif repo in (REPOS['rhsc6']['id'], REPOS['rhsc7']['id']):
             downstream_repo = settings.capsule_repo
         if force or settings.cdn or not downstream_repo:

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -474,7 +474,6 @@ class GenericRHRepository(BaseRepository):
         """Set a new distro value, we have to reinitialise the repo data also,
         if not found raise exception
         """
-
         if distro is not None and distro not in DISTROS_SUPPORTED:
             raise DistroNotSupportedError(f'distro "{distro}" not supported')
         if distro is None:
@@ -982,7 +981,9 @@ class RepositoryCollection:
             rh_repos_id = [getattr(repo, 'rh_repository_id') for repo in self.rh_repos]
         custom_repos_label = []  # type: List[str]
         if enable_custom_repos:
-            custom_repos_label = [repo['label'] for repo in self.custom_repos_info]
+            custom_repos_label = [
+                repo['label'] for repo in self.custom_repos_info if repo['content-type'] == 'yum'
+            ]
 
         setup_virtual_machine(
             vm,

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -17,50 +17,42 @@
 :Upstream: No
 """
 import pytest
+from broker import VMBroker
 
 from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.cli.factory import make_org
 from robottelo.config import settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
 from robottelo.constants import CONTAINER_UPSTREAM_NAME
+from robottelo.constants import DISTRO_RHEL6
 from robottelo.constants import DISTROS_SUPPORTED
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
 from robottelo.constants.repos import FAKE_0_YUM_REPO
-from robottelo.datafactory import xdist_adapter
+from robottelo.hosts import ContentHost
 from robottelo.products import DockerRepository
 from robottelo.products import PuppetRepository
 from robottelo.products import RepositoryCollection
 from robottelo.products import SatelliteToolsRepository
 from robottelo.products import YumRepository
-from robottelo.vm import VirtualMachine
 
 
-def _distro_cdn_variants():
-    distro_cdn = []
-    for cdn in [False, True]:
-        for distro in DISTROS_SUPPORTED:
-            distro_cdn.append((distro, cdn))
-
-    return distro_cdn
-
-
-@pytest.fixture(scope='module')
-def module_org():
+@pytest.fixture
+def org():
     return make_org()
 
 
-@pytest.fixture(scope='module')
-def module_lce(module_org):
-    return make_lifecycle_environment({'organization-id': module_org['id']})
+@pytest.fixture
+def lce(org):
+    return make_lifecycle_environment({'organization-id': org['id']})
 
 
 @pytest.mark.tier4
-@pytest.mark.libvirt_content_host
-@pytest.mark.parametrize('value', **xdist_adapter(_distro_cdn_variants()))
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
-def test_vm_install_package(value, module_org, module_lce):
-    """Install a package with all supported distros and cdn not cdn variants
+@pytest.mark.parametrize('cdn', [True, False], ids=['cdn', 'no_cdn'])
+@pytest.mark.parametrize('distro', DISTROS_SUPPORTED)
+def test_vm_install_package(org, lce, distro, cdn):
+    """Install a package with all supported distros and cdn / non-cdn variants
 
     :id: b2a6065a-69f6-4805-a28b-eaaa812e0f4b
 
@@ -68,17 +60,12 @@ def test_vm_install_package(value, module_org, module_lce):
 
     :expectedresults: Package is install is installed
     """
-    # the value is support distro DISTRO_RH6 or DISTRO_RH7
-    # this will create 4 tests:
-    #  - one test with disto rhel6 cdn False
-    #  - one test with distro rhel7 cdn False
-    #  - one test with disto rhel6 cdn True
-    #  - one test with distro rhel7 cdn True
-    distro, cdn = value
+    if distro == DISTRO_RHEL6:
+        pytest.skip(f'{DISTRO_RHEL6!s} skipped until ELS subscriptions are in manifest.')
     repos_collection = RepositoryCollection(
         distro=distro,
         repositories=[
-            SatelliteToolsRepository(cdn=cdn),
+            SatelliteToolsRepository(cdn=cdn, distro=distro),
             YumRepository(url=FAKE_0_YUM_REPO),
             DockerRepository(url=CONTAINER_REGISTRY_HUB, upstream_name=CONTAINER_UPSTREAM_NAME),
             PuppetRepository(
@@ -86,12 +73,13 @@ def test_vm_install_package(value, module_org, module_lce):
             ),
         ],
     )
-    # this will create repositories , content view and activation key
-    repos_collection.setup_content(module_org['id'], module_lce['id'], upload_manifest=True)
-    with VirtualMachine(distro=distro) as vm:
-        # this will install katello ca, register vm host, enable rh repos,
+    # Create repos, content view, and activation key.
+    repos_collection.setup_content(org['id'], lce['id'], upload_manifest=True)
+    with VMBroker(nick=distro, host_classes={'host': ContentHost}) as host:
         # install katello-agent
-        repos_collection.setup_virtual_machine(vm, enable_custom_repos=True)
-        # install a package
-        result = vm.run(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
-        assert result.return_code == 0
+        repos_collection.setup_virtual_machine(
+            host, enable_custom_repos=True, install_katello_agent=False
+        )
+        # install a package from custom repo
+        result = host.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
+        assert result.status == 0

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -222,8 +222,6 @@ def test_end_to_end(session, module_repos_col, vm):
         'cves': 'N/A',
         'type': 'Security Advisory',
         'severity': 'N/A',
-        'issued': 'Jan 27, 12:00 AM',
-        'last_updated_on': 'Jan 27, 12:00 AM',
         'reboot_suggested': 'No',
         'topic': '',
         'description': 'Sea_Erratum',
@@ -245,7 +243,13 @@ def test_end_to_end(session, module_repos_col, vm):
         assert session.errata.search(value, applicable=True)[0]['Errata ID']
         # Check all tabs of Errata Details page
         errata = session.errata.read(CUSTOM_REPO_ERRATA_ID)
-        assert errata['details'] == ERRATA_DETAILS
+        # We ignore issued date and updated date in ERRATA_DETAILS, so we don't perform an
+        # equality check here.
+        # TODO: Find a way to account for browser time zone, so that the errata dates displayed
+        # in the UI can be compared to the UTC values in ERRATA_DETAILS.
+        assert (
+            not ERRATA_DETAILS.items() - errata['details'].items()
+        ), 'Errata details do not match expected values.'
         assert set(errata['packages']['independent_packages']) == set(
             ERRATA_PACKAGES['independent_packages']
         )


### PR DESCRIPTION
- Convert `test_vm_install_products_package.py` to use `VMBroker`
- Add RHEL 8 satellite tools repo info to `robottelo.constants.repos`
- Skip tests for RHEL 6 content host in `test_vm_install_products_package.py` , because RHEL 6 content hosts require ELS subscriptions to access the Server and Satellite Tools repos. The automation manifests currently do not have these subscriptions, and this skip will be removed when the subscriptions have been added.
- Remove errata date checking in `tests/foreman/ui/test_errata.py::test_end_to_end`, because the dates shown in the UI depend on the browser locale. Finding and accounting for the selenium browser's time zone would require a fair bit of work, so I've just removed it for now.

Test results:
```
# pytest tests/foreman/cli/test_vm_install_products_package.py
[...]
collected 6 items                                                                                                                                                                                                                            

tests/foreman/cli/test_vm_install_products_package.py ss.... [100%]

=== 4 passed, 2 skipped in 3024.55s (0:50:24) ===

# pytest tests/foreman/ui/test_errata.py::test_end_to_end
[...]
collected 1 item

tests/foreman/ui/test_errata.py . [100%]

=== 1 passed in 1095.09s (0:18:15) ===
```