### PR TITLE
Update bookmark tests to be more parallel safe

### DIFF
--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -209,7 +209,9 @@ def test_positive_update_bookmark_public(
     with Session(
         test_name, default_viewer_role.login, default_viewer_role.password
     ) as non_admin_session:
-        assert any(d['Name'] == nonpublic_name for d in non_admin_session.bookmark.search(nonpublic_name))
+        assert any(
+            d['Name'] == nonpublic_name for d in non_admin_session.bookmark.search(nonpublic_name)
+        )
         assert not non_admin_session.bookmark.search(public_name)
 
 


### PR DESCRIPTION
Based on #6868, changing the tests to search through the list for matches rather than blindly looking at only the first element when checking for a bookmark to exist.