### PR TITLE
moving content from robottelo to ui.yaml

### DIFF
--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -1,7 +1,4 @@
 ROBOTTELO:
-  # The directory where screenshots will be saved.
-  # Note:- Content under /tmp may be deleted after a reboot.
-  SCREENSHOTS_PATH: /tmp/robottelo/screenshots/
   LOCALE: en_US.UTF-8
   # Update upstream=false for downstream run
   UPSTREAM: false
@@ -11,52 +8,11 @@ ROBOTTELO:
   TMP_DIR: /var/tmp
   # Web Server to provide various test artifacts
   ARTIFACTS_SERVER: replace-with-artifacts-server
-  # Webdriver logging options
-  # A list of commands to be logged
-  LOG_DRIVER_COMMANDS:
-    - newSession
-    - windowMaximize
-    - get
-    - findElement
-    - sendKeysToElement
-    - clickElement
-    - mouseMoveTo
+
   # - The URL of container hosting repos on SatLab
   # Example url - http://<container_hostname_or_ip>:<port>
   # Use https://github.com/SatelliteQE/fedorapeople-repos to deploy and configure the repos hosting container
   REPOS_HOSTING_URL: replace-with-repo-hosting-url
-  # browser tells robottelo which browser to use when testing UI. Valid values
-  # are:
-  # * selenium
-  # * docker: to use a browser inside a docker container. In order to use this
-  #   feature make sure that the docker daemon is running locally and has its
-  #   unix socket published at unix://var/run/docker.sock. Also make sure that
-  #   the docker image selenium/standalone-firefox is available.
-  # * remote: to access the remote browser, the webdriver and command_executor
-  #   are required.
-  BROWSER: selenium
-  # Webdriver to use. Valid values are chrome, firefox, ie, edge, phantomjs
-  WEBDRIVER: chrome
-  # Run browser for UI tests with semicolon delimeted options such as headless. Currently supported for only chrome.
-  BROWSEROPTIONS: replace-with-browser-options
-  # The base DesiredCapabilities dict will be get by the browser
-  # specified by webdriver config. If you override browserName then that
-  # browser will be used instead.
-  WEBDRIVER_DESIRED_CAPABILITIES:
-    PLATFORM:
-    MAXDURATION:
-    IDLETIMEOUT:
-    START-MAXIMISED:
-    SCREENRESOLUTION:
-    TAGS:
-  # Binary location for selected wedriver (not needed if using saucelabs)
-  # webdriver_binary=/usr/bin/chromedriver
-  # webdriver_binary=C:\\Program Files (x86)\\Microsoft Web Driver\\MicrosoftWebDriver.exe
-  WEBDRIVER_BINARY: /usr/bin/chromedriver
-  # Zalenium command_executor
-  COMMAND_EXECUTOR: http://127.0.0.1:4444/wd/hub
-  # CDN sync
-  CDN: true
   # Run one datapoint or multiple datapoints for tests
   RUN_ONE_DATAPOINT: false
   # Satellite version supported by this branch

--- a/conf/ui.yaml.template
+++ b/conf/ui.yaml.template
@@ -1,0 +1,45 @@
+UI:
+  SCREENSHOTS_PATH: /tmp/robottelo/screenshots/
+  # Webdriver logging options
+  LOG_DRIVER_COMMANDS:
+  - newSession
+  - windowMaximize
+  - get
+  - findElement
+  - sendKeysToElement
+  - clickElement
+  - mouseMoveTo
+
+  # browser tells robottelo which browser to use when testing UI. Valid values
+  # are:
+  # * selenium
+  # * docker: to use a browser inside a docker container. In order to use this
+  #   feature make sure that the docker daemon is running locally and has its
+  #   unix socket published at unix://var/run/docker.sock. Also make sure that
+  #   the docker image selenium/standalone-firefox is available.
+  # * remote: to access the remote browser, the webdriver and command_executor
+  #   are required.
+  BROWSER: selenium
+  # Webdriver to use. Valid values are chrome, firefox
+  WEBDRIVER: chrome
+  # Binary location for selected wedriver (not needed if using saucelabs)
+  WEBDRIVER_BINARY: /usr/bin/chromedriver
+
+  # Web_Kaifuku Settings (checkout https://github.com/RonnyPfannschmidt/webdriver_kaifuku)
+  WEBKAIFUKU:
+    webdriver: chrome/remote
+    webdriver_options:
+      command_executor: http://localhost:4444/wd/hub
+      desired_capabilities:
+        browserName: chrome
+        chromeOptions:
+          args:
+            - 'disable-web-security'
+            - 'ignore-certificate-errors'
+          prefs:
+            download.prompt_for_download: False
+        platform: any
+        maxduration: 5400
+        idletimeout: 1000
+        start-maximised: true
+        screenresolution: 1600x1200

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -152,15 +152,12 @@ def configure_airgun():
                 'username': settings.server.admin_username,
             },
             'selenium': {
-                'browser': settings.robottelo.browser,
-                'screenshots_path': settings.robottelo.screenshots_path,
-                'webdriver': settings.robottelo.webdriver,
-                'webdriver_binary': settings.robottelo.webdriver_binary,
-                'command_executor': settings.robottelo.command_executor,
+                'browser': settings.ui.browser,
+                'screenshots_path': settings.ui.screenshots_path,
+                'webdriver': settings.ui.webdriver,
+                'webdriver_binary': settings.ui.webdriver_binary,
             },
-            'webdriver_desired_capabilities': (
-                settings.robottelo.webdriver_desired_capabilities or {}
-            ),
+            'webkaifuku': {'config': settings.ui.webkaifuku} or {},
         }
     )
 

--- a/robottelo/datafactory.py
+++ b/robottelo/datafactory.py
@@ -40,7 +40,7 @@ def filtered_datapoint(func):
             if (
                 'ui' in args
                 or kwargs.get('interface') == 'ui'
-                and settings.robottelo.webdriver == 'chrome'
+                and settings.ui.webdriver == 'chrome'
             ):
                 # Chromedriver only supports BMP chars
                 utf8 = dataset.pop('utf8', None)

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -721,7 +721,7 @@ def test_positive_assign_compliance_policy(session, scap_policy):
         assert not session.host.search(f'compliance_policy = {scap_policy["name"]}')
 
 
-@pytest.mark.skipif((settings.robottelo.webdriver != 'chrome'), reason='Only tested on Chrome')
+@pytest.mark.skipif((settings.ui.webdriver != 'chrome'), reason='Only tested on Chrome')
 @pytest.mark.tier3
 def test_positive_export(session):
     """Create few hosts and export them via UI


### PR DESCRIPTION
### PR Description

- Addition of Web-Kaifuku
- Addition of ui.yaml file for configuration (Airgun PR : https://github.com/SatelliteQE/airgun/pull/620)
- update the mapping of settings with Airgun 
- CI PR : 399

### Test Result

- with remote zalenium server 

```
============================= test session starts ==============================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-1.16, xdist-2.3.0, cov-2.12.1, reportportal-5.0.8, mock-3.6.1, forked-1.3.0collected 6 items / 5 deselected / 1 selected

tests/foreman/ui/test_hostgroup.py ========== 1 passed, 5 deselected, 16 warnings in 2375.79s (0:39:35) ===========
```
