### PR TITLE
All pre_upgrade scenarios test cases get failed due to absence of "upgrade_workers.json" file 

### DIFF
--- a/tests/upgrades/scenario_workers.py
+++ b/tests/upgrades/scenario_workers.py
@@ -26,7 +26,8 @@ def save_worker_hostname(test_name, default_sat):
 
 @pytest.fixture(scope='session')
 def shared_workers():
-    return json.loads(json_file.read_text())
+    if json_file.exists():
+        return json.loads(json_file.read_text())
 
 
 def get_worker_hostname_from_testname(test_name, shared_workers):


### PR DESCRIPTION
We are rolling back the changes that @jaryn made in the https://github.com/SatelliteQE/robottelo/pull/9021. 

All the pre-upgrade scenarios test cases are getting failed due to the absence of  upgrade_workers.json. As we all know the pre-upgrade and post-upgrade test cases are tightly coupled in a single scenario and the post-upgrade test cases always depend on the pre-upgrade test case's execution status that means pre_upgrade test cases would be executed first before post-upgrade.

here the worker.json is used to keep the track of the setup that we use in pre-upgrade so that we can use the same setup to execute the post-upgrade test cases after the upgrade.


**Test Result:**

```
$ pytest -s -m "pre_upgrade" tests/upgrades/test_bookmarks.py::TestPublicDisableBookmark::test_pre_create_public_disable_bookmark
platform linux -- Python 3.8.0, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
tests/upgrades/test_bookmarks.py .


================================================================================================ warnings summary =================================================================================================
========================================================================================= 1 passed, 48 warnings in 57.00s =========================================================================================

upgrade_worker.json

cat upgrade_workers.json
{"test_pre_create_public_disable_bookmark": "robottelo-3-62.abc.com"}


```