### PR TITLE
[cherrypick] move junit xml properties recording from fixtures to hooks

### DIFF
--- a/pytest_fixtures/reporting_fixtures.py
+++ b/pytest_fixtures/reporting_fixtures.py
@@ -50,15 +50,3 @@ def pytest_sessionstart(session):
 def record_testsuite_timestamp_xml(record_testsuite_property):
     now = datetime.datetime.utcnow()
     record_testsuite_property('start_time', now.strftime(FMT_XUNIT_TIME))
-
-
-@pytest.fixture(autouse=True, scope='function')
-def record_test_timestamp_xml(request):
-    now = datetime.datetime.utcnow()
-    request.node.user_properties.append(('start_time', now.strftime(FMT_XUNIT_TIME)))
-
-
-@pytest.fixture(autouse=True, scope='function')
-def record_test_markers_xml(request, record_property):
-    for marker in request.node.iter_markers():
-        request.node.user_properties.append((marker.name, next(iter(marker.args), None)))

--- a/tests/robottelo/conftest.py
+++ b/tests/robottelo/conftest.py
@@ -31,9 +31,9 @@ def exec_test(request, dummy_test):
     pytest_args.append(f'--junit-xml={report_file}')
     with NamedTemporaryFile(dir=test_dir, mode='w', prefix='test_', suffix='.py') as f:
         f.seek(0)
-        f.write(dummy_test)
+        f.write(dummy_test['body'])
         f.flush()
-        pytest_args.append(f'{f.name}::test_dummy')
+        pytest_args.append(f'{f.name}::{dummy_test["name"]}')
         pytest.main(pytest_args)
     yield report_file
     for logfile in glob.glob('robottelo*.log'):

--- a/tests/robottelo/test_report.py
+++ b/tests/robottelo/test_report.py
@@ -5,10 +5,11 @@ import xmltodict
 
 XUNIT_TIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
 dummy_test_count = 2
-dummy_test = f'''import pytest
+dummy_test_name = 'test_junit_dummy'
+dummy_test_body = f'''import pytest
 
 @pytest.mark.parametrize('param', list(range(0, {dummy_test_count})))
-def test_dummy(param):
+def {dummy_test_name}(param):
     """A dummy test used by test_junit_timestamps.
     Not to be run as a standalone test
     """
@@ -27,7 +28,12 @@ property_paths = [
 
 @pytest.mark.parametrize('property_level', property_paths, ids=['testsuite', 'testcase'])
 @pytest.mark.parametrize('exec_test', ['-n2', '-n0'], ids=['xdist', 'non_xdist'], indirect=True)
-@pytest.mark.parametrize('dummy_test', [dummy_test], ids=['dummy_test'], indirect=True)
+@pytest.mark.parametrize(
+    'dummy_test',
+    [{'name': dummy_test_name, 'body': dummy_test_body}],
+    ids=['dummy_test'],
+    indirect=True,
+)
 def test_junit_timestamps(exec_test, property_level):
     """Asserts the 'start_time' property nodes existence in the junit-xml test report"""
     with open(exec_test, 'rb') as f:


### PR DESCRIPTION
backport of https://github.com/SatelliteQE/robottelo/pull/8903