### PR TITLE
Parametrize rhel content host fixtures

### DIFF
--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -1,0 +1,10 @@
+content_host:
+    deploy_workflow: workflow-name
+    default_rhel_version: 7
+    rhel_versions:
+        - 6
+        - 7
+        - 8
+    # hardware:
+        # memory:
+        # cores:

--- a/conftest.py
+++ b/conftest.py
@@ -3,6 +3,7 @@
 pytest_plugins = [
     # Plugins
     'pytest_plugins.disable_rp_params',
+    'pytest_plugins.fixture_markers',
     'pytest_plugins.infra_dependent_markers',
     'pytest_plugins.issue_handlers',
     'pytest_plugins.logging_hooks',

--- a/pytest_fixtures/broker.py
+++ b/pytest_fixtures/broker.py
@@ -56,6 +56,20 @@ def rhel7_host():
 
 
 @pytest.fixture
+def rhel_contenthost(request):
+    """A function-level fixture that provides a content host object parametrized"""
+    # Request should be parametrized through pytest_fixtures.fixture_markers
+    # unpack params dict
+    workflow = request.param.get('workflow', settings.content_host.deploy_workflow)
+    rhel_version = request.param.get('rhel', settings.content_host.default_rhel_version)
+    # TODO: target_memory/cores, host type, other fields?
+    with VMBroker(
+        workflow=workflow, rhel_version=rhel_version, host_classes={'host': ContentHost}
+    ) as host:
+        yield host
+
+
+@pytest.fixture
 def rhel7_contenthost():
     """A function-level fixture that provides a content host object based on the rhel7 nick"""
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as host:

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -1,0 +1,15 @@
+from robottelo.config import settings
+
+
+def pytest_generate_tests(metafunc):
+    if 'rhel_contenthost' in metafunc.fixturenames:
+        rhel_parameters = [
+            dict(workflow=settings.content_host.deploy_workflow, rhel_version=ver)
+            for ver in settings.content_host.rhel_versions
+        ]
+        metafunc.parametrize(
+            'rhel_contenthost',
+            rhel_parameters,
+            ids=[f'rhel_{r["rhel_version"]}' for r in rhel_parameters],
+            indirect=True,
+        )

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -27,6 +27,11 @@ VALIDATORS = dict(
         Validator('server.ssh_username', default='root'),
         Validator('server.ssh_password', default=None),
     ],
+    content_host=[
+        Validator('content_host.rhel_versions', must_exist=True),
+        Validator('content_host.default_rhel_version', must_exist=True),
+        Validator('content_host.deploy_workflow', must_exist=True),
+    ],
     subscription=[
         Validator('subscription.rhn_username', must_exist=True),
         Validator('subscription.rhn_password', must_exist=True),

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -234,7 +234,7 @@ def test_positive_delete_manifest_as_another_user(function_org):
 
 
 @pytest.mark.tier2
-def test_positive_subscription_status_disabled(module_ak, rhel7_contenthost, module_org):
+def test_positive_subscription_status_disabled(module_ak, rhel_contenthost, module_org):
     """Verify that Content host Subscription status is set to 'Disabled'
      for a golden ticket manifest
 
@@ -248,15 +248,15 @@ def test_positive_subscription_status_disabled(module_ak, rhel7_contenthost, mod
 
     :CaseImportance: Medium
     """
-    rhel7_contenthost.install_katello_ca()
-    rhel7_contenthost.register_contenthost(module_org.label, module_ak.name)
-    assert rhel7_contenthost.subscribed
-    host_content = entities.Host(id=rhel7_contenthost.nailgun_host.id).read_raw().content
+    rhel_contenthost.install_katello_ca()
+    rhel_contenthost.register_contenthost(module_org.label, module_ak.name)
+    assert rhel_contenthost.subscribed
+    host_content = entities.Host(id=rhel_contenthost.nailgun_host.id).read_raw().content
     assert 'Simple Content Access' in str(host_content)
 
 
 @pytest.mark.tier2
-def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custom_repo):
+def test_sca_end_to_end(module_ak, rhel_contenthost, module_org, rh_repo, custom_repo):
     """Perform end to end testing for Simple Content Access Mode
 
     :id: c6c4b68c-a506-46c9-bd1d-22e4c1926ef8
@@ -268,9 +268,9 @@ def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custo
 
     :CaseImportance: Critical
     """
-    rhel7_contenthost.install_katello_ca()
-    rhel7_contenthost.register_contenthost(module_org.label, module_ak.name)
-    assert rhel7_contenthost.subscribed
+    rhel_contenthost.install_katello_ca()
+    rhel_contenthost.register_contenthost(module_org.label, module_ak.name)
+    assert rhel_contenthost.subscribed
     # Check to see if Organization is in SCA Mode
     assert entities.Organization(id=module_org.id).read().simple_content_access is True
     # Verify that you cannot attach a subscription to an activation key in SCA Mode
@@ -282,7 +282,7 @@ def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custo
     assert 'Simple Content Access' in ak_context.value.response.text
     # Verify that you cannot attach a subscription to an Host in SCA Mode
     with pytest.raises(HTTPError) as host_context:
-        entities.HostSubscription(host=rhel7_contenthost.nailgun_host.id).add_subscriptions(
+        entities.HostSubscription(host=rhel_contenthost.nailgun_host.id).add_subscriptions(
             data={'subscriptions': [{'id': subscription.id, 'quantity': 1}]}
         )
     assert 'Simple Content Access' in host_context.value.response.text
@@ -292,15 +292,15 @@ def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custo
     content_view.update(['repository'])
     content_view.publish()
     assert len(content_view.repository) == 2
-    host = rhel7_contenthost.nailgun_host
+    host = rhel_contenthost.nailgun_host
     host.content_facet_attributes = {'content_view_id': content_view.id}
     host.update(['content_facet_attributes'])
-    rhel7_contenthost.run('subscription-manager repos --enable *')
-    repos = rhel7_contenthost.run('subscription-manager refresh && yum repolist')
+    rhel_contenthost.run('subscription-manager repos --enable *')
+    repos = rhel_contenthost.run('subscription-manager refresh && yum repolist')
     assert content_view.repository[1].name in repos.stdout
     assert 'Red Hat Satellite Tools' in repos.stdout
     # install package and verify it succeeds or is already installed
-    package = rhel7_contenthost.run('yum install -y python-pulp-manifest')
+    package = rhel_contenthost.run('yum install -y python-pulp-manifest')
     assert 'Complete!' in package.stdout or 'already installed' in package.stdout
 
 


### PR DESCRIPTION
Very early draft.

We may need the complexity offered by even far more powerful parametrization driven by marks.

The ManageIQ/integration_tests project had an abstract mark parametrization, used for compute resource providers, this may turn into that instead.

https://github.com/ManageIQ/integration_tests/blob/5c9fea2b256a283700e664b31f586b2681d139b3/cfme/markers/env.py

https://github.com/ManageIQ/integration_tests/blob/5c9fea2b256a283700e664b31f586b2681d139b3/cfme/markers/env_markers/provider.py

https://github.com/ManageIQ/integration_tests/blob/5c9fea2b256a283700e664b31f586b2681d139b3/cfme/utils/testgen.py