### PR TITLE
Get GCE cert details from json

### DIFF
--- a/conf/gce.yaml.template
+++ b/conf/gce.yaml.template
@@ -1,12 +1,8 @@
 GCE:
   # Google Provider as Compute Resource
-  # Project name in Google provider
-  PROJECT_ID:  # example-project-id
-  # Service Account email id which has compute admin permission
-  CLIENT_EMAIL: client@example.com
   # client json Certificate path which is local path on satellite
   CERT_PATH: /path/to/certificate.json
   # Zones
   ZONE: example-zone
-  # client certificate URL
-  CERT_URL: /path/to/certificate/url
+  # client certificate
+  CERT: "{}" # client json Certificate

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -128,11 +128,9 @@ VALIDATORS = dict(
     ],
     gce=[
         Validator(
-            'gce.project_id',
-            'gce.client_email',
             'gce.cert_path',
             'gce.zone',
-            'gce.cert_url',
+            'gce.cert',
             must_exist=True,
         ),
         Validator('gce.cert_path', startswith='/usr/share/foreman/'),

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -1,6 +1,5 @@
 """Several helper methods and functions."""
 import contextlib
-import json
 import os
 import random
 import re
@@ -17,7 +16,6 @@ from robottelo.config import get_credentials
 from robottelo.config import get_url
 from robottelo.config import settings
 from robottelo.constants import PULP_PUBLISHED_YUM_REPOS_PATH
-from robottelo.errors import GCECertNotFoundError
 from robottelo.logging import logger
 
 
@@ -552,19 +550,6 @@ def slugify_component(string, keep_hyphens=True):
 
 
 # --- Issue based Pytest markers ---
-
-
-def download_gce_cert():
-    _, gce_cert = mkstemp(suffix='.json')
-    cert = json.loads(settings.gce.cert)
-    with open(gce_cert, 'w') as f:
-        json.dump(cert, f)
-    ssh.upload_file(gce_cert, settings.gce.cert_path)
-    if ssh.command(f'[ -f {settings.gce.cert_path} ]').return_code != 0:
-        raise GCECertNotFoundError(
-            f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
-        )
-    return download_server_file('json', settings.gce.cert_url)
 
 
 def idgen(val):

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -27,6 +27,7 @@ from nailgun import entities
 
 from robottelo.config import settings
 from robottelo.constants import VALID_GCE_ZONES
+from robottelo.helpers import download_gce_cert
 
 
 GCE_SETTINGS = dict(
@@ -115,6 +116,11 @@ def gce_hostgroup(
         ptable=default_partitiontable,
     ).create()
     return hgroup
+
+
+@pytest.fixture(scope='module', autouse=True)
+def download_cert():
+    download_gce_cert()
 
 
 class TestGCEComputeResourceTestCases:

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -26,13 +26,12 @@ from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import GCE_EXTERNAL_IP_DEFAULT
 from robottelo.constants import GCE_MACHINE_TYPE_DEFAULT
 from robottelo.constants import GCE_NETWORK_DEFAULT
-from robottelo.helpers import download_gce_cert
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skip_if_not_set('http_proxy', 'gce')
-def test_positive_default_end_to_end_with_custom_profile(session, module_org, module_loc):
+def test_positive_default_end_to_end_with_custom_profile(session, module_org, module_loc, gce_cert):
     """Create GCE compute resource with default properties and apply it's basic functionality.
 
     :id: 59ffd83e-a984-4c22-b91b-cad055b4fbd7
@@ -56,7 +55,6 @@ def test_positive_default_end_to_end_with_custom_profile(session, module_org, mo
     cr_description = gen_string('alpha')
     new_org = entities.Organization().create()
     new_loc = entities.Location().create()
-    download_gce_cert()
     http_proxy = entities.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.auth_proxy_url,
@@ -73,8 +71,8 @@ def test_positive_default_end_to_end_with_custom_profile(session, module_org, mo
                 'description': cr_description,
                 'provider': FOREMAN_PROVIDERS['google'],
                 'provider_content.http_proxy.value': http_proxy.name,
-                'provider_content.google_project_id': settings.gce.project_id,
-                'provider_content.client_email': settings.gce.client_email,
+                'provider_content.google_project_id': gce_cert['project_id'],
+                'provider_content.client_email': gce_cert['client_email'],
                 'provider_content.certificate_path': settings.gce.cert_path,
                 'provider_content.zone.value': settings.gce.zone,
                 'organizations.resources.assigned': [module_org.name],
@@ -87,8 +85,8 @@ def test_positive_default_end_to_end_with_custom_profile(session, module_org, mo
         assert cr_values['provider_content']['http_proxy']['value'] == http_proxy.name
         assert cr_values['organizations']['resources']['assigned'] == [module_org.name]
         assert cr_values['locations']['resources']['assigned'] == [module_loc.name]
-        assert cr_values['provider_content']['google_project_id'] == settings.gce.project_id
-        assert cr_values['provider_content']['client_email'] == settings.gce.client_email
+        assert cr_values['provider_content']['google_project_id'] == gce_cert['project_id']
+        assert cr_values['provider_content']['client_email'] == gce_cert['client_email']
         # Compute Resource Edit/Updates and Assertions
         session.computeresource.edit(
             cr_name,

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -32,7 +32,6 @@ from widgetastic.exceptions import NoSuchElementException
 from wrapanapi import GoogleCloudSystem
 
 from robottelo import manifests
-from robottelo import ssh
 from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.api.utils import create_role_permissions
 from robottelo.api.utils import promote
@@ -65,7 +64,7 @@ from robottelo.constants import PERMISSIONS
 from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.datafactory import gen_string
-from robottelo.helpers import download_server_file
+from robottelo.helpers import download_gce_cert
 from robottelo.hosts import ContentHost
 from robottelo.ui.utils import create_fake_host
 
@@ -1844,12 +1843,7 @@ def gce_domain(module_org, module_loc):
 
 @pytest.fixture
 def download_cert():
-    ssh.command(f'curl {settings.gce.cert_url} -o {settings.gce.cert_path}')
-    if not ssh.command(f'[ -f {settings.gce.cert_path} ]').return_code == 0:
-        raise FileNotFoundError(
-            f"The GCE certificate {settings.gce.cert_path} is not found in satellite."
-        )
-    return download_server_file('json', settings.gce.cert_url)
+    download_gce_cert()
 
 
 @pytest.fixture

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -34,15 +34,6 @@ from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import LATEST_RHEL7_GCE_IMG_UUID
 from robottelo.constants import VALID_GCE_ZONES
-from robottelo.helpers import download_gce_cert
-
-GCE_SETTINGS = dict(
-    project_id=settings.gce.project_id,
-    client_email=settings.gce.client_email,
-    cert_path=settings.gce.cert_path,
-    zone=settings.gce.zone,
-    cert_url=settings.gce.cert_url,
-)
 
 
 class TestScenarioPositiveGCEHostComputeResource:
@@ -60,10 +51,6 @@ class TestScenarioPositiveGCEHostComputeResource:
         1. The host should be provisioned on GCE CR created in previous version
         2. The GCE CR attributes should be manipulated
     """
-
-    @pytest.fixture(scope='class', autouse=True)
-    def get_gce_cert(self):
-        download_gce_cert()
 
     @pytest.fixture(scope='class')
     def arch_os_domain(self, default_sat):
@@ -83,7 +70,7 @@ class TestScenarioPositiveGCEHostComputeResource:
                 entities.Host(id=host[0].id).delete()
 
     @pre_upgrade
-    def test_pre_create_gce_cr_and_host(self, arch_os_domain, function_org):
+    def test_pre_create_gce_cr_and_host(self, arch_os_domain, function_org, gce_cert):
         """"""
         arch, os, domain_name = arch_os_domain
         cr_name = gen_string('alpha')
@@ -94,10 +81,10 @@ class TestScenarioPositiveGCEHostComputeResource:
                 {
                     'name': cr_name,
                     'provider': FOREMAN_PROVIDERS['google'],
-                    'provider_content.google_project_id': GCE_SETTINGS['project_id'],
-                    'provider_content.client_email': GCE_SETTINGS['client_email'],
-                    'provider_content.certificate_path': GCE_SETTINGS['cert_path'],
-                    'provider_content.zone.value': GCE_SETTINGS['zone'],
+                    'provider_content.google_project_id': gce_cert['project_id'],
+                    'provider_content.client_email': gce_cert['client_email'],
+                    'provider_content.certificate_path': settings.gce.cert_path,
+                    'provider_content.zone.value': settings.gce.zone,
                     'organizations.resources.assigned': [function_org.name],
                     'locations.resources.assigned': [loc.name],
                 }


### PR DESCRIPTION
GCE certificate already contains project ID and client email so those values are not required in config separately. 

This PR also include fix for some API tests, that were missing fixture for downloading certificate. If you run those test separately certificate could be missing, so I created fixture with `autouse` option as all of tests in file require certificate.


Test results (not including provisioning tests):
```
pytest -v tests/foreman/ui/test_computeresource_gce.py
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo3.9/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.16, xdist-2.3.0, forked-1.3.0, mock-3.6.1, reportportal-5.0.8, services-2.2.1, cov-2.12.1
collected 1 item                                                                                                                                                                

tests/foreman/ui/test_computeresource_gce.py::test_positive_default_end_to_end_with_custom_profile PASSED                                                                 [100%]

=================================================================== 1 passed, 0 warnings in 215.61s (0:03:35) ===================================================================

pytest -v tests/upgrades/test_host.py -k test_pre_create_gce_cr_and_host -m pre_upgrade
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo3.9/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.16, xdist-2.3.0, forked-1.3.0, mock-3.6.1, reportportal-5.0.8, services-2.2.1, cov-2.12.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                   

tests/upgrades/test_host.py::TestScenarioPositiveGCEHostComputeResource::test_pre_create_gce_cr_and_host PASSED                                                           [100%]

============================================================ 1 passed, 1 deselected, 0 warnings in 61.97s (0:01:01) =============================================================

pytest -v tests/foreman/api/test_computeresource_gce.py -k TestGCEComputeResourceTestCases
============================================================================== test session starts ==============================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo3.9/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.16, xdist-2.3.0, forked-1.3.0, mock-3.6.1, reportportal-5.0.8, services-2.2.1, cov-2.12.1
collected 9 items / 3 deselected / 6 selected                                                                                                                                   

tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases::test_positive_crud_gce_cr PASSED                                                          [ 16%]
tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases::test_positive_check_available_images FAILED                                               [ 33%]
tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases::test_positive_check_available_networks PASSED                                             [ 50%]
tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases::test_positive_check_available_flavors PASSED                                              [ 66%]
tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases::test_positive_create_finish_template_image PASSED                                         [ 83%]
tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases::test_positive_create_cloud_init_image PASSED                                              [100%]

=========================================== short test summary info ============================================================================
FAILED tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases::test_positive_check_available_images - assert 14 == 1800
======================================================= 1 failed, 5 passed, 3 deselected, 0 warnings in 92.99s (0:01:32) =======================================================
```
One fail not related to this changes, same issue is also presented in current automation.