### PR TITLE
Use json gce cert from conf instead of downloading from url

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -1,5 +1,6 @@
 """Several helper methods and functions."""
 import contextlib
+import json
 import os
 import random
 import re
@@ -702,7 +703,11 @@ def slugify_component(string, keep_hyphens=True):
 
 
 def download_gce_cert():
-    ssh.command(f'curl {settings.gce.cert_url} -o {settings.gce.cert_path}')
+    _, gce_cert = mkstemp(suffix='.json')
+    cert = json.loads(settings.gce.cert)
+    with open(gce_cert, 'w') as f:
+        json.dump(cert, f)
+    ssh.upload_file(gce_cert, settings.gce.cert_path)
     if ssh.command(f'[ -f {settings.gce.cert_path} ]').return_code != 0:
         raise GCECertNotFoundError(
             f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -34,7 +34,6 @@ GCE_SETTINGS = dict(
     client_email=settings.gce.client_email,
     cert_path=settings.gce.cert_path,
     zone=settings.gce.zone,
-    cert_url=settings.gce.cert_url,
 )
 
 


### PR DESCRIPTION
Using end to end test:
```pytest -v tests/foreman/ui/test_computeresource_gce.py 
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo3.9/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.16, xdist-2.3.0, forked-1.3.0, mock-3.6.1, reportportal-5.0.8, services-2.2.1, cov-2.12.1
collected 1 item                                                                                                                                                                

tests/foreman/ui/test_computeresource_gce.py::test_positive_default_end_to_end_with_custom_profile PASSED                                                                 [100%]
=================================================================== 1 passed, 3 warnings in 226.69s (0:03:46) ===================================================================
```
