### PR TITLE
API Assertion error errata

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -740,7 +740,7 @@ FAKE_4_CUSTOM_PACKAGE = 'kangaroo-0.1-1.noarch'  # for RHBA-2012:1030
 FAKE_4_CUSTOM_PACKAGE_NAME = 'kangaroo'
 FAKE_5_CUSTOM_PACKAGE = 'kangaroo-0.2-1.noarch'  # for RHBA-2012:1030
 FAKE_6_CUSTOM_PACKAGE = 'kangaroo-0.3-1.noarch'  # for RHEA-2012:0059
-REAL_0_RH_PACKAGE = 'rhevm-sdk-python-3.3.0.21-1.el6ev.noarch'
+REAL_0_RH_PACKAGE = 'rhev-agent-2.3.16-3.el6.x86_64'
 REAL_RHEL7_0_0_PACKAGE = 'python-pulp-common-2.21.0-1.el7sat.noarch'
 REAL_RHEL7_0_0_PACKAGE_NAME = 'python-pulp-common'
 REAL_RHEL7_0_1_PACKAGE = 'python-pulp-common-2.21.0.2-1.el7sat.noarch '
@@ -793,8 +793,8 @@ FAKE_9_YUM_UPDATED_PACKAGES = [
     'kangaroo-0.2-1.noarch',
 ]
 REAL_0_ERRATA_ID = 'RHBA-2021:1314'  # for rhst7 (update every GA day)
-REAL_1_ERRATA_ID = 'RHBA-2016:1357'  # for REAL_0_RH_PACKAGE
-REAL_2_ERRATA_ID = 'RHEA-2014:0657'  # for REAL_0_RH_PACKAGE
+REAL_1_ERRATA_ID = 'RHBA-2012:1076'  # for REAL_0_RH_PACKAGE
+REAL_2_ERRATA_ID = 'RHBA-2012:0707'  # for REAL_0_RH_PACKAGE
 REAL_4_ERRATA_ID = 'RHSA-2014:1873'  # for rhva6 with type=security and cves
 REAL_4_ERRATA_CVES = ['CVE-2014-3633', 'CVE-2014-3657', 'CVE-2014-7823']
 REAL_RHEL7_0_ERRATA_ID = 'RHBA-2020:3615'  # for REAL_RHEL7_0_0_PACKAGE

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -257,6 +257,24 @@ class ContentHost(Host):
     def subscription_manager_list(self):
         return self.execute('subscription-manager list')
 
+    def subscription_manager_get_pool(self, sub_list=[]):
+        pool_ids = []
+        for sub in sub_list:
+            result = self.execute(
+                f'subscription-manager list --available --pool-only --matches="{sub}"'
+            )
+            result = result.stdout
+            result = result.split('\n')
+            result = ' '.join(result).split()
+            pool_ids.append(result)
+        return pool_ids
+
+    def subscription_manager_attach_pool(self, pool_list=[]):
+        result = []
+        for pool in pool_list:
+            result.append(self.execute(f'subscription-manager attach --pool={pool}'))
+        return result
+
     def create_custom_repos(self, **kwargs):
         """Create custom repofiles.
         Each ``kwargs`` item will result in one repository file created. Where

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -258,6 +258,9 @@ class ContentHost(Host):
         return self.execute('subscription-manager list')
 
     def subscription_manager_get_pool(self, sub_list=[]):
+        """
+        Return pool ids for the corresponding subscriptions in the list
+        """
         pool_ids = []
         for sub in sub_list:
             result = self.execute(
@@ -270,6 +273,9 @@ class ContentHost(Host):
         return pool_ids
 
     def subscription_manager_attach_pool(self, pool_list=[]):
+        """
+        Attach pool ids to the host and return the result
+        """
         result = []
         for pool in pool_list:
             result.append(self.execute(f'subscription-manager attach --pool={pool}'))

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -478,6 +478,12 @@ def test_positive_filter_by_envs(module_org):
 
 @pytest.fixture(scope='module')
 def setup_content_rhel6():
+    """Setup content fot rhel6 content host
+    Using `Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)`
+    from manifest, SATTOOLS_REPO for host-tools and yum_9 repo as custom repo.
+
+    :return: Activation Key, Organization, subscription list
+    """
     org = entities.Organization().create()
     with manifests.clone() as manifest:
         upload_manifest(org.id, manifest.content)

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -292,6 +292,8 @@ def test_positive_install_multiple_in_host(
         counter decreased by one; it's possible to schedule another errata
         installation
 
+    :CaseImportance: Medium
+
     :CaseLevel: System
     """
     rhel7_contenthost.install_katello_ca(default_sat)
@@ -544,6 +546,8 @@ def test_positive_get_count_for_host(setup_content_rhel6, rhel6_contenthost, def
     :expectedresults: The available errata count is retrieved.
 
     :CaseLevel: System
+
+    :CaseImportance: Medium
     """
     ak_name = setup_content_rhel6[0].name
     org_label = setup_content_rhel6[1].label
@@ -582,6 +586,8 @@ def test_positive_get_applicable_for_host(setup_content_rhel6, rhel6_contenthost
     :expectedresults: The available errata is retrieved.
 
     :CaseLevel: System
+
+    :CaseImportance: Medium
     """
     ak_name = setup_content_rhel6[0].name
     org_label = setup_content_rhel6[1].label

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -46,6 +46,11 @@ CUSTOM_REPO_ERRATA_ID = settings.repos.yum_6.errata[2]
 
 
 @pytest.fixture(scope='module')
+def module_org():
+    return entities.Organization().create()
+
+
+@pytest.fixture(scope='module')
 def activation_key(module_org, module_lce):
     activation_key = entities.ActivationKey(
         environment=module_lce, organization=module_org
@@ -242,7 +247,7 @@ def test_positive_install_in_host(
         package_name=constants.FAKE_1_CUSTOM_PACKAGE,
     )
     rhel7_contenthost.add_rex_key(satellite=default_sat)
-    default_sat.JobInvocation().run(
+    default_sat.api.JobInvocation().run(
         data={
             'feature': 'katello_errata_install',
             'inputs': {'errata': f'{CUSTOM_REPO_ERRATA_ID}'},
@@ -287,7 +292,7 @@ def test_positive_install_multiple_in_host(
     assert applicable_errata_count > 1
     rhel7_contenthost.add_rex_key(satellite=default_sat)
     for errata in settings.repos.yum_9.errata[:2]:
-        default_sat.JobInvocation().run(
+        default_sat.api.JobInvocation().run(
             data={
                 'feature': 'katello_errata_install',
                 'inputs': {'errata': f'{errata}'},
@@ -728,6 +733,7 @@ def test_positive_get_diff_for_cv_envs():
     assert {cvv.id for cvv in cvvs} == set(both_cvvs_errata['comparison'])
 
 
+@pytest.mark.skip_if_open("BZ:2013093")
 @pytest.mark.tier3
 def test_positive_incremental_update_required(
     module_org,


### PR DESCRIPTION
1. Adding two method in robottelo/hosts.py for getting and attaching pool_id.
2. Adding `wait_for_tasks` for `Actions::Katello::Host::UploadProfiles`
3. Moving from module_org to function where there is no need of RH repo.
4. Merging two tests `test_positive_filter_by_cve` and `test_positive_sort_by_issued_date`
5. A module fixture to setup content for rhel6 and removing the corresponding extra code.
6. Reassessing case importance 