### PR TITLE
[Cherry-pick] Fixed test_negative_settings_access_to_non_admin test failure

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -273,7 +273,12 @@ def test_negative_settings_access_to_non_admin():
     entities.User(admin=False, login=login, password=password).create()
     try:
         with Session(user=login, password=password) as session:
-            assert session.settings.robottelo.browser.title == 'Permission denied'
+            result = session.settings.permission_denied()
+            assert (
+                result == 'Permission denied You are not authorized to perform this action. '
+                'Please request one of the required permissions listed below '
+                'from a Satellite administrator: view_settings Back'
+            )
     finally:
         User.delete({'login': login})
 


### PR DESCRIPTION
This PR depends on https://github.com/SatelliteQE/airgun/pull/605

**Test Result:**

```
$ pytest -s tests/foreman/ui/test_settings.py::test_negative_settings_access_to_non_admin
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.0, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
collected 1 item                                                                                                                                                                                                  

tests/foreman/ui/test_settings.py 
.
========================================================================================= 1 passed, 4 warnings in 48.70s ==========================================================================================

```