### PR TITLE
Stop using wait for sync plan tasks

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -33,7 +33,6 @@ from requests.exceptions import HTTPError
 
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import wait_for_syncplan_tasks
 from robottelo.api.utils import wait_for_tasks
 from robottelo.config import get_credentials
 from robottelo.config import get_url
@@ -70,20 +69,14 @@ def valid_sync_interval():
     return {i.replace(' ', '_'): i for i in ['hourly', 'daily', 'weekly', 'custom cron']}
 
 
-def validate_task_status(repo_id, max_tries=6, repo_backend_id=None):
-    """Wait for Pulp and foreman_tasks to complete or timeout
+def validate_task_status(repo_id, max_tries=6):
+    """Wait for foreman_tasks to complete or timeout
 
     :param repo_id: Repository Id to identify the correct task
     :param max_tries: Max tries to poll for the task creation
-    :param repo_backend_id: Backend identifier of repository to filter the
-        pulp tasks
     """
-    if repo_backend_id:
-        wait_for_syncplan_tasks(repo_backend_id)
     wait_for_tasks(
-        search_query='resource_type = Katello::Repository'
-        ' and owner.login = foreman_admin'
-        f' and resource_id = {repo_id}',
+        search_query='Actions::Katello::Repository::Sync' f' and resource_id = {repo_id}',
         max_tries=max_tries,
     )
 

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -24,7 +24,6 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo import manifests
-from robottelo.api.utils import wait_for_syncplan_tasks
 from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import CLIFactoryError
@@ -100,20 +99,15 @@ def valid_name_interval_update_tests():
     ]
 
 
-def validate_task_status(repo_id, max_tries=6, repo_name=None):
-    """Wait for Pulp and foreman_tasks to complete or timeout
+def validate_task_status(repo_id, max_tries=6):
+    """Wait for foreman_tasks to complete or timeout
 
     :param repo_id: Repository Id to identify the correct task
     :param max_tries: Max tries to poll for the task creation
-    :param repo_name: Repository name of repository to filter the
         pulp tasks
     """
-    if repo_name:
-        wait_for_syncplan_tasks(repo_name=repo_name)
     wait_for_tasks(
-        search_query='resource_type = Katello::Repository'
-        ' and owner.login = foreman_admin'
-        f' and resource_id = {repo_id}',
+        search_query='Actions::Katello::Repository::Sync' f' and resource_id = {repo_id}',
         max_tries=max_tries,
     )
 

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -24,27 +24,21 @@ import pytest
 from fauxfactory import gen_choice
 from nailgun import entities
 
-from robottelo.api.utils import wait_for_syncplan_tasks
 from robottelo.api.utils import wait_for_tasks
 from robottelo.constants import SYNC_INTERVAL
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import valid_cron_expressions
 
 
-def validate_task_status(repo_id, max_tries=10, repo_backend_id=None):
-    """Wait for Pulp and foreman_tasks to complete or timeout
+def validate_task_status(repo_id, max_tries=10):
+    """Wait for foreman_tasks to complete or timeout
 
     :param repo_id: Repository Id to identify the correct task
     :param max_tries: Max tries to poll for the task creation
-    :param repo_backend_id: Backend identifier of repository to filter the
         pulp tasks
     """
-    if repo_backend_id:
-        wait_for_syncplan_tasks(repo_backend_id)
     wait_for_tasks(
-        search_query='resource_type = Katello::Repository'
-        ' and owner.login = foreman_admin'
-        ' and resource_id = {}'.format(repo_id),
+        search_query='Actions::Katello::Repository::Sync' f' and resource_id = {repo_id}',
         max_tries=max_tries,
     )
 


### PR DESCRIPTION
  Pulp3 does not support password access so it no longer works
  Pulp3 is faster so its likely we do not need this check

As we now use multiple Satellites in test runs intermittent failures due to overloading should decrease.
If tests fail intermittently because of this change we can look to rewrite `wait_for_syncplan_tasks` to use certificate access.
