### PR TITLE
Fix katello agent tests to run on different satellite

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -68,6 +68,14 @@ def satellite_host(satellite_factory):
     VMBroker(hosts=[new_sat]).checkin()
 
 
+@pytest.fixture(scope='module')
+def module_satellite_host(satellite_factory):
+    """A fixture that provides a Satellite based on config settings"""
+    new_sat = satellite_factory()
+    yield new_sat
+    VMBroker(hosts=[new_sat]).checkin()
+
+
 @pytest.fixture
 def capsule_host(capsule_factory):
     """A fixture that provides a Capsule based on config settings"""
@@ -89,4 +97,11 @@ def capsule_configured(capsule_host, default_sat):
 def destructive_sat(satellite_host):
     """Destructive tests require changing settings.server.hostname for now"""
     with satellite_host as sat:
+        yield sat
+
+
+@pytest.fixture(scope='module')
+def module_destructive_sat(module_satellite_host):
+    """Destructive tests require changing settings.server.hostname for now"""
+    with module_satellite_host as sat:
         yield sat

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -243,7 +243,7 @@ class Base:
         )
         response = ssh.command(
             cmd.encode('utf-8'),
-            hostname=hostname or cls.hostname,
+            hostname=hostname or settings.server.hostname or cls.hostname,
             output_format=output_format,
             timeout=timeout,
         )

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -210,3 +210,22 @@ def test_positive_rct_shows_golden_ticket_enabled(module_gt_manifest_org, defaul
     result = default_sat.execute(f'rct cat-manifest {module_gt_manifest_org.manifest_filename}')
     assert result.status == 0
     assert 'Content Access Mode: Simple Content Access' in result.stdout
+
+
+@pytest.mark.tier3
+def test_negative_unregister_and_pull_content(vm):
+    """Attempt to retrieve content after host has been unregistered from Satellite
+
+    :id: de0d0d91-b1e1-4f0e-8a41-c27df4d6b6fd
+
+    :expectedresults: Host can no longer retrieve content from satellite
+
+    :CaseLevel: System
+
+    :CaseImportance: Critical
+    """
+    result = vm.run('subscription-manager unregister')
+    assert result.status == 0
+    # Try installing any package from available repos on vm
+    result = vm.run('yum install -y katello-agent')
+    assert result.status != 0

--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -16,99 +16,90 @@
 
 :Upstream: No
 """
-import time
-
 import pytest
-from broker import VMBroker
 
-from robottelo.api.utils import wait_for_errata_applicability_task
-from robottelo.cli.activationkey import ActivationKey
-from robottelo.cli.factory import make_activation_key
-from robottelo.cli.factory import make_host_collection
+from robottelo import constants
 from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.cli.factory import setup_org_for_a_rh_repo
-from robottelo.cli.host import Host
-from robottelo.cli.hostcollection import HostCollection
 from robottelo.config import settings
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_GROUP
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_GROUP_NAME
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE_NAME
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-from robottelo.hosts import ContentHost
+from robottelo.helpers import InstallerCommand
 
 
-pytestmark = [pytest.mark.skip_if_not_set('clients', 'fake_manifest')]
+pytestmark = [
+    pytest.mark.run_in_one_thread,
+    pytest.mark.skip_if_not_set('clients', 'fake_manifest'),
+]
 
 
 @pytest.fixture(scope='module')
-def katello_agent_repos(module_ak, module_cv, module_lce, module_org):
+def sat_with_katello_agent(module_destructive_sat):
+    """Enable katello-agent on destructive_sat"""
+    module_destructive_sat.register_to_dogfood()
+    # Enable katello-agent from satellite-installer
+    result = module_destructive_sat.install(
+        InstallerCommand('foreman-proxy-content-enable-katello-agent true')
+    )
+    assert result.status == 0
+    # Verify katello-agent is enabled
+    result = module_destructive_sat.install(
+        InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
+    )
+    assert 'true' in result.stdout
+    yield module_destructive_sat
+
+
+@pytest.fixture(scope='module')
+def katello_agent_repos(sat_with_katello_agent):
     """Create Org, Lifecycle Environment, Content View, Activation key"""
-    setup_org_for_a_rh_repo(
-        {
-            'product': PRDS['rhel'],
-            'repository-set': REPOSET['rhst7'],
-            'repository': REPOS['rhst7']['name'],
-            'organization-id': module_org.id,
-            'content-view-id': module_cv.id,
-            'lifecycle-environment-id': module_lce.id,
-            'activationkey-id': module_ak.id,
-        }
-    )
-    # Create custom repository content
-    setup_org_for_a_custom_repo(
-        {
-            'url': settings.repos.yum_1.url,
-            'organization-id': module_org.id,
-            'content-view-id': module_cv.id,
-            'lifecycle-environment-id': module_lce.id,
-            'activationkey-id': module_ak.id,
-        }
-    )
+    sat = sat_with_katello_agent
+    org = sat.api.Organization().create()
+    lce = sat.api.LifecycleEnvironment(organization=org).create()
+    cv = sat.api.ContentView(organization=org).create()
+    ak = sat.api.ActivationKey(environment=lce, organization=org).create()
+    with sat:
+        setup_org_for_a_rh_repo(
+            {
+                'product': constants.PRDS['rhel'],
+                'repository-set': constants.REPOSET['rhst7'],
+                'repository': constants.REPOS['rhst7']['name'],
+                'organization-id': org.id,
+                'content-view-id': cv.id,
+                'lifecycle-environment-id': lce.id,
+                'activationkey-id': ak.id,
+            }
+        )
+        # Create custom repository content
+        setup_org_for_a_custom_repo(
+            {
+                'url': settings.repos.yum_1.url,
+                'organization-id': org.id,
+                'content-view-id': cv.id,
+                'lifecycle-environment-id': lce.id,
+                'activationkey-id': ak.id,
+            }
+        )
     return {
-        'ak': module_ak,
-        'cv': module_cv,
-        'lce': module_lce,
-        'org': module_org,
-    }
+        'ak': ak,
+        'cv': cv,
+        'lce': lce,
+        'org': org,
+    }, sat_with_katello_agent
 
 
 @pytest.fixture
-def katello_agent_client(katello_agent_repos, rhel7_contenthost, default_sat):
-    rhel7_contenthost.install_katello_ca(default_sat)
+def katello_agent_client(katello_agent_repos, rhel7_contenthost):
+    katello_agent_repos, sat_with_katello_agent = katello_agent_repos
+    rhel7_contenthost.install_katello_ca(sat_with_katello_agent)
     # Register content host and install katello-agent
     rhel7_contenthost.register_contenthost(
         katello_agent_repos['org'].label,
         katello_agent_repos['ak'].name,
     )
     assert rhel7_contenthost.subscribed
-    host_info = Host.info({'name': rhel7_contenthost.hostname})
-    rhel7_contenthost.enable_repo(REPOS['rhst7']['id'])
+    host_info = sat_with_katello_agent.cli.Host.info({'name': rhel7_contenthost.hostname})
+    rhel7_contenthost.enable_repo(constants.REPOS['rhst7']['id'])
     rhel7_contenthost.install_katello_agent()
-    yield {'client': rhel7_contenthost, 'host_info': host_info}
-
-
-@pytest.mark.tier3
-def test_positive_get_errata_info(katello_agent_client):
-    """Get errata info
-
-    :id: afb5ab34-1703-49dc-8ddc-5e032c1b86d7
-
-    :expectedresults: Errata info was displayed
-
-    :CaseLevel: System
-    """
-    client = katello_agent_client['client']
-    host_info = katello_agent_client['host_info']
-    client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
-    result = Host.errata_info({'host-id': host_info['id'], 'id': settings.repos.yum_0.errata[1]})
-    assert result[0]['errata-id'] == settings.repos.yum_0.errata[1]
-    assert FAKE_2_CUSTOM_PACKAGE in result[0]['packages']
+    yield {'client': rhel7_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent}
 
 
 @pytest.mark.tier3
@@ -122,45 +113,21 @@ def test_positive_apply_errata(katello_agent_client):
 
     :CaseLevel: System
     """
+    sat = katello_agent_client['sat']
     client = katello_agent_client['client']
     host_info = katello_agent_client['host_info']
-    client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
-    Host.errata_apply({'errata-ids': settings.repos.yum_0.errata[1], 'host-id': host_info['id']})
+    client.run(f'yum install -y {constants.FAKE_1_CUSTOM_PACKAGE}')
+    result = sat.cli.Host.errata_info(
+        {'host-id': host_info['id'], 'id': settings.repos.yum_0.errata[1]}
+    )
+    assert result[0]['errata-id'] == settings.repos.yum_0.errata[1]
+    assert constants.FAKE_2_CUSTOM_PACKAGE in result[0]['packages']
 
-
-@pytest.mark.tier3
-def test_positive_apply_security_erratum(katello_agent_client):
-    """Apply security erratum to a host
-
-    :id: 4d1095c8-d354-42ac-af44-adf6dbb46deb
-
-    :expectedresults: erratum is recognized by the
-        `yum update --security` command on client
-
-    :CaseLevel: System
-
-    :customerscenario: true
-
-    :BZ: 1420671, 1740790
-    """
-    client = katello_agent_client['client']
-    host_info = katello_agent_client['host_info']
-    client.download_install_rpm(settings.repos.yum_1.url, FAKE_2_CUSTOM_PACKAGE)
-    # Check the system is up to date
-    result = client.run('yum update --security | grep "No packages needed for security"')
+    sat.cli.Host.errata_apply(
+        {'errata-ids': settings.repos.yum_0.errata[1], 'host-id': host_info['id']}
+    )
+    result = client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}')
     assert result.status == 0
-    before_downgrade = int(time.time())
-    # Downgrade walrus package
-    client.run(f'yum downgrade -y {FAKE_2_CUSTOM_PACKAGE_NAME}')
-    # Wait for errata applicability cache is counted
-    wait_for_errata_applicability_task(int(host_info['id']), before_downgrade)
-    # Check that host has applicable errata
-    host_errata = Host.errata_list({'host-id': host_info['id']})
-    assert host_errata[0]['erratum-id'] == settings.repos.yum_0.errata[1]
-    assert host_errata[0]['installable'] == 'true'
-    # Check the erratum becomes available
-    result = client.run('yum update --assumeno --security | grep "No packages needed for security"')
-    assert result.status == 1
 
 
 @pytest.mark.tier3
@@ -174,10 +141,13 @@ def test_positive_install_package(katello_agent_client):
 
     :CaseLevel: System
     """
+    sat = katello_agent_client['sat']
     client = katello_agent_client['client']
     host_info = katello_agent_client['host_info']
-    Host.package_install({'host-id': host_info['id'], 'packages': FAKE_0_CUSTOM_PACKAGE_NAME})
-    result = client.run(f'rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}')
+    sat.cli.Host.package_install(
+        {'host-id': host_info['id'], 'packages': constants.FAKE_0_CUSTOM_PACKAGE_NAME}
+    )
+    result = client.run(f'rpm -q {constants.FAKE_0_CUSTOM_PACKAGE_NAME}')
     assert result.status == 0
 
 
@@ -191,11 +161,14 @@ def test_positive_remove_package(katello_agent_client):
 
     :CaseLevel: System
     """
+    sat = katello_agent_client['sat']
     client = katello_agent_client['client']
     host_info = katello_agent_client['host_info']
-    client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
-    Host.package_remove({'host-id': host_info['id'], 'packages': FAKE_1_CUSTOM_PACKAGE_NAME})
-    result = client.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE_NAME}')
+    client.run(f'yum install -y {constants.FAKE_1_CUSTOM_PACKAGE}')
+    sat.cli.Host.package_remove(
+        {'host-id': host_info['id'], 'packages': constants.FAKE_1_CUSTOM_PACKAGE_NAME}
+    )
+    result = client.run(f'rpm -q {constants.FAKE_1_CUSTOM_PACKAGE_NAME}')
     assert result.status != 0
 
 
@@ -209,11 +182,14 @@ def test_positive_upgrade_package(katello_agent_client):
 
     :CaseLevel: System
     """
+    sat = katello_agent_client['sat']
     client = katello_agent_client['client']
     host_info = katello_agent_client['host_info']
-    client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
-    Host.package_upgrade({'host-id': host_info['id'], 'packages': FAKE_1_CUSTOM_PACKAGE_NAME})
-    result = client.run(f'rpm -q {FAKE_2_CUSTOM_PACKAGE}')
+    client.run(f'yum install -y {constants.FAKE_1_CUSTOM_PACKAGE}')
+    sat.cli.Host.package_upgrade(
+        {'host-id': host_info['id'], 'packages': constants.FAKE_1_CUSTOM_PACKAGE_NAME}
+    )
+    result = client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}')
     assert result.status == 0
 
 
@@ -228,11 +204,12 @@ def test_positive_upgrade_packages_all(katello_agent_client):
 
     :CaseLevel: System
     """
+    sat = katello_agent_client['sat']
     client = katello_agent_client['client']
     host_info = katello_agent_client['host_info']
-    client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
-    Host.package_upgrade_all({'host-id': host_info['id']})
-    result = client.run(f'rpm -q {FAKE_2_CUSTOM_PACKAGE}')
+    client.run(f'yum install -y {constants.FAKE_1_CUSTOM_PACKAGE}')
+    sat.cli.Host.package_upgrade_all({'host-id': host_info['id']})
+    result = client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}')
     assert result.status == 0
 
 
@@ -248,84 +225,15 @@ def test_positive_install_and_remove_package_group(katello_agent_client):
 
     :CaseLevel: System
     """
+    sat = katello_agent_client['sat']
     client = katello_agent_client['client']
     host_info = katello_agent_client['host_info']
-    hammer_args = {'groups': FAKE_0_CUSTOM_PACKAGE_GROUP_NAME, 'host-id': host_info['id']}
-    Host.package_group_install(hammer_args)
-    for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+    hammer_args = {'groups': constants.FAKE_0_CUSTOM_PACKAGE_GROUP_NAME, 'host-id': host_info['id']}
+    sat.cli.Host.package_group_install(hammer_args)
+    for package in constants.FAKE_0_CUSTOM_PACKAGE_GROUP:
         result = client.run(f'rpm -q {package}')
         assert result.status == 0
-    Host.package_group_remove(hammer_args)
-    for package in FAKE_0_CUSTOM_PACKAGE_GROUP:
+    sat.cli.Host.package_group_remove(hammer_args)
+    for package in constants.FAKE_0_CUSTOM_PACKAGE_GROUP:
         result = client.run(f'rpm -q {package}')
         assert result.status != 0
-
-
-@pytest.mark.tier3
-def test_negative_unregister_and_pull_content(katello_agent_client):
-    """Attempt to retrieve content after host has been unregistered from Satellite
-
-    :id: de0d0d91-b1e1-4f0e-8a41-c27df4d6b6fd
-
-    :expectedresults: Host can no longer retrieve content from satellite
-
-    :CaseLevel: System
-    """
-    client = katello_agent_client['client']
-    result = client.run('subscription-manager unregister')
-    assert result.status == 0
-    result = client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
-    assert result.status != 0
-
-
-@pytest.mark.tier3
-@pytest.mark.upgrade
-def test_positive_register_host_ak_with_host_collection(
-    katello_agent_client, module_cv, module_lce, module_org, rhel7_contenthost, default_sat
-):
-    """Attempt to register a host using activation key with host collection
-
-    :id: 7daf4e40-3fa6-42af-b3f7-1ca1a5c9bfeb
-
-    :BZ: 1385814
-
-    :expectedresults: Host successfully registered and listed in host
-        collection
-
-    :CaseLevel: System
-    """
-    # client = katello_agent_client['client']
-    host_info = katello_agent_client['host_info']
-    # create a new activation key
-    activation_key = make_activation_key(
-        {
-            'lifecycle-environment-id': module_lce.id,
-            'organization-id': module_org.id,
-            'content-view-id': module_cv.id,
-        }
-    )
-    hc = make_host_collection({'organization-id': module_org.id})
-    ActivationKey.add_host_collection(
-        {
-            'id': activation_key['id'],
-            'organization-id': module_org.id,
-            'host-collection-id': hc['id'],
-        }
-    )
-    # add the registered instance host to collection
-    HostCollection.add_host(
-        {'id': hc['id'], 'organization-id': module_org.id, 'host-ids': host_info['id']}
-    )
-
-    with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
-        vm.install_katello_ca(default_sat)
-        # register the client host with the current activation key
-        vm.register_contenthost(module_org.name, activation_key=activation_key['name'])
-        assert vm.subscribed
-        # note: when registering the host, it should be automatically added to the host-collection
-        client_host = Host.info({'name': vm.hostname})
-        hosts = HostCollection.hosts({'id': hc['id'], 'organization-id': module_org.id})
-        assert len(hosts) == 2
-        expected_hosts_ids = {host_info['id'], client_host['id']}
-        hosts_ids = {host['id'] for host in hosts}
-        assert hosts_ids == expected_hosts_ids


### PR DESCRIPTION
Katello-agent is disabled for 6.10 and can be enabled by satellite-installer flags, so moving these tests to run on different module-level satellite

Moving tests to respective modules which are not related to katello-agent, @swadeley @tstrych request to review.

Also fixes - https://github.com/SatelliteQE/robottelo/issues/8852


Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>