### PR TITLE
endtoend/utils.py VirtualMachine to VMBroker

### DIFF
--- a/tests/foreman/endtoend/utils.py
+++ b/tests/foreman/endtoend/utils.py
@@ -1,7 +1,8 @@
 """Module that aggregates common bits of the end to end tests."""
+from broker import VMBroker
+
 from robottelo.config import setting_is_set
-from robottelo.constants import DISTRO_RHEL6
-from robottelo.vm import VirtualMachine
+from robottelo.hosts import ContentHost
 
 AK_CONTENT_LABEL = 'rhel-6-server-rhev-agent-rpms'
 
@@ -25,15 +26,15 @@ class ClientProvisioningMixin:
         """
         if not setting_is_set('clients'):
             return
-        with VirtualMachine(distro=DISTRO_RHEL6) as vm:
+        with VMBroker(nick='rhel6', host_classes={'host': ContentHost}) as host:
             # Pull rpm from Foreman server and install on client
-            vm.install_katello_ca()
+            host.install_katello_ca()
             # Register client with foreman server using act keys
-            vm.register_contenthost(organization_label, activation_key_name)
-            assert vm.subscribed
+            host.register_contenthost(organization_label, activation_key_name)
+            assert host.subscribed
             # Install rpm on client
-            result = vm.run(f'yum install -y {package_name}')
-            assert result.return_code == 0
+            result = host.run(f'yum install -y {package_name}')
+            assert result.status == 0
             # Verify that the package is installed by querying it
-            result = vm.run(f'rpm -q {package_name}')
-            assert result.return_code == 0
+            result = host.run(f'rpm -q {package_name}')
+            assert result.status == 0


### PR DESCRIPTION
`client_provisioning` method is not a test and `test_cli_endtoend.py` calls `client_provisioning` method, hence executing the following: 
```
$ pytest -k test_positive_cli_end_to_end tests/foreman/endtoend/test_cli_endtoend.py
========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.8.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/satelliteqe/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.8, forked-1.3.0, mock-3.6.1, xdist-2.2.1, cov-2.11.1, ibutsu-1.14.1, services-2.2.1
collected 4 items / 3 deselected / 1 selected                                                                                                                  

tests/foreman/endtoend/test_cli_endtoend.py .                                                                                                                                                                                      [100%]

============================================================================================== 1 passed, 3 deselected in 819.05s (0:13:39) ===============================================================================================
```
This might not work in PRT as I had to comment `@pytest.mark.on_premises_provisioning` for the execution. 