### PR TITLE
Add widgetastic.patternfly4 as requirement for Robottelo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ unittest2==1.1.0
 wait-for==1.1.5
 widgetastic.core==0.62
 widgetastic.patternfly==1.3.2
+widgetastic.patternfly4==0.22.1
 wrapanapi==3.5.8
 
 # Get airgun, nailgun and upgrade from master


### PR DESCRIPTION
This is required for adding support for PF4 components.
Do not merge this PR before https://github.com/SatelliteQE/airgun/pull/568 is merged.
