### PR TITLE
Fix crud infrastructure tests for 6.10

### DIFF
--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -118,7 +118,7 @@ def test_positive_end_to_end(session, rhev_data, module_org, module_loc, module_
         assert not session.computeresource.search(name)
         assert session.computeresource.search(new_name)[0]['Name'] == new_name
         session.computeresource.delete(new_name)
-        assert not session.computeresource.search(new_name)
+        assert not entities.AbstractComputeResource().search(query={'search': f'name={new_name}'})
 
 
 @pytest.mark.on_premises_provisioning

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -174,4 +174,4 @@ def test_positive_end_to_end(session, module_org, module_loc, valid_domain_name)
         assert session.domain.search(new_name)[0]['Description'] == new_name
         # Delete domain
         session.domain.delete(new_name)
-        assert not session.domain.search(new_name)
+        assert not entities.Domain().search(query={'search': f'name={new_name}'})

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -82,7 +82,7 @@ def test_positive_create_update_delete(session, module_org, module_loc):
         assert session.http_proxy.search(updated_proxy_name)[0]['Name'] == updated_proxy_name
         # Delete http_proxy
         session.http_proxy.delete(updated_proxy_name)
-        assert not session.http_proxy.search(updated_proxy_name)
+        assert not entities.HTTPProxy().search(query={'search': f'name={updated_proxy_name}'})
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
This PR fixes few issues related to new PatternFly 4 changes for Infrastructure tab in Satellite 6.10. 
I can't provide test result for http proxy test because of [bz#1966942](https://bugzilla.redhat.com/show_bug.cgi?id=1966942)
and I was not able to run computeresource test. With that said, the code change in this PR is not likely to cause any regression.

```
$ pytest tests/foreman/ui/test_domain.py -k test_positive_end_to_end 
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/jpathan/projects/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.13, services-2.2.1, cov-2.11.1, mock-3.5.1, reportportal-5.0.7, xdist-2.2.1, forked-1.3.0
collected 6 items / 5 deselected / 1 selected

tests/foreman/ui/test_domain.py .                                        [100%]

=========== 1 passed, 5 deselected, 10 warnings in 176.66s (0:02:56) ===========
```

Note: Depends on https://github.com/SatelliteQE/airgun/pull/575