### PR TITLE
Replacing the subscription and resource group in Azure

### DIFF
--- a/conf/azure.yaml.template
+++ b/conf/azure.yaml.template
@@ -5,6 +5,8 @@ AZURERM:
   CLIENT_SECRET:
   # The subscription ID is a GUID that uniquely identifies your subscription to use Azure services.
   SUBSCRIPTION_ID:
+  # The resource group where the resources will be created under above subscription
+  RESOURCE_GROUP:
   # Tenant ID, the ID of the AAD directory in which you created the application
   TENANT_ID:
   # Azure Region

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -13,7 +13,6 @@ from robottelo.api.utils import promote
 from robottelo.api.utils import publish_puppet_module
 from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
-from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
@@ -373,6 +372,7 @@ def azurerm_settings():
         'tenant': settings.azurerm.tenant_id,
         'app_ident': settings.azurerm.client_id,
         'sub_id': settings.azurerm.subscription_id,
+        'resource_group': settings.azurerm.resource_group,
         'secret': settings.azurerm.client_secret,
         'region': settings.azurerm.azure_region.lower().replace(' ', ''),
     }
@@ -476,7 +476,7 @@ def azurermclient(azurerm_settings):
         tenant_id=azurerm_settings['tenant'],
         subscription_id=azurerm_settings['sub_id'],
         provisioning={
-            "resource_group": AZURERM_RG_DEFAULT,
+            "resource_group": azurerm_settings['resource_group'],
             "template_container": None,
             "region_api": azurerm_settings['region'],
         },

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -163,9 +163,8 @@ AZURERM_RHEL7_UD_IMG_URN = 'marketplace://RedHat:RHEL:7-RAW-CI:7.6.2019072418'
 AZURERM_RHEL7_FT_BYOS_IMG_URN = 'marketplace://RedHat:rhel-byos:rhel-lvm78:7.8.20200410'
 AZURERM_RHEL7_FT_CUSTOM_IMG_URN = 'custom://vm1-shared-image-20200514081407'
 AZURERM_RHEL7_FT_GALLERY_IMG_URN = 'gallery://RHEL77img'
-AZURERM_RG_DEFAULT = 'SATQE'
 AZURERM_PLATFORM_DEFAULT = 'Linux'
-AZURERM_VM_SIZE_DEFAULT = 'Standard_B2ms'
+AZURERM_VM_SIZE_DEFAULT = 'Standard_B1s'
 AZURERM_PREMIUM_OS_Disk = True
 AZURERM_FILE_URI = (
     'https://raw.githubusercontent.com/SatelliteQE/robottelo/master/tests/foreman/data/uri.sh'

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -25,7 +25,6 @@ from robottelo.config import settings
 from robottelo.constants import AZURERM_FILE_URI
 from robottelo.constants import AZURERM_PLATFORM_DEFAULT
 from robottelo.constants import AZURERM_PREMIUM_OS_Disk
-from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_IMG_URN
@@ -191,7 +190,7 @@ class TestAzureRMHostProvisioningTestCase:
         """
         request.cls.region = settings.azurerm.azure_region
         request.cls.rhel7_ft_img = AZURERM_RHEL7_FT_IMG_URN
-        request.cls.rg_default = AZURERM_RG_DEFAULT
+        request.cls.rg_default = settings.azurerm.resource_group
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
@@ -341,7 +340,7 @@ class TestAzureRMUserDataProvisioning:
 
         request.cls.region = settings.azurerm.azure_region
         request.cls.rhel7_ud_img = AZURERM_RHEL7_UD_IMG_URN
-        request.cls.rg_default = AZURERM_RG_DEFAULT
+        request.cls.rg_default = settings.azurerm.resource_group
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
@@ -503,7 +502,7 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = {
-            "resource_group": AZURERM_RG_DEFAULT,
+            "resource_group": settings.azurerm.resource_group,
             "vm_size": AZURERM_VM_SIZE_DEFAULT,
             "username": module_azurerm_gallery_finishimg.username,
             "password": settings.azurerm.password,
@@ -629,7 +628,7 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = {
-            "resource_group": AZURERM_RG_DEFAULT,
+            "resource_group": settings.azurerm.resource_group,
             "vm_size": AZURERM_VM_SIZE_DEFAULT,
             "username": module_azurerm_custom_finishimg.username,
             "password": settings.azurerm.password,

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -29,7 +29,6 @@ from robottelo.config import settings
 from robottelo.constants import AZURERM_FILE_URI
 from robottelo.constants import AZURERM_PLATFORM_DEFAULT
 from robottelo.constants import AZURERM_PREMIUM_OS_Disk
-from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
 from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
@@ -259,7 +258,7 @@ class TestAzureRMComputeResourceTestCase:
             {
                 'compute-profile-id': int(profile['id']),
                 'compute-resource': module_azurerm_cr.name,
-                'compute-attributes': f'resource_group={AZURERM_RG_DEFAULT},'
+                'compute-attributes': f'resource_group={settings.azurerm.resource_group},'
                 f'vm_size={AZURERM_VM_SIZE_DEFAULT},'
                 f'username={username},'
                 f'password={password},'
@@ -279,7 +278,7 @@ class TestAzureRMComputeResourceTestCase:
         result_info = ComputeProfile.info({'name': cp_name})
         vm_attributes = result_info['compute-attributes'][0]['vm-attributes']
         assert module_azurerm_cr.name == result_info['compute-attributes'][0]['compute-resource']
-        assert AZURERM_RG_DEFAULT in vm_attributes
+        assert settings.azurerm.resource_group in vm_attributes
         assert AZURERM_VM_SIZE_DEFAULT in vm_attributes
         assert username in vm_attributes
         assert password in vm_attributes
@@ -299,7 +298,7 @@ class TestAzureRMFinishTemplateProvisioning:
         """
         request.cls.region = settings.azurerm.azure_region
         request.cls.rhel7_ft_img = AZURERM_RHEL7_FT_IMG_URN
-        request.cls.rg_default = AZURERM_RG_DEFAULT
+        request.cls.rg_default = settings.azurerm.resource_group
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
@@ -419,7 +418,7 @@ class TestAzureRMUserDataProvisioning:
         """
         request.cls.region = settings.azurerm.azure_region
         request.cls.rhel7_ft_img = AZURERM_RHEL7_UD_IMG_URN
-        request.cls.rg_default = AZURERM_RG_DEFAULT
+        request.cls.rg_default = settings.azurerm.resource_group
         request.cls.premium_os_disk = AZURERM_PREMIUM_OS_Disk
         request.cls.platform = AZURERM_PLATFORM_DEFAULT
         request.cls.vm_size = AZURERM_VM_SIZE_DEFAULT
@@ -545,7 +544,7 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
         request.cls.fullhostname = f'{self.hostname}.{module_domain.name}'.lower()
 
         request.cls.compute_attrs = (
-            f'resource_group={AZURERM_RG_DEFAULT},vm_size={AZURERM_VM_SIZE_DEFAULT}, '
+            f'resource_group={settings.azurerm.resource_group},vm_size={AZURERM_VM_SIZE_DEFAULT}, '
             f'username={module_azurerm_byos_finishimg.username}, '
             f'ssh_key_data={settings.azurerm.ssh_pub_key}, platform={AZURERM_PLATFORM_DEFAULT},'
             f'script_command={"touch /var/tmp/test.txt"}, script_uris={AZURERM_FILE_URI},'

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -24,7 +24,6 @@ from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.config import settings
 from robottelo.constants import AZURERM_FILE_URI
 from robottelo.constants import AZURERM_PLATFORM_DEFAULT
-from robottelo.constants import AZURERM_RG_DEFAULT
 from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
 from robottelo.constants import COMPUTE_PROFILE_SMALL
 
@@ -45,7 +44,7 @@ def module_azure_cp_attrs(module_azurerm_cr, module_azurerm_finishimg):
         compute_profile=COMPUTE_PROFILE_SMALL,
         compute_resource=module_azurerm_cr,
         vm_attrs={
-            "resource_group": AZURERM_RG_DEFAULT,
+            "resource_group": settings.azurerm.resource_group,
             "vm_size": AZURERM_VM_SIZE_DEFAULT,
             "username": module_azurerm_finishimg.username,
             "password": settings.azurerm.password,


### PR DESCRIPTION
Replacement:
- The new subscription and resource group changes in Azure for SatelliteQE replicated in confs here.
- resource group is now a conf setting.

Improvement:
- The CPU cores are reduced to 1 and the memory is also reduced to 1 GB for a provisioned host for saving more resources which were failing tests for y-stream and z-stream concurrent azure tests. Earlier it was 2 Cores and 8 GB of memory, which was hogging the resources and increasing the amnt of money.

TEST results are intact post these changes:
```
% pytest -s tests/foreman/api/test_computeresource_azurerm.py                                           

========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.8.2, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/jitendrayejare/JWorkspace/GitRepos/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.8, ibutsu-1.14.1, cov-2.11.1, services-2.2.1, xdist-2.2.1, mock-3.6.0, forked-1.3.0
collecting ... 2021-07-28 19:51:02 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 11 items / 1 deselected / 10 selected                                                                                                                                                          

tests/foreman/api/test_computeresource_azurerm.py [INFO 210728 19:51:06] Using token authentication
..........

====================================================================== 10 passed, 1 deselected in 1026.86s (0:17:06) =======================================================================
```