### PR TITLE
Use /root directory due to Foreman temporary directories cleanup

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1560,7 +1560,7 @@ def make_template(options=None):
     # Assigning default values for attribute
     args = {
         'audit-comment': None,
-        'file': f'/tmp/{gen_alphanumeric()}',
+        'file': f'/root/{gen_alphanumeric()}',
         'location-ids': None,
         'locked': None,
         'name': gen_alphanumeric(6),


### PR DESCRIPTION
Foreman is using private `/tmp` dirs. This might be a cause of our tests failing. However, I am not 100% sure if the test failure is caused by the private /tmp dirs.
```
robottelo/cli/factory.py:113: in create_object
    result = cli_object.create(options)
robottelo/cli/base.py:125: in create
    result = cls.execute(cls._construct_command(options), output_format='csv', timeout=timeout)
robottelo/cli/base.py:252: in execute
    return cls._handle_response(response, ignore_stderr=ignore_stderr)
robottelo/cli/base.py:97: in _handle_response
    raise CLIReturnCodeError(*error_data)
E   robottelo.cli.base.CLIReturnCodeError: CLIReturnCodeError(return_code=70, stderr='Could not create the provisioning template:\n  Error: No such file or directory @ rb_sysopen - /tmp/J7eaicwj8v\n', msg='Command "template create" finished with return_code 70\nstderr contains:\nCould not create the provisioning template:\n  Error: No such file or directory @ rb_sysopen - /tmp/J7eaicwj8v\n'

During handling of the above exception, another exception occurred:
tests/foreman/cli/test_template.py:161: in test_positive_add_os_by_id
    new_template = make_template()
robottelo/decorators/init.py:20: in cacheable_function
    new_object = func(options)
robottelo/cli/factory.py:1587: in make_template
    return create_object(Template, args, options)
robottelo/cli/factory.py:116: in create_object
    raise CLIFactoryError(
E   robottelo.cli.factory.CLIFactoryError: Failed to create Template with data:
E   { 'audit-comment': None,
E     'file': '/tmp/J7eaicwj8v',
E     'location-ids': None,
E     'locked': None,
E     'name': 'tM5KZG',
E     'operatingsystem-ids': None,
E     'organization-ids': None,
E     'type': 'PXELinux'}
E   Command "template create" finished with return_code 70
E   stderr contains:
E   Could not create the provisioning template:
E     Error: No such file or directory @ rb_sysopen - /tmp/J7eaicwj8v
```

See: https://community.theforeman.org/t/temporary-directories-cleanup/22698