### PR TITLE
fix template sync asserts

### DIFF
--- a/pytest_fixtures/templatesync_fixtures.py
+++ b/pytest_fixtures/templatesync_fixtures.py
@@ -22,7 +22,7 @@ def create_import_export_local_dir():
         f'mkdir -p {dir_path} && '
         f'chown foreman -R {root_dir} && '
         f'restorecon -R -v {root_dir} && '
-        f'semanage fcontext -a -t tmp_t {dir_path}'
+        f'chcon -t httpd_sys_rw_content_t {dir_path} -R'
     )
     # Copying the file to new directory to be modified by tests
     ssh.command(f'cp example_template.erb {dir_path}')

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1807,8 +1807,6 @@ HAMMER_CONFIG = "~/.hammer/cli.modules.d/foreman.yml"
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
 
-FOREMAN_TEMPLATES_COMMUNITY_URL = 'https://github.com/theforeman/community-templates.git'
-
 FOREMAN_TEMPLATE_TEST_TEMPLATE = (
     'https://raw.githubusercontent.com/SatelliteQE/foreman_templates/example/'
     'example_template.erb'

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -25,7 +25,6 @@ from robottelo.cli.template import Template
 from robottelo.cli.template_sync import TemplateSync
 from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL
 from robottelo.constants import FOREMAN_TEMPLATE_TEST_TEMPLATE
-from robottelo.constants import FOREMAN_TEMPLATES_COMMUNITY_URL
 
 
 class TestTemplateSyncTestCase:
@@ -48,8 +47,6 @@ class TestTemplateSyncTestCase:
         """
         # Check all Downloadable templates exists
         if not get(FOREMAN_TEMPLATE_IMPORT_URL).status_code == 200:
-            raise HTTPError('The foreman templates git url is not accessible')
-        if not get(FOREMAN_TEMPLATES_COMMUNITY_URL).status_code == 200:
             raise HTTPError('The foreman templates git url is not accessible')
 
         # Download the Test Template in test running folder
@@ -142,7 +139,10 @@ class TestTemplateSyncTestCase:
         :CaseImportance: Medium
         """
         dir_path = '/tmp'
-        TemplateSync.exports(
+        output = TemplateSync.exports(
             {'repo': dir_path, 'organization-id': module_org.id, 'filter': 'ansible'}
         )
-        assert ssh.command(f'find {dir_path} -type f -name *ansible* | wc -l').stdout[0] == '23'
+        exported_count = [row == 'Exported: true' for row in output].count(True)
+        assert exported_count == int(
+            ssh.command(f'find {dir_path} -type f -name *ansible* | wc -l').stdout[0]
+        )

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -19,7 +19,8 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo import ssh
-from robottelo.constants import FOREMAN_TEMPLATES_COMMUNITY_URL
+from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL
+from robottelo.constants import FOREMAN_TEMPLATE_ROOT_DIR
 
 
 @pytest.fixture(scope='module')
@@ -48,9 +49,9 @@ def test_positive_import_templates(session, templates_org, templates_loc):
             associate = always
             filter = Alterator default PXELinux
             prefix = <any_prefix>
-            repo = Community Repo
+            repo = custom Repo
             dirname = provisioning_templates
-        3. Submit to Import the template from community repo.
+        3. Submit to Import the template from custom repo.
 
     :expectedresults:
 
@@ -60,6 +61,7 @@ def test_positive_import_templates(session, templates_org, templates_loc):
     :CaseImportance: Critical
     """
     import_template = 'Alterator default PXELinux'
+    branch = 'automation'
     prefix_name = gen_string('alpha', 8)
     with session:
         session.organization.select(org_name=templates_org.name)
@@ -68,14 +70,15 @@ def test_positive_import_templates(session, templates_org, templates_loc):
             {
                 'sync_type': 'Import',
                 'template.associate': 'Always',
+                'template.branch': branch,
                 'template.dirname': 'provisioning_templates',
                 'template.filter': import_template,
                 'template.lock': 'Lock',
                 'template.prefix': f'{prefix_name} ',
-                'template.repo': FOREMAN_TEMPLATES_COMMUNITY_URL,
+                'template.repo': FOREMAN_TEMPLATE_IMPORT_URL,
             }
         )
-        assert import_title == f'Import from {FOREMAN_TEMPLATES_COMMUNITY_URL}'
+        assert import_title == f'Import from {FOREMAN_TEMPLATE_IMPORT_URL} and branch {branch}'
         imported_template = f'{prefix_name} {import_template}'
         assert session.provisioningtemplate.is_locked(imported_template)
         pt = session.provisioningtemplate.read(imported_template)
@@ -89,7 +92,7 @@ def test_positive_import_templates(session, templates_org, templates_loc):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_export_templates(session):
+def test_positive_export_templates(session, create_import_export_local_dir):
     """Export the satellite templates to local directory
 
     :id: 1c24cf51-7198-48aa-a70a-8c0441333374
@@ -101,8 +104,8 @@ def test_positive_export_templates(session):
         1. Navigate to Host -> Sync Templates, and choose Export.
         2. Select fields:
             metadata_export_mode = keep
-            filter = Alterator default PXELinux
-            repo = '/var/lib/pulp/katello-export'
+            filter = Kickstart default PXELinux
+            repo = `FOREMAN_TEMPLATE_ROOT_DIR`
             dirname = `dir_name`
         3. Submit to Export the template to local directory.
 
@@ -114,22 +117,20 @@ def test_positive_export_templates(session):
 
     :CaseImportance: Critical
     """
-    repo = '/var/lib/pulp/katello-export'
-    export_template = 'Alterator default PXELinux'
-    dir_name = gen_string('alpha', 8)
-    dir_path = f'{repo}/{dir_name}'
+    dir_name, dir_path = create_import_export_local_dir
+    export_template = 'Kickstart default PXELinux'
     with session:
         export_title = session.sync_template.sync(
             {
                 'sync_type': 'Export',
                 'template.metadata_export_mode': 'Keep',
                 'template.filter': export_template,
-                'template.repo': repo,
+                'template.repo': FOREMAN_TEMPLATE_ROOT_DIR,
                 'template.dirname': dir_name,
             }
         )
-        assert export_title == f'Export to {repo} as user {session._user}'
-    exported_file = f'{dir_path}/provisioning_templates/PXELinux/alterator_default_pxelinux.erb'
+        assert export_title == f'Export to {FOREMAN_TEMPLATE_ROOT_DIR} as user {session._user}'
+    exported_file = f'{dir_path}/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb'
     result = ssh.command(f'find {exported_file} -type f')
     assert result.return_code == 0
     search_string = f'name: {export_template}'


### PR DESCRIPTION
depends on: https://github.com/SatelliteQE/foreman_templates/pull/4

resolves #8586

Foreman community template repo is archived and we never really had control about templates. There are many tests that are using our repo, so this test does not change coverage. 

Test results:
```
pytest -v tests/foreman/*/test_templatesync.py
================================================================================= test session starts =================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, forked-1.3.0, xdist-2.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16
collected 27 items / 1 deselected / 26 selected                                                                                                                                       

tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_filtered_templates_from_git PASSED                                                       [  3%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_import_filtered_templates_from_git_with_negate PASSED                                                    [  7%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_and_associate PASSED                                                                     [ 11%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_to_subdirectory PASSED                                                                   [ 15%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_filtered_templates_to_localdir PASSED                                                    [ 19%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_filtered_templates_negate PASSED                                                         [ 23%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_and_import_with_metadata PASSED                                                          [ 26%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_verbose_true PASSED                                                          [ 30%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_verbose_false PASSED                                                         [ 34%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_changed_key_true PASSED                                                      [ 38%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_changed_key_false PASSED                                                     [ 42%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_name_key PASSED                                                              [ 46%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_imported_key PASSED                                                          [ 50%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_file_key PASSED                                                              [ 53%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_corrupted_metadata PASSED                                                    [ 57%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_filtered_skip_message PASSED                                                 [ 61%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_no_name_error PASSED                                                         [ 65%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_no_model_error PASSED                                                        [ 69%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_blank_model_error PASSED                                                     [ 73%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_json_output PASSED                                                                       [ 76%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_log_to_production PASSED                                                                 [ 80%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_log_to_production PASSED                                                                 [ 84%]
tests/foreman/cli/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_force_locked_template PASSED                                                             [ 88%]
tests/foreman/cli/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_filtered_templates_to_temp_dir PASSED                                                    [ 92%]
tests/foreman/ui/test_templatesync.py::test_positive_import_templates PASSED                                                                                                    [ 96%]
tests/foreman/ui/test_templatesync.py::test_positive_export_templates PASSED                                                                                                    [100%]

============================================================== 26 passed, 1 deselected, 64 warnings in 442.76s (0:07:22) ==============================================================
```