### PR TITLE
Fixed test_negative_settings_access_to_non_admin test failure

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -273,7 +273,12 @@ def test_negative_settings_access_to_non_admin():
     entities.User(admin=False, login=login, password=password).create()
     try:
         with Session(user=login, password=password) as session:
-            assert session.settings.robottelo.browser.title == 'Permission denied'
+            result = session.settings.permission_denied()
+            assert (
+                result == 'Permission denied You are not authorized to perform this action. '
+                'Please request one of the required permissions listed below '
+                'from a Satellite administrator: view_settings Back'
+            )
     finally:
         User.delete({'login': login})
 


### PR DESCRIPTION
This PR is depends on the airgun PR: https://github.com/SatelliteQE/airgun/pull/604

**Test result:**

```
#pytest tests/foreman/ui/test_settings.py::test_negative_settings_access_to_non_admin
=============================================================================================== test session starts ===============================================================================================
tests/foreman/ui/test_settings.py .                                                                                                                                                                         [100%]

================================================================================================ warnings summary =================================================================================================
========================================================================================= 1 passed, 4 warnings in 43.76s ==========================================================================================
```