### PR TITLE
Add kickstart sync to capsule test

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -850,6 +850,12 @@ CUSTOM_PUPPET_MODULE_REPOS = {
 }
 CUSTOM_PUPPET_MODULE_REPOS_VERSION = '-0.2.0.tar.gz'
 
+KICKSTART_CONTENT = [
+    'treeinfo',
+    'images/pxeboot/initrd.img',
+    'images/pxeboot/vmlinuz',
+]
+
 #: All permissions exposed by the server.
 #: :mod:`tests.foreman.api.test_permission` makes use of this.
 PERMISSIONS = {


### PR DESCRIPTION
Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_sync_kickstart_repo
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 1 item                                                                                                                                                                                                                          

tests/foreman/api/test_contentmanagement.py .                                                                                                                                                                                       [100%]

=============================================================================================== 1 passed, 3 warnings in 1111.62s (0:18:31) ================================================================================================
```