### PR TITLE
[6.9.z] Update settings path for ssh_client

### DIFF
--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -45,8 +45,8 @@ SERVER:
   # Admin password when accessing API and UI
   ADMIN_PASSWORD: changeme
 
-SSH_CLIENT:
-  # Time to wait for the ssh command to finish, in seconds
-  COMMAND_TIMEOUT: 300
-  # Time to wait for establishing the ssh connection, in seconds
-  CONNECTION_TIMEOUT: 10
+  SSH_CLIENT:
+    # Time to wait for the ssh command to finish, in seconds
+    COMMAND_TIMEOUT: 300
+    # Time to wait for establishing the ssh connection, in seconds
+    CONNECTION_TIMEOUT: 60

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -108,7 +108,7 @@ def get_client(
     if password is None and key_filename is None:
         key_string = key_string or settings.server.ssh_key_string
         key_string = paramiko.rsakey.RSAKey.from_private_key(StringIO(str(key_string)))
-    timeout = timeout or settings.ssh_client.connection_timeout
+    timeout = timeout or settings.server.ssh_client.connection_timeout
     client = _call_paramiko_sshclient()
     client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     client.connect(
@@ -370,8 +370,8 @@ def command(
     from robottelo.config import settings
 
     hostname = hostname or settings.server.hostname
-    timeout = timeout or settings.ssh_client.command_timeout
-    connection_timeout = connection_timeout or settings.ssh_client.connection_timeout
+    timeout = timeout or settings.server.ssh_client.command_timeout
+    connection_timeout = connection_timeout or settings.server.ssh_client.connection_timeout
     with get_connection(
         hostname=hostname,
         username=username,
@@ -398,9 +398,9 @@ def execute_command(cmd, connection, output_format=None, timeout=None, connectio
     from robottelo.config import settings
 
     if timeout is None:
-        timeout = settings.ssh_client.command_timeout
+        timeout = settings.server.ssh_client.command_timeout
     if connection_timeout is None:
-        connection_timeout = settings.ssh_client.connection_timeout
+        connection_timeout = settings.server.ssh_client.connection_timeout
     logger.info('>>> %s', cmd)
     _, stdout, stderr = connection.exec_command(cmd, timeout=connection_timeout)
     if timeout:

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -117,8 +117,8 @@ class TestSSH:
         settings.server.ssh_password = None
         settings.server.ssh_key = key_filename
         settings.server.ssh_key_string = None
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
         with ssh.get_connection() as connection:
             assert connection.set_missing_host_key_policy_ == 1
             assert connection.connect_ == 1
@@ -149,8 +149,8 @@ class TestSSH:
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
         settings.server.ssh_key_string = None
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
         with ssh.get_connection() as connection:
             assert connection.set_missing_host_key_policy_ == 1
             assert connection.connect_ == 1
@@ -184,8 +184,8 @@ class TestSSH:
         settings.server.ssh_password = None
         settings.server.ssh_key = None
         settings.server.ssh_key_string = key_string.getvalue()  # resolve StringIO stream
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
         with ssh.get_connection() as connection:
             assert connection.set_missing_host_key_policy_ == 1
             assert connection.connect_ == 1
@@ -266,8 +266,8 @@ class TestSSH:
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
         ssh.add_authorized_key('ssh-rsa xxxx user@host')
 
     @mock.patch('robottelo.config.settings')
@@ -277,8 +277,8 @@ class TestSSH:
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
 
         with ssh.get_connection() as connection:
             ret = ssh.execute_command('ls -la', connection)
@@ -292,8 +292,8 @@ class TestSSH:
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
 
         with ssh.get_connection() as connection:
             ret = ssh.execute_command('ls -la', connection, output_format='base')
@@ -307,8 +307,8 @@ class TestSSH:
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
 
         ret = ssh.command('ls -la')
         assert ret.stdout == ['ls -la']
@@ -321,8 +321,8 @@ class TestSSH:
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
 
         ret = ssh.command('ls -la', output_format='base')
         assert ret.stdout == 'ls -la'
@@ -335,8 +335,8 @@ class TestSSH:
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
 
         ret = ssh.command('a,b,c\n1,2,3', output_format='csv')
         assert ret.stdout == [{'a': '1', 'b': '2', 'c': '3'}]
@@ -349,8 +349,8 @@ class TestSSH:
         settings.server.ssh_username = 'nobody'
         settings.server.ssh_key = None
         settings.server.ssh_password = 'test_password'
-        settings.ssh_client.command_timeout = 300
-        settings.ssh_client.connection_timeout = 10
+        settings.server.ssh_client.command_timeout = 300
+        settings.server.ssh_client.connection_timeout = 10
 
         ret = ssh.command('{"a": 1, "b": true}', output_format='json')
         assert ret.stdout == {'a': '1', 'b': True}


### PR DESCRIPTION
This now follows our settings path rules for easily identifiable
settings locations.