### PR TITLE
sftp is slow, using scp for now

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -437,9 +437,9 @@ class ContentHost(Host):
             with NamedTemporaryFile(dir=robottelo_tmp_dir) as content_file:
                 content_file.write(local_path.content.read())
                 content_file.seek(0)
-                self.session.sftp_write(source=content_file.name, destination=remote_path)
+                self.session.scp_write(source=content_file.name, destination=remote_path)
         else:
-            self.session.sftp_write(source=local_path, destination=remote_path)
+            self.session.scp_write(source=local_path, destination=remote_path)
 
     def put_ssh_key(self, source_key_path, destination_key_name):
         """Copy ssh key to virtual machine ssh path and ensure proper permission is
@@ -961,7 +961,7 @@ class ContentHost(Host):
             'certs.sh',
             'extensions.txt',
         ]:
-            self.session.sftp_write(get_data_file(file), f'/root/{file}')
+            self.session.scp_write(get_data_file(file), f'/root/{file}')
         self.execute('echo 100001 > serial')
         self.execute('bash generate-ca.sh')
         result = self.execute(f'yes | bash generate-crt.sh {self.hostname}')


### PR DESCRIPTION
tested by `test_xxx` 
with average around `6` seconds

```
def test_xxx():
    from robottelo import manifests
    from robottelo import ssh
    from time import time
    sum = 0
    loops = 10
    for x in range(loops):
        st = time()
        client = ssh.get_client()
        ct = time()
        with manifests.clone() as manifest:
            client.put(manifest, manifest.filename)
        ft = time()
        print(f"get_client takes: {ct-st} seconds\nmanifest_clone takes: {ft-ct} seconds")
        sum += (ft-ct)
    print(f'average is {sum / loops}')
```

what, just looked at the copied files  and they have different sizes :O ?
```
 2.3M Nov  4 11:16 manifest-1636039012.zip
 2.5M Nov  4 11:16 manifest-1636039008.zip
 2.6M Nov  4 11:16 manifest-1636039004.zip
 2.9M Nov  4 11:16 manifest-1636038999.zip
 2.5M Nov  4 11:16 manifest-1636038995.zip
 2.6M Nov  4 11:16 manifest-1636038991.zip
 2.5M Nov  4 11:16 manifest-1636038987.zip
 2.5M Nov  4 11:16 manifest-1636038983.zip
 3.6M Nov  4 11:16 manifest-1636038965.zip
```