### PR TITLE
Fix OpenSCAP longrun tests

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1531,6 +1531,8 @@ LDAP_ATTR = {
     'mail': 'mail',
 }
 
+OSCAP_TARGET_CORES = 4
+OSCAP_TARGET_MEMORY = '16GiB'
 OSCAP_PERIOD = {'weekly': 'Weekly', 'monthly': 'Monthly', 'custom': 'Custom'}
 
 OSCAP_WEEKDAY = {

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -505,12 +505,10 @@ class ContentHost(Host):
         self.execute('puppet agent -t 2> /dev/null')
 
     def job_invocation(self, job_template):
-        """
-        Invoke a job on the host.
-        Args:
-            job-template: name of job-templete to be used.
+        """Invoke a job on the host by passing name of the job-template.
 
-        Returns:
+        :param job-template: name of job-templete to be used.
+        :return: None.
 
         """
         invocation_command = make_job_invocation(
@@ -527,15 +525,7 @@ class ContentHost(Host):
                     )
                 )
             )
-            data = self.execute(
-                'rpm -qa |grep scap; yum repolist;cat /etc/foreman_scap_client/config.yaml; '
-                'cat /etc/cron.d/foreman_scap_client_cron;tail -n 100 /var/log/messages'
-            )
-            raise AssertionError(
-                f'Failed to execute foreman_scap_client run. '
-                f'host_data_stdout: {data.stdout}, and host_data_stderr: {data.stderr}'
-                f'job_invocation: {result}'
-            )
+            raise AssertionError(result)
 
     def execute_foreman_scap_client(self, policy_id=None):
         """Executes foreman_scap_client on the vm to create security audit report.
@@ -557,8 +547,9 @@ class ContentHost(Host):
             )
             raise ContentHostError(
                 f'Failed to execute foreman_scap_client run. '
-                f'Command exited with code: {result.status}, stderr: {result.stderr}, stdout: {result.stdout}'
-                f'host_data_stdout: {data.stdout}, and host_data_stderr: {data.stderr}'
+                f'Command exited with code: {result.status}, stderr: {result.stderr}, '
+                f'stdout: {result.stdout} host_data_stdout: {data.stdout}, '
+                f'and host_data_stderr: {data.stderr}'
             )
 
     def configure_rex(self, satellite, org, subnet_id=None, by_ip=True, register=True):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1196,27 +1196,3 @@ class Satellite(Capsule):
         update_provisioning_template(name=template, old=old, new=new)
         yield
         update_provisioning_template(name=template, old=new, new=old)
-
-    def job_invocation(self, hostname, job_template):
-        """Invoke a job on the content host by passing it's hostname and name of the job-template.
-
-        :param hostname: hostname of client.
-        :param job_template: name of job-templete to be used.
-        :return: None.
-
-        """
-        invocation_command = self.cli.JobInvocation.create(
-            {'job-template': job_template, 'search-query': f"name ~ {hostname}"}
-        )
-        result = self.cli.JobInvocation.info({'id': invocation_command['id']})
-        try:
-            assert result['success'] == '1'
-        except AssertionError:
-            result = 'host output: {}'.format(
-                ' '.join(
-                    self.cli.JobInvocation.get_output(
-                        {'id': invocation_command['id'], 'host': hostname}
-                    )
-                )
-            )
-            raise AssertionError(result)

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -277,7 +277,7 @@ def test_positive_upload_to_satellite(
         assert result.status == 0
         # Runs the actual oscap scan on the vm/clients and
         # uploads report to Internal Capsule.
-        default_sat.job_invocation(vm.hostname, 'Run OpenSCAP scans')
+        vm.execute_foreman_scap_client()
         # Assert whether oscap reports are uploaded to
         # Satellite6.
         arf_report = Arfreport.list({'search': f'host={vm.hostname.lower()}', 'per-page': 1})
@@ -302,7 +302,7 @@ def test_positive_upload_to_satellite(
             assert updated_result.status == 0
             # Runs the actual oscap scan on the vm/clients and
             # uploads report to Internal Capsule.
-            default_sat.job_invocation(vm.hostname, 'Run OpenSCAP scans')
+            vm.execute_foreman_scap_client()
             result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})
             assert result is not None
 
@@ -416,7 +416,7 @@ def test_positive_oscap_run_with_tailoring_file_and_capsule(
         assert result.status == 0
         # Runs the actual oscap scan on the vm/clients and
         # uploads report to Internal Capsule.
-        default_sat.job_invocation(vm.hostname, 'Run OpenSCAP scans')
+        vm.execute_foreman_scap_client()
         # Assert whether oscap reports are uploaded to
         # Satellite6.
         arf_report = Arfreport.list({'search': f'host={vm.hostname.lower()}', 'per-page': 1})
@@ -654,7 +654,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
         assert result.status == 0
         # Runs the actual oscap scan on the vm/clients and
         # uploads report to Internal Capsule.
-        default_sat.job_invocation(vm.hostname, 'Run OpenSCAP scans')
+        vm.execute_foreman_scap_client()
         # Assert whether oscap reports are uploaded to
         # Satellite6.
         result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -42,6 +42,8 @@ from robottelo.constants import DISTRO_RHEL8
 from robottelo.constants import OSCAP_DEFAULT_CONTENT
 from robottelo.constants import OSCAP_PERIOD
 from robottelo.constants import OSCAP_PROFILE
+from robottelo.constants import OSCAP_TARGET_CORES
+from robottelo.constants import OSCAP_TARGET_MEMORY
 from robottelo.constants import OSCAP_WEEKDAY
 from robottelo.helpers import add_remote_execution_ssh_key
 from robottelo.helpers import file_downloader
@@ -58,8 +60,6 @@ ak_name = {
     'rhel7': gen_string('alpha'),
     'rhel6': gen_string('alpha'),
 }
-target_cores = 4
-target_memory = '16GiB'
 
 
 def fetch_scap_and_profile_id(scap_name, scap_profile):
@@ -229,8 +229,8 @@ def test_positive_upload_to_satellite(
     with VMBroker(
         nick=distro,
         host_classes={'host': ContentHost},
-        target_cores=target_cores,
-        target_memory=target_memory,
+        target_cores=OSCAP_TARGET_CORES,
+        target_memory=OSCAP_TARGET_MEMORY,
     ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
         vm.install_katello_ca(default_sat)
@@ -386,8 +386,8 @@ def test_positive_oscap_run_with_tailoring_file_and_capsule(
     with VMBroker(
         nick=DISTRO_RHEL7,
         host_classes={'host': ContentHost},
-        target_cores=target_cores,
-        target_memory=target_memory,
+        target_cores=OSCAP_TARGET_CORES,
+        target_memory=OSCAP_TARGET_MEMORY,
     ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
         vm.install_katello_ca(default_sat)
@@ -492,8 +492,8 @@ def test_positive_oscap_run_via_ansible(
     with VMBroker(
         nick=distro,
         host_classes={'host': ContentHost},
-        target_cores=target_cores,
-        target_memory=target_memory,
+        target_cores=OSCAP_TARGET_CORES,
+        target_memory=OSCAP_TARGET_MEMORY,
     ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
         vm.install_katello_ca(default_sat)
@@ -605,8 +605,8 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
     with VMBroker(
         nick=DISTRO_RHEL7,
         host_classes={'host': ContentHost},
-        target_cores=target_cores,
-        target_memory=target_memory,
+        target_cores=OSCAP_TARGET_CORES,
+        target_memory=OSCAP_TARGET_MEMORY,
     ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
         vm.install_katello_ca(default_sat)

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -58,6 +58,8 @@ ak_name = {
     'rhel7': gen_string('alpha'),
     'rhel6': gen_string('alpha'),
 }
+target_cores = 4
+target_memory = '8GiB'
 
 
 def fetch_scap_and_profile_id(scap_name, scap_profile):
@@ -224,7 +226,12 @@ def test_positive_upload_to_satellite(
         }
     )
     # Creates vm's and runs openscap scan and uploads report to satellite6.
-    with VMBroker(nick=distro, host_classes={'host': ContentHost}) as vm:
+    with VMBroker(
+        nick=distro,
+        host_classes={'host': ContentHost},
+        target_cores=target_cores,
+        target_memory=target_memory,
+    ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
         vm.install_katello_ca(default_sat)
         vm.register_contenthost(module_org.name, ak_name[distro])
@@ -370,7 +377,12 @@ def test_positive_oscap_run_with_tailoring_file_and_capsule(
         }
     )
     # Creates vm's and runs openscap scan and uploads report to satellite6.
-    with VMBroker(nick=DISTRO_RHEL7, host_classes={'host': ContentHost}) as vm:
+    with VMBroker(
+        nick=DISTRO_RHEL7,
+        host_classes={'host': ContentHost},
+        target_cores=target_cores,
+        target_memory=target_memory,
+    ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
         vm.install_katello_ca(default_sat)
         vm.register_contenthost(module_org.name, ak_name[DISTRO_RHEL7])
@@ -401,7 +413,7 @@ def test_positive_oscap_run_with_tailoring_file_and_capsule(
 
 @pytest.mark.upgrade
 @pytest.mark.tier4
-@pytest.mark.parametrize('distro', [DISTRO_RHEL7])
+@pytest.mark.parametrize('distro', [DISTRO_RHEL7, DISTRO_RHEL8])
 def test_positive_oscap_run_via_ansible(
     module_org, default_proxy, content_view, lifecycle_env, distro, default_sat
 ):
@@ -464,7 +476,12 @@ def test_positive_oscap_run_via_ansible(
             'organizations': module_org.name,
         }
     )
-    with VMBroker(nick=distro, host_classes={'host': ContentHost}) as vm:
+    with VMBroker(
+        nick=distro,
+        host_classes={'host': ContentHost},
+        target_cores=target_cores,
+        target_memory=target_memory,
+    ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
         vm.install_katello_ca(default_sat)
         vm.register_contenthost(module_org.name, ak_name[distro])
@@ -572,7 +589,12 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
             'organizations': module_org.name,
         }
     )
-    with VMBroker(nick=DISTRO_RHEL7, host_classes={'host': ContentHost}) as vm:
+    with VMBroker(
+        nick=DISTRO_RHEL7,
+        host_classes={'host': ContentHost},
+        target_cores=target_cores,
+        target_memory=target_memory,
+    ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
         vm.install_katello_ca(default_sat)
         vm.register_contenthost(module_org.name, ak_name[DISTRO_RHEL7])
@@ -619,7 +641,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
         assert result.status == 0
         # Runs the actual oscap scan on the vm/clients and
         # uploads report to Internal Capsule.
-        vm.execute_foreman_scap_client()
+        vm.job_invocation('Run OpenSCAP scans')
         # Assert whether oscap reports are uploaded to
         # Satellite6.
         result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -264,7 +264,7 @@ def test_positive_upload_to_satellite(
         assert result.status == 0
         # Runs the actual oscap scan on the vm/clients and
         # uploads report to Internal Capsule.
-        vm.execute_foreman_scap_client()
+        vm.job_invocation('Run OpenSCAP scans')
         # Assert whether oscap reports are uploaded to
         # Satellite6.
         arf_report = Arfreport.list({'search': f'host={vm.hostname.lower()}', 'per-page': 1})
@@ -289,7 +289,7 @@ def test_positive_upload_to_satellite(
             assert updated_result.status == 0
             # Runs the actual oscap scan on the vm/clients and
             # uploads report to Internal Capsule.
-            vm.execute_foreman_scap_client()
+            vm.job_invocation('Run OpenSCAP scans')
             result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})
             assert result is not None
 
@@ -391,7 +391,7 @@ def test_positive_oscap_run_with_tailoring_file_and_capsule(
         assert result.status == 0
         # Runs the actual oscap scan on the vm/clients and
         # uploads report to Internal Capsule.
-        vm.execute_foreman_scap_client()
+        vm.job_invocation('Run OpenSCAP scans')
         # Assert whether oscap reports are uploaded to
         # Satellite6.
         arf_report = Arfreport.list({'search': f'host={vm.hostname.lower()}', 'per-page': 1})
@@ -401,7 +401,7 @@ def test_positive_oscap_run_with_tailoring_file_and_capsule(
 
 @pytest.mark.upgrade
 @pytest.mark.tier4
-@pytest.mark.parametrize('distro', [DISTRO_RHEL8, DISTRO_RHEL7])
+@pytest.mark.parametrize('distro', [DISTRO_RHEL7])
 def test_positive_oscap_run_via_ansible(
     module_org, default_proxy, content_view, lifecycle_env, distro, default_sat
 ):


### PR DESCRIPTION
This PR:
- fixes OpenSCAP longrun tests failing because of memory limitation of host.

See PRT job no. 257 for test results.