### PR TITLE
Fixed settings test failure.

### DIFF
--- a/tests/foreman/api/test_setting.py
+++ b/tests/foreman/api/test_setting.py
@@ -96,8 +96,8 @@ def test_negative_update_hostname_with_empty_fact(setting_update):
 
     :parametrized: yes
 
-    :expectedresults: Error should be raised on setting empty value for
-        hostname_facts setting
+    :expectedresults: Error should be raised on setting empty value for discovery_hostname
+        setting
     """
     setting_update.value = ""
     with pytest.raises(HTTPError):
@@ -113,12 +113,14 @@ def test_positive_update_hostname_prefix_without_value(setting_update):
 
     :parametrized: yes
 
-    :expectedresults: Hostname_prefix should be set without any text
+    :BZ: 1911228
+
+    :expectedresults: Error should be raised on setting empty value for discovery_prefix setting
 
     """
     setting_update.value = ""
-    setting_update = setting_update.update({'value'})
-    assert setting_update.value == ""
+    with pytest.raises(HTTPError):
+        setting_update.update({'value'})
 
 
 @pytest.mark.tier1

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -57,12 +57,13 @@ def test_positive_update_hostname_prefix_without_value(setting_update):
 
     :parametrized: yes
 
-    :expectedresults: Hostname_prefix should be set without any text
+    :BZ: 1470083
+
+    :expectedresults: Error should be raised on setting empty value for discovery_prefix setting
 
     """
-    Settings.set({'name': "discovery_prefix", 'value': ""})
-    discovery_prefix = Settings.list({'search': 'name=discovery_prefix'})[0]
-    assert discovery_prefix['value'] == ''
+    with pytest.raises(CLIReturnCodeError):
+        Settings.set({'name': "discovery_prefix", 'value': ""})
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -165,28 +165,49 @@ def test_negative_validate_foreman_url_error_message(session, setting_update):
             assert is_valid_error_message(str(context.value))
 
 
-@pytest.mark.run_in_one_thread
+@pytest.mark.skip_if_open('BZ:1975713')
 @pytest.mark.tier2
-@pytest.mark.parametrize(
-    'setting_update',
-    ['host_dmi_uuid_duplicates', 'register_hostname_fact', 'content_view_solve_dependencies'],
-    indirect=True,
-)
+@pytest.mark.parametrize('setting_update', ['host_dmi_uuid_duplicates'], indirect=True)
 def test_positive_host_dmi_uuid_duplicates(session, setting_update):
-    """ "check the setting host_dmi_uuid_duplicates, register_hostname_fact &
-    content_view_solve_dependencies  value update.
+    """Check the setting host_dmi_uuid_duplicates value update.
 
     :id: 529ddd3a-1271-4043-9006-eac436b08b11
 
     :parametrized: yes
 
-    :expectedresults: Successfully add value to different selectors
+    :BZ: 1975713
+
+    :expectedresults: Value of host_dmi_uuid_duplicates should be updated successfully
+
+    :CaseImportance: High
+    """
+    property_value = f'[ {gen_string("alpha")} ]'
+    property_name = setting_update.name
+    with session:
+        session.settings.update(f'name = {setting_update.name}', property_value)
+        result = session.settings.read(f'name = {property_name}')
+        assert result['table'][0]['Value'] == property_value
+
+
+@pytest.mark.tier2
+@pytest.mark.parametrize(
+    'setting_update', ['register_hostname_fact', 'content_view_solve_dependencies'], indirect=True
+)
+def test_positive_register_hostname_and_cvs_dependencies_update(session, setting_update):
+    """Check the settings of register_hostname_fact & content_view_solve_dependencies value
+       update.
+
+    :id: 3d50c163-6a6d-494a-b0f2-1e1dd8a5c476
+
+    :parametrized: yes
+
+    :expectedresults: Value of register_hostname_fact and content_view_solve_dependencies
+        should be updated successfully.
 
     :CaseImportance: High
     """
     property_dict = {
         "content_view_solve_dependencies": "Yes",
-        "host_dmi_uuid_duplicates": f'[ {gen_string("alpha")} ]',
         "register_hostname_fact": gen_string('alpha'),
     }
 
@@ -449,7 +470,7 @@ def test_positive_email_yaml_config_precedence():
     """
 
 
-@pytest.mark.skip_if_open("BZ:1470083")
+@pytest.mark.skip_if_open("BZ:1989706")
 @pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_hostname'], indirect=True)
 def test_negative_update_hostname_with_empty_fact(session, setting_update):
@@ -462,7 +483,11 @@ def test_negative_update_hostname_with_empty_fact(session, setting_update):
         1. Goto settings ->Discovered tab -> Hostname_facts
         2. Set empty hostname_facts (without any value)
 
+    :BZ: 1470083, 1989706
+
     :parametrized: yes
+
+    :CaseImportance: Medium
 
     :expectedresults: Error should be raised on setting empty value for
         hostname_facts setting
@@ -472,7 +497,7 @@ def test_negative_update_hostname_with_empty_fact(session, setting_update):
     property_name = setting_update.name
     with session:
         response = session.settings.update(property_name, new_hostname)
-        assert response is not None, "Empty string accepted"
+        assert response is not None, "Value can't be blank"
 
 
 @pytest.mark.run_in_one_thread


### PR DESCRIPTION
In this PR, We have fixed CLI, API, and UI-related test failures.

**Test Results**


```
$ pytest -s tests/foreman/cli/test_setting.py
platform linux -- Python 3.8.0, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
.........................

================================================================================================ warnings summary =================================================================================================
============================================================================ 25 passed, 5 deselected, 33 warnings in 660.08s (0:11:00) ============================================================================

$ pytest -s tests/foreman/api/test_setting.py
platform linux -- Python 3.8.0, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
.......
================================================================================================ warnings summary =================================================================================================

============================================================================= 8 passed, 2 deselected, 41 warnings in 92.99s (0:01:32) =============================================================================

```