### PR TITLE
remove pit_client from 1 non-compliant test

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -737,7 +737,6 @@ class TestAnsibleREX:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    @pytest.mark.pit_client
     @pytest.mark.pit_server
     @pytest.mark.parametrize(
         'fixture_vmsetup',


### PR DESCRIPTION
The test  does not use the proper VM fixtures so it ignores the PIT deploy workflow. Thus it provides VM running incorrect rhel version.