### PR TITLE
Test coverage on http proxy feature

### DIFF
--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -184,3 +184,49 @@ def test_positive_assign_http_proxy_to_products_repositories(session, module_org
         assert repo_b2_values['repo_content']['http_proxy_policy'] == proxy_policy.format(
             http_proxy_b.name
         )
+
+
+@pytest.mark.tier1
+@pytest.mark.run_in_one_thread
+@pytest.mark.parametrize('setting_update', ['content_default_http_proxy'], indirect=True)
+def test_set_default_http_proxy(session, module_org, module_location, setting_update):
+    """Setting "Default HTTP proxy" to "no global default".
+
+    :id: e93733e1-5c05-4b7f-89e4-253b9ce55a5a
+
+    :Steps:
+        1. Navigate to Infrastructure > Http Proxies
+        2. Create a Http Proxy
+        3. GoTo to Administer > Settings > content tab
+        4. Update the "Default HTTP Proxy" with created above.
+        5. Update "Default HTTP Proxy" to "no global default".
+
+
+    :parametrized: yes
+
+    :expectedresults: Setting "Default HTTP Proxy" to "no global default" result in success.'''
+
+    :CaseImportance: Medium
+
+    :CaseLevel: Acceptance
+    """
+
+    property_name = setting_update.name
+
+    http_proxy_a = entities.HTTPProxy(
+        name=gen_string('alpha', 15),
+        url=settings.http_proxy.un_auth_proxy_url,
+        organization=[module_org.id],
+        location=[module_location.id],
+    ).create()
+
+    with session:
+        session.settings.update(
+            f'name = {property_name}', f'{http_proxy_a.name} ({http_proxy_a.url})'
+        )
+        result = session.settings.read(f'name = {property_name}')
+        assert result['table'][0]['Value'] == f'{http_proxy_a.name} ({http_proxy_a.url})'
+
+        session.settings.update(f'name = {property_name}', "no global default")
+        result = session.settings.read(f'name = {property_name}')
+        assert result['table'][0]['Value'] == "Empty"


### PR DESCRIPTION
**Test Results - 6.10.0**

```
pytest tests/foreman/ui/test_http_proxy.py -k test_set_default_http_proxy --disable-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, xdist-2.3.0, ibutsu-1.16, cov-2.12.1
collected 3 items / 2 deselected / 1 selected                                                                                                                                                                     

tests/foreman/ui/test_http_proxy.py .                                                                                                                                                                       [100%]

============================================================================= 1 passed, 2 deselected, 4 warnings in 163.52s (0:02:43) =============================================================================
```