### PR TITLE
Fix the cli output assertion error for virtwho plugin cases

### DIFF
--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -106,7 +106,7 @@ class TestVirtWhoConfigforEsx:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'Subscription attached to the host successfully.' in result
+            assert result.strip() == 'Subscription attached to the host successfully.'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -151,7 +151,7 @@ class TestVirtWhoConfigforEsx:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'Subscription attached to the host successfully.' in result
+            assert result.strip() == 'Subscription attached to the host successfully.'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -106,7 +106,7 @@ class TestVirtWhoConfigforEsx:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'attached to the host successfully' in '\n'.join(result)
+            assert 'Subscription attached to the host successfully.' in result
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -151,7 +151,7 @@ class TestVirtWhoConfigforEsx:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'attached to the host successfully' in '\n'.join(result)
+            assert 'Subscription attached to the host successfully.' in result
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -90,7 +90,7 @@ class TestVirtWhoConfigforHyperv:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'attached to the host successfully' in '\n'.join(result)
+            assert 'Subscription attached to the host successfully.' in result
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -129,7 +129,7 @@ class TestVirtWhoConfigforHyperv:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'attached to the host successfully' in '\n'.join(result)
+            assert 'Subscription attached to the host successfully.' in result
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -90,7 +90,7 @@ class TestVirtWhoConfigforHyperv:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'Subscription attached to the host successfully.' in result
+            assert result.strip() == 'Subscription attached to the host successfully.'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -129,7 +129,7 @@ class TestVirtWhoConfigforHyperv:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'Subscription attached to the host successfully.' in result
+            assert result.strip() == 'Subscription attached to the host successfully.'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -89,7 +89,7 @@ class TestVirtWhoConfigforKubevirt:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'Subscription attached to the host successfully.' in result
+            assert result.strip() == 'Subscription attached to the host successfully.'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -128,7 +128,7 @@ class TestVirtWhoConfigforKubevirt:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'Subscription attached to the host successfully.' in result
+            assert result.strip() == 'Subscription attached to the host successfully.'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -89,7 +89,7 @@ class TestVirtWhoConfigforKubevirt:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'attached to the host successfully' in '\n'.join(result)
+            assert 'Subscription attached to the host successfully.' in result
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -128,7 +128,7 @@ class TestVirtWhoConfigforKubevirt:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'attached to the host successfully' in '\n'.join(result)
+            assert 'Subscription attached to the host successfully.' in result
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -89,7 +89,7 @@ class TestVirtWhoConfigforLibvirt:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'attached to the host successfully' in '\n'.join(result)
+            assert 'Subscription attached to the host successfully.' in result
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -128,7 +128,7 @@ class TestVirtWhoConfigforLibvirt:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'attached to the host successfully' in '\n'.join(result)
+            assert 'Subscription attached to the host successfully.' in result
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -89,7 +89,7 @@ class TestVirtWhoConfigforLibvirt:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'Subscription attached to the host successfully.' in result
+            assert result.strip() == 'Subscription attached to the host successfully.'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
@@ -128,7 +128,7 @@ class TestVirtWhoConfigforLibvirt:
                         vdc_id = item['id']
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
-            assert 'Subscription attached to the host successfully.' in result
+            assert result.strip() == 'Subscription attached to the host successfully.'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 


### PR DESCRIPTION
**Description**
Most virt-who plugin CLI cases failed due to the assertion error. It was imported from the transition about paramiko to ssh2.

**Test Result**
```
(3.8_rot) [hkx303@kuhuang robottelo]$ pytest tests/foreman/virtwho/cli/test_esx.py -k test_positive_deploy_configure_by_id -s
================== 1 passed, 9 deselected, 11 warnings in 242.70s (0:04:02) ==================
```