### PR TITLE
Add test for REX installation of Ansible collection.

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -42,8 +42,6 @@ from robottelo.constants import REPOSET
 from robottelo.hosts import ContentHost
 from robottelo.utils.issue_handlers import is_open
 
-# from pytest_fixtures.api_fixtures import module_gt_manifest_org
-
 
 @pytest.fixture()
 def fixture_vmsetup(request, module_org, default_sat):
@@ -569,10 +567,6 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseComponent: RemoteExecution
-
-        :Assignee: pondrejk
-
         :CaseAutomation: Automated
 
         :CaseLevel: System
@@ -646,10 +640,6 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseComponent: RemoteExecution
-
-        :Assignee: pondrejk
-
         :CaseAutomation: Automated
 
         :CaseLevel: System
@@ -699,10 +689,6 @@ class TestAnsibleREX:
             1. Run Ansible Command job with concurrency-setting
 
         :expectedresults: multiple asserts along the code
-
-        :CaseComponent: RemoteExecution
-
-        :Assignee: pondrejk
 
         :CaseAutomation: Automated
 
@@ -777,10 +763,6 @@ class TestAnsibleREX:
             4. Check the service is started on the host
 
         :expectedresults: multiple asserts along the code
-
-        :CaseComponent: RemoteExecution
-
-        :Assignee: pondrejk
 
         :CaseAutomation: Automated
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -551,9 +551,9 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseComponent: Ansible
+        :CaseComponent: RemoteExecution
 
-        :Assignee: dsynk
+        :Assignee: pondrejk
 
         :CaseAutomation: Automated
 
@@ -628,9 +628,9 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseComponent: Ansible
+        :CaseComponent: RemoteExecution
 
-        :Assignee: dsynk
+        :Assignee: pondrejk
 
         :CaseAutomation: Automated
 
@@ -682,9 +682,9 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseComponent: Ansible
+        :CaseComponent: RemoteExecution
 
-        :Assignee: dsynk
+        :Assignee: pondrejk
 
         :CaseAutomation: Automated
 
@@ -760,9 +760,9 @@ class TestAnsibleREX:
 
         :expectedresults: multiple asserts along the code
 
-        :CaseComponent: Ansible
+        :CaseComponent: RemoteExecution
 
-        :Assignee: dsynk
+        :Assignee: pondrejk
 
         :CaseAutomation: Automated
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -908,3 +908,5 @@ class TestAnsibleREX:
                     JobInvocation.get_output({'id': collection_job['id'], 'host': client.hostname})
                 )
             )
+        collection_path = str(client.execute('ls /etc/ansible/collections/ansible_collections'))
+        assert 'oasis' in collection_path


### PR DESCRIPTION
Satellite 6.10 introduces an Ansible remote execution job template for installing Ansible Collections on hosts. This PR adds a CLI test of this feature.  
```
$ pytest tests/foreman/cli/test_remoteexecution.py::TestAnsibleREX::test_positive_install_ansible_collection 
============================================================================================================================== test session starts ===============================================================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dsynk/qe_forks/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, cov-2.11.1, xdist-2.3.0, mock-3.6.1, ibutsu-1.16
collected 1 item                                                                                                                                                                                                                                                                 

tests/foreman/cli/test_remoteexecution.py .                                                                                                                                                                                                                                [100%]
=================================================================================================================== 1 passed, 4 warnings in 586.31s (0:09:46) ====================================================================================================================
```

While writing this test, I noticed that CaseComponent and Assignee fields for the Ansible remote execution tests had not been updated, so this PR updates those fields as well.