### PR TITLE
refactor auth module and add password reset test

### DIFF
--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -430,7 +430,6 @@ def test_positive_schedule_generation_and_get_mail(session, module_org, module_l
         f'send "q\\r"\n'
     )
 
-    
     default_sat.execute(f"expect -c '{expect_script}'")
     default_sat.get(remote_path=gzip_path, local_path=local_gzip_file)
     os.system(f'gunzip {local_gzip_file}')


### PR DESCRIPTION
```
========================================================= test session starts ==========================================================
platform linux -- Python 3.8.6, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-1.16, xdist-2.3.0, cov-2.12.1, reportportal-5.0.8, mock-3.6.1, forked-1.3.0
collected 10 items / 9 deselected / 1 selected                                                                                         

tests/foreman/cli/test_auth.py .                                                                                                 [100%]

=========================================================== warnings summary ===========================================================
env/lib/python3.8/site-packages/attrdict/mapping.py:4
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/attrdict/mapping.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping

env/lib/python3.8/site-packages/attrdict/mixins.py:5
env/lib/python3.8/site-packages/attrdict/mixins.py:5
  /home/okhatavk/Satellite/robottelo/env/lib/python3.8/site-packages/attrdict/mixins.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Mapping, MutableMapping, Sequence

-- Docs: https://docs.pytest.org/en/stable/warnings.html
======================================= 1 passed, 9 deselected, 3 warnings in 281.23s (0:04:41) ========================================

```