### PR TITLE
Add stubbed test cases for pulp3 feature area

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1722,3 +1722,33 @@ class TestContentViewRedHatOstreeContent:
         content_view.publish()
         promote(content_view.read().version[0], module_lce.id)
         assert len(content_view.read().version[0].read().environment) == 2
+
+    @pytest.mark.stubbed
+    @pytest.mark.tier1
+    def test_positive_check_pulp3_is_installed(self):
+        """Ensure that pulp3 is installed
+
+        :id: 5d5690bf-56c7-4dba-bb09-de0f5f4861b1
+
+        :expectedresults: Pulp3 is active
+
+        :CaseLevel: System
+
+        :CaseImportance: Critical
+        """
+        pass
+
+    @pytest.mark.stubbed
+    @pytest.mark.tier1
+    def test_positive_check_pulp2_is_removed(self):
+        """Ensure that pulp2 is removed from system
+
+        :id: 4b0ebd09-e417-4c42-a437-d11db724e671
+
+        :expectedresults: Cannot log into pulp2 db
+
+        :CaseLevel: System
+
+        :CaseImportance: Critical
+        """
+        pass

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4916,3 +4916,33 @@ class TestContentViewFileRepo:
         """
         result = ssh.command('sudo -u postgres psql -d foreman -c "\\d katello_repository_rpms"')
         assert 'id|bigint' in result.stdout[3].replace(' ', '')
+
+    @pytest.mark.stubbed
+    @pytest.mark.tier1
+    def test_positive_check_pulp3_is_installed(self):
+        """Ensure that pulp3 is installed
+
+        :id: 12a3ca7d-b865-47bd-9cd1-affd3674b628
+
+        :expectedresults: Pulp3 is active
+
+        :CaseLevel: System
+
+        :CaseImportance: Critical
+        """
+        pass
+
+    @pytest.mark.stubbed
+    @pytest.mark.tier1
+    def test_positive_check_pulp2_is_removed(self):
+        """Ensure that pulp2 is removed from system
+
+        :id: c1c89433-fd7d-498a-9fc6-2fbd3e926732
+
+        :expectedresults: Cannot log into pulp2 db
+
+        :CaseLevel: System
+
+        :CaseImportance: Critical
+        """
+        pass

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -4111,3 +4111,33 @@ def test_positive_depsolve_with_module_errata(session, module_org):
             assert items['Name'] in rpm_pack
         assert result['module_streams']['table'][0]['Name'] == mod_stream
         assert result['errata']['table'][0]['Errata ID'] == FAKE_4_ERRATA_ID
+
+    @pytest.mark.stubbed
+    @pytest.mark.tier1
+    def test_positive_check_pulp3_is_installed():
+        """Ensure that pulp3 is installed
+
+        :id: 5cee7333-67de-4916-923c-f238b989f587
+
+        :expectedresults: Pulp3 is active
+
+        :CaseLevel: System
+
+        :CaseImportance: Critical
+        """
+        pass
+
+    @pytest.mark.stubbed
+    @pytest.mark.tier1
+    def test_positive_check_pulp2_is_removed():
+        """Ensure that pulp2 is removed from system
+
+        :id: e89673be-f43a-4daf-8dfa-fa86f02952be
+
+        :expectedresults: Cannot log into pulp2 db
+
+        :CaseLevel: System
+
+        :CaseImportance: Critical
+        """
+        pass


### PR DESCRIPTION
Stubbed test cases for pulp3.  I'm putting these in ContentView component for now because they're stubbed.  It feels needless to create a separate file for just pulp stubs.  If automation can be written for this in the future, then I'll transition them to a separate file specifically for pulp. 