### PR TITLE
rhel8 and rhel8-fips rex tests

### DIFF
--- a/pytest_fixtures/broker.py
+++ b/pytest_fixtures/broker.py
@@ -84,6 +84,13 @@ def rhel8_contenthost():
 
 
 @pytest.fixture
+def rhel8_contenthost_fips():
+    """A function-level fixture that provides a content host object based on the rhel8_fips nick"""
+    with VMBroker(nick='rhel8_fips', host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture
 def rhel6_contenthost():
     """A function-level fixture that provides a content host object based on the rhel6 nick"""
     with VMBroker(nick='rhel6', host_classes={'host': ContentHost}) as host:

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -182,8 +182,8 @@ class TestRemoteExecution:
     @pytest.mark.tier3
     @pytest.mark.parametrize(
         'fixture_vmsetup',
-        [{'nick': 'rhel7'}, {'nick': 'rhel7_fips'}],
-        ids=['rhel7', 'rhel7_fips'],
+        [{'nick': 'rhel7'}, {'nick': 'rhel7_fips'}, {'nick': 'rhel8'}, {'nick': 'rhel8_fips'}],
+        ids=['rhel7', 'rhel7_fips', 'rhel8', 'rhel8_fips'],
         indirect=True,
     )
     def test_positive_run_custom_job_template_by_ip(self, fixture_vmsetup, module_org):
@@ -192,6 +192,10 @@ class TestRemoteExecution:
         :id: 9740eb1d-59f5-42b2-b3ab-659ca0202c74
 
         :expectedresults: Verify the job was successfully ran against the host
+
+        :bz: 1872688, 1811166
+
+        :customerscenario: true
 
         :parametrized: yes
         """
@@ -645,8 +649,8 @@ class TestAnsibleREX:
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'fixture_vmsetup',
-        [{'nick': 'rhel7'}, {'nick': 'rhel7_fips'}],
-        ids=['rhel7', 'rhel7_fips'],
+        [{'nick': 'rhel7'}, {'nick': 'rhel7_fips'}, {'nick': 'rhel8'}, {'nick': 'rhel8_fips'}],
+        ids=['rhel7', 'rhel7_fips', 'rhel8', 'rhel8_fips'],
         indirect=True,
     )
     @pytest.mark.skipif(
@@ -674,6 +678,10 @@ class TestAnsibleREX:
         :CaseAutomation: Automated
 
         :CaseLevel: System
+
+        :bz: 1872688, 1811166
+
+        :customerscenario: true
 
         :parametrized: yes
         """


### PR DESCRIPTION
- depends on "rhel8_fips broker nick added" satelliteqe-jenkins MR
- fixes #8321
- related bz updated with qe whiteboard and qe_cov flags
- non-ansible rhel8 fips test bound to fail due to bz#1872688