### PR TITLE
Add test for negative api ping

### DIFF
--- a/tests/foreman/api/test_ping.py
+++ b/tests/foreman/api/test_ping.py
@@ -1,0 +1,45 @@
+"""Test Class for api ping
+
+:Requirement: Ping
+
+:CaseAutomation: Automated
+
+:CaseLevel: Component
+
+:CaseComponent: API
+
+:Assignee: gtalreja
+
+:TestType: Functional
+
+:CaseImportance: Critical
+
+:Upstream: No
+"""
+import pytest
+
+pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
+
+
+@pytest.mark.build_sanity
+def test_positive_ping(target_sat):
+    """Check if all services are running
+
+    :id: b8ecc7ba-8007-4067-bf99-21a82c833de7
+
+    :expectedresults: Overall and individual services status should be 'ok'.
+    """
+    response = target_sat.api.Ping().search_json()
+    assert response['status'] == 'ok'  # overall status
+
+    # Check that all services are OK. ['services'] is in this format:
+    #
+    # {'services': {
+    #    'candlepin': {'duration_ms': '40', 'status': 'ok'},
+    #    'candlepin_auth': {'duration_ms': '41', 'status': 'ok'},
+    #    …
+    # }, 'status': 'ok'}
+    services = response['services']
+    assert all(
+        [service['status'] == 'ok' for service in services.values()]
+    ), 'Not all services seem to be up and running!'

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -18,9 +18,10 @@
 """
 import pytest
 
+pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
 
-@pytest.mark.tier1
-@pytest.mark.upgrade
+
+@pytest.mark.build_sanity
 def test_positive_ping(target_sat):
     """hammer ping return code
 

--- a/tests/foreman/destructive/test_ping.py
+++ b/tests/foreman/destructive/test_ping.py
@@ -21,8 +21,19 @@ import pytest
 pytestmark = pytest.mark.destructive
 
 
-def test_negative_ping_fail_status_code(target_sat):
-    """Negative test to verify non-zero status code of ping fail
+@pytest.fixture(scope='module')
+def tomcat_service_teardown(request, module_target_sat):
+    assert module_target_sat.cli.Service.stop(options={'only': 'tomcat.service'}).status == 0
+
+    @request.addfinalizer
+    def _finalize():
+        assert module_target_sat.cli.Service.start(options={'only': 'tomcat.service'}).status == 0
+
+    yield module_target_sat
+
+
+def test_negative_cli_ping_fail_status(tomcat_service_teardown):
+    """Negative test to verify non-zero status code of CLI ping fail
 
     :id: 8f8675aa-df52-11eb-9353-b0a460e02491
 
@@ -30,14 +41,24 @@ def test_negative_ping_fail_status_code(target_sat):
 
     :BZ: 1941240
 
-    :CaseImportance: Critical
-
     :expectedresults: Hammer ping fails and returns non-zero(1) status code.
-
     """
-    command_out = target_sat.execute('satellite-maintain service stop --only tomcat.service')
-    assert command_out.status == 0
-    result = target_sat.execute("hammer ping")
+    result = tomcat_service_teardown.execute("hammer ping")
     assert result.status == 1
-    command_out = target_sat.execute('satellite-maintain service start --only tomcat.service')
-    assert command_out.status == 0
+
+
+def test_negative_api_ping_fail_status(tomcat_service_teardown):
+    """Negative test to verify FAIL status when API ping fail
+
+    :id: 6bd2c552-29d7-4f49-81dd-f8d5ff0e7c39
+
+    :customerscenario: true
+
+    :BZ: 1835122
+
+    :CaseComponent: API
+
+    :expectedresults: API ping fails and shows FAIL status.
+    """
+    response = tomcat_service_teardown.api.Ping().search_json()
+    assert response['status'] == 'FAIL'

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1028,31 +1028,6 @@ class TestEndToEnd:
         assert len(results) == 1
         assert results[0].login == 'admin'
 
-    @pytest.mark.build_sanity
-    @pytest.mark.skip_if_open('BZ:1897360')
-    def test_positive_ping(self):
-        """Check if all services are running
-
-        :id: b8ecc7ba-8007-4067-bf99-21a82c833de7
-
-        :expectedresults: Overall and individual services status should be
-            'ok'.
-        """
-        response = entities.Ping().search_json()
-        assert response['status'] == 'ok'  # overall status
-
-        # Check that all services are OK. ['services'] is in this format:
-        #
-        # {'services': {
-        #    'candlepin': {'duration_ms': '40', 'status': 'ok'},
-        #    'candlepin_auth': {'duration_ms': '41', 'status': 'ok'},
-        #    …
-        # }, 'status': 'ok'}
-        services = response['services']
-        assert all(
-            [service['status'] == 'ok' for service in services.values()]
-        ), 'Not all services seem to be up and running!'
-
     @pytest.mark.skip_if_not_set('libvirt')
     @pytest.mark.tier4
     @pytest.mark.upgrade


### PR DESCRIPTION
**Description:**
- Add negative API ping to test to cover BZ-1835122.
- Move API ping tests from endtoend to api/test_ping.py to keep alike CLI tests.
- Update pytest marks for cli/test_ping.py.

**Test Results:**
```
$ pytest -qv --disable-warnings tests/foreman/api/test_ping.py 
=============================================================== test session starts ===============================================================
platform linux -- Python 3.8.2, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gtalreja/sat_workspace/robottelo, configfile: pyproject.toml
plugins: xdist-2.4.0, services-2.2.1, forked-1.3.0, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16, cov-3.0.0
collected 2 items                                                                                                                                 

tests/foreman/api/test_ping.py ..                                                                                                           [100%]

========================================================= 2 passed, 4 warnings in 53.10s ==========================================================
```
```
$ pytest -qv --disable-warnings tests/foreman/cli/test_ping.py 
=============================================================== test session starts ===============================================================
platform linux -- Python 3.8.2, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gtalreja/sat_workspace/robottelo, configfile: pyproject.toml
plugins: xdist-2.4.0, services-2.2.1, forked-1.3.0, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16, cov-3.0.0
collected 2 items                                                                                                                                 

tests/foreman/cli/test_ping.py ..                                                                                                           [100%]

========================================================= 2 passed, 3 warnings in 52.60s ==========================================================
```
Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>