### PR TITLE
DRAFT Dynamically replace default_sat from marks

### DIFF
--- a/pytest_fixtures/xdist.py
+++ b/pytest_fixtures/xdist.py
@@ -7,12 +7,18 @@ from broker import VMBroker
 from robottelo.config import configure_airgun
 from robottelo.config import configure_nailgun
 from robottelo.config import settings
+from robottelo.hosts import Satellite
 from robottelo.logging import logger
 
 
 @pytest.fixture(scope="session", autouse=True)
-def align_to_satellite(worker_id, satellite_factory):
-    """Attempt to align a Satellite to the current xdist worker"""
+def worker_default_host(worker_id):
+    """Define the session scoped default satellite hostname for a worker
+
+    Accounts for settings.server.xdist_behavior
+
+    Basis for the 'default_sat' fixture with no modifications like destructive
+    """
     # clear any hostname that may have been previously set
     settings.set("server.hostname", None)
     on_demand_sat = None
@@ -28,6 +34,7 @@ def align_to_satellite(worker_id, satellite_factory):
         settings.server.hostnames += [host.hostname for host in hosts]
 
     # attempt to align a worker to a satellite
+    # TODO don't set settings.server.hostname, just return it (helpers refactor)
     if settings.server.xdist_behavior == 'run-on-one' and settings.server.hostnames:
         settings.set("server.hostname", settings.server.hostnames[0])
     elif settings.server.hostnames and worker_pos < len(settings.server.hostnames):
@@ -36,15 +43,39 @@ def align_to_satellite(worker_id, satellite_factory):
         settings.set("server.hostname", random.choice(settings.server.hostnames))
     # get current satellite information
     elif settings.server.xdist_behavior == 'on-demand':
-        on_demand_sat = satellite_factory()
+        on_demand_sat = Satellite.factory()
         if on_demand_sat.hostname:
             settings.set("server.hostname", on_demand_sat.hostname)
-        # if no satellite was received, fallback to balance
-        if not settings.server.hostname:
-            settings.set("server.hostname", random.choice(settings.server.hostnames))
+        else:
+            pytest.fail('Unable to deploy a Satellite instance on-demand, check broker logs')
+
     logger.info(f'xdist worker {worker_id} was assigned hostname {settings.server.hostname}')
-    configure_airgun()
-    configure_nailgun()
-    yield
+    target_sat = on_demand_sat or Satellite(hostname=settings.server.hostname)
+    configure_airgun(host=target_sat)
+    configure_nailgun(host=target_sat)
+    yield target_sat
     if on_demand_sat and settings.server.auto_checkin:
         VMBroker(hosts=[on_demand_sat]).checkin()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def align_to_satellite(worker_default_host, request):
+    """Identify whether the default satellite should be used for the requesting test case
+
+    Test cases marked destructive should have a new satellite deployed on demand as a target
+    """
+    target_sat = worker_default_host
+    replaced = False
+    if request.node.get_closest_marker('destructive') is not None:
+        if settings.server.xdist_behavior in ['run-on-one', 'balance']:
+            pytest.skip('destructive test requires on-demand settings.server.xdist_behavior')
+        logger.info(f'Deploying Satellite instance for destructive test: {request.node_id}')
+        target_sat = Satellite.factory()
+        logger.info(f'Destructive Satellite instance deployed: {target_sat.hostname}')
+        replaced = True
+        configure_airgun(host=target_sat)
+        configure_nailgun(host=target_sat)
+    yield target_sat
+    if replaced:
+        configure_airgun(host=worker_default_host)
+        configure_nailgun(host=worker_default_host)

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -101,7 +101,7 @@ def setting_is_set(option):
     return isinstance(opt_inst, DynaBox)
 
 
-def configure_nailgun():
+def configure_nailgun(host=None):
     """Configure NailGun's entity classes.
 
     Do the following:
@@ -120,7 +120,9 @@ def configure_nailgun():
     from nailgun.config import ServerConfig
 
     entity_mixins.CREATE_MISSING = True
-    entity_mixins.DEFAULT_SERVER_CONFIG = ServerConfig(get_url(), get_credentials(), verify=False)
+    entity_mixins.DEFAULT_SERVER_CONFIG = ServerConfig(
+        host.url if host is not None else get_url(), get_credentials(), verify=False
+    )
     gpgkey_init = entities.GPGKey.__init__
 
     def patched_gpgkey_init(self, server_config=None, **kwargs):
@@ -136,7 +138,7 @@ def configure_nailgun():
 configure_nailgun()
 
 
-def configure_airgun():
+def configure_airgun(host=None):
     """Pass required settings to AirGun"""
     import airgun
 
@@ -147,7 +149,7 @@ def configure_airgun():
                 'tmp_dir': settings.robottelo.tmp_dir,
             },
             'satellite': {
-                'hostname': settings.server.get('hostname', None),
+                'hostname': host.hostname or settings.server.get('hostname', None),
                 'password': settings.server.admin_password,
                 'username': settings.server.admin_username,
             },


### PR DESCRIPTION
Adjust align_to_xdist fixture, splitting a session scoped default worker
alignment from the function scoped satellite hostname selection based on
test context.

First relevant mark is destructive.

Yet untested, pushing the branch early though.