### PR TITLE
Read rhel_compose_id parameter from the content_host conf

### DIFF
--- a/pytest_fixtures/content_hosts.py
+++ b/pytest_fixtures/content_hosts.py
@@ -18,6 +18,9 @@ def host_conf(request):
         params = request.param
     conf['workflow'] = params.get('workflow', settings.content_host.deploy_workflow)
     _rhelver = f"rhel{params.get('rhel_version', settings.content_host.default_rhel_version)}"
+    rhel_compose_id = settings.get(f"content_host.hardware.{_rhelver}.compose")
+    if rhel_compose_id:
+        conf['rhel_compose_id'] = rhel_compose_id
     conf['rhel_version'] = settings.content_host.hardware.get(_rhelver).release
     conf['memory'] = params.get('memory', settings.content_host.hardware.get(_rhelver).memory)
     conf['cores'] = params.get('cores', settings.content_host.hardware.get(_rhelver).cores)


### PR DESCRIPTION
> This PR is a piece needed to have PIT automation done

## Problem statement

For RHEL candidate deployments we use a different AT workflow than it is used for content hosts in the standard pipelines.
Currently, there is no way to set the `rhel_compose_id` parameter that is needed for the *deploy_rhel_cmp_template*.

## Solution
The patch included :slightly_smiling_face: 
