### PR TITLE
Fixed `host_conf` fixture called in high scope fixtures

### DIFF
--- a/pytest_fixtures/content_hosts.py
+++ b/pytest_fixtures/content_hosts.py
@@ -11,75 +11,74 @@ from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
 
-@pytest.fixture
 def host_conf(request):
-    """A function-level fixture that returns parameters for VMBroker host deployment"""
+    """A function that returns arguments for VMBroker host deployment"""
     conf = params = {}
-    if hasattr(request.node, 'callspec'):
-        params = [*request.node.callspec.params.values()][0]
+    if hasattr(request, 'param'):
+        params = request.param
     conf['workflow'] = params.get('workflow', settings.content_host.deploy_workflow)
     _rhelver = f"rhel{params.get('rhel_version', settings.content_host.default_rhel_version)}"
-    conf['rhel_ver'] = settings.content_host.hardware.get(_rhelver).release
+    conf['rhel_version'] = settings.content_host.hardware.get(_rhelver).release
     conf['memory'] = params.get('memory', settings.content_host.hardware.get(_rhelver).memory)
     conf['cores'] = params.get('cores', settings.content_host.hardware.get(_rhelver).cores)
     return conf
 
 
 @pytest.fixture
-def rhel_contenthost(host_conf):
+def rhel_contenthost(request):
     """A function-level fixture that provides a content host object parametrized"""
     # Request should be parametrized through pytest_fixtures.fixture_markers
     # unpack params dict
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': '7'}])
-def rhel7_contenthost(host_conf):
+def rhel7_contenthost(request):
     """A function-level fixture that provides a rhel7 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope="class", params=[{'rhel_version': '7'}])
-def rhel7_contenthost_class(host_conf):
+def rhel7_contenthost_class(request):
     """A fixture for use with unittest classes. Provides a rhel7 Content Host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope='module', params=[{'rhel_version': '7'}])
-def rhel7_contenthost_module(host_conf):
+def rhel7_contenthost_module(request):
     """A module-level fixture that provides a rhel7 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': '8'}])
-def rhel8_contenthost(host_conf):
+def rhel8_contenthost(request):
     """A fixture that provides a rhel8 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope='module', params=[{'rhel_version': '8'}])
-def rhel8_contenthost_module(host_conf):
+def rhel8_contenthost_module(request):
     """A module-level fixture that provides a rhel8 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(params=[{'rhel_version': 6}])
-def rhel6_contenthost(host_conf):
+def rhel6_contenthost(request):
     """A function-level fixture that provides a rhel6 content host object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}) as host:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}) as host:
         yield host
 
 
 @pytest.fixture(scope='module')
-def content_hosts(host_conf):
+def content_hosts(request):
     """A module-level fixture that provides two rhel7 content hosts object"""
-    with VMBroker(**host_conf, host_classes={'host': ContentHost}, _count=2) as hosts:
+    with VMBroker(**host_conf(request), host_classes={'host': ContentHost}, _count=2) as hosts:
         hosts[0].set_infrastructure_type('physical')
         yield hosts
 


### PR DESCRIPTION
This fixes the issue/error we are seeing in content host tests which are calling module-level content host fixtures, where these fixtures calling `host_conf` func level fixture.

Error:
```
Failed on setup with "ScopeMismatch: You tried to access the 'function' scoped fixture 'host_conf' with a 'module' scoped request object, involved factories
pytest_fixtures/content_hosts.py:51:  def rhel7_contenthost_module(host_conf)
pytest_fixtures/content_hosts.py:14:  def host_conf(request)"
```