### PR TITLE
Refactor ssh module and helper functions

### DIFF
--- a/pytest_fixtures/broker.py
+++ b/pytest_fixtures/broker.py
@@ -151,7 +151,8 @@ def satellite_latest(default_sat):
 def capsule_latest(default_sat):
     """A fixture that provides an unconfigured latest Capsule"""
     version_args = dict(
-        deploy_sat_version=default_sat.version or settings.server.version.get('release', ''),
+        deploy_sat_version=getattr(default_sat, 'version', None)
+        or settings.server.version.get('release', ''),
         deploy_snap_version=settings.server.version.get('snap', ''),
     )
 

--- a/pytest_fixtures/oscap_fixtures.py
+++ b/pytest_fixtures/oscap_fixtures.py
@@ -1,11 +1,11 @@
-import os
+from pathlib import PurePath
 
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo import ssh
 from robottelo.cli.factory import make_scapcontent
+from robottelo.config import robottelo_tmp_dir
 from robottelo.config import settings
 from robottelo.constants import OSCAP_PROFILE
 from robottelo.helpers import file_downloader
@@ -22,11 +22,10 @@ def tailoring_file_path():
 
 
 @pytest.fixture(scope="session")
-def oscap_content_path():
+def oscap_content_path(default_sat):
     """Download scap content from satellite and return local path of it."""
-    _, file_name = os.path.split(settings.oscap.content_path)
-    local_file = f"/tmp/{file_name}"
-    ssh.download_file(settings.oscap.content_path, local_file)
+    local_file = robottelo_tmp_dir.joinpath(PurePath(settings.oscap.content_path).name)
+    default_sat.download(remote_path=settings.oscap.content_path, local_path=local_file)
     return local_file
 
 

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -1,4 +1,5 @@
 """Several helper methods and functions."""
+import base64
 import contextlib
 import json
 import os
@@ -113,6 +114,19 @@ def file_downloader(file_url, local_path=None, file_name=None, hostname=None):
     return [f'{local_path}{file_name}', file_name]
 
 
+def line_count(file, host):
+    """Get number of lines in a file."""
+    return host.execute(f'wc -l < {file}').stdout.strip('\n')
+
+
+def cut_lines(start_line, end_line, source_file, out_file, host):
+    """Given start and end line numbers, cut lines from source file
+    and put them in out file."""
+    return host.execute(
+        f'sed -n "{start_line},{end_line} p" {source_file} < {source_file} > {out_file}'
+    )
+
+
 def get_nailgun_config(user=None):
     """Return a NailGun configuration file constructed from default values.
 
@@ -194,27 +208,24 @@ def md5_by_url(url, hostname=None):
     return result.stdout[0]
 
 
-def add_remote_execution_ssh_key(hostname, key_path=None, proxy_hostname=None, **kwargs):
-    """Add remote execution keys to the client
+def validate_ssh_pub_key(key):
+    """Validates if a string is in valid ssh pub key format
 
-    :param str proxy_hostname: external capsule hostname
-    :param str hostname: The client hostname
-    :param str key: Path to a key on the satellite server
-    :param dict kwargs: directly passed to `ssh.add_authorized_key`
+    :param key: A string containing a ssh public key encoded in base64
+    :return: Boolean
     """
 
-    # get satellite box ssh-key or defaults to foreman-proxy
-    key_path = key_path or '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
-    # This connection defaults to settings.server
-    server_key = ssh.command(
-        cmd='cat %s' % key_path, output_format='base', hostname=proxy_hostname
-    ).stdout
-    # Sometimes stdout contains extra empty string. Skipping it
-    if isinstance(server_key, list):
-        server_key = server_key[0]
+    if not isinstance(key, str):
+        raise ValueError(f"Key should be a string type, received: {type(key)}")
 
-    # add that key to the client using hostname and kwargs for connection
-    ssh.add_authorized_key(server_key, hostname=hostname, **kwargs)
+    # 1) a valid pub key has 3 parts separated by space
+    # 2) The second part (key string) should be a valid base64
+    try:
+        key_type, key_string, _ = key.split()  # need more than one value to unpack
+        base64.decodebytes(key_string.encode('ascii'))
+        return key_type in ('ecdsa-sha2-nistp256', 'ssh-dss', 'ssh-rsa', 'ssh-ed25519')
+    except (ValueError, base64.binascii.Error):
+        return False
 
 
 def get_available_capsule_port(port_pool=None):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2,6 +2,7 @@ import re
 import time
 from functools import cached_property
 from pathlib import Path
+from pathlib import PurePath
 from urllib.parse import urljoin
 from urllib.parse import urlunsplit
 
@@ -23,8 +24,8 @@ from robottelo.config import settings
 from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS
 from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS_PATH
 from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS_VERSION
-from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.helpers import InstallerCommand
+from robottelo.helpers import validate_ssh_pub_key
 
 
 POWER_OPERATIONS = {
@@ -409,14 +410,63 @@ class ContentHost(Host):
         """Copy ssh key to virtual machine ssh path and ensure proper permission is
         set
 
-        :param source_key_path: The ssh key file path to copy to vm
-        :param destination_key_name: The ssh key file name when copied to vm
+        Args:
+            source_key_path: The ssh key file path to copy to vm
+            destination_key_name: The ssh key file name when copied to vm
         """
         destination_key_path = f'/root/.ssh/{destination_key_name}'
         self.put(local_path=source_key_path, remote_path=destination_key_path)
         result = self.run(f'chmod 600 {destination_key_path}')
         if result.status != 0:
             raise CLIFactoryError(f'Failed to chmod ssh key file:\n{result.stderr}')
+
+    def add_authorized_key(self, pub_key):
+        """Inject a public key into the authorized keys file
+
+        Args:
+            pub_key: public key string, file-like object, or path string
+        Raises:
+            ValueError: if the pub_key isn't valid or found
+        """
+        if getattr(pub_key, 'read', False):  # key is a file-like object
+            key_content = pub_key.read()
+        elif validate_ssh_pub_key(pub_key):  # key is a valid key-string
+            key_content = pub_key
+        # use expanduser here to handle relative paths with ~ resolving locally
+        elif Path(pub_key).expanduser().exists():  # key is a path to a pub key-file
+            key_content = Path(pub_key).expanduser().read_text()
+        else:
+            raise ValueError('Invalid key')
+        key_content = key_content.strip()
+        ssh_path = PurePath('~/.ssh')
+        auth_file = ssh_path.joinpath('authorized_keys')
+        # ensure ssh directory exists
+        self.execute(f'mkdir -p {ssh_path}')
+        # append the key if doesn't exists
+        self.execute(
+            "grep -q '{key}' {dest} || echo '{key}' >> {dest}".format(
+                key=key_content, dest=auth_file
+            )
+        )
+        # set proper permissions
+        self.execute(f'chmod 700 {ssh_path}')
+        self.execute(f'chmod 600 {auth_file}')
+        self.execute(f'chown -R {self.username} {ssh_path}')
+        # Restore SELinux context with restorecon, if it's available:
+        self.execute(f'command -v restorecon && restorecon -RvF {ssh_path} || true')
+
+    def add_rex_key(self, satellite, key_path=None):
+        """Read a public key from the passed Satellite, and add it to authorized_keys
+
+        Args:
+            satellite: ``Capsule`` or ``Satellite`` instance
+            key_path: optional path to the key on the satellite
+        """
+        if key_path is not None:
+            sat_key = satellite.execute(f'cat {key_path}').stdout.strip()
+        else:
+            sat_key = satellite.rex_pub_key
+        self.add_authorized_key(pub_key=sat_key)
 
     def update_known_hosts(self, ssh_key_name, host, user=None):
         """Create host entry in vm ssh config and known_hosts files to allow vm
@@ -535,7 +585,7 @@ class ContentHost(Host):
             self.install_katello_ca(satellite)
             self.register_contenthost(org.label, lce='Library')
             assert self.subscribed
-        add_remote_execution_ssh_key(self.ip_addr, proxy_hostname=satellite.hostname)
+        self.add_rex_key(satellite=satellite)
         if register and subnet_id is not None:
             host = self.nailgun_host.read()
             host.name = self.hostname
@@ -861,6 +911,8 @@ class ContentHost(Host):
 
 
 class Capsule(ContentHost):
+    rex_key_path = '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
+
     @property
     def nailgun_capsule(self):
         from nailgun.entities import Capsule as NailgunCapsule
@@ -875,6 +927,10 @@ class Capsule(ContentHost):
         :rtype: bool
         """
         return self.execute('rpm -q satellite &>/dev/null').status != 0
+
+    @property
+    def rex_pub_key(self):
+        return self.execute(f'cat {self.rex_key_path}').stdout.strip()
 
     def restart_services(self):
         """Restart services, returning True if passed and stdout if not"""

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -31,7 +31,6 @@ from robottelo.cli.factory import setup_org_for_a_rh_repo
 from robottelo.config import settings
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import repos
-from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.hosts import ContentHost
 from robottelo.products import RepositoryCollection
 from robottelo.products import YumRepository
@@ -189,7 +188,7 @@ def test_positive_install_in_hc(module_org, activation_key, custom_repo, rh_repo
             client.register_contenthost(module_org.label, activation_key.name)
             assert client.subscribed
             client.enable_repo(constants.REPOS['rhst7']['id'])
-            add_remote_execution_ssh_key(client.hostname)
+            client.add_rex_key(satellite=default_sat)
         host_ids = [client.nailgun_host.id for client in clients]
         _install_package(
             module_org,
@@ -197,11 +196,11 @@ def test_positive_install_in_hc(module_org, activation_key, custom_repo, rh_repo
             host_ids=host_ids,
             package_name=constants.FAKE_1_CUSTOM_PACKAGE,
         )
-        host_collection = entities.HostCollection(organization=module_org).create()
+        host_collection = default_sat.api.HostCollection(organization=module_org).create()
         host_ids = [client.nailgun_host.id for client in clients]
         host_collection.host_ids = host_ids
         host_collection = host_collection.update(['host_ids'])
-        entities.JobInvocation().run(
+        default_sat.api.JobInvocation().run(
             data={
                 'feature': 'katello_errata_install',
                 'inputs': {'errata': f'{CUSTOM_REPO_ERRATA_ID}'},
@@ -242,8 +241,8 @@ def test_positive_install_in_host(
         host_ids=[host_id],
         package_name=constants.FAKE_1_CUSTOM_PACKAGE,
     )
-    add_remote_execution_ssh_key(rhel7_contenthost.hostname)
-    entities.JobInvocation().run(
+    rhel7_contenthost.add_rex_key(satellite=default_sat)
+    default_sat.JobInvocation().run(
         data={
             'feature': 'katello_errata_install',
             'inputs': {'errata': f'{CUSTOM_REPO_ERRATA_ID}'},
@@ -286,9 +285,9 @@ def test_positive_install_multiple_in_host(
     host = host.read()
     applicable_errata_count = host.content_facet_attributes['errata_counts']['total']
     assert applicable_errata_count > 1
-    add_remote_execution_ssh_key(rhel7_contenthost.hostname)
+    rhel7_contenthost.add_rex_key(satellite=default_sat)
     for errata in constants.FAKE_9_YUM_ERRATUM[:2]:
-        entities.JobInvocation().run(
+        default_sat.JobInvocation().run(
             data={
                 'feature': 'katello_errata_install',
                 'inputs': {'errata': f'{errata}'},
@@ -304,7 +303,7 @@ def test_positive_install_multiple_in_host(
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_list(module_org, custom_repo):
+def test_positive_list(module_org, custom_repo, default_sat):
     """View all errata specific to repository
 
     :id: 1efceabf-9821-4804-bacf-2213ac0c7550
@@ -318,9 +317,9 @@ def test_positive_list(module_org, custom_repo):
 
     :CaseLevel: System
     """
-    repo1 = entities.Repository(id=custom_repo['repository-id']).read()
-    repo2 = entities.Repository(
-        product=entities.Product().create(), url=repos.FAKE_3_YUM_REPO
+    repo1 = default_sat.api.Repository(id=custom_repo['repository-id']).read()
+    repo2 = default_sat.api.Repository(
+        product=default_sat.api.Product().create(), url=repos.FAKE_3_YUM_REPO
     ).create()
     repo2.sync()
     repo1_errata_ids = [
@@ -338,7 +337,7 @@ def test_positive_list(module_org, custom_repo):
 
 
 @pytest.mark.tier3
-def test_positive_list_updated(module_org):
+def test_positive_list_updated(module_org, default_sat):
     """View all errata in an Org sorted by Updated
 
     :id: 560d6584-70bd-4d1b-993a-cc7665a9e600
@@ -351,7 +350,7 @@ def test_positive_list_updated(module_org):
 
     :CaseLevel: System
     """
-    repo = entities.Repository(name=constants.REPOS['rhva6']['name']).search(
+    repo = default_sat.api.Repository(name=constants.REPOS['rhva6']['name']).search(
         query={'organization_id': module_org.id}
     )
     if repo:
@@ -367,9 +366,9 @@ def test_positive_list_updated(module_org):
                 'basearch': constants.DEFAULT_ARCHITECTURE,
             }
         )
-        repo = entities.Repository(id=result['repository-id'])
+        repo = default_sat.api.Repository(id=result['repository-id'])
     assert repo.sync()['result'] == 'success'
-    erratum_list = entities.Errata(repository=repo).search(
+    erratum_list = default_sat.api.Errata(repository=repo).search(
         query={'order': 'updated ASC', 'per_page': '1000'}
     )
     updated = [errata.updated for errata in erratum_list]
@@ -377,7 +376,7 @@ def test_positive_list_updated(module_org):
 
 
 @pytest.mark.tier3
-def test_positive_filter_by_cve(module_org):
+def test_positive_filter_by_cve(module_org, default_sat):
     """Filter errata by CVE
 
     :id: a921d4c2-8d3d-4462-ba6c-fbd4b898a3f2
@@ -390,7 +389,7 @@ def test_positive_filter_by_cve(module_org):
 
     :CaseLevel: System
     """
-    repo = entities.Repository(name=constants.REPOS['rhva6']['name']).search(
+    repo = default_sat.api.Repository(name=constants.REPOS['rhva6']['name']).search(
         query={'organization_id': module_org.id}
     )
     if repo:
@@ -406,9 +405,9 @@ def test_positive_filter_by_cve(module_org):
                 'basearch': constants.DEFAULT_ARCHITECTURE,
             }
         )
-        repo = entities.Repository(id=result['repository-id'])
+        repo = default_sat.api.Repository(id=result['repository-id'])
     assert repo.sync()['result'] == 'success'
-    erratum_list = entities.Errata(repository=repo).search(
+    erratum_list = default_sat.api.Errata(repository=repo).search(
         query={'order': 'cve DESC', 'per_page': '1000'}
     )
     # Most of Errata don't have any CVEs. Removing empty CVEs from results
@@ -890,7 +889,7 @@ def test_errata_installation_with_swidtags(
     )
 
     # install older module stream
-    add_remote_execution_ssh_key(rhel8_contenthost.ip_addr)
+    rhel8_contenthost.add_rex_key(satellite=default_sat)
     _set_prerequisites_for_swid_repos(module_org, vm=rhel8_contenthost)
     _run_remote_command_on_content_host(
         module_org, f'dnf -y module install {module_name}:0:{version}', rhel8_contenthost

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -83,7 +83,6 @@ from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FAKE_2_YUM_REPO
 from robottelo.constants.repos import FAKE_3_YUM_REPO
 from robottelo.constants.repos import FAKE_9_YUM_REPO
-from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.hosts import ContentHost
 
 PER_PAGE = 10
@@ -398,7 +397,7 @@ def cv_filter_cleanup(filter_id, cv, org, lce):
     'filter_by_org', ('id', 'name', 'title'), ids=('org_id', 'org_name', 'org_title')
 )
 def test_positive_install_by_host_collection_and_org(
-    module_org, host_collection, errata_hosts, filter_by_hc, filter_by_org
+    module_org, host_collection, errata_hosts, filter_by_hc, filter_by_org, default_sat
 ):
     """Use host collection id or name and org id, name, or label to install an update on the host
     collection.
@@ -425,7 +424,7 @@ def test_positive_install_by_host_collection_and_org(
     errata_id = REPO_WITH_ERRATA['errata'][0]['id']
 
     for host in errata_hosts:
-        add_remote_execution_ssh_key(host.hostname)
+        host.add_rex_key(satellite=default_sat)
 
     if filter_by_hc == 'id':
         host_collection_query = f'host_collection_id = {host_collection["id"]}'
@@ -609,7 +608,7 @@ def test_positive_list_affected_chosts(module_org, errata_hosts):
 
 
 @pytest.mark.tier3
-def test_install_errata_to_one_host(module_org, errata_hosts, host_collection):
+def test_install_errata_to_one_host(module_org, errata_hosts, host_collection, default_sat):
     """Install an erratum to one of the hosts in a host collection.
 
     :id: bfcee2de-3448-497e-a696-fcd30cea9d33
@@ -642,7 +641,7 @@ def test_install_errata_to_one_host(module_org, errata_hosts, host_collection):
     assert result.status == 0, f'Failed to erase the rpm: {result.stdout}'
     # Add ssh keys
     for host in errata_hosts:
-        add_remote_execution_ssh_key(host.hostname)
+        host.add_rex_key(satellite=default_sat)
     # Apply errata to the host collection using job invocation
     JobInvocation.create(
         {

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1970,12 +1970,6 @@ class HostSubscription:
         self.subscription_name = host_subscription['subscription_name']
         self.client = None
 
-    def set_client(self, client):
-        self.client = client
-
-    def get_client(self):
-        return self.client
-
     def _register_client(
         self,
         activation_key=None,
@@ -1995,8 +1989,7 @@ class HostSubscription:
             command is launched
         :return: the registration result
         """
-        if activation_key is None:
-            activation_key = self.ak
+        activation_key = activation_key or self.ak
 
         if lce:
             result = self.client.register_contenthost(
@@ -2078,7 +2071,7 @@ def test_positive_register(request, module_host_subscription, host_subscription_
 
     :CaseLevel: System
     """
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     activation_key = module_host_subscription._make_activation_key(add_subscription=False)
     hosts = Host.list(
         {
@@ -2126,7 +2119,7 @@ def test_positive_attach(request, module_host_subscription, host_subscription_cl
 
     :CaseLevel: System
     """
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     # create an activation key without subscriptions
     activation_key = module_host_subscription._make_activation_key(add_subscription=False)
     # register the client host
@@ -2166,7 +2159,7 @@ def test_positive_attach_with_lce(module_host_subscription, host_subscription_cl
 
     :CaseLevel: System
     """
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     module_host_subscription._register_client(lce=True, auto_attach=True)
     assert module_host_subscription.client.subscribed
     host = Host.info({'name': module_host_subscription.client.hostname})
@@ -2198,7 +2191,7 @@ def test_negative_without_attach(request, module_host_subscription, host_subscri
 
     :CaseLevel: System
     """
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     module_host_subscription._host_subscription_register(request)
     host = Host.info({'name': module_host_subscription.client.hostname})
     module_host_subscription.client.register_contenthost(
@@ -2228,7 +2221,7 @@ def test_negative_without_attach_with_lce(module_host_subscription, host_subscri
     :CaseLevel: System
     """
     # Setup as in host_subscription
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
     content_view = entities.ContentView(organization=org).create()
@@ -2286,7 +2279,7 @@ def test_positive_remove(request, module_host_subscription, host_subscription_cl
 
     :CaseLevel: System
     """
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     activation_key = module_host_subscription._make_activation_key(add_subscription=True)
     module_host_subscription._host_subscription_register(request)
     host = Host.info({'name': module_host_subscription.client.hostname})
@@ -2348,7 +2341,7 @@ def test_positive_auto_attach(request, module_host_subscription, host_subscripti
 
     :CaseLevel: System
     """
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     activation_key = module_host_subscription._make_activation_key(add_subscription=True)
     module_host_subscription._host_subscription_register(request)
     host = Host.info({'name': module_host_subscription.client.hostname})
@@ -2374,7 +2367,7 @@ def test_positive_unregister_host_subscription(module_host_subscription, host_su
 
     :CaseLevel: System
     """
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     # register the host client
     activation_key = module_host_subscription._make_activation_key(add_subscription=True)
     module_host_subscription._register_client(
@@ -2415,7 +2408,7 @@ def test_syspurpose_end_to_end(module_host_subscription, host_subscription_clien
 
     :CaseLevel: System
     """
-    module_host_subscription.set_client(host_subscription_client)
+    module_host_subscription.client = host_subscription_client
     # Create an activation key with test values
     purpose_addons = "test-addon1, test-addon2"
     activation_key = entities.ActivationKey(

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -43,7 +43,6 @@ from robottelo.constants import OSCAP_DEFAULT_CONTENT
 from robottelo.constants import OSCAP_PERIOD
 from robottelo.constants import OSCAP_PROFILE
 from robottelo.constants import OSCAP_WEEKDAY
-from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.helpers import file_downloader
 from robottelo.helpers import ProxyError
 from robottelo.hosts import ContentHost
@@ -477,7 +476,7 @@ def test_positive_oscap_run_via_ansible(
             }
         )
         vm.configure_rhel_repo(rhel_repo)
-        add_remote_execution_ssh_key(vm.ip_addr)
+        vm.add_rex_key(satellite=default_sat)
         Host.update(
             {
                 'name': vm.hostname.lower(),
@@ -592,7 +591,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
             '--fetch-remote-resources --results-arf results.xml '
             '/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml',
         )
-        add_remote_execution_ssh_key(vm.ip_addr)
+        vm.add_rex_key(satellite=default_sat)
         Host.update(
             {
                 'name': vm.hostname.lower(),

--- a/tests/foreman/rhai/conftest.py
+++ b/tests/foreman/rhai/conftest.py
@@ -10,7 +10,6 @@ from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import DISTRO_RHEL8
-from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.hosts import ContentHost
 from robottelo.logging import logger
 
@@ -124,7 +123,7 @@ def vm_rhel8(activation_key, module_org, default_sat):
             rhel_distro=DISTRO_RHEL8,
             register_insights=False,
         )
-        add_remote_execution_ssh_key(vm.ip_addr)
+        vm.add_rex_key(satellite=default_sat)
         yield vm
 
 

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -21,8 +21,8 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
+from robottelo.cli import hammer
 from robottelo.config import settings
-from robottelo.ssh import get_connection
 
 BCK_MSG = "**** Hostname change complete! ****"
 BAD_HN_MSG = (
@@ -38,7 +38,7 @@ class TestRenameHost:
     """Implements ``katello-change-hostname`` tests"""
 
     @pytest.mark.skip_if_open("BZ:1925616")
-    def test_positive_rename_satellite(self, module_org, module_product):
+    def test_positive_rename_satellite(self, module_org, module_product, destructive_sat):
         """run katello-change-hostname on Satellite server
 
         :id: 9944bfb1-1440-4820-ada8-2e219f09c0be
@@ -71,75 +71,60 @@ class TestRenameHost:
         """
         username = settings.server.admin_username
         password = settings.server.admin_password
-        with get_connection() as connection:
-            old_hostname = connection.run('hostname').stdout[0]
-            new_hostname = f'new-{old_hostname}'
-            # create installation medium with hostname in path
-            medium_path = 'http://{}/testpath-{}/os/'.format(old_hostname, gen_string('alpha'))
-            medium = entities.Media(organization=[module_org], path_=medium_path).create()
-            repo = entities.Repository(product=module_product, name='testrepo').create()
-            result = connection.run(
-                'satellite-change-hostname {} -y -u {} -p {}'.format(
-                    new_hostname, username, password
-                ),
-                timeout=1200,
-            )
-            assert result.return_code == 0, 'unsuccessful rename'
-            assert BCK_MSG in result.stdout
-            # services running after rename?
-            result = connection.run('hammer ping')
-            assert result.return_code == 0, 'services did not start properly'
-            # basic hostname check
-            result = connection.run('hostname')
-            assert result.return_code == 0
-            assert new_hostname in result.stdout, 'hostname left unchanged'
-            # check default capsule
-            result = connection.run(
-                'hammer -u {1} -p {2} --output json capsule \
-                        info --name {0}'.format(
-                    new_hostname, username, password
-                ),
-                output_format='json',
-            )
-            assert result.return_code == 0, 'internal capsule not renamed correctly'
-            assert result.stdout['url'] == f"https://{new_hostname}:9090"
-            # check old consumer certs were deleted
-            result = connection.run(f'rpm -qa | grep ^{old_hostname}')
-            assert result.return_code == 1, 'old consumer certificates not removed'
-            # check new consumer certs were created
-            result = connection.run(f'rpm -qa | grep ^{new_hostname}')
-            assert result.return_code == 0, 'new consumer certificates not created'
-            # check if installation media paths were updated
-            result = connection.run(
-                'hammer -u {1} -p {2} --output json \
-                        medium info --id {0}'.format(
-                    medium.id, username, password
-                ),
-                output_format='json',
-            )
-            assert result.return_code == 0
-            assert new_hostname in result.stdout['path'], 'medium path not updated correctly'
-            # check answer file for instances of old hostname
-            ans_f = '/etc/foreman-installer/scenarios.d/satellite-answers.yaml'
-            result = connection.run(f'grep " {old_hostname}" {ans_f}')
-            assert result.return_code == 1, 'old hostname was not correctly replaced in answers.yml'
+        old_hostname = destructive_sat.execute('hostname').stdout
+        new_hostname = f'new-{old_hostname}'
+        # create installation medium with hostname in path
+        medium_path = f'http://{old_hostname}/testpath-{gen_string("alpha")}/os/'
+        medium = entities.Media(organization=[module_org], path_=medium_path).create()
+        repo = entities.Repository(product=module_product, name='testrepo').create()
+        result = destructive_sat.execute(
+            f'satellite-change-hostname {new_hostname} -y -u {username} -p {password}',
+            timeout=1200,
+        )
+        assert result.status == 0, 'unsuccessful rename'
+        assert BCK_MSG in result.stdout
+        # services running after rename?
+        result = destructive_sat.execute('hammer ping')
+        assert result.status == 0, 'services did not start properly'
+        # basic hostname check
+        result = destructive_sat.execute('hostname')
+        assert result.status == 0
+        assert new_hostname in result.stdout, 'hostname left unchanged'
+        # check default capsule
+        result = destructive_sat.execute(
+            f'hammer -u {username} -p {password} --output json capsule info --name {new_hostname}'
+        )
+        assert result.status == 0, 'internal capsule not renamed correctly'
+        assert hammer.parse_json(result.stdout)['url'] == f"https://{new_hostname}:9090"
+        # check old consumer certs were deleted
+        result = destructive_sat.execute(f'rpm -qa | grep ^{old_hostname}')
+        assert result.status == 1, 'old consumer certificates not removed'
+        # check new consumer certs were created
+        result = destructive_sat.execute(f'rpm -qa | grep ^{new_hostname}')
+        assert result.status == 0, 'new consumer certificates not created'
+        # check if installation media paths were updated
+        result = destructive_sat.execute(
+            f'hammer -u {username} -p {password} --output json medium info --id {medium.id}'
+        )
+        assert result.status == 0
+        assert new_hostname in hammer.parse_json(result.stdout)['path']
+        # check answer file for instances of old hostname
+        ans_f = '/etc/foreman-installer/scenarios.d/satellite-answers.yaml'
+        result = destructive_sat.execute(f'grep " {old_hostname}" {ans_f}')
+        assert result.status == 1, 'old hostname was not correctly replaced in answers.yml'
 
-            # check repository published at path
-            result = connection.run(
-                'hammer -u {1} -p {2} --output json \
-                        repository info --id {0}'.format(
-                    repo.id, username, password
-                ),
-                output_format='json',
-            )
-            assert result.return_code == 0
-            assert (
-                new_hostname in result.stdout['published-at']
-            ), 'repository published path not updated correctly'
+        # check repository published at path
+        result = destructive_sat.execute(
+            f'hammer -u {username} -p {password} --output json repository info --id {repo.id}'
+        )
+        assert result.status == 0
+        assert (
+            new_hostname in hammer.parse_json(result.stdout)['published-at']
+        ), 'repository published path not updated correctly'
 
-            # check for any other occurences of old hostname
-            result = connection.run(f'grep " {old_hostname}" /etc/* -r')
-            assert result.return_code == 1, 'there are remaining instances of the old hostname'
+        # check for any other occurences of old hostname
+        result = destructive_sat.execute(f'grep " {old_hostname}" /etc/* -r')
+        assert result.status == 1, 'there are remaining instances of the old hostname'
 
         repo.sync()
         cv = entities.ContentView(organization=module_org).create()
@@ -147,7 +132,8 @@ class TestRenameHost:
         cv.update(['repository'])
         cv.publish()
 
-    def test_negative_rename_sat_to_invalid_hostname(self):
+    @pytest.mark.destructive
+    def test_negative_rename_sat_to_invalid_hostname(self, destructive_sat):
         """change to invalid hostname on Satellite server
 
         :id: 385fad60-3990-42e0-9436-4ebb71918125
@@ -161,23 +147,19 @@ class TestRenameHost:
         """
         username = settings.server.admin_username
         password = settings.server.admin_password
-        with get_connection() as connection:
-            original_name = connection.run('hostname').stdout[0]
-            hostname = gen_string('alpha')
-            result = connection.run(
-                'satellite-change-hostname -y \
-                        {} -u {} -p {}'.format(
-                    hostname, username, password
-                ),
-                output_format='plain',
-            )
-            assert result.return_code == 1
-            assert BAD_HN_MSG.format(hostname) in result.stdout
-            # assert no changes were made
-            result = connection.run('hostname')
-            assert original_name == result.stdout[0], "Invalid hostame assigned"
+        original_name = destructive_sat.execute('hostname').stdout
+        hostname = gen_string('alpha')
+        result = destructive_sat.execute(
+            f'satellite-change-hostname -y {hostname} -u {username} -p {password}'
+        )
+        assert result.status == 1
+        assert BAD_HN_MSG.format(hostname) in result.stdout
+        # assert no changes were made
+        result = destructive_sat.execute('hostname')
+        assert original_name == result.stdout, "Invalid hostame assigned"
 
-    def test_negative_rename_sat_no_credentials(self):
+    @pytest.mark.destructive
+    def test_negative_rename_sat_no_credentials(self, destructive_sat):
         """change hostname without credentials on Satellite server
 
         :id: ed4f7611-33c9-455f-8557-507cc59ede92
@@ -189,20 +171,18 @@ class TestRenameHost:
 
         :CaseAutomation: Automated
         """
-        with get_connection() as connection:
-            original_name = connection.run('hostname').stdout[0]
-            hostname = gen_string('alpha')
-            result = connection.run(
-                f'satellite-change-hostname -y {hostname}', output_format='plain'
-            )
-            assert result.return_code == 1
-            assert NO_CREDS_MSG in result.stdout
-            # assert no changes were made
-            result = connection.run('hostname')
-            assert original_name == result.stdout[0], "Invalid hostame assigned"
+        original_name = destructive_sat.execute('hostname').stdout
+        hostname = gen_string('alpha')
+        result = destructive_sat.execute(f'satellite-change-hostname -y {hostname}')
+        assert result.status == 1
+        assert NO_CREDS_MSG in result.stdout
+        # assert no changes were made
+        result = destructive_sat.execute('hostname')
+        assert original_name == result.stdout, "Invalid hostame assigned"
 
     @pytest.mark.skip_if_open("BZ:1925616")
-    def test_negative_rename_sat_wrong_passwd(self):
+    @pytest.mark.destructive
+    def test_negative_rename_sat_wrong_passwd(self, destructive_sat):
         """change hostname with wrong password on Satellite server
 
         :id: e6d84c5b-4bb1-4400-8022-d01cc9216936
@@ -215,22 +195,18 @@ class TestRenameHost:
         :CaseAutomation: Automated
         """
         username = settings.server.admin_username
-        with get_connection() as connection:
-            original_name = connection.run('hostname').stdout[0]
-            new_hostname = f'new-{original_name}'
-            password = gen_string('alpha')
-            result = connection.run(
-                'satellite-change-hostname -y \
-                        {} -u {} -p {}'.format(
-                    new_hostname, username, password
-                ),
-                output_format='plain',
-            )
-            assert result.return_code == 1
-            assert BAD_CREDS_MSG in result.stderr
+        original_name = destructive_sat.execute('hostname').stdout
+        new_hostname = f'new-{original_name}'
+        password = gen_string('alpha')
+        result = destructive_sat.execute(
+            f'satellite-change-hostname -y {new_hostname} -u {username} -p {password}'
+        )
+        assert result.status == 1
+        assert BAD_CREDS_MSG in result.stderr
 
     @pytest.mark.stubbed
-    def test_positive_rename_capsule(self):
+    @pytest.mark.destructive
+    def test_positive_rename_capsule(self, destructive_sat):
         """run katello-change-hostname on Capsule
 
         :id: 4aa9fd86-bba9-49e4-a67a-8685e1ab5a74
@@ -261,15 +237,12 @@ class TestRenameHost:
         username = settings.server.admin_username
         password = settings.server.admin_password
         # the rename part of the test, not necessary to run from robottelo
-        with get_connection() as connection:
-            hostname = gen_string('alpha')
-            result = connection.run(
-                'satellite-change-hostname -y -u {} -p {}\
-                        --disable-system-checks\
-                        --scenario capsule {}'.format(
-                    username, password, hostname
-                ),
-                output_format='plain',
-            )
-            assert result.return_code == 0
-            assert BCK_MSG in result.stdout
+        hostname = gen_string('alpha')
+        result = destructive_sat.execute(
+            'satellite-change-hostname '
+            f'-y -u {username} -p {password} '
+            '--disable-system-checks '
+            f'--scenario capsule {hostname}'
+        )
+        assert result.status == 0
+        assert BCK_MSG in result.stdout

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -26,7 +26,6 @@ from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo import ssh
 from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_fake_host
@@ -51,12 +50,12 @@ from robottelo.constants import VIRT_WHO_HYPERVISOR_TYPES
 from robottelo.constants.repos import CUSTOM_MODULE_STREAM_REPO_2
 from robottelo.constants.repos import FAKE_1_YUM_REPO
 from robottelo.constants.repos import FAKE_6_YUM_REPO
-from robottelo.helpers import add_remote_execution_ssh_key
+from robottelo.helpers import cut_lines
+from robottelo.helpers import line_count
 from robottelo.products import RepositoryCollection
 from robottelo.products import RHELAnsibleEngineRepository
 from robottelo.products import SatelliteToolsRepository
 from robottelo.products import YumRepository
-from robottelo.rhsso_utils import run_command
 from robottelo.virtwho_utils import create_fake_hypervisor_content
 
 if not setting_is_set('clients') or not setting_is_set('fake_manifest'):
@@ -121,7 +120,7 @@ def vm_module_streams(repos_collection_for_module_streams, rhel8_contenthost, de
     repos_collection_for_module_streams.setup_virtual_machine(
         rhel8_contenthost, default_sat, install_katello_agent=True
     )
-    add_remote_execution_ssh_key(rhel8_contenthost.ip_addr)
+    rhel8_contenthost.add_rex_key(satellite=default_sat)
     yield rhel8_contenthost
 
 
@@ -137,24 +136,6 @@ def set_ignore_facts_for_os(value=False):
 def run_remote_command_on_content_host(command, vm_module_streams):
     result = vm_module_streams.run(command)
     assert result.status == 0
-    return result
-
-
-def line_count(file, connection=None):
-    """Get number of lines in a file."""
-    connection = connection or ssh.get_connection()
-    result = connection.run(f'wc -l < {file}', output_format='plain')
-    count = result.stdout.strip('\n')
-    return count
-
-
-def cut_lines(start_line, end_line, source_file, out_file, connection=None):
-    """Given start and end line numbers, cut lines from source file
-    and put them in out file."""
-    connection = connection or ssh.get_connection()
-    result = connection.run(
-        f'sed -n "{start_line},{end_line} p" {source_file} < {source_file} > {out_file}'
-    )
     return result
 
 
@@ -440,7 +421,7 @@ def test_positive_remove_package_group(session, vm):
 
 
 @pytest.mark.tier3
-def test_actions_katello_host_package_update_timeout(session, vm):
+def test_actions_katello_host_package_update_timeout(session, vm, default_sat):
     """Check that Actions::Katello::Host::Package::Update task will time
     out if goferd does not respond while attempting to update a package.
 
@@ -458,12 +439,11 @@ def test_actions_katello_host_package_update_timeout(session, vm):
     source_log = '/var/log/foreman/production.log'
     test_logfile = '/var/tmp/logfile_package_update_timeout'
     # Install fake package with older version
-    vm.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
+    vm.execute(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     # Remove gofer to break communications on package status
-    vm.run('rpm -e --nodeps gofer')
-    with ssh.get_connection() as connection:
-        # get the number of lines in the source log before the test
-        line_count_start = line_count(source_log, connection)
+    vm.execute('rpm -e --nodeps gofer')
+    # get the number of lines in the source log before the test
+    line_count_start = line_count(source_log, default_sat)
     # Attempt to update fake package, check for warning
     with session:
         result = session.contenthost.execute_package_action(
@@ -484,13 +464,12 @@ def test_actions_katello_host_package_update_timeout(session, vm):
         packages = session.contenthost.search_package(vm.hostname, FAKE_2_CUSTOM_PACKAGE)
         assert packages[0]['Installed Package'] == FAKE_2_CUSTOM_PACKAGE
     # Get the log extract to check for the expected error message
-    with ssh.get_connection() as connection:
-        # get the number of lines in the source log after the test
-        line_count_end = line_count(source_log, connection)
-        # get the log lines of interest, put them in test_logfile
-        cut_lines(line_count_start, line_count_end, source_log, test_logfile, connection)
+    # get the number of lines in the source log after the test
+    line_count_end = line_count(source_log, default_sat)
+    # get the log lines of interest, put them in test_logfile
+    cut_lines(line_count_start, line_count_end, source_log, test_logfile, default_sat)
     # Use same location on remote and local for log file extract
-    ssh.download_file(test_logfile)
+    default_sat.get(remote_path=test_logfile)
     # Search the log file extract for the line with error message
     with open(test_logfile) as logfile:
         for line in logfile:
@@ -1443,10 +1422,10 @@ def test_content_access_after_stopped_foreman(
         )
         repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
         repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
-    result = rhel7_contenthost.run(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
+    result = rhel7_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
-    run_command('systemctl stop foreman')
-    result = ssh.command('foreman-maintain service status --only=foreman')
-    assert result.return_code == 1
-    result = rhel7_contenthost.run(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
+    assert default_sat.execute('systemctl stop foreman').status == 0
+    result = default_sat.execute('foreman-maintain service status --only=foreman')
+    assert result.status == 1
+    result = rhel7_contenthost.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
     assert result.status == 0

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -49,7 +49,6 @@ from robottelo.constants import REAL_4_ERRATA_ID
 from robottelo.constants.repos import FAKE_3_YUM_REPO
 from robottelo.constants.repos import FAKE_6_YUM_REPO
 from robottelo.constants.repos import FAKE_9_YUM_REPO
-from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.hosts import ContentHost
 from robottelo.manifests import upload_manifest_locked
 from robottelo.products import RepositoryCollection
@@ -312,8 +311,7 @@ def test_content_host_errata_page_pagination(session, org, lce, default_sat):
     )
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
     with VMBroker(nick=repos_collection.distro, host_classes={'host': ContentHost}) as client:
-        # add_remote_execution_ssh_key for REX
-        add_remote_execution_ssh_key(client.ip_addr)
+        client.add_rex_key(satellite=default_sat)
         # Add repo and install packages that need errata
         repos_collection.setup_virtual_machine(client, default_sat)
         assert _install_client_package(client, pkgs)

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -26,7 +26,6 @@ from robottelo import constants
 from robottelo.api.utils import promote
 from robottelo.api.utils import update_vm_host_location
 from robottelo.datafactory import gen_string
-from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.hosts import ContentHost
 from robottelo.products import RepositoryCollection
 from robottelo.products import SatelliteToolsRepository
@@ -85,7 +84,7 @@ def vm_content_hosts(module_loc, module_repos_collection, default_sat):
             module_repos_collection.setup_virtual_machine(
                 client, default_sat, install_katello_agent=False
             )
-            add_remote_execution_ssh_key(client.ip_addr)
+            client.add_rex_key(satellite=default_sat)
             update_vm_host_location(client, module_loc.id)
         smart_proxy = (
             entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
@@ -103,7 +102,7 @@ def vm_content_hosts_module_stream(module_loc, module_repos_collection_module_st
             module_repos_collection_module_stream.setup_virtual_machine(
                 client, default_sat, install_katello_agent=False
             )
-            add_remote_execution_ssh_key(client.ip_addr)
+            client.add_rex_key(satellite=default_sat)
             update_vm_host_location(client, module_loc.id)
         smart_proxy = (
             entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -19,25 +19,25 @@
 import os
 
 import pytest
-from nailgun import entities
 
-from robottelo import ssh
+from robottelo.config import robottelo_tmp_dir
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT
 from robottelo.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def oscap_content_path():
+def oscap_content_path(default_sat):
     _, file_name = os.path.split(settings.oscap.content_path)
-    local_file = f"/tmp/{file_name}"
-    ssh.download_file(settings.oscap.content_path, local_file)
+
+    local_file = robottelo_tmp_dir.joinpath(file_name)
+    default_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
     return local_file
 
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, oscap_content_path):
+def test_positive_end_to_end(session, oscap_content_path, default_sat):
     """Perform end to end testing for openscap content component
 
     :id: 9870555d-0b60-41ab-a481-81d4d3f78fec
@@ -55,8 +55,8 @@ def test_positive_end_to_end(session, oscap_content_path):
     """
     title = gen_string('alpha')
     new_title = gen_string('alpha')
-    org = entities.Organization().create()
-    loc = entities.Location().create()
+    org = default_sat.api.Organization().create()
+    loc = default_sat.api.Location().create()
     with session:
         session.oscapcontent.create(
             {

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -19,6 +19,7 @@
 import csv
 import json
 import os
+from pathlib import PurePath
 
 import pytest
 import yaml
@@ -26,10 +27,10 @@ from lxml import etree
 from nailgun import entities
 
 from robottelo import manifests
-from robottelo import ssh
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
+from robottelo.config import robottelo_tmp_dir
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -411,8 +412,9 @@ def test_positive_schedule_generation_and_get_mail(session, module_org, module_l
                 'email_to': 'root@localhost',
             },
         )
-    file_path = '/tmp/{}.json'.format(gen_string('alpha'))
-    gzip_path = f'{file_path}.gz'
+    file_path = PurePath('/tmp/').joinpath(f'{gen_string("alpha")}.json')
+    gzip_path = PurePath(f'{file_path}.gz')
+    local_gzip_file = robottelo_tmp_dir.joinpath(gzip_path.name)
     expect_script = (
         f'#!/usr/bin/env expect\n'
         f'spawn mail\n'
@@ -427,12 +429,12 @@ def test_positive_schedule_generation_and_get_mail(session, module_org, module_l
         f'expect "&"\n'
         f'send "q\\r"\n'
     )
-    ssh.command(f'expect -c \'{expect_script}\'', hostname=default_sat.hostname)
-    ssh.download_file(gzip_path)
-    os.system(f'gunzip {gzip_path}')
-    with open(file_path) as json_file:
-        data = json.load(json_file)
-    assert len(data) >= len(entities.Subscription(organization=module_org).search()) > 0
+    default_sat.execute(f"expect -c '{expect_script}'")
+    default_sat.get(remote_path=gzip_path, local_path=local_gzip_file)
+    os.system(f'gunzip {local_gzip_file}')
+    data = json.load(local_gzip_file.read_text())
+    subscription_search = default_sat.api.Subscription(organization=module_org).search()
+    assert len(data) >= len(subscription_search) > 0
     keys_expected = ['Available', 'Contract number', 'ID', 'Name', 'Quantity', 'SKU']
     for subscription in data:
         assert sorted(list(subscription.keys())) == keys_expected

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -1,10 +1,13 @@
 """Tests for module ``robottelo.helpers``."""
 from unittest import mock
 
+import pytest
+
 from robottelo.helpers import escape_search
 from robottelo.helpers import get_available_capsule_port
 from robottelo.helpers import slugify_component
 from robottelo.helpers import Storage
+from robottelo.helpers import validate_ssh_pub_key
 
 
 class FakeSSHResult:
@@ -12,6 +15,56 @@ class FakeSSHResult:
         self.stdout = stdout
         self.stderr = stderr
         self.return_code = return_code
+
+
+class TestPubKey:
+    @pytest.mark.parametrize(
+        'invalid_key',
+        [
+            "ssh-rsa1 xxxxxx user@host",  # rsa1 is unsafe
+            "foo bar blaz",  # not a valid type
+            "ssh-rsa /gfdgdf/fsdfsdfsdf/@ user@host",  # not valid base64 data
+            "sdhsfbghjsbgjhbg user@host",  # not a valid format
+        ],
+        ids=['rsa1', 'foo', 'base64', 'format'],
+    )
+    def test_invalid_ssh_pub_keys(self, invalid_key):
+        assert not validate_ssh_pub_key(invalid_key)
+
+    @pytest.mark.parametrize(
+        'valid_key',
+        [
+            (
+                "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDuMCPmX7iBXAxH5oLznswA5cc"
+                "fV/FABwIWnYl0OYRkDhv3mu9Eogk4H6sCguq4deJtRkwg2C3yEmsNYfBWYu4y5Rk"
+                "I4TH/k3N161wn91nBxs/+wqoN3g9tUuWrf98PG4NnYvmZU67RuiSUNXpgLEPfo8j"
+                "MKkJ5veKu++DmHdpfqFB9ljWEfWz+kAAKgwo251VRDaKwFsb91LbLFpqn9rfMJUB"
+                "hOn+Uebfd0TrHzw08gbVmvfAn61isvFVhvIJBTjNSWsBIm8SuCvhH+inYOwttfE8"
+                "FGeR1KSp9Xl0PCYDK0BwvQO3qwD+nehsEUR/FJUXm1IZPc8fi17ieGgPOnrgf"
+                " user@new-host"
+            ),
+            (
+                "ssh-dss AAAAB3NzaC1kc3MAAACBAMzXU0Jl0fRCKy5B7R8KVKMLJYuhVPagBSi7"
+                "UxRAiVHOHzscQzt5wrgRqknuQ9/xIAVAMUVy3ND5zBLkqKwGm9DKGeYEv7xxDi6Z"
+                "z5QjsI9oSSqFSMauDxgl+foC4QPrIlUvb9ez5bVg6aJHKJEngDo+lvfVROgQOvTx"
+                "I9IXn7oLAAAAFQCz4jDBOnTjkWXgw8sT46HM1jK4SwAAAIAS2BvUlEevY+2YOiqD"
+                "SRy9Dhr+/bWLuLl7oUTEnxPhCyo8paaU0fJO1w3BUsbO3Rg4sBgXChRNyg7iKriB"
+                "WbPH6EK1e6IcYv8wUdobB3wg+RJlYU2cq7V8HcPJh+hfAGfMD6UnTDLg+P5SCEW7"
+                "Ag+knZNwfKv9IAtd0W86EFdVWwAAAIEAkj5boIRqLiUGbRipEzWzZbWMis2S8Ji2"
+                "oR6fUD/h6bZ5ta8nEWApri5OQExK7upelTjSR+MHEDRmeepchkTX0LOjBkZgsPyb"
+                "6nEpQUQUJAuns8yAnhsKuEuZmlAGwXOSKiD/KRyJu4KjbbV4oyKXU1fF70zPLmOT"
+                "fyvserP5qyo= user@new-host"
+            ),
+            (
+                "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAy"
+                "NTYAAABBBPWuLEsYvplkL6XR5wbxzXyzw8tLE/JjLXlzUgxv4LhJN4iufXLPSOvj"
+                "sk0ek1TE059poyy5ps+GU2DkisSUVYA= user@new-host"
+            ),
+        ],
+        ids=['rsa', 'dss', 'ecdsa'],
+    )
+    def test_valid_ssh_pub_keys(self, valid_key):
+        assert validate_ssh_pub_key(valid_key)
 
 
 class TestEscapeSearch:

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -4,7 +4,6 @@ from io import StringIO
 from unittest import mock
 
 import paramiko
-import pytest
 
 from robottelo import ssh
 
@@ -198,77 +197,6 @@ class TestSSH:
         assert connection.set_missing_host_key_policy_ == 1
         assert connection.connect_ == 1
         assert connection.close_ == 1
-
-    def test_valid_ssh_pub_keys(self):
-        valid_keys = (
-            (
-                "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDuMCPmX7iBXAxH5oLznswA5cc"
-                "fV/FABwIWnYl0OYRkDhv3mu9Eogk4H6sCguq4deJtRkwg2C3yEmsNYfBWYu4y5Rk"
-                "I4TH/k3N161wn91nBxs/+wqoN3g9tUuWrf98PG4NnYvmZU67RuiSUNXpgLEPfo8j"
-                "MKkJ5veKu++DmHdpfqFB9ljWEfWz+kAAKgwo251VRDaKwFsb91LbLFpqn9rfMJUB"
-                "hOn+Uebfd0TrHzw08gbVmvfAn61isvFVhvIJBTjNSWsBIm8SuCvhH+inYOwttfE8"
-                "FGeR1KSp9Xl0PCYDK0BwvQO3qwD+nehsEUR/FJUXm1IZPc8fi17ieGgPOnrgf"
-                " user@new-host"
-            ),
-            (
-                "ssh-dss AAAAB3NzaC1kc3MAAACBAMzXU0Jl0fRCKy5B7R8KVKMLJYuhVPagBSi7"
-                "UxRAiVHOHzscQzt5wrgRqknuQ9/xIAVAMUVy3ND5zBLkqKwGm9DKGeYEv7xxDi6Z"
-                "z5QjsI9oSSqFSMauDxgl+foC4QPrIlUvb9ez5bVg6aJHKJEngDo+lvfVROgQOvTx"
-                "I9IXn7oLAAAAFQCz4jDBOnTjkWXgw8sT46HM1jK4SwAAAIAS2BvUlEevY+2YOiqD"
-                "SRy9Dhr+/bWLuLl7oUTEnxPhCyo8paaU0fJO1w3BUsbO3Rg4sBgXChRNyg7iKriB"
-                "WbPH6EK1e6IcYv8wUdobB3wg+RJlYU2cq7V8HcPJh+hfAGfMD6UnTDLg+P5SCEW7"
-                "Ag+knZNwfKv9IAtd0W86EFdVWwAAAIEAkj5boIRqLiUGbRipEzWzZbWMis2S8Ji2"
-                "oR6fUD/h6bZ5ta8nEWApri5OQExK7upelTjSR+MHEDRmeepchkTX0LOjBkZgsPyb"
-                "6nEpQUQUJAuns8yAnhsKuEuZmlAGwXOSKiD/KRyJu4KjbbV4oyKXU1fF70zPLmOT"
-                "fyvserP5qyo= user@new-host"
-            ),
-            (
-                "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAy"
-                "NTYAAABBBPWuLEsYvplkL6XR5wbxzXyzw8tLE/JjLXlzUgxv4LhJN4iufXLPSOvj"
-                "sk0ek1TE059poyy5ps+GU2DkisSUVYA= user@new-host"
-            ),
-        )
-        for key in valid_keys:
-            assert ssh.is_ssh_pub_key(key)
-
-    def test_invalid_ssh_pub_keys(self):
-        invalid_keys = (
-            "ssh-rsa1 xxxxxx user@host",  # rsa1 is unsafe
-            "foo bar blaz",  # not a valid type
-            "ssh-rsa /gfdgdf/fsdfsdfsdf/@ user@host",  # not valid base64 data
-            "sdhsfbghjsbgjhbg user@host",  # not a valid format
-        )
-        for key in invalid_keys:
-            assert not ssh.is_ssh_pub_key(key)
-
-    def test_add_authorized_key_raises_invalid_key(self):
-        with pytest.raises(AttributeError):
-            ssh.add_authorized_key('sfsdfsdfsdf')
-        with pytest.raises(AttributeError):
-            ssh.add_authorized_key('sdhsfbghjsbgjhbg user@host')
-        with pytest.raises(AttributeError):
-            ssh.add_authorized_key('ssh-rsa /gfdgdf/fsdfsdfsdf/@ user@host')
-
-    def test_fails_with_invalid_key_format(self):
-        with pytest.raises(ValueError):
-            ssh.add_authorized_key([])
-        with pytest.raises(ValueError):
-            ssh.add_authorized_key(123456)
-        with pytest.raises(ValueError):
-            ssh.add_authorized_key(9999.456789)
-        with pytest.raises(ValueError):
-            ssh.add_authorized_key({"invalid": "format"})
-
-    @mock.patch('robottelo.config.settings')
-    def test_add_authorized_key(self, settings):
-        ssh._call_paramiko_sshclient = MockSSHClient
-        settings.server.hostname = 'example.com'
-        settings.server.ssh_username = 'nobody'
-        settings.server.ssh_key = None
-        settings.server.ssh_password = 'test_password'
-        settings.server.ssh_client.command_timeout = 300
-        settings.server.ssh_client.connection_timeout = 10
-        ssh.add_authorized_key('ssh-rsa xxxx user@host')
 
     @mock.patch('robottelo.config.settings')
     def test_execute_command(self, settings):


### PR DESCRIPTION
Remove most uses of get_connection outside of the ssh module

Convert tests to use default_sat.execute, to use status instead of
return_code, and to treat stdout as a string instead of a list

Updated several uses of download_file and upload_file as well, in order
to eliminate ssh module use from test files that were being modified.

Moved two small functions from test modules where they were duplicated
into robottelo.helpers

Changed target for this branch to `unstable`, which @JacobCallahan created to collect this MR and some of his outstanding work continuing the ssh module refactoring.