### PR TITLE
Fix valid_sync_interval, no underscore required

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -65,7 +65,7 @@ sync_date_deltas = {
 @filtered_datapoint
 def valid_sync_interval():
     """Returns a list of valid sync intervals."""
-    return {i.replace(' ', '_'): i for i in ['hourly', 'daily', 'weekly', 'custom cron']}
+    return ['hourly', 'daily', 'weekly', 'custom cron']
 
 
 def validate_task_status(repo_id, max_tries=6):
@@ -367,7 +367,7 @@ def test_positive_update_interval(module_org, interval):
     if interval == SYNC_INTERVAL['custom']:
         sync_plan.cron_expression = gen_choice(valid_cron_expressions())
     sync_plan = sync_plan.create()
-    # get another random interval and workaround issue #7231
+    # get another random interval
     new_interval = gen_choice(valid_sync_interval())
     while new_interval == interval:
         new_interval = gen_choice(valid_sync_interval())


### PR DESCRIPTION
Hello

A recent change[1] introduced an underscore into 'custom cron'

[1] https://github.com/SatelliteQE/robottelo/pull/8706