### PR TITLE
Search the SKU via subscription CLI for virt-who API cases

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -19,9 +19,11 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from wait_for import wait_for
 
+from robottelo.cli.host import Host
+from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import create_http_proxy
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -60,23 +62,6 @@ def virtwho_config(form_data):
 
 
 class TestVirtWhoConfigforEsx:
-    def _try_to_get_guest_bonus(self, hypervisor_name, sku):
-        subscriptions = entities.Subscription().search(query={'search': sku})
-        for item in subscriptions:
-            item = item.read_json()
-            if hypervisor_name.lower() in item['hypervisor']['name']:
-                return item['id']
-
-    def _get_guest_bonus(self, hypervisor_name, sku):
-        vdc_id, time = wait_for(
-            self._try_to_get_guest_bonus,
-            func_args=(hypervisor_name, sku),
-            fail_condition=None,
-            timeout=15,
-            delay=1,
-        )
-        return vdc_id
-
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
@@ -111,19 +96,15 @@ class TestVirtWhoConfigforEsx:
             ),
         ]
         for hostname, sku in hosts:
-            if 'type=NORMAL' in sku:
-                subscriptions = entities.Subscription().search(query={'search': sku})
-                vdc_id = subscriptions[0].id
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
-                vdc_id = self._get_guest_bonus(hypervisor_name, sku)
-            host, time = wait_for(
-                entities.Host().search,
-                func_args=(None, {'search': hostname}),
-                fail_condition=[],
-                timeout=5,
-                delay=1,
-            )
-            entities.HostSubscription(host=host[0].id).add_subscriptions(
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            entities.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
             result = entities.Host().search(query={'search': hostname})[0].read_json()
@@ -167,19 +148,15 @@ class TestVirtWhoConfigforEsx:
             ),
         ]
         for hostname, sku in hosts:
-            if 'type=NORMAL' in sku:
-                subscriptions = entities.Subscription().search(query={'search': sku})
-                vdc_id = subscriptions[0].id
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
-                vdc_id = self._get_guest_bonus(hypervisor_name, sku)
-            host, time = wait_for(
-                entities.Host().search,
-                func_args=(None, {'search': hostname}),
-                fail_condition=[],
-                timeout=5,
-                delay=1,
-            )
-            entities.HostSubscription(host=host[0].id).add_subscriptions(
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            entities.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
             result = entities.Host().search(query={'search': hostname})[0].read_json()

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -19,9 +19,11 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from wait_for import wait_for
 
+from robottelo.cli.host import Host
+from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -58,23 +60,6 @@ def virtwho_config(form_data):
 
 
 class TestVirtWhoConfigforHyperv:
-    def _try_to_get_guest_bonus(self, hypervisor_name, sku):
-        subscriptions = entities.Subscription().search(query={'search': sku})
-        for item in subscriptions:
-            item = item.read_json()
-            if hypervisor_name.lower() in item['hypervisor']['name']:
-                return item['id']
-
-    def _get_guest_bonus(self, hypervisor_name, sku):
-        vdc_id, time = wait_for(
-            self._try_to_get_guest_bonus,
-            func_args=(hypervisor_name, sku),
-            fail_condition=None,
-            timeout=15,
-            delay=1,
-        )
-        return vdc_id
-
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
@@ -109,19 +94,15 @@ class TestVirtWhoConfigforHyperv:
             ),
         ]
         for hostname, sku in hosts:
-            if 'type=NORMAL' in sku:
-                subscriptions = entities.Subscription().search(query={'search': sku})
-                vdc_id = subscriptions[0].id
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
-                vdc_id = self._get_guest_bonus(hypervisor_name, sku)
-            host, time = wait_for(
-                entities.Host().search,
-                func_args=(None, {'search': hostname}),
-                fail_condition=[],
-                timeout=5,
-                delay=1,
-            )
-            entities.HostSubscription(host=host[0].id).add_subscriptions(
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            entities.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
             result = entities.Host().search(query={'search': hostname})[0].read_json()
@@ -165,19 +146,15 @@ class TestVirtWhoConfigforHyperv:
             ),
         ]
         for hostname, sku in hosts:
-            if 'type=NORMAL' in sku:
-                subscriptions = entities.Subscription().search(query={'search': sku})
-                vdc_id = subscriptions[0].id
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
-                vdc_id = self._get_guest_bonus(hypervisor_name, sku)
-            host, time = wait_for(
-                entities.Host().search,
-                func_args=(None, {'search': hostname}),
-                fail_condition=[],
-                timeout=5,
-                delay=1,
-            )
-            entities.HostSubscription(host=host[0].id).add_subscriptions(
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            entities.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
             result = entities.Host().search(query={'search': hostname})[0].read_json()

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -19,9 +19,11 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from wait_for import wait_for
 
+from robottelo.cli.host import Host
+from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -57,23 +59,6 @@ def virtwho_config(form_data):
 
 @pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
-    def _try_to_get_guest_bonus(self, hypervisor_name, sku):
-        subscriptions = entities.Subscription().search(query={'search': sku})
-        for item in subscriptions:
-            item = item.read_json()
-            if hypervisor_name.lower() in item['hypervisor']['name']:
-                return item['id']
-
-    def _get_guest_bonus(self, hypervisor_name, sku):
-        vdc_id, time = wait_for(
-            self._try_to_get_guest_bonus,
-            func_args=(hypervisor_name, sku),
-            fail_condition=None,
-            timeout=15,
-            delay=1,
-        )
-        return vdc_id
-
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
@@ -108,19 +93,15 @@ class TestVirtWhoConfigforKubevirt:
             ),
         ]
         for hostname, sku in hosts:
-            if 'type=NORMAL' in sku:
-                subscriptions = entities.Subscription().search(query={'search': sku})
-                vdc_id = subscriptions[0].id
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
-                vdc_id = self._get_guest_bonus(hypervisor_name, sku)
-            host, time = wait_for(
-                entities.Host().search,
-                func_args=(None, {'search': hostname}),
-                fail_condition=[],
-                timeout=5,
-                delay=1,
-            )
-            entities.HostSubscription(host=host[0].id).add_subscriptions(
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            entities.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
             result = entities.Host().search(query={'search': hostname})[0].read_json()
@@ -164,19 +145,15 @@ class TestVirtWhoConfigforKubevirt:
             ),
         ]
         for hostname, sku in hosts:
-            if 'type=NORMAL' in sku:
-                subscriptions = entities.Subscription().search(query={'search': sku})
-                vdc_id = subscriptions[0].id
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
-                vdc_id = self._get_guest_bonus(hypervisor_name, sku)
-            host, time = wait_for(
-                entities.Host().search,
-                func_args=(None, {'search': hostname}),
-                fail_condition=[],
-                timeout=5,
-                delay=1,
-            )
-            entities.HostSubscription(host=host[0].id).add_subscriptions(
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            entities.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
             result = entities.Host().search(query={'search': hostname})[0].read_json()

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -19,9 +19,11 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from wait_for import wait_for
 
+from robottelo.cli.host import Host
+from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -57,23 +59,6 @@ def virtwho_config(form_data):
 
 
 class TestVirtWhoConfigforLibvirt:
-    def _try_to_get_guest_bonus(self, hypervisor_name, sku):
-        subscriptions = entities.Subscription().search(query={'search': sku})
-        for item in subscriptions:
-            item = item.read_json()
-            if hypervisor_name.lower() in item['hypervisor']['name']:
-                return item['id']
-
-    def _get_guest_bonus(self, hypervisor_name, sku):
-        vdc_id, time = wait_for(
-            self._try_to_get_guest_bonus,
-            func_args=(hypervisor_name, sku),
-            fail_condition=None,
-            timeout=15,
-            delay=1,
-        )
-        return vdc_id
-
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
@@ -108,19 +93,15 @@ class TestVirtWhoConfigforLibvirt:
             ),
         ]
         for hostname, sku in hosts:
-            if 'type=NORMAL' in sku:
-                subscriptions = entities.Subscription().search(query={'search': sku})
-                vdc_id = subscriptions[0].id
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
-                vdc_id = self._get_guest_bonus(hypervisor_name, sku)
-            host, time = wait_for(
-                entities.Host().search,
-                func_args=(None, {'search': hostname}),
-                fail_condition=[],
-                timeout=5,
-                delay=1,
-            )
-            entities.HostSubscription(host=host[0].id).add_subscriptions(
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            entities.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
             result = entities.Host().search(query={'search': hostname})[0].read_json()
@@ -164,19 +145,15 @@ class TestVirtWhoConfigforLibvirt:
             ),
         ]
         for hostname, sku in hosts:
-            if 'type=NORMAL' in sku:
-                subscriptions = entities.Subscription().search(query={'search': sku})
-                vdc_id = subscriptions[0].id
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
-                vdc_id = self._get_guest_bonus(hypervisor_name, sku)
-            host, time = wait_for(
-                entities.Host().search,
-                func_args=(None, {'search': hostname}),
-                fail_condition=[],
-                timeout=5,
-                delay=1,
-            )
-            entities.HostSubscription(host=host[0].id).add_subscriptions(
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            entities.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
             result = entities.Host().search(query={'search': hostname})[0].read_json()


### PR DESCRIPTION
**Description**
A lot of virt-who API case failed due to [BZ1970391](https://bugzilla.redhat.com/show_bug.cgi?id=1970391), we decide to use the subscription CLI to search the SKU in the virt-who API cases, it can be also more stable and faster.

**Test Result**
```
(3.8_env) [hkx303@kuhuang robottelo]$ pytest tests/foreman/virtwho/api/test_libvirt.py -k test_positive_deploy_configure_by_id tests/foreman/virtwho/api/test_libvirt.py -k test_positive_deploy_configure_by_script
==================================== test session starts =====================================
platform linux -- Python 3.8.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, reportportal-5.0.8, cov-2.12.1, ibutsu-1.16, xdist-2.3.0, mock-3.6.1, forked-1.3.0
collected 6 items / 4 deselected / 2 selected                                                

tests/foreman/virtwho/api/test_libvirt.py ..
================== 2 passed, 4 deselected, 27 warnings in 601.02s (0:10:01) ==================
```

```
(3.8_env) [hkx303@kuhuang robottelo]$ pytest tests/upgrades/test_virtwho.py -m "pre_upgrade"
==================================== test session starts =====================================
platform linux -- Python 3.8.7, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, reportportal-5.0.8, cov-2.12.1, ibutsu-1.16, xdist-2.3.0, mock-3.6.1, forked-1.3.0
collected 2 items / 1 deselected / 1 selected                                                

tests/upgrades/test_virtwho.py .                                                       [100%]


================== 1 passed, 1 deselected, 14 warnings in 205.23s (0:03:25) ==================
```


