### PR TITLE
global registration feature automation pr_1

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -158,3 +158,7 @@ REPOS:
 
   EPEL_REPO:
     URL:
+
+  GR_YUM_REPO:
+    URL:
+    GPG_URL:

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -20,6 +20,7 @@ import copy
 import csv
 import os
 import random
+import re
 
 import pytest
 import yaml
@@ -1469,9 +1470,10 @@ def test_global_registration_with_capsule_host():
     """
 
 
-@pytest.mark.stubbed
 @pytest.mark.tier2
-def test_global_registration_with_gpg_repo_and_default_package():
+def test_global_registration_with_gpg_repo_and_default_package(
+    session, module_activation_key, module_os, module_proxy, rhel7_contenthost
+):
     """Host registration form produces a correct registration command and host is
     registered successfully with gpg repo enabled and have default package
     installed.
@@ -1490,14 +1492,43 @@ def test_global_registration_with_gpg_repo_and_default_package():
         4. open the global registration form and update the gpg repo and key
         5. check host is registered successfully with installed same package
         6. check gpg repo is exist in registered host
-
-    :CaseAutomation: ManualOnly
     """
+    client = rhel7_contenthost
+    with session:
+        repo_name = 'foreman_register'
+        repo_url = settings.repos.gr_yum_repo.url
+        repo_gpg_url = settings.repos.gr_yum_repo.gpg_url
+        cmd = session.host.get_register_command(
+            {
+                'general.capsule': module_proxy.name,
+                'general.operating_system': module_os.title,
+                'advanced.activation_keys': module_activation_key.name,
+                'general.insecure': True,
+                'advanced.force': True,
+                'advanced.install_packages': 'mlocate vim',
+                'advanced.repository': repo_url,
+                'advanced.repository_gpg_key_url': repo_gpg_url,
+            }
+        )
+
+    # rhel repo required for insights client installation,
+    # syncing it to the satellite would take too long
+    client.configure_rhel_repo(settings.repos.rhel7_repo)
+    # run curl
+    result = client.execute(cmd)
+    assert result.status == 0
+    result = client.execute('yum list installed | grep mlocate')
+    assert result.status == 0
+    assert 'mlocate' in result.stdout
+    result = client.execute(f'yum -v repolist {repo_name}')
+    assert result.status == 0
+    assert repo_url in result.stdout
 
 
-@pytest.mark.stubbed
 @pytest.mark.tier3
-def test_global_re_registration_host_with_force_ignore_error_options():
+def test_global_re_registration_host_with_force_ignore_error_options(
+    session, module_activation_key, module_os, module_proxy, rhel7_contenthost
+):
     """If the ignore_error and force checkbox is checked then registered host can
     get re-registered without any error.
 
@@ -1513,14 +1544,32 @@ def test_global_re_registration_host_with_force_ignore_error_options():
         3. open the global registration form and select --force and --Ignore Errors option
         4. registered the host with generated curl command
         5. re-register the same host again and check it is getting registered
-
-    :CaseAutomation: ManualOnly
     """
+    client = rhel7_contenthost
+    with session:
+        cmd = session.host.get_register_command(
+            {
+                'general.capsule': module_proxy.name,
+                'general.operating_system': module_os.title,
+                'advanced.activation_keys': module_activation_key.name,
+                'general.insecure': True,
+                'advanced.force': True,
+                'advanced.ignore_error': True,
+            }
+        )
+    result = client.execute(cmd)
+    assert result.status == 0
+    # rerun the register command
+    result = client.execute(cmd)
+    assert result.status == 0
+    result = client.execute('subscription-manager identity')
+    assert result.status == 0
 
 
-@pytest.mark.stubbed
 @pytest.mark.tier2
-def test_global_registration_token_restriction():
+def test_global_registration_token_restriction(
+    session, module_activation_key, rhel7_contenthost, module_os, module_proxy
+):
     """Global registration token should be only used for registration call, it
     should be restricted for any other api calls.
 
@@ -1535,8 +1584,32 @@ def test_global_registration_token_restriction():
         1. open the global registration form and generate the curl token
         2. use that curl token to execute other api calls e.g. GET /hosts, /users
 
-    :CaseAutomation: ManualOnly
     """
+    client = rhel7_contenthost
+    with session:
+        cmd = session.host.get_register_command(
+            {
+                'general.capsule': module_proxy.name,
+                'general.operating_system': module_os.title,
+                'advanced.activation_keys': module_activation_key.name,
+                'general.insecure': True,
+            }
+        )
+
+    pattern = re.compile("Authorization.*(?=')")
+    auth_header = re.search(pattern, cmd).group()
+
+    # build curl
+    curl_users = (
+        f'curl -X GET -k -H {auth_header} -i https://{settings.server.hostname}/api/users/'
+    )
+    curl_hosts = (
+        f'curl -X GET -k -H {auth_header} -i https://{settings.server.hostname}/api/hosts/'
+    )
+    for curl_cmd in (curl_users, curl_hosts):
+        result = client.execute(curl_cmd)
+        assert result.status == 0
+        'Unable to authenticate user' in result.stdout
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
Added gitlab pr 376

```
=========================================================== warnings summary ===========================================================
env/lib/python3.8/site-packages/attrdict/mapping.py:4
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/attrdict/mapping.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

env/lib/python3.8/site-packages/attrdict/mixins.py:5
env/lib/python3.8/site-packages/attrdict/mixins.py:5
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/attrdict/mixins.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, MutableMapping, Sequence

tests/foreman/ui/test_host.py: 25 warnings
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/urllib3/connectionpool.py:981: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-2-40.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
====================================== 5 passed, 31 deselected, 28 warnings in 2234.17s (0:37:14) ======================================
```
