### PR TITLE
updated the certs tests to use host class

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -24,6 +24,7 @@ from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS
 from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS_PATH
 from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS_VERSION
 from robottelo.helpers import add_remote_execution_ssh_key
+from robottelo.helpers import get_data_file
 from robottelo.helpers import InstallerCommand
 
 
@@ -1056,18 +1057,55 @@ class Satellite(Capsule):
         pub_url = urlunsplit(('http', self.hostname, 'pub/', '', ''))  # use url with https?
         return urljoin(pub_url, 'katello-ca-consumer-latest.noarch.rpm')
 
-    def capsule_certs_generate(self, capsule, **extra_kwargs):
+    def capsule_certs_generate(self, capsule, cert_path=None, **extra_kwargs):
         """Generate capsule certs, returning the cert path and the installer command args"""
         command = InstallerCommand(
             command='capsule-certs-generate',
             foreman_proxy_fqdn=capsule.hostname,
-            certs_tar=f'/root/{capsule.hostname}-certs.tar',
+            certs_tar=cert_path or f'/root/{capsule.hostname}-certs.tar',
             **extra_kwargs,
         )
         result = self.execute(command.get_command())
         install_cmd = InstallerCommand.from_cmd_str(cmd_str=result.stdout)
         install_cmd.opts['certs-tar-file'] = f'/root/{capsule.hostname}-certs.tar'
         return install_cmd
+
+    def custom_cert_generate(self, capsule_hostname):
+        """copy all configuration files to satellite host for generating custom certs"""
+        self.execute(f'mkdir ssl-build/{capsule_hostname}')
+        for file in [
+            'generate-ca.sh',
+            'generate-crt.sh',
+            'openssl.cnf',
+            'certs.sh',
+            'extensions.txt',
+        ]:
+            self.session.sftp_write(get_data_file(file), f'/root/{file}')
+        self.execute('echo 100001 > serial')
+        self.execute('bash generate-ca.sh')
+        result = self.execute(f'yes | bash generate-crt.sh {self.hostname}')
+        assert result.status == 0
+        result = self.execute('bash certs.sh')
+        assert result.status == 0
+
+    def custom_certs_cleanup(self):
+        """cleanup all cert configuration files"""
+        files = [
+            'cacert.crt',
+            'cacert.crt',
+            'certindex*',
+            'generate-*.sh',
+            'capsule_cert',
+            'openssl.cnf',
+            'private',
+            'serial*',
+            'certs/*',
+            'extensions.txt',
+            'certs',
+            'certs.sh',
+            self.hostname,
+        ]
+        self.execute(f'cd /root && rm -rf {" ".join(files)}')
 
     def __enter__(self):
         """Satellite objects can be used as a context manager to temporarily force everything

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -21,13 +21,9 @@ import re
 from pathlib import Path
 
 import pytest
+from attrdict import AttrDict
 from fauxfactory import gen_string
 
-from robottelo import ssh
-from robottelo.helpers import get_data_file
-from robottelo.ssh import download_file
-from robottelo.ssh import get_connection
-from robottelo.ssh import upload_file
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -44,116 +40,60 @@ class TestKatelloCertsCheck:
     invalid_inputs = [
         (
             {
-                'check': "Checking CA bundle against the certificate file",
-                'message': "error 26 at 0 depth lookup:unsupported certificate purpose",
+                'check': 'Checking CA bundle against the certificate file',
+                'message': 'error 26 at 0 depth lookup:unsupported certificate purpose',
             },
-            "certs/invalid.crt",
-            "certs/invalid.key",
-            "certs/ca.crt",
+            'certs/invalid.crt',
+            'certs/invalid.key',
+            'certs/ca.crt',
         ),
         (
             {
-                'check': "Checking for use of shortname as CN",
-                'message': "shortname.crt is using a shortname for "
-                "Common Name (CN) and cannot be used",
+                'check': 'Checking for use of shortname as CN',
+                'message': 'shortname.crt is using a shortname for '
+                'Common Name (CN) and cannot be used',
             },
-            "certs/shortname.crt",
-            "certs/shortname.key",
-            "certs/ca.crt",
+            'certs/shortname.crt',
+            'certs/shortname.key',
+            'certs/ca.crt',
         ),
     ]
 
-    @pytest.fixture(scope="module")
-    def cert_data(self, default_sat):
+    @pytest.fixture
+    def cert_setup_destructive_teardown(self, destructive_sat):
         """Get host name, scripts, and create working directory."""
-        sat6_hostname = default_sat.hostname
+        sat_hostname = destructive_sat.hostname
         capsule_hostname = 'capsule.example.com'
-        key_file_name = '{0}/{0}.key'.format(sat6_hostname)
-        cert_file_name = '{0}/{0}.crt'.format(sat6_hostname)
-        ca_bundle_file_name = 'cacert.crt'
-        success_message = "Validation succeeded"
+        key_file_name = f'{sat_hostname}/{sat_hostname}.key'
+        cert_file_name = f'{sat_hostname}/{sat_hostname}.crt'
         cert_data = {
-            'sat6_hostname': sat6_hostname,
             'capsule_hostname': capsule_hostname,
             'key_file_name': key_file_name,
             'cert_file_name': cert_file_name,
-            'ca_bundle_file_name': ca_bundle_file_name,
-            'success_message': success_message,
+            'ca_bundle_file_name': 'cacert.crt',
+            'success_message': 'Validation succeeded',
         }
-        return cert_data
+        destructive_sat.custom_cert_generate(capsule_hostname)
+        yield cert_data, destructive_sat
+        destructive_sat.custom_certs_cleanup()
 
-    @pytest.fixture()
-    def cert_setup(self, cert_data):
-        """copy all configuration files to satellite host for generating custom certs"""
-        # Need a subdirectory under ssl-build with same name as Capsule name
-        with get_connection(timeout=100) as connection:
-            connection.run('mkdir ssl-build/{}'.format(cert_data['capsule_hostname']))
-            # Ignore creation error, but assert directory exists
-            assert connection.run('test -e ssl-build/{}'.format(cert_data['capsule_hostname']))
-        upload_file(
-            local_file=get_data_file('generate-ca.sh'),
-            remote_file="generate-ca.sh",
-        )
-        upload_file(
-            local_file=get_data_file('generate-crt.sh'),
-            remote_file="generate-crt.sh",
-        )
-        upload_file(local_file=get_data_file('openssl.cnf'), remote_file="openssl.cnf")
-        # create the CA cert.
-        with get_connection(timeout=300) as connection:
-            result = connection.run('echo 100001 > serial')
-            result = connection.run("bash generate-ca.sh")
-            assert result.return_code == 0
-        # create the Satellite's cert
-        with get_connection(timeout=300) as connection:
-            result = connection.run(
-                "yes | bash {} {}".format('generate-crt.sh', cert_data['sat6_hostname'])
-            )
-            assert result.return_code == 0
-
-    @pytest.fixture()
-    def certs_cleanup(self, default_sat):
-        """cleanup all cert configuration files"""
-        yield
-        files = [
-            'cacert.crt',
-            'cacert.crt',
-            'certindex*',
-            'generate-*.sh',
-            'capsule_cert' 'openssl.cnf',
-            'private',
-            'serial*',
-            'certs/*',
-            default_sat.hostname,
-        ]
-        with get_connection(timeout=300) as connection:
-            files = " ".join(files)
-            result = connection.run(f"rm -rf {files}")
-            assert result.return_code == 0
-
-    @pytest.fixture()
-    def generate_certs(self):
-        """generate custom certs in satellite host"""
-        upload_file(
-            local_file=get_data_file('certs.sh'),
-            remote_file="certs.sh",
-        )
-        upload_file(
-            local_file=get_data_file('extensions.txt'),
-            remote_file="extensions.txt",
-        )
-        with get_connection(timeout=300) as connection:
-            result = connection.run("bash certs.sh")
-            assert result.return_code == 0
-
-    @pytest.fixture()
-    def update_system_date(self):
-        """update the satellite date to verify cert expiration"""
-        result = ssh.command("date -s 'next year'")
-        assert result.return_code == 0
-        yield
-        result = ssh.command("date -s 'last year'")
-        assert result.return_code == 0, 'Failed to revert the date setting'
+    @pytest.fixture(scope='module')
+    def cert_setup_teardown(self, default_sat):
+        """Get host name, scripts, and create working directory."""
+        sat_hostname = default_sat.hostname
+        capsule_hostname = 'capsule.example.com'
+        key_file_name = f'{sat_hostname}/{sat_hostname}.key'
+        cert_file_name = f'{sat_hostname}/{sat_hostname}.crt'
+        cert_data = {
+            'capsule_hostname': capsule_hostname,
+            'key_file_name': key_file_name,
+            'cert_file_name': cert_file_name,
+            'ca_bundle_file_name': 'cacert.crt',
+            'success_message': 'Validation succeeded',
+        }
+        default_sat.custom_cert_generate(capsule_hostname)
+        yield cert_data, default_sat
+        default_sat.custom_certs_cleanup()
 
     def validate_output(self, result, cert_data):
         """Validate katello-certs-check output against a set.
@@ -171,7 +111,7 @@ class TestKatelloCertsCheck:
             '--certs-update-server',
             '--certs-update-server-ca',
         }
-        assert result.return_code == 0
+        assert result.status == 0
         assert cert_data['success_message'] in result.stdout
 
         # validate correct installer used
@@ -181,7 +121,7 @@ class TestKatelloCertsCheck:
         assert len(re.findall(pattern, result.stdout)) == count
 
         # validate all checks passed
-        assert not any(flag for flag in re.findall(r"\[([A-Z]+)\]", result.stdout) if flag != 'OK')
+        assert not any(flag for flag in re.findall(r'\[([A-Z]+)\]', result.stdout) if flag != 'OK')
         # validate options in output
         commands = result.stdout.split('To')
         commands.pop(0)
@@ -193,9 +133,7 @@ class TestKatelloCertsCheck:
         assert set(options) == expected_result
 
     @pytest.mark.tier1
-    def test_positive_validate_katello_certs_check_output(
-        self, cert_setup, cert_data, certs_cleanup
-    ):
+    def test_positive_validate_katello_certs_check_output(self, cert_setup_teardown):
         """Validate that katello-certs-check generates correct output.
 
         :id: 4c9e4c6e-8d8e-4953-87a1-09cb55df3adf
@@ -211,21 +149,17 @@ class TestKatelloCertsCheck:
         :expectedresults: Katello-certs-check should generate correct commands
          with options.
         """
-        with get_connection() as connection:
-            result = connection.run(
-                'katello-certs-check -c {} -k {} -b {}'.format(
-                    cert_data['cert_file_name'],
-                    cert_data['key_file_name'],
-                    cert_data['ca_bundle_file_name'],
-                ),
-                output_format='plain',
-            )
+        cert_data, default_sat = cert_setup_teardown
+        hostname = default_sat.hostname
+        command = (
+            f'katello-certs-check -c {hostname}/{hostname}.crt '
+            f'-k {hostname}/{hostname}.key -b cacert.crt'
+        )
+        result = default_sat.execute(command)
         self.validate_output(result, cert_data)
 
     @pytest.mark.tier1
-    def test_katello_certs_check_output_wildcard_inputs(
-        self, generate_certs, cert_data, certs_cleanup
-    ):
+    def test_katello_certs_check_output_wildcard_inputs(self, cert_setup_teardown):
         """Validate that katello-certs-check generates correct output with wildcard certs.
 
         :id: 7f9da806-5b23-11eb-b7ea-d46d6dd3b5b2
@@ -241,17 +175,20 @@ class TestKatelloCertsCheck:
         :expectedresults: katello-certs-check should generate correct commands
          with options.
         """
-        with get_connection() as connection:
-            result = connection.run(
-                'katello-certs-check -c certs/wildcard.crt -k certs/wildcard.key -b certs/ca.crt',
-                output_format='plain',
-            )
+        cert_data, default_sat = cert_setup_teardown
+        command = 'katello-certs-check -c certs/wildcard.crt -k certs/wildcard.key -b certs/ca.crt'
+        result = default_sat.execute(command)
         self.validate_output(result, cert_data)
 
-    @pytest.mark.parametrize("error, cert_file, key_file, ca_file", invalid_inputs)
+    @pytest.mark.parametrize('error, cert_file, key_file, ca_file', invalid_inputs)
     @pytest.mark.tier1
     def test_katello_certs_check_output_invalid_input(
-        self, generate_certs, error, cert_file, key_file, ca_file, certs_cleanup
+        self,
+        cert_setup_teardown,
+        error,
+        cert_file,
+        key_file,
+        ca_file,
     ):
         """Validate that katello-certs-check raise the correct errors for invalid
          inputs
@@ -271,24 +208,21 @@ class TestKatelloCertsCheck:
         :expectedresults: Katello-certs-check should raise error when it receives the invalid
          inputs.
         """
-        with get_connection() as connection:
-            certs_check_result = connection.run(
-                f'katello-certs-check -c {cert_file} -k {key_file} -b {ca_file}',
-                output_format='plain',
-            )
-            for result in certs_check_result.stdout.split("\n\n"):
-                if error['check'] in result:
-                    assert '[FAIL]' in result
-                    assert (
-                        error['message']
-                        in f'{certs_check_result.stdout} {certs_check_result.stderr}'
-                    )
-                    break
-            else:
-                pytest.fail('Failed to receive the error for invalid katello-cert-check')
+        cert_data, default_sat = cert_setup_teardown
+        command = f'katello-certs-check -c {cert_file} -k {key_file} -b {ca_file}'
+        certs_check_result = default_sat.execute(command)
+        for result in certs_check_result.stdout.split('\n\n'):
+            if error['check'] in result:
+                assert '[FAIL]' in result
+                assert (
+                    error['message'] in f'{certs_check_result.stdout} {certs_check_result.stderr}'
+                )
+                break
+        else:
+            pytest.fail('Failed to receive the error for invalid katello-cert-check')
 
     @pytest.mark.destructive
-    def test_positive_update_katello_certs(self, cert_setup, cert_data, certs_cleanup):
+    def test_positive_update_katello_certs(self, cert_setup_destructive_teardown):
         """Update certificates on a currently running satellite instance.
 
         :id: 0ddf6954-dc83-435e-b156-b567b877c2a5
@@ -307,45 +241,40 @@ class TestKatelloCertsCheck:
         :CaseAutomation: Automated
         """
         try:
-            with get_connection(timeout=600) as connection:
-                # Check for hammer ping SSL cert error
-                result = connection.run('hammer ping')
-                assert result.return_code == 0, 'Hammer Ping fail'
-                result = connection.run(
-                    'satellite-installer --scenario satellite '
-                    '--certs-server-cert {} '
-                    '--certs-server-key {} '
-                    '--certs-server-ca-cert {} '
-                    '--certs-update-server --certs-update-server-ca'.format(
-                        cert_data['cert_file_name'],
-                        cert_data['key_file_name'],
-                        cert_data['ca_bundle_file_name'],
-                    ),
-                    timeout=500,
-                )
-                # assert no hammer ping SSL cert error
-                result = connection.run('hammer ping')
-                assert 'SSL certificate verification failed' not in result.stdout
-                assert 'ok' in result.stdout[1]
-                # assert all services are running
-                result = connection.run('foreman-maintain health check --label services-up -y')
-                assert result.return_code == 0, 'Not all services are running'
+            cert_data, satellite = cert_setup_destructive_teardown
+            result = satellite.execute('hammer ping')
+            assert result.status == 0, f'Hammer Ping failed:\n{result.stderr}'
+            command = (
+                'satellite-installer --scenario satellite '
+                f'--certs-server-cert "/root/{cert_data["cert_file_name"]}" '
+                f'--certs-server-key "/root/{cert_data["key_file_name"]}" '
+                f'--certs-server-ca-cert "/root/{cert_data["ca_bundle_file_name"]}" '
+                '--certs-update-server --certs-update-server-ca'
+            )
+            result = satellite.execute(command)
+            assert result.status == 0
+            # assert no hammer ping SSL cert error
+            result = satellite.execute('hammer ping')
+            assert 'SSL certificate verification failed' not in result.stdout
+            assert result.stdout.count('ok') == 7
+            # assert all services are running
+            result = satellite.execute('foreman-maintain health check --label services-up -y')
+            assert result.status == 0, 'Not all services are running'
         finally:
             # revert to original certs
-            with get_connection(timeout=600) as connection:
-                result = connection.run(
-                    'satellite-installer --scenario satellite --certs-reset', timeout=500
-                )
-                # Check for hammer ping SSL cert error
-                result = connection.run('hammer ping')
-                assert result.return_code == 0, 'Hammer Ping fail'
-                # assert all services are running
-                result = connection.run('foreman-maintain health check --label services-up -y')
-                assert result.return_code == 0, 'Not all services are running'
+            command = 'satellite-installer --scenario satellite --certs-reset'
+            result = satellite.execute(command)
+            assert result.status == 0
+            # Check for hammer ping SSL cert error
+            result = satellite.execute('hammer ping')
+            assert result.status == 0, f'Hammer Ping failed:\n{result.stderr}'
+            # assert all services are running
+            result = satellite.execute('foreman-maintain health check --label services-up -y')
+            assert result.status == 0, 'Not all services are running'
 
     @pytest.mark.destructive
     def test_positive_generate_capsule_certs_using_absolute_path(
-        self, cert_setup, cert_data, certs_cleanup
+        self, cert_setup_destructive_teardown
     ):
         """Create Capsule certs using absolute paths.
 
@@ -367,40 +296,40 @@ class TestKatelloCertsCheck:
 
         :CaseAutomation: Automated
         """
-        with get_connection(timeout=300) as connection:
-            connection.run('mkdir -p /root/capsule_cert')
-            connection.run(
-                f"cp {cert_data['ca_bundle_file_name']} /root/capsule_cert/ca_cert_bundle.pem"
-            )
-            connection.run(f"cp {cert_data['cert_file_name']} /root/capsule_cert/capsule_cert.pem")
-            connection.run(
-                f"cp {cert_data['key_file_name']} /root/capsule_cert/capsule_cert_key.pem"
-            )
-            result = connection.run(
-                'capsule-certs-generate '
-                f"--foreman-proxy-fqdn {cert_data['capsule_hostname']} "
-                '--certs-tar /root/capsule_cert/capsule_certs_Abs.tar '
-                '--server-cert /root/capsule_cert/capsule_cert.pem '
-                '--server-key /root/capsule_cert/capsule_cert_key.pem '
-                '--server-ca-cert /root/capsule_cert/ca_cert_bundle.pem '
-                '--foreman-proxy-cname capsule.example1.com '
-                '--certs-update-server'
-            )
-            assert result.return_code == 0, 'Capsule certs generate script failed.'
-            # assert include cname in certificates when specified --foreman-proxy-cname'
-            result = connection.run(
-                'openssl x509 -in /root/ssl-build/capsule.example.com/'
-                'capsule.example.com-foreman-client.crt -text | '
-                'grep capsule.example1.com'
-            )
-            assert 'DNS:capsule.example1.com' in " ".join(result.stdout)
-            # assert the certs.tar was built
-            assert connection.run('test -e /root/capsule_cert/capsule_certs_Abs.tar')
+        cert_data, satellite = cert_setup_destructive_teardown
+        satellite.execute('mkdir -p /root/capsule_cert')
+        satellite.execute(
+            f'cp {cert_data["ca_bundle_file_name"]} /root/capsule_cert/ca_cert_bundle.pem'
+        )
+        satellite.execute(f'cp {cert_data["cert_file_name"]} /root/capsule_cert/capsule_cert.pem')
+        satellite.execute(
+            f'cp {cert_data["key_file_name"]} /root/capsule_cert/capsule_cert_key.pem'
+        )
+        result = satellite.execute(
+            'capsule-certs-generate '
+            f'--foreman-proxy-fqdn {cert_data["capsule_hostname"]} '
+            '--certs-tar /root/capsule_cert/capsule_certs_Abs.tar '
+            '--server-cert /root/capsule_cert/capsule_cert.pem '
+            '--server-key /root/capsule_cert/capsule_cert_key.pem '
+            '--server-ca-cert /root/capsule_cert/ca_cert_bundle.pem '
+            '--foreman-proxy-cname capsule.example1.com '
+            '--certs-update-server'
+        )
+        assert result.status == 0, 'Capsule certs generate script failed.'
+        # assert include cname in certificates when specified --foreman-proxy-cname'
+        result = satellite.execute(
+            'openssl x509 -in /root/ssl-build/capsule.example.com/'
+            'capsule.example.com-foreman-client.crt -text | '
+            'grep capsule.example1.com'
+        )
+        assert 'DNS:capsule.example1.com' in result.stdout
+        # assert the certs.tar was built
+        assert satellite.execute('test -e /root/capsule_cert/capsule_certs_Abs.tar')
 
     @pytest.mark.destructive
     @pytest.mark.upgrade
     def test_positive_generate_capsule_certs_using_relative_path(
-        self, cert_setup, cert_data, certs_cleanup
+        self, cert_setup_destructive_teardown
     ):
         """Create Capsule certs using relative paths.
 
@@ -419,37 +348,30 @@ class TestKatelloCertsCheck:
 
         :CaseAutomation: Automated
         """
-        with get_connection(timeout=300) as connection:
-            connection.run('mkdir -p /root/capsule_cert')
-            connection.run(
-                'cp "{}" /root/capsule_cert/ca_cert_bundle.pem'.format(
-                    cert_data['ca_bundle_file_name']
-                )
-            )
-            connection.run(
-                'cp "{}" /root/capsule_cert/capsule_cert.pem'.format(cert_data['cert_file_name'])
-            )
-            connection.run(
-                'cp "{}" /root/capsule_cert/capsule_cert_key.pem'.format(cert_data['key_file_name'])
-            )
-            result = connection.run(
-                'capsule-certs-generate '
-                '--foreman-proxy-fqdn {} '
-                '--certs-tar ~/capsule_cert/capsule_certs_Rel.tar '
-                '--server-cert ~/capsule_cert/capsule_cert.pem '
-                '--server-key ~/capsule_cert/capsule_cert_key.pem '
-                '--server-ca-cert ~/capsule_cert/ca_cert_bundle.pem '
-                '--certs-update-server'.format(cert_data['capsule_hostname']),
-                timeout=80,
-            )
-            assert result.return_code == 0, 'Capsule certs generate script failed.'
-            # assert the certs.tar was built
-            assert connection.run('test -e root/capsule_cert/capsule_certs_Rel.tar')
+        cert_data, satellite = cert_setup_destructive_teardown
+        satellite.execute('mkdir -p /root/capsule_cert')
+        satellite.execute(
+            f'cp "{cert_data["ca_bundle_file_name"]}" /root/capsule_cert/ca_cert_bundle.pem'
+        )
+        satellite.execute(f'cp "{cert_data["cert_file_name"]}" /root/capsule_cert/capsule_cert.pem')
+        satellite.execute(
+            f'cp "{cert_data["key_file_name"]}" /root/capsule_cert/capsule_cert_key.pem'
+        )
+        result = satellite.execute(
+            'capsule-certs-generate '
+            f'--foreman-proxy-fqdn {cert_data["capsule_hostname"]} '
+            '--certs-tar ~/capsule_cert/capsule_certs_Rel.tar '
+            '--server-cert ~/capsule_cert/capsule_cert.pem '
+            '--server-key ~/capsule_cert/capsule_cert_key.pem '
+            '--server-ca-cert ~/capsule_cert/ca_cert_bundle.pem '
+            '--certs-update-server',
+        )
+        assert result.status == 0, 'Capsule certs generate script failed.'
+        # assert the certs.tar was built
+        assert satellite.execute('test -e root/capsule_cert/capsule_certs_Rel.tar')
 
     @pytest.mark.tier1
-    def test_negative_check_expiration_of_certificate(
-        self, cert_setup, cert_data, update_system_date, certs_cleanup
-    ):
+    def test_negative_check_expiration_of_certificate(self, cert_setup_teardown):
         """Check expiration of certificate.
 
         :id: 0acce44f-ebe5-42e1-a74b-3d4d20b97946
@@ -464,15 +386,14 @@ class TestKatelloCertsCheck:
 
         :CaseAutomation: NotAutomated
         """
-        with get_connection() as connection:
-            result = connection.run(
-                'katello-certs-check -c {} -k {} -b {}'.format(
-                    cert_data['cert_file_name'],
-                    cert_data['key_file_name'],
-                    cert_data['ca_bundle_file_name'],
-                ),
-                output_format='plain',
-            )
+        cert_data, default_sat = cert_setup_teardown
+        hostname = default_sat.hostname
+        default_sat.execute("date -s 'next year'")
+        command = (
+            f'katello-certs-check -c {hostname}/{hostname}.key '
+            f'-k {hostname}/{hostname}.crt -b cacert.crt'
+        )
+        result = default_sat.execute(command)
         messages = [
             'Checking expiration of certificate: \n[FAIL]',
             'Checking CA bundle against the certificate file: \n[FAIL]',
@@ -485,6 +406,7 @@ class TestKatelloCertsCheck:
                     break
             else:
                 assert False, f'Failed, Unable to find message "{message}" in result'
+        default_sat.execute("date -s 'last year'")
 
     @pytest.mark.stubbed
     @pytest.mark.tier1
@@ -529,32 +451,27 @@ class TestCapsuleCertsCheckTestCase:
     on both Satellite Server's base system and on local host.
     """
 
-    @pytest.fixture(scope="module")
-    def file_setup(self):
+    @pytest.fixture
+    def capsule_certs_teardown(self, default_sat):
         """Create working directory and file."""
-        capsule_hostname = 'capsule.example.com'
+        capsule = AttrDict({'hostname': 'capsule.example.com'})
         tmp_dir = '/var/tmp/{}'.format(gen_string('alpha', 6))
         caps_cert_file = f'{tmp_dir}/ssl-build/capsule.example.com/cert-data'
         # Use same path locally as on remote for storing files
         Path(f'{tmp_dir}/ssl-build/capsule.example.com/').mkdir(parents=True, exist_ok=True)
-        with get_connection(timeout=200) as connection:
-            result = ssh.command(f'mkdir {tmp_dir}')
-            assert result.return_code == 0, 'Create working directory failed.'
-            # Generate a Capsule cert for capsule.example.com
-            result = connection.run(
-                'capsule-certs-generate '
-                '--foreman-proxy-fqdn capsule.example.com '
-                '--certs-tar {}/capsule_certs.tar '.format(tmp_dir),
-                timeout=100,
-            )
+        result = default_sat.execute(f'mkdir {tmp_dir}')
+        assert result.status == 0, 'Create working directory failed.'
+        # Generate a Capsule cert for capsule.example.com
+        default_sat.capsule_certs_generate(capsule, f'{tmp_dir}/capsule_certs.tar')
         return {
             'tmp_dir': tmp_dir,
             'caps_cert_file': caps_cert_file,
-            'capsule_hostname': capsule_hostname,
-        }
+            'capsule_hostname': capsule.hostname,
+        }, default_sat
 
+    @pytest.mark.destructive
     @pytest.mark.tier1
-    def test_positive_validate_capsule_certificate(self, file_setup):
+    def test_positive_validate_capsule_certificate(self, capsule_certs_teardown):
         """Check that Capsules cert handles additional proxy names.
 
         :id: 8b53fc3d-704f-44f4-899e-74654529bfcf
@@ -573,42 +490,43 @@ class TestCapsuleCertsCheckTestCase:
 
         :CaseAutomation: Automated
         """
+        file_setup, default_sat = capsule_certs_teardown
         DNS_Check = False
-        with get_connection(timeout=200) as connection:
-            # extract the cert from the tar file
-            result = connection.run(
-                'tar -xf {0}/capsule_certs.tar --directory {0}/ '.format(file_setup['tmp_dir'])
+        # extract the cert from the tar file
+        result = default_sat.execute(
+            f'tar -xf {file_setup["tmp_dir"]}/capsule_certs.tar '
+            f'--directory {file_setup["tmp_dir"]}/ '
+        )
+        assert result.status == 0, 'Extraction to working directory failed.'
+        # Extract raw data from RPM to a file
+        default_sat.execute(
+            'rpm2cpio {0}/ssl-build/{1}/'
+            '{1}-qpid-router-server*.rpm'
+            '>> {0}/ssl-build/{1}/cert-raw-data'.format(
+                file_setup['tmp_dir'], file_setup['capsule_hostname']
             )
-            assert result.return_code == 0, 'Extraction to working directory failed.'
-            # Extract raw data from RPM to a file
-            result = connection.run(
-                'rpm2cpio {0}/ssl-build/{1}/'
-                '{1}-qpid-router-server*.rpm'
-                '>> {0}/ssl-build/{1}/cert-raw-data'.format(
-                    file_setup['tmp_dir'], file_setup['capsule_hostname']
-                )
+        )
+        # Extract the cert data from file cert-raw-data and write to cert-data
+        default_sat.execute(
+            'openssl x509 -noout -text -in {0}/ssl-build/{1}/cert-raw-data'
+            '>> {0}/ssl-build/{1}/cert-data'.format(
+                file_setup['tmp_dir'], file_setup['capsule_hostname']
             )
-            # Extract the cert data from file cert-raw-data and write to cert-data
-            result = connection.run(
-                'openssl x509 -noout -text -in {0}/ssl-build/{1}/cert-raw-data'
-                '>> {0}/ssl-build/{1}/cert-data'.format(
-                    file_setup['tmp_dir'], file_setup['capsule_hostname']
-                )
-            )
-            # use same location on remote and local for cert_file
-            download_file(file_setup['caps_cert_file'])
-            # search the file for the line with DNS
-            with open(file_setup['caps_cert_file']) as file:
-                for line in file:
-                    if re.search(r'\bDNS:', line):
-                        match = re.search(r'{}'.format(file_setup['capsule_hostname']), line)
-                        assert match, "No proxy name found."
-                        if is_open('BZ:1747581'):
-                            DNS_Check = True
-                        else:
-                            match = re.search(r'\[]', line)
-                            assert not match, "Incorrect parsing of alternative proxy name."
-                            DNS_Check = True
-                        break
-                    # if no match for "DNS:" found, then raise error.
-            assert DNS_Check, "Cannot find Subject Alternative Name"
+        )
+        # use same location on remote and local for cert_file
+        default_sat.get(file_setup['caps_cert_file'])
+        # search the file for the line with DNS
+        with open(file_setup['caps_cert_file']) as file:
+            for line in file:
+                if re.search(r'\bDNS:', line):
+                    match = re.search(r'{}'.format(file_setup['capsule_hostname']), line)
+                    assert match, 'No proxy name found.'
+                    if is_open('BZ:1747581'):
+                        DNS_Check = True
+                    else:
+                        match = re.search(r'\[]', line)
+                        assert not match, 'Incorrect parsing of alternative proxy name.'
+                        DNS_Check = True
+                    break
+                # if no match for "DNS:" found, then raise error.
+        assert DNS_Check, 'Cannot find Subject Alternative Name'


### PR DESCRIPTION
```
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, cov-2.10.1, xdist-2.2.1, reportportal-5.0.8, mock-3.5.1, forked-1.3.0, ibutsu-1.14.1, picked-0.4.6collected 11 items / 2 deselected / 9 selected

../../okhatavk/Satellite/robottelo/tests/foreman/sys/test_katello_certs_check.py  [ 11%]                                                                 [100%]

=============================== warnings summary ===============================

```