### PR TITLE
Apply PR 8949 changes to content_info module

### DIFF
--- a/robottelo/content_info.py
+++ b/robottelo/content_info.py
@@ -1,4 +1,8 @@
 """Module that gather several informations about host"""
+import re
+
+import requests
+
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 
@@ -27,27 +31,47 @@ def get_repo_files(repo_path, extension='rpm', hostname=None):
     return sorted(repo_file for repo_file in result.stdout.splitlines() if repo_file)
 
 
-def get_repomd_revision(repo_path, hostname=None):
-    """Fetches a revision of repository.
+def get_repo_files_by_url(url, extension='rpm'):
+    """Returns a list of repo files (for example rpms) in a specific repository
+    published at some url.
+    :param url: url where the repo or CV is published
+    :param extension: extension of searched files. Defaults to 'rpm'
+    :return:  list representing rpm package names
+    """
+    if not url.endswith('/'):
+        url += '/'
 
-    :param str repo_path: unix path to the repo, e.g. '/var/lib/pulp/fooRepo'
-    :param str optional hostname: hostname or IP address of the remote host. If
-        ``None`` the hostname will be get from ``main.server.hostname`` config.
+    result = requests.get(url, verify=False)
+    if result.status_code != 200:
+        raise requests.HTTPError(f'{url} is not accessible')
+
+    links = re.findall(r'(?<=href=").*?(?=">)', result.text)
+
+    if 'Packages/' not in links:
+        return sorted(line for line in links if extension in line)
+
+    files = []
+    subs = get_repo_files_by_url(f'{url}Packages/', extension='/')
+    for sub in subs:
+        files.extend(get_repo_files_by_url(f'{url}Packages/{sub}', extension))
+
+    return sorted(files)
+
+
+def get_repomd_revision(repo_url):
+    """Fetches a revision of a repository.
+
+    :param str repo_url: the 'Published_At' link of a repo
     :return: string containing repository revision
     :rtype: str
     """
     repomd_path = 'repodata/repomd.xml'
-    result = ssh.command(
-        f"grep -oP '(?<=<revision>).*?(?=</revision>)' {repo_path}/{repomd_path}",
-        hostname=hostname,
-    )
-    # strip empty lines
-    stdout = [line for line in result.stdout.splitlines() if line]
-    if result.status != 0 or len(stdout) != 1:
-        raise CLIReturnCodeError(
-            result.status,
-            result.stderr,
-            f'Unable to fetch revision for {repo_path}. Please double check your '
-            'hostname, path and contents of repomd.xml',
-        )
-    return stdout[0]
+    result = requests.get(f'{repo_url}/{repomd_path}', verify=False)
+    if result.status_code != 200:
+        raise requests.HTTPError(f'{repo_url}/{repomd_path} is not accessible')
+
+    match = re.search('(?<=<revision>).*?(?=</revision>)', result.text)
+    if not match:
+        raise ValueError(f'<revision> not found in {repo_url}/{repomd_path}')
+
+    return match.group(0)

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -32,6 +32,7 @@ from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
 from robottelo.content_info import get_repo_files
+from robottelo.content_info import get_repo_files_by_url
 from robottelo.content_info import get_repomd_revision
 from robottelo.helpers import create_repo
 from robottelo.helpers import form_repo_path


### PR DESCRIPTION
This should go into unstable before its merged back to master. 

Changes were accepted in master that weren't resolved by the rebase of the commits in unstable, because changes were introduced to a file that had been removed.

Original commit: https://github.com/SatelliteQE/robottelo/pull/8949/commits/ce8327a028cad6f8c0fc86ec631c6fb037f04562