### PR TITLE
Replace symlinks checks in contentmanagement

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -824,6 +824,11 @@ FAKE_0_CUSTOM_PACKAGE_GROUP = [
 ]
 
 FAKE_1_YUM_REPO_RPMS = ['bear-4.1-1.noarch.rpm', 'camel-0.1-1.noarch.rpm', 'cat-1.0-1.noarch.rpm']
+FAKE_3_YUM_REPO_RPMS = [
+    'ant-7.7.7-1.noarch.rpm',
+    'monkey-7.2.3-1.noarch.rpm',
+    'seal-1.0.10-1.noarch.rpm',
+]
 FAKE_0_PUPPET_MODULE = 'httpd'
 FAKE_0_YUM_REPO_STRING_BASED_VERSIONS_COUNTS = {'rpm': 35, 'package_group': 2, 'erratum': 4}
 PULP_PUBLISHED_ISO_REPOS_PATH = '/var/lib/pulp/published/http/isos'

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -366,6 +366,26 @@ def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None, repo=None, 
     return os.path.join(PULP_PUBLISHED_YUM_REPOS_PATH, repo_path)
 
 
+def form_repo_url(capsule, org=None, lce=None, cv=None, prod=None, repo=None):
+    """Forms url of a repo or CV published on a Satellite or Capsule.
+
+    :param object capsule: Capsule or Satellite object providing its url
+    :param str org: organization label
+    :param str lce: lifecycle environment label
+    :param str cv: content view label
+    :param str prod: product label
+    :param str repo: repository label
+    :return: url of the specific repo or CV
+    """
+    if not all([capsule, org, prod, repo]):
+        raise ValueError('`capsule`, `org`, `prod` and `repo` arguments are required')
+
+    if lce and cv:
+        return f'{capsule.url}/pulp/content/{org}/{lce}/{cv}/custom/{prod}/{repo}/'
+    else:
+        return f'{capsule.url}/pulp/content/{org}/Library/custom/{prod}/{repo}/'
+
+
 def create_repo(name, repo_fetch_url=None, packages=None, wipe_repodata=False, hostname=None):
     """Creates a repository from given packages and publishes it into pulp's
     directory for web access.

--- a/robottelo/host_info.py
+++ b/robottelo/host_info.py
@@ -2,6 +2,7 @@
 import functools
 import re
 
+import requests
 from packaging.version import Version
 from ssh2.exceptions import AuthenticationError
 
@@ -99,30 +100,51 @@ def get_repo_files(repo_path, extension='rpm', hostname=None):
     return sorted(repo_file for repo_file in result.stdout if repo_file)
 
 
-def get_repomd_revision(repo_path, hostname=None):
-    """Fetches a revision of repository.
+def get_repo_files_by_url(url, extension='rpm'):
+    """Returns a list of repo files (for example rpms) in a specific repository
+    published at some url.
 
-    :param str repo_path: unix path to the repo, e.g. '/var/lib/pulp/fooRepo'
-    :param str optional hostname: hostname or IP address of the remote host. If
-        ``None`` the hostname will be get from ``main.server.hostname`` config.
+    :param url: url where the repo or CV is published
+    :param extension: extension of searched files. Defaults to 'rpm'
+    :return:  list representing rpm package names
+    """
+    if not url.endswith('/'):
+        url += '/'
+
+    result = requests.get(url, verify=False)
+    if result.status_code != 200:
+        raise requests.HTTPError(f'{url} is not accessible')
+
+    links = re.findall(r'(?<=href=").*?(?=">)', result.text)
+
+    if 'Packages/' not in links:
+        return sorted(line for line in links if extension in line)
+
+    files = []
+    subs = get_repo_files_by_url(f'{url}Packages/', extension='/')
+    for sub in subs:
+        files.extend(get_repo_files_by_url(f'{url}Packages/{sub}', extension))
+
+    return sorted(files)
+
+
+def get_repomd_revision(repo_url):
+    """Fetches a revision of a repository.
+
+    :param str repo_url: the 'Published_At' link of a repo
     :return: string containing repository revision
     :rtype: str
     """
     repomd_path = 'repodata/repomd.xml'
-    result = ssh.command(
-        f"grep -oP '(?<=<revision>).*?(?=</revision>)' {repo_path}/{repomd_path}",
-        hostname=hostname,
-    )
-    # strip empty lines
-    stdout = [line for line in result.stdout if line]
-    if result.return_code != 0 or len(stdout) != 1:
-        raise CLIReturnCodeError(
-            result.return_code,
-            result.stderr,
-            f'Unable to fetch revision for {repo_path}. Please double check your '
-            'hostname, path and contents of repomd.xml',
-        )
-    return stdout[0]
+    result = requests.get(f'{repo_url}/{repomd_path}', verify=False)
+    if result.status_code != 200:
+        raise requests.HTTPError(f'{repo_url}/{repomd_path} is not accessible')
+
+    match = re.search('(?<=<revision>).*?(?=</revision>)', result.text)
+    if not match:
+        raise ValueError(f'<revision> not found in {repo_url}/{repomd_path}')
+
+    return match.group(0)
 
 
 class SatVersionDependentValues:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -983,9 +983,9 @@ class Capsule(ContentHost):
                 f'{settings.robottelo.tmp_dir}/capsule-{self.ip_addr}.log',
             )
             raise CapsuleHostError(f'foreman installer failed at capsule host: {result.stderr}')
-        result = self.execute('systemctl status pulp_celerybeat.service')
+        result = self.execute('satellite-maintain service status')
         if 'inactive (dead)' in '\n'.join(result.stdout):
-            raise CapsuleHostError('pulp_celerybeat service not running')
+            raise CapsuleHostError('a core service is not running at capsule host')
 
 
 class Satellite(Capsule):


### PR DESCRIPTION
Pulp3 does not use the symlinks nor the on-disk directory structure that pulp2 used for content anymore. Instead it uses "artifacts" which hold the content and repo metadata, but they are hidden from the user (using hashes for filenames and dirs).
So in this PR I replaced the symlink checks with checks for the artifact existence. I feel it's less deterministic, I'm not happy about that, but I can't see any better solution right now.

I would appreciate your input @latran @swadeley

Test results:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_on_demand_sync tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_update_with_immediate_sync tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_uploaded_content_library_sync
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.3.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 3 items                                                                                                                                                                                                                         

tests/foreman/api/test_contentmanagement.py ...                                                                                                                                                                                     [100%]

=============================================================================================== 3 passed, 3 warnings in 2973.05s (0:49:33) ================================================================================================
```