### PR TITLE
Rewrite test_positive_mirror_on_sync for pulp3

### DIFF
--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -372,7 +372,7 @@ def get_func_name(func, test_item=None):
     return '.'.join(names)
 
 
-def form_repo_url(capsule, org=None, lce=None, cv=None, prod=None, repo=None):
+def form_repo_url(capsule, org, prod, repo, lce=None, cv=None):
     """Forms url of a repo or CV published on a Satellite or Capsule.
 
     :param object capsule: Capsule or Satellite object providing its url
@@ -383,9 +383,6 @@ def form_repo_url(capsule, org=None, lce=None, cv=None, prod=None, repo=None):
     :param str repo: repository label
     :return: url of the specific repo or CV
     """
-    if not all([capsule, org, prod, repo]):
-        raise ValueError('`capsule`, `org`, `prod` and `repo` arguments are required')
-
     if lce and cv:
         return f'{capsule.url}/pulp/content/{org}/{lce}/{cv}/custom/{prod}/{repo}/'
     else:


### PR DESCRIPTION
I am afraid that the original pulp2 approach using the `createrepo` command (as described in the :BZ:) is not feasible now because it's not supported in pulp3. So I'm removing it in this PR as outdated.

However, the _mirror-on-sync_ test case still seems valid to me - I think we should test that the repo mirrors the upstream repo on resync. But it's rather 'repository related' feature than 'capsule related' (on Capsule the content is reflected with new CV version), so I've moved it under the `TestSatelliteContentManagement` class.

@latran, please review

Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_mirror_on_sync
====================================================================== test session starts =======================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 1 item                                                                                                                                                 

tests/foreman/api/test_contentmanagement.py .                                                                                                              [100%]
...
================================================================ 1 passed, 25 warnings in 53.81s =================================================================
```