### PR TITLE
Automated stubbed test case in repository Upstream authorization feature

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -951,9 +951,8 @@ def test_positive_repo_discovery_change_ssl():
     pass
 
 
-@pytest.mark.stubbed
 @pytest.mark.tier1
-def test_positive_remove_credentials():
+def test_positive_remove_credentials(session, function_product, function_org, function_location):
     """User can remove the upstream_username and upstream_password from a repository in the UI.
 
     :id: 1d4fc498-1e89-41ae-830f-d239ce389831
@@ -970,7 +969,29 @@ def test_positive_remove_credentials():
 
     :expectedresults: 'Upstream Authorization' value is cleared.
     """
-    pass
+    repo_name = gen_string('alpha')
+    upstream_username = gen_string('alpha')
+    upstream_password = gen_string('alphanumeric')
+    with session:
+        session.organization.select(org_name=function_org.name)
+        session.location.select(loc_name=function_location.name)
+        session.repository.create(
+            function_product.name,
+            {
+                'name': repo_name,
+                'repo_type': REPO_TYPE['yum'],
+                'repo_content.upstream_url': settings.repos.yum_1.url,
+                'repo_content.upstream_username': upstream_username,
+                'repo_content.upstream_password': upstream_password,
+            },
+        )
+        session.repository.update(
+            function_product.name,
+            repo_name,
+            {'repo_content.upstream_authorization': False},
+        )
+        repo_values = session.repository.read(function_product.name, repo_name)
+        assert not repo_values['repo_content']['upstream_authorization']
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
```
**Test Result - 6.10**

pytest tests/foreman/ui/test_repository.py -k test_positive_remove_credentials
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, ibutsu-1.16, cov-3.0.0, xdist-2.4.0
collected 26 items / 25 deselected / 1 selected                                                                                                                                                                   

tests/foreman/ui/test_repository.py .                                                                                                                                                                       [100%]
============================================================================ 1 passed, 25 deselected,in 169.51s (0:02:49) =============================================================================
```



