### PR TITLE
Fix use of deprecated xunit fixture

### DIFF
--- a/pytest_fixtures/reporting_fixtures.py
+++ b/pytest_fixtures/reporting_fixtures.py
@@ -53,6 +53,6 @@ def record_testsuite_timestamp_xml(record_testsuite_property):
 
 
 @pytest.fixture(autouse=True, scope='function')
-def record_test_timestamp_xml(record_property):
+def record_test_timestamp_xml(request):
     now = datetime.datetime.utcnow()
-    record_property('start_time', now.strftime(FMT_XUNIT_TIME))
+    request.node.user_properties.append(('start_time', now.strftime(FMT_XUNIT_TIME)))


### PR DESCRIPTION
`PytestWarning: record_property is incompatible with junit_family 'xunit2' (use 'legacy' or 'xunit1')`

There is a warning for using this fixture, and its incompatibility with xunit2

https://docs.pytest.org/en/6.2.x/_modules/_pytest/junitxml.html#record_property

Following the implementation here, I just set it on user_properties.

The testcase properties are the same, picture shows two xml files, one from master and one after this change. 

![image](https://user-images.githubusercontent.com/21315076/129977297-a7bfe97b-aa6f-4ad1-bf80-bd1360bca8cd.png)
