### PR TITLE
Update PERMISSIONS constant to reflect changes in Satellite 6.10

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -968,6 +968,18 @@ PERMISSIONS = {
         'view_arf_reports',
         'destroy_arf_reports',
     ],
+    'ForemanOpenscap::OvalContent': [
+        'create_oval_contents',
+        'destroy_oval_contents',
+        'edit_oval_contents',
+        'view_oval_contents',
+    ],
+    'ForemanOpenscap::OvalPolicy': [
+        'create_oval_policies',
+        'destroy_oval_policies',
+        'edit_oval_policies',
+        'view_oval_policies',
+    ],
     'ForemanOpenscap::Policy': [
         'assign_policies',
         'create_policies',
@@ -1114,6 +1126,19 @@ PERMISSIONS = {
     ],
     'Usergroup': ['view_usergroups', 'create_usergroups', 'edit_usergroups', 'destroy_usergroups'],
     'User': ['view_users', 'create_users', 'edit_users', 'destroy_users'],
+    'Webhook': [
+        'create_webhooks',
+        'destroy_webhooks',
+        'edit_webhooks',
+        'view_webhooks',
+    ],
+    'WebhookTemplate': [
+        'create_webhook_templates',
+        'destroy_webhook_templates',
+        'edit_webhook_templates',
+        'lock_webhook_templates',
+        'view_webhook_templates',
+    ],
     'Host': [
         'auto_provision_discovered_hosts',
         'build_hosts',
@@ -1146,7 +1171,6 @@ PERMISSIONS = {
         'destroy_content_views',
         'publish_content_views',
         'promote_or_remove_content_views',
-        'export_content_views',
     ],
     'Katello::GpgKey': [
         'view_content_credentials',


### PR DESCRIPTION
Changes in available user permissions introduced in Satellite 6.10 caused failures in the following 3 critical tests:

- tests/foreman/api/test_permission.py::TestPermission::test_positive_search
- tests/foreman/api/test_permission.py::TestPermission::test_positive_search_by_name
- tests/foreman/api/test_permission.py::TestPermission::test_positive_search_by_resource_type

Example pytest output before making this change:

```
$ pytest tests/foreman/api/test_permission.py::TestPermission::test_positive_search
===================================================== test session starts =====================================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dsynk/qe_forks/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, xdist-2.2.1, services-2.2.1, reportportal-5.0.8, ibutsu-1.14.1, mock-3.6.0, cov-2.11.1
collected 1 item                                                                                                              

tests/foreman/api/test_permission.py F                                                                                  [100%]

========================================================== FAILURES ===========================================================
_____________________________________________ TestPermission.test_positive_search _____________________________________________

self = <tests.foreman.api.test_permission.TestPermission object at 0x7f3506117bb0>

    @pytest.mark.tier1
    def test_positive_search(self):
        """search with no parameters return all permissions
    
        :id: e58308df-19ec-415d-8fa1-63ebf3cd0ad6
    
        :expectedresults: Search returns a list of all expected permissions
    
        :CaseImportance: Critical
        """
        permissions = entities.Permission().search(query={'per_page': '1000'})
        names = {perm.name for perm in permissions}
        resource_types = {perm.resource_type for perm in permissions}
        expected_names = set(self.permission_names)
        expected_resource_types = set(self.permission_resource_types)
    
        added_resource_types = tuple(resource_types - expected_resource_types)
        removed_resource_types = tuple(expected_resource_types - resource_types)
        added_names = tuple(names - expected_names)
        removed_names = tuple(expected_names - names)
    
        diff = {}
        if added_resource_types:
            diff['added_resource_types'] = added_resource_types
        if removed_resource_types:
            diff['removed_resource_types'] = removed_resource_types
        if added_names:
            diff['added_names'] = added_names
        if removed_names:
            diff['removed_names'] = removed_names
    
        if diff:
>           pytest.fail(json.dumps(diff, indent=True, sort_keys=True))
E           Failed: {
E            "added_names": [
E             "edit_oval_contents",
E             "destroy_oval_policies",
E             "create_webhooks",
E             "view_oval_contents",
E             "destroy_oval_contents",
E             "lock_webhook_templates",
E             "view_webhook_templates",
E             "edit_oval_policies",
E             "create_oval_contents",
E             "destroy_webhooks",
E             "destroy_webhook_templates",
E             "edit_webhook_templates",
E             "edit_webhooks",
E             "view_oval_policies",
E             "create_oval_policies",
E             "view_webhooks",
E             "create_webhook_templates"
E            ],
E            "added_resource_types": [
E             "WebhookTemplate",
E             "Webhook",
E             "ForemanOpenscap::OvalPolicy",
E             "ForemanOpenscap::OvalContent"
E            ],
E            "removed_names": [
E             "export_content_views"
E            ]
E           }

tests/foreman/api/test_permission.py:164: Failed
```
Sample pytest output after making these changes:
```
$ pytest tests/foreman/api/test_permission.py::TestPermission::test_positive_search
===================================================== test session starts =====================================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dsynk/qe_forks/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, xdist-2.2.1, services-2.2.1, reportportal-5.0.8, ibutsu-1.14.1, mock-3.6.0, cov-2.11.1
collected 1 item                                                                                                              

tests/foreman/api/test_permission.py .                                                                                  [100%]

====================================================== warnings summary =======================================================
../venvs/robottelo/lib64/python3.9/site-packages/attrdict/mapping.py:4
  /home/dsynk/qe_forks/venvs/robottelo/lib64/python3.9/site-packages/attrdict/mapping.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Mapping

../venvs/robottelo/lib64/python3.9/site-packages/attrdict/mixins.py:5
../venvs/robottelo/lib64/python3.9/site-packages/attrdict/mixins.py:5
  /home/dsynk/qe_forks/venvs/robottelo/lib64/python3.9/site-packages/attrdict/mixins.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Mapping, MutableMapping, Sequence

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=============================================== 1 passed, 3 warnings in 16.29s ================================================
```