### PR TITLE
Revert "Update pytest-reportportal to 5.0.9"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyotp==2.6.0
 pytest==6.2.4
 pytest-services==2.2.1
 pytest-mock==3.6.1
-pytest-reportportal==5.0.9
+pytest-reportportal==5.0.8
 pytest-xdist==2.2.1
 pytest-ibutsu==1.14.1
 PyYAML==5.4.1


### PR DESCRIPTION
Reverts SatelliteQE/robottelo#8677

This release included a lot more than the changelog let on, and it looks like a change to the python client introduced a ValueError when a parent item is included in the options.|

This causes the parent wrapper to go unused, with test cases added directly to the launch outside of the wrapper.

```
2021-06-10 15:44:20 - pytest_reportportal.service - DEBUG - ReportPortal - Start TestItem: request_body={'attributes': [{'value': 'tier2'}, {'key': 'component', 'value': 'ContentViews'}, {'key': 'assignee', 'value': 'ltran'}, {'key': 'importance', 'value': 'Low'}], 'name': 'tests/foreman/api/test_contentview.py::TestContentViewPublishPromote::test_negative_add_components_to_composite', 'description': 'Attempt to associate components in a non-composite content\nview\n\n:id: 60aa7a4e-df6e-407e-86c7-a4c540bda8b5\n\n:expectedresults: User cannot add components to the view\n\n:CaseLevel: Integration\n\n:CaseImportance: Low', 'start_time': '1623339860857', 'item_type': 'STEP', 'parent_item_id': '5a6a1785-eac8-42f9-b29b-d2c97a240fd2', 'code_ref': '/opt/app-root/src/robottelo/tests/foreman/api/test_contentview.py:test_negative_add_components_to_composite'}

2021-06-10 15:44:20 - reportportal_client.helpers - DEBUG - not enough values to unpack (expected 2, got 1)
```