### PR TITLE
Update case importance for OpenSCAP and HTTP Proxy tests

### DIFF
--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -48,7 +48,7 @@ class TestOscapPolicy:
 
         :CaseLevel: Integration
 
-        :CaseImportance: High
+        :CaseImportance: Critical
         """
         name = gen_string('alpha')
         new_name = gen_string('alpha')

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -124,7 +124,7 @@ class TestRepository:
 
         :Assignee: jpathan
 
-        :CaseImportance: Critical
+        :CaseImportance: High
         """
         repo_options = {
             'http_proxy_policy': 'use_selected_http_proxy',

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -104,7 +104,8 @@ def test_insights_client_registration_with_http_proxy():
         1. Create HTTP Proxy.
         2. Set created proxy as "Default HTTP Proxy" in settings.
         3. Edit /etc/resolv.conf and comment out all entries so that
-            satellite can not directly communicate outside.
+            satellite can not directly communicate outside. Ensure that
+            NetworkManger won't change it.
         4. Register a host with satellite.
         5. Register host with insights.
         6. Try insights-client register/unregister/test-connection/status
@@ -114,6 +115,8 @@ def test_insights_client_registration_with_http_proxy():
     :expectedresults:
         1. insights-client register/unregister/test-connection/status
             works with http proxy set.
+
+    :CaseAutomation: NotAutomated
 
     :CaseImportance: High
     """

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -88,3 +88,32 @@ def test_positive_create_update_delete(module_org, module_location):
     HttpProxy.delete({'id': updated_http_proxy['id']})
     with pytest.raises(CLIReturnCodeError):
         HttpProxy.info({'id': updated_http_proxy['id']})
+
+
+@pytest.mark.tier3
+@pytest.mark.run_in_one_thread
+@pytest.mark.stubbed
+def test_insights_client_registration_with_http_proxy():
+    """Verify that insights-client registration work with http proxy.
+
+    :id: 5158d5c1-2b88-4c05-914b-f1c53656ffc2
+
+    :customerscenario: true
+
+    :Steps:
+        1. Create HTTP Proxy.
+        2. Set created proxy as "Default HTTP Proxy" in settings.
+        3. Edit /etc/resolv.conf and comment out all entries so that
+            satellite can not directly communicate outside.
+        4. Register a host with satellite.
+        5. Register host with insights.
+        6. Try insights-client register/unregister/test-connection/status
+
+    :BZ: 1959932
+
+    :expectedresults:
+        1. insights-client register/unregister/test-connection/status
+            works with http proxy set.
+
+    :CaseImportance: High
+    """

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -83,7 +83,7 @@ class TestOpenScap:
 
         :customerscenario: true
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         scap_contents = [content['title'] for content in Scapcontent.list()]
         for title in OSCAP_DEFAULT_CONTENT.values():
@@ -112,7 +112,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content and it's info is not listed.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         result = Scapcontent.with_user(
             default_viewer_role.login, default_viewer_role.password
@@ -143,7 +143,7 @@ class TestOpenScap:
 
         :expectedresults: The info of the scap-content is listed.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         title = gen_string('alpha')
         make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
@@ -170,7 +170,7 @@ class TestOpenScap:
 
         :expectedresults: The info of the scap-content is not listed.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         invalid_scap_id = gen_string('alpha')
         with pytest.raises(CLIReturnCodeError):
@@ -201,7 +201,7 @@ class TestOpenScap:
 
         :BZ: 1471801
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         scap_content = make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
         assert scap_content['title'] == title
@@ -232,7 +232,7 @@ class TestOpenScap:
 
         :CaseAutomation: Automated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         title = gen_string('alpha')
         scap_content = make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
@@ -263,7 +263,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content is not created.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         with pytest.raises(CLIFactoryError):
             make_scapcontent({'title': title, 'scap-file': settings.oscap.content_path})
@@ -291,7 +291,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content is created.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         scap_content = make_scapcontent(
             {'original-filename': name, 'scap-file': settings.oscap.content_path}
@@ -321,7 +321,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content is not created.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
 
         :BZ: 1482395
         """
@@ -350,7 +350,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content is not created.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         with pytest.raises(CLIFactoryError):
             make_scapcontent({'title': title})
@@ -374,7 +374,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content is updated successfully.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
 
         :BZ: 1490302
         """
@@ -405,7 +405,7 @@ class TestOpenScap:
 
         :expectedresults: The scap-content is deleted successfully.
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         scap_content = make_scapcontent({'scap-file': settings.oscap.content_path})
         Scapcontent.delete({'id': scap_content['id']})
@@ -433,7 +433,7 @@ class TestOpenScap:
 
         :CaseAutomation: Automated
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         scap_content = make_scapcontent({'scap-file': settings.oscap.content_path})
         Scapcontent.delete({'title': scap_content['title']})
@@ -461,6 +461,8 @@ class TestOpenScap:
             3. Pass valid parameters and valid name.
 
         :expectedresults: The policy is created successfully.
+
+        :CaseImportance: Medium
         """
         scap_policy = make_scap_policy(
             {
@@ -495,6 +497,8 @@ class TestOpenScap:
             3. Pass valid parameters and invalid name.
 
         :expectedresults: The policy is not created.
+
+        :CaseImportance: Medium
         """
         with pytest.raises(CLIFactoryError):
             make_scap_policy(
@@ -526,6 +530,8 @@ class TestOpenScap:
             3. Pass valid parameters without passing the scap-content-id.
 
         :expectedresults: The policy is not created.
+
+        :CaseImportance: Medium
         """
         with pytest.raises(CLIFactoryError):
             make_scap_policy(
@@ -557,6 +563,8 @@ class TestOpenScap:
             4. Associate multiple hostgroups with policy
 
         :expectedresults: The policy is created and associated successfully.
+
+        :CaseImportance: Medium
         """
         hostgroup = make_hostgroup()
         name = gen_string('alphanumeric')
@@ -723,6 +731,8 @@ class TestOpenScap:
             5. Pass name as the parameter.
 
         :expectedresults: The policies are listed successfully and information is displayed.
+
+        :CaseImportance: Critical
         """
         hostgroup = make_hostgroup()
         name = gen_string('alphanumeric')
@@ -776,6 +786,8 @@ class TestOpenScap:
             3. Pass hostgoups as the parameter.
 
         :expectedresults: The scap policy is updated.
+
+        :CaseImportance: Medium
         """
         hostgroup = make_hostgroup()
         name = gen_string('alphanumeric')
@@ -821,6 +833,8 @@ class TestOpenScap:
             3. Pass period as parameter and weekday as parameter.
 
         :expectedresults: The scap policy is updated.
+
+        :CaseImportance: Medium
         """
         name = gen_string('alphanumeric')
         scap_policy = make_scap_policy(
@@ -866,6 +880,8 @@ class TestOpenScap:
             3. Pass scap-content-id as parameter.
 
         :expectedresults: The scap policy is updated.
+
+        :CaseImportance: Medium
         """
         name = gen_string('alphanumeric')
         scap_policy = make_scap_policy(
@@ -908,6 +924,8 @@ class TestOpenScap:
             3. Pass host name as the parameter.
 
         :expectedresults: The scap policy is updated.
+
+        :CaseImportance: Medium
         """
         host = entities.Host()
         host.create()

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -47,8 +47,6 @@ class TestTailoringFiles:
         :expectedresults: Tailoring file will be added to satellite
 
         :parametrized: yes
-
-        :CaseImportance: Critical
         """
         tailoring_file = make_tailoringfile(
             {'name': name, 'scap-file': tailoring_file_path['satellite']}
@@ -67,7 +65,7 @@ class TestTailoringFiles:
 
         :expectedresults: Tailoring file will be added to satellite
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         name = gen_string('alphanumeric') + ' ' + gen_string('alphanumeric')
         tailoring_file = make_tailoringfile(
@@ -91,7 +89,7 @@ class TestTailoringFiles:
 
         :expectedresults: Tailoring file information should be displayed
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         name = gen_string('alphanumeric')
         make_tailoringfile({'name': name, 'scap-file': tailoring_file_path['satellite']})
@@ -113,7 +111,7 @@ class TestTailoringFiles:
 
         :expectedresults: Tailoring files list should be displayed
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         name = gen_string('alphanumeric')
         make_tailoringfile({'name': name, 'scap-file': tailoring_file_path['satellite']})
@@ -132,7 +130,7 @@ class TestTailoringFiles:
 
         :expectedresults: Tailoring file will not be added to satellite
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         default_sat.put(get_data_file(SNIPPET_DATA_FILE), f'/tmp/{SNIPPET_DATA_FILE}')
         name = gen_string('alphanumeric')
@@ -154,7 +152,7 @@ class TestTailoringFiles:
 
         :parametrized: yes
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         with pytest.raises(CLIFactoryError):
             make_tailoringfile({'name': name, 'scap-file': tailoring_file_path['satellite']})
@@ -176,7 +174,7 @@ class TestTailoringFiles:
 
         :expectedresults: Association should give some warning
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
 
     @pytest.mark.skip_if_open("BZ:1857572")
@@ -196,7 +194,7 @@ class TestTailoringFiles:
 
         BZ: 1857572
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         name = gen_string('alphanumeric')
         file_path = f'/var{tailoring_file_path["satellite"]}'
@@ -224,7 +222,7 @@ class TestTailoringFiles:
 
         :expectedresults: Tailoring file should be deleted
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """
         tailoring_file = make_tailoringfile({'scap-file': tailoring_file_path['satellite']})
         TailoringFiles.delete({'id': tailoring_file['id']})
@@ -256,8 +254,6 @@ class TestTailoringFiles:
 
         :expectedresults: ARF report should be sent to satellite reflecting
                          the changes done via tailoring files
-
-        :CaseImportance: Critical
         """
 
     @pytest.mark.stubbed
@@ -283,8 +279,6 @@ class TestTailoringFiles:
 
         :expectedresults: ARF report should be sent to satellite
                          reflecting the changes done via tailoring files
-
-        :CaseImportance: Critical
         """
 
     @pytest.mark.stubbed
@@ -311,5 +305,5 @@ class TestTailoringFiles:
         :expectedresults: ARF report should have information
                           about the tailoring file used, if any
 
-        :CaseImportance: Critical
+        :CaseImportance: Medium
         """

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -239,7 +239,7 @@ def test_positive_assign_http_proxy_to_products(module_org):
 
     :Assignee: jpathan
 
-    :CaseImportance: Critical
+    :CaseImportance: High
     """
     # create HTTP proxies
     http_proxy_a = HttpProxy.create(

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -12,7 +12,7 @@
 
 :TestType: Functional
 
-:CaseImportance: Critical
+:CaseImportance: High
 
 :Upstream: No
 """
@@ -178,6 +178,8 @@ def test_positive_upload_to_satellite(
     :CaseLevel: System
 
     :BZ: 1479413, 1722475, 1420439, 1722475
+
+    :CaseImportance: Critical
     """
     hgrp_name = gen_string('alpha')
     policy_name = gen_string('alpha')
@@ -574,8 +576,6 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
     :expectedresults: REX job should be success and ARF report should be sent to satellite
 
     :BZ: 1814988
-
-    :CaseImportance: Critical
     """
     hgrp_name = gen_string('alpha')
     policy_name = gen_string('alpha')

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -323,5 +323,7 @@ def test_http_proxy_containing_special_characters():
         2. Manifest refresh, repository enable/disable and repository sync operation
             finished successfully.
 
+    :CaseAutomation: NotAutomated
+
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -201,6 +201,7 @@ def test_set_default_http_proxy(session, module_org, module_location, setting_up
         4. Update the "Default HTTP Proxy" with created above.
         5. Update "Default HTTP Proxy" to "no global default".
 
+    :BZ: 1918167, 1913290
 
     :parametrized: yes
 
@@ -293,3 +294,34 @@ def test_check_http_proxy_value_repository_details(
         session.repository.search(function_product.name, repo_name)[0]['Name']
         repo_values = session.repository.read(function_product.name, repo_name)
         assert repo_values['repo_content']['http_proxy_policy'] == 'Global Default (None)'
+
+
+@pytest.mark.tier3
+@pytest.mark.run_in_one_thread
+@pytest.mark.stubbed
+def test_http_proxy_containing_special_characters():
+    """Test Manifest refresh and redhat repository sync with http proxy special
+        characters in password.
+
+    :id: 16082c6a-9320-4a9a-bd6c-5687b099c940
+
+    :customerscenario: true
+
+    :Steps:
+        1. Navigate to Infrastructure > Http Proxies
+        2. Create HTTP Proxy with special characters in password.
+        3. Go To to Administer > Settings > content tab
+        4. Fill the details related to HTTP Proxy and click on "Test connection" button.
+        5. Update the "Default HTTP Proxy" with created above.
+        6. Refresh manifest.
+        7. Enable and sync any redhat repositories.
+
+    :BZ: 1844840
+
+    :expectedresults:
+        1. "Test connection" button workes as expected.
+        2. Manifest refresh, repository enable/disable and repository sync operation
+            finished successfully.
+
+    :CaseImportance: High
+    """

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -100,7 +100,7 @@ def test_negative_create_with_same_name(session, oscap_content_path):
 
     :customerscenario: true
 
-    :CaseImportance: Critical
+    :CaseImportance: Medium
     """
     content_name = gen_string('alpha')
     with session:

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -60,8 +60,6 @@ def test_positive_check_dashboard(
     :BZ: 1424936
 
     :CaseLevel: Integration
-
-    :CaseImportance: Critical
     """
     name = gen_string('alpha')
     oscap_content_title = gen_string('alpha')
@@ -122,7 +120,7 @@ def test_positive_end_to_end(
 
     :CaseLevel: Integration
 
-    :CaseImportance: High
+    :CaseImportance: Critical
     """
     name = '{} {}'.format(gen_string('alpha'), gen_string('alpha'))
     new_name = gen_string('alpha')

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -32,8 +32,6 @@ def test_positive_end_to_end(session, tailoring_file_path):
     :expectedresults: All expected CRUD actions finished successfully
 
     :CaseLevel: Integration
-
-    :CaseImportance: High
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -81,7 +79,7 @@ def test_positive_download_tailoring_file():
 
     :expectedresults: The tailoring file should be downloaded
 
-    :CaseImportance: Critical
+    :CaseImportance: Medium
     """
 
 
@@ -138,5 +136,5 @@ def test_positive_fetch_tailoring_file_information_from_arfreports():
     :expectedresults: ARF report should have information
                       about the tailoring file used, if any
 
-    :CaseImportance: Critical
+    :CaseImportance: Medium
     """


### PR DESCRIPTION
This PR updates case importance for OpenSCAP and HTTP Proxy tests. It also adds 2 stubbed tests related to HTTP Proxy.