### PR TITLE
api test hostgroup and api test product puppet fixes

### DIFF
--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -32,9 +32,11 @@ from robottelo import manifests
 from robottelo import ssh
 from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
+from robottelo.constants import CONTAINER_REGISTRY_HUB
+from robottelo.constants import CONTAINER_UPSTREAM_NAME
+from robottelo.constants import REPO_TYPE
 from robottelo.constants import VALID_GPG_KEY_BETA_FILE
 from robottelo.constants import VALID_GPG_KEY_FILE
-from robottelo.constants.repos import FAKE_1_PUPPET_REPO
 from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
@@ -356,15 +358,18 @@ def test_positive_sync_several_repos(module_org):
     rpm_repo = entities.Repository(
         product=product, content_type='yum', url=FAKE_1_YUM_REPO
     ).create()
-    puppet_repo = entities.Repository(
-        product=product, content_type='puppet', url=FAKE_1_PUPPET_REPO
+    docker_repo = entities.Repository(
+        content_type=REPO_TYPE['docker'],
+        docker_upstream_name=CONTAINER_UPSTREAM_NAME,
+        product=product,
+        url=CONTAINER_REGISTRY_HUB,
     ).create()
     assert rpm_repo.read().content_counts['rpm'] == 0
-    assert puppet_repo.read().content_counts['puppet_module'] == 0
+    assert docker_repo.read().content_counts['docker_tag'] == 0
 
     product.sync()
     assert rpm_repo.read().content_counts['rpm'] >= 1
-    assert puppet_repo.read().content_counts['puppet_module'] >= 1
+    assert docker_repo.read().content_counts['docker_tag'] >= 1
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
test_results:
```
pytest -vv tests/foreman/api/test_hostgroup.py::TestHostGroup::test_inherit_puppetclass tests/foreman/api/test_product.py::test_positive_sync_several_repos
tests/foreman/api/test_hostgroup.py::TestHostGroup::test_inherit_puppetclass PASSED    [ 50%]
tests/foreman/api/test_product.py::test_positive_sync_several_repos PASSED             [100%]
========================= 2 passed, 17 warnings in 116.84s (0:01:56) =========================
```

docker repo used instead of puppet repo and puppet module workaround used for work around puppet class 

asking for review owners of the test, which are also tier1 reviewers 