### PR TITLE
Add docker sync test to capsule

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -7,6 +7,7 @@ All functions in this module will be treated as fixtures that apply the contenth
 import pytest
 from broker import VMBroker
 
+from robottelo import constants
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
@@ -97,8 +98,8 @@ def registered_hosts(organization_ak_setup, content_hosts, default_sat):
     return content_hosts
 
 
-@pytest.fixture()
-def docker_contenthost(rhel7_contenthost, default_sat):
+@pytest.fixture
+def container_contenthost(rhel7_contenthost, default_sat):
     """Fixture that installs docker on the content host"""
     rhel7_contenthost.install_katello_ca(default_sat)
 
@@ -108,6 +109,7 @@ def docker_contenthost(rhel7_contenthost, default_sat):
         'extras': settings.repos.rhel7_extras,
     }
     rhel7_contenthost.create_custom_repos(**repos)
-    rhel7_contenthost.execute('yum -y install docker')
-    rhel7_contenthost.execute('systemctl start docker')
+    for service in constants.CONTAINER_CLIENTS:
+        rhel7_contenthost.execute(f'yum -y install {service}')
+        rhel7_contenthost.execute(f'systemctl start {service}')
     return rhel7_contenthost

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -95,3 +95,19 @@ def registered_hosts(organization_ak_setup, content_hosts, default_sat):
         vm.register_contenthost(org.label, ak.name)
         assert vm.subscribed
     return content_hosts
+
+
+@pytest.fixture()
+def docker_contenthost(rhel7_contenthost, default_sat):
+    """Fixture that installs docker on the content host"""
+    rhel7_contenthost.install_katello_ca(default_sat)
+
+    repos = {
+        'server': settings.repos.rhel7_os,
+        'optional': settings.repos.rhel7_optional,
+        'extras': settings.repos.rhel7_extras,
+    }
+    rhel7_contenthost.create_custom_repos(**repos)
+    rhel7_contenthost.execute('yum -y install docker')
+    rhel7_contenthost.execute('systemctl start docker')
+    return rhel7_contenthost

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -715,6 +715,7 @@ REP_TEM_APPLIED_ERRATA_INPUT = {
 CONTAINER_REGISTRY_HUB = 'https://mirror.gcr.io'
 CONTAINER_UPSTREAM_NAME = 'library/busybox'
 CONTAINER_RH_REGISTRY_UPSTREAM_NAME = 'openshift3/ose-metrics-hawkular-openshift-agent'
+CONTAINER_CLIENTS = ['docker', 'podman']
 CUSTOM_LOCAL_FOLDER = '/var/www/html/myrepo/'
 CUSTOM_LOCAL_FILE = '/var/www/html/myrepo/test.txt'
 CUSTOM_FILE_REPO_FILES_COUNT = 3

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1198,7 +1198,7 @@ class TestDockerClient:
     """
 
     @pytest.mark.tier3
-    def test_positive_pull_image(self, module_org, docker_contenthost, default_sat):
+    def test_positive_pull_image(self, module_org, container_contenthost, default_sat):
         """A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
 
@@ -1216,7 +1216,7 @@ class TestDockerClient:
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
         try:
-            result = docker_contenthost.execute(
+            result = container_contenthost.execute(
                 f'docker login -u {settings.server.admin_username}'
                 f' -p {settings.server.admin_password} {default_sat.hostname}'
             )
@@ -1224,7 +1224,7 @@ class TestDockerClient:
 
             # publishing takes few seconds sometimes
             result, _ = wait_for(
-                lambda: docker_contenthost.execute(f'docker pull {repo["published-at"]}'),
+                lambda: container_contenthost.execute(f'docker pull {repo["published-at"]}'),
                 num_sec=60,
                 delay=2,
                 fail_condition=lambda out: out.status != 0,
@@ -1232,22 +1232,24 @@ class TestDockerClient:
             )
             assert result.status == 0
             try:
-                result = docker_contenthost.execute(f'docker run {repo["published-at"]}')
+                result = container_contenthost.execute(f'docker run {repo["published-at"]}')
                 assert result.status == 0
             finally:
                 # Stop and remove the container
-                result = docker_contenthost.execute(f'docker ps -a | grep {repo["published-at"]}')
+                result = container_contenthost.execute(
+                    f'docker ps -a | grep {repo["published-at"]}'
+                )
                 container_id = result.stdout[0].split()[0]
-                docker_contenthost.execute(f'docker stop {container_id}')
-                docker_contenthost.execute(f'docker rm {container_id}')
+                container_contenthost.execute(f'docker stop {container_id}')
+                container_contenthost.execute(f'docker rm {container_id}')
         finally:
             # Remove docker image
-            docker_contenthost.execute(f'docker rmi {repo["published-at"]}')
+            container_contenthost.execute(f'docker rmi {repo["published-at"]}')
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     def test_positive_container_admin_end_to_end_search(
-        self, module_org, docker_contenthost, default_sat
+        self, module_org, container_contenthost, default_sat
     ):
         """Verify that docker command line can be used against
         Satellite server to search for container images stored
@@ -1305,28 +1307,28 @@ class TestDockerClient:
 
         # 3. Try to search for docker images on Satellite
         remote_search_command = f'docker search {default_sat.hostname}/{CONTAINER_UPSTREAM_NAME}'
-        result = docker_contenthost.execute(remote_search_command)
+        result = container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri not in result.stdout
 
         # 4. Use Docker client to login to Satellite docker hub
-        result = docker_contenthost.execute(
+        result = container_contenthost.execute(
             f'docker login -u {settings.server.admin_username}'
             f' -p {settings.server.admin_password} {default_sat.hostname}'
         )
         assert result.status == 0
 
         # 5. Search for docker images
-        result = docker_contenthost.execute(remote_search_command)
+        result = container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri in result.stdout
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = docker_contenthost.execute(f'docker logout {default_sat.hostname}')
+        result = container_contenthost.execute(f'docker logout {default_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to search for docker images
-        result = docker_contenthost.execute(remote_search_command)
+        result = container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri not in result.stdout
 
@@ -1340,14 +1342,14 @@ class TestDockerClient:
         )
 
         # 9. Search for docker images
-        result = docker_contenthost.execute(remote_search_command)
+        result = container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri in result.stdout
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     def test_positive_container_admin_end_to_end_pull(
-        self, module_org, docker_contenthost, default_sat
+        self, module_org, container_contenthost, default_sat
     ):
         """Verify that docker command line can be used against
         Satellite server to pull in container images stored
@@ -1406,11 +1408,11 @@ class TestDockerClient:
 
         # 3. Try to pull in docker image from Satellite
         docker_pull_command = f'docker pull {docker_repo_uri}'
-        result = docker_contenthost.execute(docker_pull_command)
+        result = container_contenthost.execute(docker_pull_command)
         assert result.status == 1
 
         # 4. Use Docker client to login to Satellite docker hub
-        result = docker_contenthost.execute(
+        result = container_contenthost.execute(
             f'docker login -u {settings.server.admin_username}'
             f' -p {settings.server.admin_password} {default_sat.hostname}'
         )
@@ -1419,7 +1421,7 @@ class TestDockerClient:
         # 5. Pull in docker image
         # publishing takes few seconds sometimes
         result, _ = wait_for(
-            lambda: docker_contenthost.execute(docker_pull_command),
+            lambda: container_contenthost.execute(docker_pull_command),
             num_sec=60,
             delay=2,
             fail_condition=lambda out: out.status != 0,
@@ -1428,11 +1430,11 @@ class TestDockerClient:
         assert result.status == 0
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = docker_contenthost.execute(f'docker logout {default_sat.hostname}')
+        result = container_contenthost.execute(f'docker logout {default_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to pull in docker image
-        result = docker_contenthost.execute(docker_pull_command)
+        result = container_contenthost.execute(docker_pull_command)
         assert result.status == 1
 
         # 8. Set 'Unauthenticated Pull' option to true
@@ -1445,13 +1447,13 @@ class TestDockerClient:
         )
 
         # 9. Pull in docker image
-        result = docker_contenthost.execute(docker_pull_command)
+        result = container_contenthost.execute(docker_pull_command)
         assert result.status == 0
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_upload_image(self, module_org, default_sat, docker_contenthost):
+    def test_positive_upload_image(self, module_org, default_sat, container_contenthost):
         """A Docker-enabled client can create a new ``Dockerfile``
         pointing to an existing Docker image from a Satellite 6 and modify it.
         Then, using ``docker build`` generate a new image which can then be
@@ -1482,7 +1484,7 @@ class TestDockerClient:
             compute_resource = make_compute_resource({
                 'organization-ids': [module_org.id],
                 'provider': 'Docker',
-                'url': f'http://{docker_contenthost.ip_addr}:2375',
+                'url': f'http://{container_contenthost.ip_addr}:2375',
             })
             container = make_container({
                 'compute-resource-id': compute_resource['id'],
@@ -1495,18 +1497,18 @@ class TestDockerClient:
 
             # Commit a new docker image and verify image was created
             image_name = f'{repo_name}/{CONTAINER_UPSTREAM_NAME}'
-            result = docker_contenthost.execute(
+            result = container_contenthost.execute(
                 f'docker commit {container["uuid"]} {image_name}:latest && '
                 f'docker images --all | grep {image_name}'
             )
             assert result.status == 0
 
             # Save the image to a tar archive
-            result = docker_contenthost.execute(f'docker save -o {repo_name}.tar {image_name}')
+            result = container_contenthost.execute(f'docker save -o {repo_name}.tar {image_name}')
             assert result.status == 0
 
             tar_file = f'{repo_name}.tar'
-            docker_contenthost.get(remote_path=tar_file)
+            container_contenthost.get(remote_path=tar_file)
             default_sat.put(
                 local_path=tar_file,
                 remote_path=f'/tmp/{tar_file}',


### PR DESCRIPTION
Adding end to end test for synchronization of docker-type repositories with multiple schema versions to the capsule and pull from capsule to a content host (support for `docker login` and `docker search` are new in 6.10 capsule's Container_Gateway, opposed to Crane in 6.9).

In this PR I'm moving the `docker_host` fixture from `tests/foreman/cli/test_docker.py` to `pytest_fixtures/content_hosts.py` so that I can use it too in `tests/foreman/api/test_contentmanagement.py`.
@JacobCallahan @mshriver please ack if it's appropriate location or approach
@spusateri I ran `cli/test_docker.py::TestDockerClient::test_positive_pull_image` with this change and it passed

Also after discussion with @latran I'm moving the `TestCapsuleContentManagement` class under the Capsule-Content component and assigning it to myself.

Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_sync_container_repo_end_to_end
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 1 item                                                                                                                                                                                                                          

tests/foreman/api/test_contentmanagement.py .                                                                                                                                                                                       [100%]
...
=============================================================================================== 1 passed, 3 warnings in 3332.51s (0:55:32) ================================================================================================
```
