### PR TITLE
added tests to search products on any org

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1245,7 +1245,7 @@ def test_positive_search_product_any_organization(session):
         4. Assert that user must select and Organization
 
     :expectedresults: UI asks to select an Organization on products page
-    when Any Organization is selected
+        when Any Organization is selected
     """
     org = entities.Organization().create()
     entities.Product(organization=org).create()

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -25,7 +25,6 @@ import pytest
 from airgun.session import Session
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
-from widgetastic.exceptions import NoSuchElementException
 
 from robottelo import manifests
 from robottelo.api.utils import create_role_permissions
@@ -1227,6 +1226,7 @@ def test_positive_sync_repo_and_verify_checksum(session, module_org):
         results = session.product.verify_content_checksum([product.name])
         assert results['task']['result'] == 'success'
 
+
 @pytest.mark.tier2
 def test_positive_search_product_any_organization(session):
     """Navigating to products page when Any Organization is selected should
@@ -1251,10 +1251,6 @@ def test_positive_search_product_any_organization(session):
     entities.Product(organization=org).create()
     with session:
         session.organization.select(org_name='Any Organization')
-        try:
-            search_page = session.product.search(gen_string("alpha"))
-        except NoSuchElementException:
-            search_page = None
-        return search_page
+        session.product.search(gen_string("alpha"))
         product_page = session.browser.selenium.page_source
         assert 'access requires selecting a specific organization' in product_page


### PR DESCRIPTION
When trying to access the products page and "Any Organization" is selected, Users should see a landing page that asks them to select an Org. 

Currently, there are no views in airgun that allow us to see this. This is the current workaround.

Link to airgun page for possible functionality https://github.com/SatelliteQE/airgun/pull/640
![Screenshot from 2021-12-01 15-09-09](https://user-images.githubusercontent.com/26364615/144306470-06e5a2da-f213-4593-8fc0-edbcfc44faa7.png)
 