### PR TITLE
Test coverage around Http proxy feature repository details

### DIFF
--- a/pytest_fixtures/api_fixtures.py
+++ b/pytest_fixtures/api_fixtures.py
@@ -53,6 +53,16 @@ def function_org():
     return entities.Organization().create()
 
 
+@pytest.fixture(scope='function')
+def function_location():
+    return entities.Location().create()
+
+
+@pytest.fixture(scope='function')
+def function_product(function_org):
+    return entities.Product(organization=function_org).create()
+
+
 @pytest.fixture(scope='module')
 def module_org():
     return entities.Organization().create()


### PR DESCRIPTION
**Test results - 6.10**

```
pytest tests/foreman/ui/test_http_proxy.py -k test_check_http_proxy_value_repository_details
========================= test session 
starts=============================================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, ibutsu-1.16, cov-3.0.0, xdist-2.4.0
collected 4 items / 3 deselected / 1 selected                                                                                                                                                                     

tests/foreman/ui/test_http_proxy.py .                                                                                                                                                                       [100%]

============================================================================= 1 passed, 3 deselected, 4 warnings in 387.39s (0:06:27) =============================================================================
```


