### PR TITLE
Automate api tests related RH Cloud plugin and fix tests failing because of manifest issue.

### DIFF
--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -3,6 +3,7 @@ from broker.broker import VMBroker
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import DISTRO_RHEL7
 from robottelo.constants import DISTRO_RHEL8
 from robottelo.helpers import file_downloader
 
@@ -62,11 +63,15 @@ def organization_ak_setup(rhcloud_sat_host, rhcloud_manifest_org):
 
 @pytest.fixture(scope='module')
 def rhcloud_registered_hosts(organization_ak_setup, content_hosts, rhcloud_sat_host):
-    """Fixture that registers content hosts to Satellite."""
+    """Fixture that registers content hosts to Satellite and Insights."""
     org, ak = organization_ak_setup
     for vm in content_hosts:
-        vm.install_katello_ca(rhcloud_sat_host)
-        vm.register_contenthost(org.label, ak.name)
+        vm.configure_rhai_client(
+            satellite=rhcloud_sat_host,
+            activation_key=ak.name,
+            org=org.label,
+            rhel_distro=DISTRO_RHEL7,
+        )
         assert vm.subscribed
     return content_hosts
 

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -1,10 +1,10 @@
 import pytest
 from broker.broker import VMBroker
 
-from robottelo import manifests
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL8
+from robottelo.helpers import file_downloader
 
 
 @pytest.fixture(scope='module')
@@ -19,10 +19,10 @@ def rhcloud_sat_host(satellite_factory):
 def rhcloud_manifest_org(rhcloud_sat_host):
     """A module level fixture to get organization with manifest."""
     org = rhcloud_sat_host.api.Organization().create()
-    with manifests.original_manifest() as manifest:
-        rhcloud_sat_host.api.Subscription().upload(
-            data={'organization_id': org.id}, files={'content': manifest.content}
-        )
+    manifests_path = file_downloader(
+        file_url=settings.fake_manifest.url['default'], hostname=rhcloud_sat_host.hostname
+    )[0]
+    rhcloud_sat_host.cli.Subscription.upload({'file': manifests_path, 'organization-id': org.id})
     return org
 
 

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -55,3 +55,16 @@ def fixable_rhel8_vm(rhel8_insights_vm):
     rhel8_insights_vm.run('dnf update -y dnf')
     rhel8_insights_vm.run('sed -i -e "/^best/d" /etc/dnf/dnf.conf')
     rhel8_insights_vm.run('insights-client')
+
+
+def disable_inventory_settings(default_sat):
+    default_sat.update_setting('obfuscate_inventory_hostnames', False)
+    default_sat.update_setting('obfuscate_inventory_ips', False)
+    default_sat.update_setting('exclude_installed_packages', False)
+
+
+@pytest.fixture
+def inventory_settings():
+    disable_inventory_settings()
+    yield
+    disable_inventory_settings()

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -1,50 +1,70 @@
 import pytest
-from nailgun import entities
+from broker.broker import VMBroker
 
+from robottelo import manifests
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import DISTRO_RHEL8
 
 
-@pytest.fixture
-def set_rh_cloud_token(default_sat):
-    """A function-level fixture to set rh cloud token value."""
-    default_sat.update_setting('rh_cloud_token', settings.rh_cloud.token)
-    yield
-    default_sat.update_setting('rh_cloud_token', '')
-
-
-@pytest.fixture
-def unset_rh_cloud_token(default_sat):
-    """A function-level fixture to unset rh cloud token value."""
-    yield
-    default_sat.update_setting('rh_cloud_token', '')
+@pytest.fixture(scope='module')
+def rhcloud_sat_host(satellite_factory):
+    """A module level fixture that provides a Satellite based on config settings"""
+    new_sat = satellite_factory()
+    yield new_sat
+    VMBroker(hosts=[new_sat]).checkin()
 
 
 @pytest.fixture(scope='module')
-def organization_ak_setup(module_manifest_org):
+def rhcloud_manifest_org(rhcloud_sat_host):
+    """A module level fixture to get organization with manifest."""
+    org = rhcloud_sat_host.api.Organization().create()
+    with manifests.original_manifest() as manifest:
+        rhcloud_sat_host.api.Subscription().upload(
+            data={'organization_id': org.id}, files={'content': manifest.content}
+        )
+    return org
+
+
+@pytest.fixture
+def set_rh_cloud_token(rhcloud_sat_host):
+    """A function-level fixture to set rh cloud token value."""
+    rhcloud_sat_host.update_setting('rh_cloud_token', settings.rh_cloud.token)
+    yield
+    rhcloud_sat_host.update_setting('rh_cloud_token', '')
+
+
+@pytest.fixture
+def unset_rh_cloud_token(rhcloud_sat_host):
+    """A function-level fixture to unset rh cloud token value."""
+    yield
+    rhcloud_sat_host.update_setting('rh_cloud_token', '')
+
+
+@pytest.fixture(scope='module')
+def organization_ak_setup(rhcloud_sat_host, rhcloud_manifest_org):
     """A module-level fixture to create an Activation key in module_org"""
-    ak = entities.ActivationKey(
-        content_view=module_manifest_org.default_content_view,
-        organization=module_manifest_org,
-        environment=entities.LifecycleEnvironment(id=module_manifest_org.library.id),
+    ak = rhcloud_sat_host.api.ActivationKey(
+        content_view=rhcloud_manifest_org.default_content_view,
+        organization=rhcloud_manifest_org,
+        environment=rhcloud_sat_host.api.LifecycleEnvironment(id=rhcloud_manifest_org.library.id),
         auto_attach=True,
     ).create()
-    subscription = entities.Subscription(organization=module_manifest_org).search(
+    subscription = rhcloud_sat_host.api.Subscription(organization=rhcloud_manifest_org).search(
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]
     ak.add_subscriptions(data={'quantity': 10, 'subscription_id': subscription.id})
-    yield module_manifest_org, ak
+    yield rhcloud_manifest_org, ak
     ak.delete()
 
 
 @pytest.fixture(scope='module')
-def rhel8_insights_vm(default_sat, organization_ak_setup, rhel8_contenthost_module):
+def rhel8_insights_vm(rhcloud_sat_host, organization_ak_setup, rhel8_contenthost_module):
     """A module-level fixture to create rhel8 content host registered with insights."""
     org, ak = organization_ak_setup
-    rhel8_contenthost_module.configure_rex(satellite=default_sat, org=org, register=False)
+    rhel8_contenthost_module.configure_rex(satellite=rhcloud_sat_host, org=org, register=False)
     rhel8_contenthost_module.configure_rhai_client(
-        satellite=default_sat, activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
+        satellite=rhcloud_sat_host, activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
     )
     yield rhel8_contenthost_module
 
@@ -58,11 +78,11 @@ def fixable_rhel8_vm(rhel8_insights_vm):
 
 
 @pytest.fixture
-def inventory_settings(default_sat):
-    hostnames_setting = default_sat.update_setting('obfuscate_inventory_hostnames', False)
-    ip_setting = default_sat.update_setting('obfuscate_inventory_ips', False)
-    packages_setting = default_sat.update_setting('exclude_installed_packages', False)
+def inventory_settings(rhcloud_sat_host):
+    hostnames_setting = rhcloud_sat_host.update_setting('obfuscate_inventory_hostnames', False)
+    ip_setting = rhcloud_sat_host.update_setting('obfuscate_inventory_ips', False)
+    packages_setting = rhcloud_sat_host.update_setting('exclude_installed_packages', False)
     yield
-    default_sat.update_setting('obfuscate_inventory_hostnames', hostnames_setting)
-    default_sat.update_setting('obfuscate_inventory_ips', ip_setting)
-    default_sat.update_setting('exclude_installed_packages', packages_setting)
+    rhcloud_sat_host.update_setting('obfuscate_inventory_hostnames', hostnames_setting)
+    rhcloud_sat_host.update_setting('obfuscate_inventory_ips', ip_setting)
+    rhcloud_sat_host.update_setting('exclude_installed_packages', packages_setting)

--- a/pytest_fixtures/rh_cloud.py
+++ b/pytest_fixtures/rh_cloud.py
@@ -57,14 +57,12 @@ def fixable_rhel8_vm(rhel8_insights_vm):
     rhel8_insights_vm.run('insights-client')
 
 
-def disable_inventory_settings(default_sat):
-    default_sat.update_setting('obfuscate_inventory_hostnames', False)
-    default_sat.update_setting('obfuscate_inventory_ips', False)
-    default_sat.update_setting('exclude_installed_packages', False)
-
-
 @pytest.fixture
-def inventory_settings():
-    disable_inventory_settings()
+def inventory_settings(default_sat):
+    hostnames_setting = default_sat.update_setting('obfuscate_inventory_hostnames', False)
+    ip_setting = default_sat.update_setting('obfuscate_inventory_ips', False)
+    packages_setting = default_sat.update_setting('exclude_installed_packages', False)
     yield
-    disable_inventory_settings()
+    default_sat.update_setting('obfuscate_inventory_hostnames', hostnames_setting)
+    default_sat.update_setting('obfuscate_inventory_ips', ip_setting)
+    default_sat.update_setting('exclude_installed_packages', packages_setting)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1299,32 +1299,3 @@ class Satellite(Capsule):
         setting.value = value
         setting.update({'value'})
         return default_setting_value
-
-    def wait_for_tasks(
-        self, search_query, search_rate=1, max_tries=10, poll_rate=None, poll_timeout=None
-    ):
-        """Search for tasks by specified search query and poll them to ensure that
-        task has finished.
-
-        :param search_query: Search query that will be passed to API call.
-        :param search_rate: Delay between searches.
-        :param max_tries: How many times search should be executed.
-        :param poll_rate: Delay between the end of one task check-up and
-                the start of the next check-up. Parameter for
-                ``nailgun.entities.ForemanTask.poll()`` method.
-        :param poll_timeout: Maximum number of seconds to wait until timing out.
-                Parameter for ``nailgun.entities.ForemanTask.poll()`` method.
-        :return: List of ``nailgun.entities.ForemanTasks`` entities.
-        :raises: ``AssertionError``. If not tasks were found until timeout.
-        """
-        for _ in range(max_tries):
-            tasks = self.api.ForemanTask().search(query={'search': search_query})
-            if len(tasks) > 0:
-                for task in tasks:
-                    task.poll(poll_rate=poll_rate, timeout=poll_timeout)
-                break
-            else:
-                time.sleep(search_rate)
-        else:
-            raise AssertionError(f"No task was found using query '{search_query}'")
-        return tasks

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1291,7 +1291,11 @@ class Satellite(Capsule):
         update_provisioning_template(name=template, old=new, new=old)
 
     def update_setting(self, name, value):
-        """change setting value"""
+        """changes setting value and returns the setting value before the change."""
         setting = self.api.Setting().search(query={'search': f'name="{name}"'})[0]
+        default_setting_value = setting.value
+        if default_setting_value is None:
+            default_setting_value = ''
         setting.value = value
         setting.update({'value'})
+        return default_setting_value

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1299,3 +1299,32 @@ class Satellite(Capsule):
         setting.value = value
         setting.update({'value'})
         return default_setting_value
+
+    def wait_for_tasks(
+        self, search_query, search_rate=1, max_tries=10, poll_rate=None, poll_timeout=None
+    ):
+        """Search for tasks by specified search query and poll them to ensure that
+        task has finished.
+
+        :param search_query: Search query that will be passed to API call.
+        :param search_rate: Delay between searches.
+        :param max_tries: How many times search should be executed.
+        :param poll_rate: Delay between the end of one task check-up and
+                the start of the next check-up. Parameter for
+                ``nailgun.entities.ForemanTask.poll()`` method.
+        :param poll_timeout: Maximum number of seconds to wait until timing out.
+                Parameter for ``nailgun.entities.ForemanTask.poll()`` method.
+        :return: List of ``nailgun.entities.ForemanTasks`` entities.
+        :raises: ``AssertionError``. If not tasks were found until timeout.
+        """
+        for _ in range(max_tries):
+            tasks = self.api.ForemanTask().search(query={'search': search_query})
+            if len(tasks) > 0:
+                for task in tasks:
+                    task.poll(poll_rate=poll_rate, timeout=poll_timeout)
+                break
+            else:
+                time.sleep(search_rate)
+        else:
+            raise AssertionError(f"No task was found using query '{search_query}'")
+        return tasks

--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -4,8 +4,6 @@ import json
 import tarfile
 from pathlib import Path
 
-from robottelo import ssh
-
 
 def get_host_counts(tarobj):
     """Returns hosts count from tar file.
@@ -66,10 +64,11 @@ def get_local_file_data(path):
     }
 
 
-def get_remote_report_checksum(org_id):
+def get_remote_report_checksum(satellite, org_id):
     """Returns checksum of red_hat_inventory report present on satellite.
 
     Args:
+        satellite: satellite host
         org_id: organization-id
     """
     remote_paths = [
@@ -78,7 +77,7 @@ def get_remote_report_checksum(org_id):
     ]
 
     for path in remote_paths:
-        result = ssh.command(f'sha256sum {path}', output_format='plain')
+        result = satellite.execute(f'sha256sum {path}')
         if result.status != 0:
             continue
         checksum, _ = result.stdout.split(maxsplit=1)

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -71,7 +71,7 @@ def test_rhcloud_inventory_api_e2e(
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     # Generate report
     timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
-    rhcloud_sat_host.api.RHCloud(organization_id=org.id).generate_report()
+    rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_generate_report()
     result = rhcloud_sat_host.wait_for_tasks(
         search_query=f'{generate_report_task} and started_at >= "{timestamp}"',
         search_rate=15,
@@ -80,7 +80,9 @@ def test_rhcloud_inventory_api_e2e(
     task_output = rhcloud_sat_host.api.ForemanTask().search(query={'search': result[0].id})
     assert task_output[0].result == 'success', f'result: {result}\n task_output: {task_output}'
     # Download report
-    rhcloud_sat_host.api.RHCloud(organization_id=1).download_report(destination=local_report_path)
+    rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_download_report(
+        destination=local_report_path
+    )
     common_assertion(local_report_path)
     # Assert Hostnames, IP addresses, and installed packages are present in report.
     json_data = get_report_data(local_report_path)
@@ -127,7 +129,7 @@ def test_rhcloud_inventory_api_hosts_synchronization(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    inventory_sync = rhcloud_sat_host.api.RHCloud(organization_id=org.id).inventory_sync()
+    inventory_sync = rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_inventory_sync()
     result = rhcloud_sat_host.wait_for_tasks(
         search_query=f'id = {inventory_sync["task"]["id"]}',
         search_rate=15,

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -21,7 +21,6 @@ from datetime import datetime
 import pytest
 from fauxfactory import gen_alphanumeric
 
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import robottelo_tmp_dir
 from robottelo.rh_cloud_utils import get_local_file_data
 from robottelo.rh_cloud_utils import get_report_data
@@ -73,7 +72,7 @@ def test_rhcloud_inventory_api_e2e(
     # Generate report
     timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
     rhcloud_sat_host.api.RHCloud(organization_id=org.id).generate_report()
-    result = wait_for_tasks(
+    result = rhcloud_sat_host.wait_for_tasks(
         search_query=f'{generate_report_task} and started_at >= "{timestamp}"',
         search_rate=15,
         max_tries=10,
@@ -129,7 +128,7 @@ def test_rhcloud_inventory_api_hosts_synchronization(
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = registered_hosts
     inventory_sync = rhcloud_sat_host.api.RHCloud(organization_id=org.id).inventory_sync()
-    result = wait_for_tasks(
+    result = rhcloud_sat_host.wait_for_tasks(
         search_query=f'id = {inventory_sync["task"]["id"]}',
         search_rate=15,
         max_tries=10,

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -44,7 +44,7 @@ def common_assertion(report_path):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_rhcloud_inventory_api_e2e(
-    inventory_settings, organization_ak_setup, registered_hosts, rhcloud_sat_host
+    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
 ):
     """Generate report using rh_cloud plugin api's and verify its basic properties.
 
@@ -66,7 +66,7 @@ def test_rhcloud_inventory_api_e2e(
     :BZ: 1807829, 1926100, 1965234
     """
     org, ak = organization_ak_setup
-    virtual_host, baremetal_host = registered_hosts
+    virtual_host, baremetal_host = rhcloud_registered_hosts
     generate_report_task = 'ForemanInventoryUpload::Async::UploadReportJob'
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     # Generate report
@@ -104,7 +104,7 @@ def test_rhcloud_inventory_api_e2e(
 
 @pytest.mark.tier3
 def test_rhcloud_inventory_api_hosts_synchronization(
-    organization_ak_setup, registered_hosts, rhcloud_sat_host
+    organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
 ):
     """Test RH Cloud plugin api to synchronize list of available hosts from cloud.
 
@@ -126,7 +126,7 @@ def test_rhcloud_inventory_api_hosts_synchronization(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
-    virtual_host, baremetal_host = registered_hosts
+    virtual_host, baremetal_host = rhcloud_registered_hosts
     inventory_sync = rhcloud_sat_host.api.RHCloud(organization_id=org.id).inventory_sync()
     result = rhcloud_sat_host.wait_for_tasks(
         search_query=f'id = {inventory_sync["task"]["id"]}',

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1087,7 +1087,7 @@ class TestRepository:
             Check that a package removed upstream is removed downstream when the repo
             is next synced if mirror-on-sync is enabled (the default setting).
 
-        :id: 637d6479-842d-4570-97eb-3a986eca2142
+        :id: 1a901b8c-5b8e-470a-a455-71d161ca92b8
 
         :Setup:
             1. Create product with yum type repository (repo 1), URL to upstream, sync it.

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1087,7 +1087,7 @@ class TestRepository:
             Check that a package removed upstream is removed downstream when the repo
             is next synced if mirror-on-sync is enabled (the default setting).
 
-        :id: 1a901b8c-5b8e-470a-a455-71d161ca92b8
+        :id: 637d6479-842d-4570-97eb-3a986eca2142
 
         :Setup:
             1. Create product with yum type repository (repo 1), URL to upstream, sync it.

--- a/tests/foreman/cli/test_rhcloud_insights.py
+++ b/tests/foreman/cli/test_rhcloud_insights.py
@@ -26,7 +26,7 @@ from robottelo.hosts import ContentHost
 
 @pytest.mark.tier4
 @pytest.mark.parametrize('distro', [DISTRO_RHEL8, DISTRO_RHEL7])
-def test_positive_connection_option(organization_ak_setup, default_sat, distro):
+def test_positive_connection_option(organization_ak_setup, rhcloud_sat_host, distro):
     """Verify that 'insights-client --test-connection' successfully tests the proxy connection via
     the Satellite.
 
@@ -48,7 +48,7 @@ def test_positive_connection_option(organization_ak_setup, default_sat, distro):
     """
     org, activation_key = organization_ak_setup
     with VMBroker(nick=distro, host_classes={'host': ContentHost}) as vm:
-        vm.configure_rhai_client(default_sat, activation_key.name, org.label, distro)
+        vm.configure_rhai_client(rhcloud_sat_host, activation_key.name, org.label, distro)
         result = vm.run('insights-client --test-connection')
         assert result.status == 0, (
             'insights-client --test-connection failed.\n'

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -73,7 +73,7 @@ def test_positive_inventory_generate_upload_cli(
     )
     rhcloud_sat_host.get(remote_path=remote_report_path, local_path=local_report_path)
     local_file_data = get_local_file_data(local_report_path)
-    assert local_file_data['checksum'] == get_remote_report_checksum(org.id)
+    assert local_file_data['checksum'] == get_remote_report_checksum(rhcloud_sat_host, org.id)
     assert local_file_data['size'] > 0
     assert local_file_data['extractable']
     assert local_file_data['json_files_parsable']

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -25,7 +25,7 @@ from robottelo.rh_cloud_utils import get_remote_report_checksum
 
 @pytest.mark.tier3
 def test_positive_inventory_generate_upload_cli(
-    organization_ak_setup, registered_hosts, rhcloud_sat_host
+    organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
 ):
     """Tests Insights inventory generation and upload via foreman-rake commands:
     https://github.com/theforeman/foreman_rh_cloud/blob/master/README.md

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -25,7 +25,7 @@ from robottelo.rh_cloud_utils import get_remote_report_checksum
 
 @pytest.mark.tier3
 def test_positive_inventory_generate_upload_cli(
-    organization_ak_setup, registered_hosts, default_sat
+    organization_ak_setup, registered_hosts, rhcloud_sat_host
 ):
     """Tests Insights inventory generation and upload via foreman-rake commands:
     https://github.com/theforeman/foreman_rh_cloud/blob/master/README.md
@@ -63,7 +63,7 @@ def test_positive_inventory_generate_upload_cli(
     org, _ = organization_ak_setup
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:report:generate_upload'
     upload_success_msg = f"Generated and uploaded inventory report for organization '{org.name}'"
-    result = default_sat.execute(cmd)
+    result = rhcloud_sat_host.execute(cmd)
     assert result.status == 0
     assert upload_success_msg in result.stdout
 
@@ -71,7 +71,7 @@ def test_positive_inventory_generate_upload_cli(
     remote_report_path = (
         f'/var/lib/foreman/red_hat_inventory/uploads/done/report_for_{org.id}.tar.xz'
     )
-    default_sat.get(remote_path=remote_report_path, local_path=local_report_path)
+    rhcloud_sat_host.get(remote_path=remote_report_path, local_path=local_report_path)
     local_file_data = get_local_file_data(local_report_path)
     assert local_file_data['checksum'] == get_remote_report_checksum(org.id)
     assert local_file_data['size'] > 0

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -19,6 +19,7 @@
 from datetime import datetime
 
 import pytest
+from airgun.session import Session
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_LOC
@@ -62,7 +63,7 @@ def test_rhcloud_insights_e2e(
     job_query = (
         f'Remote action: Insights remediations for selected issues on {rhel8_insights_vm.hostname}'
     )
-    with rhcloud_sat_host.ui_session as session:
+    with Session(hostname=rhcloud_sat_host.hostname) as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         session.cloudinsights.save_token_sync_hits(settings.rh_cloud.token)

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -20,7 +20,6 @@ from datetime import datetime
 
 import pytest
 
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_LOC
 
@@ -68,7 +67,7 @@ def test_rhcloud_insights_e2e(
         session.location.select(loc_name=DEFAULT_LOC)
         session.cloudinsights.save_token_sync_hits(settings.rh_cloud.token)
         timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query=f'Insights full sync and started_at >= "{timestamp}"',
             search_rate=15,
             max_tries=10,
@@ -83,7 +82,7 @@ def test_rhcloud_insights_e2e(
         )
         timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.remediate(query)
-        result = wait_for_tasks(
+        result = rhcloud_sat_host.wait_for_tasks(
             search_query=f'{job_query} and started_at >= "{timestamp}"',
             search_rate=15,
             max_tries=10,
@@ -92,7 +91,7 @@ def test_rhcloud_insights_e2e(
         assert task_output[0].result == 'success', f'result: {result}\n task_output: {task_output}'
         timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.sync_hits()
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query=f'Insights full sync and started_at >= "{timestamp}"',
             search_rate=15,
             max_tries=10,

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -21,7 +21,6 @@ from datetime import timedelta
 
 import pytest
 
-from robottelo.api.utils import wait_for_tasks
 from robottelo.rh_cloud_utils import get_local_file_data
 from robottelo.rh_cloud_utils import get_remote_report_checksum
 from robottelo.rh_cloud_utils import get_report_data
@@ -56,7 +55,7 @@ def common_assertion(report_path, inventory_data, org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_rhcloud_inventory_e2e(
-    inventory_settings, organization_ak_setup, registered_hosts, session
+    inventory_settings, organization_ak_setup, registered_hosts, rhcloud_sat_host
 ):
     """Generate report and verify its basic properties
 
@@ -81,11 +80,11 @@ def test_rhcloud_inventory_e2e(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = registered_hosts
-    with session:
+    with rhcloud_sat_host.ui_session as session:
         session.organization.select(org_name=org.name)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
             f' and started_at >= "{timestamp}"',
             search_rate=15,
@@ -178,7 +177,7 @@ def test_hosts_synchronization():
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_names(
-    default_sat, inventory_settings, organization_ak_setup, registered_hosts, session
+    rhcloud_sat_host, inventory_settings, organization_ak_setup, registered_hosts
 ):
     """Test whether `Obfuscate host names` setting works as expected.
 
@@ -203,14 +202,14 @@ def test_obfuscate_host_names(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = registered_hosts
-    with session:
+    with rhcloud_sat_host.ui_session as session:
         session.organization.select(org_name=org.name)
         # Enable obfuscate_hostnames setting on inventory page.
         session.cloudinventory.update({'obfuscate_hostnames': True})
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
             f' and started_at >= "{timestamp}"',
             search_rate=15,
@@ -236,11 +235,11 @@ def test_obfuscate_host_names(
         session.cloudinventory.update({'obfuscate_hostnames': False})
 
         # Enable obfuscate_hostnames setting.
-        default_sat.update_setting('obfuscate_inventory_hostnames', True)
+        rhcloud_sat_host.update_setting('obfuscate_inventory_hostnames', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
             f' and started_at >= "{timestamp}"',
             search_rate=15,
@@ -262,7 +261,7 @@ def test_obfuscate_host_names(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_ipv4_addresses(
-    default_sat, inventory_settings, organization_ak_setup, registered_hosts, session
+    rhcloud_sat_host, inventory_settings, organization_ak_setup, registered_hosts
 ):
     """Test whether `Obfuscate host ipv4 addresses` setting works as expected.
 
@@ -291,14 +290,14 @@ def test_obfuscate_host_ipv4_addresses(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = registered_hosts
-    with session:
+    with rhcloud_sat_host.ui_session as session:
         session.organization.select(org_name=org.name)
         # Enable obfuscate_ips setting on inventory page.
         session.cloudinventory.update({'obfuscate_ips': True})
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
             f' and started_at >= "{timestamp}"',
             search_rate=15,
@@ -329,11 +328,11 @@ def test_obfuscate_host_ipv4_addresses(
         session.cloudinventory.update({'obfuscate_ips': False})
 
         # Enable obfuscate_inventory_ips setting.
-        default_sat.update_setting('obfuscate_inventory_ips', True)
+        rhcloud_sat_host.update_setting('obfuscate_inventory_ips', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
             f' and started_at >= "{timestamp}"',
             search_rate=15,
@@ -362,7 +361,7 @@ def test_obfuscate_host_ipv4_addresses(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_exclude_packages_setting(
-    default_sat, inventory_settings, organization_ak_setup, registered_hosts, session
+    rhcloud_sat_host, inventory_settings, organization_ak_setup, registered_hosts
 ):
     """Test whether `Exclude Packages` setting works as expected.
 
@@ -392,13 +391,13 @@ def test_exclude_packages_setting(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = registered_hosts
-    with session:
+    with rhcloud_sat_host.ui_session as session:
         session.organization.select(org_name=org.name)
         # Enable exclude_packages setting on inventory page.
         session.cloudinventory.update({'exclude_packages': True})
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
             f' and started_at >= "{timestamp}"',
             search_rate=15,
@@ -423,10 +422,10 @@ def test_exclude_packages_setting(
             assert 'installed_packages' not in host_profiles
 
         # Enable exclude_installed_packages setting.
-        default_sat.update_setting('exclude_installed_packages', True)
+        rhcloud_sat_host.update_setting('exclude_installed_packages', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
-        wait_for_tasks(
+        rhcloud_sat_host.wait_for_tasks(
             search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
             f' and started_at >= "{timestamp}"',
             search_rate=15,

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -21,6 +21,7 @@ from datetime import timedelta
 
 import pytest
 from airgun.session import Session
+from wait_for import wait_for
 
 from robottelo.constants import DEFAULT_LOC
 from robottelo.rh_cloud_utils import get_local_file_data
@@ -87,11 +88,20 @@ def test_rhcloud_inventory_e2e(
         session.location.select(loc_name=DEFAULT_LOC)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
-        rhcloud_sat_host.wait_for_tasks(
-            search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
-            f' and started_at >= "{timestamp}"',
-            search_rate=15,
-            max_tries=10,
+        wait_for(
+            lambda: rhcloud_sat_host.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                    f'and started_at >= "{timestamp}"'
+                }
+            )[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
@@ -213,11 +223,20 @@ def test_obfuscate_host_names(
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
-        rhcloud_sat_host.wait_for_tasks(
-            search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
-            f' and started_at >= "{timestamp}"',
-            search_rate=15,
-            max_tries=10,
+        wait_for(
+            lambda: rhcloud_sat_host.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                    f'and started_at >= "{timestamp}"'
+                }
+            )[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
@@ -243,11 +262,20 @@ def test_obfuscate_host_names(
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
-        rhcloud_sat_host.wait_for_tasks(
-            search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
-            f' and started_at >= "{timestamp}"',
-            search_rate=15,
-            max_tries=10,
+        wait_for(
+            lambda: rhcloud_sat_host.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                    f'and started_at >= "{timestamp}"'
+                }
+            )[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
@@ -302,11 +330,20 @@ def test_obfuscate_host_ipv4_addresses(
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
-        rhcloud_sat_host.wait_for_tasks(
-            search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
-            f' and started_at >= "{timestamp}"',
-            search_rate=15,
-            max_tries=10,
+        wait_for(
+            lambda: rhcloud_sat_host.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                    f'and started_at >= "{timestamp}"'
+                }
+            )[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
@@ -337,11 +374,20 @@ def test_obfuscate_host_ipv4_addresses(
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
-        rhcloud_sat_host.wait_for_tasks(
-            search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
-            f' and started_at >= "{timestamp}"',
-            search_rate=15,
-            max_tries=10,
+        wait_for(
+            lambda: rhcloud_sat_host.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                    f'and started_at >= "{timestamp}"'
+                }
+            )[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
@@ -403,11 +449,20 @@ def test_exclude_packages_setting(
         session.cloudinventory.update({'exclude_packages': True})
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
-        rhcloud_sat_host.wait_for_tasks(
-            search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
-            f' and started_at >= "{timestamp}"',
-            search_rate=15,
-            max_tries=10,
+        wait_for(
+            lambda: rhcloud_sat_host.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                    f'and started_at >= "{timestamp}"'
+                }
+            )[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
@@ -431,11 +486,20 @@ def test_exclude_packages_setting(
         rhcloud_sat_host.update_setting('exclude_installed_packages', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
-        rhcloud_sat_host.wait_for_tasks(
-            search_query='label = ForemanInventoryUpload::Async::GenerateReportJob'
-            f' and started_at >= "{timestamp}"',
-            search_rate=15,
-            max_tries=10,
+        wait_for(
+            lambda: rhcloud_sat_host.api.ForemanTask()
+            .search(
+                query={
+                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
+                    f'and started_at >= "{timestamp}"'
+                }
+            )[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -55,7 +55,7 @@ def common_assertion(report_path, inventory_data, org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_rhcloud_inventory_e2e(
-    inventory_settings, organization_ak_setup, registered_hosts, rhcloud_sat_host
+    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
 ):
     """Generate report and verify its basic properties
 
@@ -79,7 +79,7 @@ def test_rhcloud_inventory_e2e(
     :BZ: 1807829, 1926100
     """
     org, ak = organization_ak_setup
-    virtual_host, baremetal_host = registered_hosts
+    virtual_host, baremetal_host = rhcloud_registered_hosts
     with rhcloud_sat_host.ui_session as session:
         session.organization.select(org_name=org.name)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
@@ -177,7 +177,7 @@ def test_hosts_synchronization():
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_names(
-    rhcloud_sat_host, inventory_settings, organization_ak_setup, registered_hosts
+    rhcloud_sat_host, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
 ):
     """Test whether `Obfuscate host names` setting works as expected.
 
@@ -201,7 +201,7 @@ def test_obfuscate_host_names(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
-    virtual_host, baremetal_host = registered_hosts
+    virtual_host, baremetal_host = rhcloud_registered_hosts
     with rhcloud_sat_host.ui_session as session:
         session.organization.select(org_name=org.name)
         # Enable obfuscate_hostnames setting on inventory page.
@@ -261,7 +261,7 @@ def test_obfuscate_host_names(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_ipv4_addresses(
-    rhcloud_sat_host, inventory_settings, organization_ak_setup, registered_hosts
+    rhcloud_sat_host, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
 ):
     """Test whether `Obfuscate host ipv4 addresses` setting works as expected.
 
@@ -289,7 +289,7 @@ def test_obfuscate_host_ipv4_addresses(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
-    virtual_host, baremetal_host = registered_hosts
+    virtual_host, baremetal_host = rhcloud_registered_hosts
     with rhcloud_sat_host.ui_session as session:
         session.organization.select(org_name=org.name)
         # Enable obfuscate_ips setting on inventory page.
@@ -361,7 +361,7 @@ def test_obfuscate_host_ipv4_addresses(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_exclude_packages_setting(
-    rhcloud_sat_host, inventory_settings, organization_ak_setup, registered_hosts
+    rhcloud_sat_host, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
 ):
     """Test whether `Exclude Packages` setting works as expected.
 
@@ -390,7 +390,7 @@ def test_exclude_packages_setting(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
-    virtual_host, baremetal_host = registered_hosts
+    virtual_host, baremetal_host = rhcloud_registered_hosts
     with rhcloud_sat_host.ui_session as session:
         session.organization.select(org_name=org.name)
         # Enable exclude_packages setting on inventory page.


### PR DESCRIPTION
This PR:
- Automates `test_rhcloud_inventory_api_hosts_synchronization` and `test_rhcloud_inventory_api_hosts_synchronization` test.
- Fixes tests failing because of manifest issue.
- Changes existing RH Cloud tests/fixtures//helpers so that tests can be executed on a separate satellite.
- Depends on https://github.com/SatelliteQE/nailgun/pull/791
- See PRT job 468 for test result.