### PR TITLE
Fix location context for Hosts Content tests

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -316,7 +316,7 @@ def test_positive_search_by_subscription_status(session, vm):
 
 
 @pytest.mark.tier3
-def test_negative_install_package(session, vm):
+def test_negative_install_package(session, vm, default_location):
     """Attempt to install non-existent package to a host remotely
 
     :id: d60b70f9-c43f-49c0-ae9f-187ffa45ac97
@@ -330,6 +330,7 @@ def test_negative_install_package(session, vm):
     :CaseLevel: System
     """
     with session:
+        session.location.select(loc_name=default_location.name)
         result = session.contenthost.execute_package_action(
             vm.hostname, 'Package Install', gen_string('alphanumeric')
         )


### PR DESCRIPTION
21 High Imp Hosts-Content tests are failing mostly due to error:
```
navmazing.NavigationTriesExceeded: Navigation failed to reach [Edit] in the specified tries
```

Raising an initial PR with one test fix and test result, rest I am handing over to @swadeley to use this with other tests which needs context/location switching.
```
obottelo % pytest -s tests/foreman/ui/test_contenthost.py -k test_negative_install_package
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.8.2, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/jitendrayejare/JWorkspace/GitRepos/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, ibutsu-1.16, reportportal-5.0.8, services-2.2.1, mock-3.6.1, xdist-2.4.0, forked-1.3.0
collecting ... 2021-11-27 00:00:53 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 28 items / 27 deselected / 1 selected

.
============ 1 passed, 27 deselected, 3 warnings in 322.78s (0:20:15) ========
```