### PR TITLE
fix `_setup_vm_client_host 6.10`

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -70,11 +70,11 @@ def module_loc(module_org):
 
 
 @pytest.fixture
-def module_vm_client_by_ip(rhel7_host, module_org, module_loc):
+def module_vm_client_by_ip(rhel7_contenthost, module_org, module_loc):
     """Setup a VM client to be used in remote execution by ip"""
-    _setup_vm_client_host(rhel7_host.host, module_org.label)
-    update_vm_host_location(rhel7_host.host, location_id=module_loc.id)
-    yield rhel7_host.host
+    _setup_vm_client_host(rhel7_contenthost, module_org.label)
+    update_vm_host_location(rhel7_contenthost, location_id=module_loc.id)
+    yield rhel7_contenthost
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
**6.10**
Updating correct fixture for vmbroker
```
(env) [akjha@akjha robottelo]$ pytest -k test_positive_run_custom_job_template_by_ip tests/foreman/ui/test_remoteexecution.py 
==================================================================== test session starts =====================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.8, forked-1.3.0, mock-3.6.1, xdist-2.3.0, cov-2.12.0, services-2.2.1, ibutsu-1.16
collected 4 items / 3 deselected / 1 selected                                                                                                                

tests/foreman/ui/test_remoteexecution.py .                                                                                                             [100%]

======================================================== 1 passed, 3 deselected in 635.36s (0:10:35) =========================================================



(env) [akjha@akjha robottelo]$ pytest -k test_positive_run_scheduled_job_template_by_ip tests/foreman/ui/test_remoteexecution.py 
==================================================================== test session starts =====================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.8, forked-1.3.0, mock-3.6.1, xdist-2.3.0, cov-2.12.0, services-2.2.1, ibutsu-1.16
collected 4 items / 3 deselected / 1 selected                                                                                                                

tests/foreman/ui/test_remoteexecution.py .                                                                                                             [100%]

======================================================== 1 passed, 3 deselected in 872.40s (0:14:32) =========================================================



(env) [akjha@akjha robottelo]$ pytest -k test_positive_run_default_job_template_by_ip tests/foreman/ui/test_remoteexecution.py 
==================================================================== test session starts =====================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.8, forked-1.3.0, mock-3.6.1, xdist-2.3.0, cov-2.12.0, services-2.2.1, ibutsu-1.16
collected 15 items / 14 deselected / 1 selected                                                                                                              

tests/foreman/ui/test_remoteexecution.py .                                                                                                             [100%]

======================================================== 1 passed, 14 deselected in 617.48s (0:10:17) ========================================================

```