### PR TITLE
Remove unused artifact server setting

### DIFF
--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -6,8 +6,6 @@ ROBOTTELO:
   VERBOSITY: debug
   # Directory for temporary files
   TMP_DIR: /var/tmp
-  # Web Server to provide various test artifacts
-  ARTIFACTS_SERVER: replace-with-artifacts-server
 
   # - The URL of container hosting repos on SatLab
   # Example url - http://<container_hostname_or_ip>:<port>


### PR DESCRIPTION
This previously pointed to a no longer used artifacts server. Nothing in the framework is using this setting anymore.