### PR TITLE
Automate RH Cloud Inventory tests

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -45,10 +45,15 @@ def unset_rh_cloud_token(rhcloud_sat_host):
 @pytest.fixture(scope='module')
 def organization_ak_setup(rhcloud_sat_host, rhcloud_manifest_org):
     """A module-level fixture to create an Activation key in module_org"""
+    purpose_addons = "test-addon1, test-addon2"
     ak = rhcloud_sat_host.api.ActivationKey(
         content_view=rhcloud_manifest_org.default_content_view,
         organization=rhcloud_manifest_org,
         environment=rhcloud_sat_host.api.LifecycleEnvironment(id=rhcloud_manifest_org.library.id),
+        purpose_addons=[purpose_addons],
+        service_level='Self-Support',
+        purpose_usage='test-usage',
+        purpose_role='test-role',
         auto_attach=True,
     ).create()
     subscription = rhcloud_sat_host.api.Subscription(organization=rhcloud_manifest_org)
@@ -100,7 +105,9 @@ def inventory_settings(rhcloud_sat_host):
     hostnames_setting = rhcloud_sat_host.update_setting('obfuscate_inventory_hostnames', False)
     ip_setting = rhcloud_sat_host.update_setting('obfuscate_inventory_ips', False)
     packages_setting = rhcloud_sat_host.update_setting('exclude_installed_packages', False)
+    parameter_tags_setting = rhcloud_sat_host.update_setting('include_parameter_tags', False)
     yield
     rhcloud_sat_host.update_setting('obfuscate_inventory_hostnames', hostnames_setting)
     rhcloud_sat_host.update_setting('obfuscate_inventory_ips', ip_setting)
     rhcloud_sat_host.update_setting('exclude_installed_packages', packages_setting)
+    rhcloud_sat_host.update_setting('include_parameter_tags', parameter_tags_setting)

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -330,5 +330,7 @@ def test_include_parameter_tags_setting(
     json_data = get_report_data(local_report_path)
     common_assertion(local_report_path)
     for host in json_data['hosts']:
-        assert type(host['tags'][0]['value']) is str
-        assert host['tags'][0]['namespace'] == 'satellite_parameter'
+        for tag in host['tags']:
+            if tag['namespace'] == 'satellite_parameter':
+                assert type(tag['value']) is str
+                break


### PR DESCRIPTION
This PR adds automation for following RH Cloud tests:

- test_system_purpose_sla_field
- test_rhcloud_inventory_without_manifest
- test_include_parameter_tags_setting

Test result: 
```
$ pytest tests/foreman/api/test_rhcloud_inventory.py tests/foreman/ui/test_rhcloud_inventory.py -k 'test_rhcloud_inventory_without_manifest or test_include_parameter_tags_setting or test_system_purpose_sla_field' 
============================= test session starts ==============================
collected 17 items / 14 deselected / 3 selected

tests/foreman/api/test_rhcloud_inventory.py ..                           [ 66%]
tests/foreman/ui/test_rhcloud_inventory.py .                             [100%]
========== 3 passed, 14 deselected, 37 warnings in 1105.61s (0:18:25) ==========
```