### PR TITLE
Changing wget to curl api/test_errata.py for interop

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -836,7 +836,7 @@ def _run_remote_command_on_content_host(module_org, command, vm, return_result=F
 
 def _set_prerequisites_for_swid_repos(module_org, vm):
     _run_remote_command_on_content_host(
-        module_org, f'wget --no-check-certificate {settings.repos.swid_tools_repo}', vm
+        module_org, f'curl --insecure --remote-name {settings.repos.swid_tools_repo}', vm
     )
     _run_remote_command_on_content_host(module_org, "mv *swid*.repo /etc/yum.repos.d", vm)
     _run_remote_command_on_content_host(module_org, "yum install -y swid-tools", vm)


### PR DESCRIPTION
```
env) [akjha@akjha robottelo]$ pytest -k test_errata_installation_with_swidtags tests/foreman/api/test_errata.py
==================================================================== test session starts =====================================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/akjha/satelliteqe/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.8, forked-1.3.0, mock-3.6.1, cov-3.0.0, xdist-2.3.0, services-2.2.1, ibutsu-1.16
collected 14 items / 13 deselected / 1 selected                                                                                                              

tests/foreman/api/test_errata.py .                                                                                                                     [100%]

======================================================== 1 passed, 13 deselected in 659.08s (0:10:59) ========================================================
```