### PR TITLE
6.9.z fix user end to end

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -112,8 +112,9 @@ def test_positive_end_to_end(session, test_name, module_org, module_loc):
         current_user = newsession.activationkey.read(ak_name, 'current_user')['current_user']
         assert current_user == f'{firstname} {lastname}'
         # Delete user
-        session.user.delete(new_name)
-        assert not session.user.search(new_name)
+    with Session('deletehostsession') as deletehostsession:
+        deletehostsession.user.delete(new_name)
+        assert not deletehostsession.user.search(new_name)
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
This PR backports https://github.com/SatelliteQE/robottelo/pull/9134 to the 6.9.z branch.