### PR TITLE
[cherry-pick] Use /root directory due to Foreman temporary directories cleanup

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1560,7 +1560,7 @@ def make_template(options=None):
     # Assigning default values for attribute
     args = {
         'audit-comment': None,
-        'file': f'/tmp/{gen_alphanumeric()}',
+        'file': f'/root/{gen_alphanumeric()}',
         'location-ids': None,
         'locked': None,
         'name': gen_alphanumeric(6),


### PR DESCRIPTION
See: https://community.theforeman.org/t/temporary-directories-cleanup/22698
(cherry picked from commit 294a1fd310af6375b72586e8f99e45af84f382ba)