### PR TITLE
fix in capsule upgrade playbook test

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -23,7 +23,7 @@ from nailgun.entity_mixins import TaskFailedError
 from robottelo.api.utils import wait_for_tasks
 
 
-CAPSULE_TARGET_VERSION = '6.9.z'
+CAPSULE_TARGET_VERSION = '6.10.z'
 
 
 @pytest.mark.tier4


### PR DESCRIPTION
the test is failing with `"stderr": "Can't upgrade to 6.9.z\nPossible target versions are:\n6.10.z"`