### PR TITLE
vm2br_ui_test_contenthost

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2578,17 +2578,17 @@ def vm_setup_ssh_config(vm, ssh_key_name, host, user=None):
     # setup the config file
     ssh_config_file_path = f'{ssh_path}/config'
     result = vm.run(f'touch {ssh_config_file_path}')
-    if result.return_code != 0:
+    if result.status != 0:
         raise CLIFactoryError(f'Failed to create ssh config file:\n{result.stderr}')
     result = vm.run(
         'echo "\nHost {0}\n\tHostname {0}\n\tUser {1}\n'
         '\tIdentityFile {2}\n" >> {3}'.format(host, user, ssh_key_file_path, ssh_config_file_path)
     )
-    if result.return_code != 0:
+    if result.status != 0:
         raise CLIFactoryError(f'Failed to write to ssh config file:\n{result.stderr}')
     # add host entry to ssh known_hosts
     result = vm.run(f'ssh-keyscan {host} >> {ssh_path}/known_hosts')
-    if result.return_code != 0:
+    if result.status != 0:
         raise CLIFactoryError(f'Failed to put hostname in ssh known_hosts files:\n{result.stderr}')
 
 
@@ -2603,7 +2603,7 @@ def vm_upload_ssh_key(vm, source_key_path, destination_key_name):
     destination_key_path = f'/root/.ssh/{destination_key_name}'
     upload_file(local_file=source_key_path, remote_file=destination_key_path, hostname=vm.ip_addr)
     result = vm.run(f'chmod 600 {destination_key_path}')
-    if result.return_code != 0:
+    if result.status != 0:
         raise CLIFactoryError(f'Failed to chmod ssh key file:\n{result.stderr}')
 
 
@@ -2717,11 +2717,11 @@ def virt_who_hypervisor_config(
     )
     # ensure the virt-who config deploy script is executable
     result = virt_who_vm.run(f'chmod +x {temp_virt_who_deploy_file_path}')
-    if result.return_code != 0:
+    if result.status != 0:
         raise CLIFactoryError(f'Failed to set deployment script as executable:\n{result.stderr}')
     # execute the deployment script
     result = virt_who_vm.run(f'{temp_virt_who_deploy_file_path}')
-    if result.return_code != 0:
+    if result.status != 0:
         raise CLIFactoryError(f'Deployment script failure:\n{result.stderr}')
     # after this step, we should have virt-who service installed and started
     if exec_one_shot:
@@ -2729,13 +2729,13 @@ def virt_who_hypervisor_config(
         # to force a one shot report, for this we have to stop the virt-who
         # service
         result = virt_who_vm.run('service virt-who stop')
-        if result.return_code != 0:
+        if result.status != 0:
             raise CLIFactoryError(f'Failed to stop the virt-who service:\n{result.stderr}')
         result = virt_who_vm.run('virt-who --one-shot', timeout=900)
-        if result.return_code != 0:
+        if result.status != 0:
             raise CLIFactoryError(f'Failed when executing virt-who --one-shot:\n{result.stderr}')
         result = virt_who_vm.run('service virt-who start')
-        if result.return_code != 0:
+        if result.status != 0:
             raise CLIFactoryError(f'Failed to start the virt-who service:\n{result.stderr}')
     # after this step the hypervisor as a content host should be created
     # do not confuse virt-who host with hypervisor host as they can be

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -111,9 +111,6 @@ def repos_collection_for_module_streams(module_org):
 @pytest.fixture
 def vm(repos_collection, rhel7_contenthost):
     """Virtual machine registered in satellite with katello-agent installed"""
-    # with VirtualMachine(distro=repos_collection.distro) as vm:
-    #     repos_collection.setup_virtual_machine(vm)
-    #     yield vm
     repos_collection.setup_virtual_machine(rhel7_contenthost)
     yield rhel7_contenthost
 
@@ -121,12 +118,6 @@ def vm(repos_collection, rhel7_contenthost):
 @pytest.fixture
 def vm_module_streams(repos_collection_for_module_streams, rhel8_contenthost):
     """Virtual machine registered in satellite without katello-agent installed"""
-    # with VirtualMachine(distro=repos_collection_for_module_streams.distro) as vm_module_streams:
-    #     repos_collection_for_module_streams.setup_virtual_machine(
-    #         vm_module_streams, install_katello_agent=True
-    #     )
-    #     add_remote_execution_ssh_key(vm_module_streams.ip_addr)
-    #     yield vm_module_streams
     repos_collection_for_module_streams.setup_virtual_machine(
         rhel8_contenthost, install_katello_agent=True
     )

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -58,7 +58,6 @@ from robottelo.products import SatelliteToolsRepository
 from robottelo.products import YumRepository
 from robottelo.rhsso_utils import run_command
 from robottelo.virtwho_utils import create_fake_hypervisor_content
-from robottelo.vm import VirtualMachine
 
 if not setting_is_set('clients') or not setting_is_set('fake_manifest'):
     pytest.skip('skipping tests due to missing settings', allow_module_level=True)
@@ -110,22 +109,29 @@ def repos_collection_for_module_streams(module_org):
 
 
 @pytest.fixture
-def vm(repos_collection):
+def vm(repos_collection, rhel7_contenthost):
     """Virtual machine registered in satellite with katello-agent installed"""
-    with VirtualMachine(distro=repos_collection.distro) as vm:
-        repos_collection.setup_virtual_machine(vm)
-        yield vm
+    # with VirtualMachine(distro=repos_collection.distro) as vm:
+    #     repos_collection.setup_virtual_machine(vm)
+    #     yield vm
+    repos_collection.setup_virtual_machine(rhel7_contenthost)
+    yield rhel7_contenthost
 
 
 @pytest.fixture
-def vm_module_streams(repos_collection_for_module_streams):
+def vm_module_streams(repos_collection_for_module_streams, rhel8_contenthost):
     """Virtual machine registered in satellite without katello-agent installed"""
-    with VirtualMachine(distro=repos_collection_for_module_streams.distro) as vm_module_streams:
-        repos_collection_for_module_streams.setup_virtual_machine(
-            vm_module_streams, install_katello_agent=True
-        )
-        add_remote_execution_ssh_key(vm_module_streams.ip_addr)
-        yield vm_module_streams
+    # with VirtualMachine(distro=repos_collection_for_module_streams.distro) as vm_module_streams:
+    #     repos_collection_for_module_streams.setup_virtual_machine(
+    #         vm_module_streams, install_katello_agent=True
+    #     )
+    #     add_remote_execution_ssh_key(vm_module_streams.ip_addr)
+    #     yield vm_module_streams
+    repos_collection_for_module_streams.setup_virtual_machine(
+        rhel8_contenthost, install_katello_agent=True
+    )
+    add_remote_execution_ssh_key(rhel8_contenthost.ip_addr)
+    yield rhel8_contenthost
 
 
 def set_ignore_facts_for_os(value=False):
@@ -139,7 +145,7 @@ def set_ignore_facts_for_os(value=False):
 
 def run_remote_command_on_content_host(command, vm_module_streams):
     result = vm_module_streams.run(command)
-    assert result.return_code == 0
+    assert result.status == 0
     return result
 
 
@@ -156,7 +162,7 @@ def cut_lines(start_line, end_line, source_file, out_file, connection=None):
     and put them in out file."""
     connection = connection or ssh.get_connection()
     result = connection.run(
-        'sed -n "{0},{1} p" {2} < {2} > {3}'.format(start_line, end_line, source_file, out_file)
+        f'sed -n "{start_line},{end_line} p" {source_file} < {source_file} > {out_file}'
     )
     return result
 
@@ -169,7 +175,6 @@ def module_host_template(module_org, module_loc):
     return host_template
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_end_to_end(session, repos_collection, vm):
     """Create all entities required for content host, set up host, register it
@@ -185,7 +190,7 @@ def test_positive_end_to_end(session, repos_collection, vm):
     :CaseImportance: Critical
     """
     result = vm.run(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
-    assert result.return_code == 0
+    assert result.status == 0
     with session:
         # Ensure content host is searchable
         assert session.contenthost.search(vm.hostname)[0]['Name'] == vm.hostname
@@ -203,8 +208,9 @@ def test_positive_end_to_end(session, repos_collection, vm):
         )
         lce_name = repos_collection.setup_content_data['lce']['name']
         assert chost['details']['lce'][lce_name][lce_name]
-        assert chost['details']['registered_by'] == 'Activation Key {}'.format(
-            repos_collection.setup_content_data['activation_key']['name']
+        assert (
+            chost['details']['registered_by']
+            == f'Activation Key {repos_collection.setup_content_data["activation_key"]["name"]}'
         )
         assert chost['provisioning_details']['name'] == vm.hostname
         assert repos_collection.custom_product['name'] in {
@@ -243,7 +249,6 @@ def test_positive_end_to_end(session, repos_collection, vm):
         assert not session.contenthost.search(vm.hostname)
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_positive_end_to_end_bulk_update(session, vm):
@@ -264,19 +269,24 @@ def test_positive_end_to_end_bulk_update(session, vm):
     hc_name = gen_string('alpha')
     description = gen_string('alpha')
     result = vm.run(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
-    assert result.return_code == 0
+    assert result.status == 0
     with session:
         # Ensure content host is searchable
         assert session.contenthost.search(vm.hostname)[0]['Name'] == vm.hostname
         # Update package using bulk action
         # use the Host Collection view to access Update Packages dialogue
         session.hostcollection.create(
-            {'name': hc_name, 'unlimited_hosts': False, 'max_hosts': 2, 'description': description}
+            {
+                'name': hc_name,
+                'unlimited_hosts': False,
+                'max_hosts': 2,
+                'description': description,
+            }
         )
         session.hostcollection.associate_host(hc_name, vm.hostname)
         # make a note of time for later CLI wait_for_tasks, and include
         # 5 mins margin of safety.
-        timestamp = (datetime.utcnow() - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M")
+        timestamp = (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%d %H:%M')
         # Update the package by name
         session.hostcollection.manage_packages(
             hc_name,
@@ -288,8 +298,8 @@ def test_positive_end_to_end_bulk_update(session, vm):
         host = entities.Host().search(query={'search': f'name={vm.hostname}'})
         wait_for_tasks(
             search_query='label = Actions::Katello::Host::UploadProfiles'
-            ' and resource_id = {}'
-            ' and started_at >= "{}"'.format(host[0].id, timestamp),
+            f' and resource_id = {host[0].id}'
+            f' and started_at >= "{timestamp}"',
             search_rate=15,
             max_tries=10,
         )
@@ -300,7 +310,6 @@ def test_positive_end_to_end_bulk_update(session, vm):
         session.contenthost.delete(vm.hostname)
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_search_by_subscription_status(session, vm):
     """Register host into the system and search for it afterwards by
@@ -334,7 +343,6 @@ def test_positive_search_by_subscription_status(session, vm):
         assert values['table'][0]['Name'] == vm.hostname
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_negative_install_package(session, vm):
     """Attempt to install non-existent package to a host remotely
@@ -356,7 +364,6 @@ def test_negative_install_package(session, vm):
         assert result['result'] == 'warning'
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_remove_package(session, vm):
@@ -378,7 +385,6 @@ def test_positive_remove_package(session, vm):
         assert not packages
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_upgrade_package(session, vm):
     """Upgrade a host package remotely
@@ -399,7 +405,6 @@ def test_positive_upgrade_package(session, vm):
         assert packages[0]['Installed Package'] == FAKE_2_CUSTOM_PACKAGE
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_install_package_group(session, vm):
@@ -421,7 +426,6 @@ def test_positive_install_package_group(session, vm):
             assert packages[0]['Installed Package'] == package
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_remove_package_group(session, vm):
     """Remove a package group from a host remotely
@@ -442,7 +446,6 @@ def test_positive_remove_package_group(session, vm):
             assert not session.contenthost.search_package(vm.hostname, package)
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_actions_katello_host_package_update_timeout(session, vm):
     """Check that Actions::Katello::Host::Package::Update task will time
@@ -501,10 +504,9 @@ def test_actions_katello_host_package_update_timeout(session, vm):
             ):
                 error_line_found = True
                 break
-    assert error_line_found, "The expected time out error was not found in logs."
+    assert error_line_found, 'The expected time out error was not found in logs.'
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_search_errata_non_admin(session, vm, module_org, test_name, default_viewer_role):
     """Search for host's errata by non-admin user with enough permissions
@@ -528,7 +530,6 @@ def test_positive_search_errata_non_admin(session, vm, module_org, test_name, de
         assert FAKE_2_ERRATA_ID in {errata['Id'] for errata in chost['errata']['table']}
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_ensure_errata_applicability_with_host_reregistered(session, vm):
@@ -558,19 +559,18 @@ def test_positive_ensure_errata_applicability_with_host_reregistered(session, vm
     """
     vm.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     result = vm.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
-    assert result.return_code == 0
+    assert result.status == 0
     result = vm.run('subscription-manager refresh  && yum repolist')
-    assert result.return_code == 0
+    assert result.status == 0
     with session:
         chost = session.contenthost.read(vm.hostname, widget_names='errata')
         assert FAKE_2_ERRATA_ID in {errata['Id'] for errata in chost['errata']['table']}
         result = vm.run('subscription-manager refresh  && yum repolist')
-        assert result.return_code == 0
+        assert result.status == 0
         chost = session.contenthost.read(vm.hostname, widget_names='errata')
         assert FAKE_2_ERRATA_ID in {errata['Id'] for errata in chost['errata']['table']}
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_positive_host_re_registion_with_host_rename(session, module_org, repos_collection, vm):
     """Ensure that content host should get re-registered after change in the hostname
@@ -595,21 +595,20 @@ def test_positive_host_re_registion_with_host_rename(session, module_org, repos_
     """
     vm.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     result = vm.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
-    assert result.return_code == 0
+    assert result.status == 0
     vm.unregister()
-    updated_hostname = '{}.{}'.format(gen_string('alpha'), vm.hostname).lower()
+    updated_hostname = f'{gen_string("alpha")}.{vm.hostname}'.lower()
     vm.run(f'hostnamectl set-hostname {updated_hostname}')
-    assert result.return_code == 0
+    assert result.status == 0
     vm.register_contenthost(
         module_org.name,
         activation_key=repos_collection.setup_content_data['activation_key']['name'],
     )
-    assert result.return_code == 0
+    assert result.status == 0
     with session:
         assert session.contenthost.search(updated_hostname)[0]['Name'] == updated_hostname
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 @pytest.mark.upgrade
@@ -645,7 +644,7 @@ def test_positive_check_ignore_facts_os_setting(session, vm, module_org, request
     """
     major = str(gen_integer(15, 99))
     minor = str(gen_integer(1, 9))
-    expected_os = f"RedHat {major}.{minor}"
+    expected_os = f'RedHat {major}.{minor}'
     set_ignore_facts_for_os(False)
     host = (
         entities.Host()
@@ -666,7 +665,7 @@ def test_positive_check_ignore_facts_os_setting(session, vm, module_org, request
         facts['operatingsystem'] = 'RedHat'
         facts['osfamily'] = 'RedHat'
         facts['operatingsystemmajrelease'] = major
-        facts['operatingsystemrelease'] = f"{major}.{minor}"
+        facts['operatingsystemrelease'] = f'{major}.{minor}'
         host.upload_facts(data={'name': vm.hostname, 'facts': facts})
         session.contenthost.search('')
         updated_os = session.contenthost.read(vm.hostname, widget_names='details')['details']['os']
@@ -686,9 +685,8 @@ def test_positive_check_ignore_facts_os_setting(session, vm, module_org, request
 
 @pytest.mark.skip_if_not_set('clients', 'fake_manifest', 'compute_resources')
 @pytest.mark.tier3
-@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
-def test_positive_virt_who_hypervisor_subscription_status(session):
+def test_positive_virt_who_hypervisor_subscription_status(session, rhel7_contenthost):
     """Check that virt-who hypervisor shows the right subscription status
     without and with attached subscription.
 
@@ -720,47 +718,37 @@ def test_positive_virt_who_hypervisor_subscription_status(session):
             'hypervisor-username': 'root',
         }
     )
-    # create a virtual machine to host virt-who service
-    with VirtualMachine() as virt_who_vm:
-        # configure virtual machine and setup virt-who service
-        # do not supply subscription to attach to virt_who hypervisor
-        virt_who_data = virt_who_hypervisor_config(
-            virt_who_config['general-information']['id'],
-            virt_who_vm,
-            org_id=org.id,
-            lce_id=lce.id,
-            hypervisor_hostname=provisioning_server,
-            configure_ssh=True,
+    # use broker virtual machine to host virt-who service
+    # configure virtual machine and setup virt-who service
+    # do not supply subscription to attach to virt_who hypervisor
+    virt_who_data = virt_who_hypervisor_config(
+        virt_who_config['general-information']['id'],
+        rhel7_contenthost,
+        org_id=org.id,
+        lce_id=lce.id,
+        hypervisor_hostname=provisioning_server,
+        configure_ssh=True,
+    )
+    virt_who_hypervisor_host = virt_who_data['virt_who_hypervisor_host']
+    with session:
+        session.organization.select(org.name)
+        assert (
+            session.contenthost.search(virt_who_hypervisor_host['name'])[0]['Subscription Status']
+            == 'yellow'
         )
-        virt_who_hypervisor_host = virt_who_data['virt_who_hypervisor_host']
-        with session:
-            session.organization.select(org.name)
-            assert (
-                session.contenthost.search(virt_who_hypervisor_host['name'])[0][
-                    'Subscription Status'
-                ]
-                == 'yellow'
-            )
-            chost = session.contenthost.read(
-                virt_who_hypervisor_host['name'], widget_names='details'
-            )
-            assert chost['details']['subscription_status'] == 'Unsubscribed hypervisor'
-            session.contenthost.add_subscription(
-                virt_who_hypervisor_host['name'], VDC_SUBSCRIPTION_NAME
-            )
-            assert (
-                session.contenthost.search(virt_who_hypervisor_host['name'])[0][
-                    'Subscription Status'
-                ]
-                == 'green'
-            )
-            chost = session.contenthost.read(
-                virt_who_hypervisor_host['name'], widget_names='details'
-            )
-            assert chost['details']['subscription_status'] == 'Fully entitled'
+        chost = session.contenthost.read(virt_who_hypervisor_host['name'], widget_names='details')
+        assert chost['details']['subscription_status'] == 'Unsubscribed hypervisor'
+        session.contenthost.add_subscription(
+            virt_who_hypervisor_host['name'], VDC_SUBSCRIPTION_NAME
+        )
+        assert (
+            session.contenthost.search(virt_who_hypervisor_host['name'])[0]['Subscription Status']
+            == 'green'
+        )
+        chost = session.contenthost.read(virt_who_hypervisor_host['name'], widget_names='details')
+        assert chost['details']['subscription_status'] == 'Fully entitled'
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_module_stream_actions_on_content_host(session, vm_module_streams):
@@ -774,7 +762,7 @@ def test_module_stream_actions_on_content_host(session, vm_module_streams):
 
     :CaseLevel: System
     """
-    stream_version = "5.21"
+    stream_version = '5.21'
     run_remote_command_on_content_host('dnf -y upload-profile', vm_module_streams)
     with session:
         entities.Parameter(
@@ -783,7 +771,7 @@ def test_module_stream_actions_on_content_host(session, vm_module_streams):
         # install Module Stream
         result = session.contenthost.execute_module_stream_action(
             vm_module_streams.hostname,
-            action_type="Install",
+            action_type='Install',
             module_name=FAKE_2_CUSTOM_PACKAGE_NAME,
             stream_version=stream_version,
         )
@@ -801,7 +789,7 @@ def test_module_stream_actions_on_content_host(session, vm_module_streams):
         # remove Module Stream
         result = session.contenthost.execute_module_stream_action(
             vm_module_streams.hostname,
-            action_type="Remove",
+            action_type='Remove',
             module_name=FAKE_2_CUSTOM_PACKAGE_NAME,
             stream_version=stream_version,
         )
@@ -820,7 +808,7 @@ def test_module_stream_actions_on_content_host(session, vm_module_streams):
         )
         assert module_stream[0]['Name'] == FAKE_2_CUSTOM_PACKAGE_NAME
         assert module_stream[0]['Stream'] == stream_version
-        assert module_stream[0]['Status'] == "Enabled"
+        assert module_stream[0]['Status'] == 'Enabled'
 
         # disable Module Stream
         result = session.contenthost.execute_module_stream_action(
@@ -838,7 +826,7 @@ def test_module_stream_actions_on_content_host(session, vm_module_streams):
         )
         assert module_stream[0]['Name'] == FAKE_2_CUSTOM_PACKAGE_NAME
         assert module_stream[0]['Stream'] == stream_version
-        assert module_stream[0]['Status'] == "Disabled"
+        assert module_stream[0]['Status'] == 'Disabled'
 
         # reset Module Stream
         result = session.contenthost.execute_module_stream_action(
@@ -862,10 +850,9 @@ def test_module_stream_actions_on_content_host(session, vm_module_streams):
         )
         assert module_stream[0]['Name'] == FAKE_2_CUSTOM_PACKAGE_NAME
         assert module_stream[0]['Stream'] == stream_version
-        assert module_stream[0]['Status'] == ""
+        assert module_stream[0]['Status'] == ''
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_module_streams_customize_action(session, vm_module_streams):
     """Check remote execution for customized module action is working on content host.
@@ -879,8 +866,8 @@ def test_module_streams_customize_action(session, vm_module_streams):
     :CaseImportance: Medium
     """
     with session:
-        search_stream_version = "5.21"
-        install_stream_version = "0.71"
+        search_stream_version = '5.21'
+        install_stream_version = '0.71'
         run_remote_command_on_content_host('dnf -y upload-profile', vm_module_streams)
         run_remote_command_on_content_host(
             f'dnf module reset {FAKE_2_CUSTOM_PACKAGE_NAME} -y', vm_module_streams
@@ -891,8 +878,8 @@ def test_module_streams_customize_action(session, vm_module_streams):
 
         # installing walrus:0.71 version
         customize_values = {
-            'template_content.module_spec': '{}:{}'.format(
-                FAKE_2_CUSTOM_PACKAGE_NAME, install_stream_version
+            'template_content.module_spec': (
+                f'{FAKE_2_CUSTOM_PACKAGE_NAME}:{install_stream_version}'
             )
         }
         # run customize action on module streams
@@ -915,7 +902,6 @@ def test_module_streams_customize_action(session, vm_module_streams):
         assert module_stream[0]['Stream'] == install_stream_version
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_install_modular_errata(session, vm_module_streams):
@@ -928,8 +914,8 @@ def test_install_modular_errata(session, vm_module_streams):
     :CaseLevel: System
     """
     with session:
-        stream_version = "0"
-        module_name = "kangaroo"
+        stream_version = '0'
+        module_name = 'kangaroo'
         run_remote_command_on_content_host('dnf -y upload-profile', vm_module_streams)
         result = session.contenthost.execute_module_stream_action(
             vm_module_streams.hostname,
@@ -981,7 +967,6 @@ def test_install_modular_errata(session, vm_module_streams):
         assert module_stream[0]['Name'] == module_name
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_module_status_update_from_content_host_to_satellite(session, vm_module_streams):
     """Verify dnf upload-profile updates the module stream status to Satellite.
@@ -993,9 +978,9 @@ def test_module_status_update_from_content_host_to_satellite(session, vm_module_
     :CaseLevel: System
     """
     with session:
-        module_name = "walrus"
-        stream_version = "0.71"
-        profile = "flipper"
+        module_name = 'walrus'
+        stream_version = '0.71'
+        profile = 'flipper'
         run_remote_command_on_content_host('dnf -y upload-profile', vm_module_streams)
 
         # reset walrus module streams
@@ -1030,7 +1015,6 @@ def test_module_status_update_from_content_host_to_satellite(session, vm_module_
         )
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.tier3
 def test_module_status_update_without_force_upload_package_profile(session, vm, vm_module_streams):
     """Verify you do not have to run dnf upload-profile or restart rhsmcertd
@@ -1047,14 +1031,14 @@ def test_module_status_update_without_force_upload_package_profile(session, vm, 
     with session:
         # Ensure content host is searchable
         assert session.contenthost.search(vm.hostname)[0]['Name'] == vm.hostname
-        module_name = "walrus"
-        stream_version = "0.71"
-        profile = "flipper"
+        module_name = 'walrus'
+        stream_version = '0.71'
+        profile = 'flipper'
         # reset walrus module streams
         run_remote_command_on_content_host(f'dnf module reset {module_name} -y', vm_module_streams)
         # make a note of time for later CLI wait_for_tasks, and include
         # 5 mins margin of safety.
-        timestamp = (datetime.utcnow() - timedelta(minutes=5)).strftime("%Y-%m-%d %H:%M")
+        timestamp = (datetime.utcnow() - timedelta(minutes=5)).strftime('%Y-%m-%d %H:%M')
         # install walrus module stream with flipper profile
         run_remote_command_on_content_host(
             f'dnf module install {module_name}:{stream_version}/{profile} -y',
@@ -1064,8 +1048,8 @@ def test_module_status_update_without_force_upload_package_profile(session, vm, 
         host = entities.Host().search(query={'search': f'name={vm.hostname}'})
         wait_for_tasks(
             search_query='label = Actions::Katello::Host::UploadProfiles'
-            ' and resource_id = {}'
-            ' and started_at >= "{}"'.format(host[0].id, timestamp),
+            f' and resource_id = {host[0].id}'
+            f' and started_at >= "{timestamp}"',
             search_rate=15,
             max_tries=10,
         )
@@ -1093,7 +1077,6 @@ def test_module_status_update_without_force_upload_package_profile(session, vm, 
         )
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_module_stream_update_from_satellite(session, vm_module_streams):
@@ -1106,8 +1089,8 @@ def test_module_stream_update_from_satellite(session, vm_module_streams):
     :CaseLevel: System
     """
     with session:
-        module_name = "duck"
-        stream_version = "0"
+        module_name = 'duck'
+        stream_version = '0'
         run_remote_command_on_content_host('dnf -y upload-profile', vm_module_streams)
         # reset duck module
         run_remote_command_on_content_host(f'dnf module reset {module_name} -y', vm_module_streams)
@@ -1128,7 +1111,7 @@ def test_module_stream_update_from_satellite(session, vm_module_streams):
         )
         assert module_stream[0]['Name'] == module_name
         assert module_stream[0]['Stream'] == stream_version
-        assert module_stream[0]['Status'] == "Enabled"
+        assert module_stream[0]['Status'] == 'Enabled'
 
         # install module stream and downgrade it to generate the errata
         run_remote_command_on_content_host(
@@ -1154,7 +1137,6 @@ def test_module_stream_update_from_satellite(session, vm_module_streams):
         )
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_syspurpose_attributes_empty(session, vm_module_streams):
@@ -1175,12 +1157,11 @@ def test_syspurpose_attributes_empty(session, vm_module_streams):
             'details'
         ]
         syspurpose_status = details['system_purpose_status']
-        assert syspurpose_status.lower() == "not specified"
+        assert syspurpose_status.lower() == 'not specified'
         for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
             assert details[spname] == ''
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_set_syspurpose_attributes_cli(session, vm_module_streams):
@@ -1199,7 +1180,7 @@ def test_set_syspurpose_attributes_cli(session, vm_module_streams):
         # Set sypurpose attributes
         for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
             run_remote_command_on_content_host(
-                'syspurpose set-{} "{}"'.format(*spdata), vm_module_streams
+                f'syspurpose set-{spdata[0]} "{spdata[1]}"', vm_module_streams
             )
 
         details = session.contenthost.read(vm_module_streams.hostname, widget_names='details')[
@@ -1209,7 +1190,6 @@ def test_set_syspurpose_attributes_cli(session, vm_module_streams):
             assert details[spname] == spdata[1]
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_unset_syspurpose_attributes_cli(session, vm_module_streams):
@@ -1228,13 +1208,11 @@ def test_unset_syspurpose_attributes_cli(session, vm_module_streams):
     # Set sypurpose attributes...
     for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
         run_remote_command_on_content_host(
-            'syspurpose set-{} "{}"'.format(*spdata), vm_module_streams
+            f'syspurpose set-{spdata[0]} "{spdata[1]}"', vm_module_streams
         )
     for spname, spdata in DEFAULT_SYSPURPOSE_ATTRIBUTES.items():
         # ...and unset them.
-        run_remote_command_on_content_host(
-            'syspurpose unset-{}'.format(*spdata), vm_module_streams
-        )
+        run_remote_command_on_content_host(f'syspurpose unset-{spdata[0]}', vm_module_streams)
 
     with session:
         details = session.contenthost.read(vm_module_streams.hostname, widget_names='details')[
@@ -1244,7 +1222,6 @@ def test_unset_syspurpose_attributes_cli(session, vm_module_streams):
             assert details[spname] == ''
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_syspurpose_matched(session, vm_module_streams):
@@ -1262,15 +1239,14 @@ def test_syspurpose_matched(session, vm_module_streams):
     :CaseImportance: High
     """
     run_remote_command_on_content_host('syspurpose set-sla Premium', vm_module_streams)
-    run_remote_command_on_content_host("subscription-manager attach --auto", vm_module_streams)
+    run_remote_command_on_content_host('subscription-manager attach --auto', vm_module_streams)
     with session:
         details = session.contenthost.read(vm_module_streams.hostname, widget_names='details')[
             'details'
         ]
-        assert details['system_purpose_status'] == "Matched"
+        assert details['system_purpose_status'] == 'Matched'
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_syspurpose_bulk_action(session, vm):
@@ -1301,7 +1277,6 @@ def test_syspurpose_bulk_action(session, vm):
             assert val in result.stdout
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.skip_if_not_set('clients', 'fake_manifest')
 @pytest.mark.tier3
 def test_syspurpose_mismatched(session, vm_module_streams):
@@ -1325,7 +1300,7 @@ def test_syspurpose_mismatched(session, vm_module_streams):
         details = session.contenthost.read(vm_module_streams.hostname, widget_names='details')[
             'details'
         ]
-        assert details['system_purpose_status'] == "Mismatched"
+        assert details['system_purpose_status'] == 'Mismatched'
 
 
 @pytest.mark.tier3
@@ -1367,11 +1342,11 @@ def test_pagination_multiple_hosts_multiple_pages(session, module_host_template)
     with session(url=start_url):
         # Search for all the hosts by os. This uses pagination to get more than one page.
         all_fake_hosts_found = session.contenthost.search(
-            f"os = {module_host_template.operatingsystem.name}"
+            f'os = {module_host_template.operatingsystem.name}'
         )
         # Assert dump of fake hosts found includes the higest numbered host created for this test
         match = re.search(fr'test-{host_num:0>2}', str(all_fake_hosts_found))
-        assert match, "Highest numbered host not found."
+        assert match, 'Highest numbered host not found.'
         # Get all the pagination values
         pagination_values = session.contenthost.read_all('Pagination')['Pagination']
         # Assert total pages reported is greater than one page of hosts
@@ -1400,21 +1375,20 @@ def test_search_for_virt_who_hypervisors(session):
     org = entities.Organization().create()
     with session:
         session.organization.select(org.name)
-        assert not session.contenthost.search("hypervisor = true")
+        assert not session.contenthost.search('hypervisor = true')
         # create virt-who hypervisor through the fake json conf
         data = create_fake_hypervisor_content(org.label, hypervisors=1, guests=1)
         hypervisor_name = data['hypervisors'][0]['hypervisorId']
-        hypervisor_display_name = f"virt-who-{hypervisor_name}-{org.id}"
+        hypervisor_display_name = f'virt-who-{hypervisor_name}-{org.id}'
         # Search with hypervisor=True gives the correct result.
         assert (
-            session.contenthost.search("hypervisor = true")[0]['Name']
+            session.contenthost.search('hypervisor = true')[0]['Name']
         ) == hypervisor_display_name
         # Search with hypervisor=false gives the correct result.
-        content_hosts = [host['Name'] for host in session.contenthost.search("hypervisor = false")]
+        content_hosts = [host['Name'] for host in session.contenthost.search('hypervisor = false')]
         assert hypervisor_display_name not in content_hosts
 
 
-@pytest.mark.libvirt_content_host
 @pytest.mark.destructive
 @pytest.mark.run_in_one_thread
 @pytest.mark.upgrade
@@ -1434,9 +1408,9 @@ def test_content_access_after_stopped_foreman(session, vm, foreman_service_teard
     :Assignee: lpramuk
     """
     result = vm.run(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
-    assert result.return_code == 0
+    assert result.status == 0
     run_command('systemctl stop foreman')
     result = ssh.command('foreman-maintain service status --only=foreman')
     assert result.return_code == 1
     result = vm.run(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
-    assert result.return_code == 0
+    assert result.status == 0


### PR DESCRIPTION

- vm2br conversion
- return_code -> status
- double quotes -> single quotes  (I skipped it in comments)
- .format() -> f'strings
- rhel7 and rhel8 content host
- robottelo factory changed return_code -> status, but I hope from now it will be used only with broker vm

test results (all the contenthost tests if not mentioned otherwise): 
before the change:
```
=========================== short test summary info ============================
FAILED tests/foreman/ui/test_contenthost.py::test_positive_end_to_end_bulk_update
FAILED tests/foreman/ui/test_contenthost.py::test_syspurpose_bulk_action - Va...
FAILED tests/foreman/ui/test_contenthost.py::test_pagination_multiple_hosts_multiple_pages
FAILED tests/foreman/ui/test_contenthost.py::test_content_access_after_stopped_foreman
============ 4 failed, 25 passed, 41 warnings in 7880.79s (2:11:20) ============
```

1 run (no rhel8 defined in my broker) :
```
=========================== short test summary info ============================
FAILED tests/foreman/ui/test_contenthost.py::test_syspurpose_bulk_action - Va...
FAILED tests/foreman/ui/test_contenthost.py::test_pagination_multiple_hosts_multiple_pages
ERROR tests/foreman/ui/test_contenthost.py::test_module_stream_actions_on_content_host
ERROR tests/foreman/ui/test_contenthost.py::test_module_streams_customize_action
ERROR tests/foreman/ui/test_contenthost.py::test_install_modular_errata - Exc...
ERROR tests/foreman/ui/test_contenthost.py::test_module_status_update_from_content_host_to_satellite
ERROR tests/foreman/ui/test_contenthost.py::test_module_status_update_without_force_upload_package_profile
ERROR tests/foreman/ui/test_contenthost.py::test_module_stream_update_from_satellite
ERROR tests/foreman/ui/test_contenthost.py::test_syspurpose_attributes_empty
ERROR tests/foreman/ui/test_contenthost.py::test_set_syspurpose_attributes_cli
ERROR tests/foreman/ui/test_contenthost.py::test_unset_syspurpose_attributes_cli
ERROR tests/foreman/ui/test_contenthost.py::test_syspurpose_matched - Excepti...
ERROR tests/foreman/ui/test_contenthost.py::test_syspurpose_mismatched - Exce...
====== 2 failed, 16 passed, 17 warnings, 11 errors in 8938.53s (2:28:58) =======
```
I made a rerun of all 2 failed + 11 error tests = 13 tests.
2. (1. rerun)  with rhel8 
```
============================== short test summary info ==============================
FAILED tests/foreman/ui/test_contenthost.py::test_syspurpose_bulk_action - ValueEr...
FAILED tests/foreman/ui/test_contenthost.py::test_pagination_multiple_hosts_multiple_pages
FAILED tests/foreman/ui/test_contenthost.py::test_module_status_update_without_force_upload_package_profile
============== 3 failed, 10 passed, 11 warnings in 7607.04s (2:06:47) ===============
```

3. (2. rerun) of just `test_module_status_update_without_force_upload_package_profile`
```
tests/foreman/ui/test_contenthost.py::test_module_status_update_without_force_upload_package_profile
========== 1 passed, 28 deselected, 3 warnings in 1819.98s (0:30:19) ===========
```

`test_syspurpose_bulk_action` and `test_pagination_multiple_hosts_multiple_pages` were and are failing 
otherwise it should be fine