### PR TITLE
Azure fixes

### DIFF
--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -20,6 +20,7 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
+from robottelo.api.utils import satellite_setting
 from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.config import settings
 from robottelo.constants import AZURERM_FILE_URI
@@ -140,7 +141,6 @@ class TestAzureRMComputeResourceTestCase:
 
         :CaseLevel: Integration
         """
-
         cr_nws = module_azurerm_cr.available_networks()
         portal_nws = azurermclient.list_network()
         assert len(portal_nws) == len(cr_nws['results'])
@@ -207,8 +207,8 @@ class TestAzureRMHostProvisioningTestCase:
             "script_uris": AZURERM_FILE_URI,
             "image_id": self.rhel7_ft_img,
         }
-
         nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+
         request.cls.interfaces_attributes = {
             "0": {
                 "compute_attributes": {
@@ -259,7 +259,8 @@ class TestAzureRMHostProvisioningTestCase:
         ).create()
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        host.delete()
+        with satellite_setting('destroy_vm_on_host_delete=True'):
+            host.delete()
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_ft):
@@ -409,7 +410,8 @@ class TestAzureRMUserDataProvisioning:
         ).create()
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        host.delete()
+        with satellite_setting('destroy_vm_on_host_delete=True'):
+            host.delete()
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_ud):
@@ -563,7 +565,8 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
         ).create()
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        host.delete()
+        with satellite_setting('destroy_vm_on_host_delete=True'):
+            host.delete()
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_gallery_ft):
@@ -689,7 +692,8 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
         ).create()
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        host.delete()
+        with satellite_setting('destroy_vm_on_host_delete=True'):
+            host.delete()
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_custom_ft):

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -20,6 +20,7 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
+from robottelo.api.utils import satellite_setting
 from robottelo.api.utils import set_hammer_api_timeout
 from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.cli.computeprofile import ComputeProfile
@@ -359,7 +360,8 @@ class TestAzureRMFinishTemplateProvisioning:
         )
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        Host.delete({'name': self.fullhostname}, timeout=1800)
+        with satellite_setting('destroy_vm_on_host_delete=True'):
+            Host.delete({'name': self.fullhostname}, timeout=1800)
         set_hammer_api_timeout(reverse=True)
 
     @pytest.fixture(scope='class')
@@ -478,7 +480,8 @@ class TestAzureRMUserDataProvisioning:
         )
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default user data', reverse=True)
-        Host.delete({'name': self.fullhostname}, timeout=1800)
+        with satellite_setting('destroy_vm_on_host_delete=True'):
+            Host.delete({'name': self.fullhostname}, timeout=1800)
         set_hammer_api_timeout(reverse=True)
 
     @pytest.fixture(scope='class')
@@ -597,7 +600,8 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
         )
         yield host
         skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        Host.delete({'name': self.fullhostname}, timeout=1800)
+        with satellite_setting('destroy_vm_on_host_delete=True'):
+            Host.delete({'name': self.fullhostname}, timeout=1800)
         set_hammer_api_timeout(reverse=True)
 
     @pytest.fixture(scope='class')
@@ -605,7 +609,7 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
         """Returns the AzureRM Client Host object to perform the assertions"""
         return azurermclient.get_vm(name=class_byos_ft_host['name'].split('.')[0])
 
-    @pytest.mark.skip_if_open("BZ:1850934")
+    @pytest.mark.skip_if_open('BZ:1937960')
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_azurerm_byosft_host_provisioned(
@@ -636,7 +640,7 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
             7. The host Name and Platform should be same on Azure Cloud as provided during
                provisioning.
 
-        :BZ: 1850934
+        :BZ: 1850934, 1937960
         """
 
         assert class_byos_ft_host['name'] == self.fullhostname


### PR DESCRIPTION
- Azure Teardown improved with a Settings Context manager since the setting is changed to preserve the VM on host delete. But now we are deleting the VM along with the host with the new context manager. This will help us to remove the VMs on teardown automatically!
- UI test failure fixes for not tearing down and checking for the existence of VM fails.
- BYOS test has been skipped with 1937960