### PR TITLE
Added timeout to extend the syncing for test_positive_sync_kickstart_repo

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -124,7 +124,7 @@ class TestSatelliteContentManagement:
         repo = entities.Repository(
             product=product, url=constants.repos.CUSTOM_KICKSTART_REPO
         ).create()
-        repo.sync()
+        repo.sync(timeout=1000)
         repo.download_policy = 'immediate'
         repo = repo.update(['download_policy'])
         call_entity_method_with_timeout(repo.sync, timeout=600)


### PR DESCRIPTION
This was failing before due to timeout.  Adding timeout so it can finish syncing and executing rest of test.

```
 pytest tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_repo

============================ 1 passed, 3 warnings in 163.97s (0:02:43) =========================
```