### PR TITLE
removed the bz as no more reproducible the issue on 6.10

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -387,7 +387,7 @@ def test_positive_create_with_https(
     assert users[0].login == ldap_auth_source['ldap_user_name']
 
 
-@pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPEN_LDAP'], indirect=True)
+@pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
 @pytest.mark.tier2
 def test_positive_add_katello_role(
     test_name,
@@ -443,7 +443,6 @@ def test_positive_add_katello_role(
         assert ldap_auth_source['ldap_user_name'] in current_user
 
 
-@pytest.mark.skip_if_open('BZ:1851905')
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
 @pytest.mark.upgrade
 @pytest.mark.tier2
@@ -495,8 +494,6 @@ def test_positive_update_external_roles(
             with pytest.raises(NavigationTriesExceeded):
                 ldapsession.architecture.search('')
             ldapsession.location.create({'name': location_name})
-            if is_open('BZ:1851905'):
-                ldapsession.browser.execute_script('window.history.go(-1)')
             assert ldapsession.location.search(location_name)[0]['Name'] == location_name
             current_user = ldapsession.location.read(location_name, 'current_user')['current_user']
             assert ldap_auth_source['ldap_user_name'] in current_user
@@ -513,7 +510,6 @@ def test_positive_update_external_roles(
         assert ldap_auth_source['ldap_user_name'] in current_user
 
 
-@pytest.mark.skip_if_open('BZ:1851905')
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
 @pytest.mark.tier2
 @pytest.mark.upgrade
@@ -561,8 +557,6 @@ def test_positive_delete_external_roles(
             with pytest.raises(NavigationTriesExceeded):
                 ldapsession.architecture.search('')
             ldapsession.location.create({'name': location_name})
-            if is_open('BZ:1851905'):
-                ldapsession.browser.execute_script('window.history.go(-1)')
             assert ldapsession.location.search(location_name)[0]['Name'] == location_name
             current_user = ldapsession.location.read(location_name, 'current_user')['current_user']
             assert ldap_auth_source['ldap_user_name'] in current_user
@@ -576,7 +570,6 @@ def test_positive_delete_external_roles(
             ldapsession.location.create({'name': gen_string('alpha')})
 
 
-@pytest.mark.skip_if_open('BZ:1851905')
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
 @pytest.mark.tier2
 def test_positive_update_external_user_roles(
@@ -629,8 +622,6 @@ def test_positive_update_external_user_roles(
             test_name, ldap_auth_source['ldap_user_name'], ldap_auth_source['ldap_user_passwd']
         ) as ldapsession:
             ldapsession.location.create({'name': location_name})
-            if is_open('BZ:1851905'):
-                ldapsession.browser.execute_script("window.history.go(-1)")
             assert ldapsession.location.search(location_name)[0]['Name'] == location_name
             current_user = ldapsession.location.read(location_name, 'current_user')['current_user']
             assert ldap_auth_source['ldap_user_name'] in current_user
@@ -699,8 +690,6 @@ def test_positive_add_admin_role_with_org_loc(
         test_name, ldap_auth_source['ldap_user_name'], ldap_auth_source['ldap_user_passwd']
     ) as session:
         session.location.create({'name': location_name})
-        if is_open('BZ:1851905'):
-            session.browser.execute_script('window.history.go(-1)')
         assert session.location.search(location_name)[0]['Name'] == location_name
         location = session.location.read(location_name, ['current_user', 'primary'])
         assert ldap_auth_source['ldap_user_name'] in location['current_user']
@@ -1878,7 +1867,6 @@ def test_positive_group_sync_open_ldap_authsource(
         assert user_name.capitalize() in current_user
 
 
-@pytest.mark.skip_if_open('BZ:1851905')
 @pytest.mark.tier2
 def test_verify_group_permissions(
     session, auth_source_ipa, multigroup_setting_cleanup, groups_teardown, ldap_tear_down
@@ -1921,8 +1909,6 @@ def test_verify_group_permissions(
     location_name = gen_string('alpha')
     with Session(user=idm_users[1], password=settings.server.ssh_password) as ldapsession:
         ldapsession.location.create({'name': location_name})
-        if is_open('BZ:1851905'):
-            ldapsession.browser.execute_script('window.history.go(-1)')
         assert ldapsession.location.search(location_name)[0]['Name'] == location_name
 
 


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, ibutsu-1.14.1, picked-0.4.6collected 73 items / 72 deselected / 1 selected

../../okhatavk/Satellite/robottelo/tests/foreman/ui/test_ldap_authentication.py 2021-07-29 16:59:16 - robottelo.collection - INFO - Processing test items to add testimony token markers
[INFO 210729 16:59:18] Using username and password authentication
. [100%]

=============================== warnings summary ===============================
```