### PR TITLE
remove 'Background' download policy and related tests due to deprecation

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -320,7 +320,6 @@ REPO_TYPE = {
 
 DOWNLOAD_POLICIES = {
     'on_demand': "On Demand",
-    'background': "Background",
     'immediate': "Immediate",
 }
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -339,28 +339,6 @@ class TestRepository:
     @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
-        **datafactory.parametrized([{'content_type': 'yum', 'download_policy': 'immediate'}]),
-        indirect=True,
-    )
-    def test_positive_create_immediate_update_to_background(self, repo):
-        """Update `immediate` download policy to `background`
-        for a newly created YUM repository
-
-        :id: 9aaf53be-1127-4559-9faf-899888a52846
-
-        :parametrized: yes
-
-        :expectedresults: immediate download policy is updated to background
-
-        :CaseImportance: Critical
-        """
-        repo.download_policy = 'background'
-        repo = repo.update(['download_policy'])
-        assert repo.download_policy == 'background'
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options',
         **datafactory.parametrized([{'content_type': 'yum', 'download_policy': 'on_demand'}]),
         indirect=True,
     )
@@ -383,72 +361,6 @@ class TestRepository:
     @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
-        **datafactory.parametrized([{'content_type': 'yum', 'download_policy': 'on_demand'}]),
-        indirect=True,
-    )
-    def test_positive_create_on_demand_update_to_background(self, repo):
-        """Update `on_demand` download policy to `background`
-        for a newly created YUM repository
-
-        :id: 1d9888a0-c5b5-41a7-815d-47e936022a60
-
-        :parametrized: yes
-
-        :expectedresults: on_demand download policy is updated to background
-
-        :CaseImportance: Critical
-        """
-        repo.download_policy = 'background'
-        repo = repo.update(['download_policy'])
-        assert repo.download_policy == 'background'
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options',
-        **datafactory.parametrized([{'content_type': 'yum', 'download_policy': 'background'}]),
-        indirect=True,
-    )
-    def test_positive_create_background_update_to_immediate(self, repo):
-        """Update `background` download policy to `immediate`
-        for a newly created YUM repository
-
-        :id: 169530a7-c5ce-4ca5-8cdd-15398e13e2af
-
-        :parametrized: yes
-
-        :expectedresults: background download policy is updated to immediate
-
-        :CaseImportance: Critical
-        """
-        repo.download_policy = 'immediate'
-        repo = repo.update(['download_policy'])
-        assert repo.download_policy == 'immediate'
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options',
-        **datafactory.parametrized([{'content_type': 'yum', 'download_policy': 'background'}]),
-        indirect=True,
-    )
-    def test_positive_create_background_update_to_on_demand(self, repo):
-        """Update `background` download policy to `on_demand`
-        for a newly created YUM repository
-
-        :id: 40a3e963-61ff-41c4-aa6c-d9a4a638af4a
-
-        :parametrized: yes
-
-        :expectedresults: background download policy is updated to on_demand
-
-        :CaseImportance: Critical
-        """
-        repo.download_policy = 'on_demand'
-        repo = repo.update(['download_policy'])
-        assert repo.download_policy == 'on_demand'
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options',
         **datafactory.parametrized(
             {
                 checksum_type: {'checksum_type': checksum_type, 'download_policy': 'immediate'}
@@ -466,30 +378,6 @@ class TestRepository:
 
         :expectedresults: A repository is created and has expected checksum
             type.
-
-        :CaseImportance: Critical
-        """
-        assert repo.checksum_type == repo_options['checksum_type']
-
-    @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options',
-        **datafactory.parametrized(
-            {
-                checksum_type: {'checksum_type': checksum_type, 'download_policy': 'background'}
-                for checksum_type in ('sha1', 'sha256')
-            }
-        ),
-        indirect=True,
-    )
-    def test_positive_create_checksum_with_background_policy(self, repo_options, repo):
-        """Attempt to create repository with checksum and background policy.
-
-        :id: 4757ae21-f792-4886-a86a-799949ad82d0
-
-        :parametrized: yes
-
-        :expectedresults: A repository is created and has expected checksum type.
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
in 6.10, the `Background` download policy was removed so such strategy is no longer included in the options.
Broke several Critical tests

This also fixes some failing Critical tests
```
$ pytest -n4 --importance Critical -k test_positive_create tests/foreman/api/test_repository.py 
==== test session starts ====
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16, xdist-2.4.0
gw0 [42] / gw1 [42] / gw2 [42] / gw3 [42]
.............................s............                                                                                                                                                                                              [100%]
==== warnings summary ====
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/_pytest/config/__init__.py:676
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/_pytest/config/__init__.py:676
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/_pytest/config/__init__.py:676
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/_pytest/config/__init__.py:676
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/_pytest/config/__init__.py:676
  /home/rplevka/.virtualenvs/robottelo/lib/python3.9/site-packages/_pytest/config/__init__.py:676: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: pytest_fixtures.content_hosts
    self.import_plugin(import_spec)

../../../.virtualenvs/robottelo/lib/python3.9/site-packages/attrdict/mapping.py:4
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/attrdict/mapping.py:4
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/attrdict/mapping.py:4
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/attrdict/mapping.py:4
../../../.virtualenvs/robottelo/lib/python3.9/site-packages/attrdict/mapping.py:4
  /home/rplevka/.virtualenvs/robottelo/lib/python3.9/site-packages/attrdict/mapping.py:4: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Mapping

../../../.virtualenvs/robottelo/lib/python3.9/site-packages/attrdict/mixins.py:5: 10 warnings
  /home/rplevka/.virtualenvs/robottelo/lib/python3.9/site-packages/attrdict/mixins.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Mapping, MutableMapping, Sequence

tests/foreman/api/test_repository.py: 56 warnings
  /home/rplevka/.virtualenvs/robottelo/lib/python3.9/site-packages/urllib3/connectionpool.py:981: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-2-11.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==== 41 passed, 1 skipped, 76 warnings in 66.03s (0:01:06) ====
```