### PR TITLE
Fix use of deprecated xunit fixture

### DIFF
--- a/pytest_fixtures/reporting_fixtures.py
+++ b/pytest_fixtures/reporting_fixtures.py
@@ -53,6 +53,6 @@ def record_testsuite_timestamp_xml(record_testsuite_property):
 
 
 @pytest.fixture(autouse=True, scope='function')
-def record_test_timestamp_xml(record_property):
+def record_test_timestamp_xml(request):
     now = datetime.datetime.utcnow()
-    record_property('start_time', now.strftime(FMT_XUNIT_TIME))
+    request.node.user_properties.append(('start_time', now.strftime(FMT_XUNIT_TIME)))


### PR DESCRIPTION
There is a warning for using this fixture, and its incompatibility with
xunit2

https://docs.pytest.org/en/6.2.x/_modules/_pytest/junitxml.html#record_property

Following the implementation here, I just set it on user_properties

backporting #8862