### PR TITLE
adding tmp directory

### DIFF
--- a/tmp/example-capsule-ip.log
+++ b/tmp/example-capsule-ip.log
@@ -1,0 +1,1 @@
+sample error file


### PR DESCRIPTION
I encountered this when my capsule installation in the PR #8659  failed in PRT 127 with error `failed on setup with "FileNotFoundError: [Errno 2] No such file or directory:<virtualenv>robottelo/tmp/capsule-<ip>.log` in sat-results. The missing directory is `robottelo/tmp`. When the capsule installation failed, according to [this](https://github.com/SatelliteQE/robottelo/blob/3dd2a277701ac46467b9e97279c43db1081d5489/robottelo/hosts.py#L504) , the capsule.log should be copied over to the base testing machine.

Or am I missing something?