### PR TITLE
Added automated customer scenario for BZ#1733269

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1063,6 +1063,7 @@ def make_user(options=None):
         'mail': f'{login}@example.com',
         'organization-ids': None,
         'password': gen_alphanumeric(),
+        'timezone': None,
     }
     logger.debug(
         'User "{}" password not provided {} was generated'.format(args['login'], args['password'])

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -654,3 +654,44 @@ def test_negative_update_name(new_name, module_org):
     """
     with pytest.raises(CLIReturnCodeError):
         Org.update({'id': module_org.id, 'new-name': new_name})
+
+
+@pytest.mark.tier2
+def test_positive_create_user_with_timezone(module_org):
+    """Create and remove user with valid timezone in an organization
+
+    :id: b9b92c00-ee99-4da2-84c5-0a576a862100
+
+    :customerscenario: true
+
+    :BZ: 1733269
+
+    :CaseLevel: Integration
+
+    :CaseImportance: High
+
+    :steps:
+        1. Add user from organization with valid timezone
+        2. Validate user's timezone
+        3. Remove user from organization and validate
+
+    :expectedresults: User created and removed successfully with valid timezone
+
+    """
+    users_timezones = [
+        'Pacific Time (US & Canada)',
+        'International Date Line West',
+        'American Samoa',
+        'Tokyo',
+        'Samoa',
+    ]
+    for timezone in users_timezones:
+        user = make_user({'timezone': timezone, 'admin': '1'})
+        Org.add_user({'name': module_org.name, 'user': user['login']})
+
+        org_info = Org.info({'name': module_org.name})
+        assert user['login'] in org_info['users']
+        assert user['timezone'] == timezone
+        Org.remove_user({'id': module_org.id, 'user-id': user['id']})
+        org_info = Org.info({'name': module_org.name})
+        assert user['login'] not in org_info['users']


### PR DESCRIPTION
It creates user with a valid timezone. 

pytest tests/foreman/cli/test_organization.py -k test_positive_create_user_with_timezone 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/shwsingh/SatelliteQE/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, cov-2.12.1, ibutsu-1.16, xdist-2.3.0, mock-3.6.1
collected 37 items / 36 deselected / 1 selected                                                                                                                                                                   

tests/foreman/cli/test_organization.py .                                                                                                                                                                    [100%]

================================================================================================ warnings summary =================================================================================================
../SatEnv/lib64/python3.8/site-packages/attrdict/mapping.py:4
  /home/shwsingh/SatelliteQE/SatEnv/lib64/python3.8/site-packages/attrdict/mapping.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

../SatEnv/lib64/python3.8/site-packages/attrdict/mixins.py:5
../SatEnv/lib64/python3.8/site-packages/attrdict/mixins.py:5
  /home/shwsingh/SatelliteQE/SatEnv/lib64/python3.8/site-packages/attrdict/mixins.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, MutableMapping, Sequence

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================================================ 1 passed, 36 deselected, 3 warnings in 228.21s (0:03:48) =============================================================================