### PR TITLE
Increased the timeout for satellite-installer

### DIFF
--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -69,7 +69,7 @@ class TestScenarioPerformanceTuning:
                 remote_path="/etc/foreman-installer/custom-hiera.yaml",
             )
             installer_obj = InstallerCommand(tuning='medium')
-            command_output = default_sat.execute(installer_obj.get_command())
+            command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
             assert 'Success!' in command_output.stdout
             installer_obj = InstallerCommand(help='tuning')
             command_output = default_sat.execute(installer_obj.get_command())
@@ -78,7 +78,7 @@ class TestScenarioPerformanceTuning:
         except Exception as exp:
             logger.critical(exp)
             installer_obj = InstallerCommand(tuning='default')
-            command_output = default_sat.execute(installer_obj.get_command())
+            command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
             assert 'Success!' in command_output.stdout
             assert 'default: "default"' in command_output.stdout
             raise
@@ -102,7 +102,7 @@ class TestScenarioPerformanceTuning:
 
         """
         installer_obj = InstallerCommand(help='tuning')
-        command_output = default_sat.execute(installer_obj.get_command())
+        command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
         assert 'default: "medium"' in command_output.stdout
         default_sat.get(
             local_path="custom-hiera-after-upgrade.yaml",
@@ -110,7 +110,7 @@ class TestScenarioPerformanceTuning:
         )
         assert filecmp.cmp('custom-hiera-before-upgrade.yaml', 'custom-hiera-after-upgrade.yaml')
         installer_obj = InstallerCommand(tuning='default')
-        command_output = default_sat.execute(installer_obj.get_command())
+        command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
         assert 'Success!' in command_output.stdout
         installer_obj = InstallerCommand(help='tuning')
         command_output = default_sat.execute(installer_obj.get_command())


### PR DESCRIPTION
Performance Tuning pre-upgrade test cases get failed on the upgrade base version setup due to ssh timeout, therefore we have increased the timeout value.

```
E   ssh2.exceptions.Timeout

During handling of the above exception, another exception occurred:
E   assert 'default: "default"' in '\x1b[34m2021-10-22 07:27:22\x1b[0m [\x1b[32mNOTICE\x1b[0m] [\x1b[36mroot\x1b[0m] Loading default values from puppet m...[1m\x1b[36m/var/log/forem
```

**Test Results:**

**Pre-Upgrade:**

```
$ pytest -s -m "pre_upgrade" tests/upgrades/test_performance_tuning.py
plugins: reportportal-5.0.8, xdist-2.4.0, services-2.2.1, ibutsu-1.16, forked-1.3.0, mock-3.6.1
collected 2 items / 1 deselected / 1 selected
tests/upgrades/test_performance_tuning.py .

================================================================================================ warnings summary =================================================================================================
============================================================================= 1 passed, 1 deselected, 3 warnings in 195.30s (0:03:15) =============================================================================
```

**Post-Upgrade:**

```
$ pytest -s -m "post_upgrade" tests/upgrades/test_performance_tuning.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.0, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_performance_tuning.py .

============================================================================= 1 passed, 1 deselected, 3 warnings in 210.29s (0:03:30) =============================================================================

```