### PR TITLE
Update host power control

### DIFF
--- a/conf/broker.yaml.template
+++ b/conf/broker.yaml.template
@@ -2,7 +2,5 @@ BROKER:
     # The path where your broker settings and inventory are located
     BROKER_DIRECTORY: "."
     HOST_WORKFLOWS:
-        POWER_CYCLE: powercycle-vm
-        # POWER_OFF:
-        # POWER_ON:
+        POWER_CONTROL: vm-power-operation
         EXTEND: extend-vm

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -32,9 +32,7 @@ from robottelo.helpers import download_gce_cert
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skip_if_not_set('http_proxy', 'gce')
-def test_positive_default_end_to_end_with_custom_profile(
-    session, module_org, module_loc, module_gce_settings
-):
+def test_positive_default_end_to_end_with_custom_profile(session, module_org, module_loc):
     """Create GCE compute resource with default properties and apply it's basic functionality.
 
     :id: 59ffd83e-a984-4c22-b91b-cad055b4fbd7


### PR DESCRIPTION
Consolidate to a single workflow for power control
Update ContentHost.power_control function behavior

The test case using this function is failing before the call to `ContentHost.power_control` is made. I've otherwise tested the function with `VmState.STOPPED`, `VmState.RUNNING`, and `reboot`. 

`tests/foreman/cli/test_contentview.py::TestContentView::test_positive_remove_cv_version_from_multi_env_capsule_scenario`