### PR TITLE
[Cherry-Picked] Content host test fixtures recent updates to 6.9.z

### DIFF
--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -1,0 +1,20 @@
+content_host:
+    deploy_workflow: workflow-name
+    default_rhel_version: 7
+    rhel_versions:
+        - 6
+        - 7
+        - 8
+    hardware:
+        RHEL6:
+            RELEASE: 6.10
+            MEMORY: 1GiB
+            CORES: 1
+        RHEL7:
+            RELEASE: 7.9
+            MEMORY: 1GiB
+            CORES: 1
+        RHEL8:
+            RELEASE: 8.3
+            MEMORY: 1536 MiB
+            CORES: 1

--- a/pytest_fixtures/content_hosts.py
+++ b/pytest_fixtures/content_hosts.py
@@ -1,0 +1,102 @@
+"""
+This module is to define pytest functions for content hosts
+
+The functions in this module are read in the pytest_plugins/fixture_markers.py module
+All functions in this module will be treated as fixtures that apply the contenthost mark
+"""
+import pytest
+from broker.broker import VMBroker
+
+from robottelo.config import settings
+from robottelo.hosts import ContentHost
+
+
+@pytest.fixture
+def host_conf(request):
+    """A function-level fixture that returns parameters for VMBroker host deployment"""
+    conf = params = {}
+    if hasattr(request.node, 'callspec'):
+        params = [*request.node.callspec.params.values()][0]
+    conf['workflow'] = params.get('workflow', settings.content_host.deploy_workflow)
+    _rhelver = f"rhel{params.get('rhel_version', settings.content_host.default_rhel_version)}"
+    conf['rhel_ver'] = settings.content_host.hardware.get(f'{_rhelver}').release
+    conf['memory'] = params.get('memory', settings.content_host.hardware.get(f'{_rhelver}').memory)
+    conf['cores'] = params.get('cores', settings.content_host.hardware.get(f'{_rhelver}').cores)
+    return conf
+
+
+@pytest.fixture
+def rhel_contenthost(host_conf):
+    """A function-level fixture that provides a content host object parametrized"""
+    # Request should be parametrized through pytest_fixtures.fixture_markers
+    # unpack params dict
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture
+def rhel7_contenthost(host_conf):
+    """A function-level fixture that provides a rhel7 content host object"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture(scope='module')
+def rhel7_contenthost_module(host_conf):
+    """A module-level fixture that provides a content host object based on the rhel7 nick"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture(params=[{'rhel_version': '8'}])
+def rhel8_contenthost(host_conf):
+    """A fixture that provides a content host object based on the rhel8 nick"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture(scope='module', params=[{'rhel_version': '8'}])
+def rhel8_contenthost_module(host_conf):
+    """A module-level fixture that provides a content host object based on the rhel8 nick"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture(params=[{'rhel_version': 6}])
+def rhel6_contenthost(host_conf):
+    """A function-level fixture that provides a content host object based on the rhel6 nick"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture(scope="module")
+def rhel77_contenthost_module(host_conf):
+    """A module-level fixture that provides a RHEL7.7 Content Host object"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture(scope="class")
+def rhel77_contenthost_class(host_conf):
+    """A fixture for use with unittest classes. Provides a Content Host object"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture(scope='module')
+def content_hosts(host_conf):
+    """A module-level fixture that provides two content hosts object based on the rhel7 nick"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}, _count=2) as hosts:
+        hosts[0].set_infrastructure_type('physical')
+        yield hosts
+
+
+@pytest.fixture(scope='module')
+def registered_hosts(organization_ak_setup, content_hosts, default_sat):
+    """Fixture that registers content hosts to Satellite."""
+    org, ak = organization_ak_setup
+    for vm in content_hosts:
+        vm.install_katello_ca(default_sat)
+        vm.register_contenthost(org.label, ak.name)
+        assert vm.subscribed
+    return content_hosts

--- a/pytest_fixtures/content_hosts.py
+++ b/pytest_fixtures/content_hosts.py
@@ -19,9 +19,9 @@ def host_conf(request):
         params = [*request.node.callspec.params.values()][0]
     conf['workflow'] = params.get('workflow', settings.content_host.deploy_workflow)
     _rhelver = f"rhel{params.get('rhel_version', settings.content_host.default_rhel_version)}"
-    conf['rhel_ver'] = settings.content_host.hardware.get(f'{_rhelver}').release
-    conf['memory'] = params.get('memory', settings.content_host.hardware.get(f'{_rhelver}').memory)
-    conf['cores'] = params.get('cores', settings.content_host.hardware.get(f'{_rhelver}').cores)
+    conf['rhel_ver'] = settings.content_host.hardware.get(_rhelver).release
+    conf['memory'] = params.get('memory', settings.content_host.hardware.get(_rhelver).memory)
+    conf['cores'] = params.get('cores', settings.content_host.hardware.get(_rhelver).cores)
     return conf
 
 
@@ -34,58 +34,51 @@ def rhel_contenthost(host_conf):
         yield host
 
 
-@pytest.fixture
+@pytest.fixture(params=[{'rhel_version': '7'}])
 def rhel7_contenthost(host_conf):
     """A function-level fixture that provides a rhel7 content host object"""
     with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
         yield host
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope="class", params=[{'rhel_version': '7'}])
+def rhel7_contenthost_class(host_conf):
+    """A fixture for use with unittest classes. Provides a rhel7 Content Host object"""
+    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+        yield host
+
+
+@pytest.fixture(scope='module', params=[{'rhel_version': '7'}])
 def rhel7_contenthost_module(host_conf):
-    """A module-level fixture that provides a content host object based on the rhel7 nick"""
+    """A module-level fixture that provides a rhel7 content host object"""
     with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': '8'}])
 def rhel8_contenthost(host_conf):
-    """A fixture that provides a content host object based on the rhel8 nick"""
+    """A fixture that provides a rhel8 content host object"""
     with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope='module', params=[{'rhel_version': '8'}])
 def rhel8_contenthost_module(host_conf):
-    """A module-level fixture that provides a content host object based on the rhel8 nick"""
+    """A module-level fixture that provides a rhel8 content host object"""
     with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': 6}])
 def rhel6_contenthost(host_conf):
-    """A function-level fixture that provides a content host object based on the rhel6 nick"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
-        yield host
-
-
-@pytest.fixture(scope="module")
-def rhel77_contenthost_module(host_conf):
-    """A module-level fixture that provides a RHEL7.7 Content Host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
-        yield host
-
-
-@pytest.fixture(scope="class")
-def rhel77_contenthost_class(host_conf):
-    """A fixture for use with unittest classes. Provides a Content Host object"""
+    """A function-level fixture that provides a rhel6 content host object"""
     with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope='module')
 def content_hosts(host_conf):
-    """A module-level fixture that provides two content hosts object based on the rhel7 nick"""
+    """A module-level fixture that provides two rhel7 content hosts object"""
     with VMBroker(**host_conf, host_classes={'host': ContentHost}, _count=2) as hosts:
         hosts[0].set_infrastructure_type('physical')
         yield hosts

--- a/pytest_fixtures/content_hosts.py
+++ b/pytest_fixtures/content_hosts.py
@@ -11,75 +11,74 @@ from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
 
-@pytest.fixture
 def host_conf(request):
-    """A function-level fixture that returns parameters for VMBroker host deployment"""
+    """A function that returns arguments for VMBroker host deployment"""
     conf = params = {}
-    if hasattr(request.node, 'callspec'):
-        params = [*request.node.callspec.params.values()][0]
+    if hasattr(request, 'param'):
+        params = request.param
     conf['workflow'] = params.get('workflow', settings.content_host.deploy_workflow)
     _rhelver = f"rhel{params.get('rhel_version', settings.content_host.default_rhel_version)}"
-    conf['rhel_ver'] = settings.content_host.hardware.get(_rhelver).release
+    conf['rhel_version'] = settings.content_host.hardware.get(_rhelver).release
     conf['memory'] = params.get('memory', settings.content_host.hardware.get(_rhelver).memory)
     conf['cores'] = params.get('cores', settings.content_host.hardware.get(_rhelver).cores)
     return conf
 
 
 @pytest.fixture
-def rhel_contenthost(host_conf):
+def rhel_contenthost(request):
     """A function-level fixture that provides a content host object parametrized"""
     # Request should be parametrized through pytest_fixtures.fixture_markers
     # unpack params dict
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': '7'}])
-def rhel7_contenthost(host_conf):
+def rhel7_contenthost(request):
     """A function-level fixture that provides a rhel7 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope="class", params=[{'rhel_version': '7'}])
-def rhel7_contenthost_class(host_conf):
+def rhel7_contenthost_class(request):
     """A fixture for use with unittest classes. Provides a rhel7 Content Host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope='module', params=[{'rhel_version': '7'}])
-def rhel7_contenthost_module(host_conf):
+def rhel7_contenthost_module(request):
     """A module-level fixture that provides a rhel7 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': '8'}])
-def rhel8_contenthost(host_conf):
+def rhel8_contenthost(request):
     """A fixture that provides a rhel8 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope='module', params=[{'rhel_version': '8'}])
-def rhel8_contenthost_module(host_conf):
+def rhel8_contenthost_module(request):
     """A module-level fixture that provides a rhel8 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': 6}])
-def rhel6_contenthost(host_conf):
+def rhel6_contenthost(request):
     """A function-level fixture that provides a rhel6 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope='module')
-def content_hosts(host_conf):
+def content_hosts(request):
     """A module-level fixture that provides two rhel7 content hosts object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}, _count=2) as hosts:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}, _count=2) as hosts:
         hosts[0].set_infrastructure_type('physical')
         yield hosts
 

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -1,0 +1,33 @@
+from inspect import getmembers
+from inspect import isfunction
+
+from pytest_fixtures import content_hosts
+from robottelo.config import settings
+
+
+def pytest_generate_tests(metafunc):
+    if 'rhel_contenthost' in metafunc.fixturenames:
+        rhel_parameters = [
+            dict(workflow=settings.content_host.deploy_workflow, rhel_version=ver)
+            for ver in settings.content_host.rhel_versions
+        ]
+        metafunc.parametrize(
+            'rhel_contenthost',
+            rhel_parameters,
+            ids=[f'rhel_{r["rhel_version"]}' for r in rhel_parameters],
+            indirect=True,
+        )
+
+
+def pytest_configure(config):
+    """Register markers related to testimony tokens"""
+    for marker in ['content_host: Test uses a content host deployed by broker']:
+        config.addinivalue_line("markers", marker)
+
+
+def pytest_collection_modifyitems(session, items, config):
+    content_host_fixture_names = [m[0] for m in getmembers(content_hosts, isfunction)]
+    for item in items:
+        if set(item.fixturenames).intersection(set(content_host_fixture_names)):
+            # TODO check param for indirect version parametrization
+            item.add_marker('content_host')

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -75,22 +75,22 @@ def vm(
     rh_repo_gt_manifest,
     module_gt_manifest_org,
     module_ak,
-    rhel77_contenthost_module,
+    rhel7_contenthost_module,
     default_sat,
 ):
     # python-psutil obsoleted by python2-psutil, install older python2-psutil for errata test.
-    rhel77_contenthost_module.run(
+    rhel7_contenthost_module.run(
         'rpm -Uvh https://download.fedoraproject.org/pub/epel/7/x86_64/Packages/p/'
         'python2-psutil-5.6.7-1.el7.x86_64.rpm'
     )
-    rhel77_contenthost_module.install_katello_ca(default_sat)
-    rhel77_contenthost_module.register_contenthost(module_gt_manifest_org.label, module_ak.name)
-    host = entities.Host().search(query={'search': f'name={rhel77_contenthost_module.hostname}'})
+    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.register_contenthost(module_gt_manifest_org.label, module_ak.name)
+    host = entities.Host().search(query={'search': f'name={rhel7_contenthost_module.hostname}'})
     host_id = host[0].id
     host_content = entities.Host(id=host_id).read_json()
     assert host_content["subscription_status"] == 5
-    rhel77_contenthost_module.install_katello_host_tools()
-    return rhel77_contenthost_module
+    rhel7_contenthost_module.install_katello_host_tools()
+    return rhel7_contenthost_module
 
 
 @pytest.mark.tier2

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1320,25 +1320,25 @@ def new_module_ak(module_manifest_org, rh_repo_module_manifest, default_lce):
 
 
 @pytest.fixture
-def errata_host(module_manifest_org, rhel77_contenthost_module, new_module_ak, default_sat):
+def errata_host(module_manifest_org, rhel7_contenthost_module, new_module_ak, default_sat):
     """A RHEL77 Content Host that has applicable errata and registered to Library"""
     # python-psutil is obsoleted by python2-psutil, so get older python2-psutil for errata test
-    rhel77_contenthost_module.run(f'rpm -Uvh {settings.repos.epel_repo.url}/{PSUTIL_RPM}')
-    rhel77_contenthost_module.install_katello_ca(default_sat)
-    rhel77_contenthost_module.register_contenthost(module_manifest_org.label, new_module_ak.name)
-    assert rhel77_contenthost_module.nailgun_host.read_json()['subscription_status'] == 0
-    rhel77_contenthost_module.install_katello_host_tools()
-    return rhel77_contenthost_module
+    rhel7_contenthost_module.run(f'rpm -Uvh {settings.repos.epel_repo.url}/{PSUTIL_RPM}')
+    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.register_contenthost(module_manifest_org.label, new_module_ak.name)
+    assert rhel7_contenthost_module.nailgun_host.read_json()['subscription_status'] == 0
+    rhel7_contenthost_module.install_katello_host_tools()
+    return rhel7_contenthost_module
 
 
 @pytest.fixture
-def chost(module_manifest_org, rhel77_contenthost_module, new_module_ak, default_sat):
+def chost(module_manifest_org, rhel7_contenthost_module, new_module_ak, default_sat):
     """A RHEL77 Content Host registered to Library that does not have applicable errata"""
-    rhel77_contenthost_module.install_katello_ca(default_sat)
-    rhel77_contenthost_module.register_contenthost(module_manifest_org.label, new_module_ak.name)
-    assert rhel77_contenthost_module.nailgun_host.read_json()['subscription_status'] == 0
-    rhel77_contenthost_module.install_katello_host_tools()
-    return rhel77_contenthost_module
+    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.register_contenthost(module_manifest_org.label, new_module_ak.name)
+    assert rhel7_contenthost_module.nailgun_host.read_json()['subscription_status'] == 0
+    rhel7_contenthost_module.install_katello_host_tools()
+    return rhel7_contenthost_module
 
 
 @pytest.mark.tier2

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -255,7 +255,7 @@ def test_positive_candlepin_events_processed_by_STOMP():
 
 @pytest.mark.tier2
 def test_positive_auto_attach_disabled_golden_ticket(
-    module_org, golden_ticket_host_setup, rhel77_contenthost_class, default_sat
+    module_org, golden_ticket_host_setup, rhel7_contenthost_class, default_sat
 ):
     """Verify that Auto-Attach is disabled or "Not Applicable"
     when a host organization is in Simple Content Access mode (Golden Ticket)
@@ -269,12 +269,10 @@ def test_positive_auto_attach_disabled_golden_ticket(
 
     :CaseImportance: Medium
     """
-    rhel77_contenthost_class.install_katello_ca(default_sat)
-    rhel77_contenthost_class.register_contenthost(
-        module_org.label, golden_ticket_host_setup['name']
-    )
-    assert rhel77_contenthost_class.subscribed
-    host = Host.list({'search': rhel77_contenthost_class.hostname})
+    rhel7_contenthost_class.install_katello_ca(default_sat)
+    rhel7_contenthost_class.register_contenthost(module_org.label, golden_ticket_host_setup['name'])
+    assert rhel7_contenthost_class.subscribed
+    host = Host.list({'search': rhel7_contenthost_class.hostname})
     host_id = host[0]['id']
     with pytest.raises(CLIReturnCodeError) as context:
         Host.subscription_auto_attach({'host-id': host_id})


### PR DESCRIPTION
CherryPicked `Content Host` recent additions and updates to 6.9.z from master.

Cherry-Pick Command :

```
# git cherry-pick 8fa0e4f5f8a240899cfa1745c0ac61d8678e692f 8bdd80902886472d5ed2ae35da559cf002e63ee3 2f0ef92a197e486b5f62b104ef1f87757189a0ac 3cd6050840836ff2d402b2b98c803bc7584732e5 1cd5d72d1525da2670fe8db829f7ba2e71e0490d..74da7f7bb4f3a0ef67205519c04377ad12407249
```