### PR TITLE
Updated Polarion Group ID to take only release version

### DIFF
--- a/scripts/polarion-test-run-upload.sh
+++ b/scripts/polarion-test-run-upload.sh
@@ -65,7 +65,7 @@ fi
 
 TOKEN_PREFIX=""
 POLARION_SELECTOR="name=Satellite 6"
-TEST_RUN_GROUP_ID="$(echo ${TEST_RUN_ID} | cut -d' ' -f2)"
+TEST_RUN_GROUP_ID="$(echo ${TEST_RUN_ID} | cut -d' ' -f2 | cut -d'-' -f1)"
 
 set -x
 betelgeuse ${TOKEN_PREFIX} test-run \


### PR DESCRIPTION
Updated `Group ID` in polarion to take only release version of Satellite and exclude snap version from it. Earlier it include `snap version` in group ID. 

 sh scripts/polarion-test-run-upload.sh -u shwsingh -p **** -s <polarion-url> -P "Interop" -i "Satellite 6.10.0-14.0 rhel7" -r results.xml 
+ betelgeuse test-run --custom-fields isautomated=true --custom-fields arch=x8664 --custom-fields variant=server --response-property 'name=Satellite 6' --test-run-title 'Satellite 6.10.0-14.0 rhel7' --test-run-id 'Satellite 6.10.0-14.0 rhel7' --test-run-group-id 6.10.0 --status inprogress results.xml tests/foreman shwsingh Interop results.xml
+ curl -f -k -u shwsingh:**** -F file=@results.xml <polarion-url>/import/xunit
{
  "files" : {
    "results.xml" : {
      "job-ids" : [ 305488 ]
    }
  }
}


![image](https://user-images.githubusercontent.com/30014856/131304288-aa3ec5f2-e862-40d3-a01a-082d9b193a19.png)

