### PR TITLE
Fix PAT tests and added new test as closeloop

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -518,7 +518,7 @@ class TestPersonalAccessToken:
         permissions = [
             permission['name']
             for permission in Filter.available_permissions(
-                {"search": "resource_type=PersonalAccessToken"}
+                {'search': 'resource_type=PersonalAccessToken'}
             )
         ]
         permissions = ','.join(permissions)


### PR DESCRIPTION
Change in output of cli commands
Adding new test for closeloop

```
(env) [akjha@akjha robottelo]$ pytest --log-cli-level ERROR tests/foreman/cli/test_user.py::TestPersonalAccessToken 
==================================================================== test session starts =====================================================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.8, forked-1.3.0, mock-3.6.1, cov-2.12.1, services-2.2.1, xdist-2.4.0, ibutsu-1.16
collected 4 items                                                                                                                                            

tests/foreman/cli/test_user.py::TestPersonalAccessToken::test_personal_access_token_admin_user PASSED                                                  [ 25%]
tests/foreman/cli/test_user.py::TestPersonalAccessToken::test_positive_personal_access_token_user_with_role PASSED                                     [ 50%]
tests/foreman/cli/test_user.py::TestPersonalAccessToken::test_expired_personal_access_token PASSED                                                     [ 75%]
tests/foreman/cli/test_user.py::TestPersonalAccessToken::test_custom_pat_role PASSED                                                                   [100%]

=============================================================== 4 passed in 204.55s (0:03:24) ================================================================

```