### PR TITLE
Missing module_product fixture, culprit of 478 failures

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -16,6 +16,11 @@ def function_product(function_org):
 
 
 @pytest.fixture(scope='module')
+def module_product(module_org):
+    return entities.Product(organization=module_org).create()
+
+
+@pytest.fixture(scope='module')
 def rh_repo_gt_manifest(module_gt_manifest_org):
     """Use GT manifest org, creates RH tools repo, syncs and returns RH repo."""
     # enable rhel repo and return its ID


### PR DESCRIPTION
From #9067, one fixture that left behind `module_product` and that caused 478 failures in CI.

This addition should fix all of them.

Ran repo tests locally using `module_product` fixture works as expected:

```
% pytest tests/foreman/cli/test_repository.py -k test_positive_create_with_name_label 
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.8.2, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/jitendrayejare/JWorkspace/GitRepos/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, ibutsu-1.16, reportportal-5.0.8, services-2.2.1, mock-3.6.1, xdist-2.4.0, forked-1.3.0
collected 233 items / 226 deselected / 7 selected                                                                                                                                                        

tests/foreman/cli/test_repository.py .......                                                                                                                                                       [100%]

========= 7 passed, 226 deselected, 3 warnings in 184.05s (0:03:04) ==========
```