### PR TITLE
Fix ISO sync test

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -349,7 +349,7 @@ REPOSET = {
     'rhel7': 'Red Hat Enterprise Linux 7 Server (RPMs)',
     'rhva6': ('Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)'),
     'rhsc7': 'Red Hat Satellite Capsule 6.9 (for RHEL 7 Server) (RPMs)',
-    'rhsc7_iso': 'Red Hat Satellite Capsule 6.9 (for RHEL 7 Server) (ISOs)',
+    'rhsc7_iso': 'Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (ISOs)',
     'rhsc6': 'Red Hat Satellite Capsule 6.9 (for RHEL 6 Server) (RPMs)',
     'rhst7': 'Red Hat Satellite Tools 6.9 (for RHEL 7 Server) (RPMs)',
     'rhst7_64': 'Red Hat Satellite Tools 6.4 (for RHEL 7 Server) (RPMs)',
@@ -414,8 +414,8 @@ REPOS = {
         'key': 'rhsc',
     },
     'rhsc7_iso': {
-        'id': 'rhel-7-server-satellite-capsule-6.9-isos',
-        'name': ('Red Hat Satellite Capsule 6.9 for RHEL 7 Server ISOs x86_64'),
+        'id': 'rhel-7-server-satellite-capsule-6.4-isos',
+        'name': ('Red Hat Satellite Capsule 6.4 for RHEL 7 Server ISOs x86_64'),
     },
     'rhsc6': {
         'id': 'rhel-6-server-satellite-capsule-6.9-rpms',


### PR DESCRIPTION
As per previous discussion with fdiprete the capsule isos end in 6.4, but the version was accidentally bumped in robottelo to non-existing one.

Fixing that plus few other fixes.

Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_iso_library_sync
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 1 item                                                                                                                                                                                                                          

tests/foreman/api/test_contentmanagement.py .                                                                                                                                                                                       [100%]

...
=============================================================================================== 1 passed, 16 warnings in 1495.97s (0:24:55) ===============================================================================================
```