### PR TITLE
Export templates using ssh

### DIFF
--- a/conf/git.yaml.template
+++ b/conf/git.yaml.template
@@ -1,4 +1,6 @@
 GIT:
   USERNAME: admin
   PASSWORD: chageme
-  URL: http://localhost:port
+  SSH_PORT: 22
+  HTTP_PORT: 80
+  HOSTNAME: localhost

--- a/pytest_fixtures/component/templatesync.py
+++ b/pytest_fixtures/component/templatesync.py
@@ -1,5 +1,3 @@
-from urllib.parse import urlparse
-
 import pytest
 import requests
 from fauxfactory import gen_string
@@ -36,30 +34,75 @@ def create_import_export_local_dir(default_sat):
 @pytest.fixture(scope='session')
 def git_port(default_sat):
     """Allow port for git service"""
-    port = urlparse(settings.git.url).port
-    if port:
-        default_sat.execute(f'semanage port -a -t http_port_t -p tcp {port}')
+    default_sat.execute(f'semanage port -a -t http_port_t -p tcp {settings.git.http_port}')
+    default_sat.execute(f'semanage port -a -t ssh_port_t -p tcp {settings.git.ssh_port}')
 
 
 @pytest.fixture(scope='session')
-def git_repository(git_port):
+def git_pub_key(default_sat, git_port):
+    """Copy ssh public key to git service"""
+    git = settings.git
+    key_path = '/usr/share/foreman/.ssh/'
+    default_sat.execute(f'sudo -u foreman ssh-keygen -q -t rsa -f {key_path}id_rsa -N "" <<<y')
+    key = default_sat.execute(f'cat {key_path}id_rsa.pub').stdout.strip()
+    title = gen_string('alpha')
+    auth = (git.username, git.password)
+    url = f'http://{git.hostname}:{git.http_port}'
+    res = requests.post(
+        f'{url}/api/v1/user/keys',
+        auth=auth,
+        json={'key': key, 'title': title},
+    )
+    res.raise_for_status()
+    id = res.json()['id']
+    # add ssh key to known host
+    default_sat.execute(
+        f'ssh-keyscan -t rsa -p {git.ssh_port} {git.hostname} > {key_path}/known_hosts'
+    )
+    yield
+    res = requests.delete(
+        f'{url}/api/v1/user/keys/{id}',
+        auth=auth,
+    )
+    res.raise_for_status()
+
+
+@pytest.fixture(scope='session')
+def git_repository(git_port, git_pub_key):
+    """Encapsulate creating initialized repository"""
+    repo_gen = create_git_repository(True)
+    yield next(repo_gen)
+    next(repo_gen)
+
+
+@pytest.fixture(scope='function')
+def git_empty_repository(git_port, git_pub_key):
+    """Encapsulate creating empty repository"""
+    repo_gen = create_git_repository(False)
+    yield next(repo_gen)
+    next(repo_gen)
+
+
+def create_git_repository(init):
     """Creates a new repository on git provider for exporting templates.
 
     Finally, deletes repository from git provider after tests are completed as a teardown part.
+
+    :returns: dict: repository name, flag if repository is empty
     """
     auth = (settings.git.username, settings.git.password)
+    url = f'http://{settings.git.hostname}:{settings.git.http_port}'
     name = gen_string('alpha')
     res = requests.post(
-        f"{settings.git.url}/api/v1/user/repos",
+        f'{url}/api/v1/user/repos',
         auth=auth,
-        json={"name": name, "auto_init": True, "default_branch": "master"},
+        json={'name': name, 'auto_init': init, 'default_branch': 'master'},
     )
     res.raise_for_status()
     yield name
-    res = requests.delete(
-        f"{settings.git.url}/api/v1/repos/{settings.git.username}/{name}", auth=auth
-    )
+    res = requests.delete(f'{url}/api/v1/repos/{settings.git.username}/{name}', auth=auth)
     res.raise_for_status()
+    yield
 
 
 @pytest.fixture()
@@ -69,10 +112,11 @@ def git_branch(git_repository):
     Finally, removes branch from the git repository after test is completed as a teardown part.
     """
     auth = (settings.git.username, settings.git.password)
-    url = f"{settings.git.url}/api/v1/repos/{settings.git.username}/{git_repository}/branches"
+    path = f'/api/v1/repos/{settings.git.username}/{git_repository}/branches'
+    url = f'http://{settings.git.hostname}:{settings.git.http_port}{path}'
     new_branch = gen_string('alpha')
     res = requests.post(
-        url, auth=auth, json={"new_branch_name": new_branch, "old_branch_name": "master"}
+        url, auth=auth, json={'new_branch_name': new_branch, 'old_branch_name': 'master'}
     )
     res.raise_for_status()
     yield new_branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ productmd==1.33
 pyotp==2.6.0
 pytest==6.2.5
 pytest-services==2.2.1
+pytest_lazy-fixture==0.6.3
 pytest-mock==3.6.1
 pytest-reportportal==5.0.8
 pytest-xdist==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ productmd==1.33
 pyotp==2.6.0
 pytest==6.2.5
 pytest-services==2.2.1
-pytest_lazy-fixture==0.6.3
 pytest-mock==3.6.1
 pytest-reportportal==5.0.8
 pytest-xdist==2.4.0

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -147,7 +147,9 @@ VALIDATORS = dict(
         Validator(
             'git.username',
             'git.password',
-            'git.url',
+            'git.ssh_port',
+            'git.http_port',
+            'git.hostname',
             must_exist=True,
         ),
     ],

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1808,6 +1808,7 @@ VMWARE_CONSTANTS = {
 HAMMER_CONFIG = "~/.hammer/cli.modules.d/foreman.yml"
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
+FOREMAN_TEMPLATE_IMPORT_API_URL = 'http://api.github.com/repos/SatelliteQE/foreman_templates'
 
 FOREMAN_TEMPLATE_TEST_TEMPLATE = (
     'https://raw.githubusercontent.com/SatelliteQE/foreman_templates/example/'


### PR DESCRIPTION
Adding test for exporting templates to git using ssh. Also adding test to cover BZ: [1785613](https://bugzilla.redhat.com/show_bug.cgi?id=1785613)
~~To reduce number of similar test I used test parametrization. Using different fixtures in one test required one additional package `pytest_lazy-fixture` which basically takes name of fixture and evaluates it.~~ Updated to use indirect parametrization.

Test results:
```
pytest tests/foreman/*/test_templatesync.py
================================================================ test session starts ================================================================
platform linux -- Python 3.9.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, ibutsu-1.16, xdist-2.4.0, lazy-fixture-0.6.3
collected 43 items                                                                                                                                  

tests/foreman/api/test_templatesync.py .............................                                                                          [ 67%]
tests/foreman/cli/test_templatesync.py ........                                                                                               [ 86%]
tests/foreman/ui/test_templatesync.py ......                                                                                                  [100%]

==================================================== 43 passed, 0 warnings in 485.91s (0:08:05) ====================================================
```