### PR TITLE
Improve reliability of ui custom cron test

### DIFF
--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -386,20 +386,6 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org):
         validate_task_status(repo['id'], module_org.id, max_tries=2)
 
 
-@pytest.mark.stubbed
-@pytest.mark.tier4
-@pytest.mark.upgrade
-def test_positive_synchronize_custom_product_custom_cron(module_org):
-    """Create a sync plan with custom cron with 1 min interval, add a
-    custom product and verify the product gets synchronized on the next
-    sync occurrence
-
-    :id: 5f398103-7c36-4524-a1cb-c258d97cecba
-
-    :expectedresults: Product is synchronized successfully.
-    """
-
-
 @pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_custom_product_past_sync_date(module_org):

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -246,7 +246,7 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
         session.syncplan.add_product(plan_name, product.name)
         # check that product was not synced
         with pytest.raises(AssertionError) as context:
-            validate_task_status(repo.id, module_org.id, max_tries=2)
+            validate_task_status(repo.id, module_org.id, max_tries=1)
         assert 'No task was found using query' in str(context.value)
         validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Waiting part of delay that is left and check that product was synced
@@ -274,7 +274,9 @@ def test_positive_synchronize_custom_product_custom_cron_past_sync_date(session,
     :CaseLevel: System
     """
     interval = 60 * 60  # 'hourly' sync interval in seconds
-    delay = 5 * 60
+    cron_multiple = 5  # sync event is on every multiple of this value, starting from 00 mins
+    delay = (cron_multiple) * 60
+    guardtime = 180  # do not start test less than 3 mins before the next sync event
     plan_name = gen_string('alpha')
     product = entities.Product(organization=module_org).create()
     repo = entities.Repository(product=product).create()
@@ -282,11 +284,14 @@ def test_positive_synchronize_custom_product_custom_cron_past_sync_date(session,
         # workaround: force session.browser to point to browser object on next line
         session.contenthost.read_all('current_user')
         startdate = session.browser.get_client_datetime() - timedelta(seconds=(interval - delay))
+        # if < 3mins before the target event rather wait 3 mins for the next test window
+        if int(startdate.strftime('%M')) % (cron_multiple) < (guardtime):
+            time.sleep(guardtime)
         session.syncplan.create(
             {
                 'name': plan_name,
                 'interval': SYNC_INTERVAL['custom'],
-                'cron_expression': '*/5 * * * *',
+                'cron_expression': f'*/{cron_multiple} * * * *',
                 'description': 'sync plan create with start time',
                 'date_time.start_date': startdate.strftime("%Y-%m-%d"),
                 'date_time.hours': startdate.strftime('%H'),
@@ -296,13 +301,13 @@ def test_positive_synchronize_custom_product_custom_cron_past_sync_date(session,
         assert session.syncplan.search(plan_name)[0]['Name'] == plan_name
         session.syncplan.add_product(plan_name, product.name)
         # Waiting part of delay and check that product was not synced
-        time.sleep(delay / 4)
+        time.sleep(delay * 1 / cron_multiple)
         with pytest.raises(AssertionError) as context:
-            validate_task_status(repo.id, module_org.id, max_tries=2)
+            validate_task_status(repo.id, module_org.id, max_tries=1)
         assert 'No task was found using query' in str(context.value)
         validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
         # Waiting part of delay that is left and check that product was synced
-        time.sleep(delay * 3 / 4)
+        time.sleep(delay * (cron_multiple - 1) / cron_multiple)
         validate_task_status(repo.id, module_org.id)
         validate_repo_content(repo, ['erratum', 'package', 'package_group'])
         repo_values = session.repository.read(product.name, repo.name)


### PR DESCRIPTION
 Remove cli custom cron stubbed test

Hello robottelers

I have made the UI custom cron test more reliable by preventing the test starting less than 2 mins before the next sync event set by the custom cron expression.

I have removed the stubbed CLI custom cron test as it essentially duplicates the UI test except it called for an unrealistic 1 minute interval. I don't believe there is any valid use case for that test. The UI test with 5 minute interval will catch a failure to sync on the first sync event.

Thank you

UPDATE: I had to change the guard time to 3 mins to get it to pass reliably. It was that or change cron event to multiples of 10 which would have made the test time longer.