### PR TITLE
ui/test host location selected at the start of session

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -50,6 +50,7 @@ from robottelo.cli.proxy import Proxy
 from robottelo.cli.scap_policy import Scappolicy
 from robottelo.cli.scapcontent import Scapcontent
 from robottelo.cli.settings import Settings
+from robottelo.cli.user import User
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import DEFAULT_ARCHITECTURE
@@ -74,6 +75,13 @@ def _get_set_from_list_of_dict(value):
     :param list value: a list of simple dict.
     """
     return {tuple(sorted(list(global_param.items()), key=lambda t: t[0])) for global_param in value}
+
+
+# this fixture inherits the fixture called module_user in confest.py, method name has to be same
+@pytest.fixture(scope='module')
+def module_user(module_user, smart_proxy_location):
+    User.update({'id': module_user.id, 'default-location-id': smart_proxy_location.id})
+    yield module_user
 
 
 @pytest.fixture
@@ -1431,9 +1439,7 @@ def test_positive_global_registration_end_to_end(
                 'search-query': f"name ~ {client.hostname}",
             }
         )
-        result = ' '.join(
-            JobInvocation.get_output({'id': invocation_command['id'], 'host': client.hostname})
-        )
+        result = JobInvocation.get_output({'id': invocation_command['id'], 'host': client.hostname})
         assert (
             invocation_command['message'] == f'Job invocation {invocation_command["id"]} created'
         ), result


### PR DESCRIPTION
resolves #9040 only for `ui/test_host.py`

test results:

```
tests/foreman/ui/test_host.py::test_positive_end_to_end FAILED                                                                                                                         [  5%]
tests/foreman/ui/test_host.py::test_positive_read_from_details_page PASSED                                                                                                             [ 10%]
tests/foreman/ui/test_host.py::test_positive_read_from_edit_page PASSED                                                                                                                [ 15%]
tests/foreman/ui/test_host.py::test_positive_create_with_puppet_class PASSED                                                                                                           [ 20%]
tests/foreman/ui/test_host.py::test_positive_assign_taxonomies PASSED                                                                                                                  [ 25%]
tests/foreman/ui/test_host.py::test_negative_delete_primary_interface PASSED                                                                                                           [ 30%]
tests/foreman/ui/test_host.py::test_positive_search_by_parameter PASSED                                                                                                                [ 35%]
tests/foreman/ui/test_host.py::test_positive_search_by_parameter_with_different_values PASSED                                                                                          [ 40%]
tests/foreman/ui/test_host.py::test_positive_search_by_parameter_with_prefix PASSED                                                                                                    [ 45%]
tests/foreman/ui/test_host.py::test_positive_search_by_parameter_with_operator PASSED                                                                                                  [ 50%]
tests/foreman/ui/test_host.py::test_positive_search_by_org PASSED                                                                                                                      [ 55%]
tests/foreman/ui/test_host.py::test_positive_validate_inherited_cv_lce PASSED                                                                                                          [ 60%]
tests/foreman/ui/test_host.py::test_positive_global_registration_form PASSED                                                                                                           [ 65%]
tests/foreman/ui/test_host.py::test_positive_global_registration_end_to_end FAILED                                                                                                     [ 70%]
tests/foreman/ui/test_host.py::test_global_registration_with_gpg_repo_and_default_package[rhel7_contenthost0] PASSED                                                                   [ 75%]
tests/foreman/ui/test_host.py::test_global_re_registration_host_with_force_ignore_error_options[rhel7_contenthost0] PASSED                                                             [ 80%]
tests/foreman/ui/test_host.py::test_global_registration_token_restriction[rhel7_contenthost0] PASSED                                                                                   [ 85%]
tests/foreman/ui/test_host.py::test_positive_inherit_puppet_env_from_host_group_when_create PASSED                                                                                     [ 90%]
tests/foreman/ui/test_host.py::test_positive_set_multi_line_and_with_spaces_parameter_value PASSED                                                                                     [ 95%]
tests/foreman/ui/test_host.py::test_positive_bulk_delete_host PASSED                                                                                                                   [100%]
```

I fixed global registration end to end afterwards by removing the text formatting `(' ').join` 
But `test_positive_end_to_end` is showing ` Message: element not interactable` 
No idea how should I debug this one, so I wanted to run PRT to see if the result is same.

part of log and full traceback,
```
2021-10-07 14:49:32 - widgetastic_null - DEBUG - [HostCreateView/additional_information/comment]: fill('Host with fake data') started
2021-10-07 14:49:32 - widgetastic_null - DEBUG - click: TextInput(locator='.//*[(self::input or self::textarea) and @id="host_comment"]')
2021-10-07 14:49:32 - widgetastic_null - DEBUG - move_to_element: TextInput(locator='.//*[(self::input or self::textarea) and @id="host_comment"]')
2021-10-07 14:49:32 - widgetastic_null - DEBUG - clear: TextInput(locator='.//*[(self::input or self::textarea) and @id="host_comment"]')
2021-10-07 14:49:32 - widgetastic_null - ERROR - [HostCreateView/additional_information/comment]: An exception happened during fill('Host with fake data') call (elapsed 166 ms)
2021-10-07 14:49:32 - widgetastic_null - ERROR - [HostCreateView/additional_information/comment]: Message: element not interactable
Traceback (most recent call last):
      File "<path_to_lib>/lib/python3.9/site-packages/widgetastic/log.py", line 130, in wrapped
        result = f(self, *args, **kwargs)
      File "<path_to_lib>/lib/python3.9/site-packages/widgetastic/widget/base.py", line 41, in wrapped
        return method(self, Fillable.coerce(value), *args, **kwargs)
      File "<path_to_lib>/lib/python3.9/site-packages/widgetastic/widget/input.py", line 63, in fill
        self.browser.clear(self)
      File "<path_to_lib>/lib/python3.9/site-packages/widgetastic/browser.py", line 789, in clear
        result = el.clear()
      File "<path_to_lib>/lib/python3.9/site-packages/selenium/webdriver/remote/webelement.py", line 95, in clear
        self._execute(Command.CLEAR_ELEMENT)
      File "<path_to_lib>/lib/python3.9/site-packages/selenium/webdriver/remote/webelement.py", line 633, in _execute
        return self._parent.execute(command, params)
      File "<path_to_lib>/lib/python3.9/site-packages/selenium/webdriver/remote/webdriver.py", line 321, in execute
        self.error_handler.check_response(response)
      File "<path_to_lib>/lib/python3.9/site-packages/selenium/webdriver/remote/errorhandler.py", line 242, in check_response
        raise exception_class(message, screen, stacktrace)
    selenium.common.exceptions.ElementNotInteractableException: Message: element not interactable
      (Session info: chrome=94.0.4606.71)
 ```