### PR TITLE
Set SELinux boolean to allow repo discovery with non-standard ports

### DIFF
--- a/pytest_fixtures/sys_fixtures.py
+++ b/pytest_fixtures/sys_fixtures.py
@@ -12,6 +12,14 @@ def foreman_service_teardown():
     run_command('foreman-maintain service start --only=foreman')
 
 
+@pytest.fixture
+def allow_repo_discovery():
+    """Set SELinux boolean to allow Rails to connect to non-standard ports."""
+    ssh_command('setsebool foreman_rails_can_connect_all on')
+    yield
+    ssh_command('setsebool foreman_rails_can_connect_all off')
+
+
 @pytest.fixture(autouse=True, scope="session")
 def relax_bfa():
     """Relax BFA protection against failed login attempts

--- a/tests/foreman/ui/test_contentcredential.py
+++ b/tests/foreman/ui/test_contentcredential.py
@@ -265,6 +265,7 @@ def test_positive_add_repo_from_product_with_repos(session, module_org, gpg_cont
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+@pytest.mark.usefixtures('allow_repo_discovery')
 def test_positive_add_product_using_repo_discovery(session, gpg_path):
     """Create gpg key with valid name and valid gpg key
     then associate it with custom product using Repo discovery method
@@ -346,6 +347,7 @@ def test_positive_add_product_and_search(session, module_org, gpg_content):
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+@pytest.mark.usefixtures('allow_repo_discovery')
 def test_positive_update_key_for_product_using_repo_discovery(session, gpg_path):
     """Create gpg key with valid name and valid content then associate it with custom product
     using Repo discovery method then update the key
@@ -402,6 +404,7 @@ def test_positive_update_key_for_product_using_repo_discovery(session, gpg_path)
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+@pytest.mark.usefixtures('allow_repo_discovery')
 def test_positive_delete_key_for_product_using_repo_discovery(session, gpg_path):
     """Create gpg key with valid name and valid gpg then associate
     it with custom product using Repo discovery method then delete it

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -267,6 +267,7 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+@pytest.mark.usefixtures('allow_repo_discovery')
 def test_positive_discover_repo_via_existing_product(session, module_org):
     """Create repository via repo-discovery under existing product
 
@@ -294,6 +295,7 @@ def test_positive_discover_repo_via_existing_product(session, module_org):
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
+@pytest.mark.usefixtures('allow_repo_discovery')
 def test_positive_discover_repo_via_new_product(session, module_org):
     """Create repository via repo discovery under new product
 


### PR DESCRIPTION
Repository discovery fails when using an url in the `URL to Discover` field that specifies non-standard ports, e.g., `http://repo.example.com:50123/repo_discovery/`, with SELinux logging AVC denials:

```
type=AVC msg=audit(1621276635.135:12036): avc:  denied  { name_connect } for  pid=61024 comm="diagnostic_con*" dest=50123 scontext=system_u:system_r:foreman_rails_t:s0 tcontext=system_u:object_r:ephemeral_port_t:s0 tclass=tcp_socket permissive=0
```

This PR adds a fixture that enables the SELinux boolean `foreman_rails_can_connect_all` before repo discovery tests run, and disables the boolean afterwards.

Before fix:

```
# pytest -k discover tests/foreman/ui/test_repository.py
[...]
collected 23 items / 21 deselected / 2 selected

tests/foreman/ui/test_repository.py FF [100%]
[...]
FAILED tests/foreman/ui/test_repository.py::test_positive_discover_repo_via_existing_product - widgetastic.exceptions.RowNotFound: Row not found when using filters ()/{'discovered_repository__contains': 'fakerepo01'}
FAILED tests/foreman/ui/test_repository.py::test_positive_discover_repo_via_new_product - widgetastic.exceptions.RowNotFound: Row not found when using filters ()/{'discovered_repository__contains': 'fakerepo01'}
=== 2 failed, 21 deselected, 1 warning in 204.58s (0:03:24) ===
```

After fix:

```
# pytest -k discover tests/foreman/ui/test_repository.py
[...]
collected 23 items / 21 deselected / 2 selected

tests/foreman/ui/test_repository.py .. [100%]
[...]
=== 2 passed, 21 deselected, 1 warning in 537.86s (0:08:57) ===
```
