### PR TITLE
Remove use of pre-made repofiles in favor of repofile construction

### DIFF
--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -234,13 +234,6 @@ VALIDATORS = dict(
     ],
     repos=[
         Validator(
-            'repos.rhel6_repo',
-            'repos.rhel7_repo',
-            'repos.rhel8_repo',
-            must_exist=True,
-            is_type_of=str,
-        ),
-        Validator(
             'repos.rhel6_os',
             'repos.rhel7_os',
             'repos.rhel8_os.baseos',

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -944,10 +944,10 @@ class RepositoryCollection:
             install_katello_agent=install_katello_agent,
         )
         if configure_rhel_repo:
-            rhel_repo_option_name = f'rhel{constants.DISTROS_MAJOR_VERSION[self.distro]}_repo'
+            rhel_repo_option_name = f'rhel{constants.DISTROS_MAJOR_VERSION[self.distro]}_os'
             rhel_repo_url = getattr(settings, rhel_repo_option_name, None)
             if not rhel_repo_url:
                 raise ValueError(
                     f'Settings option "{rhel_repo_option_name}" is not set or does not exist'
                 )
-            vm.configure_rhel_repo(rhel_repo_url)
+            vm.create_custom_repos(**{rhel_repo_option_name: rhel_repo_url})

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1796,7 +1796,7 @@ def test_installer_inventory_plugin_update(destructive_sat):
     :customerscenario: true
 
     """
-    destructive_sat.create_custom_repos(rhel7=settings.repos.rhel7_repo)
+    destructive_sat.create_custom_repos(rhel7=settings.repos.rhel7_os)
     installer_obj = InstallerCommand(
         'enable-foreman-plugin-rh-cloud',
         foreman_proxy_plugin_remote_execution_ssh_install_key=['true'],

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1419,7 +1419,7 @@ def test_positive_global_registration_end_to_end(
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as client:
         # rhel repo required for insights client installation,
         # syncing it to the satellite would take too long
-        client.configure_rhel_repo(settings.repos.rhel7_repo)
+        client.create_custom_repos(rhel7=settings.repos.rhel7_os)
         # run curl
         result = client.execute(cmd)
         assert result.status == 0
@@ -1603,7 +1603,7 @@ def test_global_registration_with_capsule_host(
                 'general.insecure': True,
             }
         )
-    client.configure_rhel_repo(settings.repos.rhel7_repo)
+    client.create_custom_repos(rhel7=settings.repos.rhel7_os)
     # run curl
     client.execute(cmd)
     result = client.execute('subscription-manager identity')
@@ -1655,7 +1655,7 @@ def test_global_registration_with_gpg_repo_and_default_package(
 
     # rhel repo required for insights client installation,
     # syncing it to the satellite would take too long
-    client.configure_rhel_repo(settings.repos.rhel7_repo)
+    client.create_custom_repos(rhel7=settings.repos.rhel7_os)
     # run curl
     result = client.execute(cmd)
     assert result.status == 0


### PR DESCRIPTION
This change gets rid of repofiles previously hosted on "rhel_repo_host"
in favor of direct references to repo baseurls already established on
"rhel_os_repo_host"

We will now construct repofiles on the host instead of copying them from one location to another. This is more in line with what we were already doing in a number of other instances.