### PR TITLE
Removing export from hammer repository command

### DIFF
--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -12,7 +12,6 @@ Subcommands::
 
     create                        Create a repository
     delete                        Destroy a repository
-    export                        Export a repository
     info                          Show a repository
     list                          List of repositories
     remove-content                Remove content from the repository
@@ -42,12 +41,6 @@ class Repository(Base):
             cls.command_requires_org = True
 
         return result
-
-    @classmethod
-    def export(cls, options=None):
-        """Export a repository"""
-        cls.command_sub = 'export'
-        return cls.execute(cls._construct_command(options), output_format='csv', ignore_stderr=True)
 
     @classmethod
     def info(cls, options=None):

--- a/tests/robottelo/test_cli_method_calls.py
+++ b/tests/robottelo/test_cli_method_calls.py
@@ -58,9 +58,7 @@ def test_cli_proxy_method_called(mocker, command_sub):
     assert execute.called_once_with(construct.return_value)
 
 
-@pytest.mark.parametrize(
-    'command_sub', ['export', 'synchronize', 'remove-content', 'upload-content']
-)
+@pytest.mark.parametrize('command_sub', ['synchronize', 'remove-content', 'upload-content'])
 def test_cli_repository_method_called(mocker, command_sub):
     """Check Repository methods are called and command_sub edited
     This is a parametrized test called by Pytest for each of Repository methods


### PR DESCRIPTION
`hammer repository export` doesn't exist anymore so removing that command