### PR TITLE
Fix test failure for test_positive_non_admin_user_actions

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -3505,8 +3505,15 @@ def test_positive_non_admin_user_actions(session, module_org, test_name):
         # assert that the user can delete a content view
         session.contentview.delete(cv_copy_name)
         assert session.contentview.search(cv_copy_name)[0]['Name'] != cv_copy_name
+        session.contentview.update(cv_name, {'details.name': cv_new_name})
+        assert session.contentview.search(cv_new_name)[0]['Name'] == cv_new_name
+        # Publish and promote CV to next environment
+        result = session.contentview.publish(cv_new_name)
+        assert result['Version'] == VERSION
+        result = session.contentview.promote(cv_new_name, VERSION, lce.name)
+        assert f'Promoted to {lce.name}' in result['Status']
         # check that cv tabs are accessible
-        cv = session.contentview.read(cv_name)
+        cv = session.contentview.read(cv_new_name)
         for tab_name in [
             'details',
             'versions',
@@ -3517,13 +3524,6 @@ def test_positive_non_admin_user_actions(session, module_org, test_name):
             'ostree_content',
         ]:
             assert cv.get(tab_name) is not None
-        session.contentview.update(cv_name, {'details.name': cv_new_name})
-        assert session.contentview.search(cv_new_name)[0]['Name'] == cv_new_name
-        # Publish and promote CV to next environment
-        result = session.contentview.publish(cv_new_name)
-        assert result['Version'] == VERSION
-        result = session.contentview.promote(cv_new_name, VERSION, lce.name)
-        assert f'Promoted to {lce.name}' in result['Status']
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
This test has been failing for a while due to `access denied` flash messages in the created user login when the user navigates to the tabs in a contentview due to permissions.  I'm moving the validation that causes the flashes to the end so it doesn't disrupt the remainder of the other validations.

```
=============== warnings summary ========
../venv/my_robo_env/lib64/python3.8/site-packages/attrdict/mapping.py:4
  /home/ltran/Projects/venv/my_robo_env/lib64/python3.8/site-packages/attrdict/mapping.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

../venv/my_robo_env/lib64/python3.8/site-packages/attrdict/mixins.py:5
../venv/my_robo_env/lib64/python3.8/site-packages/attrdict/mixins.py:5
  /home/ltran/Projects/venv/my_robo_env/lib64/python3.8/site-packages/attrdict/mixins.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, MutableMapping, Sequence

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================== 1 passed, 3 warnings in 261.25s (0:04:21) ==============
```