### PR TITLE
Add a test for insights remediation feature

### DIFF
--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -1,0 +1,2 @@
+RH_CLOUD:
+  #Token:

--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -1,2 +1,2 @@
 RH_CLOUD:
-  #Token:
+  Token: rh_cloud_token_value

--- a/pytest_fixtures/content_hosts.py
+++ b/pytest_fixtures/content_hosts.py
@@ -61,6 +61,13 @@ def rhel8_contenthost_fips():
         yield host
 
 
+@pytest.fixture(scope="module")
+def rhel8_contenthost_module():
+    """A module-level fixture that provides a content host object based on the rhel8 nick"""
+    with VMBroker(nick='rhel8', host_classes={'host': ContentHost}) as host:
+        yield host
+
+
 @pytest.fixture
 def rhel6_contenthost():
     """A function-level fixture that provides a content host object based on the rhel6 nick"""

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -23,7 +23,7 @@ def unset_set_cloud_token():
     rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
         0
     ]
-    rh_cloud_token_setting.value = 'invalid_token_value'
+    rh_cloud_token_setting.value = ''
     rh_cloud_token_setting.update({'value'})
     yield
     rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
@@ -65,5 +65,5 @@ def rhel8_insights_vm(organization_ak_setup, rhel8_contenthost_module):
 def fixable_rhel8_vm(rhel8_insights_vm):
     """A function-level fixture to create dnf related insights recommendation for rhel8 host."""
     rhel8_insights_vm.run('dnf update -y dnf')
-    rhel8_insights_vm.run("sed -i -e '/^best/d' /etc/dnf/dnf.conf")
-    rhel8_insights_vm.run('insights-client --register')
+    rhel8_insights_vm.run('sed -i -e "/^best/d" /etc/dnf/dnf.conf')
+    rhel8_insights_vm.run('insights-client')

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -17,6 +17,14 @@ def set_rh_cloud_token():
 
 
 @pytest.fixture(scope='module')
+def enable_lab_features():
+    """A module-level fixture to enable lab features."""
+    setting_update('lab_features', True)
+    yield
+    setting_update('lab_features', False)
+
+
+@pytest.fixture(scope='module')
 def organization_ak_setup(module_manifest_org):
     """A module-level fixture to create an Activation key in module_org"""
     ak = entities.ActivationKey(

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -4,7 +4,6 @@ from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL8
-from robottelo.helpers import add_remote_execution_ssh_key
 
 
 @pytest.fixture

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -43,10 +43,10 @@ def organization_ak_setup(module_manifest_org):
 def rhel8_insights_vm(default_sat, organization_ak_setup, rhel8_contenthost_module):
     """A module-level fixture to create rhel8 content host registered with insights."""
     org, ak = organization_ak_setup
+    rhel8_contenthost_module.configure_rex(satellite=default_sat, org=org, register=False)
     rhel8_contenthost_module.configure_rhai_client(
         satellite=default_sat, activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
     )
-    add_remote_execution_ssh_key(rhel8_contenthost_module.ip_addr)
     yield rhel8_contenthost_module
 
 

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -5,30 +5,21 @@ from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL8
 from robottelo.helpers import add_remote_execution_ssh_key
-from robottelo.rh_cloud_utils import setting_update
 
 
 @pytest.fixture
-def set_rh_cloud_token():
+def set_rh_cloud_token(default_sat):
     """A function-level fixture to set rh cloud token value."""
-    setting_update('rh_cloud_token', settings.rh_cloud.token)
+    default_sat.update_setting('rh_cloud_token', settings.rh_cloud.token)
     yield
-    setting_update('rh_cloud_token', '')
+    default_sat.update_setting('rh_cloud_token', '')
 
 
 @pytest.fixture
-def unset_rh_cloud_token():
+def unset_rh_cloud_token(default_sat):
     """A function-level fixture to unset rh cloud token value."""
     yield
-    setting_update('rh_cloud_token', '')
-
-
-@pytest.fixture(scope='module')
-def enable_lab_features():
-    """A module-level fixture to enable lab features."""
-    setting_update('lab_features', True)
-    yield
-    setting_update('lab_features', False)
+    default_sat.update_setting('rh_cloud_token', '')
 
 
 @pytest.fixture(scope='module')
@@ -49,11 +40,11 @@ def organization_ak_setup(module_manifest_org):
 
 
 @pytest.fixture(scope='module')
-def rhel8_insights_vm(organization_ak_setup, rhel8_contenthost_module):
+def rhel8_insights_vm(default_sat, organization_ak_setup, rhel8_contenthost_module):
     """A module-level fixture to create rhel8 content host registered with insights."""
     org, ak = organization_ak_setup
     rhel8_contenthost_module.configure_rhai_client(
-        activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
+        satellite=default_sat, activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
     )
     add_remote_execution_ssh_key(rhel8_contenthost_module.ip_addr)
     yield rhel8_contenthost_module

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -8,18 +8,12 @@ from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.rh_cloud_utils import setting_update
 
 
-@pytest.fixture(scope='module')
-def set_rh_cloud_token():
-    """A module-level fixture to set rh cloud token value."""
-    setting_update('rh_cloud_token', settings.rh_cloud.token)
-
-
 @pytest.fixture
-def unset_set_cloud_token():
-    """A function-level fixture to unset and reset rh cloud token value."""
-    setting_update('rh_cloud_token', '')
-    yield
+def set_rh_cloud_token():
+    """A function-level fixture to set rh cloud token value."""
     setting_update('rh_cloud_token', settings.rh_cloud.token)
+    yield
+    setting_update('rh_cloud_token', '')
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -5,32 +5,21 @@ from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL8
 from robottelo.helpers import add_remote_execution_ssh_key
+from robottelo.rh_cloud_utils import setting_update
 
 
 @pytest.fixture(scope='module')
 def set_rh_cloud_token():
     """A module-level fixture to set rh cloud token value."""
-    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
-        0
-    ]
-    rh_cloud_token_setting.value = settings.rh_cloud.token
-    rh_cloud_token_setting.update({'value'})
+    setting_update('rh_cloud_token', settings.rh_cloud.token)
 
 
 @pytest.fixture
 def unset_set_cloud_token():
     """A function-level fixture to unset and reset rh cloud token value."""
-    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
-        0
-    ]
-    rh_cloud_token_setting.value = ''
-    rh_cloud_token_setting.update({'value'})
+    setting_update('rh_cloud_token', '')
     yield
-    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
-        0
-    ]
-    rh_cloud_token_setting.value = settings.rh_cloud.token
-    rh_cloud_token_setting.update({'value'})
+    setting_update('rh_cloud_token', settings.rh_cloud.token)
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -16,6 +16,13 @@ def set_rh_cloud_token():
     setting_update('rh_cloud_token', '')
 
 
+@pytest.fixture
+def unset_rh_cloud_token():
+    """A function-level fixture to unset rh cloud token value."""
+    yield
+    setting_update('rh_cloud_token', '')
+
+
 @pytest.fixture(scope='module')
 def enable_lab_features():
     """A module-level fixture to enable lab features."""

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -1,7 +1,36 @@
 import pytest
 from nailgun import entities
 
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import DISTRO_RHEL8
+from robottelo.helpers import add_remote_execution_ssh_key
+
+
+@pytest.fixture(scope='module')
+def set_rh_cloud_token():
+    """A module-level fixture to set rh cloud token value."""
+    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
+        0
+    ]
+    rh_cloud_token_setting.value = settings.rh_cloud.token
+    rh_cloud_token_setting.update({'value'})
+
+
+@pytest.fixture
+def unset_set_cloud_token():
+    """A function-level fixture to unset and reset rh cloud token value."""
+    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
+        0
+    ]
+    rh_cloud_token_setting.value = 'invalid_token_value'
+    rh_cloud_token_setting.update({'value'})
+    yield
+    rh_cloud_token_setting = entities.Setting().search(query={'search': 'name="rh_cloud_token"'})[
+        0
+    ]
+    rh_cloud_token_setting.value = settings.rh_cloud.token
+    rh_cloud_token_setting.update({'value'})
 
 
 @pytest.fixture(scope='module')
@@ -17,4 +46,24 @@ def organization_ak_setup(module_manifest_org):
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]
     ak.add_subscriptions(data={'quantity': 10, 'subscription_id': subscription.id})
-    return module_manifest_org, ak
+    yield module_manifest_org, ak
+    ak.delete()
+
+
+@pytest.fixture(scope='module')
+def rhel8_insights_vm(organization_ak_setup, rhel8_contenthost_module):
+    """A module-level fixture to create rhel8 content host registered with insights."""
+    org, ak = organization_ak_setup
+    rhel8_contenthost_module.configure_rhai_client(
+        activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
+    )
+    add_remote_execution_ssh_key(rhel8_contenthost_module.ip_addr)
+    yield rhel8_contenthost_module
+
+
+@pytest.fixture
+def fixable_rhel8_vm(rhel8_insights_vm):
+    """A function-level fixture to create dnf related insights recommendation for rhel8 host."""
+    rhel8_insights_vm.run('dnf update -y dnf')
+    rhel8_insights_vm.run("sed -i -e '/^best/d' /etc/dnf/dnf.conf")
+    rhel8_insights_vm.run('insights-client --register')

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1195,3 +1195,9 @@ class Satellite(Capsule):
         update_provisioning_template(name=template, old=old, new=new)
         yield
         update_provisioning_template(name=template, old=new, new=old)
+
+    def update_setting(self, name, value):
+        """change setting value"""
+        setting = self.api.Setting().search(query={'search': f'name="{name}"'})[0]
+        setting.value = value
+        setting.update({'value'})

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -4,6 +4,8 @@ import json
 import tarfile
 from pathlib import Path
 
+from nailgun import entities
+
 from robottelo import ssh
 
 
@@ -100,3 +102,10 @@ def get_report_data(report_path):
             if file_name != 'metadata.json':
                 json_data = json.load(tarobj.extractfile(file_))
     return json_data
+
+
+def setting_update(name, value):
+    """change setting value"""
+    setting = entities.Setting().search(query={'search': f'name="{name}"'})[0]
+    setting.value = value
+    setting.update({'value'})

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -4,8 +4,6 @@ import json
 import tarfile
 from pathlib import Path
 
-from nailgun import entities
-
 from robottelo import ssh
 
 
@@ -102,10 +100,3 @@ def get_report_data(report_path):
             if file_name != 'metadata.json':
                 json_data = json.load(tarobj.extractfile(file_))
     return json_data
-
-
-def setting_update(name, value):
-    """change setting value"""
-    setting = entities.Setting().search(query={'search': f'name="{name}"'})[0]
-    setting.value = value
-    setting.update({'value'})

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -1,0 +1,75 @@
+"""Tests for RH Cloud - Insights
+
+:Requirement: RH Cloud - Insights
+
+:CaseAutomation: Automated
+
+:CaseLevel: System
+
+:CaseComponent: RHCloud-Insights
+
+:Assignee: jpathan
+
+:TestType: Functional
+
+:CaseImportance: Critical
+
+:Upstream: No
+"""
+import pytest
+
+from robottelo.config import settings
+
+
+@pytest.mark.tier3
+def test_rhcloud_insights_e2e(
+    session, rhel8_insights_vm, fixable_rhel8_vm, organization_ak_setup, unset_set_cloud_token
+):
+    """Synchronize hits data from cloud, verify it is displayed in Satellite and run remediation.
+
+    :id: d952e83c-3faf-4299-a048-2eb6ccb8c9c2
+
+    :Steps:
+        1. Prepare misconfigured machine and upload its data to Insights.
+        2. Add Cloud API key in Satellite.
+        3. In Satellite UI, Configure -> Insights -> Add RH Cloud token and syns recommendations.
+        4. Run remediation for dnf.conf recommendation against rhel8 host.
+        5. Assert that job completed successfully.
+        6. Upload insights data again.
+        7. Sync Insights recommendations.
+        8. Search for previously remediated issue.
+
+    :expectedresults:
+        1. Insights recommendation related to dnf.conf issue is listed for misconfigured machine.
+        2. Remediation job finished successfully.
+        3. Insights recommendation related to dnf.conf issue is not listed.
+
+    :CaseAutomation: Automated
+    """
+    org, ak = organization_ak_setup
+    query = 'dnf.conf'
+    with session:
+        session.organization.select(org_name=org.name)
+        # uncomment once https://bugzilla.redhat.com/show_bug.cgi?id=1965901 is fixed
+        # session.cloudinsights.save_token_sync_hits(settings.rh_cloud.token)
+        result = session.cloudinsights.search(query)[0]
+        assert result['Hostname'] == rhel8_insights_vm.hostname
+        assert (
+            result['Recommendation'] == 'The dnf installs lower versions of packages when the '
+            '"best" option is not present in the /etc/dnf/dnf.conf'
+        )
+        session.cloudinsights.remediate(query)
+        session.jobinvocation.wait_job_invocation_state(
+            entity_name='Insights remediations for selected issues',
+            host_name=rhel8_insights_vm.hostname,
+        )
+        status = session.jobinvocation.read(
+            entity_name='Insights remediations for selected issues',
+            host_name=rhel8_insights_vm.hostname,
+        )
+        assert status['overview']['hosts_table'][0]['Status'] == 'success'
+        rhel8_insights_vm.run('insights-client')
+        session.cloudinsights.sync_hits()
+        # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1962048
+        session.browser.refresh()
+        assert not session.cloudinsights.search(query)

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -84,10 +84,7 @@ def test_rhcloud_insights_e2e(
             max_tries=10,
         )
         task_output = entities.ForemanTask().search(query={'search': result[0].id})
-        try:
-            assert task_output[0].result == 'success'
-        except AssertionError:
-            raise AssertionError(f'result: {result} task_output: {task_output}')
+        assert task_output[0].result == 'success', f'result: {result}\n task_output: {task_output}'
         timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.sync_hits()
         wait_for_tasks(

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -27,7 +27,9 @@ from robottelo.config import settings
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_rhcloud_insights_e2e(session, rhel8_insights_vm, fixable_rhel8_vm, organization_ak_setup):
+def test_rhcloud_insights_e2e(
+    session, rhel8_insights_vm, fixable_rhel8_vm, organization_ak_setup, enable_lab_features
+):
     """Synchronize hits data from cloud, verify it is displayed in Satellite and run remediation.
 
     :id: d952e83c-3faf-4299-a048-2eb6ccb8c9c2

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: System
 
-:CaseComponent: RH Cloud - Inventory
+:CaseComponent: RHCloud-Inventory
 
 :Assignee: jpathan
 
@@ -27,9 +27,7 @@ from robottelo.config import settings
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_rhcloud_insights_e2e(
-    session, rhel8_insights_vm, fixable_rhel8_vm, organization_ak_setup, unset_set_cloud_token
-):
+def test_rhcloud_insights_e2e(session, rhel8_insights_vm, fixable_rhel8_vm, organization_ak_setup):
     """Synchronize hits data from cloud, verify it is displayed in Satellite and run remediation.
 
     :id: d952e83c-3faf-4299-a048-2eb6ccb8c9c2


### PR DESCRIPTION
This pr depends on: https://github.com/SatelliteQE/airgun/pull/576 
I also need to add `rh_cloud.yaml` file in our gitlab.
Test result:
```
$ pytest -Wignore tests/foreman/ui/test_rhcloud_insights.py 
============================= test session starts ==============================
collected 1 item

tests/foreman/ui/test_rhcloud_insights.py .E                             [100%]

==================================== ERRORS ====================================
________________ ERROR at teardown of test_rhcloud_insights_e2e ________________

    @pytest.fixture
    def unset_set_cloud_token():
        """A function-level fixture to unset and reset rh cloud token value."""
        setting_update('rh_cloud_token', '')
        yield
>       setting_update('rh_cloud_token', settings.rh_cloud.token)

pytest_fixtures/rh_cloud.py:22: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
robottelo/rh_cloud_utils.py:94: in setting_update
    setting.update({'value'})
../nailgun/nailgun/entity_mixins.py:1042: in update
    return self.read(attrs=self.update_json(fields))
../nailgun/nailgun/entity_mixins.py:1018: in update_json
    response = self.update_raw(fields)
../nailgun/nailgun/entity_mixins.py:998: in update_raw
    return client.put(
../nailgun/nailgun/client.py:172: in put
    data = dumps(data)
/usr/local/lib/python3.8/json/__init__.py:231: in dumps
    return _default_encoder.encode(obj)
/usr/local/lib/python3.8/json/encoder.py:199: in encode
    chunks = self.iterencode(o, _one_shot=True)
/usr/local/lib/python3.8/json/encoder.py:257: in iterencode
    return _iterencode(o, 0)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <json.encoder.JSONEncoder object at 0x7f28443ad8e0>
o = <SettingsNodeWrapper for "rh_cloud.token" wrapping value of type str: ***trimmed**output**token***value>

    def default(self, o):
        """Implement this method in a subclass such that it returns
        a serializable object for ``o``, or calls the base implementation
        (to raise a ``TypeError``).
    
        For example, to support arbitrary iterators, you could
        implement default like this::
    
            def default(self, o):
                try:
                    iterable = iter(o)
                except TypeError:
                    pass
                else:
                    return list(iterable)
                # Let the base class default method raise the TypeError
                return JSONEncoder.default(self, o)
    
        """
>       raise TypeError(f'Object of type {o.__class__.__name__} '
                        f'is not JSON serializable')
E       TypeError: Object of type str is not JSON serializable

/usr/local/lib/python3.8/json/encoder.py:179: TypeError
=========================== short test summary info ============================
ERROR tests/foreman/ui/test_rhcloud_insights.py::test_rhcloud_insights_e2e - ...
==================== 1 passed, 1 error in 752.80s (0:12:32) ====================

```
The test is currently failing at teardown, will fix this issue soon.