### PR TITLE
Adding test coverage around rh_cloud stubbed cases

### DIFF
--- a/robottelo/rh_cloud_utils.py
+++ b/robottelo/rh_cloud_utils.py
@@ -99,3 +99,18 @@ def get_report_data(report_path):
             if file_name != 'metadata.json':
                 json_data = json.load(tarobj.extractfile(file_))
     return json_data
+
+
+def get_report_metadata(report_path):
+    """Returns metadata.json contents from the report
+
+    Args:
+        report_path: path to tar file
+    """
+    json_meta_data = {}
+    with tarfile.open(report_path, mode='r') as tarobj:
+        for file_ in tarobj.getmembers():
+            file_name = Path(file_.name).name
+            if file_name == 'metadata.json':
+                json_meta_data = json.load(tarobj.extractfile(file_))
+    return json_meta_data


### PR DESCRIPTION
**Test results 6.10**

```
pytest tests/foreman/api/test_rhcloud_inventory.py -k test_rhcloud_inventory_api_e2e
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, ibutsu-1.16, cov-3.0.0, xdist-2.4.0
collected 8 items / 7 deselected / 1 selected                                                                                                                                                                     

tests/foreman/api/test_rhcloud_inventory.py .                                                                                                                                                               [100%]

============================================================================ 1 passed, 7 deselected,in 1211.83s (0:20:11) ============================================================================



pytest tests/foreman/api/test_rhcloud_inventory.py -k test_rh_cloud_tag_values
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, ibutsu-1.16, cov-3.0.0, xdist-2.4.0
collected 8 items / 7 deselected / 1 selected                                                                                                                                                                     

tests/foreman/api/test_rhcloud_inventory.py .                                                                                                                                                               [100%]

============================================================================ 1 passed, 7 deselected,in 1083.83s (0:18:03) =====================================================================

```

