### PR TITLE
Use default_sat instead of settings.server.hostname

### DIFF
--- a/robottelo/decorators/func_locker.py
+++ b/robottelo/decorators/func_locker.py
@@ -75,10 +75,9 @@ def set_default_scope(value):
 
 def _get_default_scope():
     # this is the default locking scope
-    if LOCK_DEFAULT_SCOPE is None:
-        return settings.server.hostname
-    else:
-        return LOCK_DEFAULT_SCOPE
+    from robottelo.config import settings
+
+    return LOCK_DEFAULT_SCOPE or settings.server.hostname
 
 
 def get_temp_dir():

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -865,7 +865,10 @@ class Capsule(ContentHost):
 
 class Satellite(Capsule):
     def __init__(self, hostname=None, **kwargs):
-        hostname = hostname or settings.server.hostname
+        from robottelo.config import settings
+
+        hostname = hostname or settings.server.hostname  # instance attr set by broker.Host
+        self.port = kwargs.get('port', settings.server.port)
         super().__init__(hostname=hostname, **kwargs)
         # create dummy classes for later population
         self._api = type('api', (), {'_configured': False})
@@ -895,7 +898,7 @@ class Satellite(Capsule):
         # set the server configuration to point to this satellite
         self.nailgun_cfg = ServerConfig(
             auth=(settings.server.admin_username, settings.server.admin_password),
-            url=f'https://{self.hostname}',
+            url=f'{self.url}',
             verify=False,
         )
         # add each nailgun entity to self.api, injecting our server config
@@ -959,6 +962,10 @@ class Satellite(Capsule):
     @cached_property
     def version(self):
         return self.execute('rpm -q satellite').stdout.split('-')[1]
+
+    @cached_property
+    def url(self):
+        return f'https://{self.hostname}'
 
     def capsule_certs_generate(self, capsule, **extra_kwargs):
         """Generate capsule certs, returning the cert path and the installer command args"""

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -75,9 +75,9 @@ def module_gce_finishimg(
 
 
 @pytest.fixture(scope='class')
-def gce_domain(module_org, module_location, default_smart_proxy):
+def gce_domain(module_org, module_location, default_smart_proxy, default_sat):
     """Sets Domain for GCE Host Provisioning"""
-    _, _, dom = settings.server.hostname.partition('.')
+    _, _, dom = default_sat.hostname.partition('.')
     domain = entities.Domain().search(query={'search': f'name="{dom}"'})
     domain = domain[0].read()
     domain.location.append(module_location)

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -660,7 +660,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_on_demand_sync(self, capsule_configured):
+    def test_positive_on_demand_sync(self, capsule_configured, default_sat):
         """Create a repository with 'on_demand' sync, add it to lifecycle
         environment with a capsule, sync repository, examine existing packages
         on capsule, download any package, examine packages once more
@@ -775,8 +775,9 @@ class TestCapsuleContentManagement:
         assert broken_links == links
 
         # Download package from satellite and get its md5 checksum
+        # Not using default_sat.url as it uses https
         published_repo_url = 'http://{}{}/pulp/{}/'.format(
-            settings.server.hostname,
+            default_sat.hostname,
             f':{settings.server.port}' if settings.server.port else '',
             lce_repo_path.split('http/')[1],
         )

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -32,7 +32,6 @@ from requests.exceptions import HTTPError
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.config import get_credentials
-from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
@@ -306,7 +305,7 @@ class TestOrganizationUpdate:
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
-    def test_positive_add_and_remove_smart_proxy(self):
+    def test_positive_add_and_remove_smart_proxy(self, default_sat):
         """Add a smart proxy to an organization
 
         :id: e21de720-3fa2-429b-bd8e-b6a48a13146d
@@ -318,15 +317,15 @@ class TestOrganizationUpdate:
         :CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
+        smart_proxy = default_sat.api.SmartProxy().search(
+            query={'search': f'url = {default_sat.url}:9090'}
         )
         # Check that proxy is found and unpack it from the list
         assert len(smart_proxy) > 0
         smart_proxy = smart_proxy[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
-        org = entities.Organization().create()
+        org = default_sat.api.Organization().create()
         org.smart_proxy = []
         org = org.update(['smart_proxy'])
         # Verify smart proxy was actually removed

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -756,12 +756,11 @@ class TestRepository:
     @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
-        **parametrized(
-            [
-                {'checksum_type': checksum_type, 'download_policy': 'on_demand'}
-                for checksum_type in ('sha1', 'sha256')
-            ]
-        ),
+        [
+            {'checksum_type': checksum_type, 'download_policy': 'on_demand'}
+            for checksum_type in ('sha1', 'sha256')
+        ],
+        ids=['sha1', 'sha256'],
         indirect=True,
     )
     def test_negative_create_checksum_with_on_demand_policy(self, repo_options):
@@ -867,7 +866,7 @@ class TestRepository:
 
     @pytest.mark.tier1
     @pytest.mark.parametrize(
-        'repo_options', **parametrized([{'unprotected': False}]), indirect=True
+        'repo_options', [{'unprotected': False}], ids=['protected'], indirect=True
     )
     def test_positive_update_unprotected(self, repo):
         """Update repository unprotected flag to another valid one.
@@ -880,6 +879,7 @@ class TestRepository:
 
         :CaseImportance: Critical
         """
+        assert repo.unprotected is False
         repo.unprotected = True
         repo = repo.update(['unprotected'])
         assert repo.unprotected is True
@@ -959,7 +959,7 @@ class TestRepository:
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
     @pytest.mark.parametrize(
-        'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
+        'repo_options', [{'url': FAKE_YUM_SRPM_REPO}], ids=['yum_fake'], indirect=True
     )
     def test_positive_create_delete_srpm_repo(self, repo):
         """Create a repository, sync SRPM contents and remove repo
@@ -985,7 +985,8 @@ class TestRepository:
     )
     @pytest.mark.parametrize(
         'repo_options',
-        **parametrized([{'content_type': 'yum', 'url': FAKE_2_YUM_REPO}]),
+        [{'content_type': 'yum', 'url': FAKE_2_YUM_REPO}],
+        ids=['yum_fake_2'],
         indirect=True,
     )
     def test_positive_remove_contents(self, repo):
@@ -1190,7 +1191,8 @@ class TestRepository:
     )
     @pytest.mark.parametrize(
         'repo_options',
-        **parametrized([{'content_type': 'yum', 'url': FAKE_2_YUM_REPO}]),
+        [{'content_type': 'yum', 'url': FAKE_2_YUM_REPO}],
+        ids=['yum_fake_2'],
         indirect=True,
     )
     def test_positive_resynchronize_rpm_repo(self, repo):
@@ -1246,7 +1248,8 @@ class TestRepository:
     )
     @pytest.mark.parametrize(
         'repo_options',
-        **parametrized([{'content_type': 'yum', 'url': FAKE_2_YUM_REPO}]),
+        [{'content_type': 'yum', 'url': FAKE_2_YUM_REPO}],
+        ids=['yum_fake_2'],
         indirect=True,
     )
     def test_positive_delete_rpm(self, repo):
@@ -1277,7 +1280,7 @@ class TestRepository:
         **parametrized([{'content_type': 'yum', 'unprotected': False, 'url': FAKE_2_YUM_REPO}]),
         indirect=True,
     )
-    def test_positive_access_protected_repository(self, module_org, repo):
+    def test_positive_access_protected_repository(self, module_org, repo, default_sat):
         """Access protected/https repository data file URL using organization
         debug certificate
 
@@ -1298,7 +1301,7 @@ class TestRepository:
         repo.sync()
         repo_data_file_url = urljoin(repo.full_path, 'repodata/repomd.xml')
         # ensure the url is based on the protected base server URL
-        assert repo_data_file_url.startswith(f'https://{settings.server.hostname}')
+        assert repo_data_file_url.startswith(default_sat.url)
         # try to access repository data without organization debug certificate
         with pytest.raises(SSLError):
             client.get(repo_data_file_url, verify=False)
@@ -1319,9 +1322,8 @@ class TestRepository:
     )
     @pytest.mark.parametrize(
         'repo_options',
-        **parametrized(
-            [{'content_type': 'yum', 'unprotected': False, 'url': CUSTOM_MODULE_STREAM_REPO_2}]
-        ),
+        [{'content_type': 'yum', 'unprotected': False, 'url': CUSTOM_MODULE_STREAM_REPO_2}],
+        ids=['protected_yum'],
         indirect=True,
     )
     def test_module_stream_repository_crud_operations(self, repo):
@@ -1383,7 +1385,8 @@ class TestRepositorySync:
     )
     @pytest.mark.parametrize(
         'repo_options',
-        **parametrized([{'content_type': 'yum', 'url': FAKE_0_YUM_REPO_STRING_BASED_VERSIONS}]),
+        [{'content_type': 'yum', 'url': FAKE_0_YUM_REPO_STRING_BASED_VERSIONS}],
+        ids=['yum_repo'],
         indirect=True,
     )
     def test_positive_sync_yum_with_string_based_version(self, repo):
@@ -1679,7 +1682,9 @@ class TestDockerRepository:
         ),
         indirect=True,
     )
-    def test_negative_synchronize_private_registry_no_passwd(self, repo_options, module_product):
+    def test_negative_synchronize_private_registry_no_passwd(
+        self, repo_options, module_product, default_sat
+    ):
         """Create and try to sync a Docker-type repository from a private
         registry providing empty password and the sync must fail with
         reasonable error message.
@@ -1697,11 +1702,11 @@ class TestDockerRepository:
 
         :CaseLevel: Integration
         """
-        msg = (
-            '422 Client Error: Unprocessable Entity for url: '
-            f'https://{settings.server.hostname}/katello/api/v2/repositories'
-        )
-        with pytest.raises(HTTPError, match=msg):
+        with pytest.raises(
+            HTTPError,
+            match='422 Client Error: Unprocessable Entity for url: '
+            f'{default_sat.url}/katello/api/v2/repositories',
+        ):
             entities.Repository(**repo_options).create()
 
     @pytest.mark.tier2

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -25,7 +25,6 @@ from nailgun import entities
 from nailgun.config import ServerConfig
 from requests.exceptions import HTTPError
 
-from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import parametrized
@@ -149,15 +148,13 @@ class TestCannedRole:
         """
         return entities.Domain(name=gen_string('alpha'), organization=orgs, location=locs).create()
 
-    def user_config(self, user):
+    def user_config(self, user, satellite):
         """Returns The ```nailgun.confin.ServerConfig``` for given user
 
         :param user: The nailgun.entities.User object of an user with passwd
             parameter
         """
-        return ServerConfig(
-            auth=(user.login, user.passwd), url=f'https://{settings.server.hostname}', verify=False
-        )
+        return ServerConfig(auth=(user.login, user.passwd), url=satellite.url, verify=False)
 
     @pytest.fixture
     def role_taxonomies(self):
@@ -513,7 +510,9 @@ class TestCannedRole:
         assert role_taxonomies['loc'].id == org_admin.location[0].id
 
     @pytest.mark.tier3
-    def test_negative_access_entities_from_org_admin(self, role_taxonomies, filter_taxonomies):
+    def test_negative_access_entities_from_org_admin(
+        self, role_taxonomies, filter_taxonomies, default_sat
+    ):
         """User can not access resources in taxonomies assigned to role if
         its own taxonomies are not same as its role
 
@@ -536,13 +535,15 @@ class TestCannedRole:
         domain = self.create_domain(
             orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id]
         )
-        sc = self.user_config(user)
+        sc = self.user_config(user, default_sat)
         # Getting the domain from user
         with pytest.raises(HTTPError):
             entities.Domain(sc, id=domain.id).read()
 
     @pytest.mark.tier3
-    def test_negative_access_entities_from_user(self, role_taxonomies, filter_taxonomies):
+    def test_negative_access_entities_from_user(
+        self, role_taxonomies, filter_taxonomies, default_sat
+    ):
         """User can not access resources within its own taxonomies if assigned
         role does not have permissions for user taxonomies
 
@@ -565,7 +566,7 @@ class TestCannedRole:
         domain = self.create_domain(
             orgs=[filter_taxonomies['org'].id], locs=[filter_taxonomies['loc'].id]
         )
-        sc = self.user_config(user)
+        sc = self.user_config(user, default_sat)
         # Getting the domain from user
         with pytest.raises(HTTPError):
             entities.Domain(sc, id=domain.id).read()
@@ -898,7 +899,7 @@ class TestCannedRole:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_user_group_users_access_as_org_admin(self, role_taxonomies):
+    def test_positive_user_group_users_access_as_org_admin(self, role_taxonomies, default_sat):
         """Users in usergroup can have access to the resources in taxonomies if
         the taxonomies of Org Admin role is same
 
@@ -956,9 +957,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc'].id],
         ).create()
         for login, password in ((userone_login, userone_pass), (usertwo_login, usertwo_pass)):
-            sc = ServerConfig(
-                auth=(login, password), url=f'https://{settings.server.hostname}', verify=False
-            )
+            sc = ServerConfig(auth=(login, password), url=default_sat.url, verify=False)
             try:
                 entities.Domain(sc).search(
                     query={
@@ -1005,7 +1004,9 @@ class TestCannedRole:
         """
 
     @pytest.mark.tier2
-    def test_negative_assign_org_admin_to_user_group(self, role_taxonomies, filter_taxonomies):
+    def test_negative_assign_org_admin_to_user_group(
+        self, role_taxonomies, filter_taxonomies, default_sat
+    ):
         """Users in usergroup can not have access to the resources in
         taxonomies if the taxonomies of Org Admin role is not same
 
@@ -1036,12 +1037,14 @@ class TestCannedRole:
         assert user_group.name == ug_name
         dom = self.create_domain(orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id])
         for user in [user_one, user_two]:
-            sc = self.user_config(user)
+            sc = self.user_config(user, default_sat)
             with pytest.raises(HTTPError):
                 entities.Domain(sc, id=dom.id).read()
 
     @pytest.mark.tier2
-    def test_negative_assign_taxonomies_by_org_admin(self, role_taxonomies, filter_taxonomies):
+    def test_negative_assign_taxonomies_by_org_admin(
+        self, role_taxonomies, filter_taxonomies, default_sat
+    ):
         """Org Admin doesn't have permissions to assign org to any of
         its entities
 
@@ -1083,9 +1086,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(
-            auth=(user_login, user_pass), url=f'https://{settings.server.hostname}', verify=False
-        )
+        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
         # Getting the domain from user1
         dom = entities.Domain(sc, id=dom.id).read()
         dom.organization = [filter_taxonomies['org']]
@@ -1125,7 +1126,9 @@ class TestCannedRole:
         assert org_admin.id not in [role.id for role in user.role]
 
     @pytest.mark.tier2
-    def test_positive_taxonomies_control_to_superadmin_with_org_admin(self, role_taxonomies):
+    def test_positive_taxonomies_control_to_superadmin_with_org_admin(
+        self, role_taxonomies, default_sat
+    ):
         """Super Admin can access entities in taxonomies assigned to Org Admin
 
         :id: 37db0b40-ed35-4e70-83e8-83cff27caae2
@@ -1143,7 +1146,7 @@ class TestCannedRole:
         :CaseLevel: Integration
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
-        sc = self.user_config(user)
+        sc = self.user_config(user, default_sat)
         # Creating resource
         dom_name = gen_string('alpha')
         dom = entities.Domain(
@@ -1164,7 +1167,9 @@ class TestCannedRole:
             pytest.fail(str(err))
 
     @pytest.mark.tier2
-    def test_positive_taxonomies_control_to_superadmin_without_org_admin(self, role_taxonomies):
+    def test_positive_taxonomies_control_to_superadmin_without_org_admin(
+        self, role_taxonomies, default_sat
+    ):
         """Super Admin can access entities in taxonomies assigned to Org Admin
         after deleting Org Admin role/user
 
@@ -1184,7 +1189,7 @@ class TestCannedRole:
         :CaseLevel: Integration
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
-        sc = self.user_config(user)
+        sc = self.user_config(user, default_sat)
         # Creating resource
         dom_name = gen_string('alpha')
         dom = entities.Domain(
@@ -1212,7 +1217,7 @@ class TestCannedRole:
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_negative_create_roles_by_org_admin(self, role_taxonomies):
+    def test_negative_create_roles_by_org_admin(self, role_taxonomies, default_sat):
         """Org Admin doesnt have permissions to create new roles
 
         :id: 806ecc16-0dc7-405b-90d3-0584eced27a3
@@ -1240,9 +1245,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(
-            auth=(user_login, user_pass), url=f'https://{settings.server.hostname}', verify=False
-        )
+        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
         role_name = gen_string('alpha')
         with pytest.raises(HTTPError):
             entities.Role(
@@ -1253,7 +1256,7 @@ class TestCannedRole:
             ).create()
 
     @pytest.mark.tier1
-    def test_negative_modify_roles_by_org_admin(self, role_taxonomies):
+    def test_negative_modify_roles_by_org_admin(self, role_taxonomies, default_sat):
         """Org Admin has no permissions to modify existing roles
 
         :id: 93ad9d7d-afad-4403-84a9-d59cc2ddfa58
@@ -1270,7 +1273,7 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_role = entities.Role().create()
-        sc = self.user_config(user)
+        sc = self.user_config(user, default_sat)
         test_role = entities.Role(sc, id=test_role.id).read()
         with pytest.raises(HTTPError):
             test_role.organization = [role_taxonomies['org']]
@@ -1278,7 +1281,7 @@ class TestCannedRole:
             test_role.update(['organization', 'location'])
 
     @pytest.mark.tier2
-    def test_negative_admin_permissions_to_org_admin(self, role_taxonomies):
+    def test_negative_admin_permissions_to_org_admin(self, role_taxonomies, default_sat):
         """Org Admin has no access to Super Admin user
 
         :id: cdebf9a8-35c2-4730-8423-de47a2c15ff5
@@ -1307,15 +1310,13 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(
-            auth=(user_login, user_pass), url=f'https://{settings.server.hostname}', verify=False
-        )
+        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
         with pytest.raises(HTTPError):
             entities.User(sc, id=1).read()
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_create_user_by_org_admin(self, role_taxonomies):
+    def test_positive_create_user_by_org_admin(self, role_taxonomies, default_sat):
         """Org Admin can create new users
 
         :id: f4edbe25-3ee6-46d6-8fca-a04f6ddc8eed
@@ -1354,9 +1355,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc_user = ServerConfig(
-            auth=(user_login, user_pass), url=f'https://{settings.server.hostname}', verify=False
-        )
+        sc_user = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
         user_login = gen_string('alpha')
         user_pass = gen_string('alphanumeric')
         user = entities.User(
@@ -1375,7 +1374,7 @@ class TestCannedRole:
             assert location.name == name
 
     @pytest.mark.tier2
-    def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies):
+    def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies, default_sat):
         """Org Admin can access users inside its taxonomies
 
         :id: c43275de-e0ff-4a22-b103-391a5ab81874
@@ -1397,7 +1396,7 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_user = self.create_simple_user(filter_taxos=role_taxonomies)
-        sc = self.user_config(user)
+        sc = self.user_config(user, default_sat)
         try:
             entities.User(sc, id=test_user.id).read()
         except HTTPError as err:
@@ -1405,7 +1404,7 @@ class TestCannedRole:
 
     @pytest.mark.skip_if_open('BZ:1694199')
     @pytest.mark.tier2
-    def test_positive_create_nested_location(self, role_taxonomies):
+    def test_positive_create_nested_location(self, role_taxonomies, default_sat):
         """Org Admin can create nested locations
 
         :id: 971bc909-96a5-4614-b254-04a51c708432
@@ -1437,16 +1436,14 @@ class TestCannedRole:
         )
         user.role = [org_admin]
         user = user.update(['role'])
-        sc = ServerConfig(
-            auth=(user_login, user_pass), url=f'https://{settings.server.hostname}', verify=False
-        )
+        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
         name = gen_string('alphanumeric')
         location = entities.Location(sc, name=name, parent=role_taxonomies['loc'].id).create()
         assert location.name == name
 
     @pytest.mark.tier2
     def test_negative_access_users_outside_org_admin_taxonomies(
-        self, role_taxonomies, filter_taxonomies
+        self, role_taxonomies, filter_taxonomies, default_sat
     ):
         """Org Admin can not access users outside its taxonomies
 
@@ -1469,12 +1466,12 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_user = self.create_simple_user(filter_taxos=filter_taxonomies)
-        sc = self.user_config(user)
+        sc = self.user_config(user, default_sat)
         with pytest.raises(HTTPError):
             entities.User(sc, id=test_user.id).read()
 
     @pytest.mark.tier1
-    def test_negative_create_taxonomies_by_org_admin(self, role_taxonomies):
+    def test_negative_create_taxonomies_by_org_admin(self, role_taxonomies, default_sat):
         """Org Admin cannot define/create organizations but can create
             locations
 
@@ -1503,9 +1500,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(
-            auth=(user_login, user_pass), url=f'https://{settings.server.hostname}', verify=False
-        )
+        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
         with pytest.raises(HTTPError):
             entities.Organization(sc, name=gen_string('alpha')).create()
         try:
@@ -1518,7 +1513,7 @@ class TestCannedRole:
     @pytest.mark.upgrade
     @pytest.mark.tier1
     def test_positive_access_all_global_entities_by_org_admin(
-        self, role_taxonomies, filter_taxonomies
+        self, role_taxonomies, filter_taxonomies, default_sat
     ):
         """Org Admin can access all global entities in any taxonomies
         regardless of its own assigned taxonomies
@@ -1548,9 +1543,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc'], filter_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(
-            auth=(user_login, user_pass), url=f'https://{settings.server.hostname}', verify=False
-        )
+        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
         try:
             for entity in [
                 entities.Architecture,

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -23,7 +23,6 @@ from requests import HTTPError
 
 from robottelo.api.utils import one_to_many_names
 from robottelo.cleanup import capsule_cleanup
-from robottelo.config import settings
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.helpers import default_url_on_new_port
@@ -34,15 +33,13 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
-def module_proxy_attrs():
+def module_proxy_attrs(default_sat):
     """Find a ``SmartProxy``.
 
     Every Satellite has a built-in smart proxy, so searching for an
     existing smart proxy should always succeed.
     """
-    smart_proxy = entities.SmartProxy().search(
-        query={'search': f'url = https://{settings.server.hostname}:9090'}
-    )
+    smart_proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})
     # Check that proxy is found and unpack it from the list
     assert len(smart_proxy) > 0, "No smart proxy is found"
     smart_proxy = smart_proxy[0]

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -31,7 +31,6 @@ from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import upload_manifest
 from robottelo.cli.subscription import Subscription
-from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -183,7 +182,7 @@ def test_negative_upload():
 
 
 @pytest.mark.tier2
-def test_positive_delete_manifest_as_another_user(function_org):
+def test_positive_delete_manifest_as_another_user(function_org, default_sat):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
 
@@ -198,7 +197,7 @@ def test_positive_delete_manifest_as_another_user(function_org):
     :CaseImportance: Medium
     """
     user1_password = gen_string('alphanumeric')
-    user1 = entities.User(
+    user1 = default_sat.api.User(
         admin=True,
         password=user1_password,
         organization=[function_org],
@@ -206,11 +205,11 @@ def test_positive_delete_manifest_as_another_user(function_org):
     ).create()
     sc1 = ServerConfig(
         auth=(user1.login, user1_password),
-        url=f'https://{settings.server.hostname}',
+        url=default_sat.url,
         verify=False,
     )
     user2_password = gen_string('alphanumeric')
-    user2 = entities.User(
+    user2 = default_sat.api.User(
         admin=True,
         password=user2_password,
         organization=[function_org],
@@ -218,7 +217,7 @@ def test_positive_delete_manifest_as_another_user(function_org):
     ).create()
     sc2 = ServerConfig(
         auth=(user2.login, user2_password),
-        url=f'https://{settings.server.hostname}',
+        url=default_sat.url,
         verify=False,
     )
     # use the first admin to upload a manifest

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -79,7 +79,7 @@ def module_user(module_org, module_location):
 
 
 @pytest.fixture(scope="function")
-def tftpboot(module_org):
+def tftpboot(module_org, default_sat):
     """This fixture removes the current deployed templates from TFTP, and sets up new ones.
     It manipulates the global defaults, so it shouldn't be used in concurrent environment
 
@@ -106,7 +106,7 @@ def tftpboot(module_org):
         },
         'ipxe': {
             'setting': 'global_iPXE',
-            'path': f'https://{settings.server.hostname}/unattended/iPXE?bootsrap=1',
+            'path': f'{default_sat.url}/unattended/iPXE?bootsrap=1',
             'kind': 'iPXE',
         },
     }
@@ -228,7 +228,7 @@ class TestProvisioningTemplate:
     @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.run_in_one_thread
-    def test_positive_build_pxe_default(self, tftpboot):
+    def test_positive_build_pxe_default(self, tftpboot, default_sat):
         """Call the "build_pxe_default" path.
 
         :id: ca19d9da-1049-4b39-823b-933fc1a0cebd
@@ -258,5 +258,5 @@ class TestProvisioningTemplate:
                 rendered = ssh.command(f"cat {template['path']}").stdout[0]
             assert (
                 rendered == f"{settings.server.scheme}://"
-                f"{settings.server.hostname} {template['kind']}"
+                f"{default_sat.hostname} {template['kind']}"
             )

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -18,15 +18,13 @@
 """
 import pytest
 from broker.broker import VMBroker
-from nailgun import entities
 
-from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
 
 @pytest.mark.tier1
 def test_positive_register(
-    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv
+    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv, default_sat
 ):
     """System is registered
 
@@ -46,17 +44,17 @@ def test_positive_register(
 
     :CaseImportance: Critical
     """
-    hg = entities.HostGroup(location=[module_location], organization=[module_org]).create()
+    hg = default_sat.api.HostGroup(location=[module_location], organization=[module_org]).create()
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         # assure system is not registered
         result = vm.execute('subscription-manager identity')
         # result will be 1 if not registered
         assert result.status == 1
         assert vm.execute(
-            f'curl -o /root/bootstrap.py "http://{settings.server.hostname}/pub/bootstrap.py" '
+            f'curl -o /root/bootstrap.py "http://{default_sat.hostname}/pub/bootstrap.py" '
         )
         assert vm.execute(
-            f'python /root/bootstrap.py -s {settings.server.hostname} -o {module_org.name}'
+            f'python /root/bootstrap.py -s {default_sat.hostname} -o {module_org.name}'
             f' -L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             ' --skip puppet --skip foreman'
         )
@@ -66,7 +64,7 @@ def test_positive_register(
         assert result.status == 0
         # register system once again
         assert vm.execute(
-            f'python /root/bootstrap.py -s "{settings.server.hostname}" -o {module_org.name} '
+            f'python /root/bootstrap.py -s "{default_sat.hostname}" -o {module_org.name} '
             f'-L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             '--skip puppet --skip foreman '
         )

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1216,7 +1216,7 @@ class TestDockerClient:
     """
 
     @pytest.mark.tier3
-    def test_positive_pull_image(self, module_org, docker_host):
+    def test_positive_pull_image(self, module_org, docker_host, default_sat):
         """A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
 
@@ -1236,7 +1236,7 @@ class TestDockerClient:
         try:
             result = docker_host.execute(
                 f'docker login -u {settings.server.admin_username}'
-                f' -p {settings.server.admin_password} {settings.server.hostname}'
+                f' -p {settings.server.admin_password} {default_sat.hostname}'
             )
             assert result.status == 0
 
@@ -1264,7 +1264,7 @@ class TestDockerClient:
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
-    def test_positive_container_admin_end_to_end_search(self, module_org, docker_host):
+    def test_positive_container_admin_end_to_end_search(self, module_org, docker_host, default_sat):
         """Verify that docker command line can be used against
         Satellite server to search for container images stored
         on Satellite instance.
@@ -1315,14 +1315,12 @@ class TestDockerClient:
             }
         )
         docker_repo_uri = (
-            f' {settings.server.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f' {default_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
             f'{CONTAINER_UPSTREAM_NAME} '
         ).lower()
 
         # 3. Try to search for docker images on Satellite
-        remote_search_command = (
-            f'docker search {settings.server.hostname}/{CONTAINER_UPSTREAM_NAME}'
-        )
+        remote_search_command = f'docker search {default_sat.hostname}/{CONTAINER_UPSTREAM_NAME}'
         result = docker_host.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri not in result.stdout
@@ -1330,7 +1328,7 @@ class TestDockerClient:
         # 4. Use Docker client to login to Satellite docker hub
         result = docker_host.execute(
             f'docker login -u {settings.server.admin_username}'
-            f' -p {settings.server.admin_password} {settings.server.hostname}'
+            f' -p {settings.server.admin_password} {default_sat.hostname}'
         )
         assert result.status == 0
 
@@ -1340,7 +1338,7 @@ class TestDockerClient:
         assert docker_repo_uri in result.stdout
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = docker_host.execute(f'docker logout {settings.server.hostname}')
+        result = docker_host.execute(f'docker logout {default_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to search for docker images
@@ -1364,7 +1362,7 @@ class TestDockerClient:
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
-    def test_positive_container_admin_end_to_end_pull(self, module_org, docker_host):
+    def test_positive_container_admin_end_to_end_pull(self, module_org, docker_host, default_sat):
         """Verify that docker command line can be used against
         Satellite server to pull in container images stored
         on Satellite instance.
@@ -1416,7 +1414,7 @@ class TestDockerClient:
             }
         )
         docker_repo_uri = (
-            f'{settings.server.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f'{default_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
             f'{docker_upstream_name}'
         ).lower()
 
@@ -1428,7 +1426,7 @@ class TestDockerClient:
         # 4. Use Docker client to login to Satellite docker hub
         result = docker_host.execute(
             f'docker login -u {settings.server.admin_username}'
-            f' -p {settings.server.admin_password} {settings.server.hostname}'
+            f' -p {settings.server.admin_password} {default_sat.hostname}'
         )
         assert result.status == 0
 
@@ -1444,7 +1442,7 @@ class TestDockerClient:
         assert result.status == 0
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = docker_host.execute(f'docker logout {settings.server.hostname}')
+        result = docker_host.execute(f'docker logout {default_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to pull in docker image
@@ -1464,11 +1462,10 @@ class TestDockerClient:
         result = docker_host.execute(docker_pull_command)
         assert result.status == 0
 
-    @pytest.mark.stubbed
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_upload_image(self, module_org):
+    def test_positive_upload_image(self, module_org, default_sat):
         """A Docker-enabled client can create a new ``Dockerfile``
         pointing to an existing Docker image from a Satellite 6 and modify it.
         Then, using ``docker build`` generate a new image which can then be
@@ -1527,7 +1524,7 @@ class TestDockerClient:
             ssh.upload_file(
                 local_file=tar_file,
                 remote_file=f'/tmp/{tar_file}',
-                hostname=settings.server.hostname,
+                hostname=default_sat.hostname,
             )
 
             # Upload tarred repository
@@ -1537,7 +1534,7 @@ class TestDockerClient:
 
             # Verify repository was uploaded successfully
             repo = Repository.info({'id': repo['id']})
-            assert settings.server.hostname == repo['published-at']
+            assert default_sat.hostname == repo['published-at']
 
             repo_name = '-'.join((module_org.label, product['label'], repo['label'])).lower()
             assert repo_name in repo['published-at']

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -71,9 +71,9 @@ from robottelo.hosts import ContentHostError
 
 
 @pytest.fixture(scope="module")
-def module_default_proxy():
+def module_default_proxy(default_sat):
     """Use the default installation smart proxy"""
-    return Proxy.list({'search': f'url = https://{settings.server.hostname}:9090'})[0]
+    return Proxy.list({'search': f'url = {default_sat.url}:9090'})[0]
 
 
 @pytest.fixture(scope="function")

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -57,9 +57,9 @@ PUPPET_MODULES = [
 
 
 @pytest.fixture(scope='module')
-def content_source():
+def content_source(default_sat):
     """Return the proxy."""
-    return Proxy.list({'search': f'url = https://{settings.server.hostname}:9090'})[0]
+    return Proxy.list({'search': f'url = {default_sat.url}:9090'})[0]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -468,7 +468,7 @@ class TestRemoteExecution:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_run_receptor_installer(self):
+    def test_positive_run_receptor_installer(self, default_sat):
         """Run Receptor installer ("Configure Cloud Connector")
 
         :CaseComponent: RHCloud-CloudConnector
@@ -484,7 +484,7 @@ class TestRemoteExecution:
         # Set Host parameter source_display_name to something random.
         # To avoid 'name has already been taken' error when run multiple times
         # on a machine with the same hostname.
-        host_id = Host.info({'name': settings.server.hostname})['id']
+        host_id = Host.info({'name': default_sat.hostname})['id']
         Host.set_parameter(
             {'host-id': host_id, 'name': 'source_display_name', 'value': gen_string('alpha')}
         )
@@ -496,7 +496,7 @@ class TestRemoteExecution:
                 'job-template': template_name,
                 'inputs': f'satellite_user="{settings.server.admin_username}",\
                         satellite_password="{settings.server.admin_password}"',
-                'search-query': f'name ~ {settings.server.hostname}',
+                'search-query': f'name ~ {default_sat.hostname}',
             }
         )
         invocation_id = invocation['id']
@@ -509,7 +509,7 @@ class TestRemoteExecution:
         assert entities.JobInvocation(id=invocation_id).read().status == 0
 
         result = ' '.join(
-            JobInvocation.get_output({'id': invocation_id, 'host': settings.server.hostname})
+            JobInvocation.get_output({'id': invocation_id, 'host': default_sat.hostname})
         )
         assert 'project-receptor.satellite_receptor_installer' in result
         assert 'Exit status: 0' in result

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -80,9 +80,9 @@ def fetch_scap_and_profile_id(scap_name, scap_profile):
 
 
 @pytest.fixture(scope='module')
-def default_proxy():
+def default_proxy(default_sat):
     """Returns default capsule/proxy id"""
-    proxy = Proxy.list({'search': settings.server.hostname})[0]
+    proxy = Proxy.list({'search': default_sat.hostname})[0]
     p_features = set(proxy.get('features').split(', '))
     if {'Puppet', 'Ansible', 'Openscap'}.issubset(p_features):
         proxy_id = proxy.get('id')
@@ -160,6 +160,7 @@ def test_positive_upload_to_satellite(
     lifecycle_env,
     puppet_env,
     distro,
+    default_sat,
 ):
     """Perform end to end oscap test, and push the updated scap content via puppet
      after first run.
@@ -199,11 +200,11 @@ def test_positive_upload_to_satellite(
     # Creates host_group.
     make_hostgroup(
         {
-            'content-source': settings.server.hostname,
+            'content-source': default_sat.hostname,
             'name': hgrp_name,
             'puppet-environment-id': puppet_env.id,
-            'puppet-ca-proxy': settings.server.hostname,
-            'puppet-proxy': settings.server.hostname,
+            'puppet-ca-proxy': default_sat.hostname,
+            'puppet-proxy': default_sat.hostname,
             'organizations': module_org.name,
             'puppet-classes': puppet_classes,
         }
@@ -296,7 +297,7 @@ def test_positive_upload_to_satellite(
 @pytest.mark.upgrade
 @pytest.mark.tier4
 def test_positive_oscap_run_with_tailoring_file_and_capsule(
-    module_org, default_proxy, content_view, lifecycle_env, puppet_env
+    module_org, default_proxy, content_view, lifecycle_env, puppet_env, default_sat
 ):
     """End-to-End Oscap run with tailoring files and default capsule via puppet
 
@@ -326,16 +327,16 @@ def test_positive_oscap_run_with_tailoring_file_and_capsule(
     policy_name = gen_string('alpha')
     tailoring_file_name = gen_string('alpha')
     tailor_path = file_downloader(
-        file_url=settings.oscap.tailoring_path, hostname=settings.server.hostname
+        file_url=settings.oscap.tailoring_path, hostname=default_sat.hostname
     )[0]
     # Creates host_group.
     make_hostgroup(
         {
-            'content-source': settings.server.hostname,
+            'content-source': default_sat.hostname,
             'name': hgrp_name,
             'puppet-environment-id': puppet_env.id,
-            'puppet-ca-proxy': settings.server.hostname,
-            'puppet-proxy': settings.server.hostname,
+            'puppet-ca-proxy': default_sat.hostname,
+            'puppet-proxy': default_sat.hostname,
             'organizations': module_org.name,
             'puppet-classes': puppet_classes,
         }

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -24,7 +24,6 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo import ssh
-from robottelo.config import settings
 from robottelo.helpers import get_data_file
 from robottelo.ssh import download_file
 from robottelo.ssh import get_connection
@@ -65,9 +64,9 @@ class TestKatelloCertsCheck:
     ]
 
     @pytest.fixture(scope="module")
-    def cert_data(self):
+    def cert_data(self, default_sat):
         """Get host name, scripts, and create working directory."""
-        sat6_hostname = settings.server.hostname
+        sat6_hostname = default_sat.hostname
         capsule_hostname = 'capsule.example.com'
         key_file_name = '{0}/{0}.key'.format(sat6_hostname)
         cert_file_name = '{0}/{0}.crt'.format(sat6_hostname)
@@ -113,7 +112,7 @@ class TestKatelloCertsCheck:
             assert result.return_code == 0
 
     @pytest.fixture()
-    def certs_cleanup(self):
+    def certs_cleanup(self, default_sat):
         """cleanup all cert configuration files"""
         yield
         files = [
@@ -125,7 +124,7 @@ class TestKatelloCertsCheck:
             'private',
             'serial*',
             'certs/*',
-            settings.server.hostname,
+            default_sat.hostname,
         ]
         with get_connection(timeout=300) as connection:
             files = " ".join(files)

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -258,7 +258,6 @@ class TestRenameHost:
         """
         # Save original hostname, get credentials, eventually will
         # end up in setUpClass
-        # original_name = settings.server.hostname
         username = settings.server.admin_username
         password = settings.server.admin_password
         # the rename part of the test, not necessary to run from robottelo

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2876,7 +2876,7 @@ def test_positive_subscribe_system_with_puppet_modules(session, rhel7_contenthos
 
 
 @pytest.mark.tier3
-def test_positive_delete_with_kickstart_repo_and_host_group(session):
+def test_positive_delete_with_kickstart_repo_and_host_group(session, default_sat):
     """Check that Content View associated with kickstart repository and
     which is used by a host group can be removed from the system
 
@@ -2893,7 +2893,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(session):
     :CaseImportance: High
     """
     hg_name = gen_string('alpha')
-    sat_hostname = settings.server.hostname
+    sat_hostname = default_sat.hostname
     org = entities.Organization().create()
     # Create a new Lifecycle environment
     lc_env = entities.LifecycleEnvironment(organization=org).create()

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -22,7 +22,6 @@ from nailgun import entities
 
 from robottelo.api.utils import update_vm_host_location
 from robottelo.cli.host import Host
-from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.helpers import add_remote_execution_ssh_key
 
@@ -54,10 +53,10 @@ def module_org():
 
 
 @pytest.fixture(scope='module')
-def module_loc(module_org):
+def module_loc(module_org, default_sat):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
-        entities.SmartProxy().search(query={'search': f'name={settings.server.hostname}'})[0].read()
+        entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
     )
     smart_proxy.location.append(entities.Location(id=location.id))
     smart_proxy.update(['location'])

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -18,18 +18,10 @@
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
-
-from robottelo.config import settings
-
-
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
 
 
 @pytest.mark.tier2
-def test_positive_end_to_end(session, module_org, module_loc):
+def test_positive_end_to_end(session, module_org, module_location, default_sat):
     """Perform end to end testing for Job Template component.
 
     :id: 2e0e31c5-e557-4151-83f9-21820c9cb1be
@@ -105,7 +97,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
                 'job.foreign_input_sets': job_foreign_input_sets,
                 'type.snippet': True,
                 'organizations.resources.assigned': [module_org.name, "Default Organization"],
-                'locations.resources.assigned': [module_loc.name],
+                'locations.resources.assigned': [module_location.name],
             }
         )
         template = session.jobtemplate.read(template_name, editor_view_option='Editor')
@@ -122,7 +114,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         assert template['job']['overridable'] is False
         assert template['type']['snippet']
         assert module_org.name in template['organizations']['resources']['assigned']
-        assert module_loc.name in template['locations']['resources']['assigned']
+        assert module_location.name in template['locations']['resources']['assigned']
         assert len(template['inputs']) == 3
         assert template['inputs'][0]['name'] == template_inputs[0]['name']
         assert template['inputs'][0]['required'] == template_inputs[0]['required']
@@ -215,7 +207,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
             editor_view_option='Preview',
             widget_names='template.template_editor.editor',
         )
-        assert settings.server.hostname in template_values['template']['template_editor']['editor']
+        assert default_sat.hostname in template_values['template']['template_editor']['editor']
         session.jobtemplate.clone(template_new_name, {'template.name': template_clone_name})
         assert session.jobtemplate.search(template_clone_name)[0]['Name'] == template_clone_name
         for name in (template_new_name, template_clone_name):

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -26,7 +26,6 @@ from wait_for import wait_for
 
 from robottelo.api.utils import update_vm_host_location
 from robottelo.cli.host import Host
-from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.hosts import ContentHost
@@ -59,10 +58,10 @@ def module_org():
 
 
 @pytest.fixture(scope='module')
-def module_loc(module_org):
+def module_loc(module_org, default_sat):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
-        entities.SmartProxy().search(query={'search': f'name={settings.server.hostname}'})[0].read()
+        entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
     )
     smart_proxy.location.append(entities.Location(id=location.id))
     smart_proxy.update(['location'])

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -30,23 +30,12 @@ from robottelo import ssh
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
-from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.datafactory import gen_string
 from robottelo.ui.utils import create_fake_host
-
-
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
-
-
-@pytest.fixture(scope='module')
-def module_loc():
-    return entities.Location().create()
 
 
 @pytest.fixture(scope='module')
@@ -394,7 +383,7 @@ def test_positive_autocomplete(session):
 
 
 @pytest.mark.tier2
-def test_positive_schedule_generation_and_get_mail(session, module_org, module_loc):
+def test_positive_schedule_generation_and_get_mail(session, module_org, module_loc, default_sat):
     """Schedule generating a report. Request the result be sent via e-mail.
 
     :id: cd19b90d-836f-4efd-c3bc-d5e09a909a67
@@ -438,7 +427,7 @@ def test_positive_schedule_generation_and_get_mail(session, module_org, module_l
         f'expect "&"\n'
         f'send "q\\r"\n'
     )
-    ssh.command(f'expect -c \'{expect_script}\'', hostname=settings.server.hostname)
+    ssh.command(f'expect -c \'{expect_script}\'', hostname=default_sat.hostname)
     ssh.download_file(gzip_path)
     os.system(f'gunzip {gzip_path}')
     with open(file_path) as json_file:

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -355,7 +355,7 @@ def test_negative_update_email_delivery_method_smtp():
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_update_email_delivery_method_sendmail(session):
+def test_positive_update_email_delivery_method_sendmail(session, default_sat):
     """Updating Sendmail params on Email tab
 
     :id: c774e713-9640-402d-8987-c3509e918eb6
@@ -394,7 +394,7 @@ def test_positive_update_email_delivery_method_sendmail(session):
     }
     mail_config_new_params = {
         "delivery_method": "Sendmail",
-        "email_reply_address": f"root@{ssh.settings.server.hostname}",
+        "email_reply_address": f"root@{default_sat.hostname}",
         "email_subject_prefix": [gen_string('alpha')],
         "sendmail_location": "/usr/sbin/sendmail",
         "send_welcome_email": "Yes",

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -37,7 +37,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -47,7 +47,7 @@ def form_data(default_org):
         'hypervisor_server': settings.virtwho.esx.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.esx.hypervisor_username,
         'hypervisor_password': settings.virtwho.esx.hypervisor_password,
     }

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -35,7 +35,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -45,7 +45,7 @@ def form_data(default_org):
         'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
         'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
     }

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -35,7 +35,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -44,7 +44,7 @@ def form_data(default_org):
         'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -35,7 +35,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -45,7 +45,7 @@ def form_data(default_org):
         'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form

--- a/tests/foreman/virtwho/api/test_rhevm.py
+++ b/tests/foreman/virtwho/api/test_rhevm.py
@@ -35,7 +35,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -45,7 +45,7 @@ def form_data(default_org):
         'hypervisor_server': settings.virtwho.rhevm.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.rhevm.hypervisor_username,
         'hypervisor_password': settings.virtwho.rhevm.hypervisor_password,
     }

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -42,7 +42,7 @@ from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -52,7 +52,7 @@ def form_data():
         'hypervisor-server': settings.virtwho.esx.hypervisor_server,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.esx.hypervisor_username,
         'hypervisor-password': settings.virtwho.esx.hypervisor_password,
     }
@@ -317,7 +317,7 @@ class TestVirtWhoConfigforEsx:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_rhsm_option(self, form_data, virtwho_config):
+    def test_positive_rhsm_option(self, form_data, virtwho_config, default_sat):
         """Verify rhsm options in the configure file"
 
         :id: b5b93d4d-e780-41c0-9eaa-2407cc1dcc9b
@@ -335,13 +335,13 @@ class TestVirtWhoConfigforEsx:
         deploy_configure_by_command(command, form_data['hypervisor-type'])
         rhsm_username = get_configure_option('rhsm_username', config_file)
         assert not User.exists(search=('login', rhsm_username))
-        assert get_configure_option('rhsm_hostname', config_file) == settings.server.hostname
+        assert get_configure_option('rhsm_hostname', config_file) == default_sat.hostname
         assert get_configure_option('rhsm_prefix', config_file) == '/rhsm'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_post_hypervisors(self):
+    def test_positive_post_hypervisors(self, default_sat):
         """Post large json file to /rhsm/hypervisors"
 
         :id: e344c9d2-3538-4432-9a74-b025e9ef852d
@@ -359,7 +359,7 @@ class TestVirtWhoConfigforEsx:
         """
         org = Org.info({'name': DEFAULT_ORG})
         data = hypervisor_json_create(hypervisors=100, guests=10)
-        url = f"https://{settings.server.hostname}/rhsm/hypervisors/{org['label']}"
+        url = f"{default_sat.url}/rhsm/hypervisors/{org['label']}"
         auth = (settings.server.admin_username, settings.server.admin_password)
         result = requests.post(url, auth=auth, verify=False, json=data)
         if result.status_code != 200:

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -32,7 +32,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -42,7 +42,7 @@ def form_data():
         'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
         'hypervisor-password': settings.virtwho.hyperv.hypervisor_password,
     }

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -32,7 +32,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data():
         'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -32,7 +32,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -42,7 +42,7 @@ def form_data():
         'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form

--- a/tests/foreman/virtwho/cli/test_rhevm.py
+++ b/tests/foreman/virtwho/cli/test_rhevm.py
@@ -32,7 +32,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -42,7 +42,7 @@ def form_data():
         'hypervisor-server': settings.virtwho.rhevm.hypervisor_server,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.rhevm.hypervisor_username,
         'hypervisor-password': settings.virtwho.rhevm.hypervisor_password,
     }

--- a/tests/upgrades/scenario_workers.py
+++ b/tests/upgrades/scenario_workers.py
@@ -14,13 +14,13 @@ _json_file = 'upgrade_workers.json'
 json_file = Path(_json_file)
 
 
-def save_worker_hostname(test_name):
+def save_worker_hostname(test_name, default_sat):
     data = {}
     if json_file.exists():
         data = json.loads(json_file.read_text())
     # Removing the parameter name from test name before save
     test_name = test_name.split('[')[0] if '[' in test_name else test_name
-    data.update({test_name: settings.server.hostname})
+    data.update({test_name: default_sat.hostname})
     json_file.write_text(json.dumps(data))
 
 
@@ -35,10 +35,10 @@ def get_worker_hostname_from_testname(test_name, shared_workers):
 
 
 @pytest.fixture(autouse=True)
-def save_pre_upgrade_worker_hostname(request):
+def save_pre_upgrade_worker_hostname(request, default_sat):
     """Saves the worker id of pre_upgrade test in json"""
     if request.node.get_closest_marker('pre_upgrade'):
-        save_worker_hostname(request.node.name)
+        save_worker_hostname(request.node.name, default_sat)
 
 
 @pytest.fixture(autouse=True)
@@ -47,6 +47,8 @@ def set_post_upgrade_hostname(request, shared_workers):
 
     The limitation of this implementation is that the XDIST_BEHAVIOR won't be observed,
     and tests running under xdist will not be isolated.
+
+    This is overriding the session scoped align_to_satellite fixture
     """
     post_upgrade = request.node.get_closest_marker('post_upgrade')
     if post_upgrade:

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -1,5 +1,8 @@
 """Test for Client related Upgrade Scenario's
 
+content-host-d containers use SATHOST env var, which is passed through sat6-upgrade functions
+sat6-upgrade requires env.satellite_hostname to be set, this is required for these tests
+
 :Requirement: Upgraded Satellite
 
 :CaseAutomation: Automated
@@ -45,8 +48,6 @@ from robottelo.constants.repos import FAKE_9_YUM_REPO
 
 # host machine for containers
 docker_vm = settings.upgrade.docker_vm
-# script in container /tmp requires SATHOST
-SATHOST = settings.server.hostname
 
 
 @pytest.fixture(scope='module')

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -66,11 +66,13 @@ class TestScenarioPositiveGCEHostComputeResource:
         download_gce_cert()
 
     @pytest.fixture(scope='class')
-    def arch_os_domain(self):
-        arch = entities.Architecture().search(query={'search': 'name=x86_64'})[0]
-        os = entities.OperatingSystem().search(query={'search': 'family=Redhat and major=7'})[0]
+    def arch_os_domain(self, default_sat):
+        arch = default_sat.api.Architecture().search(query={'search': 'name=x86_64'})[0]
+        os = default_sat.api.OperatingSystem().search(
+            query={'search': 'family=Redhat and major=7'}
+        )[0]
 
-        domain_name = settings.server.hostname.split('.', 1)[1]
+        domain_name = default_sat.hostname.split('.', 1)[1]
         return namedtuple('ArchOsDomain', ['arch', 'os', 'domain'])(arch, os, domain_name)
 
     @pytest.fixture(scope='class')

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -34,7 +34,7 @@ class TestUserGroupMembership:
     """
 
     @pre_upgrade
-    def test_pre_create_usergroup_with_ldap_user(self, request):
+    def test_pre_create_usergroup_with_ldap_user(self, request, default_sat):
         """Create Usergroup in preupgrade version.
 
         :id: preupgrade-4b11d883-f523-4f38-b65a-650ecd90335c
@@ -46,7 +46,7 @@ class TestUserGroupMembership:
 
         :expectedresults: The usergroup, with ldap user as member, should be created successfully.
         """
-        authsource = entities.AuthSourceLDAP(
+        authsource = default_sat.api.AuthSourceLDAP(
             onthefly_register=True,
             account=settings.ldap.username,
             account_password=settings.ldap.password,
@@ -65,14 +65,14 @@ class TestUserGroupMembership:
         assert authsource.name == request.node.name + "_server"
         sc = ServerConfig(
             auth=(settings.ldap.username, settings.ldap.password),
-            url=f'https://{settings.server.hostname}',
+            url=default_sat.url,
             verify=False,
         )
 
         with pytest.raises(HTTPError):
             entities.User(sc).search()
-        user_group = entities.UserGroup(name=request.node.name + "_user_group").create()
-        user = entities.User().search(query={'search': f'login={settings.ldap.username}'})[0]
+        user_group = default_sat.api.UserGroup(name=request.node.name + "_user_group").create()
+        user = default_sat.api.User().search(query={'search': f'login={settings.ldap.username}'})[0]
         user_group.user = [user]
         user_group = user_group.update(['user'])
         assert user.login == user_group.user[0].read().login


### PR DESCRIPTION
Fixtures and tests using settings.server.hostname should reference default_sat.hostname instead

In addition to the results below, I ran a full high importance CI pipeline collecting the test modules that have hit BoxKeyError - I did not see any BoxKeyError failures in any of the test results.


### api/test_host.py
```
14:01:09  + py.test tests/foreman/api/test_host.py --junit-xml=sat-results.xml -o junit_suite_name=sat-result
14:01:19  ============================= test session starts ==============================
14:01:19  collected 62 items / 13 deselected / 49 selected
14:01:19  
14:07:53  tests/foreman/api/test_host.py ......................................... [ 83%]
14:09:10  ........                                                                 [100%]
```

### api/test_hostgroup.py

test_inherit_puppetclass failure is being addressed by @tstrych 
test_positive_create_with_properties I'm debugging locally
```
 =========================== short test summary info ============================
14:34:22  FAILED tests/foreman/api/test_hostgroup.py::TestHostGroup::test_inherit_puppetclass
14:34:22  FAILED tests/foreman/api/test_hostgroup.py::TestHostGroup::test_positive_create_with_properties
14:34:22  ===== 2 failed, 49 passed, 2 deselected, 333 warnings in 177.91s (0:02:57) =====
```

### api/test_role.py

Failing test is failing in master
```
20:14:37  =========================== short test summary info ============================
20:14:37  FAILED tests/foreman/api/test_role.py::TestCannedRole::test_negative_create_taxonomies_by_org_admin
20:14:37  = 1 failed, 42 passed, 1 skipped, 6 deselected, 474 warnings in 505.91s (0:08:25) =
```

### api/test_repository.py

Test failures, generally consistent with master branch results
```
= 23 failed, 154 passed, 4 skipped, 7 deselected, 815 warnings, 34 errors in 1642.23s (0:27:22) =
```

### api/test_user.py


```
18:21:31  + py.test tests/foreman/api/test_user.py --junit-xml=sat-results.xml -o junit_suite_name=sat-result
18:21:39  ============================= test session starts ==============================
18:21:40  collected 144 items / 3 deselected / 141 selected
18:21:40  
18:22:11  tests/foreman/api/test_user.py ......................................... [ 29%]
18:22:47  ........................................................................ [ 80%]
18:24:12  ............................    

18:24:12  ========= 141 passed, 3 deselected, 417 warnings in 153.38s (0:02:33) ==========
```

### ui/test_hostcollection.py

Test failures are equivalent to master branch.
```
20:04:42  =========================== short test summary info ============================
20:04:42  FAILED tests/foreman/ui/test_hostcollection.py::test_positive_install_package
20:04:42  ERROR tests/foreman/ui/test_hostcollection.py::test_positive_remove_package
20:04:42  ERROR tests/foreman/ui/test_hostcollection.py::test_positive_upgrade_package
20:04:42  ERROR tests/foreman/ui/test_hostcollection.py::test_positive_install_package_group
20:04:42  ERROR tests/foreman/ui/test_hostcollection.py::test_positive_remove_package_group
20:04:42  ERROR tests/foreman/ui/test_hostcollection.py::test_positive_install_errata
20:04:42  ERROR tests/foreman/ui/test_hostcollection.py::test_positive_change_assigned_content
20:04:42  ERROR tests/foreman/ui/test_hostcollection.py::test_positive_install_module_stream
20:04:42  ERROR tests/foreman/ui/test_hostcollection.py::test_positive_install_modular_errata
20:04:42  ======= 1 failed, 5 passed, 206 warnings, 8 errors in 5291.53s (1:28:11) =======
```