### PR TITLE
Added a wait_for in test_reporttemplates.py

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -21,6 +21,7 @@ from broker.broker import VMBroker
 from fauxfactory import gen_string
 from nailgun import entities
 from requests import HTTPError
+from wait_for import wait_for
 
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
@@ -548,6 +549,12 @@ def test_positive_schedule_entitlements_report(setup_content):
                 "input_values": {"Days from Now": "no limit"},
             }
         )
-        data_csv = rt.report_data(data={'id': rt.id, 'job_id': scheduled_csv['job_id']})
+        data_csv, _ = wait_for(
+            rt.report_data,
+            func_kwargs={'data': {'id': rt.id, 'job_id': scheduled_csv['job_id']}},
+            fail_condition=None,
+            timeout=300,
+            delay=10,
+        )
         assert vm.hostname in data_csv
         assert DEFAULT_SUBSCRIPTION_NAME in data_csv


### PR DESCRIPTION
Robottelo should wait for Satellite to generate the csv file before accessing it. I suspect this to be the culprit of the test's failures (exclusively) in automation since the Satellite instance in automation is busy and may not manage to finish the job before a request for the file arrives, therefore returning a `HTTP 204`, resulting in `data_csv = None`.

```
$ pytest tests/foreman/api/test_reporttemplates.py::test_positive_schedule_entitlements_report
============================= test session starts ==============================
collected 1 item                                                               

tests/foreman/api/test_reporttemplates.py .                              [100%]
================== 1 passed, 35 warnings in 395.55s (0:06:35) ==================
```
