### PR TITLE
Changed the way the `locked` property is checked

### DIFF
--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -77,11 +77,11 @@ def test_positive_import_templates(session, templates_org, templates_loc):
         )
         assert import_title == f'Import from {FOREMAN_TEMPLATES_COMMUNITY_URL}'
         imported_template = f'{prefix_name} {import_template}'
+        assert session.provisioningtemplate.is_locked(imported_template)
         pt = session.provisioningtemplate.read(imported_template)
         assert pt['template']['name'] == imported_template
         assert pt['template']['default'] is False
         assert pt['type']['snippet'] is False
-        assert pt['template']['locked'] is True
         assert pt['locations']['resources']['assigned'][0] == templates_loc.name
         assert pt['organizations']['resources']['assigned'][0] == templates_org.name
         assert f'name: {import_template}' in pt['template']['template_editor']['editor']


### PR DESCRIPTION
This change is connected to https://github.com/SatelliteQE/airgun/pull/588. With it the test passes:
```
pytest tests/foreman/ui/test_templatesync.py::test_positive_import_templates
============================= test session starts ==============================
collected 1 item                                                               

tests/foreman/ui/test_templatesync.py .                                  [100%]
================== 1 passed, 3 warnings in 135.29s (0:02:15) ===================
```