### PR TITLE
Add test install applicable package to a registerd host

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1328,9 +1328,9 @@ def new_module_ak(module_manifest_org, rh_repo_module_manifest, default_lce):
 
 
 @pytest.fixture
-def chost(module_manifest_org, rhel77_contenthost_module, new_module_ak):
+def errata_host(module_manifest_org, rhel77_contenthost_module, new_module_ak):
     """A RHEL77 Content Host that has applicable errata and registered to Library"""
-    # python-psutil is obsoleted by python2-psutil, so install older python2-psutil for errata test
+    # python-psutil is obsoleted by python2-psutil, so get older python2-psutil for errata test
     rhel77_contenthost_module.run(f'rpm -Uvh {EPEL_REPO}/python2-psutil-5.6.7-1.el7.x86_64.rpm')
     rhel77_contenthost_module.install_katello_ca()
     rhel77_contenthost_module.register_contenthost(module_manifest_org.label, new_module_ak.name)
@@ -1339,8 +1339,18 @@ def chost(module_manifest_org, rhel77_contenthost_module, new_module_ak):
     return rhel77_contenthost_module
 
 
+@pytest.fixture
+def chost(module_manifest_org, rhel77_contenthost_module, new_module_ak):
+    """A RHEL77 Content Host registered to Library that does not have applicable errata"""
+    rhel77_contenthost_module.install_katello_ca()
+    rhel77_contenthost_module.register_contenthost(module_manifest_org.label, new_module_ak.name)
+    assert rhel77_contenthost_module.nailgun_host.read_json()['subscription_status'] == 0
+    rhel77_contenthost_module.install_katello_host_tools()
+    return rhel77_contenthost_module
+
+
 @pytest.mark.tier2
-def test_apply_errata_using_default_content_view(chost):
+def test_apply_errata_using_default_content_view(errata_host):
     """Updating an applicable errata on a host attached to the default content view
      causes the errata to not be applicable.
 
@@ -1357,30 +1367,30 @@ def test_apply_errata_using_default_content_view(chost):
     :CaseImportance: High
     """
     # check that package errata is applicable
-    erratum = Host.errata_list({'host': chost.hostname, 'search': f'id = {REAL_0_ERRATA_ID}'})
+    erratum = Host.errata_list({'host': errata_host.hostname, 'search': f'id = {REAL_0_ERRATA_ID}'})
     assert len(erratum) == 1
     assert erratum[0]['installable'] == 'true'
     # note time for later wait_for_tasks include 2 mins margin of safety.
     timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
     # Update errata from Library, i.e. Default CV
-    chost.run(f'yum -y update --advisory {REAL_0_ERRATA_ID}')
+    errata_host.run(f'yum -y update --advisory {REAL_0_ERRATA_ID}')
     # Wait for upload profile event (in case Satellite system slow)
     wait_for_tasks(
         search_query=(
             'label = Actions::Katello::Host::UploadProfiles'
-            f' and resource_id = {chost.nailgun_host.id}'
+            f' and resource_id = {errata_host.nailgun_host.id}'
             f' and started_at >= "{timestamp}"'
         ),
         search_rate=15,
         max_tries=10,
     )
-    # Assert that the eratum is no longer applicable
-    erratum = Host.errata_list({'host': chost.hostname, 'search': f'id = {REAL_0_ERRATA_ID}'})
+    # Assert that the erratum is no longer applicable
+    erratum = Host.errata_list({'host': errata_host.hostname, 'search': f'id = {REAL_0_ERRATA_ID}'})
     assert len(erratum) == 0
 
 
 @pytest.mark.tier2
-def test_update_applicable_package_using_default_content_view(chost):
+def test_update_applicable_package_using_default_content_view(errata_host):
     """Updating an applicable package on a host attached to the default content view causes the
     package to not be applicable or installable.
 
@@ -1400,7 +1410,7 @@ def test_update_applicable_package_using_default_content_view(chost):
     # check that package is applicable
     applicable_packages = Package.list(
         {
-            'host-id': chost.nailgun_host.id,
+            'host-id': errata_host.nailgun_host.id,
             'packages-restrict-applicable': 'true',
             'search': f'name={REAL_RHEL7_0_2_PACKAGE_NAME}',
         }
@@ -1410,12 +1420,12 @@ def test_update_applicable_package_using_default_content_view(chost):
     # note time for later wait_for_tasks include 2 mins margin of safety.
     timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
     # Update package from Library, i.e. Default CV
-    chost.run(f'yum -y update {REAL_RHEL7_0_2_PACKAGE_NAME}')
+    errata_host.run(f'yum -y update {REAL_RHEL7_0_2_PACKAGE_NAME}')
     # Wait for upload profile event (in case Satellite system slow)
     wait_for_tasks(
         search_query=(
             'label = Actions::Katello::Host::UploadProfiles'
-            f' and resource_id = {chost.nailgun_host.id}'
+            f' and resource_id = {errata_host.nailgun_host.id}'
             f' and started_at >= "{timestamp}"'
         ),
         search_rate=15,
@@ -1424,7 +1434,7 @@ def test_update_applicable_package_using_default_content_view(chost):
     # Assert that the package is no longer applicable
     applicable_packages = Package.list(
         {
-            'host-id': chost.nailgun_host.id,
+            'host-id': errata_host.nailgun_host.id,
             'packages-restrict-applicable': 'true',
             'search': f'name={REAL_RHEL7_0_2_PACKAGE_NAME}',
         }
@@ -1433,7 +1443,7 @@ def test_update_applicable_package_using_default_content_view(chost):
 
 
 @pytest.mark.tier2
-def test_downgrade_applicable_package_using_default_content_view(chost):
+def test_downgrade_applicable_package_using_default_content_view(errata_host):
     """Downgrading a package on a host attached to the default content view
     causes the package to become applicable and installable.
 
@@ -1452,7 +1462,61 @@ def test_downgrade_applicable_package_using_default_content_view(chost):
     :CaseImportance: High
     """
     # Update package from Library, i.e. Default CV
-    chost.run(f'yum -y update {REAL_RHEL7_0_2_PACKAGE_NAME}')
+    errata_host.run(f'yum -y update {REAL_RHEL7_0_2_PACKAGE_NAME}')
+    # Assert that the package is not applicable
+    applicable_packages = Package.list(
+        {
+            'host-id': errata_host.nailgun_host.id,
+            'packages-restrict-applicable': 'true',
+            'search': f'name={REAL_RHEL7_0_2_PACKAGE_NAME}',
+        }
+    )
+    assert len(applicable_packages) == 0
+    # note time for later wait_for_tasks include 2 mins margin of safety.
+    timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
+    # Downgrade package (we can't get it from Library, so get older one from EPEL)
+    errata_host.run(f'curl -O {EPEL_REPO}/python2-psutil-5.6.7-1.el7.x86_64.rpm')
+    errata_host.run('yum -y downgrade python2-psutil-5.6.7-1.el7.x86_64.rpm')
+    # Wait for upload profile event (in case Satellite system slow)
+    wait_for_tasks(
+        search_query=(
+            'label = Actions::Katello::Host::UploadProfiles'
+            f' and resource_id = {errata_host.nailgun_host.id}'
+            f' and started_at >= "{timestamp}"'
+        ),
+        search_rate=15,
+        max_tries=10,
+    )
+    # check that package is applicable
+    applicable_packages = Package.list(
+        {
+            'host-id': errata_host.nailgun_host.id,
+            'packages-restrict-applicable': 'true',
+            'search': f'name={REAL_RHEL7_0_2_PACKAGE_NAME}',
+        }
+    )
+    assert len(applicable_packages) == 1
+    assert REAL_RHEL7_0_2_PACKAGE_NAME in applicable_packages[0]['filename']
+
+
+@pytest.mark.tier2
+def test_install_applicable_package_to_registerd_host(chost):
+    """Installing an older package to an already registered host should show the newer package
+    and errata as applicable and installable.
+
+    :id: 519bfe91-cf86-4d6e-94ef-aaf3e5d40a81
+
+    :setup: Register a host to default org with Library
+
+    :steps:
+        1. Ensure package is not applicable
+        2. Install package that has errata
+        3. Ensure the expected package is applicable
+
+    :expectedresults: Installed package shows errata as applicable and installable
+
+    :CaseImportance: High
+    """
     # Assert that the package is not applicable
     applicable_packages = Package.list(
         {
@@ -1464,9 +1528,9 @@ def test_downgrade_applicable_package_using_default_content_view(chost):
     assert len(applicable_packages) == 0
     # note time for later wait_for_tasks include 2 mins margin of safety.
     timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
-    # Downgrade package (we can't get it from Library, so we install older one from EPEL)
+    # python-psutil is obsoleted by python2-psutil, so download older python2-psutil for this test
     chost.run(f'curl -O {EPEL_REPO}/python2-psutil-5.6.7-1.el7.x86_64.rpm')
-    chost.run('yum -y downgrade python2-psutil-5.6.7-1.el7.x86_64.rpm')
+    chost.run('yum -y install python2-psutil-5.6.7-1.el7.x86_64.rpm')
     # Wait for upload profile event (in case Satellite system slow)
     wait_for_tasks(
         search_query=(


### PR DESCRIPTION
  Pulp3 related. Requested by jsherrill

Adding a test that required the content host to not have applicable errata before registration, so I am adding a new fixture but renaming the older fixture to make it clear which has errata by default and which does not.

