### PR TITLE
Fix IndexError in report hook

### DIFF
--- a/pytest_fixtures/reporting_fixtures.py
+++ b/pytest_fixtures/reporting_fixtures.py
@@ -61,4 +61,4 @@ def record_test_timestamp_xml(request):
 @pytest.fixture(autouse=True, scope='function')
 def record_test_markers_xml(request, record_property):
     for marker in request.node.iter_markers():
-        request.node.user_properties.append((marker.name, marker.args[0]))
+        request.node.user_properties.append((marker.name, next(iter(marker.args), None)))


### PR DESCRIPTION
not all marks have args, so this produces an IndexError