### PR TITLE
[cherry-pick] Fix positive recommend repos test

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -358,8 +358,9 @@ REPOSET = {
     'rhaht': 'Red Hat Enterprise Linux Atomic Host (Trees)',
     'rhdt7': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7 Server'),
     'rhscl7': ('Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server'),
-    'rhae2': 'Red Hat Ansible Engine 2.7 RPMs for Red Hat Enterprise Linux 7 Server',
+    'rhae2': 'Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server',
     'rhst8': 'Red Hat Satellite Tools 6.9 for RHEL 8 x86_64 (RPMs)',
+    'fdrh8': 'Fast Datapath for RHEL 8 x86_64 (RPMs)',
 }
 
 NO_REPOS_AVAILABLE = "This system has no repositories available through subscriptions."
@@ -540,9 +541,9 @@ REPOS = {
         ),
     },
     'rhae2': {
-        'id': 'rhel-7-server-ansible-2.7-rpms',
-        'name': 'Red Hat Ansible Engine 2.7 RPMs for Red Hat Enterprise Linux 7 Server x86_64',
-        'version': '2.7',
+        'id': 'rhel-7-server-ansible-2.9-rpms',
+        'name': 'Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server x86_64',
+        'version': '2.9',
         'arch': 'x86_64',
         'reposet': REPOSET['rhae2'],
         'product': PRDS['rhae'],

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -867,7 +867,8 @@ def test_positive_recommended_repos(session, module_org):
         session.organization.select(module_org.name)
         rrepos_on = session.redhatrepository.read(recommended_repo='on')
         assert REPOSET['rhel7'] in [repo['name'] for repo in rrepos_on]
-        sat_version = get_sat_version().public
+        v = get_sat_version()
+        sat_version = f'{v.major}.{v.minor}'
         cap_tool_repos = [
             repo['name']
             for repo in rrepos_on
@@ -876,7 +877,7 @@ def test_positive_recommended_repos(session, module_org):
         cap_tools_repos = [repo for repo in cap_tool_repos if repo.split()[4] != sat_version]
         assert not cap_tools_repos, 'Tools/Capsule repos do not match with Satellite version'
         rrepos_off = session.redhatrepository.read(recommended_repo='off')
-        assert REPOSET['rhae2'] in [repo['name'] for repo in rrepos_off]
+        assert REPOSET['fdrh8'] in [repo['name'] for repo in rrepos_off]
         assert len(rrepos_off) > len(rrepos_on)
 
 


### PR DESCRIPTION
  Trim sat version to two digits
  Bump Ansible to 2.9
  Reverse change from fdrh8 to rhae2

For 6.9 branch, but same commit as: https://github.com/SatelliteQE/robottelo/pull/8703