### PR TITLE
[6.9] assertions fixes in rex tests

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -158,7 +158,7 @@ class TestRemoteExecution:
             f'''stat -c '%U' /home/{username}/{filename}''',
         )
         # assert the file is owned by the effective user
-        assert username == result.stdout
+        assert username == result.stdout.strip('\n')
 
     @pytest.mark.tier3
     @pytest.mark.parametrize(
@@ -518,7 +518,7 @@ class TestAnsibleREX:
             f'''stat -c '%U' /home/{username}/{filename}''',
         )
         # assert the file is owned by the effective user
-        assert username == result.stdout, "file ownership mismatch"
+        assert username == result.stdout.strip('\n'), "file ownership mismatch"
 
     @pytest.mark.tier3
     @pytest.mark.upgrade


### PR DESCRIPTION
To address issues in 6.9 rex tests like:

```
AssertionError: assert 'HOkFmitmVy' == 'HOkFmitmVy\n'
  - HOkFmitmVy
  ?           -
  + HOkFmitmVy
```
```
pytest tests/foreman/cli/test_remoteexecution.py -k test_positive_run_effective_user_job
================================================ test session starts ================================================                                                                  

tests/foreman/cli/test_remoteexecution.py .                                                                   [100%]
```