### PR TITLE
Temporary fix for boxkey errors in ssh.py

### DIFF
--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -10,7 +10,6 @@ from io import StringIO
 import paramiko
 
 from robottelo.cli import hammer
-from robottelo.config import settings
 from robottelo.logging import logger
 
 
@@ -98,6 +97,9 @@ def get_client(
     Processes ssh credentials in the order: password, key_filename, ssh_key
     Config validation enforces one of the three must be set in settings.server
     """
+    # temporary workaround due to import order.
+    from robottelo.config import settings
+
     hostname = hostname or settings.server.hostname
     username = username or settings.server.ssh_username
     password = password or settings.server.ssh_password
@@ -220,6 +222,8 @@ def add_authorized_key(
 
     :param key: either a file path, key string or a file-like obj to append.
     """
+    # temporary workaround due to import order.
+    from robottelo.config import settings
 
     if getattr(key, 'read', None):  # key is a file-like object
         key_content = key.read()  # pragma: no cover
@@ -361,6 +365,9 @@ def command(
     :param int timeout: Time to wait for the ssh command to finish.
     :param connection_timeout: Time to wait for establishing the connection.
     """
+    # temporary workaround due to import order.
+    from robottelo.config import settings
+
     hostname = hostname or settings.server.hostname
     timeout = timeout or settings.ssh_client.command_timeout
     connection_timeout = connection_timeout or settings.ssh_client.connection_timeout
@@ -386,6 +393,9 @@ def execute_command(cmd, connection, output_format=None, timeout=None, connectio
     :param connection_timeout: Time to wait for establishing the connection.
     :return: SSHCommandResult
     """
+    # temporary workaround due to import order.
+    from robottelo.config import settings
+
     if timeout is None:
         timeout = settings.ssh_client.command_timeout
     if connection_timeout is None:

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -98,7 +98,7 @@ class MockSSHClient:
 class TestSSH:
     """Tests for module ``robottelo.ssh``."""
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_get_connection_key(self, settings):
         """Test method ``get_connection`` using key file to connect to the
         server.
@@ -132,7 +132,7 @@ class TestSSH:
         assert connection.connect_ == 1
         assert connection.close_ == 1
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_get_connection_pass(self, settings):
         """Test method ``get_connection`` using password of user to connect to
         the server
@@ -164,7 +164,7 @@ class TestSSH:
         assert connection.connect_ == 1
         assert connection.close_ == 1
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_get_connection_key_string(self, settings):
         """Test method ``get_connection`` using key file to connect to the
         server.
@@ -259,7 +259,7 @@ class TestSSH:
         with pytest.raises(ValueError):
             ssh.add_authorized_key({"invalid": "format"})
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_add_authorized_key(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient
         settings.server.hostname = 'example.com'
@@ -270,7 +270,7 @@ class TestSSH:
         settings.ssh_client.connection_timeout = 10
         ssh.add_authorized_key('ssh-rsa xxxx user@host')
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_execute_command(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient
         settings.server.hostname = 'example.com'
@@ -285,7 +285,7 @@ class TestSSH:
             assert ret.stdout == ['ls -la']
             assert isinstance(ret, ssh.SSHCommandResult)
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_execute_command_base_output(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient
         settings.server.hostname = 'example.com'
@@ -300,7 +300,7 @@ class TestSSH:
             assert ret.stdout == 'ls -la'
             assert isinstance(ret, ssh.SSHCommandResult)
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_command(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient
         settings.server.hostname = 'example.com'
@@ -314,7 +314,7 @@ class TestSSH:
         assert ret.stdout == ['ls -la']
         assert isinstance(ret, ssh.SSHCommandResult)
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_command_base_output(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient
         settings.server.hostname = 'example.com'
@@ -328,7 +328,7 @@ class TestSSH:
         assert ret.stdout == 'ls -la'
         assert isinstance(ret, ssh.SSHCommandResult)
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_parse_csv(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient
         settings.server.hostname = 'example.com'
@@ -342,7 +342,7 @@ class TestSSH:
         assert ret.stdout == [{'a': '1', 'b': '2', 'c': '3'}]
         assert isinstance(ret, ssh.SSHCommandResult)
 
-    @mock.patch('robottelo.ssh.settings')
+    @mock.patch('robottelo.config.settings')
     def test_parse_json(self, settings):
         ssh._call_paramiko_sshclient = MockSSHClient
         settings.server.hostname = 'example.com'


### PR DESCRIPTION
This is a temporary fix resulting from issues we're seeing around import
order causing boxkey errors with settings.server.hostname.
By delaying the import of he settings object, we should only import
after that setting has been set.