### PR TITLE
Export templates to github

### DIFF
--- a/conf/github.yaml.template
+++ b/conf/github.yaml.template
@@ -1,0 +1,3 @@
+GITHUB:
+    USERNAME:
+    TOKEN:

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -141,6 +141,13 @@ VALIDATORS = dict(
         Validator('gce.cert_path', startswith='/usr/share/foreman/'),
         Validator('gce.zone', is_in=VALID_GCE_ZONES),
     ],
+    github=[
+        Validator(
+            'github.username',
+            'github.token',
+            must_exist=True,
+        ),
+    ],
     http_proxy=[
         Validator(
             'http_proxy.un_auth_proxy_url',

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1814,6 +1814,8 @@ HAMMER_CONFIG = "~/.hammer/cli.modules.d/foreman.yml"
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
 
+FOREMAN_TEMPLATE_EXPORT_API = 'https://api.github.com/repos/SatelliteQE/foreman_templates/'
+
 FOREMAN_TEMPLATE_TEST_TEMPLATE = (
     'https://raw.githubusercontent.com/SatelliteQE/foreman_templates/example/'
     'example_template.erb'


### PR DESCRIPTION
Tested with my credentials, we need to create shared user with token to run this test.

Test results:
```
pytest -v tests/foreman/cli/test_templatesync.py -k test_positive_export_filtered_templates_to_git
================================================================================= test session starts =================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, forked-1.3.0, xdist-2.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16
collected 3 items / 2 deselected / 1 selected                                                                                                                                         

tests/foreman/cli/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_filtered_templates_to_git PASSED                                                         [100%]

==================================================================== 1 passed, 2 deselected, 4 warnings in 23.78s =====================================================================
```