### PR TITLE
Refactor helper functions to take satellite obj

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -74,11 +74,11 @@ def module_manifest_org():
 
 
 @pytest.fixture(scope='module')
-def module_gt_manifest_org():
+def module_gt_manifest_org(default_sat):
     """Creates a new org and loads GT manifest in the new org"""
     org = entities.Organization().create()
     manifest = manifests.clone(org_environment_access=True, name='golden_ticket')
-    manifests.upload_manifest_locked(org.id, manifest, interface=manifests.INTERFACE_CLI)
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=org.id, manifest=manifest)
     org.manifest_filename = manifest.filename
     return org
 

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -2330,6 +2330,7 @@ def setup_cdn_and_custom_repositories(org_id, repos, download_policy='on_demand'
 
 
 def setup_cdn_and_custom_repos_content(
+    satellite,
     org_id,
     lce_id=None,
     repos=None,
@@ -2362,7 +2363,10 @@ def setup_cdn_and_custom_repos_content(
         # Upload the organization manifest
         try:
             manifests.upload_manifest_locked(
-                org_id, manifests.clone(), interface=manifests.INTERFACE_CLI
+                satellite=satellite,
+                org_id=org_id,
+                manifest=manifests.clone(),
+                interface=manifests.INTERFACE_CLI,
             )
         except CLIReturnCodeError as err:
             raise CLIFactoryError(f'Failed to upload manifest\n{err.msg}')

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -815,9 +815,10 @@ class ContentHost(Host):
         ]
         repos.extend(extra_repos)
         content_setup_data = cli_factory.setup_cdn_and_custom_repos_content(
-            org['id'],
-            lce['id'],
-            repos,
+            satellite=satellite,
+            org_id=org['id'],
+            lce_id=lce['id'],
+            repos=repos,
             upload_manifest=upload_manifest,
             rh_subscriptions=[constants.DEFAULT_SUBSCRIPTION_NAME],
         )

--- a/robottelo/manifests.py
+++ b/robottelo/manifests.py
@@ -10,10 +10,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import padding
-from nailgun import entities
 
-from robottelo import ssh
-from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.constants import INTERFACE_API
 from robottelo.constants import INTERFACE_CLI
@@ -195,7 +192,7 @@ def original_manifest(name='default'):
 
 
 @lock_function
-def upload_manifest_locked(org_id, manifest=None, interface=INTERFACE_API, timeout=None):
+def upload_manifest_locked(satellite, org_id, manifest=None, interface=INTERFACE_API, timeout=None):
     """Upload a manifest with locking, using the requested interface.
 
     :type org_id: int
@@ -212,14 +209,14 @@ def upload_manifest_locked(org_id, manifest=None, interface=INTERFACE_API, timeo
 
         # for API interface
         manifest = manifests.clone()
-        upload_manifest_locked(org_id, manifest, interface=INTERFACE_API)
+        upload_manifest_locked(default_sat, org_id, manifest, interface=INTERFACE_API)
 
         # for CLI interface
         manifest = manifests.clone()
-        upload_manifest_locked(org_id, manifest, interface=INTERFACE_CLI)
+        upload_manifest_locked(default_sat, org_id, manifest, interface=INTERFACE_CLI)
 
         # or in one line with default interface
-        result = upload_manifest_locked(org_id, manifests.clone())
+        result = upload_manifest_locked(default_sat, org_id, manifests.clone())
         subscription_id = result[id']
     """
 
@@ -235,15 +232,15 @@ def upload_manifest_locked(org_id, manifest=None, interface=INTERFACE_API, timeo
         timeout = 1500
     if interface == INTERFACE_API:
         with manifest:
-            result = entities.Subscription().upload(
+            result = satellite.api.Subscription().upload(
                 data={'organization_id': org_id}, files={'content': manifest.content}
             )
     else:
         # interface is INTERFACE_CLI
         with manifest:
-            ssh.get_client().put(manifest, manifest.filename)
+            satellite.put(manifest, manifest.filename)
 
-        result = Subscription.upload(
+        result = satellite.cli.Subscription.upload(
             {'file': manifest.filename, 'organization-id': org_id}, timeout=timeout
         )
 

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -871,6 +871,7 @@ class RepositoryCollection:
 
     def setup_content(
         self,
+        satellite,
         org_id,
         lce_id,
         upload_manifest=False,
@@ -896,7 +897,7 @@ class RepositoryCollection:
         if self.need_subscription:
             # upload manifest only when needed
             if upload_manifest and not self.organization_has_manifest(org_id):
-                manifests.upload_manifest_locked(org_id, interface=manifests.INTERFACE_CLI)
+                manifests.upload_manifest_locked(satellite=satellite, org_id=org_id)
             if not rh_subscriptions:
                 # add the default subscription if no subscription provided
                 rh_subscriptions = [constants.DEFAULT_SUBSCRIPTION_NAME]

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -813,11 +813,13 @@ def test_positive_incremental_update_required(
 
 
 @pytest.fixture(scope='module')
-def repos_collection(module_org, module_lce):
+def repos_collection(default_sat, module_org, module_lce):
     repos_collection = RepositoryCollection(
         distro=constants.DISTRO_RHEL8, repositories=[YumRepository(url=settings.repos.swid_tag.url)]
     )
-    repos_collection.setup_content(module_org.id, module_lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=module_org.id, lce_id=module_lce.id, upload_manifest=True
+    )
     return repos_collection
 
 

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -181,7 +181,7 @@ def test_negative_rct_not_shows_golden_ticket_enabled(default_sat):
     org = entities.Organization().create()
     # upload organization manifest with org environment access disabled
     manifest = manifests.clone()
-    manifests.upload_manifest_locked(org.id, manifest, interface=manifests.INTERFACE_CLI)
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=org.id, manifest=manifest)
     result = default_sat.execute(f'rct cat-manifest {manifest.filename}')
     assert result.status == 0
     assert 'Content Access Mode: Simple Content Access' not in result.stdout

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -68,7 +68,9 @@ def test_vm_install_package(org, lce, distro, cdn, default_sat):
         ],
     )
     # Create repos, content view, and activation key.
-    repos_collection.setup_content(org['id'], lce['id'], upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=org['id'], lce_id=lce['id'], upload_manifest=True
+    )
     with VMBroker(nick=distro, host_classes={'host': ContentHost}) as host:
         # install katello-agent
         repos_collection.setup_virtual_machine(

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -98,7 +98,9 @@ def test_positive_end_to_end_register(session, rhel7_contenthost, default_sat):
     repos_collection = RepositoryCollection(
         distro=constants.DISTRO_RHEL7, repositories=[SatelliteToolsRepository()]
     )
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=org.id, lce_id=lce.id, upload_manifest=True
+    )
     ak_name = repos_collection.setup_content_data['activation_key']['name']
 
     repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
@@ -1098,7 +1100,7 @@ def test_positive_service_level_subscription_with_custom_product(
     :CaseLevel: System
     """
     org = entities.Organization().create()
-    manifests.upload_manifest_locked(org.id)
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=org.id)
     entities_ids = setup_org_for_a_custom_repo(
         {'url': settings.repos.yum_1.url, 'organization-id': org.id}
     )

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -66,7 +66,7 @@ def module_org():
 
 
 @pytest.fixture(scope='module')
-def repos_collection(module_org):
+def repos_collection(default_sat, module_org):
     """Adds required repositories, AK, LCE and CV for content host testing"""
     lce = entities.LifecycleEnvironment(organization=module_org).create()
     repos_collection = RepositoryCollection(
@@ -78,12 +78,14 @@ def repos_collection(module_org):
             YumRepository(url=settings.repos.yum_6.url),
         ],
     )
-    repos_collection.setup_content(module_org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=module_org.id, lce_id=lce.id, upload_manifest=True
+    )
     return repos_collection
 
 
 @pytest.fixture(scope='module')
-def repos_collection_for_module_streams(module_org):
+def repos_collection_for_module_streams(default_sat, module_org):
     """Adds required repositories, AK, LCE and CV for content host testing for
     module streams"""
     lce = entities.LifecycleEnvironment(organization=module_org).create()
@@ -96,7 +98,9 @@ def repos_collection_for_module_streams(module_org):
             YumRepository(url=settings.repos.module_stream_1.url),
         ],
     )
-    repos_collection.setup_content(module_org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=module_org.id, lce_id=lce.id, upload_manifest=True
+    )
     return repos_collection
 
 
@@ -1357,7 +1361,9 @@ def test_content_access_after_stopped_foreman(
                 YumRepository(url=settings.repos.yum_6.url),
             ],
         )
-        repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+        repos_collection.setup_content(
+            satellite=default_sat, org_id=org.id, lce_id=lce.id, upload_manifest=True
+        )
         repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
     result = rhel7_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1392,7 +1392,7 @@ def test_positive_promote_composite_with_custom_content(session):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
-def test_positive_publish_rh_content_with_errata_by_date_filter(session):
+def test_positive_publish_rh_content_with_errata_by_date_filter(session, default_sat):
     """Publish a CV, containing only RH repo, having errata excluding by
     date filter
 
@@ -1415,7 +1415,11 @@ def test_positive_publish_rh_content_with_errata_by_date_filter(session):
         distro=DISTRO_RHEL6, repositories=[VirtualizationAgentsRepository()]
     )
     repos_collection.setup_content(
-        org.id, lce.id, download_policy='immediate', upload_manifest=True
+        satellite=default_sat,
+        org_id=org.id,
+        lce_id=lce.id,
+        download_policy='immediate',
+        upload_manifest=True,
     )
     cv = entities.ContentView(id=repos_collection.setup_content_data['content_view']['id']).read()
     cvf = entities.ErratumContentViewFilter(
@@ -2293,7 +2297,7 @@ def test_positive_add_all_security_errata_by_date_range_filter(session, module_o
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier3
-def test_positive_edit_rh_custom_spin(session):
+def test_positive_edit_rh_custom_spin(session, default_sat):
     """Edit content views for a custom rh spin.  For example, modify a filter
 
     :id: 05639074-ef6d-4c6b-8ff6-53033821e686
@@ -2313,7 +2317,9 @@ def test_positive_edit_rh_custom_spin(session):
     repos_collection = RepositoryCollection(
         distro=DISTRO_RHEL7, repositories=[SatelliteToolsRepository()]
     )
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=org.id, lce_id=lce.id, upload_manifest=True
+    )
     cv = entities.ContentView(id=repos_collection.setup_content_data['content_view']['id']).read()
     with session:
         session.organization.select(org.name)
@@ -2354,7 +2360,7 @@ def test_positive_edit_rh_custom_spin(session):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.upgrade
 @pytest.mark.tier2
-def test_positive_promote_with_rh_custom_spin(session):
+def test_positive_promote_with_rh_custom_spin(session, default_sat):
     """attempt to promote a content view containing a custom RH
     spin - i.e., contains filters.
 
@@ -2372,7 +2378,9 @@ def test_positive_promote_with_rh_custom_spin(session):
     repos_collection = RepositoryCollection(
         distro=DISTRO_RHEL7, repositories=[SatelliteToolsRepository()]
     )
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=org.id, lce_id=lce.id, upload_manifest=True
+    )
     cv = entities.ContentView(id=repos_collection.setup_content_data['content_view']['id']).read()
     with session:
         session.organization.select(org.name)
@@ -2812,7 +2820,9 @@ def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthos
         distro=DISTRO_RHEL7,
         repositories=[SatelliteToolsRepository(), YumRepository(url=settings.repos.yum_0.url)],
     )
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=org.id, lce_id=lce.id, upload_manifest=True
+    )
     repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
     assert rhel7_contenthost.subscribed
     with session:
@@ -2854,7 +2864,9 @@ def test_positive_subscribe_system_with_puppet_modules(session, rhel7_contenthos
             ),
         ],
     )
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=org.id, lce_id=lce.id, upload_manifest=True
+    )
     repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
     assert rhel7_contenthost.subscribed
     with session:
@@ -3007,7 +3019,7 @@ def test_positive_custom_ostree_end_to_end(session, module_org):
 
 @pytest.mark.skip_if_open("BZ:1625783")
 @pytest.mark.tier3
-def test_positive_rh_ostree_end_to_end(session):
+def test_positive_rh_ostree_end_to_end(session, default_sat):
     """Create content view with RH ostree contents, publish and promote it
     to Library +1 env. Then disassociate repository from that content view
 
@@ -3040,7 +3052,7 @@ def test_positive_rh_ostree_end_to_end(session):
     repo_name = rh_repo['name']
     # Create new org to import manifest
     org = entities.Organization().create()
-    manifests.upload_manifest_locked(org.id)
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=org.id)
     enable_sync_redhat_repo(rh_repo, org.id)
     lce = entities.LifecycleEnvironment(organization=org).create()
     with session:
@@ -3131,7 +3143,7 @@ def test_positive_mixed_content_end_to_end(session, module_org):
 
 @pytest.mark.upgrade
 @pytest.mark.tier3
-def test_positive_rh_mixed_content_end_to_end(session):
+def test_positive_rh_mixed_content_end_to_end(session, default_sat):
     """Create a CV with RH ostree as well as RH yum contents and publish and promote
     them to next environment. Remove promoted version afterwards
 
@@ -3162,7 +3174,7 @@ def test_positive_rh_mixed_content_end_to_end(session):
         'releasever': None,
     }
     org = entities.Organization().create()
-    manifests.upload_manifest_locked(org.id)
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=org.id)
     for rh_repo in [rh_ah_repo, rh_st_repo]:
         enable_sync_redhat_repo(rh_repo, org.id)
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -3312,7 +3324,9 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, default
     repos_collection = RepositoryCollection(
         distro=DISTRO_RHEL7, repositories=[SatelliteToolsRepository(), YumRepository(url=repo_url)]
     )
-    content_data = repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    content_data = repos_collection.setup_content(
+        satellite=default_sat, org_id=org.id, lce_id=lce.id, upload_manifest=True
+    )
     composite_cv = entities.ContentView(composite=True, organization=org).create()
     composite_cv.component = [
         entities.ContentView(id=content_data['content_view']['id']).read().version[0]

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -246,7 +246,9 @@ def test_positive_user_access_with_host_filter(
             distro=DISTRO_RHEL7,
             repositories=[SatelliteToolsRepository(), YumRepository(url=settings.repos.yum_6.url)],
         )
-        repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+        repos_collection.setup_content(
+            satellite=default_sat, org_id=org.id, lce_id=lce.id, upload_manifest=True
+        )
         repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
         result = rhel7_contenthost.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
         assert result.status == 0

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -49,7 +49,7 @@ def module_lce(module_org):
 
 
 @pytest.fixture(scope='module')
-def module_repos_collection(module_org, module_lce):
+def module_repos_collection(module_org, module_lce, default_sat):
     repos_collection = RepositoryCollection(
         distro=constants.DISTRO_DEFAULT,
         repositories=[
@@ -58,17 +58,21 @@ def module_repos_collection(module_org, module_lce):
             YumRepository(url=settings.repos.yum_6.url),
         ],
     )
-    repos_collection.setup_content(module_org.id, module_lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=module_org.id, lce_id=module_lce.id, upload_manifest=True
+    )
     return repos_collection
 
 
 @pytest.fixture(scope='module')
-def module_repos_collection_module_stream(module_org, module_lce):
+def module_repos_collection_module_stream(module_org, module_lce, default_sat):
     repos_collection = RepositoryCollection(
         distro=constants.DISTRO_RHEL8,
         repositories=[YumRepository(url=settings.repos.module_stream_1.url)],
     )
-    repos_collection.setup_content(module_org.id, module_lce.id, upload_manifest=True)
+    repos_collection.setup_content(
+        satellite=default_sat, org_id=module_org.id, lce_id=module_lce.id, upload_manifest=True
+    )
     return repos_collection
 
 

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -238,7 +238,7 @@ def test_positive_update_compresource(session):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_delete_with_manifest_lces(session):
+def test_positive_delete_with_manifest_lces(session, default_sat):
     """Create Organization with valid values and upload manifest.
     Then try to delete that organization.
 
@@ -250,8 +250,8 @@ def test_positive_delete_with_manifest_lces(session):
 
     :CaseImportance: Critical
     """
-    org = entities.Organization().create()
-    upload_manifest_locked(org.id)
+    org = default_sat.api.Organization().create()
+    upload_manifest_locked(satellite=default_sat, org_id=org.id)
     with session:
         session.organization.select(org.name)
         session.lifecycleenvironment.create({'name': 'DEV'})
@@ -266,7 +266,7 @@ def test_positive_delete_with_manifest_lces(session):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_download_debug_cert_after_refresh(session):
+def test_positive_download_debug_cert_after_refresh(session, default_sat):
     """Create organization with valid manifest. Download debug
     certificate for that organization and refresh added manifest for few
     times in a row
@@ -279,13 +279,15 @@ def test_positive_download_debug_cert_after_refresh(session):
 
     :CaseImportance: Critical
     """
-    org = entities.Organization().create()
+    org = default_sat.api.Organization().create()
     try:
-        upload_manifest_locked(org.id, original_manifest())
+        upload_manifest_locked(satellite=default_sat, org_id=org.id, manifest=original_manifest())
         with session:
             session.organization.select(org.name)
             for _ in range(3):
                 assert org.download_debug_certificate()
                 session.subscription.refresh_manifest()
     finally:
-        entities.Subscription(organization=org).delete_manifest(data={'organization_id': org.id})
+        default_sat.api.Subscription(organization=org).delete_manifest(
+            data={'organization_id': org.id}
+        )

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -63,8 +63,10 @@ def module_yum_repo2(module_product):
 
 
 @pytest.fixture(scope='module')
-def module_rh_repo(module_org):
-    manifests.upload_manifest_locked(module_org.id, manifests.clone())
+def module_rh_repo(module_org, default_sat):
+    manifests.upload_manifest_locked(
+        satellite=default_sat, org_id=module_org.id, manifest=manifests.clone()
+    )
     rhst = SatelliteToolsRepository(cdn=True)
     repo_id = enable_rhrepo_and_fetchid(
         basearch=rhst.data['arch'],

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -718,7 +718,7 @@ def test_positive_sync_ansible_collection_gallaxy_repo(session, module_prod):
 
 
 @pytest.mark.tier2
-def test_positive_reposet_disable(session):
+def test_positive_reposet_disable(session, default_sat):
     """Enable RH repo, sync it and then disable
 
     :id: de596c56-1327-49e8-86d5-a1ab907f26aa
@@ -727,8 +727,8 @@ def test_positive_reposet_disable(session):
 
     :CaseLevel: Integration
     """
-    org = entities.Organization().create()
-    manifests.upload_manifest_locked(org.id)
+    org = default_sat.api.Organization().create()
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=org.id)
     sat_tools_repo = SatelliteToolsRepository(distro=DISTRO_RHEL7, cdn=True)
     repository_name = sat_tools_repo.data['repository']
     with session:
@@ -759,7 +759,7 @@ def test_positive_reposet_disable(session):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
-def test_positive_reposet_disable_after_manifest_deleted(session):
+def test_positive_reposet_disable_after_manifest_deleted(session, default_sat):
     """Enable RH repo and sync it. Remove manifest and then disable
     repository
 
@@ -773,9 +773,9 @@ def test_positive_reposet_disable_after_manifest_deleted(session):
 
     :CaseLevel: Integration
     """
-    org = entities.Organization().create()
-    manifests.upload_manifest_locked(org.id)
-    sub = entities.Subscription(organization=org)
+    org = default_sat.api.Organization().create()
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=org.id)
+    sub = default_sat.api.Subscription(organization=org)
     sat_tools_repo = SatelliteToolsRepository(distro=DISTRO_RHEL7, cdn=True)
     repository_name = sat_tools_repo.data['repository']
     repository_name_orphaned = f'{repository_name} (Orphaned)'
@@ -843,7 +843,7 @@ def test_positive_delete_random_docker_repo(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_recommended_repos(session, module_org):
+def test_positive_recommended_repos(session, module_org, default_sat):
     """list recommended repositories using
      On/Off 'Recommended Repositories' toggle.
 
@@ -858,7 +858,7 @@ def test_positive_recommended_repos(session, module_org):
 
     :BZ: 1776108
     """
-    manifests.upload_manifest_locked(module_org.id)
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=module_org.id)
     with session:
         session.organization.select(module_org.name)
         rrepos_on = session.redhatrepository.read(recommended_repo='on')

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -48,9 +48,9 @@ def module_custom_product(module_org):
 
 
 @pytest.fixture(scope='module')
-def module_org_with_manifest():
+def module_org_with_manifest(default_sat):
     org = entities.Organization().create()
-    manifests.upload_manifest_locked(org.id)
+    manifests.upload_manifest_locked(satellite=default_sat, org_id=org.id)
     return org
 
 

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -112,7 +112,9 @@ class TestSubscriptionAutoAttach:
         container_name = f"{request.node.name}_docker_client"
         org = entities.Organization(name=request.node.name + "_org").create()
         loc = entities.Location(name=request.node.name + "_loc", organization=[org]).create()
-        manifests.upload_manifest_locked(org.id, interface=manifests.INTERFACE_API)
+        manifests.upload_manifest_locked(
+            satellite=default_sat, org_id=org.id, interface=manifests.INTERFACE_API
+        )
         act_key = entities.ActivationKey(
             auto_attach=False,
             organization=org.id,


### PR DESCRIPTION
manifest upload and the function stack in robottelo.products continue to
cause BoxKeyErrors with the dynaconf/xdist integration.

Move almost all uses of upload_manifest_locked to use default API
interface instead of CLI.

Refactor a few helper functions to take an explicit satellite instance,
instead of relying on reading settings.server.hostname through
robottelo.ssh