### PR TITLE
fix export_import RH content tests

### DIFF
--- a/robottelo/cli/content_export.py
+++ b/robottelo/cli/content_export.py
@@ -39,36 +39,36 @@ class ContentExport(Base):
         return cls.execute(cls._construct_command(options), output_format='json')
 
     @classmethod
-    def completeLibrary(cls, options):
+    def completeLibrary(cls, options, timeout=None):
         """
         Make full library export
         """
         cls.command_sub = 'complete library'
-        return cls.execute(cls._construct_command(options), output_format='json')
+        return cls.execute(cls._construct_command(options), output_format='json', timeout=timeout)
 
     @classmethod
-    def completeVersion(cls, options):
+    def completeVersion(cls, options, timeout=None):
         """
         Make full CV version export
         """
         cls.command_sub = 'complete version'
-        return cls.execute(cls._construct_command(options), output_format='json')
+        return cls.execute(cls._construct_command(options), output_format='json', timeout=timeout)
 
     @classmethod
-    def incrementalLibrary(cls, options):
+    def incrementalLibrary(cls, options, timeout=None):
         """
         Make make incremental library export
         """
         cls.command_sub = 'incremental library'
-        return cls.execute(cls._construct_command(options), output_format='json')
+        return cls.execute(cls._construct_command(options), output_format='json', timeout=timeout)
 
     @classmethod
-    def incrementalVersion(cls, options):
+    def incrementalVersion(cls, options, timeout=None):
         """
         Make make incremental CV version export
         """
         cls.command_sub = 'incremental version'
-        return cls.execute(cls._construct_command(options), output_format='json')
+        return cls.execute(cls._construct_command(options), output_format='json', timeout=timeout)
 
     @classmethod
     def generateMetadata(cls, options):

--- a/robottelo/cli/content_import.py
+++ b/robottelo/cli/content_import.py
@@ -36,17 +36,17 @@ class ContentImport(Base):
         return cls.execute(cls._construct_command(options), output_format='json')
 
     @classmethod
-    def library(cls, options):
+    def library(cls, options, timeout=None):
         """
         Make library import
         """
         cls.command_sub = 'library'
-        return cls.execute(cls._construct_command(options), output_format='json')
+        return cls.execute(cls._construct_command(options), output_format='json', timeout=timeout)
 
     @classmethod
-    def version(cls, options):
+    def version(cls, options, timeout=None):
         """
         Make CV version export
         """
         cls.command_sub = 'version'
-        return cls.execute(cls._construct_command(options), output_format='json')
+        return cls.execute(cls._construct_command(options), output_format='json', timeout=timeout)

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1099,8 +1099,7 @@ class TestContentViewSync:
         cvv = cv['versions'][0]
         # Export cv
         path = ContentExport.completeVersion(
-            {'id': cvv['id'], 'organization-id': function_org.id},
-            timeout=7200000
+            {'id': cvv['id'], 'organization-id': function_org.id}, timeout=7200000
         )
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
@@ -1124,12 +1123,11 @@ class TestContentViewSync:
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
         ContentImport.version(
-            {'organization-id': importing_org['id'], 'path': import_path},
-            timeout=7200000
+            {'organization-id': importing_org['id'], 'path': import_path}, timeout=7200000
         )
-        importing_cvv = ContentView.info(
-            {'name': cv_name, 'organization-id': importing_org['id']}
-        )['versions']
+        importing_cvv = ContentView.info({'name': cv_name, 'organization-id': importing_org['id']})[
+            'versions'
+        ]
         assert len(importing_cvv) >= 1
         imported_packages = Package.list({'content-view-version-id': importing_cvv[0]['id']})
         assert len(imported_packages)


### PR DESCRIPTION
This change should fix _test_positive_export_import_redhat_cv_with_huge_contents_.
It was necessary to use separate manifest for each tests that enables and syncs RH repo, so _function_org_ fixture is used instead of _module_org_. Otherwise we get following error:
_Import is the same as existing data
Owner has already imported from another subscription management application. The following conflicts were found: [ MANIFEST_SAME, DISTRIBUTOR_CONFLICT ]_
Ability to extend timeout was added to export/import commands that may take long to run.
Tests _test_positive_export_import_redhat_cv_ and _test_positive_export_import_redhat_cv_with_huge_contents_ are nearly the same, but the second one uses huge repo, needs to have timeout extended and takes (very) long to run.