### PR TITLE
[6.9.z cherry-pick] Allow arbitrary deploy arguments for server and capsule

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -12,3 +12,5 @@ CAPSULE:
     SOURCE: "internal"
   # The Ansible Tower workflow used to deploy a capsule
   DEPLOY_WORKFLOW: deploy-sat-capsule
+  # Dictionary of arguments which should be passed along to the deploy workflow
+  # DEPLOY_ARGUMENTS:

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -26,6 +26,8 @@ SERVER:
   AUTO_CHECKIN: False
   # The Ansible Tower workflow used to deploy a satellite
   DEPLOY_WORKFLOW: "deploy-sat-jenkins"
+  # Dictionary of arguments which should be passed along to the deploy workflow
+  # DEPLOY_ARGUMENTS:
   # HTTP scheme when building the server URL
   # Suggested values for "scheme" are "http" and "https".
   SCHEME: https

--- a/pytest_fixtures/sys_fixtures.py
+++ b/pytest_fixtures/sys_fixtures.py
@@ -10,10 +10,10 @@ from robottelo.errors import GCECertNotFoundError
 
 
 @pytest.fixture
-def foreman_service_teardown(default_sat):
+def foreman_service_teardown(satellite_host):
     """stop and restart of foreman service"""
-    yield
-    default_sat.execute('foreman-maintain service start --only=foreman')
+    yield satellite_host
+    satellite_host.execute('foreman-maintain service start --only=foreman')
 
 
 @pytest.fixture

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -1,7 +1,6 @@
 from inspect import getmembers
 from inspect import isfunction
 
-from pytest_fixtures import content_hosts
 from robottelo.config import settings
 
 
@@ -26,6 +25,8 @@ def pytest_configure(config):
 
 
 def pytest_collection_modifyitems(session, items, config):
+    from pytest_fixtures import content_hosts
+
     content_host_fixture_names = [m[0] for m in getmembers(content_hosts, isfunction)]
     for item in items:
         if set(item.fixturenames).intersection(set(content_host_fixture_names)):

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -28,8 +28,8 @@ settings.validators.register(**VALIDATORS)
 
 try:
     settings.validators.validate()
-except ValidationError:
-    logger.warning("Dynaconf validation failed, continuing for the sake of unit tests")
+except ValidationError as err:
+    logger.warning(f'Dynaconf validation failed, continuing for the sake of unit tests\n{err}')
 
 
 if not os.getenv('BROKER_DIRECTORY'):

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -6,7 +6,7 @@ from robottelo.constants import VALID_GCE_ZONES
 
 VALIDATORS = dict(
     server=[
-        Validator('server.hostname', must_exist=False, default=''),
+        Validator('server.hostname', default=''),
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
         Validator('server.version.source', must_exist=True),
@@ -22,6 +22,7 @@ VALIDATORS = dict(
         Validator('server.admin_password', default='changeme'),
         Validator('server.admin_username', default='admin'),
         Validator('server.deploy_workflow', must_exist=True),
+        Validator('server.deploy_arguments', must_exist=True, is_type_of=dict, default={}),
         Validator('server.scheme', default='https'),
         Validator('server.port', default=443),
         Validator('server.ssh_username', default='root'),
@@ -57,6 +58,7 @@ VALIDATORS = dict(
         Validator('capsule.version.release', must_exist=True),
         Validator('capsule.version.source', must_exist=True),
         Validator('capsule.deploy_workflow', must_exist=True),
+        Validator('capsule.deploy_arguments', must_exist=True, is_type_of=dict, default={}),
     ],
     certs=[
         Validator(

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -361,7 +361,7 @@ class TestOperatingSystem:
 
 @pytest.mark.tier2
 @pytest.mark.skip_if_open("BZ:1649011")
-def test_positive_os_list_with_default_organization_set(satellite_latest):
+def test_positive_os_list_with_default_organization_set(satellite_host):
     """list operating systems when the default organization is set
 
     :id: 2c1ba416-a5d5-4031-b154-54794569a85b
@@ -371,21 +371,19 @@ def test_positive_os_list_with_default_organization_set(satellite_latest):
     :expectedresults: os list should list operating systems when the
         default organization is set
     """
-    satellite_latest.api.OperatingSystem().create()
-    os_list_before_default = satellite_latest.cli.OperatingSys.list()
+    satellite_host.api.OperatingSystem().create()
+    os_list_before_default = satellite_host.cli.OperatingSys.list()
     assert len(os_list_before_default) > 0
     try:
-        satellite_latest.cli.Defaults.add(
-            {'param-name': 'organization', 'param-value': DEFAULT_ORG}
-        )
-        result = satellite_latest.execute('hammer defaults list')
+        satellite_host.cli.Defaults.add({'param-name': 'organization', 'param-value': DEFAULT_ORG})
+        result = satellite_host.execute('hammer defaults list')
         assert result.status == 0
-        assert DEFAULT_ORG in "".join(result.stdout)
-        os_list_after_default = satellite_latest.cli.OperatingSys.list()
+        assert DEFAULT_ORG in ''.join(result.stdout)
+        os_list_after_default = satellite_host.cli.OperatingSys.list()
         assert len(os_list_after_default) > 0
 
     finally:
-        satellite_latest.cli.Defaults.delete({'param-name': 'organization'})
-        result = satellite_latest.execute('hammer defaults list')
+        satellite_host.cli.Defaults.delete({'param-name': 'organization'})
+        result = satellite_host.execute('hammer defaults list')
         assert result.status == 0
-        assert DEFAULT_ORG not in "".join(result.stdout)
+        assert DEFAULT_ORG not in ''.join(result.stdout)


### PR DESCRIPTION
Tis allows users to specify a dictionary of arguments that will be
passed to broker during satellite/capsule_factory checkouts