### PR TITLE
SyncPlan time format, leading zero change

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -115,7 +115,7 @@ def test_positive_end_to_end(session, module_org):
         assert syncplan_values['details']['enabled'] == 'Yes'
         assert syncplan_values['details']['interval'] == SYNC_INTERVAL['day']
         time = syncplan_values['details']['date_time'].rpartition(':')[0]
-        assert time == startdate.strftime("%B %-d, %Y, %-I")
+        assert time == startdate.strftime("%B %-d, %Y, %I")
         # Update sync plan with new description
         session.syncplan.update(plan_name, {'details.description': new_description})
         syncplan_values = session.syncplan.read(plan_name)
@@ -167,7 +167,7 @@ def test_positive_end_to_end_custom_cron(session):
         assert syncplan_values['details']['cron_expression'] == cron_expression
         assert syncplan_values['details']['recurring_logic'].isdigit()
         time = syncplan_values['details']['date_time'].rpartition(':')[0]
-        assert time == startdate.strftime("%B %-d, %Y, %-I")
+        assert time == startdate.strftime("%B %-d, %Y, %I")
         # Update sync plan with new description
         session.syncplan.update(plan_name, {'details.interval': SYNC_INTERVAL['day']})
         syncplan_values = session.syncplan.read(plan_name)


### PR DESCRIPTION
Hello

In 6.8, syncplan time had no leading zero:
Start Date
    May 25, 2021 9:19:00 PM
Next Sync
    May 25, 2021, 9:19 PM


Now in 6.9 I see:
Start Date
    May 25, 2021, 02:01 AM
Next Sync
    May 25, 2021, 11:01 PM
