### PR TITLE
test are using rhel host instead of rhel7

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -339,6 +339,7 @@ PRDS = {
     'rhdt': 'Red Hat Developer Tools for RHEL Server',
     'rhscl': 'Red Hat Software Collections (for RHEL Server)',
     'rhae': 'Red Hat Ansible Engine',
+    'rhel6': 'Red Hat Enterprise Linux Server - Extended Life Cycle Support',
     'rhel8': 'Red Hat Enterprise Linux for x86_64',
 }
 
@@ -357,7 +358,7 @@ REPOSET = {
     'rhst7_67': 'Red Hat Satellite Tools 6.7 (for RHEL 7 Server) (RPMs)',
     'rhst7_68': 'Red Hat Satellite Tools 6.8 (for RHEL 7 Server) (RPMs)',
     'rhst7_69': 'Red Hat Satellite Tools 6.9 (for RHEL 7 Server) (RPMs)',
-    'rhst6': 'Red Hat Satellite Tools 6.9 (for RHEL 6 Server) (RPMs)',
+    'rhst6': 'Red Hat Satellite Tools 6.9 (for RHEL 6 Server - ELS) (RPMs)',
     'rhaht': 'Red Hat Enterprise Linux Atomic Host (RPMs)',
     'rhdt7': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7 Server'),
     'rhscl7': ('Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server'),
@@ -489,8 +490,8 @@ REPOS = {
         'key': 'rhst',
     },
     'rhst6': {
-        'id': 'rhel-6-server-satellite-tools-6.9-rpms',
-        'name': ('Red Hat Satellite Tools 6.9 for RHEL 6 Server RPMs x86_64'),
+        'id': 'rhel-6-server-els-satellite-tools-6.9-rpms',
+        'name': ('Red Hat Satellite Tools 6.9 for RHEL 6 Server - ELS RPMs x86_64'),
         'version': '6.9',
         'reposet': REPOSET['rhst6'],
         'product': PRDS['rhel'],


### PR DESCRIPTION
This PR introduced the usage of all `rhel_contenthost` versions right now (rhel 6, rhel7 and rhel8), specified in conf/content_host.yaml
The product, repo and repository-set is set based on test name which have the rhel version in brackets.
example: `tests/foreman/cli/test_host.py::test_positive_erratum_applicability[rhel6]`

- New change introduced that all tests with fixtures that were at module level are now at function level. The consequence: not only 3 hosts are created for each version, but also the repo setup has to be done fore each of them. 

- `repo_setup` and `rhel_version` fixture should be moved elsewhere to some general place, what do you think the right place is ?  

- I was thinking that rhel_contenthost should run only on the default one if not specified otherwise. So it would not take forever.

- if pit marker specified all rhel versions will run, the problem with this approach is, if somebody wants to run multiple versions and his test is not valid for pit testing, is another marker/marker's the solution ? that would mean we have to parse the markers that are running and change the settings value during the run, this was the best idea I was able to come with. So I would appreciate some ideas from the team, especially @JacobCallahan as he is the creator of the rhel_contenthost. Maybe smth like this ?
```
@pytest.fixture
def select_rhel_version(request, pytestconfig):
    markers_arg = pytestconfig.getoption('-m')
    request.cls.marker_name = markers_arg
    if 'pit' not in markers_arg:
        settings.content_host.rhel_versions = [settings.content_host.default_version]
 ```

- no test results, impossible to test locally, just take so much time, manifest upload takes 30 minutes per each test with contenthost per each version used 

- will test it here with PRT, so I can do other work, instead of waiting, please wait for test_results