### PR TITLE
Improve test cleanup

### DIFF
--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -47,6 +47,7 @@ def module_repository(module_product):
     return repo
 
 
+@pytest.mark.skip_if_open("BZ:2009069")
 @pytest.mark.tier2
 def test_positive_search(session, module_org, module_product, module_repository):
     """Search for a docker image tag and reads details of it
@@ -61,8 +62,8 @@ def test_positive_search(session, module_org, module_product, module_repository)
     with session:
         session.organization.select(org_name=module_org.name)
         search = session.containerimagetag.search('latest')
-        assert module_product.name == search[0]['Product Name']
-        assert module_repository.name == search[0]['Repository Name']
+        assert module_product.name in [i['Product Name'] for i in search]
+        assert module_repository.name in [i['Repository Name'] for i in search]
         values = session.containerimagetag.read('latest')
         assert module_product.name == values['details']['product']
         assert module_repository.name == values['details']['repository']


### PR DESCRIPTION
This PR is meant to improve test cleanup. Currently, the test fails when running against the same Satellite multiple times, this is because the repo, product and orgs created by the fixtures are not deleted after the test finishes. 

In addition, there is an open BZ [#009069](https://bugzilla.redhat.com/show_bug.cgi?id=2009069) causing this test to fail, so I have added the 'skip_if_open' pytest mark until it is resolved. 