### PR TITLE
Automate test_insights_tab_on_host_details_page

### DIFF
--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -127,41 +127,6 @@ def test_rhcloud_inventory_e2e(
 
 
 @pytest.mark.stubbed
-def test_hits_synchronization():
-    """Synchronize hits data from cloud and verify it is displayed in Satellite
-
-    :id: c3d1edf5-f43a-4f85-bd80-825bde58f6b2
-
-    :customerscenario: true
-
-    :Steps:
-        1. Prepare misconfigured machine and upload its data to Insights
-        2. Add Cloud API key in Satellite
-        3. In Satellite UI, Configure -> Insights -> Sync now
-        4. Go to Hosts -> All Hosts
-        5. Assert there is "Insights" column with content and assert content of status popover
-        6. Open host page and assert there is new Insights recommendation tab
-        7. Assert that host properties shows reporting status for insights.
-        8. Run rh_cloud_insights:clean_statuses rake command
-        9. Assert that host properties doesn't contain insights status.
-        10. Try to delete the host
-
-    :expectedresults:
-        1. There's Insights column with number of recommendations and link to Insights page.
-        2. Insights reporting status is displayed in popover status of host
-        3. Recommendations are listed on single host page
-        4. rake command deletes insights reporting status of host.
-        5. Host is removed from Satellite.
-
-    :CaseImportance: Critical
-
-    :BZ: 1974578, 1962930, 1860422, 1865876, 1879448, 1928652
-
-    :CaseAutomation: NotAutomated
-    """
-
-
-@pytest.mark.stubbed
 def test_hosts_synchronization():
     """Synchronize list of available hosts from cloud and mark them in Satellite
 


### PR DESCRIPTION
This PR adds `test_insights_tab_on_host_details_page` and removes `test_hits_synchronization` because it's now covered in other tests.

Test result: 
```
$ pytest tests/foreman/ui/test_rhcloud_insights.py -k test_insights_tab_on_host_details_page 
============================= test session starts ==============================
collected 9 items / 8 deselected / 1 selected

tests/foreman/ui/test_rhcloud_insights.py .                              [100%]
=========== 1 passed, 8 deselected, 3 warnings in 863.63s (0:14:23) ============

```
Note: This PR depends on https://github.com/SatelliteQE/airgun/pull/639