### PR TITLE
Adding skip to test_positive_srpm_upload_publish_promote_cv

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1908,6 +1908,7 @@ class TestDockerRepository:
 class TestSRPMRepository:
     """Tests specific to using repositories containing source RPMs."""
 
+    @pytest.mark.skip_if_open("BZ:2016047")
     @pytest.mark.upgrade
     @pytest.mark.tier2
     def test_positive_srpm_upload_publish_promote_cv(self, module_org, env, repo):


### PR DESCRIPTION
Skipping api/test_repository.py::TestSRPMRepository::test_positive_srpm_upload_publish_promote_cv

============================= test session starts ==============================
platform linux -- Python 3.9.5, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, cov-2.12.1, xdist-2.3.0, ibutsu-1.16
collected 1 item

tests/foreman/api/test_repository.py s                                   [100%]

=============================== warnings summary ===============================
