### PR TITLE
Fixing assertion failures for cli/test_operatingsystem::test_positive_add_template

### DIFF
--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -304,13 +304,15 @@ class TestOperatingSystem:
         """
         template = make_template()
         os = make_os()
+        default_template_name = os['default-templates'][0]
         OperatingSys.add_provisioning_template(
             {'provisioning-template': template['name'], 'id': os['id']}
         )
         os = OperatingSys.info({'id': os['id']})
-        assert len(os['templates']) == 1
-        template_name = os['templates'][0]
-        assert template_name.startswith(template['name'])
+        assert len(os['templates']) == 2
+        provision_template_name = f"{template['name']} ({template['type']})"
+        assert default_template_name in os['templates']
+        assert provision_template_name in os['templates']
 
     @pytest.mark.tier2
     def test_positive_add_ptable(self):


### PR DESCRIPTION
Making an OS seems to create a default template, so I updated this test to make sure the default template is made and a new template can also be added.

```
tests/foreman/cli/test_operatingsystem.py .
======================== 1 passed, 3 warnings in 37.90s ========================
```