### PR TITLE
workaround for puppet module for sat 6.10

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -554,7 +554,8 @@ def module_env():
 
 @pytest.fixture(scope='module')
 def module_env_search(module_org, module_location, module_import_puppet_module):
-    """Search for puppet environment created inside module_import_puppet_module.
+    """Search for puppet environment created from module_import_puppet_module fixture.
+
     Returns the puppet environment with updated organization and location.
     """
     env = (
@@ -562,9 +563,9 @@ def module_env_search(module_org, module_location, module_import_puppet_module):
         .search(query={'search': f'name={module_import_puppet_module}'})[0]
         .read()
     )
-    env.organization.append(module_org)
+    env.organization = [module_org]
     env.update(['organization'])
-    env.location.append(module_location)
+    env.location = [module_location]
     env.update(['location'])
     return env
 
@@ -586,10 +587,7 @@ def module_puppet_classes(module_env_search):
     module_import_puppet_module.
     """
     return entities.PuppetClass().search(
-        query={
-            'search': f'name ~ {"api_test_classparameters"} '
-            f'and environment = {module_env_search.name}'
-        }
+        query={'search': f'name ~ {"generic_1"} ' f'and environment = {module_env_search.name}'}
     )
 
 

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -12,9 +12,6 @@ from nailgun.client import request
 from robottelo import ssh
 from robottelo.config import get_url
 from robottelo.config import settings
-from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS
-from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS_PATH
-from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS_VERSION
 from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import DEFAULT_PTABLE
 from robottelo.constants import DEFAULT_PXE_TEMPLATE
@@ -131,38 +128,6 @@ def publish_puppet_module(puppet_modules, repo_url, organization_id=None):
     # Puppet Class entities
     cv.publish()
     return cv.read()
-
-
-def import_puppet_module(sat, puppet_module_repo=CUSTOM_PUPPET_MODULE_REPOS['generic_1']):
-    """Download, install and import puppet module. This is workaround for 6.10, there is no longer
-    content view
-
-    :param puppet_module_repo: custom puppet module repository
-    :param sat: Satellite object
-    :return: Puppet environment name,
-        environment name is likely to be searched in next steps of the test
-    """
-    if puppet_module_repo not in list(CUSTOM_PUPPET_MODULE_REPOS.values()):
-        raise ValueError(
-            f'Custom puppet module mismatch, actual custom puppet module repo: '
-            f'"{puppet_module_repo}", does not match any available puppet module: '
-            f'"{list(CUSTOM_PUPPET_MODULE_REPOS.values())}"'
-        )
-    env_name = gen_string('alpha')
-    custom_puppet_module_repo = f'{puppet_module_repo}{CUSTOM_PUPPET_MODULE_REPOS_VERSION}'
-    sat.execute(
-        f'curl -O {settings.robottelo.repos_hosting_url}{CUSTOM_PUPPET_MODULE_REPOS_PATH}'
-        f'{custom_puppet_module_repo}',
-    )
-    sat.execute(
-        f'puppet module install {custom_puppet_module_repo} '
-        f'--target-dir /etc/puppetlabs/code/environments/{env_name}/modules/'
-    )
-    smart_proxy = (
-        entities.SmartProxy().search(query={'search': f'name={settings.server.hostname}'})[0].read()
-    )
-    smart_proxy.import_puppetclasses()
-    return env_name
 
 
 def delete_puppet_class(

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -848,6 +848,20 @@ PULP_PUBLISHED_ISO_REPOS_PATH = '/var/lib/pulp/published/http/isos'
 PULP_PUBLISHED_PUPPET_REPOS_PATH = '/var/lib/pulp/published/puppet/https/repos'
 PULP_PUBLISHED_YUM_REPOS_PATH = '/var/lib/pulp/published/yum/http/repos'
 
+CUSTOM_PUPPET_MODULE_REPOS_PATH = '/custom_puppet/system/releases/r/robottelo/'
+CUSTOM_PUPPET_MODULE_REPOS = {
+    'api_test_classparameters': 'robottelo-api_test_classparameters',
+    'api_test_variables': 'robottelo-api_test_variables',
+    'cli_test_classparameters': 'robottelo-cli_test_classparameters',
+    'cli_test_variables': 'robottelo-cli_test_variables',
+    'generic_1': 'robottelo-generic_1',
+    'generic_2': 'robottelo-generic_2',
+    'generic_3': 'robottelo-generic_3',
+    'ui_test_classparameters': 'robottelo-ui_test_classparameters',
+    'ui_test_variables': 'robottelo-ui_test_variables',
+}
+CUSTOM_PUPPET_MODULE_REPOS_VERSION = '-0.2.0.tar.gz'
+
 #: All permissions exposed by the server.
 #: :mod:`tests.foreman.api.test_permission` makes use of this.
 PERMISSIONS = {

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1066,7 +1066,7 @@ def test_positive_read_enc_information(
     host_enc_parameters = host_enc_info['data']['parameters']
     assert host_enc_parameters['organization'] == module_org.name
     assert host_enc_parameters['location'] == module_location.name
-    assert host_enc_parameters['content_view'] == default_contentview.name.replace(' ', '_')
+    assert host_enc_parameters['content_view'] == default_contentview.label
     assert host_enc_parameters['lifecycle_environment'] == module_lce_library.name
     for param in host_parameters_attributes:
         assert param['name'] in host_enc_parameters

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -252,9 +252,7 @@ def test_positive_create_and_update_with_hostgroup(
 
 
 @pytest.mark.tier2
-def test_positive_create_inherit_lce_cv(
-    module_cv_with_puppet_module, module_lce_library, module_org
-):
+def test_positive_create_inherit_lce_cv(default_contentview, module_lce_library, module_org):
     """Create a host with hostgroup specified. Make sure host inherited
     hostgroup's lifecycle environment and content-view
 
@@ -268,7 +266,7 @@ def test_positive_create_inherit_lce_cv(
     :BZ: 1391656
     """
     hostgroup = entities.HostGroup(
-        content_view=module_cv_with_puppet_module,
+        content_view=default_contentview,
         lifecycle_environment=module_lce_library,
         organization=[module_org],
     ).create()
@@ -609,7 +607,7 @@ def test_positive_create_and_update_with_compute_profile(module_compute_profile)
 
 @pytest.mark.tier2
 def test_positive_create_and_update_with_content_view(
-    module_org, module_location, module_cv_with_puppet_module, module_lce_library
+    module_org, module_location, default_contentview, module_lce_library
 ):
     """Create and update host with a content view specified
 
@@ -623,19 +621,19 @@ def test_positive_create_and_update_with_content_view(
         organization=module_org,
         location=module_location,
         content_facet_attributes={
-            'content_view_id': module_cv_with_puppet_module.id,
+            'content_view_id': default_contentview.id,
             'lifecycle_environment_id': module_lce_library.id,
         },
     ).create()
-    assert host.content_facet_attributes['content_view_id'] == module_cv_with_puppet_module.id
+    assert host.content_facet_attributes['content_view_id'] == default_contentview.id
     assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce_library.id
 
     host.content_facet_attributes = {
-        'content_view_id': module_cv_with_puppet_module.id,
+        'content_view_id': default_contentview.id,
         'lifecycle_environment_id': module_lce_library.id,
     }
     host = host.update(['content_facet_attributes'])
-    assert host.content_facet_attributes['content_view_id'] == module_cv_with_puppet_module.id
+    assert host.content_facet_attributes['content_view_id'] == default_contentview.id
     assert host.content_facet_attributes['lifecycle_environment_id'] == module_lce_library.id
 
 
@@ -1028,7 +1026,7 @@ def test_positive_read_enc_information(
     module_env_search,
     module_puppet_classes,
     module_lce_library,
-    module_cv_with_puppet_module,
+    default_contentview,
 ):
     """Attempt to read host ENC information
 
@@ -1054,7 +1052,7 @@ def test_positive_read_enc_information(
         environment=module_env_search,
         puppetclass=module_puppet_classes,
         content_facet_attributes={
-            'content_view_id': module_cv_with_puppet_module.id,
+            'content_view_id': default_contentview.id,
             'lifecycle_environment_id': module_lce_library.id,
         },
         host_parameters_attributes=host_parameters_attributes,
@@ -1068,7 +1066,7 @@ def test_positive_read_enc_information(
     host_enc_parameters = host_enc_info['data']['parameters']
     assert host_enc_parameters['organization'] == module_org.name
     assert host_enc_parameters['location'] == module_location.name
-    assert host_enc_parameters['content_view'] == module_cv_with_puppet_module.name
+    assert host_enc_parameters['content_view'] == default_contentview.name.replace(' ', '_')
     assert host_enc_parameters['lifecycle_environment'] == module_lce_library.name
     for param in host_parameters_attributes:
         assert param['name'] in host_enc_parameters

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1271,8 +1271,6 @@ def test_positive_parameter_crud(function_host):
 
 
 # -------------------------- HOST PARAMETER SCENARIOS -------------------------
-
-
 @pytest.mark.host_parameter
 @pytest.mark.tier1
 def test_negative_add_parameter(function_host):

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -506,7 +506,7 @@ def test_positive_create_with_lce_and_cv(module_lce, module_org, module_promoted
 @pytest.mark.host_create
 @pytest.mark.tier1
 def test_positive_create_with_puppet_class_name(
-    module_env_search, module_org, module_puppet_classes
+    module_env_search, module_location, module_org, module_puppet_classes
 ):
     """Check if host can be created with puppet class name
 
@@ -521,6 +521,7 @@ def test_positive_create_with_puppet_class_name(
             'puppet-classes': module_puppet_classes[0].name,
             'environment': module_env_search.name,
             'organization-id': module_org.id,
+            'location-id': module_location.id,
         }
     )
     host_classes = Host.puppetclasses({'host': host['name']})
@@ -665,7 +666,9 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel7_contenthos
 
 @pytest.mark.host_create
 @pytest.mark.tier2
-def test_positive_list_scparams(module_env_search, module_org, module_puppet_classes):
+def test_positive_list_scparams(
+    module_env_search, module_location, module_org, module_puppet_classes
+):
     """List all smart class parameters using host id
 
     :id: 61814875-5ccd-4c04-a638-d36fe089d514
@@ -681,6 +684,7 @@ def test_positive_list_scparams(module_env_search, module_org, module_puppet_cla
             'puppet-classes': module_puppet_classes[0].name,
             'environment': module_env_search.name,
             'organization-id': module_org.id,
+            'location-id': module_location.id,
         }
     )
 


### PR DESCRIPTION
multiple tests are failing,  this is the first PR and other will follow. Other PR's will use `import_puppet_module` as well. With additional changes to `import_puppet_module` will be required to test also the previous tests. 

api and cli tests were fix
test results:
```
tests/foreman/api/test_host.py::test_positive_end_to_end_with_puppet_class PASSED [ 14%]
tests/foreman/api/test_host.py::test_positive_read_enc_information PASSED     [ 28%]
tests/foreman/api/test_host.py::test_positive_create_inherit_lce_cv PASSED    [ 42%]
tests/foreman/api/test_host.py::test_positive_create_and_update_with_content_view PASSED [ 57%]
tests/foreman/cli/test_host.py::test_positive_update_host_owner_and_verify_puppet_class_name PASSED [ 71%]
tests/foreman/cli/test_host.py::test_positive_create_with_puppet_class_name PASSED [ 85%]
tests/foreman/cli/test_host.py::test_positive_list_scparams PASSED            [100%]
==================== 7 passed, 58 warnings in 313.21s (0:05:13) =====================
```


From what I understand there is no reason to change any of the test mentioned in this PR  to upgrade scenarios.
- Default content view fixture is fixed.
- New method in utils `import_puppet_module` is introduced, there is a lot of hard coded text, so please do not hesitate to comment it, we can improve it ;)  This method should be used only as temporal fix in sat 6.10. 


