### PR TITLE
ansible collection repo sync from hub

### DIFF
--- a/conf/ansible_hub.yaml.template
+++ b/conf/ansible_hub.yaml.template
@@ -1,0 +1,4 @@
+ANSIBLE_HUB:
+  URL:
+  TOKEN:
+  SSO_URL:

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -622,6 +622,8 @@ def make_repository_with_credentials(options=None, credentials=None):
         'http-proxy-policy': None,
         'ansible-collection-requirements': None,
         'ansible-collection-requirements-file': None,
+        'ansible-collection-auth-token': None,
+        'ansible-collection-auth-url': None,
         'url': settings.repos.yum_1.url,
     }
     repo_cls = _entity_with_credentials(credentials, Repository)

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -37,6 +37,11 @@ VALIDATORS = dict(
         Validator('subscription.rhn_password', must_exist=True),
         Validator('subscription.rhn_poolid', must_exist=True),
     ],
+    ansible_hub=[
+        Validator('ansible_hub.url', must_exist=True),
+        Validator('ansible_hub.token', must_exist=True),
+        Validator('ansible_hub.sso_url', must_exist=True),
+    ],
     azurerm=[
         Validator(
             'azurerm.client_id',

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2405,7 +2405,7 @@ class TestAnsibleCollectionRepository:
         ids=['ansible_galaxy', 'ansible_hub'],
         indirect=True,
     )
-    def test_positive_sync_ansible_collecion_from_galaxy(self, repo, module_org, module_product):
+    def test_positive_sync_ansible_collection_from_galaxy(self, repo, module_org, module_product):
         """Sync ansible collection repository from Ansible Galaxy
 
         :id: 4b6a819b-8c3d-4a74-bd97-ee3f34cf5d92

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2385,20 +2385,27 @@ class TestAnsibleCollectionRepository:
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
-        **parametrized(
-            [
-                {
-                    'content-type': 'ansible_collection',
-                    'url': ANSIBLE_GALAXY,
-                    'ansible-collection-requirements': '{collections: [ \
+        [
+            {
+                'content-type': 'ansible_collection',
+                'url': ANSIBLE_GALAXY,
+                'ansible-collection-requirements': '{collections: [ \
                             { name: theforeman.foreman, version: "2.1.0" }, \
                             { name: theforeman.operations, version: "0.1.0"} ]}',
-                }
-            ]
-        ),
+            },
+            {
+                'content-type': 'ansible_collection',
+                'url': settings.ansible_hub.url,
+                'ansible-collection-auth-token': settings.ansible_hub.token,
+                'ansible-collection-auth-url': settings.ansible_hub.sso_url,
+                'ansible-collection-requirements': '{collections: \
+                                                         [redhat.satellite_operations ]}',
+            },
+        ],
+        ids=['ansible_galaxy', 'ansible_hub'],
         indirect=True,
     )
-    def test_positive_sync_ansible_collecion_from_gallaxy(self, repo, module_org, module_product):
+    def test_positive_sync_ansible_collecion_from_galaxy(self, repo, module_org, module_product):
         """Sync ansible collection repository from Ansible Galaxy
 
         :id: 4b6a819b-8c3d-4a74-bd97-ee3f34cf5d92
@@ -2408,6 +2415,8 @@ class TestAnsibleCollectionRepository:
         :CaseLevel: Integration
 
         :CaseImportance: High
+
+        :parametrized: yes
 
         """
         Repository.synchronize({'id': repo['id']})


### PR DESCRIPTION
```
pytest tests/foreman/cli/test_repository.py -k test_positive_sync_ansible_collecion_from_gallaxy
=================================================== test session starts ====================================================
platform linux -- Python 3.9.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, cov-2.12.1, xdist-2.3.0, ibutsu-1.16
collected 238 items / 236 deselected / 2 selected                                                                          

tests/foreman/cli/test_repository.py ..                                                                              [100%]

================================= 2 passed, 236 deselected, 6 warnings in 80.49s (0:01:20) =================================
```

Ready for review, though putting wip to wait for the associated satelliteqe-jenkins PR