### PR TITLE
fix: fixture default_contentview

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -524,9 +524,7 @@ def module_promoted_cv(module_lce, module_published_cv):
 
 @pytest.fixture(scope='module')
 def default_contentview(module_org):
-    return entities.ContentView().search(
-        query={'search': f'name={DEFAULT_CV}', 'organization_id': f'{module_org.id}'}
-    )
+    return entities.ContentView(organization=module_org, name=DEFAULT_CV).search()
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Long story short:  default_contentview  fixture now works :tada: .
I created a test (look below):  and the result is 
```
tests/foreman/cli/test_host.py::test_default_contentview_module
====================== 1 passed, 55 deselected in 38.55s =======================
```

Long story:
So, while I was working on #8184 
I changed the `default_contentview` from not working to not working. It was merged. And it was not used anywhere in robottelo. 
Why that happened? Because I chose to use new content view and I forget to change it back, so there would be no change of 
`default_contentview` in #8184. But at the end the fixture would not work. 

@swadeley saw that, and wrote me if I can fix it, he proposed the solution :+1: 

```
def test_default_contentview_module(module_org, module_manifest_org, default_contentview):
    # 0 old version before pr 8184
    print(entities.ContentView().search(
        query={'search': 'label=Default_Organization_View', 'organization_id': f'{module_org.id}'}
    ))
    # result []

    # 1 actual from pr 8184
    print(entities.ContentView().search(
        query={'search': f'name={DEFAULT_CV}', 'organization_id': f'{module_org.id}'}))
    # result []

    # 3 new
    new = entities.ContentView(organization=module_org, name=DEFAULT_CV).search()
    print(new)
    new_id = entities.ContentView(organization=module_org.id, name=DEFAULT_CV).search()
    print(new_id)
    assert new == new_id
    # results:
    # [nailgun.entities.ContentView(...)]
    # [nailgun.entities.ContentView(...)]

    # 4 new with manifest org
    print(entities.ContentView(organization=module_manifest_org, name=DEFAULT_CV).search())
    # [nailgun.entities.ContentView(...)]

    print('double check, it works', default_contentview)
    assert default_contentview == new_id == new
 ```