### PR TITLE
Remove random interval picking, restore parameter IDs

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -65,7 +65,7 @@ sync_date_deltas = {
 @filtered_datapoint
 def valid_sync_interval():
     """Returns a list of valid sync intervals."""
-    return ['hourly', 'daily', 'weekly', 'custom cron']
+    return {i.replace(' ', '_'): i for i in ['hourly', 'daily', 'weekly', 'custom cron']}
 
 
 def validate_task_status(repo_id, max_tries=6):
@@ -368,9 +368,7 @@ def test_positive_update_interval(module_org, interval):
         sync_plan.cron_expression = gen_choice(valid_cron_expressions())
     sync_plan = sync_plan.create()
     # get another random interval
-    new_interval = gen_choice(valid_sync_interval())
-    while new_interval == interval:
-        new_interval = gen_choice(valid_sync_interval())
+    new_interval = 'hourly' if interval != 'hourly' else 'daily'
     sync_plan.interval = new_interval
     if new_interval == SYNC_INTERVAL['custom']:
         sync_plan.cron_expression = gen_choice(valid_cron_expressions())


### PR DESCRIPTION
I think this is the change that should have been made in #8751 instead of regressing the parametrization. 

I didn't catch this behavior when testing the initial parametrization change in #8706 because of the random behavior in the test case. This removes that random behavior, so a single test run now shows what the consistent test result should be.

```
❯ pytest -vx tests/foreman/api/test_syncplan.py::test_positive_update_interval
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.8.11, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/mshriver/repos/satqe/robottelo/.robottelo/bin/python3.8
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mshriver/repos/satqe/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, xdist-2.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16
collected 4 items                                                                                                                                                                                                                           

tests/foreman/api/test_syncplan.py::test_positive_update_interval[hourly] PASSED                                                                                                                                                      [ 25%]
tests/foreman/api/test_syncplan.py::test_positive_update_interval[daily] PASSED                                                                                                                                                       [ 50%]
tests/foreman/api/test_syncplan.py::test_positive_update_interval[weekly] PASSED                                                                                                                                                      [ 75%]
tests/foreman/api/test_syncplan.py::test_positive_update_interval[custom_cron] PASSED
```