### PR TITLE
Added test coverage for BZ#1960801, BZ#1860519

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -876,6 +876,10 @@ class Capsule(ContentHost):
         """
         return self.execute('rpm -q satellite &>/dev/null').status != 0
 
+    @cached_property
+    def url(self):
+        return f'https://{self.hostname}'
+
     def restart_services(self):
         """Restart services, returning True if passed and stdout if not"""
         result = self.execute('foreman-maintain service restart')
@@ -1045,10 +1049,6 @@ class Satellite(Capsule):
             return self.execute('rpm -q satellite').stdout.split('-')[1]
         else:
             return 'upstream'
-
-    @cached_property
-    def url(self):
-        return f'https://{self.hostname}'
 
     @cached_property
     def url_katello_ca_rpm(self):


### PR DESCRIPTION
In this PR, We are checking the public directory accessibility and inaccessibility from HTTP and HTTPS satellite and capsule URLs.

**Test Results:**

```
$ pytest -s  tests/foreman/installer/test_installer.py::test_installer_cap_pub_directory_accessibility
plugins: reportportal-5.0.8, xdist-2.3.0, services-2.2.1, ibutsu-1.16, forked-1.3.0, mock-3.6.1
collecting ... 2021-08-26 23:01:09 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 1 item                                                                                                                                                                                                  

tests/foreman/installer/test_installer.py::test_installer_cap_pub_directory_accessibility
PASSED
================================================================================================ warnings summary =================================================================================================
=================================================================================== 1 passed, 3 warnings in 1257.51s (0:20:57) ====================================================================================

$ pytest -s tests/foreman/installer/test_installer.py::test_installer_sat_pub_directory_accessibility
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.0, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/desingh/Satellite-QE/Robottelo/robottelo/robottelo_pyenv_38/bin/python3.8
cachedir: .pytest_cache
tests/foreman/installer/test_installer.py::test_installer_sat_pub_directory_accessibility
PASSED
================================================================================================ warnings summary =================================================================================================
=================================================================================== 1 passed, 3 warnings in 1301.57s (0:21:41) ====================================================================================
```


