### PR TITLE
fix the test as there no way to know org location in list of orgs

### DIFF
--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -355,12 +355,8 @@ class TestHostGroup:
         assert hostgroup.domain.read().name == new_domain.name
         assert hostgroup.content_view.read().name == new_cv.name
         assert hostgroup.lifecycle_environment.read().name == new_lce.name
-        assert hostgroup.location[0].read().name == new_loc.name
-        for organization in hostgroup.organization:
-            if organization.read().name == new_org.name:
-                break
-        else:
-            pytest.fail('failed to update the organization')
+        assert new_loc.name in [location.read().name for location in hostgroup.location]
+        assert new_org.name in [org.read().name for org in hostgroup.organization]
         assert hostgroup.medium.read().name == new_media.name
 
         # delete

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -356,7 +356,11 @@ class TestHostGroup:
         assert hostgroup.content_view.read().name == new_cv.name
         assert hostgroup.lifecycle_environment.read().name == new_lce.name
         assert hostgroup.location[0].read().name == new_loc.name
-        assert hostgroup.organization[0].read().name == new_org.name
+        for organization in hostgroup.organization:
+            if organization.read().name == new_org.name:
+                break
+        else:
+            pytest.fail('failed to update the organization')
         assert hostgroup.medium.read().name == new_media.name
 
         # delete


### PR DESCRIPTION
Currently the organization exists in the list of organization, but the arrangement strategy has been changed seems in API call, added some workaround.     

```
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-1.16, xdist-2.3.0, cov-2.12.1, reportportal-5.0.8, mock-3.6.1, forked-1.3.0collected 53 items / 52 deselected / 1 selected

../../okhatavk/Satellite/robottelo/tests/foreman/api/test_hostgroup.py

=========== 1 passed, 52 deselected, 3 warnings in 164.01s (0:02:44) ===========
```