### PR TITLE
add fixture to record test markers as junit testCase properties

### DIFF
--- a/pytest_fixtures/reporting_fixtures.py
+++ b/pytest_fixtures/reporting_fixtures.py
@@ -56,3 +56,9 @@ def record_testsuite_timestamp_xml(record_testsuite_property):
 def record_test_timestamp_xml(request):
     now = datetime.datetime.utcnow()
     request.node.user_properties.append(('start_time', now.strftime(FMT_XUNIT_TIME)))
+
+
+@pytest.fixture(autouse=True, scope='function')
+def record_test_markers_xml(request, record_property):
+    for marker in request.node.iter_markers():
+        request.node.user_properties.append((marker.name, marker.args[0]))

--- a/tests/robottelo/test_report.py
+++ b/tests/robottelo/test_report.py
@@ -34,11 +34,15 @@ def test_junit_timestamps(exec_test, property_level):
         junit = xmltodict.parse(f)  # NOQA
     for path in property_level:
         prop = eval(f'junit{path}')
+        if not isinstance(prop, list):
+            prop = [prop]
         try:
-            assert prop['@name'] == 'start_time'
+            assert 'start_time' in [p['@name'] for p in prop]
         except KeyError as e:
             raise AssertionError(f'Missing property node: "start_time": {e}')
         try:
-            datetime.datetime.strptime(prop['@value'], XUNIT_TIME_FORMAT)
+            for p in prop:
+                if p['@name'] == 'start_time':
+                    datetime.datetime.strptime(p['@value'], XUNIT_TIME_FORMAT)
         except ValueError as e:
             raise AssertionError(f'Unable to parse datetime for "start_time" property node: {e}')


### PR DESCRIPTION
This fixture should automatically record all testimony tags (mainly importance, component, assignee) as a junit xml properties.