### PR TITLE
Automate stubbed tests related to RH cloud inventory settings

### DIFF
--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -1,7 +1,36 @@
 import pytest
 from nailgun import entities
 
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import DISTRO_RHEL8
+from robottelo.helpers import add_remote_execution_ssh_key
+
+
+@pytest.fixture(scope='module')
+def set_rh_cloud_token():
+    """A module-level fixture to set rh cloud token value."""
+    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
+        0
+    ]
+    rh_cloud_token_setting.value = settings.rh_cloud.token
+    rh_cloud_token_setting.update({'value'})
+
+
+@pytest.fixture
+def unset_set_cloud_token():
+    """A function-level fixture to unset and reset rh cloud token value."""
+    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
+        0
+    ]
+    rh_cloud_token_setting.value = ''
+    rh_cloud_token_setting.update({'value'})
+    yield
+    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
+        0
+    ]
+    rh_cloud_token_setting.value = settings.rh_cloud.token
+    rh_cloud_token_setting.update({'value'})
 
 
 @pytest.fixture(scope='module')
@@ -17,4 +46,24 @@ def organization_ak_setup(module_manifest_org):
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]
     ak.add_subscriptions(data={'quantity': 10, 'subscription_id': subscription.id})
-    return module_manifest_org, ak
+    yield module_manifest_org, ak
+    ak.delete()
+
+
+@pytest.fixture(scope='module')
+def rhel8_insights_vm(organization_ak_setup, rhel8_contenthost_module):
+    """A module-level fixture to create rhel8 content host registered with insights."""
+    org, ak = organization_ak_setup
+    rhel8_contenthost_module.configure_rhai_client(
+        activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
+    )
+    add_remote_execution_ssh_key(rhel8_contenthost_module.ip_addr)
+    yield rhel8_contenthost_module
+
+
+@pytest.fixture
+def fixable_rhel8_vm(rhel8_insights_vm):
+    """A function-level fixture to create dnf related insights recommendation for rhel8 host."""
+    rhel8_insights_vm.run('dnf update -y dnf')
+    rhel8_insights_vm.run('sed -i -e "/^best/d" /etc/dnf/dnf.conf')
+    rhel8_insights_vm.run('insights-client')

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -1,33 +1,7 @@
 import pytest
 from nailgun import entities
 
-from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import DISTRO_RHEL8
-from robottelo.helpers import add_remote_execution_ssh_key
-
-
-def setting_update(name, value):
-    """
-    change setting value
-    """
-    setting = entities.Setting().search(query={'search': f'name="{name}"'})[0]
-    setting.value = value
-    setting.update({'value'})
-
-
-@pytest.fixture(scope='module')
-def set_rh_cloud_token():
-    """A module-level fixture to set rh cloud token value."""
-    setting_update('rh_cloud_token', settings.rh_cloud.token)
-
-
-@pytest.fixture
-def unset_set_cloud_token():
-    """A function-level fixture to unset and reset rh cloud token value."""
-    setting_update('rh_cloud_token', '')
-    yield
-    setting_update('rh_cloud_token', settings.rh_cloud.token)
 
 
 @pytest.fixture(scope='module')
@@ -43,24 +17,4 @@ def organization_ak_setup(module_manifest_org):
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]
     ak.add_subscriptions(data={'quantity': 10, 'subscription_id': subscription.id})
-    yield module_manifest_org, ak
-    ak.delete()
-
-
-@pytest.fixture(scope='module')
-def rhel8_insights_vm(organization_ak_setup, rhel8_contenthost_module):
-    """A module-level fixture to create rhel8 content host registered with insights."""
-    org, ak = organization_ak_setup
-    rhel8_contenthost_module.configure_rhai_client(
-        activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
-    )
-    add_remote_execution_ssh_key(rhel8_contenthost_module.ip_addr)
-    yield rhel8_contenthost_module
-
-
-@pytest.fixture
-def fixable_rhel8_vm(rhel8_insights_vm):
-    """A function-level fixture to create dnf related insights recommendation for rhel8 host."""
-    rhel8_insights_vm.run('dnf update -y dnf')
-    rhel8_insights_vm.run('sed -i -e "/^best/d" /etc/dnf/dnf.conf')
-    rhel8_insights_vm.run('insights-client')
+    return module_manifest_org, ak

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -7,30 +7,27 @@ from robottelo.constants import DISTRO_RHEL8
 from robottelo.helpers import add_remote_execution_ssh_key
 
 
+def setting_update(name, value):
+    """
+    change setting value
+    """
+    setting = entities.Setting().search(query={'search': f'name="{name}"'})[0]
+    setting.value = value
+    setting.update({'value'})
+
+
 @pytest.fixture(scope='module')
 def set_rh_cloud_token():
     """A module-level fixture to set rh cloud token value."""
-    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
-        0
-    ]
-    rh_cloud_token_setting.value = settings.rh_cloud.token
-    rh_cloud_token_setting.update({'value'})
+    setting_update('rh_cloud_token', settings.rh_cloud.token)
 
 
 @pytest.fixture
 def unset_set_cloud_token():
     """A function-level fixture to unset and reset rh cloud token value."""
-    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
-        0
-    ]
-    rh_cloud_token_setting.value = ''
-    rh_cloud_token_setting.update({'value'})
+    setting_update('rh_cloud_token', '')
     yield
-    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
-        0
-    ]
-    rh_cloud_token_setting.value = settings.rh_cloud.token
-    rh_cloud_token_setting.update({'value'})
+    setting_update('rh_cloud_token', settings.rh_cloud.token)
 
 
 @pytest.fixture(scope='module')

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -38,6 +38,10 @@ if not os.getenv('BROKER_DIRECTORY'):
     os.environ['BROKER_DIRECTORY'] = settings.broker.get('broker_directory')
 
 
+robottelo_tmp_dir = Path(settings.robottelo.tmp_dir)
+robottelo_tmp_dir.mkdir(parents=True, exist_ok=True)
+
+
 def get_credentials():
     """Return credentials for interacting with a Foreman deployment API.
 

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -83,3 +83,19 @@ def get_remote_report_checksum(org_id):
             continue
         checksum, _ = result.stdout.split(maxsplit=1)
         return checksum
+
+
+def get_report_data(report_path):
+    """Returns hosts count from tar file.
+
+    Args:
+        tarobj: tar file to get host count from
+    """
+    tarobj = tarfile.open(report_path, mode='r')
+    for file_ in tarobj.getmembers():
+        file_name = os.path.basename(file_.name)
+        if not file_name.endswith('.json'):
+            continue
+        if file_name != 'metadata.json':
+            json_data = json.load(tarobj.extractfile(file_))
+        return json_data

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -92,11 +92,11 @@ def get_report_data(report_path):
         tarobj: tar file to get report data from
     """
     json_data = {}
-    tarobj = tarfile.open(report_path, mode='r')
-    for file_ in tarobj.getmembers():
-        file_name = os.path.basename(file_.name)
-        if not file_name.endswith('.json'):
-            continue
-        if file_name != 'metadata.json':
-            json_data = json.load(tarobj.extractfile(file_))
+    with tarfile.open(report_path, mode='r') as tarobj:
+        for file_ in tarobj.getmembers():
+            file_name = os.path.basename(file_.name)
+            if not file_name.endswith('.json'):
+                continue
+            if file_name != 'metadata.json':
+                json_data = json.load(tarobj.extractfile(file_))
     return json_data

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -1,8 +1,8 @@
 """Utility module for RH cloud inventory tests"""
 import hashlib
 import json
-import os
 import tarfile
+from pathlib import Path
 
 from robottelo import ssh
 
@@ -16,7 +16,7 @@ def get_host_counts(tarobj):
     metadata_counts = {}
     slices_counts = {}
     for file_ in tarobj.getmembers():
-        file_name = os.path.basename(file_.name)
+        file_name = Path(file_.name).name
         if not file_name.endswith('.json'):
             continue
         json_data = json.load(tarobj.extractfile(file_))
@@ -40,7 +40,7 @@ def get_local_file_data(path):
     Args:
         path: path to tar file
     """
-    size = os.path.getsize(path)
+    size = Path(path).stat().st_size
 
     with open(path, 'rb') as fh:
         file_content = fh.read()
@@ -94,7 +94,7 @@ def get_report_data(report_path):
     json_data = {}
     with tarfile.open(report_path, mode='r') as tarobj:
         for file_ in tarobj.getmembers():
-            file_name = os.path.basename(file_.name)
+            file_name = Path(file_.name).name
             if not file_name.endswith('.json'):
                 continue
             if file_name != 'metadata.json':

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -86,11 +86,12 @@ def get_remote_report_checksum(org_id):
 
 
 def get_report_data(report_path):
-    """Returns hosts count from tar file.
+    """Returns report data from tar file.
 
     Args:
-        tarobj: tar file to get host count from
+        tarobj: tar file to get report data from
     """
+    json_data = {}
     tarobj = tarfile.open(report_path, mode='r')
     for file_ in tarobj.getmembers():
         file_name = os.path.basename(file_.name)
@@ -98,4 +99,4 @@ def get_report_data(report_path):
             continue
         if file_name != 'metadata.json':
             json_data = json.load(tarobj.extractfile(file_))
-        return json_data
+    return json_data

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -36,9 +36,9 @@ def setting_update(name, value):
 
 
 def disable_inventory_settings():
-    setting_update("obfuscate_inventory_hostnames", False)
-    setting_update("obfuscate_inventory_ips", False)
-    setting_update("exclude_installed_packages", False)
+    setting_update('obfuscate_inventory_hostnames', False)
+    setting_update('obfuscate_inventory_ips', False)
+    setting_update('exclude_installed_packages', False)
 
 
 @pytest.fixture
@@ -235,7 +235,7 @@ def test_obfuscate_host_names(inventory_settings, organization_ak_setup, registe
         session.cloudinventory.update({'obfuscate_hostnames': False})
 
         # Enable obfuscate_hostnames setting.
-        setting_update("obfuscate_inventory_hostnames", True)
+        setting_update('obfuscate_inventory_hostnames', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
@@ -328,7 +328,7 @@ def test_obfuscate_host_ipv4_addresses(
         session.cloudinventory.update({'obfuscate_ips': False})
 
         # Enable obfuscate_inventory_ips setting.
-        setting_update("obfuscate_inventory_ips", True)
+        setting_update('obfuscate_inventory_ips', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
@@ -422,7 +422,7 @@ def test_exclude_packages_setting(
             assert 'installed_packages' not in host_profiles
 
         # Enable exclude_installed_packages setting.
-        setting_update("exclude_installed_packages", True)
+        setting_update('exclude_installed_packages', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         wait_for_tasks(

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -95,6 +95,8 @@ def test_rhcloud_inventory_e2e(
         6. metadata.json lists all and only slice JSON files in tar
         7. Host counts in metadata matches host counts in slices
         8. Assert Hostnames, IP addresses, and installed packages are present in report.
+
+    :BZ: 1807829
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = registered_hosts
@@ -267,6 +269,8 @@ def test_obfuscate_host_ipv4_addresses(
 
     :id: c0fc4ee9-a6a1-42c0-83f0-0f131ca9ab41
 
+    :customerscenario: true
+
     :Steps:
 
         1. Prepare machine and upload its data to Insights
@@ -364,6 +368,8 @@ def test_exclude_packages_setting(
     """Test whether `Exclude Packages` setting works as expected.
 
     :id: 646093fa-fdd6-4f70-82aa-725e31fa3f12
+
+    :customerscenario: true
 
     :Steps:
 

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -29,9 +29,7 @@ from robottelo.rh_cloud_utils import get_report_data
 
 
 def setting_update(name, value):
-    """
-    change setting value
-    """
+    """change setting value"""
     setting = entities.Setting().search(query={'search': f'name="{name}"'})[0]
     setting.value = value
     setting.update({'value'})
@@ -43,7 +41,7 @@ def disable_inventory_settings():
     setting_update("exclude_installed_packages", False)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def inventory_settings():
     disable_inventory_settings()
     yield


### PR DESCRIPTION
This PR automates stubbed test cases related to RH cloud inventory settings and fixes issue related to `settings.robottelo.tmp_dir` not being present.

Test result from PRT job 147:
```
02:15:08  + py.test tests/foreman/ui/test_rhcloud_inventory.py --junit-xml=sat-results.xml -o junit_suite_name=sat-result
02:15:41  ============================= test session starts ==============================
02:15:41  platform linux -- Python 3.8.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
02:15:41  shared_function enabled - OFF - scope:  - storage: file
02:15:41  rootdir: /opt/app-root/src/robottelo, configfile: pyproject.toml
02:15:41  plugins: forked-1.3.0, ibutsu-1.16, mock-3.6.1, reportportal-5.0.8, services-2.2.1, xdist-2.3.0
02:15:41  collected 6 items / 2 deselected / 4 selected
02:15:41  
02:38:02  tests/foreman/ui/test_rhcloud_inventory.py ....                          [100%]
02:38:02  ========== 4 passed, 2 deselected, 134 warnings in 1338.10s (0:22:18) ==========
```