### PR TITLE
cockpit test timeout length prolonged 

### DIFF
--- a/pytest_fixtures/sys_fixtures.py
+++ b/pytest_fixtures/sys_fixtures.py
@@ -62,7 +62,7 @@ def register_to_dogfood(default_sat):
 @pytest.fixture
 def install_cockpit_plugin(default_sat, register_to_dogfood):
     cmd_result = default_sat.execute(
-        'foreman-installer --enable-foreman-plugin-remote-execution-cockpit'
+        'foreman-installer --enable-foreman-plugin-remote-execution-cockpit', timeout='30m'
     )
     if cmd_result.status != 0:
         raise SatelliteHostError(

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2197,7 +2197,7 @@ def test_positive_gce_cloudinit_provision_end_to_end(
             googleclient.disconnect()
 
 
-@pytest.mark.run_in_one_thread
+@pytest.mark.destructive
 @pytest.mark.upgrade
 @pytest.mark.usefixtures('install_cockpit_plugin')
 @pytest.mark.tier2


### PR DESCRIPTION
rather used the destructive marker, not sure about xdist behaviour with run in one thread.

test result:
```
collected 36 items / 35 deselected / 1 selected
tests/foreman/ui/test_host.py::test_positive_cockpit 
=========== 1 passed, 35 deselected, 4 warnings in 284.94s (0:04:44) ===========
```