### PR TITLE
Make default_sat dependent on align_to_xdist

### DIFF
--- a/pytest_fixtures/broker.py
+++ b/pytest_fixtures/broker.py
@@ -10,7 +10,7 @@ from robottelo.hosts import Satellite
 
 
 @pytest.fixture(scope='session')
-def default_sat():
+def default_sat(align_to_satellite):
     """Returns a Satellite object for settings.server.hostname"""
     if settings.server.hostname:
         return Satellite()


### PR DESCRIPTION
This ensures settings.server.hostname has been calculated and set

Backports #8856