### PR TITLE
Fix failure for test_positive_sync_srpm_duplicate

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2151,7 +2151,7 @@ class TestSRPMRepositoryIgnoreContent:
         """
         repo.sync()
         repo = repo.read()
-        assert repo.content_counts['srpm'] == 2
+        assert repo.content_counts['srpm'] == 4
 
     @pytest.mark.tier2
     @pytest.mark.skip('Uses deprecated SRPM repository')


### PR DESCRIPTION
Count of srpm has changed from 2 to 4

results
```
pytest tests/foreman/api/test_repository.py::TestSRPMRepositoryIgnoreContent::test_positive_sync_srpm_duplicate

============ 1 passed, 13 warnings in 27.75s ================
```