### PR TITLE
Delete user from new session in UI test_user end-to-end test

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -101,8 +101,9 @@ def test_positive_end_to_end(session, default_sat, test_name, module_org, module
         current_user = newsession.activationkey.read(ak_name, 'current_user')['current_user']
         assert current_user == f'{firstname} {lastname}'
         # Delete user
-        session.user.delete(new_name)
-        assert not session.user.search(new_name)
+    with Session('deletehostsession') as deletehostsession:
+        deletehostsession.user.delete(new_name)
+        assert not deletehostsession.user.search(new_name)
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
`tests/foreman/ui/test_user.py::test_positive_end_to_end` has been consistently failing. Previously, the test was attempting to delete a user while logged in to a UI session as that same user. This PR changes the test to start a new session as the `admin` user before attempting to delete the user created earlier in the test.

pytest output:
```
$ pytest tests/foreman/ui/test_user.py::test_positive_end_to_end 
========================================================================================= test session starts ==========================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/dsynk/qe_forks/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, cov-2.11.1, mock-3.6.1, ibutsu-1.16, xdist-2.4.0
collected 1 item                                                                                                                                                                                       

tests/foreman/ui/test_user.py .                                                                                                                                                                  [100%]

============================================================================== 1 passed, 3 warnings in 504.86s (0:08:24) ===============================================================================
```