### PR TITLE
code coverage for bz 1922134

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1350,7 +1350,10 @@ def test_negative_readonly_user_actions(function_role, content_view, module_org,
         3. add a custom repository to content view
 
     :expectedresults: User with read only role for content view cannot
-        Modify, Delete, Publish, Promote the content views
+        Modify, Delete, Publish, Promote the content views.  Same user cannot
+        create Product, Host Collection, or Activation key
+
+    :BZ: 1922134
 
     :CaseLevel: Integration
 
@@ -1405,6 +1408,15 @@ def test_negative_readonly_user_actions(function_role, content_view, module_org,
     assert len(content_view.version), 1
     with pytest.raises(HTTPError):
         promote(content_view.version[0], module_lce.id)
+    # Check that we cannot create a Product
+    with pytest.raises(HTTPError):
+        entities.Product(cfg).create()
+    # Check that we cannot create an activation key
+    with pytest.raises(HTTPError):
+        entities.ActivationKey(cfg).create()
+    # Check that we cannot create a host collection
+    with pytest.raises(HTTPError):
+        entities.HostCollection(cfg).create()
 
 
 @pytest.mark.tier2

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -26,6 +26,7 @@ from nailgun import entities
 
 from robottelo import ssh
 from robottelo.api.utils import create_sync_custom_repo
+from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.capsule import Capsule
 from robottelo.cli.contentview import ContentView
@@ -45,9 +46,11 @@ from robottelo.cli.factory import make_role
 from robottelo.cli.factory import make_user
 from robottelo.cli.filter import Filter
 from robottelo.cli.host import Host
+from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.location import Location
 from robottelo.cli.module_stream import ModuleStream
 from robottelo.cli.org import Org
+from robottelo.cli.product import Product
 from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
@@ -4094,7 +4097,10 @@ class TestContentView:
         :setup: create a user with the Content View read-only role
 
         :expectedresults: User with read-only role for content view can view
-            the content view but not Create / Modify / Promote / Publish
+            the content view but not Create / Modify / Promote / Publish /
+            create product / create host collection / create activation key
+
+        :BZ: 1922134
 
         :CaseLevel: Integration
 
@@ -4138,6 +4144,21 @@ class TestContentView:
                     'organization-id': module_org.id,
                     'to-lifecycle-environment-id': environment['id'],
                 }
+            )
+        # or create a product
+        with pytest.raises(CLIReturnCodeError):
+            Product.with_user(user['login'], password).create(
+                {'name': gen_string('alpha'), 'organization-id': module_org.id}
+            )
+        # cannot create activation key
+        with pytest.raises(CLIReturnCodeError):
+            ActivationKey.with_user(user['login'], password).create(
+                {'name': gen_string('alpha'), 'organization-id': module_org.id}
+            )
+        # cannot create host collection
+        with pytest.raises(CLIReturnCodeError):
+            HostCollection.with_user(user['login'], password).create(
+                {'organization-id': module_org.id}
             )
 
     @pytest.mark.tier2


### PR DESCRIPTION
Adding some more fields for a bz coverage.

```
pytest -s -vv tests/foreman/api/test_contentview.py::test_negative_readonly_user_actions tests/foreman/cli/test_contentview.py::TestContentView::test_negative_user_with_read_only_cv_permission tests/foreman/ui/test_contentview.py::test_negative_read_only_user_actions

============== 3 passed, 27 warnings in 391.19s (0:06:31) =======================
```