### PR TITLE
Automated stubbed test case in contentview file-repository removal

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4160,9 +4160,9 @@ class TestContentViewFileRepo:
         cv = ContentView.info({'id': cv['id']})
         assert cv['file-repositories'][0]['name'] == repo['name']
 
-    @pytest.mark.stubbed
+    @pytest.mark.skip_if_open('BZ:1908465')
     @pytest.mark.tier3
-    def test_positive_arbitrary_file_repo_removal(self):
+    def test_positive_arbitrary_file_repo_removal(self, module_org, module_product, default_sat):
         """Check a File Repository with Arbitrary File can be removed from a
         Content View
 
@@ -4179,10 +4179,21 @@ class TestContentViewFileRepo:
 
         :expectedresults: Check FR is removed from CV
 
-        :CaseAutomation: NotAutomated
+        :CaseAutomation: Automated
 
         :CaseLevel: Integration
+
+        :BZ: 1908465
         """
+        cv = cli_factory.make_content_view({'organization-id': module_org.id})
+        repo = self.make_file_repository_upload_contents(
+            module_org, module_product, satellite=default_sat
+        )
+        ContentView.add_repository(
+            {'id': cv['id'], 'repository-id': repo['id'], 'organization-id': module_org.id}
+        )
+        ContentView.remove_repository({'id': cv['id'], 'repository-id': repo['id']})
+        assert cv['file-repositories'][0]['id'] != repo['id']
 
     @pytest.mark.stubbed
     @pytest.mark.tier3


### PR DESCRIPTION
**Test results - 6.10**

```
pytest tests/foreman/cli/test_contentview.py -k test_positive_arbitrary_file_repo_removal
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, ibutsu-1.16, cov-3.0.0, xdist-2.4.0
collected 136 items / 135 deselected / 1 selected                                                                                                                                                                 

tests/foreman/cli/test_contentview.py s                                                                                                                                                                     [100%]
-- Docs: https://docs.pytest.org/en/stable/warnings.html
================================================================================= 1 skipped, 135 deselected,in 4.20s =================================================================================
```=

