### PR TITLE
Automate RH Cloud tests related to host details page

### DIFF
--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -32,7 +32,6 @@ from robottelo.constants import DISTRO_RHEL8
 @pytest.mark.tier3
 def test_rhcloud_insights_e2e(
     rhel8_insights_vm,
-    fixable_rhel8_vm,
     organization_ak_setup,
     unset_rh_cloud_token,
     rhcloud_sat_host,
@@ -65,6 +64,9 @@ def test_rhcloud_insights_e2e(
     query = 'dnf.conf'
     job_query = (
         f'Remote action: Insights remediations for selected issues on {rhel8_insights_vm.hostname}'
+    )
+    rhel8_insights_vm.run(
+        'dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client'
     )
     with Session(hostname=rhcloud_sat_host.hostname) as session:
         session.organization.select(org_name=org.name)
@@ -223,7 +225,6 @@ def test_host_sorting_based_on_recommendation_count():
 @pytest.mark.tier2
 def test_host_details_page(
     rhel8_insights_vm,
-    fixable_rhel8_vm,
     organization_ak_setup,
     set_rh_cloud_token,
     rhcloud_sat_host,
@@ -254,6 +255,9 @@ def test_host_details_page(
     """
     org, ak = organization_ak_setup
     # Sync inventory status
+    rhel8_insights_vm.run(
+        'dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client'
+    )
     inventory_sync = rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_inventory_sync()
     wait_for(
         lambda: rhcloud_sat_host.api.ForemanTask()
@@ -385,9 +389,9 @@ def test_delete_host_having_insights_recommendation(
     rhel8_contenthost.configure_rhai_client(
         satellite=rhcloud_sat_host, activation_key=ak.name, org=org.label, rhel_distro=DISTRO_RHEL8
     )
-    rhel8_contenthost.run('dnf update -y dnf')
-    rhel8_contenthost.run('sed -i -e "/^best/d" /etc/dnf/dnf.conf')
-    rhel8_contenthost.run('insights-client')
+    rhel8_contenthost.run(
+        'dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client'
+    )
     # Sync inventory status
     inventory_sync = rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_inventory_sync()
     wait_for(


### PR DESCRIPTION
This PR automates following RH Cloud tests related to host page:
- test_delete_host_having_insights_recommendation
- test_rh_cloud_insights_clean_statuses
- test_host_details_page

Depends on https://github.com/SatelliteQE/airgun/pull/635
See PRT run 521 for test result.

```
15:21:43  + py.test tests/foreman/ui/test_rhcloud_insights.py --junit-xml=sat-results.xml -o junit_suite_name=sat-result
15:21:49  ============================= test session starts ==============================
15:21:49  collected 8 items / 4 deselected / 4 selected
15:21:49  

16:13:11  tests/foreman/ui/test_rhcloud_insights.py ....                           [100%]
16:13:11  ========== 4 passed, 4 deselected, 12 warnings in 3078.86s (0:51:18) ===========
```