### PR TITLE
[cherrypick] Get GCE cert details from json (#8859)

### DIFF
--- a/conf/gce.yaml.template
+++ b/conf/gce.yaml.template
@@ -1,12 +1,8 @@
 GCE:
   # Google Provider as Compute Resource
-  # Project name in Google provider
-  PROJECT_ID:  # example-project-id
-  # Service Account email id which has compute admin permission
-  CLIENT_EMAIL: client@example.com
   # client json Certificate path which is local path on satellite
   CERT_PATH: /path/to/certificate.json
   # Zones
   ZONE: example-zone
-  # client certificate URL
-  CERT_URL: /path/to/certificate/url
+  # client certificate
+  CERT: "{}" # client json Certificate

--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -5,7 +5,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
 from wrapanapi import AzureSystem
-from wrapanapi import GoogleCloudSystem
 
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
@@ -32,7 +31,6 @@ from robottelo.constants import REPOSET
 from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.constants.repos import CUSTOM_PUPPET_REPO
-from robottelo.helpers import download_gce_cert
 from robottelo.logging import logger
 
 
@@ -323,18 +321,6 @@ def module_libvirt_image(module_cr_libvirt):
 
 
 @pytest.fixture(scope='session')
-def googleclient():
-    gceclient = GoogleCloudSystem(
-        project=settings.gce.project_id,
-        zone=settings.gce.zone,
-        file_path=download_gce_cert(),
-        file_type='json',
-    )
-    yield gceclient
-    gceclient.disconnect()
-
-
-@pytest.fixture(scope='session')
 def gce_latest_rhel_uuid(googleclient):
     template_names = [img.name for img in googleclient.list_templates(True)]
     latest_rhel7_template = max(name for name in template_names if name.startswith('rhel-7'))
@@ -343,19 +329,19 @@ def gce_latest_rhel_uuid(googleclient):
 
 
 @pytest.fixture(scope='session')
-def gce_custom_cloudinit_uuid(googleclient):
-    cloudinit_uuid = googleclient.get_template('customcinit', project=settings.gce.project_id).uuid
+def gce_custom_cloudinit_uuid(googleclient, gce_cert):
+    cloudinit_uuid = googleclient.get_template('customcinit', project=gce_cert['project_id']).uuid
     return cloudinit_uuid
 
 
 @pytest.fixture(scope='module')
-def module_gce_compute(module_org, module_location):
+def module_gce_compute(module_org, module_location, gce_cert):
     gce_cr = entities.GCEComputeResource(
         name=gen_string('alphanumeric'),
         provider='GCE',
-        email=settings.gce.client_email,
+        email=gce_cert['client_email'],
         key_path=settings.gce.cert_path,
-        project=settings.gce.project_id,
+        project=gce_cert['project_id'],
         zone=settings.gce.zone,
         organization=[module_org],
         location=[module_location],

--- a/pytest_fixtures/sys_fixtures.py
+++ b/pytest_fixtures/sys_fixtures.py
@@ -1,6 +1,12 @@
-import pytest
+import json
+from tempfile import mkstemp
 
+import pytest
+from wrapanapi.systems.google import GoogleCloudSystem
+
+from robottelo import ssh
 from robottelo.config import settings
+from robottelo.errors import GCECertNotFoundError
 
 
 @pytest.fixture
@@ -32,3 +38,30 @@ def proxy_port_range(default_sat):
         port_pool_range = settings.fake_capsules.port_range
         if default_sat.execute(f'semanage port -l | grep {port_pool_range}').status != 0:
             default_sat.execute(f'semanage port -a -t websm_port_t -p tcp {port_pool_range}')
+
+
+@pytest.fixture(scope='session')
+def gce_cert():
+    _, gce_cert_file = mkstemp(suffix='.json')
+    cert = json.loads(settings.gce.cert)
+    cert['local_path'] = gce_cert_file
+    with open(gce_cert_file, 'w') as f:
+        json.dump(cert, f)
+    ssh.upload_file(gce_cert_file, settings.gce.cert_path)
+    if ssh.command(f'[ -f {settings.gce.cert_path} ]').return_code != 0:
+        raise GCECertNotFoundError(
+            f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
+        )
+    return cert
+
+
+@pytest.fixture(scope='session')
+def googleclient(gce_cert):
+    gceclient = GoogleCloudSystem(
+        project=gce_cert['project_id'],
+        zone=settings.gce.zone,
+        file_path=gce_cert['local_path'],
+        file_type='json',
+    )
+    yield gceclient
+    gceclient.disconnect()

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -123,11 +123,9 @@ VALIDATORS = dict(
     ],
     gce=[
         Validator(
-            'gce.project_id',
-            'gce.client_email',
             'gce.cert_path',
             'gce.zone',
-            'gce.cert_url',
+            'gce.cert',
             must_exist=True,
         ),
         Validator('gce.cert_path', startswith='/usr/share/foreman/'),

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -1,6 +1,5 @@
 """Several helper methods and functions."""
 import contextlib
-import json
 import os
 import random
 import re
@@ -20,7 +19,6 @@ from robottelo.config import settings
 from robottelo.constants import PULP_PUBLISHED_YUM_REPOS_PATH
 from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
-from robottelo.errors import GCECertNotFoundError
 from robottelo.logging import logger
 
 
@@ -700,19 +698,6 @@ def slugify_component(string, keep_hyphens=True):
 
 
 # --- Issue based Pytest markers ---
-
-
-def download_gce_cert():
-    _, gce_cert = mkstemp(suffix='.json')
-    cert_json = json.loads(settings.gce.cert)
-    with open(gce_cert, 'w') as f:
-        json.dump(cert_json, f)
-    ssh.upload_file(gce_cert, settings.gce.cert_path)
-    if ssh.command(f'[ -f {settings.gce.cert_path} ]').return_code != 0:
-        raise GCECertNotFoundError(
-            f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
-        )
-    return download_server_file('json', settings.gce.cert_url)
 
 
 def idgen(val):

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -28,15 +28,6 @@ from nailgun import entities
 from robottelo.config import settings
 from robottelo.constants import VALID_GCE_ZONES
 
-
-GCE_SETTINGS = dict(
-    project_id=settings.gce.project_id,
-    client_email=settings.gce.client_email,
-    cert_path=settings.gce.cert_path,
-    zone=settings.gce.zone,
-)
-
-
 clouduser = gen_string('alpha')
 finishuser = gen_string('alpha')
 
@@ -117,11 +108,12 @@ def gce_hostgroup(
     return hgroup
 
 
+@pytest.mark.skip_if_not_set('gce')
 class TestGCEComputeResourceTestCases:
     """Tests for ``api/v2/compute_resources``."""
 
     @pytest.mark.tier1
-    def test_positive_crud_gce_cr(self, module_org, module_location):
+    def test_positive_crud_gce_cr(self, module_org, module_location, gce_cert):
         """Create, Read, Update and Delete GCE compute resources
 
         :id: b324f8cd-d509-4d7a-b738-08aefafdc2b5
@@ -137,10 +129,10 @@ class TestGCEComputeResourceTestCases:
         compresource = entities.GCEComputeResource(
             name=cr_name,
             provider='GCE',
-            email=GCE_SETTINGS['client_email'],
-            key_path=GCE_SETTINGS['cert_path'],
-            project=GCE_SETTINGS['project_id'],
-            zone=GCE_SETTINGS['zone'],
+            email=gce_cert['client_email'],
+            key_path=settings.gce.cert_path,
+            project=gce_cert['project_id'],
+            zone=settings.gce.zone,
             organization=[module_org],
             location=[module_location],
         ).create()
@@ -162,7 +154,6 @@ class TestGCEComputeResourceTestCases:
         updated.delete()
         assert not entities.GCEComputeResource().search(query={'search': f'name={new_name}'})
 
-    @pytest.mark.skip_if_open("BZ:1794744")
     @pytest.mark.tier3
     def test_positive_check_available_images(self, module_gce_compute, googleclient):
         """Verify all the images from GCE are available to select from
@@ -192,7 +183,6 @@ class TestGCEComputeResourceTestCases:
         gcloudclient_networks = googleclient.list_network()
         assert sorted(satgce_networks) == sorted(gcloudclient_networks)
 
-    @pytest.mark.skip_if_open("BZ:1794744")
     @pytest.mark.tier3
     def test_positive_check_available_flavors(self, module_gce_compute):
         """Verify flavors from GCE are available to select
@@ -251,6 +241,7 @@ class TestGCEComputeResourceTestCases:
         assert module_gce_cloudimg.username == clouduser
 
 
+@pytest.mark.skip_if_not_set('gce')
 class TestGCEHostProvisioningTestCase:
     """GCE Host Provisioning Tests
 

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -26,13 +26,12 @@ from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import GCE_EXTERNAL_IP_DEFAULT
 from robottelo.constants import GCE_MACHINE_TYPE_DEFAULT
 from robottelo.constants import GCE_NETWORK_DEFAULT
-from robottelo.helpers import download_gce_cert
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skip_if_not_set('http_proxy', 'gce')
-def test_positive_default_end_to_end_with_custom_profile(session, module_org, module_loc):
+def test_positive_default_end_to_end_with_custom_profile(session, module_org, module_loc, gce_cert):
     """Create GCE compute resource with default properties and apply it's basic functionality.
 
     :id: 59ffd83e-a984-4c22-b91b-cad055b4fbd7
@@ -56,7 +55,6 @@ def test_positive_default_end_to_end_with_custom_profile(session, module_org, mo
     cr_description = gen_string('alpha')
     new_org = entities.Organization().create()
     new_loc = entities.Location().create()
-    download_gce_cert()
     http_proxy = entities.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.auth_proxy_url,
@@ -73,8 +71,8 @@ def test_positive_default_end_to_end_with_custom_profile(session, module_org, mo
                 'description': cr_description,
                 'provider': FOREMAN_PROVIDERS['google'],
                 'provider_content.http_proxy.value': http_proxy.name,
-                'provider_content.google_project_id': settings.gce.project_id,
-                'provider_content.client_email': settings.gce.client_email,
+                'provider_content.google_project_id': gce_cert['project_id'],
+                'provider_content.client_email': gce_cert['client_email'],
                 'provider_content.certificate_path': settings.gce.cert_path,
                 'provider_content.zone.value': settings.gce.zone,
                 'organizations.resources.assigned': [module_org.name],
@@ -87,8 +85,8 @@ def test_positive_default_end_to_end_with_custom_profile(session, module_org, mo
         assert cr_values['provider_content']['http_proxy']['value'] == http_proxy.name
         assert cr_values['organizations']['resources']['assigned'] == [module_org.name]
         assert cr_values['locations']['resources']['assigned'] == [module_loc.name]
-        assert cr_values['provider_content']['google_project_id'] == settings.gce.project_id
-        assert cr_values['provider_content']['client_email'] == settings.gce.client_email
+        assert cr_values['provider_content']['google_project_id'] == gce_cert['project_id']
+        assert cr_values['provider_content']['client_email'] == gce_cert['client_email']
         # Compute Resource Edit/Updates and Assertions
         session.computeresource.edit(
             cr_name,

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -34,15 +34,6 @@ from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import LATEST_RHEL7_GCE_IMG_UUID
 from robottelo.constants import VALID_GCE_ZONES
-from robottelo.helpers import download_gce_cert
-
-GCE_SETTINGS = dict(
-    project_id=settings.gce.project_id,
-    client_email=settings.gce.client_email,
-    cert_path=settings.gce.cert_path,
-    zone=settings.gce.zone,
-    cert_url=settings.gce.cert_url,
-)
 
 
 class TestScenarioPositiveGCEHostComputeResource:
@@ -60,10 +51,6 @@ class TestScenarioPositiveGCEHostComputeResource:
         1. The host should be provisioned on GCE CR created in previous version
         2. The GCE CR attributes should be manipulated
     """
-
-    @pytest.fixture(scope='class', autouse=True)
-    def get_gce_cert(self):
-        download_gce_cert()
 
     @pytest.fixture(scope='class')
     def arch_os_domain(self, default_sat):
@@ -83,7 +70,7 @@ class TestScenarioPositiveGCEHostComputeResource:
                 entities.Host(id=host[0].id).delete()
 
     @pre_upgrade
-    def test_pre_create_gce_cr_and_host(self, arch_os_domain, function_org):
+    def test_pre_create_gce_cr_and_host(self, arch_os_domain, function_org, gce_cert):
         """"""
         arch, os, domain_name = arch_os_domain
         cr_name = gen_string('alpha')
@@ -94,10 +81,10 @@ class TestScenarioPositiveGCEHostComputeResource:
                 {
                     'name': cr_name,
                     'provider': FOREMAN_PROVIDERS['google'],
-                    'provider_content.google_project_id': GCE_SETTINGS['project_id'],
-                    'provider_content.client_email': GCE_SETTINGS['client_email'],
-                    'provider_content.certificate_path': GCE_SETTINGS['cert_path'],
-                    'provider_content.zone.value': GCE_SETTINGS['zone'],
+                    'provider_content.google_project_id': gce_cert['project_id'],
+                    'provider_content.client_email': gce_cert['client_email'],
+                    'provider_content.certificate_path': settings.gce.cert_path,
+                    'provider_content.zone.value': settings.gce.zone,
                     'organizations.resources.assigned': [function_org.name],
                     'locations.resources.assigned': [loc.name],
                 }


### PR DESCRIPTION
Test results for 6.9:
```
pytest tests/foreman/ui/test_computeresource_gce.py 
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.16, xdist-2.3.0, forked-1.3.0, mock-3.6.1, reportportal-5.0.8, services-2.2.1, cov-2.12.1
collected 1 item                                                                                                                                                                                

tests/foreman/ui/test_computeresource_gce.py .                                                                                                                                            [100%]

=========================================================================== 1 passed, 3 warnings in 211.72s (0:03:31) ===========================================================================

pytest tests/foreman/api/test_computeresource_gce.py -k TestGCEComputeResourceTestCases
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.16, xdist-2.3.0, forked-1.3.0, mock-3.6.1, reportportal-5.0.8, services-2.2.1, cov-2.12.1
collected 9 items / 3 deselected / 6 selected                                                                                                                                                   

tests/foreman/api/test_computeresource_gce.py .F....                                                                                                                                      [100%]

==================================================================================== short test summary info ====================================================================================
FAILED tests/foreman/api/test_computeresource_gce.py::TestGCEComputeResourceTestCases::test_positive_check_available_images - AssertionError: assert 14 == 1808
=============================================================== 1 failed, 5 passed, 3 deselected, 19 warnings in 91.69s (0:01:31) ===============================================================


pytest -v tests/upgrades/test_host.py -k test_pre_create_gce_cr_and_host -m pre_upgrade
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.9.5, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo3.9/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: ibutsu-1.16, xdist-2.3.0, forked-1.3.0, mock-3.6.1, reportportal-5.0.8, services-2.2.1, cov-2.12.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                                   

tests/upgrades/test_host.py::TestScenarioPositiveGCEHostComputeResource::test_pre_create_gce_cr_and_host PASSED                                                                           [100%]

==================================================================== 1 passed, 1 deselected, 5 warnings in 77.71s (0:01:17) =====================================================================```