### PR TITLE
Fix for puppet-related UI tests

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1275,9 +1275,7 @@ class Satellite(Capsule):
             f'--target-dir /etc/puppetlabs/code/environments/{env_name}/modules/'
         )
         smart_proxy = (
-            entities.SmartProxy()
-            .search(query={'search': f'name={settings.server.hostname}'})[0]
-            .read()
+            entities.SmartProxy().search(query={'search': f'name={self.hostname}'})[0].read()
         )
         smart_proxy.import_puppetclasses()
         return env_name

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -54,7 +54,7 @@ def test_positive_end_to_end(session, module_org, module_location):
         # Make an attempt to delete puppet class that associated with host group
         with pytest.raises(AssertionError) as context:
             session.puppetclass.delete(name)
-        assert f"error: '{puppet_class.name} is used by {hostgroup.name}'" in str(context.value)
+        assert f'{puppet_class.name} is used by {hostgroup.name}' in str(context.value)
         # Unassign puppet class from host group
         session.puppetclass.update(
             puppet_class.name, {'puppet_class.host_group.unassigned': [hostgroup.name]}

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -171,6 +171,7 @@ def test_positive_end_to_end(session, module_puppet_classes, sc_params_list):
 
 
 @pytest.mark.tier2
+@pytest.mark.skip_if_open("BZ:2015911")
 def test_positive_create_matcher_attribute_priority(session, sc_params_list, module_host, domain):
     """Matcher Value set on Attribute Priority for Host.
 
@@ -259,6 +260,7 @@ def test_positive_create_matcher_attribute_priority(session, sc_params_list, mod
 
 
 @pytest.mark.tier2
+@pytest.mark.skip_if_open("BZ:2015911")
 def test_positive_create_matcher_avoid_duplicate(session, sc_params_list, module_host, domain):
     """Merge the values of all the associated matchers, remove duplicates.
 


### PR DESCRIPTION
Two tests waiting for the BZ fix, one error message update, and one fix to avoid `'DynaBox' object has no attribute 'HOSTNAME'` error - thanks to @JacobCallahan !

Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/ui/test_puppetclass.py::test_positive_end_to_end
=================================================================================== test session starts ====================================================================================
platform linux -- Python 3.9.7, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 1 item                                                                                                                                                                           

tests/foreman/ui/test_puppetclass.py .                                                                                                                                               [100%]

======================================================================== 1 passed, 3 warnings in 183.45s (0:03:03) =========================================================================
```