### PR TITLE
changed asserts for ansible collections repo export

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2493,8 +2493,11 @@ class TestAnsibleCollectionRepository:
         assert cv['description'] == 'Content View used for importing library'
         prods = Product.list({'organization-id': import_org['id']})
         prod = Product.info({'id': prods[0]['id'], 'organization-id': import_org['id']})
-        assert prod['content'][0]['content-type'] == 'ansible_collection'
-        repo = Repository.info({'name': prod['content'][0]['repo-name'], 'product-id': prod['id']})
+        ac_content = [
+            cont for cont in prod['content'] if cont['content-type'] == 'ansible_collection'
+        ]
+        assert len(ac_content) > 0
+        repo = Repository.info({'name': ac_content[0]['repo-name'], 'product-id': prod['id']})
         result = default_sat.execute(f'curl {repo["published-at"]}')
         assert "available_versions" in result.stdout
 


### PR DESCRIPTION
Previously the test assumed only one content type per imported product was possible, leading to assertion errors when yum content was also present in library. Now the test filters out the ansible collection repo from product content.

```pytest tests/foreman/cli/test_repository.py -k test_positive_export_ansible_collection
================================================= test session starts ==================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, cov-2.12.1, ibutsu-1.16, xdist-2.4.0
collected 234 items / 233 deselected / 1 selected                                                                      

tests/foreman/cli/test_repository.py .                                                                           [100%]


============================== 1 passed, 233 deselected, 6 warnings in 112.23s (0:01:52) ===============================
```