### PR TITLE
[Cherry-pick] use json gce cert from conf

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -1,5 +1,6 @@
 """Several helper methods and functions."""
 import contextlib
+import json
 import os
 import random
 import re
@@ -702,7 +703,11 @@ def slugify_component(string, keep_hyphens=True):
 
 
 def download_gce_cert():
-    ssh.command(f'curl {settings.gce.cert_url} -o {settings.gce.cert_path}')
+    _, gce_cert = mkstemp(suffix='.json')
+    cert_json = json.loads(settings.gce.cert)
+    with open(gce_cert, 'w') as f:
+        json.dump(cert_json, f)
+    ssh.upload_file(gce_cert, settings.gce.cert_path)
     if ssh.command(f'[ -f {settings.gce.cert_path} ]').return_code != 0:
         raise GCECertNotFoundError(
             f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -34,7 +34,6 @@ GCE_SETTINGS = dict(
     client_email=settings.gce.client_email,
     cert_path=settings.gce.cert_path,
     zone=settings.gce.zone,
-    cert_url=settings.gce.cert_url,
 )
 
 

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -32,9 +32,7 @@ from robottelo.helpers import download_gce_cert
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skip_if_not_set('http_proxy', 'gce')
-def test_positive_default_end_to_end_with_custom_profile(
-    session, module_org, module_loc, module_gce_settings
-):
+def test_positive_default_end_to_end_with_custom_profile(session, module_org, module_loc):
     """Create GCE compute resource with default properties and apply it's basic functionality.
 
     :id: 59ffd83e-a984-4c22-b91b-cad055b4fbd7


### PR DESCRIPTION
#8811
Test results:
```pytest -v tests/foreman/ui/test_computeresource_gce.py -k test_positive_default_end_to_end_with_custom_profile
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo3.9/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.16, xdist-2.3.0, forked-1.3.0, mock-3.6.1, reportportal-5.0.8, services-2.2.1, cov-2.12.1
collected 1 item                                                                                                                                                                                

tests/foreman/ui/test_computeresource_gce.py::test_positive_default_end_to_end_with_custom_profile PASSED                                                                                 [100%]

=========================================================================== 1 passed, 0 warnings in 181.86s (0:03:01) ===========================================================================```