### PR TITLE
Remove make_gpg_key and fix test cases to use make_content_credential

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -33,7 +33,6 @@ from robottelo.cli.discoveryrule import DiscoveryRule
 from robottelo.cli.domain import Domain
 from robottelo.cli.environment import Environment
 from robottelo.cli.filter import Filter
-from robottelo.cli.gpgkey import GPGKey
 from robottelo.cli.host import Host
 from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.hostgroup import HostGroup
@@ -330,43 +329,6 @@ def make_discoveryrule(options=None):
     }
 
     return create_object(DiscoveryRule, args, options)
-
-
-@cacheable
-def make_gpg_key(options=None):
-    """Creates a GPG Key
-
-    :param options: Check options using `hammer gpg create --help` on satellite.
-
-    :returns GPGKey object
-    """
-    # Organization ID is a required field.
-    if not options or not options.get('organization-id'):
-        raise CLIFactoryError('Please provide a valid ORG ID.')
-
-    # Create a fake gpg key file if none was provided
-    if not options.get('key'):
-        _, key_filename = mkstemp(text=True)
-        os.chmod(key_filename, 0o700)
-        with open(key_filename, 'w') as gpg_key_file:
-            gpg_key_file.write(gen_alphanumeric(gen_integer(20, 50)))
-    else:
-        # If the key is provided get its local path and remove it from options
-        # to not override the remote path
-        key_filename = options.pop('key')
-
-    args = {
-        'key': f'/tmp/{gen_alphanumeric()}',
-        'name': gen_alphanumeric(),
-        'organization': None,
-        'organization-id': None,
-        'organization-label': None,
-    }
-
-    # Upload file to server
-    ssh.get_client().put(key_filename, args['key'])
-
-    return create_object(GPGKey, args, options)
 
 
 @cacheable

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -26,7 +26,7 @@ from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.defaults import Defaults
 from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_gpg_key
+from robottelo.cli.factory import make_content_credential
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product
 from robottelo.cli.factory import make_repository
@@ -58,7 +58,7 @@ def test_positive_CRUD(module_org):
     :CaseImportance: Critical
     """
     desc = list(valid_data_list().values())[0]
-    gpg_key = make_gpg_key({'organization-id': module_org.id})
+    gpg_key = make_content_credential({'organization-id': module_org.id})
     name = list(valid_data_list().values())[0]
     label = valid_labels_list()[0]
     sync_plan = make_sync_plan({'organization-id': module_org.id})
@@ -81,7 +81,7 @@ def test_positive_CRUD(module_org):
 
     # update
     desc = list(valid_data_list().values())[0]
-    new_gpg_key = make_gpg_key({'organization-id': module_org.id})
+    new_gpg_key = make_content_credential({'organization-id': module_org.id})
     new_sync_plan = make_sync_plan({'organization-id': module_org.id})
     new_prod_name = gen_string('alpha', 8)
     Product.update(

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -31,9 +31,9 @@ from robottelo.cli.content_export import ContentExport
 from robottelo.cli.content_import import ContentImport
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.factory import CLIFactoryError
+from robottelo.cli.factory import make_content_credential
 from robottelo.cli.factory import make_content_view
 from robottelo.cli.factory import make_filter
-from robottelo.cli.factory import make_gpg_key
 from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.cli.factory import make_org
 from robottelo.cli.factory import make_product
@@ -135,7 +135,7 @@ def repo(repo_options):
 @pytest.fixture
 def gpg_key(module_org):
     """Create a new GPG key."""
-    return make_gpg_key({'organization-id': module_org.id})
+    return make_content_credential({'organization-id': module_org.id})
 
 
 class TestRepository:
@@ -1414,7 +1414,7 @@ class TestRepository:
         """
         Repository.update({'id': repo['id'], 'gpg-key-id': gpg_key['id']})
 
-        gpg_key_new = make_gpg_key({'organization-id': module_org.id})
+        gpg_key_new = make_content_credential({'organization-id': module_org.id})
         Repository.update({'id': repo['id'], 'gpg-key-id': gpg_key_new['id']})
         result = Repository.info({'id': repo['id']})
         assert result['gpg-key']['id'] == gpg_key_new['id']


### PR DESCRIPTION
gpg key creation is moved to content_credential.  Cleaning up some failures that still uses `make_gpg_key`.

```
pytest tests/foreman/cli/test_product.py::test_positive_CRUD
======================= 1 passed, 9 warnings in 87.04s (0:01:27) ================


pytest tests/foreman/cli/test_repository.py::TestRepository::test_positive_create_with_gpg_key_by_id
======================= 1 passed, 7 warnings in 26.97s ==================================


pytest tests/foreman/cli/test_repository.py::TestRepository::test_positive_update_gpg_key
========================= 1 passed, 7 warnings in 40.84s ======================
```