### PR TITLE
Fix and update api/cli endtoend tests to use rhel7 client

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -42,7 +42,7 @@ def call_entity_method_with_timeout(entity_callable, timeout=300, **kwargs):
         entity_mixins.TASK_TIMEOUT = original_task_timeout
 
 
-def enable_rhrepo_and_fetchid(basearch, org_id, product, repo, reposet, releasever):
+def enable_rhrepo_and_fetchid(basearch, org_id, product, repo, reposet, releasever=None):
     """Enable a RedHat Repository and fetches it's Id.
 
     :param str org_id: The organization Id.


### PR DESCRIPTION
**Test Results:**
```
$ pytest -q -p no:warnings tests/foreman/endtoend/test_api_endtoend.py::TestEndToEnd::test_positive_end_to_end
.                                                                                                                                 [100%]
1 passed in 721.67s (0:12:01)
```
```
$ pytest -q -p no:warnings tests/foreman/endtoend/test_cli_endtoend.py -k test_positive_cli_end_to_end
.                                                                                                                                 [100%]
1 passed, 3 deselected in 968.85s (0:16:08)
```

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>