### PR TITLE
implement PIT markers, initial collection pick for PIT automation

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -12,6 +12,8 @@ def pytest_configure(config):
         "tier4: Tier 4 tests",  # Long running tests
         "destructive: Destructive tests",
         "upgrade: Upgrade tests",
+        "pit_server: PIT server scenario tests",
+        "pit_client: PIT client scenario tests",
         "run_in_one_thread: Sequential tests",
         "build_sanity: Fast, basic tests that confirm build is ready for full test suite",
     ]

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -227,6 +227,7 @@ class TestContentView:
         assert len(content_view.read().repository) == 0
 
     @pytest.mark.tier2
+    @pytest.mark.pit_server
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
@@ -649,6 +650,7 @@ class TestContentViewPublishPromote:
         assert len(content_view.version[-1].read().environment) == 0
 
     @pytest.mark.tier3
+    @pytest.mark.pit_server
     def test_positive_publish_multiple_repos(self, content_view, module_org):
         """Attempt to publish a content view with multiple YUM repos.
 

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -846,6 +846,7 @@ def _validate_swid_tags_installed(module_org, vm, module_name):
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
+@pytest.mark.pit_client
 def test_errata_installation_with_swidtags(
     module_org, module_lce, repos_collection, rhel8_contenthost, default_sat
 ):

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -30,6 +30,7 @@ from robottelo.config import get_url
 
 
 @pytest.mark.tier1
+@pytest.mark.pit_server
 def test_positive_path():
     """Check whether the path exists.
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -81,6 +81,7 @@ def module_ak(module_org, rh_repo, custom_repo):
 
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier1
+@pytest.mark.pit_server
 def test_positive_create():
     """Upload a manifest.
 
@@ -257,6 +258,8 @@ def test_positive_subscription_status_disabled(
 
 
 @pytest.mark.tier2
+@pytest.mark.pit_client
+@pytest.mark.pit_server
 def test_sca_end_to_end(module_ak, rhel_contenthost, module_org, rh_repo, custom_repo, default_sat):
     """Perform end to end testing for Simple Content Access Mode
 

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -93,6 +93,8 @@ def vm(
 
 
 @pytest.mark.tier2
+@pytest.mark.pit_client
+@pytest.mark.pit_server
 def test_positive_list_installable_updates(vm):
     """Ensure packages applicability is functioning properly.
 
@@ -133,6 +135,8 @@ def test_positive_list_installable_updates(vm):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
+@pytest.mark.pit_client
+@pytest.mark.pit_server
 def test_positive_erratum_installable(vm):
     """Ensure erratum applicability is showing properly, without attaching
     any subscription.

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1484,6 +1484,7 @@ class TestContentView:
         assert new_cv['versions'][0]['version'] == '1.0'
 
     @pytest.mark.run_in_one_thread
+    @pytest.mark.pit_server
     @pytest.mark.tier3
     def test_positive_publish_rh_and_custom_content(self, module_manifest_org, module_rhel_content):
         """attempt to publish  a content view containing a RH and custom

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1831,6 +1831,8 @@ def test_positive_package_applicability(katello_host_tools_client):
 
 
 @pytest.mark.katello_host_tools
+@pytest.mark.pit_client
+@pytest.mark.pit_server
 @pytest.mark.tier3
 def test_positive_erratum_applicability(katello_host_tools_client):
     """Ensure erratum applicability is functioning properly
@@ -2403,6 +2405,8 @@ def test_positive_unregister_host_subscription(module_host_subscription, host_su
         )
 
 
+@pytest.mark.pit_client
+@pytest.mark.pit_server
 @pytest.mark.host_subscription
 @pytest.mark.tier3
 def test_syspurpose_end_to_end(module_host_subscription, host_subscription_client):

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -233,6 +233,8 @@ class TestTailoringFiles:
 
     @pytest.mark.stubbed
     @pytest.mark.tier4
+    @pytest.mark.pit_server
+    @pytest.mark.pit_client
     @pytest.mark.upgrade
     def test_positive_oscap_run_with_tailoring_file_and_capsule(self):
         """End-to-End Oscap run with tailoring files and default capsule

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -60,6 +60,8 @@ class TestRemoteExecution:
     """Implements job execution tests in CLI."""
 
     @pytest.mark.tier3
+    @pytest.mark.pit_client
+    @pytest.mark.pit_server
     @pytest.mark.parametrize('fixture_vmsetup', [{'nick': 'rhel7'}], ids=['rhel7'], indirect=True)
     def test_positive_run_default_job_template_by_ip(self, fixture_vmsetup):
         """Run default template on host connected by ip and list task
@@ -103,6 +105,8 @@ class TestRemoteExecution:
 
     @pytest.mark.skip_if_open('BZ:1804685')
     @pytest.mark.tier3
+    @pytest.mark.pit_client
+    @pytest.mark.pit_server
     @pytest.mark.parametrize('fixture_vmsetup', [{'nick': 'rhel7'}], ids=['rhel7'], indirect=True)
     def test_positive_run_job_effective_user_by_ip(self, fixture_vmsetup):
         """Run default job template as effective user on a host by ip
@@ -520,6 +524,8 @@ class TestAnsibleREX:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
+    @pytest.mark.pit_client
+    @pytest.mark.pit_server
     @pytest.mark.parametrize('fixture_vmsetup', [{'nick': 'rhel7'}], ids=['rhel7'], indirect=True)
     def test_positive_run_effective_user_job(self, fixture_vmsetup):
         """Tests Ansible REX job having effective user runs successfully
@@ -705,6 +711,8 @@ class TestAnsibleREX:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
+    @pytest.mark.pit_client
+    @pytest.mark.pit_server
     @pytest.mark.parametrize(
         'fixture_vmsetup',
         nick_params,

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -30,6 +30,7 @@ from robottelo.constants import ROLES
 
 
 @pytest.mark.tier2
+@pytest.mark.pit_server
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, default_sat, test_name, module_org, module_location):
     """Perform end to end testing for user component


### PR DESCRIPTION
Motivation:
interop team's workflow currently doesn't support dynamic test suite, so we (At least temporarily) need a way to pick a static PIT test collection.
There's already a similar marker used for picking a collection for a sort of `sanity` checking - `@upgrade`, however, this has 2 flaws:
1. it doesn't distinguish between client and server oriented tests.
2. The majority of the picked tests are basic CRUD, which in PIT testing are providing little to no value.

Solution:
Add new markers: `pit_server` and `pit_client` and decorate some applicable tests with them.
