### PR TITLE
Suds-jerko dependency check fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ wait-for==1.2.0
 widgetastic.core==0.65
 widgetastic.patternfly==1.3.4
 widgetastic.patternfly4==0.22.3
-wrapanapi==3.5.10
+wrapanapi==3.5.11
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git@master#egg=airgun


### PR DESCRIPTION
`suds-jerko` package dependency of `wrapanapi package` for robottelo is broken with setuptools v58. There could be multiple ways to fix it like wrapanapi using an alternative suds package or another package, but that assessment and implementation will take some time.

Hence, as a temporary fix I am installing setuptools 57, which has no known side effects. Also v57 is just a month old so should not have any major consequences on our dependencied.

Checks are passing for this as well as on PR https://github.com/SatelliteQE/robottelo/pull/9067. 

Reference: https://issueexplorer.com/issue/pypa/setuptools/2784 .