### PR TITLE
Add delete repo step to a docker repo test

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -41,6 +41,7 @@ from robottelo.cli.file import File
 from robottelo.cli.filter import Filter
 from robottelo.cli.module_stream import ModuleStream
 from robottelo.cli.package import Package
+from robottelo.cli.product import Product
 from robottelo.cli.puppetmodule import PuppetModule
 from robottelo.cli.repository import Repository
 from robottelo.cli.role import Role
@@ -1073,14 +1074,18 @@ class TestRepository:
         ),
         indirect=True,
     )
-    def test_positive_synchronize_docker_repo(self, repo):
-        """Check if Docker repository can be created and synced
+    def test_positive_synchronize_docker_repo(self, repo, module_product, module_org):
+        """Check if Docker repository can be created, synced, and deleted
 
         :id: cb9ae788-743c-4785-98b2-6ae0c161bc9a
 
         :parametrized: yes
 
-        :expectedresults: Docker repository is created and synced
+        :customerscenario: true
+
+        :expectedresults: Docker repository is created, synced, and deleted
+
+        :BZ: 1810165
         """
         # Assertion that repo is not yet synced
         assert repo['sync']['status'] == 'Not Synced'
@@ -1089,6 +1094,14 @@ class TestRepository:
         # Verify it has finished
         new_repo = Repository.info({'id': repo['id']})
         assert new_repo['sync']['status'] == 'Success'
+        # For BZ#1810165, assert repo can be deleted
+        Repository.delete({'id': repo['id']})
+        assert (
+            new_repo['name']
+            not in Product.info({'id': module_product.id, 'organization-id': module_org.id})[
+                'content'
+            ]
+        )
 
     @pytest.mark.tier2
     @pytest.mark.upgrade


### PR DESCRIPTION
  Closed loop: BZ#1810165

Hello

this is for

[Bug 1810165 - "Couldn't find Katello::Content without an ID" when deleting repository](https://bugzilla.redhat.com/show_bug.cgi?id=1810165)