### PR TITLE
pull function names in fixture marker

### DIFF
--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -26,7 +26,7 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(session, items, config):
-    content_host_fixture_names = getmembers(content_hosts, isfunction)
+    content_host_fixture_names = [m[0] for m in getmembers(content_hosts, isfunction)]
     for item in items:
         if set(item.fixturenames).intersection(set(content_host_fixture_names)):
             # TODO check param for indirect version parametrization


### PR DESCRIPTION
getmembers returns a list of tuples, not a list of names

#8960 was untested and should have been marked draft. This has been tested. 

```
❯ pytest --collect-only -m "not content_host" tests/foreman/api/test_contentmanagement.py
============================================================================================================= test session starts =============================================================================================================
platform linux -- Python 3.8.11, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/mshriver/repos/satqe/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, xdist-2.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16, cov-2.12.1
collected 12 items / 1 deselected / 11 selected                                                                                                                                                                                               

<Package api>
  <Module test_contentmanagement.py>
    <Class TestSatelliteContentManagement>
        <Function test_positive_sync_repos_with_large_errata>
        <Function test_positive_sync_repos_with_lots_files>
        <Function test_positive_sync_kickstart_repo>
    <Class TestCapsuleContentManagement>
        <Function test_positive_insights_puppet_package_availability>
        <Function test_positive_uploaded_content_library_sync>
        <Function test_positive_checksum_sync>
        <Function test_positive_capsule_sync>
        <Function test_positive_iso_library_sync>
        <Function test_positive_on_demand_sync>
        <Function test_positive_update_with_immediate_sync>
        <Function test_positive_capsule_pub_url_accessible>

```