### PR TITLE
Automated stubbed test case in repository api file-removal feature

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2128,10 +2128,14 @@ class TestFileRepository:
         """
         pass
 
-    @pytest.mark.stubbed
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_positive_remove_file(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content_type': 'file', 'url': repo_constants.CUSTOM_FILE_REPO}]),
+        indirect=True,
+    )
+    def test_positive_remove_file(self, repo):
         """Check arbitrary file can be removed from File Repository
 
         :id: 65068b4c-9018-4baa-b87b-b6e9d7384a5d
@@ -2147,9 +2151,16 @@ class TestFileRepository:
 
         :CaseImportance: Critical
 
-        :CaseAutomation: NotAutomated
+        :CaseAutomation: Automated
         """
-        pass
+        with open(get_data_file(constants.RPM_TO_UPLOAD), 'rb') as handle:
+            repo.upload_content(files={'content': handle})
+        assert repo.read().content_counts['file'] == 1
+
+        file_detail = entities.File().search(query={'repository_id': repo.id})
+
+        repo.remove_content(data={'ids': [file_detail[0].id], 'content_type': 'file'})
+        assert repo.read().content_counts['file'] == 0
 
     @pytest.mark.stubbed
     @pytest.mark.tier2


### PR DESCRIPTION
**Test results - 6.10** 


```
pytest tests/foreman/api/test_repository.py -k test_positive_remove_file
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, ibutsu-1.16, cov-3.0.0, xdist-2.4.0
collected 187 items / 186 deselected / 1 selected                                                                                                                                                                 

tests/foreman/api/test_repository.py .                                                                                                                                                                      [100%]

================================================================================= 1 passed,in 49.16s =============================================================================

```

