### PR TITLE
Fix test positive install modular errata

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -725,6 +725,7 @@ FAKE_3_CUSTOM_PACKAGE_NAME = 'duck'
 FAKE_4_CUSTOM_PACKAGE = 'kangaroo-0.1-1.noarch'  # for RHBA-2012:1030
 FAKE_4_CUSTOM_PACKAGE_NAME = 'kangaroo'
 FAKE_5_CUSTOM_PACKAGE = 'kangaroo-0.2-1.noarch'  # for RHBA-2012:1030
+FAKE_6_CUSTOM_PACKAGE = 'kangaroo-0.3-1.noarch'  # for RHEA-2012:0059
 REAL_0_RH_PACKAGE = 'rhevm-sdk-python-3.3.0.21-1.el6ev.noarch'
 REAL_RHEL7_0_0_PACKAGE = 'python-pulp-common-2.21.0-1.el7sat.noarch'
 REAL_RHEL7_0_0_PACKAGE_NAME = 'python-pulp-common'

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -39,7 +39,7 @@ from robottelo.constants import FAKE_2_ERRATA_ID
 from robottelo.constants import FAKE_3_CUSTOM_PACKAGE
 from robottelo.constants import FAKE_3_CUSTOM_PACKAGE_NAME
 from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_5_CUSTOM_PACKAGE
+from robottelo.constants import FAKE_6_CUSTOM_PACKAGE
 from robottelo.constants.repos import CUSTOM_MODULE_STREAM_REPO_2
 from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FAKE_6_YUM_REPO
@@ -713,18 +713,14 @@ def test_positive_install_modular_errata(
 
     :CaseLevel: System
     """
+    stream = "0"
+    version = "20180704111719"
+    _module_install_command = 'dnf -y module install {}:{}:{}'.format(
+        FAKE_4_CUSTOM_PACKAGE_NAME, stream, version
+    )
+    _run_remote_command_on_content_hosts(_module_install_command, vm_content_hosts_module_stream)
+    _run_remote_command_on_content_hosts('dnf -y upload-profile', vm_content_hosts_module_stream)
     with session:
-        stream = "0"
-        version = "20180704111719"
-        _module_install_command = 'dnf -y module install {}:{}:{}'.format(
-            FAKE_4_CUSTOM_PACKAGE_NAME, stream, version
-        )
-        _run_remote_command_on_content_hosts(
-            _module_install_command, vm_content_hosts_module_stream
-        )
-        _run_remote_command_on_content_hosts(
-            'dnf -y upload-profile', vm_content_hosts_module_stream
-        )
         result = session.hostcollection.install_errata(
             vm_host_collection_module_stream.name,
             FAKE_0_MODULAR_ERRATA_ID,
@@ -733,4 +729,4 @@ def test_positive_install_modular_errata(
         assert result['job_status'] == 'Success'
         assert result['job_status_progress'] == '100%'
         assert int(result['total_hosts']) == 2
-        assert _is_package_installed(vm_content_hosts_module_stream, FAKE_5_CUSTOM_PACKAGE)
+        assert _is_package_installed(vm_content_hosts_module_stream, FAKE_6_CUSTOM_PACKAGE)

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -715,8 +715,8 @@ def test_positive_install_modular_errata(
     """
     stream = "0"
     version = "20180704111719"
-    _module_install_command = 'dnf -y module install {}:{}:{}'.format(
-        FAKE_4_CUSTOM_PACKAGE_NAME, stream, version
+    _module_install_command = (
+        f'dnf -y module install {FAKE_4_CUSTOM_PACKAGE_NAME}:{stream}:{version}'
     )
     _run_remote_command_on_content_hosts(_module_install_command, vm_content_hosts_module_stream)
     _run_remote_command_on_content_hosts('dnf -y upload-profile', vm_content_hosts_module_stream)


### PR DESCRIPTION
  Moved setup to before session start
  Fixed fake package name conflict

test setup was taking so long that on exit, context manager clean up, selenium session had expired.
Moving setup to before session start revealed the real cause of the test fail. Hat tip to @tpapaioa for that insight.