### PR TITLE
fixed UI CR_vmware pwr mgmt which failed on power off

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -20,6 +20,8 @@ from random import choice
 
 import pytest
 from nailgun import entities
+from wait_for import TimedOutError
+from wait_for import wait_for
 from wrapanapi.systems.virtualcenter import vim
 from wrapanapi.systems.virtualcenter import VMWareSystem
 
@@ -29,9 +31,6 @@ from robottelo.constants import COMPUTE_PROFILE_LARGE
 from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import VMWARE_CONSTANTS
 from robottelo.datafactory import gen_string
-
-from wait_for import TimedOutError
-from wait_for import wait_for
 
 pytestmark = [pytest.mark.skip_if_not_set('vmware')]
 
@@ -316,7 +315,8 @@ def test_positive_resource_vm_power_management(session, module_vmware_settings):
             wait_for(
                 lambda: (
                     session.browser.refresh(),
-                    session.computeresource.vm_status(cr_name, vm_name))[1]
+                    session.computeresource.vm_status(cr_name, vm_name),
+                )[1]
                 is not power_status,
                 timeout=30,
                 delay=2,


### PR DESCRIPTION
Fixed UI computeresource_vmware.py::test_positive_resource_vm_power_management which failed on poweroff by adding a wait_for. The wait is needed because poweron happens nearly immediately, but poweroff takes few seconds. Fix is inspired by other similar tests.

```
$ pytest tests/foreman/ui/test_computeresource_vmware.py::test_positive_resource_vm_power_management 
=========================================================================================================================== test session starts ============================================================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rmynar/rmynar/robottelo, configfile: pytest.ini
plugins: forked-1.3.0, services-2.2.1, mock-3.6.1, reportportal-5.0.8, xdist-2.3.0, ibutsu-1.16
collected 1 item / 1 deselected                                                                                                                                                                                                                                            

tests/foreman/ui/test_computeresource_vmware.py .                                                                                                                                                                                                                    [100%]

=============================================================================================================== 1 passed, 1 deselected in 116.25s (0:01:56) ================================================================================================================

$ pytest tests/foreman/ui/test_computeresource_vmware.py::test_positive_resource_vm_power_management 
=========================================================================================================================== test session starts ============================================================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rmynar/rmynar/robottelo, configfile: pytest.ini
plugins: forked-1.3.0, services-2.2.1, mock-3.6.1, reportportal-5.0.8, xdist-2.3.0, ibutsu-1.16
collected 1 item / 1 deselected                                                                                                                                                                                                                                            

tests/foreman/ui/test_computeresource_vmware.py .                                                                                                                                                                                                                    [100%]

=============================================================================================================== 1 passed, 1 deselected in 121.48s (0:02:01) ================================================================================================================
```
note: there are two test results ran in a row, one powering off, one powering on