### PR TITLE
Replacing CUSTOM_KICKSTART_REPO with Red Hat Kickstart repo

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -367,6 +367,7 @@ REPOSET = {
     'rhae2': 'Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server',
     'rhst8': 'Red Hat Satellite Tools 6.9 for RHEL 8 x86_64 (RPMs)',
     'fdrh8': 'Fast Datapath for RHEL 8 x86_64 (RPMs)',
+    'rhel8_bos_ks': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS (Kickstart)',
 }
 
 NO_REPOS_AVAILABLE = "This system has no repositories available through subscriptions."
@@ -564,6 +565,15 @@ REPOS = {
         'product': PRDS['rhel8'],
         'distro': DISTRO_RHEL8,
         'key': 'rhst',
+    },
+    'rhel8_bos_ks': {
+        'id': 'rhel-8-for-x86_64-baseos-kickstart',
+        'name': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8.4',
+        'version': '8.4',
+        'reposet': REPOSET['rhel8_bos_ks'],
+        'product': PRDS['rhel8'],
+        'distro': DISTRO_RHEL8,
+        'key': 'rhel8_bos_ks',
     },
 }
 


### PR DESCRIPTION
Need to update this repo to use a RH repo for testing as the default download policy is different for RH repos vs custom repos. We are first testing for on_demand syncing then immediate syncing. I'm currently having problems enabling the kickstart repo @ColeHiggins2 and I chose to test with, Red Hat Enterprise Linux 8 for x86_64 - BaseOS (Kickstart).

============================ test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, cov-2.12.1, xdist-2.3.0, ibutsu-1.16
collected 1 item

tests/foreman/api/test_contentmanagement.py .                            [100%]

================== 1 passed, 4 warnings in 527.46s (0:08:47) ===================
