### PR TITLE
fixed test failure by adding mirror sync options

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -931,6 +931,7 @@ class TestRepository:
                     'content-type': 'docker',
                     'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
                     'url': CONTAINER_REGISTRY_HUB,
+                    'mirror-on-sync': 'no',
                 }
             ]
         ),


### PR DESCRIPTION
6.10 "mirror on sync" now works for multiple content types. Mirror on sync is now set to "no" to retain this test's old behavior. 