### PR TITLE
Fix logging statements in API sync plan tests

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -661,8 +661,8 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org):
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
-        f"Waiting {(delay / 4)} seconds to check product {product['name']}"
-        f" was not synced by {sync_plan['name']}"
+        f"Waiting {(delay / 4)} seconds to check product {product.name}"
+        f" was not synced by {sync_plan.name}"
     )
     sleep(delay / 4)
     # Verify product is not synced and doesn't have any content
@@ -671,8 +671,8 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org):
     validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
     # Wait until the next recurrence
     logger.info(
-        f"Waiting {(delay * 3 / 4)} seconds to check product {product['name']}"
-        f" was synced by {sync_plan['name']}"
+        f"Waiting {(delay * 3 / 4)} seconds to check product {product.name}"
+        f" was synced by {sync_plan.name}"
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
@@ -710,8 +710,8 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org):
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
-        f"Waiting {(delay / 4)} seconds to check product {product['name']}"
-        f" was not synced by {sync_plan['name']}"
+        f"Waiting {(delay / 4)} seconds to check product {product.name}"
+        f" was not synced by {sync_plan.name}"
     )
     sleep(delay / 4)
     # Verify product has not been synced yet
@@ -720,8 +720,8 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org):
     validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
-        f"Waiting {(delay * 3 / 4)} seconds to check product {product['name']}"
-        f" was synced by {sync_plan['name']}"
+        f"Waiting {(delay * 3 / 4)} seconds to check product {product.name}"
+        f" was synced by {sync_plan.name}"
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
@@ -824,8 +824,8 @@ def test_positive_synchronize_rh_product_past_sync_date():
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
-        f"Waiting {(delay / 4)} seconds to check product {product['name']}"
-        f" was not synced by {sync_plan['name']}"
+        f"Waiting {(delay / 4)} seconds to check product {product.name}"
+        f" was not synced by {sync_plan.name}"
     )
     sleep(delay / 4)
     # Verify product has not been synced yet
@@ -834,8 +834,8 @@ def test_positive_synchronize_rh_product_past_sync_date():
     validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
     # Wait until the next recurrence
     logger.info(
-        f"Waiting {(delay * 3 / 4)} seconds to check product {product['name']}"
-        f" was synced by {sync_plan['name']}"
+        f"Waiting {(delay * 3 / 4)} seconds to check product {product.name}"
+        f" was synced by {sync_plan.name}"
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
@@ -886,8 +886,8 @@ def test_positive_synchronize_rh_product_future_sync_date():
     validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
     # Wait quarter of expected time
     logger.info(
-        f"Waiting {(delay / 4)} seconds to check product {product['name']}"
-        f" was not synced by {sync_plan['name']}"
+        f"Waiting {(delay / 4)} seconds to check product {product.name}"
+        f" was not synced by {sync_plan.name}"
     )
     sleep(delay / 4)
     # Verify product has not been synced yet
@@ -896,8 +896,8 @@ def test_positive_synchronize_rh_product_future_sync_date():
     validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
-        f"Waiting {(delay * 3 / 4)} seconds to check product {product['name']}"
-        f" was synced by {sync_plan['name']}"
+        f"Waiting {(delay * 3 / 4)} seconds to check product {product.name}"
+        f" was synced by {sync_plan.name}"
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
@@ -928,8 +928,8 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org):
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
-        f"Waiting {(delay / 4)} seconds to check product {product['name']}"
-        f" was not synced by {sync_plan['name']}"
+        f"Waiting {(delay / 4)} seconds to check product {product.name}"
+        f" was not synced by {sync_plan.name}"
     )
     sleep(delay / 4)
     # Verify product is not synced and doesn't have any content
@@ -938,8 +938,8 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org):
     validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
-        f"Waiting {(delay * 3 / 4)} seconds to check product {product['name']}"
-        f" was synced by {sync_plan['name']}"
+        f"Waiting {(delay * 3 / 4)} seconds to check product {product.name}"
+        f" was synced by {sync_plan.name}"
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
@@ -972,8 +972,8 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org):
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
-        f"Waiting {(delay / 4)} seconds to check product {product['name']}"
-        f" was not synced by {sync_plan['name']}"
+        f"Waiting {(delay / 4)} seconds to check product {product.name}"
+        f" was not synced by {sync_plan.name}"
     )
     sleep(delay / 4)
     # Verify product is not synced and doesn't have any content
@@ -982,8 +982,8 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org):
     validate_repo_content(repo, ['erratum', 'package', 'package_group'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
-        f"Waiting {(delay * 3 / 4)} seconds to check product {product['name']}"
-        f" was synced by {sync_plan['name']}"
+        f"Waiting {(delay * 3 / 4)} seconds to check product {product.name}"
+        f" was synced by {sync_plan.name}"
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -505,7 +505,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org):
 
     :BZ: 1655595
     """
-    delay = 2 * 60  # delay for sync date in seconds
+    delay = 4 * 60  # delay for sync date in seconds
     products = [make_product({'organization-id': module_org.id}) for _ in range(3)]
     repos = [
         make_repository({'product-id': product['id']}) for product in products for _ in range(2)
@@ -521,6 +521,10 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org):
         }
     )
     # Verify products have not been synced yet
+    logger.info(
+        f"Check products {products[0]['name']} and {products[1]['name']}"
+        f" were not synced before sync plan created in org {module_org.label}"
+    )
     for repo in repos:
         with pytest.raises(AssertionError):
             validate_task_status(repo['id'], module_org.id, max_tries=1)


### PR DESCRIPTION
Hello

When I copied new logging statements from CLI to API  [1], I fixed the ones for tests with plural `products`, but then failed to fix the others to the format required.

[1]: https://github.com/SatelliteQE/robottelo/pull/8953