### PR TITLE
fix the rhelver format in generated parameters from rhel_X to rhelX format

### DIFF
--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -14,7 +14,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize(
             'rhel_contenthost',
             rhel_parameters,
-            ids=[f'rhel_{r["rhel_version"]}' for r in rhel_parameters],
+            ids=[f'rhel{r["rhel_version"]}' for r in rhel_parameters],
             indirect=True,
         )
 


### PR DESCRIPTION
This unifies the parameter names across the whole test suite

```
$ pytest --importance Critical --collect-only -k rhel tests/foreman/api/test_subscription.py 
============================================== test session starts ==============================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16, xdist-2.4.0
collected 15 items / 12 deselected / 3 selected                                                                 

<Package api>
  <Module test_subscription.py>
    <Function test_sca_end_to_end[rhel6]>
    <Function test_sca_end_to_end[rhel7]>
    <Function test_sca_end_to_end[rhel8]>
```