### PR TITLE
Use default_sat instead of settings.server.hostname

### DIFF
--- a/robottelo/decorators/func_locker.py
+++ b/robottelo/decorators/func_locker.py
@@ -75,10 +75,9 @@ def set_default_scope(value):
 
 def _get_default_scope():
     # this is the default locking scope
-    if LOCK_DEFAULT_SCOPE is None:
-        return settings.server.hostname
-    else:
-        return LOCK_DEFAULT_SCOPE
+    from robottelo.config import settings
+
+    return LOCK_DEFAULT_SCOPE or settings.server.hostname
 
 
 def get_temp_dir():

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -75,9 +75,9 @@ def module_gce_finishimg(
 
 
 @pytest.fixture(scope='class')
-def gce_domain(module_org, module_location, default_smart_proxy):
+def gce_domain(module_org, module_location, default_smart_proxy, default_sat):
     """Sets Domain for GCE Host Provisioning"""
-    _, _, dom = settings.server.hostname.partition('.')
+    _, _, dom = default_sat.hostname.partition('.')
     domain = entities.Domain().search(query={'search': f'name="{dom}"'})
     domain = domain[0].read()
     domain.location.append(module_location)

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -658,7 +658,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_on_demand_sync(self, capsule_configured):
+    def test_positive_on_demand_sync(self, capsule_configured, default_sat):
         """Create a repository with 'on_demand' sync, add it to lifecycle
         environment with a capsule, sync repository, examine existing packages
         on capsule, download any package, examine packages once more
@@ -773,8 +773,9 @@ class TestCapsuleContentManagement:
         assert broken_links == links
 
         # Download package from satellite and get its md5 checksum
+        # Not using default_sat.url as it uses https
         published_repo_url = 'http://{}{}/pulp/{}/'.format(
-            settings.server.hostname,
+            default_sat.hostname,
             f':{settings.server.port}' if settings.server.port else '',
             lce_repo_path.split('http/')[1],
         )

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -32,15 +32,9 @@ from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
 
+from robottelo import datafactory
 from robottelo.api.utils import promote
 from robottelo.config import get_credentials
-from robottelo.config import settings
-from robottelo.datafactory import invalid_interfaces_list
-from robottelo.datafactory import invalid_values_list
-from robottelo.datafactory import parametrized
-from robottelo.datafactory import valid_data_list
-from robottelo.datafactory import valid_hosts_list
-from robottelo.datafactory import valid_interfaces_list
 
 
 @pytest.mark.tier1
@@ -111,7 +105,7 @@ def test_positive_search_by_org_id():
 
 
 @pytest.mark.tier1
-@pytest.mark.parametrize('owner_type', **parametrized(['User', 'Usergroup']))
+@pytest.mark.parametrize('owner_type', ['User', 'Usergroup'])
 def test_negative_create_with_owner_type(owner_type):
     """Create a host and specify only ``owner_type``.
 
@@ -129,7 +123,7 @@ def test_negative_create_with_owner_type(owner_type):
 
 
 @pytest.mark.tier1
-@pytest.mark.parametrize('owner_type', **parametrized(['User', 'Usergroup']))
+@pytest.mark.parametrize('owner_type', ['User', 'Usergroup'])
 def test_positive_update_owner_type(owner_type, module_org, module_location, module_user):
     """Update a host's ``owner_type``.
 
@@ -167,10 +161,10 @@ def test_positive_create_and_update_with_name():
 
     :CaseImportance: Critical
     """
-    name = gen_choice(valid_hosts_list())
+    name = gen_choice(datafactory.valid_hosts_list())
     host = entities.Host(name=name).create()
     assert host.name == f'{name}.{host.domain.read().name}'
-    new_name = gen_choice(valid_hosts_list())
+    new_name = gen_choice(datafactory.valid_hosts_list())
     host.name = new_name
     host = host.update(['name'])
     assert host.name == f'{new_name}.{host.domain.read().name}'
@@ -315,7 +309,7 @@ def test_positive_create_with_inherited_params(module_org, module_location):
 
 
 @pytest.mark.tier1
-def test_positive_create_and_update_with_puppet_proxy():
+def test_positive_create_and_update_with_puppet_proxy(default_sat):
     """Create a host with puppet proxy specified and then create new host without specified
     puppet proxy and update the new host with the same puppet proxy
 
@@ -325,19 +319,20 @@ def test_positive_create_and_update_with_puppet_proxy():
 
     :CaseImportance: Critical
     """
-    proxy = entities.SmartProxy().search(
-        query={'search': f'url = https://{settings.server.hostname}:9090'}
-    )[0]
-    host = entities.Host(puppet_proxy=proxy).create()
+    # TODO Define the default capsule/SP port + URL on hosts.Capsule
+    proxy = default_sat.api.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[
+        0
+    ]
+    host = default_sat.api.Host(puppet_proxy=proxy).create()
     assert host.puppet_proxy.read().name == proxy.name
-    new_host = entities.Host().create()
+    new_host = default_sat.api.Host().create()
     new_host.puppet_proxy = proxy
     new_host = new_host.update(['puppet_proxy'])
     assert new_host.puppet_proxy.read().name == proxy.name
 
 
 @pytest.mark.tier1
-def test_positive_create_with_puppet_ca_proxy():
+def test_positive_create_with_puppet_ca_proxy(default_sat):
     """Create a host with puppet CA proxy specified and then create new host without specified
      puppet CA proxy and update the new host with the same puppet CA proxy
 
@@ -347,9 +342,7 @@ def test_positive_create_with_puppet_ca_proxy():
 
     :CaseImportance: Critical
     """
-    proxy = entities.SmartProxy().search(
-        query={'search': f'url = https://{settings.server.hostname}:9090'}
-    )[0]
+    proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[0]
     host = entities.Host(puppet_ca_proxy=proxy).create()
     assert host.puppet_ca_proxy.read().name == proxy.name
     new_host = entities.Host().create()
@@ -502,7 +495,7 @@ def test_positive_create_and_update_with_usergroup(module_org, module_location, 
 
 
 @pytest.mark.tier1
-@pytest.mark.parametrize('build', **parametrized([True, False]))
+@pytest.mark.parametrize('build', [True, False])
 def test_positive_create_and_update_with_build_parameter(build):
     """Create and update a host with 'build' parameter specified.
     Build parameter determines whether to enable the host for provisioning
@@ -524,7 +517,7 @@ def test_positive_create_and_update_with_build_parameter(build):
 
 
 @pytest.mark.tier1
-@pytest.mark.parametrize('enabled', **parametrized([True, False]))
+@pytest.mark.parametrize('enabled', [True, False], ids=['enabled', 'disabled'])
 def test_positive_create_and_update_with_enabled_parameter(enabled):
     """Create and update a host with 'enabled' parameter specified.
     Enabled parameter determines whether to include the host within
@@ -547,7 +540,7 @@ def test_positive_create_and_update_with_enabled_parameter(enabled):
 
 
 @pytest.mark.tier1
-@pytest.mark.parametrize('managed', **parametrized([True, False]))
+@pytest.mark.parametrize('managed', [True, False], ids=['managed', 'unmanaged'])
 def test_positive_create_and_update_with_managed_parameter(managed):
     """Create and update a host with managed parameter specified.
     Managed flag shows whether the host is managed or unmanaged and
@@ -579,10 +572,10 @@ def test_positive_create_and_update_with_comment():
 
     :CaseImportance: Critical
     """
-    comment = gen_choice(list(valid_data_list().values()))
+    comment = gen_choice(list(datafactory.valid_data_list().values()))
     host = entities.Host(comment=comment).create()
     assert host.comment == comment
-    new_comment = gen_choice(list(valid_data_list().values()))
+    new_comment = gen_choice(list(datafactory.valid_data_list().values()))
     host.comment = new_comment
     host = host.update(['comment'])
     assert host.comment == new_comment
@@ -708,7 +701,7 @@ def test_positive_end_to_end_with_image(
 
 @pytest.mark.tier1
 @pytest.mark.on_premises_provisioning
-@pytest.mark.parametrize('method', **parametrized(['build', 'image']))
+@pytest.mark.parametrize('method', ['build', 'image'])
 def test_positive_create_with_provision_method(
     method, module_org, module_location, module_cr_libvirt
 ):
@@ -873,7 +866,7 @@ def test_negative_update_name(module_host):
 
     :CaseImportance: Critical
     """
-    new_name = gen_choice(invalid_values_list())
+    new_name = gen_choice(datafactory.invalid_values_list())
     host = module_host
     host.name = new_name
     with pytest.raises(HTTPError):
@@ -891,7 +884,7 @@ def test_negative_update_mac(module_host):
 
     :CaseImportance: Critical
     """
-    new_mac = gen_choice(invalid_values_list())
+    new_mac = gen_choice(datafactory.invalid_values_list())
     host = module_host
     host.mac = new_mac
     with pytest.raises(HTTPError):
@@ -940,7 +933,7 @@ def test_negative_update_os():
 
 @pytest.mark.tier3
 def test_positive_read_content_source_id(
-    module_org, module_location, module_lce, module_published_cv
+    module_org, module_location, module_lce, module_published_cv, default_sat
 ):
     """Read the host content_source_id attribute from the read request
     response
@@ -956,11 +949,7 @@ def test_positive_read_content_source_id(
 
     :CaseLevel: System
     """
-    proxy = (
-        entities.SmartProxy()
-        .search(query={'url': f'https://{settings.server.hostname}:9090'})[0]
-        .read()
-    )
+    proxy = entities.SmartProxy().search(query={'url': f'{default_sat.url}:9090'})[0].read()
     promote(module_published_cv.version[0], environment_id=module_lce.id)
     host = entities.Host(
         organization=module_org,
@@ -980,7 +969,7 @@ def test_positive_read_content_source_id(
 
 @pytest.mark.tier3
 def test_positive_update_content_source_id(
-    module_org, module_location, module_lce, module_published_cv
+    module_org, module_location, module_lce, module_published_cv, default_sat
 ):
     """Read the host content_source_id attribute from the update request
     response
@@ -996,11 +985,9 @@ def test_positive_update_content_source_id(
 
     :CaseLevel: System
     """
-    proxy = entities.SmartProxy().search(query={'url': f'https://{settings.server.hostname}:9090'})[
-        0
-    ]
+    proxy = default_sat.api.SmartProxy().search(query={'url': f'{default_sat.url}:9090'})[0]
     promote(module_published_cv.version[0], environment_id=module_lce.id)
-    host = entities.Host(
+    host = default_sat.api.Host(
         organization=module_org,
         location=module_location,
         content_facet_attributes={
@@ -1317,7 +1304,7 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
 
 
 @pytest.mark.tier1
-def test_positive_read_puppet_proxy_name():
+def test_positive_read_puppet_proxy_name(default_sat):
     """Read a hostgroup created with puppet proxy and inspect server's
     response
 
@@ -1329,16 +1316,14 @@ def test_positive_read_puppet_proxy_name():
 
     :CaseImportance: Critical
     """
-    proxy = entities.SmartProxy().search(
-        query={'search': f'url = https://{settings.server.hostname}:9090'}
-    )[0]
+    proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[0]
     host = entities.Host(puppet_proxy=proxy).create().read_json()
     assert 'puppet_proxy_name' in host
     assert proxy.name == host['puppet_proxy_name']
 
 
 @pytest.mark.tier1
-def test_positive_read_puppet_ca_proxy_name():
+def test_positive_read_puppet_ca_proxy_name(default_sat):
     """Read a hostgroup created with puppet ca proxy and inspect server's
     response
 
@@ -1350,9 +1335,7 @@ def test_positive_read_puppet_ca_proxy_name():
 
     :CaseImportance: Critical
     """
-    proxy = entities.SmartProxy().search(
-        query={'search': f'url = https://{settings.server.hostname}:9090'}
-    )[0]
+    proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[0]
     host = entities.Host(puppet_ca_proxy=proxy).create().read_json()
     assert 'puppet_ca_proxy_name' in host
     assert proxy.name == host['puppet_ca_proxy_name']
@@ -1372,10 +1355,10 @@ class TestHostInterface:
 
         :CaseImportance: Critical
         """
-        name = gen_choice(valid_interfaces_list())
+        name = gen_choice(datafactory.valid_interfaces_list())
         interface = entities.Interface(host=module_host, name=name).create()
         assert interface.name == name
-        new_name = gen_choice(valid_interfaces_list())
+        new_name = gen_choice(datafactory.valid_interfaces_list())
         interface.name = new_name
         interface = interface.update(['name'])
         assert interface.name == new_name
@@ -1395,7 +1378,7 @@ class TestHostInterface:
 
         :CaseImportance: Critical
         """
-        name = gen_choice(invalid_interfaces_list())
+        name = gen_choice(datafactory.invalid_interfaces_list())
         with pytest.raises(HTTPError) as error:
             entities.Interface(host=module_host, name=name).create()
         assert str(422) in str(error)
@@ -1460,7 +1443,7 @@ class TestHostBulkAction:
 
         host_ids = []
         for _ in range(3):
-            name = gen_choice(valid_hosts_list())
+            name = gen_choice(datafactory.valid_hosts_list())
             host = entities.Host(name=name, organization=module_org).create()
             host_ids.append(host.id)
 

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -28,7 +28,6 @@ from requests.exceptions import HTTPError
 from robottelo.api.utils import one_to_one_names
 from robottelo.api.utils import promote
 from robottelo.config import get_credentials
-from robottelo.config import settings
 from robottelo.constants import PUPPET_MODULE_NTP_PUPPETLABS
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
@@ -242,7 +241,7 @@ class TestHostGroup:
         assert hostgroup_cloned_reduced.items() <= hostgroup_origin.items()
 
     @pytest.mark.tier1
-    def test_positive_create_with_properties(self, module_org, module_location):
+    def test_positive_create_with_properties(self, module_org, module_location, default_sat):
         """Create a hostgroup with properties
 
         :id: 528afd01-356a-4082-9e88-a5b2a715a792
@@ -254,27 +253,33 @@ class TestHostGroup:
 
         :CaseImportance: High
         """
-        env = entities.Environment(location=[module_location], organization=[module_org]).create()
-        parent_hostgroup = entities.HostGroup(
+        env = default_sat.api.Environment(
             location=[module_location], organization=[module_org]
         ).create()
-        arch = entities.Architecture().create()
-        ptable = entities.PartitionTable().create()
-        os = entities.OperatingSystem(architecture=[arch], ptable=[ptable]).create()
-        media = entities.Media(
+        parent_hostgroup = default_sat.api.HostGroup(
+            location=[module_location], organization=[module_org]
+        ).create()
+        arch = default_sat.api.Architecture().create()
+        ptable = default_sat.api.PartitionTable().create()
+        os = default_sat.api.OperatingSystem(architecture=[arch], ptable=[ptable]).create()
+        media = default_sat.api.Media(
             operatingsystem=[os], location=[module_location], organization=[module_org]
         ).create()
-        proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
+        proxy = default_sat.api.SmartProxy().search(
+            query={'search': f'url = {default_sat.url}:9090'}
         )[0]
-        subnet = entities.Subnet(location=[module_location], organization=[module_org]).create()
-        domain = entities.Domain(location=[module_location], organization=[module_org]).create()
-        content_view = entities.ContentView(organization=module_org).create()
+        subnet = default_sat.api.Subnet(
+            location=[module_location], organization=[module_org]
+        ).create()
+        domain = default_sat.api.Domain(
+            location=[module_location], organization=[module_org]
+        ).create()
+        content_view = default_sat.api.ContentView(organization=module_org).create()
         content_view.publish()
         content_view = content_view.read()
-        lce = entities.LifecycleEnvironment(organization=module_org).create()
+        lce = default_sat.api.LifecycleEnvironment(organization=module_org).create()
         promote(content_view.version[0], lce.id)
-        hostgroup = entities.HostGroup(
+        hostgroup = default_sat.api.HostGroup(
             architecture=arch,
             content_source=proxy,
             content_view=content_view,
@@ -306,23 +311,26 @@ class TestHostGroup:
         assert hostgroup.lifecycle_environment.read().name == lce.name
 
         # create new properties for update
-        new_org = entities.Organization().create()
-        new_loc = entities.Location(organization=[new_org]).create()
-        new_arch = entities.Architecture().create()
-        new_ptable = entities.PartitionTable().create()
-        new_parent = entities.HostGroup(location=[new_loc], organization=[new_org]).create()
-        new_env = entities.Environment(location=[new_loc], organization=[new_org]).create()
-        new_os = entities.OperatingSystem(architecture=[new_arch], ptable=[new_ptable]).create()
-        new_subnet = entities.Subnet(location=[new_loc], organization=[new_org]).create()
-        new_domain = entities.Domain(location=[new_loc], organization=[new_org]).create()
-        new_cv = entities.ContentView(organization=new_org).create()
+        new_org = default_sat.api.Organization().create()
+        new_loc = default_sat.api.Location(organization=[new_org]).create()
+        new_arch = default_sat.api.Architecture().create()
+        new_ptable = default_sat.api.PartitionTable().create()
+        new_parent = default_sat.api.HostGroup(location=[new_loc], organization=[new_org]).create()
+        new_env = default_sat.api.Environment(location=[new_loc], organization=[new_org]).create()
+        new_os = default_sat.api.OperatingSystem(
+            architecture=[new_arch], ptable=[new_ptable]
+        ).create()
+        new_subnet = default_sat.api.Subnet(location=[new_loc], organization=[new_org]).create()
+        new_domain = default_sat.api.Domain(location=[new_loc], organization=[new_org]).create()
+        new_cv = default_sat.api.ContentView(organization=new_org).create()
         new_cv.publish()
         new_cv = new_cv.read()
-        new_lce = entities.LifecycleEnvironment(organization=new_org).create()
-        promote(new_cv.version[0], new_lce.id)
-        new_media = entities.Media(
+        new_lce = default_sat.api.LifecycleEnvironment(organization=new_org).create()
+        new_media = default_sat.api.Media(
             operatingsystem=[os], location=[new_loc], organization=[new_org]
         ).create()
+        promote(new_cv.version[0], new_lce.id)
+
         # update itself
         hostgroup.organization = [new_org]
         hostgroup.location = [new_loc]
@@ -372,7 +380,7 @@ class TestHostGroup:
 
     @pytest.mark.stubbed('Remove stub once proper infrastructure will be created')
     @pytest.mark.tier2
-    def test_positive_create_with_realm(self, module_org, module_location):
+    def test_positive_create_with_realm(self, module_org, module_location, default_sat):
         """Create a hostgroup with realm specified
 
         :id: 4f07ff8d-746f-4ab5-ae0b-03d629f6296c
@@ -385,7 +393,7 @@ class TestHostGroup:
             location=[module_location],
             organization=[module_org],
             realm_proxy=entities.SmartProxy().search(
-                query={'search': f'url = https://{settings.server.hostname}:9090'}
+                query={'search': f'url = {default_sat.url}:9090'}
             )[0],
         ).create()
         hostgroup = entities.HostGroup(
@@ -441,7 +449,7 @@ class TestHostGroup:
         assert name == hostgroup.name
 
     @pytest.mark.tier2
-    def test_positive_update_puppet_ca_proxy(self, hostgroup):
+    def test_positive_update_puppet_ca_proxy(self, hostgroup, default_sat):
         """Update a hostgroup with a new puppet CA proxy
 
         :id: fd13ab0e-1a5b-48a0-a852-3fff8306271f
@@ -450,16 +458,16 @@ class TestHostGroup:
 
         :CaseLevel: Integration
         """
-        new_proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
+        new_proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[
+            0
+        ]
         hostgroup.puppet_ca_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_ca_proxy'])
         assert hostgroup.puppet_ca_proxy.read().name == new_proxy.name
 
     @pytest.mark.stubbed('Remove stub once proper infrastructure will be created')
     @pytest.mark.tier2
-    def test_positive_update_realm(self, module_org, module_location):
+    def test_positive_update_realm(self, module_org, module_location, default_sat):
         """Update a hostgroup with a new realm
 
         :id: fd9d141f-7a71-4439-92c7-1dbc1eea4772
@@ -472,7 +480,7 @@ class TestHostGroup:
             location=[module_location],
             organization=[module_org],
             realm_proxy=entities.SmartProxy().search(
-                query={'search': f'url = https://{settings.server.hostname}:9090'}
+                query={'search': f'url = {default_sat.url}:9090'}
             )[0],
         ).create()
         hostgroup = entities.HostGroup(
@@ -482,7 +490,7 @@ class TestHostGroup:
             location=[module_location],
             organization=[module_org],
             realm_proxy=entities.SmartProxy().search(
-                query={'search': f'url = https://{settings.server.hostname}:9090'}
+                query={'search': f'url = {default_sat.url}:9090'}
             )[0],
         ).create()
         hostgroup.realm = new_realm
@@ -490,7 +498,7 @@ class TestHostGroup:
         assert hostgroup.realm.read().name == new_realm.name
 
     @pytest.mark.tier2
-    def test_positive_update_puppet_proxy(self, hostgroup):
+    def test_positive_update_puppet_proxy(self, hostgroup, default_sat):
         """Update a hostgroup with a new puppet proxy
 
         :id: 86eca603-2cdd-4563-b6f6-aaa5cea1a723
@@ -499,15 +507,15 @@ class TestHostGroup:
 
         :CaseLevel: Integration
         """
-        new_proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
+        new_proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[
+            0
+        ]
         hostgroup.puppet_proxy = new_proxy
         hostgroup = hostgroup.update(['puppet_proxy'])
         assert hostgroup.puppet_proxy.read().name == new_proxy.name
 
     @pytest.mark.tier2
-    def test_positive_update_content_source(self, hostgroup):
+    def test_positive_update_content_source(self, hostgroup, default_sat):
         """Update a hostgroup with a new puppet proxy
 
         :id: 02ef1340-a21e-41b7-8aa7-d6fdea196c16
@@ -517,7 +525,7 @@ class TestHostGroup:
         :CaseLevel: Integration
         """
         new_content_source = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
+            query={'search': f'url = {default_sat.url}:9090'}
         )[0]
         hostgroup.content_source = new_content_source
         hostgroup = hostgroup.update(['content_source'])
@@ -673,7 +681,7 @@ class TestHostGroupMissingAttr:
         ), f'{names.difference(hostgroup_attrs)} not found in {hostgroup_attrs}'
 
     @pytest.mark.tier2
-    def test_positive_read_puppet_proxy_name(self):
+    def test_positive_read_puppet_proxy_name(self, default_sat):
         """Read a hostgroup created with puppet proxy and inspect server's
         response
 
@@ -685,15 +693,13 @@ class TestHostGroupMissingAttr:
 
         :CaseLevel: Integration
         """
-        proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
+        proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[0]
         hg = entities.HostGroup(puppet_proxy=proxy).create().read_json()
         assert 'puppet_proxy_name' in hg
         assert proxy.name == hg['puppet_proxy_name']
 
     @pytest.mark.tier2
-    def test_positive_read_puppet_ca_proxy_name(self):
+    def test_positive_read_puppet_ca_proxy_name(self, default_sat):
         """Read a hostgroup created with puppet ca proxy and inspect server's
         response
 
@@ -705,9 +711,7 @@ class TestHostGroupMissingAttr:
 
         :CaseLevel: Integration
         """
-        proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
-        )[0]
+        proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[0]
         hg = entities.HostGroup(puppet_ca_proxy=proxy).create().read_json()
         assert 'puppet_ca_proxy_name' in hg
         assert proxy.name == hg['puppet_ca_proxy_name']

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -32,7 +32,6 @@ from requests.exceptions import HTTPError
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
 from robottelo.config import get_credentials
-from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import invalid_values_list
@@ -304,7 +303,7 @@ class TestOrganizationUpdate:
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
-    def test_positive_add_and_remove_smart_proxy(self):
+    def test_positive_add_and_remove_smart_proxy(self, default_sat):
         """Add a smart proxy to an organization
 
         :id: e21de720-3fa2-429b-bd8e-b6a48a13146d
@@ -316,15 +315,15 @@ class TestOrganizationUpdate:
         :CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxy = entities.SmartProxy().search(
-            query={'search': f'url = https://{settings.server.hostname}:9090'}
+        smart_proxy = default_sat.api.SmartProxy().search(
+            query={'search': f'url = {default_sat.url}:9090'}
         )
         # Check that proxy is found and unpack it from the list
         assert len(smart_proxy) > 0
         smart_proxy = smart_proxy[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
-        org = entities.Organization().create()
+        org = default_sat.api.Organization().create()
         org.smart_proxy = []
         org = org.update(['smart_proxy'])
         # Verify smart proxy was actually removed

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -23,7 +23,6 @@ from requests import HTTPError
 
 from robottelo.api.utils import one_to_many_names
 from robottelo.cleanup import capsule_cleanup
-from robottelo.config import settings
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.helpers import default_url_on_new_port
@@ -34,15 +33,13 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
-def module_proxy_attrs():
+def module_proxy_attrs(default_sat):
     """Find a ``SmartProxy``.
 
     Every Satellite has a built-in smart proxy, so searching for an
     existing smart proxy should always succeed.
     """
-    smart_proxy = entities.SmartProxy().search(
-        query={'search': f'url = https://{settings.server.hostname}:9090'}
-    )
+    smart_proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})
     # Check that proxy is found and unpack it from the list
     assert len(smart_proxy) > 0, "No smart proxy is found"
     smart_proxy = smart_proxy[0]

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -31,7 +31,6 @@ from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import upload_manifest
 from robottelo.cli.subscription import Subscription
-from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -183,7 +182,7 @@ def test_negative_upload():
 
 
 @pytest.mark.tier2
-def test_positive_delete_manifest_as_another_user(function_org):
+def test_positive_delete_manifest_as_another_user(function_org, default_sat):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
 
@@ -196,7 +195,7 @@ def test_positive_delete_manifest_as_another_user(function_org):
     :CaseImportance: Medium
     """
     user1_password = gen_string('alphanumeric')
-    user1 = entities.User(
+    user1 = default_sat.api.User(
         admin=True,
         password=user1_password,
         organization=[function_org],
@@ -204,11 +203,11 @@ def test_positive_delete_manifest_as_another_user(function_org):
     ).create()
     sc1 = ServerConfig(
         auth=(user1.login, user1_password),
-        url=f'https://{settings.server.hostname}',
+        url=default_sat.url,
         verify=False,
     )
     user2_password = gen_string('alphanumeric')
-    user2 = entities.User(
+    user2 = default_sat.api.User(
         admin=True,
         password=user2_password,
         organization=[function_org],
@@ -216,7 +215,7 @@ def test_positive_delete_manifest_as_another_user(function_org):
     ).create()
     sc2 = ServerConfig(
         auth=(user2.login, user2_password),
-        url=f'https://{settings.server.hostname}',
+        url=default_sat.url,
         verify=False,
     )
     # use the first admin to upload a manifest

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -79,7 +79,7 @@ def module_user(module_org, module_location):
 
 
 @pytest.fixture(scope="function")
-def tftpboot(module_org):
+def tftpboot(module_org, default_sat):
     """This fixture removes the current deployed templates from TFTP, and sets up new ones.
     It manipulates the global defaults, so it shouldn't be used in concurrent environment
 
@@ -106,7 +106,7 @@ def tftpboot(module_org):
         },
         'ipxe': {
             'setting': 'global_iPXE',
-            'path': f'https://{settings.server.hostname}/unattended/iPXE?bootsrap=1',
+            'path': f'{default_sat.url}/unattended/iPXE?bootsrap=1',
             'kind': 'iPXE',
         },
     }
@@ -228,7 +228,7 @@ class TestProvisioningTemplate:
     @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.run_in_one_thread
-    def test_positive_build_pxe_default(self, tftpboot):
+    def test_positive_build_pxe_default(self, tftpboot, default_sat):
         """Call the "build_pxe_default" path.
 
         :id: ca19d9da-1049-4b39-823b-933fc1a0cebd
@@ -258,5 +258,5 @@ class TestProvisioningTemplate:
                 rendered = ssh.command(f"cat {template['path']}").stdout[0]
             assert (
                 rendered == f"{settings.server.scheme}://"
-                f"{settings.server.hostname} {template['kind']}"
+                f"{default_sat.hostname} {template['kind']}"
             )

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -18,15 +18,13 @@
 """
 import pytest
 from broker.broker import VMBroker
-from nailgun import entities
 
-from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
 
 @pytest.mark.tier1
 def test_positive_register(
-    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv
+    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv, default_sat
 ):
     """System is registered
 
@@ -46,17 +44,17 @@ def test_positive_register(
 
     :CaseImportance: Critical
     """
-    hg = entities.HostGroup(location=[module_location], organization=[module_org]).create()
+    hg = default_sat.api.HostGroup(location=[module_location], organization=[module_org]).create()
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         # assure system is not registered
         result = vm.execute('subscription-manager identity')
         # result will be 1 if not registered
         assert result.status == 1
         assert vm.execute(
-            f'curl -o /root/bootstrap.py "http://{settings.server.hostname}/pub/bootstrap.py" '
+            f'curl -o /root/bootstrap.py "http://{default_sat.hostname}/pub/bootstrap.py" '
         )
         assert vm.execute(
-            f'python /root/bootstrap.py -s {settings.server.hostname} -o {module_org.name}'
+            f'python /root/bootstrap.py -s {default_sat.hostname} -o {module_org.name}'
             f' -L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             ' --skip puppet --skip foreman'
         )
@@ -66,7 +64,7 @@ def test_positive_register(
         assert result.status == 0
         # register system once again
         assert vm.execute(
-            f'python /root/bootstrap.py -s "{settings.server.hostname}" -o {module_org.name} '
+            f'python /root/bootstrap.py -s "{default_sat.hostname}" -o {module_org.name} '
             f'-L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             '--skip puppet --skip foreman '
         )

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1216,7 +1216,7 @@ class TestDockerClient:
     """
 
     @pytest.mark.tier3
-    def test_positive_pull_image(self, module_org, docker_host):
+    def test_positive_pull_image(self, module_org, docker_host, default_sat):
         """A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
 
@@ -1236,7 +1236,7 @@ class TestDockerClient:
         try:
             result = docker_host.execute(
                 f'docker login -u {settings.server.admin_username}'
-                f' -p {settings.server.admin_password} {settings.server.hostname}'
+                f' -p {settings.server.admin_password} {default_sat.hostname}'
             )
             assert result.status == 0
 
@@ -1264,7 +1264,7 @@ class TestDockerClient:
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
-    def test_positive_container_admin_end_to_end_search(self, module_org, docker_host):
+    def test_positive_container_admin_end_to_end_search(self, module_org, docker_host, default_sat):
         """Verify that docker command line can be used against
         Satellite server to search for container images stored
         on Satellite instance.
@@ -1315,14 +1315,12 @@ class TestDockerClient:
             }
         )
         docker_repo_uri = (
-            f' {settings.server.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f' {default_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
             f'{CONTAINER_UPSTREAM_NAME} '
         ).lower()
 
         # 3. Try to search for docker images on Satellite
-        remote_search_command = (
-            f'docker search {settings.server.hostname}/{CONTAINER_UPSTREAM_NAME}'
-        )
+        remote_search_command = f'docker search {default_sat.hostname}/{CONTAINER_UPSTREAM_NAME}'
         result = docker_host.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri not in result.stdout
@@ -1330,7 +1328,7 @@ class TestDockerClient:
         # 4. Use Docker client to login to Satellite docker hub
         result = docker_host.execute(
             f'docker login -u {settings.server.admin_username}'
-            f' -p {settings.server.admin_password} {settings.server.hostname}'
+            f' -p {settings.server.admin_password} {default_sat.hostname}'
         )
         assert result.status == 0
 
@@ -1340,7 +1338,7 @@ class TestDockerClient:
         assert docker_repo_uri in result.stdout
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = docker_host.execute(f'docker logout {settings.server.hostname}')
+        result = docker_host.execute(f'docker logout {default_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to search for docker images
@@ -1364,7 +1362,7 @@ class TestDockerClient:
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
-    def test_positive_container_admin_end_to_end_pull(self, module_org, docker_host):
+    def test_positive_container_admin_end_to_end_pull(self, module_org, docker_host, default_sat):
         """Verify that docker command line can be used against
         Satellite server to pull in container images stored
         on Satellite instance.
@@ -1416,7 +1414,7 @@ class TestDockerClient:
             }
         )
         docker_repo_uri = (
-            f'{settings.server.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f'{default_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
             f'{docker_upstream_name}'
         ).lower()
 
@@ -1428,7 +1426,7 @@ class TestDockerClient:
         # 4. Use Docker client to login to Satellite docker hub
         result = docker_host.execute(
             f'docker login -u {settings.server.admin_username}'
-            f' -p {settings.server.admin_password} {settings.server.hostname}'
+            f' -p {settings.server.admin_password} {default_sat.hostname}'
         )
         assert result.status == 0
 
@@ -1444,7 +1442,7 @@ class TestDockerClient:
         assert result.status == 0
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = docker_host.execute(f'docker logout {settings.server.hostname}')
+        result = docker_host.execute(f'docker logout {default_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to pull in docker image
@@ -1464,11 +1462,10 @@ class TestDockerClient:
         result = docker_host.execute(docker_pull_command)
         assert result.status == 0
 
-    @pytest.mark.stubbed
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_upload_image(self, module_org):
+    def test_positive_upload_image(self, module_org, default_sat):
         """A Docker-enabled client can create a new ``Dockerfile``
         pointing to an existing Docker image from a Satellite 6 and modify it.
         Then, using ``docker build`` generate a new image which can then be
@@ -1527,7 +1524,7 @@ class TestDockerClient:
             ssh.upload_file(
                 local_file=tar_file,
                 remote_file=f'/tmp/{tar_file}',
-                hostname=settings.server.hostname,
+                hostname=default_sat.hostname,
             )
 
             # Upload tarred repository
@@ -1537,7 +1534,7 @@ class TestDockerClient:
 
             # Verify repository was uploaded successfully
             repo = Repository.info({'id': repo['id']})
-            assert settings.server.hostname == repo['published-at']
+            assert default_sat.hostname == repo['published-at']
 
             repo_name = '-'.join((module_org.label, product['label'], repo['label'])).lower()
             assert repo_name in repo['published-at']

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -71,9 +71,9 @@ from robottelo.hosts import ContentHostError
 
 
 @pytest.fixture(scope="module")
-def module_default_proxy():
-    """ Use the default installation smart proxy """
-    return Proxy.list({'search': f'url = https://{settings.server.hostname}:9090'})[0]
+def module_default_proxy(default_sat):
+    """Use the default installation smart proxy"""
+    return Proxy.list({'search': f'url = {default_sat.url}:9090'})[0]
 
 
 @pytest.fixture(scope="function")

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -82,9 +82,9 @@ def puppet_classes(env):
 
 
 @pytest.fixture(scope='module')
-def content_source():
+def content_source(default_sat):
     """Return the proxy."""
-    return Proxy.list({'search': f'url = https://{settings.server.hostname}:9090'})[0]
+    return Proxy.list({'search': f'url = {default_sat.url}:9090'})[0]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -408,7 +408,7 @@ class TestRemoteExecution:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_run_receptor_installer(self):
+    def test_positive_run_receptor_installer(self, default_sat):
         """Run Receptor installer ("Configure Cloud Connector")
 
         :CaseComponent: RHCloud-CloudConnector
@@ -424,7 +424,7 @@ class TestRemoteExecution:
         # Set Host parameter source_display_name to something random.
         # To avoid 'name has already been taken' error when run multiple times
         # on a machine with the same hostname.
-        host_id = Host.info({'name': settings.server.hostname})['id']
+        host_id = Host.info({'name': default_sat.hostname})['id']
         Host.set_parameter(
             {'host-id': host_id, 'name': 'source_display_name', 'value': gen_string('alpha')}
         )
@@ -436,7 +436,7 @@ class TestRemoteExecution:
                 'job-template': template_name,
                 'inputs': f'satellite_user="{settings.server.admin_username}",\
                         satellite_password="{settings.server.admin_password}"',
-                'search-query': f'name ~ {settings.server.hostname}',
+                'search-query': f'name ~ {default_sat.hostname}',
             }
         )
         invocation_id = invocation['id']
@@ -449,7 +449,7 @@ class TestRemoteExecution:
         assert entities.JobInvocation(id=invocation_id).read().status == 0
 
         result = ' '.join(
-            JobInvocation.get_output({'id': invocation_id, 'host': settings.server.hostname})
+            JobInvocation.get_output({'id': invocation_id, 'host': default_sat.hostname})
         )
         assert 'project-receptor.satellite_receptor_installer' in result
         assert 'Exit status: 0' in result

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -80,9 +80,9 @@ def fetch_scap_and_profile_id(scap_name, scap_profile):
 
 
 @pytest.fixture(scope='module')
-def default_proxy():
-    """ Returns default capsule/proxy id"""
-    proxy = Proxy.list({'search': settings.server.hostname})[0]
+def default_proxy(default_sat):
+    """Returns default capsule/proxy id"""
+    proxy = Proxy.list({'search': default_sat.hostname})[0]
     p_features = set(proxy.get('features').split(', '))
     if {'Puppet', 'Ansible', 'Openscap'}.issubset(p_features):
         proxy_id = proxy.get('id')
@@ -160,6 +160,7 @@ def test_positive_upload_to_satellite(
     lifecycle_env,
     puppet_env,
     distro,
+    default_sat,
 ):
     """Perform end to end oscap test, and push the updated scap content via puppet
      after first run.
@@ -197,11 +198,11 @@ def test_positive_upload_to_satellite(
     # Creates host_group.
     make_hostgroup(
         {
-            'content-source': settings.server.hostname,
+            'content-source': default_sat.hostname,
             'name': hgrp_name,
             'puppet-environment-id': puppet_env.id,
-            'puppet-ca-proxy': settings.server.hostname,
-            'puppet-proxy': settings.server.hostname,
+            'puppet-ca-proxy': default_sat.hostname,
+            'puppet-proxy': default_sat.hostname,
             'organizations': module_org.name,
             'puppet-classes': puppet_classes,
         }
@@ -294,7 +295,7 @@ def test_positive_upload_to_satellite(
 @pytest.mark.upgrade
 @pytest.mark.tier4
 def test_positive_oscap_run_with_tailoring_file_and_capsule(
-    module_org, default_proxy, content_view, lifecycle_env, puppet_env
+    module_org, default_proxy, content_view, lifecycle_env, puppet_env, default_sat
 ):
     """End-to-End Oscap run with tailoring files and default capsule via puppet
 
@@ -324,16 +325,16 @@ def test_positive_oscap_run_with_tailoring_file_and_capsule(
     policy_name = gen_string('alpha')
     tailoring_file_name = gen_string('alpha')
     tailor_path = file_downloader(
-        file_url=settings.oscap.tailoring_path, hostname=settings.server.hostname
+        file_url=settings.oscap.tailoring_path, hostname=default_sat.hostname
     )[0]
     # Creates host_group.
     make_hostgroup(
         {
-            'content-source': settings.server.hostname,
+            'content-source': default_sat.hostname,
             'name': hgrp_name,
             'puppet-environment-id': puppet_env.id,
-            'puppet-ca-proxy': settings.server.hostname,
-            'puppet-proxy': settings.server.hostname,
+            'puppet-ca-proxy': default_sat.hostname,
+            'puppet-proxy': default_sat.hostname,
             'organizations': module_org.name,
             'puppet-classes': puppet_classes,
         }

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -24,7 +24,6 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo import ssh
-from robottelo.config import settings
 from robottelo.helpers import get_data_file
 from robottelo.ssh import download_file
 from robottelo.ssh import get_connection
@@ -65,9 +64,9 @@ class TestKatelloCertsCheck:
     ]
 
     @pytest.fixture(scope="module")
-    def cert_data(self):
+    def cert_data(self, default_sat):
         """Get host name, scripts, and create working directory."""
-        sat6_hostname = settings.server.hostname
+        sat6_hostname = default_sat.hostname
         capsule_hostname = 'capsule.example.com'
         key_file_name = '{0}/{0}.key'.format(sat6_hostname)
         cert_file_name = '{0}/{0}.crt'.format(sat6_hostname)
@@ -113,7 +112,7 @@ class TestKatelloCertsCheck:
             assert result.return_code == 0
 
     @pytest.fixture()
-    def certs_cleanup(self):
+    def certs_cleanup(self, default_sat):
         """cleanup all cert configuration files"""
         yield
         files = [
@@ -125,7 +124,7 @@ class TestKatelloCertsCheck:
             'private',
             'serial*',
             'certs/*',
-            settings.server.hostname,
+            default_sat.hostname,
         ]
         with get_connection(timeout=300) as connection:
             files = " ".join(files)

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -254,7 +254,6 @@ class TestRenameHost:
         """
         # Save original hostname, get credentials, eventually will
         # end up in setUpClass
-        # original_name = settings.server.hostname
         username = settings.server.admin_username
         password = settings.server.admin_password
         # the rename part of the test, not necessary to run from robottelo

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2876,7 +2876,7 @@ def test_positive_subscribe_system_with_puppet_modules(session, rhel7_contenthos
 
 
 @pytest.mark.tier3
-def test_positive_delete_with_kickstart_repo_and_host_group(session):
+def test_positive_delete_with_kickstart_repo_and_host_group(session, default_sat):
     """Check that Content View associated with kickstart repository and
     which is used by a host group can be removed from the system
 
@@ -2893,7 +2893,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(session):
     :CaseImportance: High
     """
     hg_name = gen_string('alpha')
-    sat_hostname = settings.server.hostname
+    sat_hostname = default_sat.hostname
     org = entities.Organization().create()
     # Create a new Lifecycle environment
     lc_env = entities.LifecycleEnvironment(organization=org).create()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -101,10 +101,10 @@ def module_org():
 
 
 @pytest.fixture(scope='module')
-def module_loc(module_org):
+def module_loc(module_org, default_sat):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
-        entities.SmartProxy().search(query={'search': f'name={settings.server.hostname}'})[0].read()
+        entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
     )
     smart_proxy.location.append(entities.Location(id=location.id))
     smart_proxy.update(['location'])
@@ -175,11 +175,9 @@ def os_path(module_os):
 
 
 @pytest.fixture(scope='module')
-def module_proxy(module_org, module_loc):
+def module_proxy(module_org, module_loc, default_sat):
     # Search for SmartProxy, and associate organization/location
-    proxy = (
-        entities.SmartProxy().search(query={'search': f'name={settings.server.hostname}'})[0].read()
-    )
+    proxy = entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
     return proxy
 
 
@@ -213,10 +211,10 @@ def module_libvirt_resource(module_org, module_loc):
 
 
 @pytest.fixture(scope='module')
-def module_libvirt_domain(module_org, module_loc, module_proxy):
+def module_libvirt_domain(module_org, module_loc, module_proxy, default_sat):
     # Search for existing domain or create new otherwise. Associate org,
     # location and dns to it
-    _, _, domain = settings.server.hostname.partition('.')
+    _, _, domain = default_sat.hostname.partition('.')
     domain = entities.Domain().search(query={'search': f'name="{domain}"'})
     if len(domain) > 0:
         domain = domain[0].read()
@@ -1245,7 +1243,7 @@ def test_positive_search_by_org(session, module_loc):
 
 
 @pytest.mark.tier2
-def test_positive_validate_inherited_cv_lce(session, module_host_template):
+def test_positive_validate_inherited_cv_lce(session, module_host_template, default_sat):
     """Create a host with hostgroup specified via CLI. Make sure host
     inherited hostgroup's lifecycle environment, content view and both
     fields are properly reflected via WebUI.
@@ -1277,7 +1275,7 @@ def test_positive_validate_inherited_cv_lce(session, module_host_template):
             'organization-ids': module_host_template.organization.id,
         }
     )
-    puppet_proxy = Proxy.list({'search': f'name = {settings.server.hostname}'})[0]
+    puppet_proxy = Proxy.list({'search': f'name = {default_sat.hostname}'})[0]
     host = make_host(
         {
             'architecture-id': module_host_template.architecture.id,
@@ -1300,7 +1298,7 @@ def test_positive_validate_inherited_cv_lce(session, module_host_template):
 
 @pytest.mark.tier2
 def test_positive_global_registration_form(
-    session, module_activation_key, module_org, module_loc, module_os
+    session, module_activation_key, module_org, module_loc, module_os, default_sat
 ):
     """Host registration form produces a correct curl command for various inputs
 
@@ -1341,7 +1339,7 @@ def test_positive_global_registration_form(
         f'remote_execution_interface={iface}',
         f'setup_insights={"true" if insights_value else "false"}',
         f'setup_remote_execution={"true" if rex_value else "false"}',
-        f'{settings.server.hostname}',
+        f'{default_sat.hostname}',
         'insecure',
     ]
     for pair in expected_pairs:
@@ -2026,7 +2024,7 @@ def test_positive_gce_cloudinit_provision_end_to_end(
 
 @pytest.mark.upgrade
 @pytest.mark.tier2
-def test_positive_cockpit(session):
+def test_positive_cockpit(session, default_sat):
     """Test whether webconsole button and cockpit integration works
 
     :id: 5a9be063-cdc4-43ce-91b9-7608fbebf8bb
@@ -2040,10 +2038,10 @@ def test_positive_cockpit(session):
         session.organization.select(org_name='Default Organization')
         session.location.select(loc_name='Any Location')
         hostname_inside_cockpit = session.host.get_webconsole_content(
-            entity_name=settings.server.hostname
+            entity_name=default_sat.hostname
         )
         assert (
-            hostname_inside_cockpit == settings.server.hostname
+            hostname_inside_cockpit == default_sat.hostname
         ), 'cockpit page shows hostname {} instead of {}'.format(
-            hostname_inside_cockpit, settings.server.hostname
+            hostname_inside_cockpit, default_sat.hostname
         )

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -22,27 +22,9 @@ import pytest
 from broker import VMBroker
 from nailgun import entities
 
+from robottelo import constants
 from robottelo.api.utils import promote
 from robottelo.api.utils import update_vm_host_location
-from robottelo.config import settings
-from robottelo.constants import DISTRO_DEFAULT
-from robottelo.constants import DISTRO_RHEL8
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_GROUP
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_GROUP_NAME
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_0_MODULAR_ERRATA_ID
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_2_ERRATA_ID
-from robottelo.constants import FAKE_3_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_3_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_6_CUSTOM_PACKAGE
-from robottelo.constants.repos import CUSTOM_MODULE_STREAM_REPO_2
-from robottelo.constants.repos import FAKE_1_YUM_REPO
-from robottelo.constants.repos import FAKE_6_YUM_REPO
 from robottelo.datafactory import gen_string
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.hosts import ContentHost
@@ -74,11 +56,11 @@ def module_lce(module_org):
 @pytest.fixture(scope='module')
 def module_repos_collection(module_org, module_lce):
     repos_collection = RepositoryCollection(
-        distro=DISTRO_DEFAULT,
+        distro=constants.DISTRO_DEFAULT,
         repositories=[
             SatelliteToolsRepository(),
-            YumRepository(url=FAKE_1_YUM_REPO),
-            YumRepository(url=FAKE_6_YUM_REPO),
+            YumRepository(url=constants.repos.FAKE_1_YUM_REPO),
+            YumRepository(url=constants.repos.FAKE_6_YUM_REPO),
         ],
     )
     repos_collection.setup_content(module_org.id, module_lce.id, upload_manifest=True)
@@ -88,14 +70,15 @@ def module_repos_collection(module_org, module_lce):
 @pytest.fixture(scope='module')
 def module_repos_collection_module_stream(module_org, module_lce):
     repos_collection = RepositoryCollection(
-        distro=DISTRO_RHEL8, repositories=[YumRepository(url=CUSTOM_MODULE_STREAM_REPO_2)]
+        distro=constants.DISTRO_RHEL8,
+        repositories=[YumRepository(url=constants.repos.CUSTOM_MODULE_STREAM_REPO_2)],
     )
     repos_collection.setup_content(module_org.id, module_lce.id, upload_manifest=True)
     return repos_collection
 
 
 @pytest.fixture
-def vm_content_hosts(request, module_loc, module_repos_collection):
+def vm_content_hosts(request, module_loc, module_repos_collection, default_sat):
     distro = module_repos_collection.distro
     with VMBroker(nick=distro, host_classes={'host': ContentHost}, _count=2) as clients:
         for client in clients:
@@ -105,7 +88,7 @@ def vm_content_hosts(request, module_loc, module_repos_collection):
 
 
 @pytest.fixture
-def vm_content_hosts_module_stream(module_loc, module_repos_collection_module_stream):
+def vm_content_hosts_module_stream(module_loc, module_repos_collection_module_stream, default_sat):
     distro = module_repos_collection_module_stream.distro
     with VMBroker(nick=distro, host_classes={'host': ContentHost}, _count=2) as clients:
         for client in clients:
@@ -115,9 +98,7 @@ def vm_content_hosts_module_stream(module_loc, module_repos_collection_module_st
             add_remote_execution_ssh_key(client.ip_addr)
             update_vm_host_location(client, module_loc.id)
         smart_proxy = (
-            entities.SmartProxy()
-            .search(query={'search': f'name={settings.server.hostname}'})[0]
-            .read()
+            entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
         )
         smart_proxy.location.append(entities.Location(id=module_loc.id))
         smart_proxy.update(['location'])
@@ -189,25 +170,21 @@ def _install_package_with_assertion(vm_clients, package_name):
     assert _is_package_installed(vm_clients, package_name)
 
 
-def _get_content_repository_urls(repos_collection, lce, content_view):
+def _get_content_repository_urls(repos_collection, lce, content_view, default_sat):
     """Returns a list of the content repository urls"""
-    custom_url_template = (
-        'https://{hostname}/pulp/repos/{org_label}/{lce.name}'
-        '/{content_view.name}/custom/{product_label}/{repository_name}'
-    )
-    rh_sat_tools_url_template = (
-        'https://{hostname}/pulp/repos/{org_label}/{lce.name}'
-        '/{content_view.name}/content/dist/rhel/server/{major_version}'
-        '/{major_version}Server/$basearch/sat-tools/{product_version}/os'
-    )
     repos_urls = [
-        custom_url_template.format(
-            hostname=settings.server.hostname,
-            org_label=repos_collection.organization['label'],
-            lce=lce,
-            content_view=content_view,
-            product_label=repos_collection.custom_product['label'],
-            repository_name=repository['name'],
+        '/'.join(
+            [
+                default_sat.url,
+                'pulp',
+                'repos',
+                repos_collection.organization["label"],
+                lce.name,
+                content_view.name,
+                'custom',
+                repos_collection.custom_product["label"],
+                repository["name"],
+            ]
         )
         for repository in repos_collection.custom_repos_info
     ]
@@ -216,13 +193,25 @@ def _get_content_repository_urls(repos_collection, lce, content_view):
     for repo in repos_collection:
         if isinstance(repo, SatelliteToolsRepository) and repo.cdn:
             repos_urls.append(
-                rh_sat_tools_url_template.format(
-                    hostname=settings.server.hostname,
-                    org_label=repos_collection.organization['label'],
-                    lce=lce,
-                    content_view=content_view,
-                    major_version=repo.distro_major_version,
-                    product_version=repo.repo_data['version'],
+                '/'.join(
+                    [
+                        default_sat.url,
+                        'pulp',
+                        'repos',
+                        repos_collection.organization["label"],
+                        lce.name,
+                        content_view.name,
+                        'content',
+                        'dist',
+                        'rhel',
+                        'server',
+                        repo.distro_major_version,
+                        f'{repo.distro_major_version}Server',
+                        '$basearch',
+                        'sat-tools',
+                        repo.repo_data["version"],
+                        'os',
+                    ]
                 )
             )
     return repos_urls
@@ -296,7 +285,7 @@ def test_negative_install_via_remote_execution(session, module_org, module_loc):
     with session:
         job_values = session.hostcollection.manage_packages(
             host_collection.name,
-            packages=FAKE_0_CUSTOM_PACKAGE_NAME,
+            packages=constants.FAKE_0_CUSTOM_PACKAGE_NAME,
             action='install',
             action_via='via remote execution',
         )
@@ -329,7 +318,7 @@ def test_negative_install_via_custom_remote_execution(session, module_org, modul
     with session:
         job_values = session.hostcollection.manage_packages(
             host_collection.name,
-            packages=FAKE_0_CUSTOM_PACKAGE_NAME,
+            packages=constants.FAKE_0_CUSTOM_PACKAGE_NAME,
             action='install',
             action_via='via remote execution - customize first',
         )
@@ -387,9 +376,9 @@ def test_positive_install_package(session, module_org, vm_content_hosts, vm_host
     with session:
         session.organization.select(org_name=module_org.name)
         session.hostcollection.manage_packages(
-            vm_host_collection.name, packages=FAKE_0_CUSTOM_PACKAGE_NAME, action='install'
+            vm_host_collection.name, packages=constants.FAKE_0_CUSTOM_PACKAGE_NAME, action='install'
         )
-        assert _is_package_installed(vm_content_hosts, FAKE_0_CUSTOM_PACKAGE_NAME)
+        assert _is_package_installed(vm_content_hosts, constants.FAKE_0_CUSTOM_PACKAGE_NAME)
 
 
 @pytest.mark.tier3
@@ -404,14 +393,14 @@ def test_positive_remove_package(session, module_org, vm_content_hosts, vm_host_
 
     :CaseLevel: System
     """
-    _install_package_with_assertion(vm_content_hosts, FAKE_0_CUSTOM_PACKAGE)
+    _install_package_with_assertion(vm_content_hosts, constants.FAKE_0_CUSTOM_PACKAGE)
     with session:
         session.organization.select(org_name=module_org.name)
         session.hostcollection.manage_packages(
-            vm_host_collection.name, packages=FAKE_0_CUSTOM_PACKAGE_NAME, action='remove'
+            vm_host_collection.name, packages=constants.FAKE_0_CUSTOM_PACKAGE_NAME, action='remove'
         )
         assert not _is_package_installed(
-            vm_content_hosts, FAKE_0_CUSTOM_PACKAGE_NAME, expect_installed=False
+            vm_content_hosts, constants.FAKE_0_CUSTOM_PACKAGE_NAME, expect_installed=False
         )
 
 
@@ -426,13 +415,13 @@ def test_positive_upgrade_package(session, module_org, vm_content_hosts, vm_host
 
     :CaseLevel: System
     """
-    _install_package_with_assertion(vm_content_hosts, FAKE_1_CUSTOM_PACKAGE)
+    _install_package_with_assertion(vm_content_hosts, constants.FAKE_1_CUSTOM_PACKAGE)
     with session:
         session.organization.select(org_name=module_org.name)
         session.hostcollection.manage_packages(
-            vm_host_collection.name, packages=FAKE_1_CUSTOM_PACKAGE_NAME, action='update'
+            vm_host_collection.name, packages=constants.FAKE_1_CUSTOM_PACKAGE_NAME, action='update'
         )
-        assert _is_package_installed(vm_content_hosts, FAKE_2_CUSTOM_PACKAGE)
+        assert _is_package_installed(vm_content_hosts, constants.FAKE_2_CUSTOM_PACKAGE)
 
 
 @pytest.mark.tier3
@@ -452,10 +441,10 @@ def test_positive_install_package_group(session, module_org, vm_content_hosts, v
         session.hostcollection.manage_packages(
             vm_host_collection.name,
             content_type='Package Group',
-            packages=FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+            packages=constants.FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
             action='install',
         )
-        for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+        for package in constants.FAKE_0_CUSTOM_PACKAGE_GROUP:
             assert _is_package_installed(vm_content_hosts, package)
 
 
@@ -471,19 +460,19 @@ def test_positive_remove_package_group(session, module_org, vm_content_hosts, vm
     :CaseLevel: System
     """
     for client in vm_content_hosts:
-        result = client.run(f'yum groups install -y {FAKE_0_CUSTOM_PACKAGE_GROUP_NAME}')
+        result = client.run(f'yum groups install -y {constants.FAKE_0_CUSTOM_PACKAGE_GROUP_NAME}')
         assert result.status == 0
-    for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+    for package in constants.FAKE_0_CUSTOM_PACKAGE_GROUP:
         assert _is_package_installed(vm_content_hosts, package)
     with session:
         session.organization.select(org_name=module_org.name)
         session.hostcollection.manage_packages(
             vm_host_collection.name,
             content_type='Package Group',
-            packages=FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+            packages=constants.FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
             action='remove',
         )
-        for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+        for package in constants.FAKE_0_CUSTOM_PACKAGE_GROUP:
             assert not _is_package_installed(vm_content_hosts, package, expect_installed=False)
 
 
@@ -499,19 +488,25 @@ def test_positive_install_errata(session, module_org, vm_content_hosts, vm_host_
 
     :CaseLevel: System
     """
-    _install_package_with_assertion(vm_content_hosts, FAKE_1_CUSTOM_PACKAGE)
+    _install_package_with_assertion(vm_content_hosts, constants.FAKE_1_CUSTOM_PACKAGE)
     with session:
         session.organization.select(org_name=module_org.name)
         task_values = session.hostcollection.install_errata(
-            vm_host_collection.name, FAKE_2_ERRATA_ID
+            vm_host_collection.name, constants.FAKE_2_ERRATA_ID
         )
         assert task_values['result'] == 'success'
-        assert _is_package_installed(vm_content_hosts, FAKE_2_CUSTOM_PACKAGE)
+        assert _is_package_installed(vm_content_hosts, constants.FAKE_2_CUSTOM_PACKAGE)
 
 
 @pytest.mark.tier3
 def test_positive_change_assigned_content(
-    session, module_org, module_lce, vm_content_hosts, vm_host_collection, module_repos_collection
+    session,
+    module_org,
+    module_lce,
+    vm_content_hosts,
+    vm_host_collection,
+    module_repos_collection,
+    default_sat,
 ):
     """Change Assigned Life cycle environment and content view of host
     collection
@@ -558,11 +553,15 @@ def test_positive_change_assigned_content(
     """
     new_lce_name = gen_string('alpha')
     new_cv_name = gen_string('alpha')
-    new_lce = entities.LifecycleEnvironment(name=new_lce_name, organization=module_org).create()
-    content_view = entities.ContentView(
+    new_lce = default_sat.api.LifecycleEnvironment(
+        name=new_lce_name, organization=module_org
+    ).create()
+    content_view = default_sat.api.ContentView(
         id=module_repos_collection.setup_content_data['content_view']['id']
     ).read()
-    new_content_view = entities.ContentView(id=content_view.copy(data={'name': new_cv_name})['id'])
+    new_content_view = default_sat.api.ContentView(
+        id=content_view.copy(data={'name': new_cv_name})['id']
+    )
     new_content_view.publish()
     new_content_view = new_content_view.read()
     new_content_view_version = new_content_view.version[0]
@@ -573,7 +572,7 @@ def test_positive_change_assigned_content(
     # /{product_name}/{repo_name}
     repo_line_start_with = 'Repo URL:  '
     expected_repo_urls = _get_content_repository_urls(
-        module_repos_collection, module_lce, content_view
+        module_repos_collection, module_lce, content_view, default_sat
     )
     for client in vm_content_hosts:
         result = client.run("subscription-manager repos")
@@ -581,7 +580,7 @@ def test_positive_change_assigned_content(
         client_repo_urls = [
             line.split(' ')[-1] for line in result.stdout if line.startswith(repo_line_start_with)
         ]
-        assert len(client_repo_urls) > 0
+        assert len(client_repo_urls)
         assert set(expected_repo_urls) == set(client_repo_urls)
     with session:
         session.organization.select(org_name=module_org.name)
@@ -590,7 +589,7 @@ def test_positive_change_assigned_content(
         )
         assert task_values['result'] == 'success'
         expected_repo_urls = _get_content_repository_urls(
-            module_repos_collection, new_lce, new_content_view
+            module_repos_collection, new_lce, new_content_view, default_sat
         )
         for client in vm_content_hosts:
             result = client.run("subscription-manager refresh")
@@ -603,7 +602,7 @@ def test_positive_change_assigned_content(
                 for line in result.stdout
                 if line.startswith(repo_line_start_with)
             ]
-            assert len(client_repo_urls) > 0
+            assert len(client_repo_urls)
             assert set(expected_repo_urls) == set(client_repo_urls)
 
 
@@ -684,13 +683,15 @@ def test_positive_install_module_stream(
         result = session.hostcollection.manage_module_streams(
             vm_host_collection_module_stream.name,
             action_type="Install",
-            module_name=FAKE_3_CUSTOM_PACKAGE_NAME,
+            module_name=constants.FAKE_3_CUSTOM_PACKAGE_NAME,
             stream_version="0",
         )
         assert result['overview']['job_status'] == 'Success'
         assert result['overview']['job_status_progress'] == '100%'
         assert int(result['overview']['total_hosts']) == 2
-        assert _is_package_installed(vm_content_hosts_module_stream, FAKE_3_CUSTOM_PACKAGE)
+        assert _is_package_installed(
+            vm_content_hosts_module_stream, constants.FAKE_3_CUSTOM_PACKAGE
+        )
 
 
 @pytest.mark.tier3
@@ -716,17 +717,19 @@ def test_positive_install_modular_errata(
     stream = "0"
     version = "20180704111719"
     _module_install_command = (
-        f'dnf -y module install {FAKE_4_CUSTOM_PACKAGE_NAME}:{stream}:{version}'
+        f'dnf -y module install {constants.FAKE_4_CUSTOM_PACKAGE_NAME}:{stream}:{version}'
     )
     _run_remote_command_on_content_hosts(_module_install_command, vm_content_hosts_module_stream)
     _run_remote_command_on_content_hosts('dnf -y upload-profile', vm_content_hosts_module_stream)
     with session:
         result = session.hostcollection.install_errata(
             vm_host_collection_module_stream.name,
-            FAKE_0_MODULAR_ERRATA_ID,
+            constants.FAKE_0_MODULAR_ERRATA_ID,
             install_via='via remote execution',
         )
         assert result['job_status'] == 'Success'
         assert result['job_status_progress'] == '100%'
         assert int(result['total_hosts']) == 2
-        assert _is_package_installed(vm_content_hosts_module_stream, FAKE_6_CUSTOM_PACKAGE)
+        assert _is_package_installed(
+            vm_content_hosts_module_stream, constants.FAKE_5_CUSTOM_PACKAGE
+        )

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -22,7 +22,6 @@ from nailgun import entities
 
 from robottelo.api.utils import update_vm_host_location
 from robottelo.cli.host import Host
-from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.helpers import add_remote_execution_ssh_key
 
@@ -54,10 +53,10 @@ def module_org():
 
 
 @pytest.fixture(scope='module')
-def module_loc(module_org):
+def module_loc(module_org, default_sat):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
-        entities.SmartProxy().search(query={'search': f'name={settings.server.hostname}'})[0].read()
+        entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
     )
     smart_proxy.location.append(entities.Location(id=location.id))
     smart_proxy.update(['location'])

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -18,18 +18,10 @@
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
-
-from robottelo.config import settings
-
-
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
 
 
 @pytest.mark.tier2
-def test_positive_end_to_end(session, module_org, module_loc):
+def test_positive_end_to_end(session, module_org, module_location, default_sat):
     """Perform end to end testing for Job Template component.
 
     :id: 2e0e31c5-e557-4151-83f9-21820c9cb1be
@@ -105,7 +97,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
                 'job.foreign_input_sets': job_foreign_input_sets,
                 'type.snippet': True,
                 'organizations.resources.assigned': [module_org.name, "Default Organization"],
-                'locations.resources.assigned': [module_loc.name],
+                'locations.resources.assigned': [module_location.name],
             }
         )
         template = session.jobtemplate.read(template_name, editor_view_option='Editor')
@@ -122,7 +114,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
         assert template['job']['overridable'] is False
         assert template['type']['snippet']
         assert module_org.name in template['organizations']['resources']['assigned']
-        assert module_loc.name in template['locations']['resources']['assigned']
+        assert module_location.name in template['locations']['resources']['assigned']
         assert len(template['inputs']) == 3
         assert template['inputs'][0]['name'] == template_inputs[0]['name']
         assert template['inputs'][0]['required'] == template_inputs[0]['required']
@@ -215,7 +207,7 @@ def test_positive_end_to_end(session, module_org, module_loc):
             editor_view_option='Preview',
             widget_names='template.template_editor.editor',
         )
-        assert settings.server.hostname in template_values['template']['template_editor']['editor']
+        assert default_sat.hostname in template_values['template']['template_editor']['editor']
         session.jobtemplate.clone(template_new_name, {'template.name': template_clone_name})
         assert session.jobtemplate.search(template_clone_name)[0]['Name'] == template_clone_name
         for name in (template_new_name, template_clone_name):

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -53,7 +53,7 @@ pytestmark = [pytest.mark.run_in_one_thread]
 EXTERNAL_GROUP_NAME = 'foobargroup'
 
 
-def set_certificate_in_satellite(server_type, hostname=None):
+def set_certificate_in_satellite(server_type, default_sat, hostname=None):
     """update the cert settings in satellite based on type of ldap server"""
     if server_type == 'IPA':
         idm_cert_path_url = os.path.join(settings.ipa.hostname, 'ipa/config/ca.crt')
@@ -61,9 +61,10 @@ def set_certificate_in_satellite(server_type, hostname=None):
             file_url=idm_cert_path_url,
             local_path=CERT_PATH,
             file_name='ipa.crt',
-            hostname=settings.server.hostname,
+            hostname=default_sat.hostname,
         )
     elif server_type == 'AD':
+        assert hostname is not None
         ssh.command('yum -y --disableplugin=foreman-protector install cifs-utils')
         command = r'mount -t cifs -o username=administrator,pass={0} //{1}/c\$ /mnt'
         ssh.command(command.format(settings.ldap.password, hostname))
@@ -320,7 +321,7 @@ def test_positive_create_org_and_loc(session, ldap_tear_down, ldap_auth_source):
 @pytest.mark.parametrize('ldap_auth_source', ['AD_2016', 'AD_2019', 'IPA'], indirect=True)
 @pytest.mark.destructive
 def test_positive_create_with_https(
-    session, subscribe_satellite, test_name, ldap_auth_source, ldap_tear_down
+    session, subscribe_satellite, test_name, ldap_auth_source, ldap_tear_down, default_sat
 ):
     """Create LDAP auth_source for IDM with HTTPS.
 
@@ -340,10 +341,12 @@ def test_positive_create_with_https(
     :parametrized: yes
     """
     if ldap_auth_source['auth_type'] == 'ipa':
-        set_certificate_in_satellite(server_type='IPA')
+        set_certificate_in_satellite(server_type='IPA', default_sat=default_sat)
         username = settings.ipa.user
     else:
-        set_certificate_in_satellite(server_type='AD', hostname=ldap_auth_source['ldap_hostname'])
+        set_certificate_in_satellite(
+            server_type='AD', default_sat=default_sat, hostname=ldap_auth_source['ldap_hostname']
+        )
         username = settings.ldap.username
     org = entities.Organization().create()
     loc = entities.Location().create()
@@ -985,7 +988,7 @@ def test_negative_login_user_with_invalid_password_otp(
 
 @pytest.mark.destructive
 def test_single_sign_on_ldap_ipa_server(
-    subscribe_satellite, enroll_idm_and_configure_external_auth, ldap_tear_down
+    subscribe_satellite, enroll_idm_and_configure_external_auth, ldap_tear_down, default_sat
 ):
     """Verify the single sign-on functionality with external authentication
 
@@ -1004,28 +1007,24 @@ def test_single_sign_on_ldap_ipa_server(
         run_command(cmd='satellite-installer --foreman-ipa-authentication=true', timeout=800)
         run_command('foreman-maintain service restart', timeout=300)
         if is_open('BZ:1941997'):
-            curl_command = (
-                f'curl -k -u : --negotiate https://{settings.server.hostname}/users/extlogin'
-            )
+            curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin'
         else:
-            curl_command = (
-                f'curl -k -u : --negotiate https://{settings.server.hostname}/users/extlogin/'
-            )
+            curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin/'
         result = run_command(curl_command)
         result = ''.join(result)
         assert 'redirected' in result
-        assert f'https://{settings.server.hostname}/hosts' in result
+        assert f'{default_sat.url}/hosts' in result
         assert 'You are being' in result
     finally:
         # resetting the settings to default for external auth
         run_command(cmd='satellite-installer --foreman-ipa-authentication=false', timeout=800)
         run_command('foreman-maintain service restart', timeout=300)
         run_command(
-            cmd=f'ipa service-del HTTP/{settings.server.hostname}',
+            cmd=f'ipa service-del HTTP/{default_sat.hostname}',
             hostname=settings.ipa.hostname,
         )
         run_command(
-            cmd=f'ipa host-del {settings.server.hostname}',
+            cmd=f'ipa host-del {default_sat.hostname}',
             hostname=settings.ipa.hostname,
         )
 
@@ -1034,7 +1033,9 @@ def test_single_sign_on_ldap_ipa_server(
     'enroll_ad_and_configure_external_auth', ['AD_2016', 'AD_2019'], indirect=True
 )
 @pytest.mark.destructive
-def test_single_sign_on_ldap_ad_server(subscribe_satellite, enroll_ad_and_configure_external_auth):
+def test_single_sign_on_ldap_ad_server(
+    subscribe_satellite, enroll_ad_and_configure_external_auth, default_sat
+):
     """Verify the single sign-on functionality with external authentication
 
     :id: 3c233aa4-c817-11ea-b105-d46d6dd3b5b2
@@ -1064,17 +1065,13 @@ def test_single_sign_on_ldap_ad_server(subscribe_satellite, enroll_ad_and_config
         # create the kerberos ticket for authentication
         run_command(f'echo {settings.ldap.password} | kinit {settings.ldap.username}')
         if is_open('BZ:1941997'):
-            curl_command = (
-                f'curl -k -u : --negotiate https://{settings.server.hostname}/users/extlogin'
-            )
+            curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin'
         else:
-            curl_command = (
-                f'curl -k -u : --negotiate https://{settings.server.hostname}/users/extlogin/'
-            )
+            curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin/'
         result = run_command(curl_command)
         result = ''.join(result)
         assert 'redirected' in result
-        assert f'https://{settings.server.hostname}/hosts' in result
+        assert f'{default_sat.url}/hosts' in result
     finally:
         # resetting the settings to default for external auth
         run_command(cmd='satellite-installer --foreman-ipa-authentication=false', timeout=800)

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -26,7 +26,6 @@ from wait_for import wait_for
 
 from robottelo.api.utils import update_vm_host_location
 from robottelo.cli.host import Host
-from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.hosts import ContentHost
@@ -59,10 +58,10 @@ def module_org():
 
 
 @pytest.fixture(scope='module')
-def module_loc(module_org):
+def module_loc(module_org, default_sat):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
-        entities.SmartProxy().search(query={'search': f'name={settings.server.hostname}'})[0].read()
+        entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
     )
     smart_proxy.location.append(entities.Location(id=location.id))
     smart_proxy.update(['location'])

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -30,23 +30,12 @@ from robottelo import ssh
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
-from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.datafactory import gen_string
 from robottelo.ui.utils import create_fake_host
-
-
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
-
-
-@pytest.fixture(scope='module')
-def module_loc():
-    return entities.Location().create()
 
 
 @pytest.fixture(scope='module')
@@ -394,7 +383,7 @@ def test_positive_autocomplete(session):
 
 
 @pytest.mark.tier2
-def test_positive_schedule_generation_and_get_mail(session, module_org, module_loc):
+def test_positive_schedule_generation_and_get_mail(session, module_org, module_loc, default_sat):
     """Schedule generating a report. Request the result be sent via e-mail.
 
     :id: cd19b90d-836f-4efd-c3bc-d5e09a909a67
@@ -438,7 +427,7 @@ def test_positive_schedule_generation_and_get_mail(session, module_org, module_l
         f'expect "&"\n'
         f'send "q\\r"\n'
     )
-    ssh.command(f'expect -c \'{expect_script}\'', hostname=settings.server.hostname)
+    ssh.command(f'expect -c \'{expect_script}\'', hostname=default_sat.hostname)
     ssh.download_file(gzip_path)
     os.system(f'gunzip {gzip_path}')
     with open(file_path) as json_file:

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -355,7 +355,7 @@ def test_negative_update_email_delivery_method_smtp():
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_update_email_delivery_method_sendmail(session):
+def test_positive_update_email_delivery_method_sendmail(session, default_sat):
     """Updating Sendmail params on Email tab
 
     :id: c774e713-9640-402d-8987-c3509e918eb6
@@ -394,7 +394,7 @@ def test_positive_update_email_delivery_method_sendmail(session):
     }
     mail_config_new_params = {
         "delivery_method": "Sendmail",
-        "email_reply_address": f"root@{ssh.settings.server.hostname}",
+        "email_reply_address": f"root@{default_sat.hostname}",
         "email_subject_prefix": [gen_string('alpha')],
         "sendmail_location": "/usr/sbin/sendmail",
         "send_welcome_email": "Yes",

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -37,7 +37,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -47,7 +47,7 @@ def form_data(default_org):
         'hypervisor_server': settings.virtwho.esx.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.esx.hypervisor_username,
         'hypervisor_password': settings.virtwho.esx.hypervisor_password,
     }

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -35,7 +35,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -45,7 +45,7 @@ def form_data(default_org):
         'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
         'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
     }

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -35,7 +35,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -44,7 +44,7 @@ def form_data(default_org):
         'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -35,7 +35,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -45,7 +45,7 @@ def form_data(default_org):
         'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form

--- a/tests/foreman/virtwho/api/test_rhevm.py
+++ b/tests/foreman/virtwho/api/test_rhevm.py
@@ -35,7 +35,7 @@ def default_org():
 
 
 @pytest.fixture()
-def form_data(default_org):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -45,7 +45,7 @@ def form_data(default_org):
         'hypervisor_server': settings.virtwho.rhevm.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': settings.server.hostname,
+        'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.rhevm.hypervisor_username,
         'hypervisor_password': settings.virtwho.rhevm.hypervisor_password,
     }

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -32,7 +32,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -42,7 +42,7 @@ def form_data():
         'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
         'hypervisor-password': settings.virtwho.hyperv.hypervisor_password,
     }

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -32,7 +32,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data():
         'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -32,7 +32,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -42,7 +42,7 @@ def form_data():
         'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form

--- a/tests/foreman/virtwho/cli/test_rhevm.py
+++ b/tests/foreman/virtwho/cli/test_rhevm.py
@@ -32,7 +32,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data():
+def form_data(default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -42,7 +42,7 @@ def form_data():
         'hypervisor-server': settings.virtwho.rhevm.hypervisor_server,
         'organization-id': 1,
         'filtering-mode': 'none',
-        'satellite-url': settings.server.hostname,
+        'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.rhevm.hypervisor_username,
         'hypervisor-password': settings.virtwho.rhevm.hypervisor_password,
     }

--- a/tests/upgrades/scenario_workers.py
+++ b/tests/upgrades/scenario_workers.py
@@ -14,13 +14,13 @@ _json_file = 'upgrade_workers.json'
 json_file = Path(_json_file)
 
 
-def save_worker_hostname(test_name):
+def save_worker_hostname(test_name, default_sat):
     data = {}
     if json_file.exists():
         data = json.loads(json_file.read_text())
     # Removing the parameter name from test name before save
     test_name = test_name.split('[')[0] if '[' in test_name else test_name
-    data.update({test_name: settings.server.hostname})
+    data.update({test_name: default_sat.hostname})
     json_file.write_text(json.dumps(data))
 
 
@@ -35,10 +35,10 @@ def get_worker_hostname_from_testname(test_name, shared_workers):
 
 
 @pytest.fixture(autouse=True)
-def save_pre_upgrade_worker_hostname(request):
+def save_pre_upgrade_worker_hostname(request, default_sat):
     """Saves the worker id of pre_upgrade test in json"""
     if request.node.get_closest_marker('pre_upgrade'):
-        save_worker_hostname(request.node.name)
+        save_worker_hostname(request.node.name, default_sat)
 
 
 @pytest.fixture(autouse=True)
@@ -47,6 +47,8 @@ def set_post_upgrade_hostname(request, shared_workers):
 
     The limitation of this implementation is that the XDIST_BEHAVIOR won't be observed,
     and tests running under xdist will not be isolated.
+
+    This is overriding the session scoped align_to_satellite fixture
     """
     post_upgrade = request.node.get_closest_marker('post_upgrade')
     if post_upgrade:

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -1,5 +1,8 @@
 """Test for Client related Upgrade Scenario's
 
+content-host-d containers use SATHOST env var, which is passed through sat6-upgrade functions
+sat6-upgrade requires env.satellite_hostname to be set, this is required for these tests
+
 :Requirement: Upgraded Satellite
 
 :CaseAutomation: Automated
@@ -45,8 +48,6 @@ from robottelo.constants.repos import FAKE_9_YUM_REPO
 
 # host machine for containers
 docker_vm = settings.upgrade.docker_vm
-# script in container /tmp requires SATHOST
-SATHOST = settings.server.hostname
 
 
 @pytest.fixture(scope='module')

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -66,11 +66,13 @@ class TestScenarioPositiveGCEHostComputeResource:
         download_gce_cert()
 
     @pytest.fixture(scope='class')
-    def arch_os_domain(self):
-        arch = entities.Architecture().search(query={'search': 'name=x86_64'})[0]
-        os = entities.OperatingSystem().search(query={'search': 'family=Redhat and major=7'})[0]
+    def arch_os_domain(self, default_sat):
+        arch = default_sat.api.Architecture().search(query={'search': 'name=x86_64'})[0]
+        os = default_sat.api.OperatingSystem().search(
+            query={'search': 'family=Redhat and major=7'}
+        )[0]
 
-        domain_name = settings.server.hostname.split('.', 1)[1]
+        domain_name = default_sat.hostname.split('.', 1)[1]
         return namedtuple('ArchOsDomain', ['arch', 'os', 'domain'])(arch, os, domain_name)
 
     @pytest.fixture(scope='class')

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -34,7 +34,7 @@ class TestUserGroupMembership:
     """
 
     @pre_upgrade
-    def test_pre_create_usergroup_with_ldap_user(self, request):
+    def test_pre_create_usergroup_with_ldap_user(self, request, default_sat):
         """Create Usergroup in preupgrade version.
 
         :id: preupgrade-4b11d883-f523-4f38-b65a-650ecd90335c
@@ -46,7 +46,7 @@ class TestUserGroupMembership:
 
         :expectedresults: The usergroup, with ldap user as member, should be created successfully.
         """
-        authsource = entities.AuthSourceLDAP(
+        authsource = default_sat.api.AuthSourceLDAP(
             onthefly_register=True,
             account=settings.ldap.username,
             account_password=settings.ldap.password,
@@ -65,14 +65,14 @@ class TestUserGroupMembership:
         assert authsource.name == request.node.name + "_server"
         sc = ServerConfig(
             auth=(settings.ldap.username, settings.ldap.password),
-            url=f'https://{settings.server.hostname}',
+            url=default_sat.url,
             verify=False,
         )
 
         with pytest.raises(HTTPError):
             entities.User(sc).search()
-        user_group = entities.UserGroup(name=request.node.name + "_user_group").create()
-        user = entities.User().search(query={'search': f'login={settings.ldap.username}'})[0]
+        user_group = default_sat.api.UserGroup(name=request.node.name + "_user_group").create()
+        user = default_sat.api.User().search(query={'search': f'login={settings.ldap.username}'})[0]
         user_group.user = [user]
         user_group = user_group.update(['user'])
         assert user.login == user_group.user[0].read().login


### PR DESCRIPTION
Add Satellite.url and Satellite.port

Fixtures and tests using settings.server.hostname should reference
default_sat.hostname instead

Update func_locker._get_default_scope
Local settings import, and flattened logic

Resolve BoxKeyError in ui/test_jobinvocation

Backporting PR #8858