### PR TITLE
puppet fixes in ui host,hostgroup and smartclassparameter,

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -138,6 +138,14 @@ def module_compute_profile():
     return entities.ComputeProfile().create()
 
 
+@pytest.fixture(scope='module')
+def module_update_default_smart_proxy(module_location, default_smart_proxy):
+    if module_location.id not in [location.id for location in default_smart_proxy.location]:
+        default_smart_proxy.location.append(entities.Location(id=module_location.id))
+    default_smart_proxy.update(['location'])
+    return default_smart_proxy
+
+
 @pytest.fixture(scope='session')
 def default_domain(default_smart_proxy):
     domain_name = settings.server.hostname.partition('.')[-1]

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -138,14 +138,6 @@ def module_compute_profile():
     return entities.ComputeProfile().create()
 
 
-@pytest.fixture(scope='module')
-def module_update_default_smart_proxy(module_location, default_smart_proxy):
-    if module_location.id not in [location.id for location in default_smart_proxy.location]:
-        default_smart_proxy.location.append(entities.Location(id=module_location.id))
-    default_smart_proxy.update(['location'])
-    return default_smart_proxy
-
-
 @pytest.fixture(scope='session')
 def default_domain(default_smart_proxy):
     domain_name = settings.server.hostname.partition('.')[-1]

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -592,7 +592,7 @@ def test_positive_create_with_puppet_class(
     """
     pc_name = 'generic_1'
     env_name = default_sat.create_custom_environment(repo=pc_name)
-    env = entities.Environment().search(query={'search': f'name={env_name}'})[0].read()
+    env = default_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
     env = entities.Environment(
         id=env.id,
         location=[module_loc],

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -147,7 +147,7 @@ def test_create_with_puppet_class(session, module_org, module_loc, default_sat):
     name = gen_string('alpha')
     pc_name = 'generic_1'
     env_name = default_sat.create_custom_environment(repo=pc_name)
-    env = entities.Environment().search(query={'search': f'name={env_name}'})[0].read()
+    env = default_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
     env = entities.Environment(
         id=env.id,
         location=[module_loc],

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -29,7 +29,7 @@ from robottelo.datafactory import gen_string
 
 PM_NAME = 'generic_1'
 
-pytestmark = [pytest.mark.run_in_one_thread]
+pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.skip_if_open("BZ:1996035")]
 
 
 @pytest.fixture(scope='module')
@@ -56,7 +56,7 @@ def module_host(
     module_loc,
     module_env_search,
     module_puppet_classes,
-    module_update_default_smart_proxy,
+    default_smart_proxy,
 ):
     lce = entities.LifecycleEnvironment().search(
         query={'search': f'organization_id="{module_org.id}" and name="{ENVIRONMENT}"'}
@@ -69,8 +69,8 @@ def module_host(
         },
         environment=module_env_search,
         puppetclass=module_puppet_classes,
-        puppet_proxy=module_update_default_smart_proxy,
-        puppet_ca_proxy=module_update_default_smart_proxy,
+        puppet_proxy=default_smart_proxy,
+        puppet_ca_proxy=default_smart_proxy,
     ).create()
     return host
 
@@ -80,7 +80,6 @@ def domain(module_host):
     return entities.Domain(id=module_host.domain.id).read()
 
 
-@pytest.mark.skip_if_open("BZ:1996035")
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_puppet_classes, sc_params_list):
     """Perform end to end testing for smart class parameter component
@@ -181,7 +180,6 @@ def test_positive_end_to_end(session, module_puppet_classes, sc_params_list):
         )
 
 
-@pytest.mark.skip_if_open("BZ:1996035")
 @pytest.mark.tier2
 def test_positive_create_matcher_attribute_priority(session, sc_params_list, module_host, domain):
     """Matcher Value set on Attribute Priority for Host.
@@ -268,7 +266,6 @@ def test_positive_create_matcher_attribute_priority(session, sc_params_list, mod
         assert output_scp == str([domain.name, module_host.mac])
 
 
-@pytest.mark.skip_if_open("BZ:1996035")
 @pytest.mark.tier2
 def test_positive_create_matcher_avoid_duplicate(session, sc_params_list, module_host, domain):
     """Merge the values of all the associated matchers, remove duplicates.
@@ -344,7 +341,6 @@ def test_positive_create_matcher_avoid_duplicate(session, sc_params_list, module
         assert output_scp == [20, 80, 90, 100]
 
 
-@pytest.mark.skip_if_open("BZ:1996035")
 @pytest.mark.tier2
 def test_positive_update_matcher_from_attribute(session, sc_params_list, module_host):
     """Impact on parameter on editing the parameter value from attribute.
@@ -411,7 +407,6 @@ def test_positive_update_matcher_from_attribute(session, sc_params_list, module_
         assert property_matcher['Value']['value'] == new_override_value
 
 
-@pytest.mark.skip_if_open("BZ:1996035")
 @pytest.mark.tier2
 def test_positive_impact_parameter_delete_attribute(
     session, sc_params_list, module_env_search, module_puppet_classes
@@ -471,7 +466,6 @@ def test_positive_impact_parameter_delete_attribute(
         assert session.sc_parameter.search(sc_param.parameter)[0]['Number of Overrides'] == '0'
 
 
-@pytest.mark.skip_if_open("BZ:1996035")
 @pytest.mark.tier2
 def test_positive_hidden_value_in_attribute(session, sc_params_list, module_host):
     """Update the hidden default value of parameter in attribute. Then unhide.


### PR DESCRIPTION
- [ BZ found](https://bugzilla.redhat.com/show_bug.cgi?id=1996035) test skipped in test host and the whole test_smartclassparameter file
- puppet workaround applied to fix 2 tests, one in hostgroup and one in test host, 
- I hope I fixed the test also in smartclassparameter file, but not 100 percent sure without test results :smile: 

Test results:
```
collected 2 items                                                                            

tests/foreman/ui/test_host.py::test_positive_create_with_puppet_class PASSED           [ 50%]
tests/foreman/ui/test_hostgroup.py::test_create_with_puppet_class PASSED               [100%]
========================= 2 passed, 18 warnings in 391.95s (0:06:31) =========================
```

and 
```
collected 7 items                                                                            

tests/foreman/ui/test_smartclassparameter.py::test_positive_end_to_end SKIPPED (BZ...) [ 14%]
tests/foreman/ui/test_smartclassparameter.py::test_positive_create_matcher_attribute_priority SKIPPED [ 28%]
tests/foreman/ui/test_smartclassparameter.py::test_positive_create_matcher_avoid_duplicate SKIPPED [ 42%]
tests/foreman/ui/test_smartclassparameter.py::test_positive_update_matcher_from_attribute SKIPPED [ 57%]
tests/foreman/ui/test_smartclassparameter.py::test_positive_impact_parameter_delete_attribute SKIPPED [ 71%]
tests/foreman/ui/test_smartclassparameter.py::test_positive_hidden_value_in_attribute SKIPPED [ 85%]
tests/foreman/ui/test_host.py::test_positive_remove_parameter_non_admin_user SKIPPED   [100%]
=============================== 7 skipped, 3 warnings in 1.04s ===============================

```


