### PR TITLE
The right place of helpers

### DIFF
--- a/pytest_plugins/issue_handlers.py
+++ b/pytest_plugins/issue_handlers.py
@@ -7,6 +7,7 @@ from datetime import datetime
 import pytest
 
 from robottelo.config import settings
+from robottelo.helpers import settingsUtils
 from robottelo.helpers import slugify_component
 from robottelo.logging import collection_logger as logger
 from robottelo.utils.issue_handlers import add_workaround
@@ -303,7 +304,7 @@ def generate_issue_collection(items, config):  # pragma: no cover
     # --- if no cache file existed write a new cache file ---
     if cached_data is None and use_bz_cache:
         collected_data['_meta'] = {
-            "version": settings.server.version,
+            "version": settingsUtils.sat_version(),
             "hostname": settings.server.hostname,
             "created": datetime.now().isoformat(),
             "pytest": {"args": config.args, "pwd": str(config.invocation_dir)},

--- a/pytest_plugins/rerun_rp/rerun_rp.py
+++ b/pytest_plugins/rerun_rp/rerun_rp.py
@@ -2,6 +2,7 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.logging import logger
+from robottelo.helpers import settingsUtils
 from robottelo.report_portal.portal import ReportPortal
 
 
@@ -120,7 +121,7 @@ def pytest_collection_modifyitems(items, config):
     if not any([fail_args, skip_arg, user_arg, upgrades_rerun]):
         return
     rp = ReportPortal()
-    version = settings.server.version
+    version = settingsUtils.sat_version()
     sat_version = f'{version.base_version}.{version.epoch}'
     logger.info(f'Fetching Report Portal launches for target Satellite version: {sat_version}')
     launch = next(

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -20,6 +20,7 @@ from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.errors import ImproperlyConfigured
+from robottelo.helpers import settingsUtils
 
 
 def call_entity_method_with_timeout(entity_callable, timeout=300, **kwargs):
@@ -653,7 +654,7 @@ def wait_for_syncplan_tasks(repo_backend_id=None, timeout=10, repo_name=None):
         # Send request to pulp API to get the task info
         req = request(
             'POST',
-            f'{settings.server.get_url()}/pulp/api/v2/tasks/search/',
+            f'{settingsUtils.server_url()}/pulp/api/v2/tasks/search/',
             verify=False,
             auth=('admin', f'{pulp_pass}'),
             headers={'content-type': 'application/json'},

--- a/robottelo/config/base.py
+++ b/robottelo/config/base.py
@@ -4,8 +4,6 @@ import os
 from configparser import ConfigParser
 from configparser import NoOptionError
 from configparser import NoSectionError
-from urllib.parse import urljoin
-from urllib.parse import urlunsplit
 
 import yaml
 
@@ -152,73 +150,11 @@ class ServerSettings(FeatureSettings):
             )
         return validation_errors
 
-    def get_credentials(self):
-        """Return credentials for interacting with a Foreman deployment API.
-
-        :return: A username-password pair.
-        :rtype: tuple
-
-        """
-        return (self.admin_username, self.admin_password)
-
     def get_hostname(self, key="hostname"):
         from robottelo.config import robottelo_root_dir
 
         reader = INIReader(robottelo_root_dir.joinpath(SETTINGS_FILE_NAME))
         return reader.get('server', key, self.hostname)
-
-    def get_url(self):
-        """Return the base URL of the Foreman deployment being tested.
-
-        The following values from the config file are used to build the URL:
-
-        * ``[server] scheme`` (default: https)
-        * ``[server] hostname`` (required)
-        * ``[server] port`` (default: none)
-
-        Setting ``port`` to 80 does *not* imply that ``scheme`` is 'https'. If
-        ``port`` is 80 and ``scheme`` is unset, ``scheme`` will still default
-        to 'https'.
-
-        :return: A URL.
-        :rtype: str
-
-        """
-        if not self.scheme:
-            scheme = 'https'
-        else:
-            scheme = self.scheme
-        # All anticipated error cases have been handled at this point.
-        if not self.port:
-            return urlunsplit((scheme, self.hostname, '', '', ''))
-        else:
-            return urlunsplit((scheme, f'{self.hostname}:{self.port}', '', '', ''))
-
-    def get_pub_url(self):
-        """Return the pub URL of the server being tested.
-
-        The following values from the config file are used to build the URL:
-
-        * ``main.server.hostname`` (required)
-
-        :return: The pub directory URL.
-        :rtype: str
-
-        """
-        return urlunsplit(('http', self.hostname, 'pub/', '', ''))
-
-    def get_cert_rpm_url(self):
-        """Return the Katello cert RPM URL of the server being tested.
-
-        The following values from the config file are used to build the URL:
-
-        * ``main.server.hostname`` (required)
-
-        :return: The Katello cert RPM URL.
-        :rtype: str
-
-        """
-        return urljoin(self.get_pub_url(), 'katello-ca-consumer-latest.noarch.rpm')
 
 
 class BrokerSettings(FeatureSettings):

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -8,8 +8,6 @@ validators = dict(
     server=[
         Validator("server.hostname", must_exist=False),
         Validator("server.hostnames", must_exist=True, is_type_of=list),
-        Validator("server.version.release", must_exist=True),
-        Validator("server.version.source", must_exist=True),
         Validator(
             "server.xdist_behavior", must_exist=True, is_in=['run-on-one', 'balance', 'on-demand']
         ),

--- a/robottelo/utils/issue_handlers/bugzilla.py
+++ b/robottelo/utils/issue_handlers/bugzilla.py
@@ -13,6 +13,7 @@ from robottelo.constants import CLOSED_STATUSES
 from robottelo.constants import OPEN_STATUSES
 from robottelo.constants import WONTFIX_RESOLUTIONS
 from robottelo.logging import logger
+from robottelo.helpers import settingsUtils
 
 
 # match any version as in `sat-6.2.x` or `sat-6.2.0` or `6.2.9`
@@ -44,17 +45,18 @@ def is_open_bz(issue, data=None):
         return True
 
     # BZ is CLOSED with a resolution in (ERRATA, CURRENT_RELEASE, ...)
-    # server.version is higher or equal than BZ version
+    # settingsUtils.sat_version() is higher or equal than BZ version
     # Consider fixed,  BZ is not open
-    if hasattr(settings.server.version, 'release'):
-        if settings.server.version.release >= extract_min_version(bz).release:
+    version = settingsUtils.sat_version()
+    if hasattr(version, 'release'):
+        if version.release >= extract_min_version(bz).release:
             return False
-    elif settings.server.version >= extract_min_version(bz):
+    elif version >= extract_min_version(bz):
         return False
 
     # Not in OPEN_STATUSES
     # Not in Wontfix resolution
-    # server.version is lower than BZ min version
+    # settingsUtils.sat_version() is lower than BZ min version
     # fixed in next version, not backported
     # so BZ is open
     return True

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -28,7 +28,6 @@ from requests.exceptions import HTTPError
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import upload_manifest
-from robottelo.config import settings
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
@@ -37,6 +36,7 @@ from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.helpers import get_nailgun_config
+from robottelo.helpers import settingsUtils
 
 
 @filtered_datapoint
@@ -283,7 +283,7 @@ def test_positive_get_releases_status_code():
     """
     act_key = entities.ActivationKey().create()
     path = act_key.path('releases')
-    response = client.get(path, auth=settings.server.get_credentials(), verify=False)
+    response = client.get(path, auth=settingsUtils.credentials(), verify=False)
     status_code = http.client.OK
     assert status_code == response.status_code
     assert 'application/json' in response.headers['content-type']
@@ -301,7 +301,7 @@ def test_positive_get_releases_content():
     """
     act_key = entities.ActivationKey().create()
     response = client.get(
-        act_key.path('releases'), auth=settings.server.get_credentials(), verify=False
+        act_key.path('releases'), auth=settingsUtils.credentials(), verify=False
     ).json()
     assert 'results' in response.keys()
     assert type(response['results']) == list

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -41,6 +41,7 @@ from robottelo.constants.repos import CUSTOM_SWID_TAG_REPO
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
+from robottelo.helpers import settingsUtils
 
 
 @pytest.fixture(scope='module')
@@ -89,7 +90,7 @@ class TestContentViewFilter:
         """
         response = client.get(
             entities.AbstractContentViewFilter().path(),
-            auth=settings.server.get_credentials(),
+            auth=settingsUtils.credentials(),
             verify=False,
         )
         assert response.status_code == http.client.OK
@@ -109,7 +110,7 @@ class TestContentViewFilter:
         """
         response = client.get(
             entities.AbstractContentViewFilter().path(),
-            auth=settings.server.get_credentials(),
+            auth=settingsUtils.credentials(),
             verify=False,
             data={'foo': 'bar'},
         )

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -40,6 +40,7 @@ from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_hosts_list
 from robottelo.datafactory import valid_interfaces_list
+from robottelo.helpers import settingsUtils
 
 
 @pytest.mark.tier1
@@ -55,7 +56,7 @@ def test_positive_get_search():
     query = gen_string('utf8', gen_integer(1, 100))
     response = client.get(
         entities.Host().path(),
-        auth=settings.server.get_credentials(),
+        auth=settingsUtils.credentials(),
         data={'search': query},
         verify=False,
     )
@@ -77,7 +78,7 @@ def test_positive_get_per_page():
     per_page = gen_integer(1, 1000)
     response = client.get(
         entities.Host().path(),
-        auth=settings.server.get_credentials(),
+        auth=settingsUtils.credentials(),
         data={'per_page': str(per_page)},
         verify=False,
     )

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -33,6 +33,7 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_hostgroups_list
 from robottelo.helpers import get_data_file
+from robottelo.helpers import settingsUtils
 
 
 @pytest.fixture
@@ -129,7 +130,7 @@ class TestHostGroup:
         # Get puppet class id for ntp module
         response = client.get(
             environment.path('self') + '/puppetclasses',
-            auth=settings.server.get_credentials(),
+            auth=settingsUtils.credentials(),
             verify=False,
         )
         response.raise_for_status()
@@ -140,7 +141,7 @@ class TestHostGroup:
         client.post(
             hostgroup.path('self') + '/puppetclass_ids',
             data={'puppetclass_id': puppet_class_id},
-            auth=settings.server.get_credentials(),
+            auth=settingsUtils.credentials(),
             verify=False,
         ).raise_for_status()
         hostgroup_attrs = hostgroup.read_json()

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -23,11 +23,10 @@ from nailgun import client
 from nailgun import entities
 from nailgun import entity_fields
 
-from robottelo.config import settings
 from robottelo.datafactory import parametrized
 from robottelo.helpers import get_nailgun_config
 from robottelo.logging import logger
-
+from robottelo.helpers import settingsUtils
 
 VALID_ENTITIES = {
     entities.ActivationKey,
@@ -139,9 +138,7 @@ class TestEntity:
         :CaseImportance: Critical
         """
         logger.info('test_get_status_code arg: %s', entity_cls)
-        response = client.get(
-            entity_cls().path(), auth=settings.server.get_credentials(), verify=False
-        )
+        response = client.get(entity_cls().path(), auth=settingsUtils.credentials(), verify=False)
         response.raise_for_status()
         assert http.client.OK == response.status_code
         assert 'application/json' in response.headers['content-type']
@@ -263,7 +260,7 @@ class TestEntityId:
         response = client.put(
             entity_cls(id=entity_id).path(),
             entity.update_payload(),
-            auth=settings.server.get_credentials(),
+            auth=settingsUtils.credentials(),
             verify=False,
         )
         assert http.client.OK == response.status_code
@@ -337,7 +334,7 @@ class TestDoubleCheck:
         response = client.put(
             entity_cls(id=entity['id']).path(),
             new_entity.create_payload(),
-            auth=settings.server.get_credentials(),
+            auth=settingsUtils.credentials(),
             verify=False,
         )
         response.raise_for_status()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -36,6 +36,7 @@ from robottelo.constants import DEFAULT_ORG
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
+from robottelo.helpers import settingsUtils
 
 
 @filtered_datapoint
@@ -75,7 +76,7 @@ class TestOrganization:
         response = client.post(
             organization.path(),
             organization.create_payload(),
-            auth=settings.server.get_credentials(),
+            auth=settingsUtils.credentials(),
             headers={'content-type': 'text/plain'},
             verify=False,
         )

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -24,6 +24,7 @@ from nailgun.entity_mixins import TaskFailedError
 from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.helpers import add_remote_execution_ssh_key
+from robottelo.helpers import settingsUtils
 from robottelo.hosts import Satellite
 
 
@@ -121,7 +122,7 @@ def test_negative_run_capsule_upgrade_playbook_on_satellite(default_org):
     )[0]
     response = client.get(
         f'https://{sat.name}/api/job_invocations/{job.id}/hosts/{sat.id}',
-        auth=settings.server.get_credentials(),
+        auth=settingsUtils.credentials(),
         verify=False,
     )
     assert 'This playbook cannot be executed on a Satellite server.' in response.text

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -25,7 +25,7 @@ import http
 import pytest
 from nailgun import client
 
-from robottelo.config import settings
+from robottelo.helpers import settingsUtils
 
 
 @pytest.mark.tier1
@@ -42,8 +42,8 @@ def test_positive_path():
 
     :CaseImportance: Critical
     """
-    path = f'{settings.server.get_url()}/rhsm'
-    response = client.get(path, auth=settings.server.get_credentials(), verify=False)
+    path = f'{settingsUtils.server_url()}/rhsm'
+    response = client.get(path, auth=settingsUtils.credentials(), verify=False)
     assert response.status_code == http.client.OK
     assert 'application/json' in response.headers['content-type']
     assert type(response.json()) is list

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -35,7 +35,6 @@ from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import wait_for_syncplan_tasks
 from robottelo.api.utils import wait_for_tasks
-from robottelo.config import settings
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
@@ -46,6 +45,7 @@ from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_cron_expressions
 from robottelo.datafactory import valid_data_list
 from robottelo.logging import logger
+from robottelo.helpers import settingsUtils
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -129,14 +129,14 @@ def test_positive_get_routes():
     org = entities.Organization().create()
     entities.SyncPlan(organization=org).create()
     response1 = client.get(
-        f'{settings.server.get_url()}/katello/api/v2/sync_plans',
-        auth=settings.server.get_credentials(),
+        f'{settingsUtils.server_url()}/katello/api/v2/sync_plans',
+        auth=settingsUtils.credentials(),
         data={'organization_id': org.id},
         verify=False,
     )
     response2 = client.get(
-        f'{settings.server.get_url()}/katello/api/v2/organizations/{org.id}/sync_plans',
-        auth=settings.server.get_credentials(),
+        f'{settingsUtils.server_url()}/katello/api/v2/organizations/{org.id}/sync_plans',
+        auth=settingsUtils.credentials(),
         verify=False,
     )
     for response in (response1, response2):

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -33,6 +33,7 @@ from robottelo.config import settings
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import valid_data_list
 from robottelo.helpers import get_nailgun_config
+from robottelo.helpers import settingsUtils
 
 
 @pytest.fixture(scope="module")
@@ -245,7 +246,7 @@ class TestProvisioningTemplate:
         """
         response = client.post(
             entities.ProvisioningTemplate().path('build_pxe_default'),
-            auth=settings.server.get_credentials(),
+            auth=settingsUtils.credentials(),
             verify=False,
         )
         response.raise_for_status()

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -933,8 +933,8 @@ class TestAvailableURLs:
 
     @pytest.fixture(scope='class')
     def api_url(self):
-        """We want to delay referencing server.get_url() until test execution"""
-        return f'{settings.server.get_url()}/api/v2'
+        """We want to delay referencing settingUtils.server_url() until test execution"""
+        return f'{settingsUtils.server_url()}/api/v2'
 
     @pytest.mark.build_sanity
     def test_positive_get_status_code(self, api_url):
@@ -946,7 +946,7 @@ class TestAvailableURLs:
             content-type
 
         """
-        response = client.get(api_url, auth=settings.server.get_credentials(), verify=False)
+        response = client.get(api_url, auth=settingsUtils.credentials(), verify=False)
         assert response.status_code == http.client.OK
         assert 'application/json' in response.headers['content-type']
 
@@ -959,7 +959,7 @@ class TestAvailableURLs:
 
         """
         # Did the server give us any paths at all?
-        response = client.get(api_url, auth=settings.server.get_credentials(), verify=False)
+        response = client.get(api_url, auth=settingsUtils.credentials(), verify=False)
         response.raise_for_status()
         # response.json()['links'] is a dict like this:
         #


### PR DESCRIPTION
The helpers in Configs are now moved to helpers.

- Removed helper functions / methods from settings objects from both Legacy and DynaConf Settings.
- Now all settings helpers are receding in New `settingsUtils` class in `helpers.py` as Static Methods.
    - Since we are moving out of Legacy settings, all the utils are now focusing on/using the DynaConf way of reading the settings.
- Number of test files are affected by this change and all of them are updated for the above changes.

Happy Helpers !