### PR TITLE
host traces test introduced

### DIFF
--- a/pytest_fixtures/component/host.py
+++ b/pytest_fixtures/component/host.py
@@ -2,6 +2,11 @@
 import pytest
 from nailgun import entities
 
+from robottelo.cli.factory import setup_org_for_a_rh_repo
+from robottelo.constants import PRDS
+from robottelo.constants import REPOS
+from robottelo.constants import REPOSET
+
 
 @pytest.fixture(scope='module')
 def module_host():
@@ -11,3 +16,29 @@ def module_host():
 @pytest.fixture(scope='module')
 def module_model():
     return entities.Model().create()
+
+
+@pytest.mark.skip_if_not_set('clients', 'fake_manifest')
+@pytest.fixture(scope="module")
+def setup_rhst_repo():
+    """Prepare Satellite tools repository for usage in specified organization"""
+    org = entities.Organization().create()
+    cv = entities.ContentView(organization=org).create()
+    lce = entities.LifecycleEnvironment(organization=org).create()
+    ak = entities.ActivationKey(
+        environment=lce,
+        organization=org,
+    ).create()
+    repo_name = 'rhst7'
+    setup_org_for_a_rh_repo(
+        {
+            'product': PRDS['rhel'],
+            'repository-set': REPOSET[repo_name],
+            'repository': REPOS[repo_name]['name'],
+            'organization-id': org.id,
+            'content-view-id': cv.id,
+            'lifecycle-environment-id': lce.id,
+            'activationkey-id': ak.id,
+        }
+    )
+    return {'ak': ak, 'cv': cv, 'lce': lce, 'org': org, 'repo_name': repo_name}

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -460,3 +460,58 @@ class HostInterface(Base):
         """Create new network interface for host"""
         cls.command_sub = 'create'
         cls.execute(cls._construct_command(options), output_format='csv')
+
+
+class HostTraces(Base):
+    """Manages traces on your hosts
+
+    Usage::
+        hammer host traces [OPTIONS] SUBCOMMAND [ARG] ...
+
+    Subcommands::
+        list                          List services that need restarting on the host
+        resolve                       Resolve Traces
+    """
+
+    command_base = 'host traces'
+
+    @classmethod
+    def list(cls, options=None):
+        """List services that need restarting on the host.
+
+        Usage::
+
+            hammer host traces list [OPTIONS]
+
+        Options::
+
+            --fields FIELDS               Show specified fields or predefined field sets only.
+                                        (See below) Comma separated list of values.
+                                        Values containing comma should be quoted or
+                                        escaped with backslash.
+                                       JSON is acceptable and preferred way for complex parameters
+            --host[-id]                   Name/id of the host
+        """
+        cls.command_sub = 'list'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def resolve(cls, options=None):
+        """Resolve Traces
+
+        Usage::
+
+            hammer host traces resolve [OPTIONS]
+
+        Options::
+
+            --async                       Do not wait for the task
+            --host[-id]                   Name/id of the host
+            --trace-ids TRACE_IDS         Array of Trace ids
+                                       Comma separated list of values.
+                                       Values containing comma should be quoted or
+                                       escaped with backslash.
+                                       JSON is acceptable and preferred way for complex parameters
+        """
+        cls.command_sub = 'resolve'
+        cls.execute(cls._construct_command(options))


### PR DESCRIPTION
this is low priority but nice to have :smile: 
this was 6.8 feature if I am not mistaken 
I should probably add some asserts around service status after the downgrade, and after `hammer host traces resolve`. To see if the test really restarted the service.  -> Marking as TODO. 

I wanted to use `tracer -a` or `tracer --all` from client, to assert the results, but code snippets below, shows that channel read method will never stops from unknown reason, which is very low level issue, and I didn't find enough courage to dig deeper.

```
from broker.hosts import Host
my_host = Host("my.fqdn.com")
res = my_host.execute("tracer -a")
```
or 
```
from broker.session import Session
s = Session(hostname='<fqdn>', password='<passwd>')
channel = s.session.open_session()
channel.execute('tracer -a')
channel.read() # << the problematic command
```
If somebody wants to debug this issue, this is as far as I get, it would require to understand the channel read method, all paths lead to C-language :smile:  :smiley: 
https://github.com/ParallelSSH/ssh2-python/blob/master/ssh2/channel.pyx#L105-L145