### PR TITLE
[VirtWho tests skip impact] Skip non sat-ci components tests Plugin

### DIFF
--- a/pytest_plugins/infra_dependent_markers.py
+++ b/pytest_plugins/infra_dependent_markers.py
@@ -6,7 +6,6 @@ def pytest_configure(config):
     markers = [
         "on_premises_provisioning: Tests that runs on on_premises Providers",
         "libvirt_discovery: Tests depends on Libvirt Provider for discovery",
-        "libvirt_content_host: Tests depends on Libvirt Provider for content hosts",
         "external_auth: External Authentication tests",
         "vlan_networking: Tests depends on static predefined vlan networking etc",
     ]

--- a/pytest_plugins/marker_deselection.py
+++ b/pytest_plugins/marker_deselection.py
@@ -3,20 +3,30 @@ import pytest
 from robottelo.logging import collection_logger as logger
 
 
+non_satCI_components = ['Virt-whoConfigurePlugin']
+
+
 def pytest_addoption(parser):
     """Add options for pytest to collect tests than can run on SatLab infra"""
-    options = [
+    infra_options = [
         '--include-onprem-provisioning',
         '--include-libvirt',
         '--include-external-auth',
         '--include-vlan-networking',
     ]
-    for opt in options:
+    for opt in infra_options:
         help_text = f'''Filter out tests depends on infra availability
 
                         Usage: `pytest tests/foreman {opt}`
                     '''
         parser.addoption(opt, action='store_true', default=False, help=help_text)
+
+    option = '--include-non-satci-tests'
+    help_text = f'''Include auto uncollected non SatCI tests
+
+        Usage: `pytest tests/foreman {option} Virt-whoConfigurePlugin,SomthingComponent`
+        '''
+    parser.addoption(option, default='', help=help_text)
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -28,17 +38,28 @@ def pytest_collection_modifyitems(items, config):
     include_libvirt = config.getoption('include_libvirt', False)
     include_eauth = config.getoption('include_external_auth', False)
     include_vlan = config.getoption('include_vlan_networking', False)
+    include_non_satci_tests = config.getvalue('include_non_satci_tests').split(',')
+
     selected = []
     deselected = []
     # Cloud Provisioning Test can be run on new pipeline
     for item in items:
+        # Include/Exclude tests those are not part of SatQE CI
+        item_component = item.get_closest_marker('component')
+        if item_component and (item_component.args[0] in non_satCI_components):
+            if item_component.args[0] in include_non_satci_tests:
+                selected.append(item)
+            else:
+                deselected.append(item)
+            continue
+
         item_marks = [m.name for m in item.iter_markers()]
         # Include / Exclude On Premises Provisioning Tests
         if 'on_premises_provisioning' in item_marks:
             selected.append(item) if include_onprem_provision else deselected.append(item)
             continue
         # Include / Exclude External Libvirt based Tests
-        if any(marker in item_marks for marker in ['libvirt_discovery', 'libvirt_content_host']):
+        if 'libvirt_discovery' in item_marks:
             selected.append(item) if include_libvirt else deselected.append(item)
             continue
         # Include / Exclude External Auth based Tests
@@ -53,7 +74,7 @@ def pytest_collection_modifyitems(items, config):
         selected.append(item)
     logger.debug(
         f'Selected {len(selected)} and deselected {len(deselected)} '
-        'tests based on new infra markers.'
+        'tests based on auto un-collectable markers and pytest options.'
     )
     items[:] = selected or items
     config.hook.pytest_deselected(items=deselected)


### PR DESCRIPTION
- Helps to skip the tests of non satCI components
- The plugin uses a component marker to select/deselect the depreciated component tests, for this PR we are skipping all `Virt-whoConfigurePlugin` component tests since VirtWho tests will now run in VirtWho QE CI. 
- The component marker is being set by another plugin called `metadata_markers` on tests on runtime.
- There is an option to `--include-non-satci-tests` to collect the non satCI components tests.

Also,
- I removed `libvirt_content_host` marker and its auto deselection from `marker_deselection` plugin as we have no longer tests that uses that marker !