### PR TITLE
Fix puppetclass and environment

### DIFF
--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -18,34 +18,21 @@
 """
 import pytest
 
-from robottelo.cli.environment import Environment
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import publish_puppet_module
 from robottelo.cli.puppet import Puppet
 from robottelo.config import settings
-from robottelo.constants.repos import CUSTOM_PUPPET_REPO
-
-
-@pytest.fixture(scope='module')
-def make_puppet():
-    """Import a parametrized puppet class."""
-    puppet_modules = [{'author': 'robottelo', 'name': 'generic_1'}]
-    org = make_org()
-    cv = publish_puppet_module(puppet_modules, CUSTOM_PUPPET_REPO, org['id'])
-    env = Environment.list({'search': f'content_view="{cv["name"]}"'})[0]
-    puppet = Puppet.info({'name': puppet_modules[0]['name'], 'environment': env['name']})
-    return puppet
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason="Missing repos_hosting_url")
-def test_positive_list_smart_class_parameters(make_puppet):
+def test_positive_list_smart_class_parameters(module_import_puppet_module):
     """List smart class parameters associated with the puppet class.
 
     :id: 56b370c2-8fc6-49be-9676-242178cc709a
 
     :expectedresults: Smart class parameters listed for the class.
     """
-    class_sc_parameters = Puppet.sc_params({'puppet-class': make_puppet['name']})
+    class_sc_parameters = Puppet.sc_params(
+        {'puppet-class': module_import_puppet_module['puppet_class']}
+    )
     assert len(class_sc_parameters) == 200


### PR DESCRIPTION
Just an easy fix for puppet removal.

Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/cli/test_puppetclass.py tests/foreman/cli/test_environment.py
====================================================== test session starts ======================================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.3.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 28 items                                                                                                              

tests/foreman/cli/test_puppetclass.py .                                                                                   [  3%]
tests/foreman/cli/test_environment.py ...........................                                                         [100%]

...
========================================== 28 passed, 14 warnings in 424.34s (0:07:04) ==========================================
```