### PR TITLE
Automated Stubbed test case for Settings feature.

### DIFF
--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -209,9 +209,9 @@ def test_positive_update_email_delivery_method_smtp():
     """
 
 
-@pytest.mark.stubbed
 @pytest.mark.tier2
-def test_positive_update_email_delivery_method_sendmail():
+@pytest.mark.parametrize('setting_update', ['delivery_method'], indirect=True)
+def test_positive_update_email_delivery_method_sendmail(setting_update):
     """Check Updating Sendmail params through settings subcommand
 
     :id: 578de898-fde2-4957-b39a-9dd059f490bf
@@ -226,8 +226,17 @@ def test_positive_update_email_delivery_method_sendmail():
 
     :CaseImportance: Low
 
-    :CaseAutomation: NotAutomated
+    :CaseAutomation: Automated
     """
+    sendmail_argument_value = gen_string('alphanumeric')
+    sendmail_config_params = {
+        'delivery_method': 'sendmail',
+        'sendmail_arguments': f'{sendmail_argument_value}',
+        'sendmail_location': '/usr/sbin/sendmail',
+    }
+    for key, value in sendmail_config_params.items():
+        Settings.set({'name': f'{key}', 'value': f'{value}'})
+        assert Settings.list({'search': f'name={key}'})[0]['value'] == value
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
Automated stubbed test case **test_positive_update_email_reply_address** in test_setting.py

```
pytest -k test_positive_update_email_reply_address tests/foreman/cli/test_setting.py 
============================ test session starts ============================
platform linux -- Python 3.8.8, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sganar/satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, xdist-2.3.0, ibutsu-1.16, cov-2.12.1
collected 30 items / 29 deselected / 1 selected                                                                                                                                                                                           

tests/foreman/cli/test_setting.py .                                                                                                                                                                                                 [100%]

=============== 1 passed, 29 deselected, 3 warnings in 31.27s================
```