### PR TITLE
Underscore under-estimated

### DIFF
--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -164,7 +164,7 @@ class TestAzureRMHostProvisioningTestCase:
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
-        request.cls.hostname = f'test_{gen_string("alpha")}'
+        request.cls.hostname = f'test-{gen_string("alpha")}'
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = {
@@ -314,7 +314,7 @@ class TestAzureRMUserDataProvisioning:
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
-        request.cls.hostname = f'test_{gen_string("alpha")}'
+        request.cls.hostname = f'test-{gen_string("alpha")}'
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = {
@@ -468,7 +468,7 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
         request.cls.region = settings.azurerm.azure_region
-        request.cls.hostname = f'test_{gen_string("alpha")}'
+        request.cls.hostname = f'test-{gen_string("alpha")}'
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = {
@@ -594,7 +594,7 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
         request.cls.region = settings.azurerm.azure_region
-        request.cls.hostname = f'test_{gen_string("alpha")}'
+        request.cls.hostname = f'test-{gen_string("alpha")}'
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = {

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -310,7 +310,7 @@ class TestAzureRMFinishTemplateProvisioning:
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
-        request.cls.hostname = f'test_{gen_string("alpha")}'
+        request.cls.hostname = f'test-{gen_string("alpha")}'
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = (
@@ -433,7 +433,7 @@ class TestAzureRMUserDataProvisioning:
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
-        request.cls.hostname = f'test_{gen_string("alpha")}'
+        request.cls.hostname = f'test-{gen_string("alpha")}'
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = (
@@ -557,7 +557,7 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
         Sets Constants for all the Tests, fixtures which will be later used for assertions
         """
         request.cls.region = settings.azurerm.azure_region
-        request.cls.hostname = f'test_{gen_string("alpha")}'
+        request.cls.hostname = f'test-{gen_string("alpha")}'
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = (

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -116,7 +116,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
     :BZ: 1850934
     """
 
-    hostname = f'test_{gen_string("alpha")}'
+    hostname = f'test-{gen_string("alpha")}'
     fqdn = f'{hostname}.{module_domain.name}'.lower()
 
     with session:
@@ -195,7 +195,7 @@ def test_positive_azurerm_host_provision_ud(
     :BZ: 1850934
     """
 
-    hostname = f'test_{gen_string("alpha")}'
+    hostname = f'test-{gen_string("alpha")}'
     fqdn = f'{hostname}.{module_domain.name}'.lower()
 
     with session:


### PR DESCRIPTION
Azure tests fixed failing due to `underscore` in name, fixed it with `hypen`.