### PR TITLE
Update :CaseComponent and :Assignee for API tests

### DIFF
--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -6,9 +6,9 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: AuditLog
 
-:Assignee: lhellebr
+:Assignee: rplevka
 
 :TestType: Functional
 
@@ -37,10 +37,6 @@ def test_positive_create_by_type():
     :BZ: 1426742, 1492668, 1492696
 
     :CaseImportance: Medium
-
-    :CaseComponent: AuditLog
-
-    :Assignee: rplevka
     """
     for entity_item in [
         {'entity': entities.Architecture()},
@@ -120,10 +116,6 @@ def test_positive_update_by_type():
         update event
 
     :CaseImportance: Medium
-
-    :CaseComponent: AuditLog
-
-    :Assignee: rplevka
     """
     for entity in [
         entities.Architecture(),
@@ -162,10 +154,6 @@ def test_positive_delete_by_type():
         delete event
 
     :CaseImportance: Medium
-
-    :CaseComponent: AuditLog
-
-    :Assignee: rplevka
     """
     for entity in [
         entities.Architecture(),

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -10,7 +10,7 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: ComputeResources-libvirt
 
 :Assignee: lhellebr
 

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: API
 
-:Assignee: lhellebr
+:Assignee: gtalreja
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -1,14 +1,14 @@
 """Test for Remote Execution
 
-:Requirement: Upgraded Satellite
+:Requirement: Remoteexecution
 
 :CaseAutomation: Automated
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: RemoteExecution
 
-:Assignee: lhellebr
+:Assignee: pondrejk
 
 :TestType: Functional
 

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: API
 
-:Assignee: lhellebr
+:Assignee: gtalreja
 
 :TestType: Functional
 

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -6,9 +6,9 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: API
+:CaseComponent: RemoteExecution
 
-:Assignee: lhellebr
+:Assignee: pondrejk
 
 :TestType: Functional
 


### PR DESCRIPTION
**Description:**
1. Update `:Assignee` for API tests to `gtalreja`.
2. Update some tests to use their respective components, rather than using misleading `:CaseComponent: API`.

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>