### PR TITLE
some tests fixed connected to airgun locators

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -438,14 +438,14 @@ def test_positive_end_to_end(session, module_host_template, module_org, module_g
             module_host_template.operatingsystem.name, module_host_template.operatingsystem.major
         )
         assert os_name in displayed_host['Operating System']
-        assert displayed_host['Installed'] == '-'
+        assert displayed_host['Installed'] == 'N/A'
         # update
         session.host.update(host_name, {'host.name': new_name})
         assert not session.host.search(host_name)
         assert session.host.search(new_host_name)[0]['Name'] == new_host_name
         # delete
         session.host.delete(new_host_name)
-        assert not session.host.search(new_host_name)
+        assert not entities.Host().search(query={'search': f'name="{new_host_name}"'})
 
 
 @pytest.mark.tier4
@@ -851,10 +851,11 @@ def test_positive_view_hosts_with_non_admin_user(test_name, module_org, module_l
         assert content_host['breadcrumb'] == created_host.name
 
 
-@pytest.mark.skip_if_open("BZ:1996035")
 @pytest.mark.tier3
 def test_positive_remove_parameter_non_admin_user(test_name, module_org, module_loc):
     """Remove a host parameter as a non-admin user with enough permissions
+
+    :BZ: 1996035
 
     :id: 598111c1-fdb6-42e9-8c28-fae999b5d112
 

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -29,7 +29,7 @@ from robottelo.datafactory import gen_string
 
 PM_NAME = 'generic_1'
 
-pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.skip_if_open("BZ:1996035")]
+pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
@@ -83,6 +83,8 @@ def domain(module_host):
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_puppet_classes, sc_params_list):
     """Perform end to end testing for smart class parameter component
+
+    :BZ: 1996035
 
     :id: 05ccb04e-5d21-44cc-a01c-807469be06c0
 
@@ -184,6 +186,8 @@ def test_positive_end_to_end(session, module_puppet_classes, sc_params_list):
 def test_positive_create_matcher_attribute_priority(session, sc_params_list, module_host, domain):
     """Matcher Value set on Attribute Priority for Host.
 
+    :BZ: 1996035
+
     :id: b83afe54-207e-4d6b-b705-1f3601c484a6
 
     :steps:
@@ -270,6 +274,8 @@ def test_positive_create_matcher_attribute_priority(session, sc_params_list, mod
 def test_positive_create_matcher_avoid_duplicate(session, sc_params_list, module_host, domain):
     """Merge the values of all the associated matchers, remove duplicates.
 
+    :BZ: 1996035
+
     :id: c8557813-2c09-4196-b1c1-f7e609aa0310
 
     :steps:
@@ -345,6 +351,8 @@ def test_positive_create_matcher_avoid_duplicate(session, sc_params_list, module
 def test_positive_update_matcher_from_attribute(session, sc_params_list, module_host):
     """Impact on parameter on editing the parameter value from attribute.
 
+    :BZ: 1996035
+
     :id: a7b3ecde-a311-421c-be4b-0f72ab1f44ba
 
     :steps:
@@ -413,6 +421,8 @@ def test_positive_impact_parameter_delete_attribute(
 ):
     """Impact on parameter after deleting associated attribute.
 
+    :BZ: 1996035
+
     :id: 5d9bed6d-d9c0-4eb3-aaf7-bdda1f9203dd
 
     :steps:
@@ -469,6 +479,8 @@ def test_positive_impact_parameter_delete_attribute(
 @pytest.mark.tier2
 def test_positive_hidden_value_in_attribute(session, sc_params_list, module_host):
     """Update the hidden default value of parameter in attribute. Then unhide.
+
+    :BZ: 1996035
 
     :id: c10c20bd-0284-4e5d-b789-fddd3b81b81b
 


### PR DESCRIPTION
connected to airgun [PR](https://github.com/SatelliteQE/airgun/pull/615)

Test results:
```
tests/foreman/ui/test_host.py::test_positive_remove_parameter_non_admin_user 
=========== 1 passed, 35 deselected, 3 warnings in 124.70s (0:02:04) ===========
```


```
tests/foreman/ui/test_host.py::test_positive_end_to_end
=========== 1 passed, 35 deselected, 3 warnings in 271.55s (0:04:31) ===========
```

```
tests/foreman/ui/test_smartclassparameter.py::test_positive_create_matcher_attribute_priority
=========== 1 passed, 5 deselected, 6 warnings in 275.68s (0:04:35) ============
```

If required I will do that, or you can also run PRT.