### PR TITLE
Azure CLI test fixes with 2 new context managers

### DIFF
--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -238,29 +238,28 @@ class TestAzureRMHostProvisioningTestCase:
         Later in tests this host will be used to perform assertions
         """
 
-        skip_yum_update_during_provisioning(template='Kickstart default finish')
-        host = entities.Host(
-            architecture=default_architecture,
-            build=True,
-            compute_resource=module_azurerm_cr,
-            compute_attributes=self.compute_attrs,
-            interfaces_attributes=self.interfaces_attributes,
-            domain=module_domain,
-            organization=module_org,
-            operatingsystem=default_os,
-            location=module_location,
-            name=self.hostname,
-            provision_method='image',
-            image=module_azurerm_finishimg,
-            root_pass=gen_string('alphanumeric'),
-            environment=module_puppet_environment,
-            puppet_proxy=default_smart_proxy,
-            puppet_ca_proxy=default_smart_proxy,
-        ).create()
-        yield host
-        skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        with satellite_setting('destroy_vm_on_host_delete=True'):
-            host.delete()
+        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+            host = entities.Host(
+                architecture=default_architecture,
+                build=True,
+                compute_resource=module_azurerm_cr,
+                compute_attributes=self.compute_attrs,
+                interfaces_attributes=self.interfaces_attributes,
+                domain=module_domain,
+                organization=module_org,
+                operatingsystem=default_os,
+                location=module_location,
+                name=self.hostname,
+                provision_method='image',
+                image=module_azurerm_finishimg,
+                root_pass=gen_string('alphanumeric'),
+                environment=module_puppet_environment,
+                puppet_proxy=default_smart_proxy,
+                puppet_ca_proxy=default_smart_proxy,
+            ).create()
+            yield host
+            with satellite_setting('destroy_vm_on_host_delete=True'):
+                host.delete()
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_ft):
@@ -389,29 +388,28 @@ class TestAzureRMUserDataProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        skip_yum_update_during_provisioning(template='Kickstart default finish')
-        host = entities.Host(
-            architecture=default_architecture,
-            build=True,
-            compute_resource=module_azurerm_cr,
-            compute_attributes=self.compute_attrs,
-            interfaces_attributes=self.interfaces_attributes,
-            domain=module_domain,
-            organization=module_org,
-            operatingsystem=default_os,
-            location=module_location,
-            name=self.hostname,
-            provision_method='image',
-            image=module_azurerm_cloudimg,
-            root_pass=gen_string('alphanumeric'),
-            environment=module_puppet_environment,
-            puppet_proxy=default_smart_proxy,
-            puppet_ca_proxy=default_smart_proxy,
-        ).create()
-        yield host
-        skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        with satellite_setting('destroy_vm_on_host_delete=True'):
-            host.delete()
+        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+            host = entities.Host(
+                architecture=default_architecture,
+                build=True,
+                compute_resource=module_azurerm_cr,
+                compute_attributes=self.compute_attrs,
+                interfaces_attributes=self.interfaces_attributes,
+                domain=module_domain,
+                organization=module_org,
+                operatingsystem=default_os,
+                location=module_location,
+                name=self.hostname,
+                provision_method='image',
+                image=module_azurerm_cloudimg,
+                root_pass=gen_string('alphanumeric'),
+                environment=module_puppet_environment,
+                puppet_proxy=default_smart_proxy,
+                puppet_ca_proxy=default_smart_proxy,
+            ).create()
+            yield host
+            with satellite_setting('destroy_vm_on_host_delete=True'):
+                host.delete()
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_ud):
@@ -544,29 +542,28 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        skip_yum_update_during_provisioning(template='Kickstart default finish')
-        host = entities.Host(
-            architecture=default_architecture,
-            build=True,
-            compute_resource=module_azurerm_cr,
-            compute_attributes=self.compute_attrs,
-            interfaces_attributes=self.interfaces_attributes,
-            domain=module_domain,
-            organization=module_org,
-            operatingsystem=default_os,
-            location=module_location,
-            name=self.hostname,
-            provision_method='image',
-            image=module_azurerm_gallery_finishimg,
-            root_pass=gen_string('alphanumeric'),
-            environment=module_puppet_environment,
-            puppet_proxy=default_smart_proxy,
-            puppet_ca_proxy=default_smart_proxy,
-        ).create()
-        yield host
-        skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        with satellite_setting('destroy_vm_on_host_delete=True'):
-            host.delete()
+        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+            host = entities.Host(
+                architecture=default_architecture,
+                build=True,
+                compute_resource=module_azurerm_cr,
+                compute_attributes=self.compute_attrs,
+                interfaces_attributes=self.interfaces_attributes,
+                domain=module_domain,
+                organization=module_org,
+                operatingsystem=default_os,
+                location=module_location,
+                name=self.hostname,
+                provision_method='image',
+                image=module_azurerm_gallery_finishimg,
+                root_pass=gen_string('alphanumeric'),
+                environment=module_puppet_environment,
+                puppet_proxy=default_smart_proxy,
+                puppet_ca_proxy=default_smart_proxy,
+            ).create()
+            yield host
+            with satellite_setting('destroy_vm_on_host_delete=True'):
+                host.delete()
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_gallery_ft):
@@ -671,29 +668,28 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        skip_yum_update_during_provisioning(template='Kickstart default finish')
-        host = entities.Host(
-            architecture=default_architecture,
-            build=True,
-            compute_resource=module_azurerm_cr,
-            compute_attributes=self.compute_attrs,
-            interfaces_attributes=self.interfaces_attributes,
-            domain=module_domain,
-            organization=module_org,
-            operatingsystem=default_os,
-            location=module_location,
-            name=self.hostname,
-            provision_method='image',
-            image=module_azurerm_custom_finishimg,
-            root_pass=gen_string('alphanumeric'),
-            environment=module_puppet_environment,
-            puppet_proxy=default_smart_proxy,
-            puppet_ca_proxy=default_smart_proxy,
-        ).create()
-        yield host
-        skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        with satellite_setting('destroy_vm_on_host_delete=True'):
-            host.delete()
+        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+            host = entities.Host(
+                architecture=default_architecture,
+                build=True,
+                compute_resource=module_azurerm_cr,
+                compute_attributes=self.compute_attrs,
+                interfaces_attributes=self.interfaces_attributes,
+                domain=module_domain,
+                organization=module_org,
+                operatingsystem=default_os,
+                location=module_location,
+                name=self.hostname,
+                provision_method='image',
+                image=module_azurerm_custom_finishimg,
+                root_pass=gen_string('alphanumeric'),
+                environment=module_puppet_environment,
+                puppet_proxy=default_smart_proxy,
+                puppet_ca_proxy=default_smart_proxy,
+            ).create()
+            yield host
+            with satellite_setting('destroy_vm_on_host_delete=True'):
+                host.delete()
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_custom_ft):

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -21,7 +21,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.api.utils import satellite_setting
-from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.config import settings
 from robottelo.constants import AZURERM_FILE_URI
 from robottelo.constants import AZURERM_PLATFORM_DEFAULT
@@ -222,6 +221,7 @@ class TestAzureRMHostProvisioningTestCase:
     @pytest.fixture(scope='class')
     def class_host_ft(
         self,
+        default_sat,
         azurermclient,
         module_azurerm_finishimg,
         module_azurerm_cr,
@@ -238,7 +238,7 @@ class TestAzureRMHostProvisioningTestCase:
         Later in tests this host will be used to perform assertions
         """
 
-        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
             host = entities.Host(
                 architecture=default_architecture,
                 build=True,
@@ -372,6 +372,7 @@ class TestAzureRMUserDataProvisioning:
     @pytest.fixture(scope='class')
     def class_host_ud(
         self,
+        default_sat,
         azurermclient,
         module_azurerm_cloudimg,
         module_azurerm_cr,
@@ -388,7 +389,7 @@ class TestAzureRMUserDataProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
             host = entities.Host(
                 architecture=default_architecture,
                 build=True,
@@ -526,6 +527,7 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
     @pytest.fixture(scope='class')
     def class_host_gallery_ft(
         self,
+        default_sat,
         azurermclient,
         module_azurerm_gallery_finishimg,
         module_azurerm_cr,
@@ -542,7 +544,7 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
             host = entities.Host(
                 architecture=default_architecture,
                 build=True,
@@ -652,6 +654,7 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
     @pytest.fixture(scope='class')
     def class_host_custom_ft(
         self,
+        default_sat,
         azurermclient,
         module_azurerm_custom_finishimg,
         module_azurerm_cr,
@@ -668,7 +671,7 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
             host = entities.Host(
                 architecture=default_architecture,
                 build=True,

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -20,8 +20,8 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
+from robottelo.api.utils import hammer_api_timeout
 from robottelo.api.utils import satellite_setting
-from robottelo.api.utils import set_hammer_api_timeout
 from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.cli.computeprofile import ComputeProfile
 from robottelo.cli.computeresource import ComputeResource
@@ -340,29 +340,27 @@ class TestAzureRMFinishTemplateProvisioning:
         Provisions the host on AzureRM using Finish template
         Later in tests this host will be used to perform assertions
         """
-        set_hammer_api_timeout()
-        skip_yum_update_during_provisioning(template='Kickstart default finish')
-        host = Host.create(
-            {
-                'name': self.hostname,
-                'compute-resource': module_azurerm_cr.name,
-                'compute-attributes': self.compute_attrs,
-                'interface': self.interfaces_attributes,
-                'location-id': module_location.id,
-                'organization-id': module_org.id,
-                'domain-id': module_domain.id,
-                'architecture-id': default_architecture.id,
-                'operatingsystem-id': default_os.id,
-                'root-password': gen_string('alpha'),
-                'image': module_azurerm_finishimg.name,
-            },
-            timeout=1800,
-        )
-        yield host
-        skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        with satellite_setting('destroy_vm_on_host_delete=True'):
-            Host.delete({'name': self.fullhostname}, timeout=1800)
-        set_hammer_api_timeout(reverse=True)
+        with hammer_api_timeout():
+            with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+                host = Host.create(
+                    {
+                        'name': self.hostname,
+                        'compute-resource': module_azurerm_cr.name,
+                        'compute-attributes': self.compute_attrs,
+                        'interface': self.interfaces_attributes,
+                        'location-id': module_location.id,
+                        'organization-id': module_org.id,
+                        'domain-id': module_domain.id,
+                        'architecture-id': default_architecture.id,
+                        'operatingsystem-id': default_os.id,
+                        'root-password': gen_string('alpha'),
+                        'image': module_azurerm_finishimg.name,
+                    },
+                    timeout=1800,
+                )
+                yield host
+                with satellite_setting('destroy_vm_on_host_delete=True'):
+                    Host.delete({'name': self.fullhostname}, timeout=1800)
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_ft):
@@ -463,26 +461,24 @@ class TestAzureRMUserDataProvisioning:
         Provisions the host on AzureRM using UserData template
         Later in tests this host will be used to perform assertions
         """
-        set_hammer_api_timeout()
-        skip_yum_update_during_provisioning(template='Kickstart default user data')
-        host = Host.create(
-            {
-                'name': self.hostname,
-                'compute-attributes': self.compute_attrs,
-                'interface': self.interfaces_attributes,
-                'image': module_azurerm_cloudimg.name,
-                'hostgroup': azurerm_hostgroup.name,
-                'location': module_location.name,
-                'organization': module_org.name,
-                'operatingsystem-id': default_os.id,
-            },
-            timeout=1800,
-        )
-        yield host
-        skip_yum_update_during_provisioning(template='Kickstart default user data', reverse=True)
-        with satellite_setting('destroy_vm_on_host_delete=True'):
-            Host.delete({'name': self.fullhostname}, timeout=1800)
-        set_hammer_api_timeout(reverse=True)
+        with hammer_api_timeout():
+            with skip_yum_update_during_provisioning(template='Kickstart default user data'):
+                host = Host.create(
+                    {
+                        'name': self.hostname,
+                        'compute-attributes': self.compute_attrs,
+                        'interface': self.interfaces_attributes,
+                        'image': module_azurerm_cloudimg.name,
+                        'hostgroup': azurerm_hostgroup.name,
+                        'location': module_location.name,
+                        'organization': module_org.name,
+                        'operatingsystem-id': default_os.id,
+                    },
+                    timeout=1800,
+                )
+                yield host
+                with satellite_setting('destroy_vm_on_host_delete=True'):
+                    Host.delete({'name': self.fullhostname}, timeout=1800)
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_ud):
@@ -579,30 +575,28 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
         Provisions the host on AzureRM with BYOS Image
         Later in tests this host will be used to perform assertions
         """
-        set_hammer_api_timeout()
-        skip_yum_update_during_provisioning(template='Kickstart default finish')
-        host = Host.create(
-            {
-                'name': self.hostname,
-                'compute-resource': module_azurerm_cr.name,
-                'compute-attributes': self.compute_attrs,
-                'interface': self.interfaces_attributes,
-                'location-id': module_location.id,
-                'organization-id': module_org.id,
-                'domain-id': module_domain.id,
-                'architecture-id': default_architecture.id,
-                'operatingsystem-id': default_os.id,
-                'root-password': gen_string('alpha'),
-                'image': module_azurerm_byos_finishimg.name,
-                'volume': "disk_size_gb=5",
-            },
-            timeout=1800,
-        )
-        yield host
-        skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
-        with satellite_setting('destroy_vm_on_host_delete=True'):
-            Host.delete({'name': self.fullhostname}, timeout=1800)
-        set_hammer_api_timeout(reverse=True)
+        with hammer_api_timeout():
+            with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+                host = Host.create(
+                    {
+                        'name': self.hostname,
+                        'compute-resource': module_azurerm_cr.name,
+                        'compute-attributes': self.compute_attrs,
+                        'interface': self.interfaces_attributes,
+                        'location-id': module_location.id,
+                        'organization-id': module_org.id,
+                        'domain-id': module_domain.id,
+                        'architecture-id': default_architecture.id,
+                        'operatingsystem-id': default_os.id,
+                        'root-password': gen_string('alpha'),
+                        'image': module_azurerm_byos_finishimg.name,
+                        'volume': "disk_size_gb=5",
+                    },
+                    timeout=1800,
+                )
+                yield host
+                with satellite_setting('destroy_vm_on_host_delete=True'):
+                    Host.delete({'name': self.fullhostname}, timeout=1800)
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_byos_ft_host):

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -20,9 +20,7 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import hammer_api_timeout
 from robottelo.api.utils import satellite_setting
-from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.cli.computeprofile import ComputeProfile
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.host import Host
@@ -325,6 +323,7 @@ class TestAzureRMFinishTemplateProvisioning:
     @pytest.fixture(scope='class')
     def class_host_ft(
         self,
+        default_sat,
         azurermclient,
         module_azurerm_finishimg,
         module_azurerm_cr,
@@ -340,8 +339,10 @@ class TestAzureRMFinishTemplateProvisioning:
         Provisions the host on AzureRM using Finish template
         Later in tests this host will be used to perform assertions
         """
-        with hammer_api_timeout():
-            with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with default_sat.hammer_api_timeout():
+            with default_sat.skip_yum_update_during_provisioning(
+                template='Kickstart default finish'
+            ):
                 host = Host.create(
                     {
                         'name': self.hostname,
@@ -445,6 +446,7 @@ class TestAzureRMUserDataProvisioning:
     @pytest.fixture(scope='class')
     def class_host_ud(
         self,
+        default_sat,
         azurermclient,
         module_azurerm_cloudimg,
         module_azurerm_cr,
@@ -461,8 +463,10 @@ class TestAzureRMUserDataProvisioning:
         Provisions the host on AzureRM using UserData template
         Later in tests this host will be used to perform assertions
         """
-        with hammer_api_timeout():
-            with skip_yum_update_during_provisioning(template='Kickstart default user data'):
+        with default_sat.hammer_api_timeout():
+            with default_sat.skip_yum_update_during_provisioning(
+                template='Kickstart default user data'
+            ):
                 host = Host.create(
                     {
                         'name': self.hostname,
@@ -560,6 +564,7 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
     @pytest.fixture(scope='class')
     def class_byos_ft_host(
         self,
+        default_sat,
         azurermclient,
         module_azurerm_byos_finishimg,
         module_azurerm_cr,
@@ -575,8 +580,10 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
         Provisions the host on AzureRM with BYOS Image
         Later in tests this host will be used to perform assertions
         """
-        with hammer_api_timeout():
-            with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with default_sat.hammer_api_timeout():
+            with default_sat.skip_yum_update_during_provisioning(
+                template='Kickstart default finish'
+            ):
                 host = Host.create(
                     {
                         'name': self.hostname,

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -21,7 +21,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo.api.utils import satellite_setting
-from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.config import settings
 from robottelo.constants import AZURERM_FILE_URI
 from robottelo.constants import AZURERM_PLATFORM_DEFAULT
@@ -93,6 +92,7 @@ def module_azure_hg(
 @pytest.mark.tier4
 def test_positive_end_to_end_azurerm_ft_host_provision(
     session,
+    default_sat,
     azurermclient,
     module_azurerm_finishimg,
     module_azurerm_cr,
@@ -125,7 +125,9 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
 
         # Provision Host
         try:
-            with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+            with default_sat.skip_yum_update_during_provisioning(
+                template='Kickstart default finish'
+            ):
                 session.host.create(
                     {
                         'host.name': hostname,
@@ -172,6 +174,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
 @pytest.mark.upgrade
 def test_positive_azurerm_host_provision_ud(
     session,
+    default_sat,
     azurermclient,
     module_azurerm_cloudimg,
     module_azurerm_cr,
@@ -205,7 +208,9 @@ def test_positive_azurerm_host_provision_ud(
 
         # Provision Host
         try:
-            with skip_yum_update_during_provisioning(template='Kickstart default user data'):
+            with default_sat.skip_yum_update_during_provisioning(
+                template='Kickstart default user data'
+            ):
                 session.host.create(
                     {
                         'host.name': hostname,

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -34,7 +34,6 @@ from robottelo import manifests
 from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.api.utils import create_role_permissions
 from robottelo.api.utils import promote
-from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.api.utils import upload_manifest
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import make_content_view
@@ -1913,7 +1912,7 @@ def gce_hostgroup(
 @pytest.mark.tier4
 @pytest.mark.skip_if_not_set('gce')
 def test_positive_gce_provision_end_to_end(
-    session, module_org, module_loc, module_os, gce_domain, gce_hostgroup, googleclient
+    session, default_sat, module_org, module_loc, module_os, gce_domain, gce_hostgroup, googleclient
 ):
     """Provision Host on GCE compute resource
 
@@ -1933,7 +1932,9 @@ def test_positive_gce_provision_end_to_end(
         session.location.select(loc_name=module_loc.name)
         # Provision GCE Host
         try:
-            with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+            with default_sat.skip_yum_update_during_provisioning(
+                template='Kickstart default finish'
+            ):
                 session.host.create(
                     {
                         'host.name': name,
@@ -1963,7 +1964,7 @@ def test_positive_gce_provision_end_to_end(
                 assert session.host.search(hostname)[0]['Name'] == hostname
                 assert host_info['properties']['properties_table']['Build'] == 'Installed clear'
                 # 1.2 GCE Backend Assertions
-                gceapi_vm = gce_client.get_vm(gceapi_vmname)
+                gceapi_vm = googleclient.get_vm(gceapi_vmname)
                 assert gceapi_vm.is_running
                 assert gceapi_vm
                 assert gceapi_vm.name == gceapi_vmname
@@ -1988,14 +1989,14 @@ def test_positive_gce_provision_end_to_end(
                 gcehost[0].delete()
             raise error
         finally:
-            gce_client.disconnect()
+            googleclient.disconnect()
 
 
 @pytest.mark.tier4
 @pytest.mark.upgrade
 @pytest.mark.skip_if_not_set('gce')
 def test_positive_gce_cloudinit_provision_end_to_end(
-    session, module_org, module_loc, module_os, gce_domain, gce_hostgroup, googleclient
+    session, default_sat, module_org, module_loc, module_os, gce_domain, gce_hostgroup, googleclient
 ):
     """Provision Host on GCE compute resource
 
@@ -2015,7 +2016,9 @@ def test_positive_gce_cloudinit_provision_end_to_end(
         session.location.select(loc_name=module_loc.name)
         # Provision GCE Host
         try:
-            with skip_yum_update_during_provisioning(template='Kickstart default user data'):
+            with default_sat.skip_yum_update_during_provisioning(
+                template='Kickstart default user data'
+            ):
                 session.host.create(
                     {
                         'host.name': name,
@@ -2038,7 +2041,7 @@ def test_positive_gce_cloudinit_provision_end_to_end(
                     == 'Pending installation clear'
                 )
                 # 1.2 GCE Backend Assertions
-                gceapi_vm = gce_client.get_vm(gceapi_vmname)
+                gceapi_vm = googleclient.get_vm(gceapi_vmname)
                 assert gceapi_vm
                 assert gceapi_vm.is_running
                 assert gceapi_vm.name == gceapi_vmname
@@ -2063,7 +2066,7 @@ def test_positive_gce_cloudinit_provision_end_to_end(
                 gcehost[0].delete()
             raise error
         finally:
-            gce_client.disconnect()
+            googleclient.disconnect()
 
 
 @pytest.mark.run_in_one_thread

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1933,62 +1933,62 @@ def test_positive_gce_provision_end_to_end(
         session.location.select(loc_name=module_loc.name)
         # Provision GCE Host
         try:
-            skip_yum_update_during_provisioning(template='Kickstart default finish')
-            session.host.create(
-                {
-                    'host.name': name,
-                    'host.hostgroup': gce_hostgroup.name,
-                    'provider_content.virtual_machine.machine_type': 'g1-small',
-                    'provider_content.virtual_machine.external_ip': True,
-                    'provider_content.virtual_machine.network': 'default',
-                    'provider_content.virtual_machine.storage': storage,
-                    'operating_system.operating_system': module_os.title,
-                    'operating_system.image': 'autogce_img',
-                    'operating_system.root_password': root_pwd,
-                }
-            )
-            wait_for(
-                lambda: entities.Host()
-                .search(query={'search': f'name={hostname}'})[0]
-                .build_status_label
-                != 'Pending installation',
-                timeout=600,
-                delay=15,
-                silent_failure=True,
-                handle_exception=True,
-            )
-            # 1. Host Creation Assertions
-            # 1.1 UI based Assertions
-            host_info = session.host.get_details(hostname)
-            assert session.host.search(hostname)[0]['Name'] == hostname
-            assert host_info['properties']['properties_table']['Build'] == 'Installed clear'
-            # 1.2 GCE Backend Assertions
-            gceapi_vm = googleclient.get_vm(gceapi_vmname)
-            assert gceapi_vm.is_running
-            assert gceapi_vm
-            assert gceapi_vm.name == gceapi_vmname
-            assert gceapi_vm.zone == settings.gce.zone
-            assert gceapi_vm.ip == host_info['properties']['properties_table']['IP Address']
-            assert 'g1-small' in gceapi_vm.raw['machineType'].split('/')[-1]
-            assert 'default' in gceapi_vm.raw['networkInterfaces'][0]['network'].split('/')[-1]
-            # 2. Host Deletion Assertions
-            message = session.host.delete(hostname)
-            # 2.1 UI based Assertions
-            assert (
-                'Are you sure you want to delete host {}? This will delete the VM and '
-                'its disks, and is irreversible. This behavior can be changed via '
-                'global setting "Destroy associated VM on host delete".'.format(hostname)
-            ) == message
-            assert not session.host.search(hostname)
-            # 2.2 GCE Backend Assertions
-            assert gceapi_vm.is_stopping or gceapi_vm.is_stopped
+            with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+                session.host.create(
+                    {
+                        'host.name': name,
+                        'host.hostgroup': gce_hostgroup.name,
+                        'provider_content.virtual_machine.machine_type': 'g1-small',
+                        'provider_content.virtual_machine.external_ip': True,
+                        'provider_content.virtual_machine.network': 'default',
+                        'provider_content.virtual_machine.storage': storage,
+                        'operating_system.operating_system': module_os.title,
+                        'operating_system.image': 'autogce_img',
+                        'operating_system.root_password': root_pwd,
+                    }
+                )
+                wait_for(
+                    lambda: entities.Host()
+                    .search(query={'search': f'name={hostname}'})[0]
+                    .build_status_label
+                    != 'Pending installation',
+                    timeout=600,
+                    delay=15,
+                    silent_failure=True,
+                    handle_exception=True,
+                )
+                # 1. Host Creation Assertions
+                # 1.1 UI based Assertions
+                host_info = session.host.get_details(hostname)
+                assert session.host.search(hostname)[0]['Name'] == hostname
+                assert host_info['properties']['properties_table']['Build'] == 'Installed clear'
+                # 1.2 GCE Backend Assertions
+                gceapi_vm = gce_client.get_vm(gceapi_vmname)
+                assert gceapi_vm.is_running
+                assert gceapi_vm
+                assert gceapi_vm.name == gceapi_vmname
+                assert gceapi_vm.zone == settings.gce.zone
+                assert gceapi_vm.ip == host_info['properties']['properties_table']['IP Address']
+                assert 'g1-small' in gceapi_vm.raw['machineType'].split('/')[-1]
+                assert 'default' in gceapi_vm.raw['networkInterfaces'][0]['network'].split('/')[-1]
+                # 2. Host Deletion Assertions
+                message = session.host.delete(hostname)
+                # 2.1 UI based Assertions
+                assert (
+                    'Are you sure you want to delete host {}? This will delete the VM and '
+                    'its disks, and is irreversible. This behavior can be changed via '
+                    'global setting "Destroy associated VM on host delete".'.format(hostname)
+                ) == message
+                assert not session.host.search(hostname)
+                # 2.2 GCE Backend Assertions
+                assert gceapi_vm.is_stopping or gceapi_vm.is_stopped
         except Exception as error:
             gcehost = entities.Host().search(query={'search': f'name={hostname}'})
             if gcehost:
                 gcehost[0].delete()
             raise error
         finally:
-            skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
+            gce_client.disconnect()
 
 
 @pytest.mark.tier4
@@ -2015,56 +2015,55 @@ def test_positive_gce_cloudinit_provision_end_to_end(
         session.location.select(loc_name=module_loc.name)
         # Provision GCE Host
         try:
-            skip_yum_update_during_provisioning(template='Kickstart default user data')
-            session.host.create(
-                {
-                    'host.name': name,
-                    'host.hostgroup': gce_hostgroup.name,
-                    'provider_content.virtual_machine.machine_type': 'g1-small',
-                    'provider_content.virtual_machine.external_ip': True,
-                    'provider_content.virtual_machine.network': 'default',
-                    'provider_content.virtual_machine.storage': storage,
-                    'operating_system.operating_system': module_os.title,
-                    'operating_system.image': 'autogce_img_cinit',
-                    'operating_system.root_password': root_pwd,
-                }
-            )
-            # 1. Host Creation Assertions
-            # 1.1 UI based Assertions
-            host_info = session.host.get_details(hostname)
-            assert session.host.search(hostname)[0]['Name'] == hostname
-            assert (
-                host_info['properties']['properties_table']['Build'] == 'Pending installation clear'
-            )
-            # 1.2 GCE Backend Assertions
-            gceapi_vm = googleclient.get_vm(gceapi_vmname)
-            assert gceapi_vm
-            assert gceapi_vm.is_running
-            assert gceapi_vm.name == gceapi_vmname
-            assert gceapi_vm.zone == settings.gce.zone
-            assert gceapi_vm.ip == host_info['properties']['properties_table']['IP Address']
-            assert 'g1-small' in gceapi_vm.raw['machineType'].split('/')[-1]
-            assert 'default' in gceapi_vm.raw['networkInterfaces'][0]['network'].split('/')[-1]
-            # 2. Host Deletion Assertions
-            message = session.host.delete(hostname)
-            # 2.1 UI based Assertions
-            assert (
-                'Are you sure you want to delete host {}? This will delete the VM and '
-                'its disks, and is irreversible. This behavior can be changed via '
-                'global setting "Destroy associated VM on host delete".'.format(hostname)
-            ) == message
-            assert not session.host.search(hostname)
-            # 2.2 GCE Backend Assertions
-            assert gceapi_vm.is_stopping or gceapi_vm.is_stopped
+            with skip_yum_update_during_provisioning(template='Kickstart default user data'):
+                session.host.create(
+                    {
+                        'host.name': name,
+                        'host.hostgroup': gce_hostgroup.name,
+                        'provider_content.virtual_machine.machine_type': 'g1-small',
+                        'provider_content.virtual_machine.external_ip': True,
+                        'provider_content.virtual_machine.network': 'default',
+                        'provider_content.virtual_machine.storage': storage,
+                        'operating_system.operating_system': module_os.title,
+                        'operating_system.image': 'autogce_img_cinit',
+                        'operating_system.root_password': root_pwd,
+                    }
+                )
+                # 1. Host Creation Assertions
+                # 1.1 UI based Assertions
+                host_info = session.host.get_details(hostname)
+                assert session.host.search(hostname)[0]['Name'] == hostname
+                assert (
+                    host_info['properties']['properties_table']['Build']
+                    == 'Pending installation clear'
+                )
+                # 1.2 GCE Backend Assertions
+                gceapi_vm = gce_client.get_vm(gceapi_vmname)
+                assert gceapi_vm
+                assert gceapi_vm.is_running
+                assert gceapi_vm.name == gceapi_vmname
+                assert gceapi_vm.zone == settings.gce.zone
+                assert gceapi_vm.ip == host_info['properties']['properties_table']['IP Address']
+                assert 'g1-small' in gceapi_vm.raw['machineType'].split('/')[-1]
+                assert 'default' in gceapi_vm.raw['networkInterfaces'][0]['network'].split('/')[-1]
+                # 2. Host Deletion Assertions
+                message = session.host.delete(hostname)
+                # 2.1 UI based Assertions
+                assert (
+                    'Are you sure you want to delete host {}? This will delete the VM and '
+                    'its disks, and is irreversible. This behavior can be changed via '
+                    'global setting "Destroy associated VM on host delete".'.format(hostname)
+                ) == message
+                assert not session.host.search(hostname)
+                # 2.2 GCE Backend Assertions
+                assert gceapi_vm.is_stopping or gceapi_vm.is_stopped
         except Exception as error:
             gcehost = entities.Host().search(query={'search': f'name={hostname}'})
             if gcehost:
                 gcehost[0].delete()
             raise error
         finally:
-            skip_yum_update_during_provisioning(
-                template='Kickstart default user data', reverse=True
-            )
+            gce_client.disconnect()
 
 
 @pytest.mark.run_in_one_thread

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -130,8 +130,7 @@ class TestScenarioPositiveGCEHostComputeResource:
             'image_id': LATEST_RHEL7_GCE_IMG_UUID,
         }
         # Host Provisioning Tests
-        try:
-            skip_yum_update_during_provisioning(template='Kickstart default finish')
+        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
             gce_hst = entities.Host(
                 name=hostname,
                 organization=org,
@@ -144,8 +143,6 @@ class TestScenarioPositiveGCEHostComputeResource:
                 operatingsystem=os,
                 provision_method='image',
             ).create()
-        finally:
-            skip_yum_update_during_provisioning(template='Kickstart default finish', reverse=True)
         wait_for(
             lambda: entities.Host()
             .search(query={'search': f'name={self.fullhost}'})[0]

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -29,7 +29,6 @@ from upgrade_tests.helpers.scenarios import create_dict
 from upgrade_tests.helpers.scenarios import get_entity_data
 from wait_for import wait_for
 
-from robottelo.api.utils import skip_yum_update_during_provisioning
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import LATEST_RHEL7_GCE_IMG_UUID
@@ -111,7 +110,7 @@ class TestScenarioPositiveGCEHostComputeResource:
         assert gce_img.name == 'autoupgrade_gce_img'
 
     @post_upgrade(depend_on=test_pre_create_gce_cr_and_host)
-    def test_post_create_gce_cr_and_host(self, arch_os_domain, delete_host):
+    def test_post_create_gce_cr_and_host(self, default_sat, arch_os_domain, delete_host):
         """"""
         arch, os, domain_name = arch_os_domain
         hostname = gen_string('alpha')
@@ -130,7 +129,7 @@ class TestScenarioPositiveGCEHostComputeResource:
             'image_id': LATEST_RHEL7_GCE_IMG_UUID,
         }
         # Host Provisioning Tests
-        with skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
             gce_hst = entities.Host(
                 name=hostname,
                 organization=org,


### PR DESCRIPTION
Azure CLI tests failing with Timeout error are now being fixed with a fix of set_hammer_api_timeout. Also, its converted to context managers.

Now there are 2 new context managers:
1. hammer_api_timeout
2. skip_yum_during_provisioning