### PR TITLE
Remove positive_create_with_gpg_key_by_name 

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -414,27 +414,6 @@ class TestRepository:
         assert repo['gpg-key']['name'] == gpg_key['name']
 
     @pytest.mark.tier1
-    def test_positive_create_with_gpg_key_by_name(
-        self, repo_options, module_org, module_product, gpg_key
-    ):
-        """Check if repository can be created with gpg key name
-
-        :id: 95cde404-3449-410d-9a08-d7f8619a2ad5
-
-        :parametrized: yes
-
-        :expectedresults: Repository is created and has gpg key
-
-        :BZ: 1103944
-
-        :CaseImportance: Critical
-        """
-        repo_options['gpg-key'] = gpg_key['name']
-        repo = make_repository(repo_options)
-        assert repo['gpg-key']['id'] == gpg_key['id']
-        assert repo['gpg-key']['name'] == gpg_key['name']
-
-    @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'publish-via-http': use_http} for use_http in ('true', 'yes', '1')]),

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -413,6 +413,23 @@ class TestRepository:
         assert repo['gpg-key']['id'] == gpg_key['id']
         assert repo['gpg-key']['name'] == gpg_key['name']
 
+    # Comment out test until https://bugzilla.redhat.com/show_bug.cgi?id=2008656 is resolved
+    # @pytest.mark.tier1
+    # def test_positive_create_with_gpg_key_by_name(
+    #         self, repo_options, module_org, module_product, gpg_key
+    # ):
+    #     """Check if repository can be created with gpg key name
+    #     :id: 95cde404-3449-410d-9a08-d7f8619a2ad5
+    #     :parametrized: yes
+    #     :expectedresults: Repository is created and has gpg key
+    #     :BZ: 1103944
+    #     :CaseImportance: Critical
+    #     """
+    #     repo_options['gpg-key'] = gpg_key['name']
+    #     repo = make_repository(repo_options)
+    #     assert repo['gpg-key']['id'] == gpg_key['id']
+    #     assert repo['gpg-key']['name'] == gpg_key['name']
+
     @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',


### PR DESCRIPTION
Create no longer supports gpg_key_name, so this test always fails. Since it only tests functionality that has been removed, removing the test seems like a reasonable option - maybe there is a better way? Leaving it draft, looking for feedback.