### PR TITLE
Update virt-who config file path and options

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -16,7 +16,7 @@ from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ORG
 
-VIRTWHO_SYSCONFIG = "/etc/sysconfig/virt-who"
+ETC_VIRTWHO_CONFIG = "/etc/virt-who.conf"
 
 
 class VirtWhoError(Exception):

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -27,10 +27,10 @@ from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import create_http_proxy
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
+from robottelo.virtwho_utils import ETC_VIRTWHO_CONFIG
 from robottelo.virtwho_utils import get_configure_command
 from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_option
-from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
 @pytest.fixture(scope='class')
@@ -184,7 +184,7 @@ class TestVirtWhoConfigforEsx:
             virtwho_config.update(['debug'])
             command = get_configure_command(virtwho_config.id)
             deploy_configure_by_command(command, form_data['hypervisor_type'])
-            assert get_configure_option('VIRTWHO_DEBUG', VIRTWHO_SYSCONFIG) == value
+            assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
@@ -217,7 +217,7 @@ class TestVirtWhoConfigforEsx:
             virtwho_config.update(['interval'])
             command = get_configure_command(virtwho_config.id)
             deploy_configure_by_command(command, form_data['hypervisor_type'])
-            assert get_configure_option('VIRTWHO_INTERVAL', VIRTWHO_SYSCONFIG) == value
+            assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
@@ -314,7 +314,7 @@ class TestVirtWhoConfigforEsx:
         command = get_configure_command(virtwho_config.id)
         deploy_configure_by_command(command, form_data['hypervisor_type'])
         # Check default NO_PROXY option
-        assert get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG) == '*'
+        assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == '*'
         # Check HTTTP Proxy and No_PROXY option
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(type='http')
         no_proxy = 'test.satellite.com'
@@ -323,14 +323,14 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.update(['http_proxy_id', 'no_proxy'])
         command = get_configure_command(virtwho_config.id)
         deploy_configure_by_command(command, form_data['hypervisor_type'])
-        assert get_configure_option('http_proxy', VIRTWHO_SYSCONFIG) == http_proxy_url
-        assert get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG) == no_proxy
+        assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
+        assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
         # Check HTTTPs Proxy option
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy()
         virtwho_config.http_proxy_id = https_proxy_id
         virtwho_config.update(['http_proxy_id'])
         deploy_configure_by_command(command, form_data['hypervisor_type'])
-        assert get_configure_option('https_proxy', VIRTWHO_SYSCONFIG) == https_proxy_url
+        assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -33,12 +33,12 @@ from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import create_http_proxy
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
+from robottelo.virtwho_utils import ETC_VIRTWHO_CONFIG
 from robottelo.virtwho_utils import get_configure_command
 from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import hypervisor_json_create
 from robottelo.virtwho_utils import virtwho_package_locked
-from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
 @pytest.fixture()
@@ -179,7 +179,7 @@ class TestVirtWhoConfigforEsx:
             VirtWhoConfig.update({'id': virtwho_config['id'], 'debug': key})
             command = get_configure_command(virtwho_config['id'])
             deploy_configure_by_command(command, form_data['hypervisor-type'])
-            assert get_configure_option('VIRTWHO_DEBUG', VIRTWHO_SYSCONFIG), value
+            assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
         VirtWhoConfig.delete({'name': new_name})
         assert not VirtWhoConfig.exists(search=('name', new_name))
 
@@ -209,7 +209,7 @@ class TestVirtWhoConfigforEsx:
             VirtWhoConfig.update({'id': virtwho_config['id'], 'interval': key})
             command = get_configure_command(virtwho_config['id'])
             deploy_configure_by_command(command, form_data['hypervisor-type'])
-            assert get_configure_option('VIRTWHO_INTERVAL', VIRTWHO_SYSCONFIG) == value
+            assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -304,14 +304,14 @@ class TestVirtWhoConfigforEsx:
         assert result['connection']['ignore-proxy'] == no_proxy
         command = get_configure_command(virtwho_config['id'])
         deploy_configure_by_command(command, form_data['hypervisor-type'])
-        assert get_configure_option('https_proxy', VIRTWHO_SYSCONFIG) == https_proxy_url
-        assert get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG) == no_proxy
+        assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
+        assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
 
         # Check the http proxy option, update it via http proxy id
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(type='http')
         VirtWhoConfig.update({'id': virtwho_config['id'], 'http-proxy-id': http_proxy_id})
         deploy_configure_by_command(command, form_data['hypervisor-type'])
-        assert get_configure_option('http_proxy', VIRTWHO_SYSCONFIG) == http_proxy_url
+        assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
 
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -29,6 +29,7 @@ from robottelo.virtwho_utils import create_http_proxy
 from robottelo.virtwho_utils import delete_configure_option
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
+from robottelo.virtwho_utils import ETC_VIRTWHO_CONFIG
 from robottelo.virtwho_utils import get_configure_command
 from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_id
@@ -36,7 +37,6 @@ from robottelo.virtwho_utils import get_configure_option
 from robottelo.virtwho_utils import get_virtwho_status
 from robottelo.virtwho_utils import restart_virtwho_service
 from robottelo.virtwho_utils import update_configure_option
-from robottelo.virtwho_utils import VIRTWHO_SYSCONFIG
 
 
 @pytest.fixture()
@@ -149,12 +149,12 @@ class TestVirtwhoConfigforEsx:
             config_id = get_configure_id(name)
             config_command = get_configure_command(config_id)
             deploy_configure_by_command(config_command, form_data['hypervisor_type'])
-            assert get_configure_option('VIRTWHO_DEBUG', VIRTWHO_SYSCONFIG) == '1'
+            assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '1'
             session.virtwho_configure.edit(name, {'debug': False})
             results = session.virtwho_configure.read(name)
             assert results['overview']['debug'] is False
             deploy_configure_by_command(config_command, form_data['hypervisor_type'])
-            assert get_configure_option('VIRTWHO_DEBUG', VIRTWHO_SYSCONFIG) == '0'
+            assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '0'
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
@@ -193,7 +193,7 @@ class TestVirtwhoConfigforEsx:
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['interval'] == option
                 deploy_configure_by_command(config_command, form_data['hypervisor_type'])
-                assert get_configure_option('VIRTWHO_INTERVAL', VIRTWHO_SYSCONFIG) == value
+                assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
@@ -305,14 +305,14 @@ class TestVirtwhoConfigforEsx:
             assert results['overview']['proxy'] == https_proxy
             assert results['overview']['no_proxy'] == no_proxy
             deploy_configure_by_command(config_command, form_data['hypervisor_type'])
-            assert get_configure_option('https_proxy', VIRTWHO_SYSCONFIG) == https_proxy
-            assert get_configure_option('NO_PROXY', VIRTWHO_SYSCONFIG) == no_proxy
+            assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy
+            assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
             # Check the http proxy setting
             session.virtwho_configure.edit(name, {'proxy': http_proxy})
             results = session.virtwho_configure.read(name)
             assert results['overview']['proxy'] == http_proxy
             deploy_configure_by_command(config_command, form_data['hypervisor_type'])
-            assert get_configure_option('http_proxy', VIRTWHO_SYSCONFIG) == http_proxy
+            assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 


### PR DESCRIPTION
**Description**
With this PR merged https://github.com/theforeman/foreman_virt_who_configure/pull/132

We are now using `tfm-rubygem-foreman_virt_who_configure-0.5.7-1.el7sat.noarch`.

Before the patch you will see this virt-who config file:`/etc/sysconfig/virt-who`.

Apply the patch and create a new config and deploy it.

You will see the `/etc/sysconfig/virt-who` gone and the new file `/etc/virt-who.conf` created.

So, we need to update our virt-who plugin cases based on the above change.

- [x] tests.foreman.virtwho.api.test_esx.TestVirtWhoConfigforEsx.test_positive_debug_option
- [x] tests.foreman.virtwho.api.test_esx.TestVirtWhoConfigforEsx.test_positive_interval_option
- [x] tests.foreman.virtwho.api.test_esx.TestVirtWhoConfigforEsx.test_positive_proxy_option
- [x] tests.foreman.virtwho.cli.test_esx.TestVirtWhoConfigforEsx.test_positive_debug_option
- [x] tests.foreman.virtwho.cli.test_esx.TestVirtWhoConfigforEsx.test_positive_interval_option
- [x] tests.foreman.virtwho.cli.test_esx.TestVirtWhoConfigforEsx.test_positive_proxy_option
- [x] tests.foreman.virtwho.ui.test_esx.TestVirtwhoConfigforEsx.test_positive_debug_option
- [x] tests.foreman.virtwho.ui.test_esx.TestVirtwhoConfigforEsx.test_positive_interval_option
- [x] tests.foreman.virtwho.ui.test_esx.TestVirtwhoConfigforEsx.test_positive_proxy_option


**Test Result**
All changed cases worked fine, linked the CLI cases
```
(3.8_rot) [hkx303@kuhuang robottelo]$ pytest tests/foreman/virtwho/cli/test_esx.py -k test_positive_debug_option  tests/foreman/virtwho/cli/test_esx.py -k test_positive_proxy_option tests/foreman/virtwho/cli/test_esx.py -k test_positive_interval_option
==================================== test session starts =====================================
platform linux -- Python 3.8.7, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1, xdist-2.4.0, forked-1.3.0
collected 30 items / 27 deselected / 3 selected                                              

tests/foreman/virtwho/cli/test_esx.py ...

================= 3 passed, 27 deselected, 4 warnings in 2362.15s (0:39:22) ==================
```

