### PR TITLE
katello-agent still required for HC in 6.9.z

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -83,10 +83,7 @@ def vm_content_hosts(module_loc, module_repos_collection, default_sat):
     distro = module_repos_collection.distro
     with VMBroker(nick=distro, host_classes={'host': ContentHost}, _count=2) as clients:
         for client in clients:
-            module_repos_collection.setup_virtual_machine(
-                client, default_sat, install_katello_agent=False
-            )
-            add_remote_execution_ssh_key(client.ip_addr)
+            module_repos_collection.setup_virtual_machine(client, default_sat)
             update_vm_host_location(client, module_loc.id)
         yield clients
 


### PR DESCRIPTION
Hello

Reverting a change due to an over enthusiastic cherry pick in https://github.com/SatelliteQE/robottelo/pull/8889