### PR TITLE
Small fix for GHA for on_push to 6.9.z

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -4,7 +4,7 @@ name: update_robottelo_image
 on:
   push:
     branches:
-      - master
+      - 6.9.z
 
 env:
     PYCURL_SSL_LIBRARY: openssl
@@ -16,6 +16,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9]
+    env:
+      SATELLITE_VERSION: 6.9
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently, on push to 6.9.z changes are being pushed to `robottelo:latest`, so that's why there is no tag for 6.9.z in quay yet.

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>