### PR TITLE
Fix syspurpose usage and role

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -1257,8 +1257,8 @@ def test_syspurpose_bulk_action(session, vm):
     """
     syspurpose_attributes = {
         'service_level': 'Standard',
-        'role': 'Production',
-        'usage_type': 'Red Hat Enterprise Linux Server',
+        'usage_type': 'Production',
+        'role': 'Red Hat Enterprise Linux Server',
     }
     with session:
         session.contenthost.bulk_set_syspurpose([vm.hostname], syspurpose_attributes)


### PR DESCRIPTION
Hello

role and usage were reversed.

You can find syspurpose defined at these two links:

https://access.redhat.com/documentation/en-us/red_hat_subscription_management/1/html/using_red_hat_subscription_management/managing_subscription_use_con#rhsm-sys-purpose-con
https://access.redhat.com/solutions/4203571