### PR TITLE
Fix test_positive_checksum_sync

### DIFF
--- a/robottelo/content_info.py
+++ b/robottelo/content_info.py
@@ -58,6 +58,20 @@ def get_repo_files_by_url(url, extension='rpm'):
     return sorted(files)
 
 
+def get_repomd(repo_url):
+    """Fetches content of the repomd file of a repository
+
+    :param repo_url: the 'Published_At' link of a repo
+    :return: string with repomd content
+    """
+    repomd_path = 'repodata/repomd.xml'
+    result = requests.get(f'{repo_url}/{repomd_path}', verify=False)
+    if result.status_code != 200:
+        raise requests.HTTPError(f'{repo_url}/{repomd_path} is not accessible')
+
+    return result.text
+
+
 def get_repomd_revision(repo_url):
     """Fetches a revision of a repository.
 
@@ -65,13 +79,8 @@ def get_repomd_revision(repo_url):
     :return: string containing repository revision
     :rtype: str
     """
-    repomd_path = 'repodata/repomd.xml'
-    result = requests.get(f'{repo_url}/{repomd_path}', verify=False)
-    if result.status_code != 200:
-        raise requests.HTTPError(f'{repo_url}/{repomd_path} is not accessible')
-
-    match = re.search('(?<=<revision>).*?(?=</revision>)', result.text)
+    match = re.search('(?<=<revision>).*?(?=</revision>)', get_repomd(repo_url))
     if not match:
-        raise ValueError(f'<revision> not found in {repo_url}/{repomd_path}')
+        raise ValueError(f'<revision> not found in repomd file of {repo_url}')
 
     return match.group(0)

--- a/robottelo/helpers.py
+++ b/robottelo/helpers.py
@@ -372,37 +372,6 @@ def get_func_name(func, test_item=None):
     return '.'.join(names)
 
 
-def form_repo_path(org=None, lce=None, cv=None, cvv=None, prod=None, repo=None, capsule=False):
-    """Forms unix path to the directory containing published repository in
-    pulp using provided entity names. Supports both repositories in content
-    view version and repositories in lifecycle environment. Note that either
-    `cvv` or `lce` is required.
-
-    :param str org: organization label
-    :param str optional lce: lifecycle environment label
-    :param str cv: content view label
-    :param str optional cvv: content view version, e.g. '1.0'
-    :param str prod: product label
-    :param str repo: repository label
-    :param bool capsule: whether the repo_path is from a capsule or not
-    :return: full unix path to the specific repository
-    :rtype: str
-    """
-    if not all([org, cv, prod, repo]):
-        raise ValueError('`org`, `cv`, `prod` and `repo` arguments are required')
-    if not any([lce, cvv]):
-        raise ValueError('Either `lce` or `cvv` is required')
-
-    if lce and capsule:
-        repo_path = f'{org}/{lce}/custom/{prod}/{repo}'
-    elif lce:
-        repo_path = f'{org}/{lce}/{cv}/custom/{prod}/{repo}'
-    elif cvv:
-        repo_path = f'{org}/content_views/{cv}/{cvv}/custom/{prod}/{repo}'
-
-    return os.path.join(PULP_PUBLISHED_YUM_REPOS_PATH, repo_path)
-
-
 def form_repo_url(capsule, org=None, lce=None, cv=None, prod=None, repo=None):
     """Forms url of a repo or CV published on a Satellite or Capsule.
 


### PR DESCRIPTION
Pulp3 related fix for the `test_positive_checksum_sync`.

Apart from the way the repomd is acquired, one important change is that we need `mirror_on_sync` set to False for the repo. Otherwise the upstream's repo checksum type takes precedence, making the selected checksum type in the repo settings irrelevant.

Last but not least, I'm removing the `form_repo_path` helper as it's not referenced from anywhere else and does not work for pulp3.

Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_checksum_sync
====================================================================== test session starts =======================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 1 item                                                                                                                                                 

tests/foreman/api/test_contentmanagement.py .                                                                                                              [100%]
...
=========================================================== 1 passed, 4 warnings in 1089.26s (0:18:09) ===========================================================
```