### PR TITLE
Failfast when no upgrade_workers.json file present

### DIFF
--- a/tests/upgrades/scenario_workers.py
+++ b/tests/upgrades/scenario_workers.py
@@ -26,8 +26,7 @@ def save_worker_hostname(test_name, default_sat):
 
 @pytest.fixture(scope='session')
 def shared_workers():
-    if json_file.exists():
-        return json.loads(json_file.read_text())
+    return json.loads(json_file.read_text())
 
 
 def get_worker_hostname_from_testname(test_name, shared_workers):


### PR DESCRIPTION
Tests used to fail like:
```
______________________________________________________________ ERROR at setup of TestPublicDisableBookmark.test_post_create_public_disable_bookmark _______________________________________________________________

request = <SubRequest 'set_post_upgrade_hostname' for <Function test_post_create_public_disable_bookmark>>, shared_workers = None

    @pytest.fixture(autouse=True)
    def set_post_upgrade_hostname(request, shared_workers):
        """Retrieves worker hostname of pre_upgrade and sets the same to run post_upgrade

        The limitation of this implementation is that the XDIST_BEHAVIOR won't be observed,
        and tests running under xdist will not be isolated.

        This is overriding the session scoped align_to_satellite fixture
        """
        post_upgrade = request.node.get_closest_marker('post_upgrade')
        if post_upgrade:
            depend_test = post_upgrade.kwargs.get('depend_on')
            if depend_test:
                pre_test_name = depend_test.__name__
>               pre_hostname = get_worker_hostname_from_testname(pre_test_name, shared_workers)

tests/upgrades/scenario_workers.py:59:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

test_name = 'test_pre_create_public_disable_bookmark', shared_workers = None

    def get_worker_hostname_from_testname(test_name, shared_workers):
>       return shared_workers.get(test_name)
E       AttributeError: 'NoneType' object has no attribute 'get'

tests/upgrades/scenario_workers.py:35: AttributeError
```
...which doesn't give much info. Now they will fail more expressively, which is better:
```
_______________________________________________________________ ERROR at setup of TestPublicEnableBookmark.test_post_create_public_enable_bookmark ________________________________________________________________

    @pytest.fixture(scope='session')
    def shared_workers():
>       return json.loads(json_file.read_text())

tests/upgrades/scenario_workers.py:29:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib64/python3.9/pathlib.py:1266: in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
/usr/lib64/python3.9/pathlib.py:1252: in open
    return io.open(self, mode, buffering, encoding, errors, newline,
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = PosixPath('upgrade_workers.json'), name = 'upgrade_workers.json', flags = 524288, mode = 438

    def _opener(self, name, flags, mode=0o666):
        # A stub for the opener argument to built-in open()
>       return self._accessor.open(self, flags, mode)
E       FileNotFoundError: [Errno 2] No such file or directory: 'upgrade_workers.json'

 Please enter the commit message for your changes. Lines starting
```