### PR TITLE
export templates to git

### DIFF
--- a/conf/git.yaml.template
+++ b/conf/git.yaml.template
@@ -1,4 +1,4 @@
 GIT:
-    USERNAME: admin
-    PASSWORD: chageme
-    URL: http://localhost:port
+  USERNAME: admin
+  PASSWORD: chageme
+  URL: http://localhost:port

--- a/conf/git.yaml.template
+++ b/conf/git.yaml.template
@@ -1,0 +1,4 @@
+GIT:
+    USERNAME: admin
+    PASSWORD: chageme
+    URL: http://localhost:port

--- a/pytest_fixtures/templatesync_fixtures.py
+++ b/pytest_fixtures/templatesync_fixtures.py
@@ -1,6 +1,8 @@
 import pytest
+import requests
 from fauxfactory import gen_string
 
+from robottelo.config import settings
 from robottelo.constants import FOREMAN_TEMPLATE_ROOT_DIR
 
 
@@ -27,3 +29,42 @@ def create_import_export_local_dir(default_sat):
     default_sat.execute(f'cp example_template.erb {dir_path}')
     yield dir_name, dir_path
     default_sat.execute(f'rm -rf {dir_path}')
+
+
+@pytest.fixture(scope='session')
+def git_repository():
+    """Creates a new repository on git provider for exporting templates.
+
+    Finally, deletes repository from git provider after tests are completed as a teardown part.
+    """
+    auth = (settings.git.username, settings.git.password)
+    name = gen_string('alpha')
+    res = requests.post(
+        f"{settings.git.url}/api/v1/user/repos",
+        auth=auth,
+        json={"name": name, "auto_init": True, "default_branch": "master"},
+    )
+    assert res.status_code == 201
+    yield name
+    res = requests.delete(
+        f"{settings.git.url}/api/v1/repos/{settings.git.username}/{name}", auth=auth
+    )
+    assert res.status_code == 204
+
+
+@pytest.fixture()
+def git_branch(git_repository):
+    """Creates a new branch in the git repository for exporting templates.
+
+    Finally, removes branch from the git repository after test is completed as a teardown part.
+    """
+    auth = (settings.git.username, settings.git.password)
+    url = f"{settings.git.url}/api/v1/repos/{settings.git.username}/{git_repository}/branches"
+    new_branch = gen_string('alpha')
+    res = requests.post(
+        url, auth=auth, json={"new_branch_name": new_branch, "old_branch_name": "master"}
+    )
+    assert res.status_code == 201
+    yield new_branch
+    res = requests.delete(f'{url}/{new_branch}', auth=auth)
+    assert res.status_code == 204

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -141,6 +141,14 @@ VALIDATORS = dict(
         Validator('gce.cert_path', startswith='/usr/share/foreman/'),
         Validator('gce.zone', is_in=VALID_GCE_ZONES),
     ],
+    git=[
+        Validator(
+            'git.username',
+            'git.password',
+            'git.url',
+            must_exist=True,
+        ),
+    ],
     http_proxy=[
         Validator(
             'http_proxy.un_auth_proxy_url',


### PR DESCRIPTION
Followup for #8986 
This PR is using lightweight Gitea container instead of Github. Each session creates new branch and each test creates its own branch in this repository. ~~This will still need setup in our automation which will be following in gitlab repos.~~ Edit: already done.

Test results:
```
pytest -v tests/foreman/*/test_templatesync.py -k test_positive_export_filtered_templates_to_git
================================================================================= test session starts =================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16, xdist-2.4.0
collected 28 items / 26 deselected / 2 selected                                                                                                                                       

tests/foreman/cli/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_filtered_templates_to_git PASSED                                                         [ 50%]
tests/foreman/ui/test_templatesync.py::test_positive_export_filtered_templates_to_git PASSED                                                                                    [100%]

============================================================== 2 passed, 26 deselected, 10 warnings in 61.80s (0:01:01) ===============================================================
```
```pytest -v tests/foreman/cli/test_templatesync.py -k test_positive_update_templates_in_git
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16, xdist-2.4.0
collected 4 items / 3 deselected / 1 selected                                                                                                                                                 

tests/foreman/cli/test_templatesync.py::TestTemplateSyncTestCase::test_positive_update_templates_in_git PASSED                                                                          [100%]

======================================================================== 1 passed, 3 deselected, 0 warnings in 21.41s =========================================================================```