### PR TITLE
content-import and content-export hammer commands

### DIFF
--- a/robottelo/cli/content_export.py
+++ b/robottelo/cli/content_export.py
@@ -1,0 +1,79 @@
+"""
+Usage::
+
+    hammer content-export [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    complete                      Prepare content for a full export to a disconnected Katello
+    generate-metadata             Writes export metadata to disk for use by the importing Katello.
+                                  This command only needs to be used if the export was performed
+                                  asynchronously or if the metadata was lost
+    incremental                   Prepare content for an incremental export to a disconnected
+                                  Katello
+    list                          View content view export histories
+
+"""
+from robottelo.cli.base import Base
+
+
+class ContentExport(Base):
+    """
+    Exports content from satellite
+    """
+
+    command_base = 'content-export'
+    command_requires_org = True
+
+    @classmethod
+    def list(cls, options=None):
+        """
+        List previous exports
+        """
+        cls.command_sub = 'list'
+        return cls.execute(cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def completeLibrary(cls, options):
+        """
+        Make full library export
+        """
+        cls.command_sub = 'complete library'
+        return cls.execute(cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def completeVersion(cls, options):
+        """
+        Make full CV version export
+        """
+        cls.command_sub = 'complete version'
+        return cls.execute(cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def incrementalLibrary(cls, options):
+        """
+        Make make incremental library export
+        """
+        cls.command_sub = 'incremental library'
+        return cls.execute(cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def incrementalVersion(cls, options):
+        """
+        Make make incremental CV version export
+        """
+        cls.command_sub = 'incremental version'
+        return cls.execute(cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def generateMetadata(cls, options):
+        """
+        Generates export metadata
+        """
+        cls.command_sub = 'generate-metadata'
+        return cls.execute(cls._construct_command(options), output_format='json')

--- a/robottelo/cli/content_import.py
+++ b/robottelo/cli/content_import.py
@@ -1,0 +1,52 @@
+"""
+Usage::
+
+    hammer content-import [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    library                       Imports a content archive to an organization's library
+                                  lifecycle environment
+    list                          View content view import histories
+    version                       Imports a content archive to a content view version
+
+"""
+from robottelo.cli.base import Base
+
+
+class ContentImport(Base):
+    """
+    Import content to satellite
+    """
+
+    command_base = 'content-import'
+    command_requires_org = True
+
+    @classmethod
+    def list(cls, options=None):
+        """
+        List previous imports
+        """
+        cls.command_sub = 'list'
+        return cls.execute(cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def library(cls, options):
+        """
+        Make library import
+        """
+        cls.command_sub = 'library'
+        return cls.execute(cls._construct_command(options), output_format='json')
+
+    @classmethod
+    def version(cls, options):
+        """
+        Make CV version export
+        """
+        cls.command_sub = 'version'
+        return cls.execute(cls._construct_command(options), output_format='json')


### PR DESCRIPTION
hammer content-import and content-export commands are new additions in 6.10, this PR should enable further testing,
some basic check:

```

from robottelo.cli.content_export import ContentExport
result = ContentExport.completeLibrary({ 'organization-id': module_org.id })

(Pdb) p result['message']
'Generated /var/lib/pulp/exports/vpTHSEqwICcX/Export-Library/1.0/2021-07-28T07-17-48-04-00/metadata.json'

(Pdb) ContentExport.list()
[{'id': '1', 'destination-server': None, 'path': '/var/lib/pulp/exports/Default_Organization/Export-Library/1.0/2021-07-28T05-13-06-04-00', 'type': 'complete', 'content-view-version': 'Export-Library 1.0', 'content-view-version-id': '7', 'created-at': '2021-07-28 09:13:10 UTC', 'updated-at': '2021-07-28 09:13:10 UTC'}, {'id': '2', 'destination-server': None, 'path': '/var/lib/pulp/exports/Default_Organization/Export-Library/2.0/2021-07-28T06-24-59-04-00', 'type': 'complete', 'content-view-version': 'Export-Library 2.0', 'content-view-version-id': '9', 'created-at': '2021-07-28 10:25:03 UTC', 'updated-at': '2021-07-28 10:25:03 UTC'}, {'id': '3', 'destination-server': None, 'path': '/var/lib/pulp/exports/vpTHSEqwICcX/Export-Library/1.0/2021-07-28T07-17-48-04-00', 'type': 'complete', 'content-view-version': 'Export-Library 1.0', 'content-view-version-id': '12', 'created-at': '2021-07-28 11:17:50 UTC', 'updated-at': '2021-07-28 11:17:50 UTC'}]
```