### PR TITLE
Update the organization to module_manifest_org for virtwho plugin cases 

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -410,19 +410,19 @@ def virtwho_package_locked():
     assert "Packages are locked" in result[1]
 
 
-def create_http_proxy(name=None, url=None, http_type='https', org_name=DEFAULT_ORG):
+def create_http_proxy(org, name=None, url=None, http_type='https'):
     """
     Creat a new http-proxy with attributes.
     :param name: Name of the proxy
     :param url: URL of the proxy including schema (https://proxy.example.com:8080)
     :param http_type: https or http
-    :param org_name: name of the organization
+    :param org: instance of the organization
     :return:
     """
-    org = entities.Organization().search(query={'search': f'name="{org_name}"'})[0]
+    org = entities.Organization().search(query={'search': f'name="{org.name}"'})[0]
     http_proxy_name = name or gen_string('alpha', 15)
-    http_proxy_url = url or '{}:{}'.format(
-        gen_url(scheme=http_type), gen_integer(min_value=10, max_value=9999)
+    http_proxy_url = (
+        url or f'{gen_url(scheme=http_type)}:{gen_integer(min_value=10, max_value=9999)}'
     )
     http_proxy = entities.HTTPProxy(
         name=http_proxy_name,

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -23,7 +23,6 @@ from nailgun import entities
 from robottelo.cli.host import Host
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import create_http_proxy
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -33,13 +32,8 @@ from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_option
 
 
-@pytest.fixture(scope='class')
-def default_org():
-    return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
-
-
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(module_manifest_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -47,7 +41,7 @@ def form_data(default_org, default_sat):
         'hypervisor_id': 'hostname',
         'hypervisor_type': settings.virtwho.esx.hypervisor_type,
         'hypervisor_server': settings.virtwho.esx.hypervisor_server,
-        'organization_id': default_org.id,
+        'organization_id': module_manifest_org.id,
         'filtering_mode': 'none',
         'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.esx.hypervisor_username,
@@ -63,7 +57,7 @@ def virtwho_config(form_data):
 
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
         :id: 72d74c05-2580-4f38-b6c0-999ff470d4d6
@@ -75,9 +69,9 @@ class TestVirtWhoConfigforEsx:
         :CaseImportance: High
         """
         assert virtwho_config.status == 'unknown'
-        command = get_configure_command(virtwho_config.id)
+        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True
+            command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = (
             entities.VirtWhoConfig()
@@ -97,7 +91,9 @@ class TestVirtWhoConfigforEsx:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -113,7 +109,9 @@ class TestVirtWhoConfigforEsx:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, module_manifest_org, form_data, virtwho_config
+    ):
         """Verify "GET /foreman_virt_who_configure/api/
 
         v2/configs/:id/deploy_script"
@@ -129,7 +127,10 @@ class TestVirtWhoConfigforEsx:
         assert virtwho_config.status == 'unknown'
         script = virtwho_config.deploy_script()
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script['virt_who_config_script'], form_data['hypervisor_type'], debug=True
+            script['virt_who_config_script'],
+            form_data['hypervisor_type'],
+            debug=True,
+            org=module_manifest_org.label,
         )
         virt_who_instance = (
             entities.VirtWhoConfig()
@@ -149,7 +150,9 @@ class TestVirtWhoConfigforEsx:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -165,7 +168,7 @@ class TestVirtWhoConfigforEsx:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_debug_option(self, form_data, virtwho_config):
+    def test_positive_debug_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify debug option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -182,14 +185,16 @@ class TestVirtWhoConfigforEsx:
         for key, value in sorted(options.items(), key=lambda item: item[0]):
             virtwho_config.debug = key
             virtwho_config.update(['debug'])
-            command = get_configure_command(virtwho_config.id)
-            deploy_configure_by_command(command, form_data['hypervisor_type'])
+            command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_interval_option(self, form_data, virtwho_config):
+    def test_positive_interval_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify interval option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -215,14 +220,16 @@ class TestVirtWhoConfigforEsx:
         for key, value in sorted(options.items(), key=lambda item: int(item[0])):
             virtwho_config.interval = key
             virtwho_config.update(['interval'])
-            command = get_configure_command(virtwho_config.id)
-            deploy_configure_by_command(command, form_data['hypervisor_type'])
+            command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -241,14 +248,16 @@ class TestVirtWhoConfigforEsx:
             virtwho_config.hypervisor_id = value
             virtwho_config.update(['hypervisor_id'])
             config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id)
-            deploy_configure_by_command(command, form_data['hypervisor_type'])
+            command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('hypervisor_id', config_file) == value
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_filter_option(self, form_data, virtwho_config):
+    def test_positive_filter_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify filter option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -272,8 +281,10 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.filter_host_parents = whitelist['filter_host_parents']
         virtwho_config.update(whitelist.keys())
         config_file = get_configure_file(virtwho_config.id)
-        command = get_configure_command(virtwho_config.id)
-        deploy_configure_by_command(command, form_data['hypervisor_type'])
+        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+        deploy_configure_by_command(
+            command, form_data['hypervisor_type'], org=module_manifest_org.label
+        )
         assert get_configure_option('filter_hosts', config_file) == whitelist['whitelist']
         assert (
             get_configure_option('filter_host_parents', config_file)
@@ -285,8 +296,10 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.exclude_host_parents = blacklist['exclude_host_parents']
         virtwho_config.update(blacklist.keys())
         config_file = get_configure_file(virtwho_config.id)
-        command = get_configure_command(virtwho_config.id)
-        deploy_configure_by_command(command, form_data['hypervisor_type'])
+        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+        deploy_configure_by_command(
+            command, form_data['hypervisor_type'], org=module_manifest_org.label
+        )
         assert get_configure_option('exclude_hosts', config_file) == blacklist['blacklist']
         assert (
             get_configure_option('exclude_host_parents', config_file)
@@ -296,7 +309,7 @@ class TestVirtWhoConfigforEsx:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, form_data, virtwho_config):
+    def test_positive_proxy_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify http_proxy option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id""
@@ -311,31 +324,39 @@ class TestVirtWhoConfigforEsx:
 
         :BZ: 1902199
         """
-        command = get_configure_command(virtwho_config.id)
-        deploy_configure_by_command(command, form_data['hypervisor_type'])
+        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+        deploy_configure_by_command(
+            command, form_data['hypervisor_type'], org=module_manifest_org.label
+        )
         # Check default NO_PROXY option
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == '*'
         # Check HTTTP Proxy and No_PROXY option
-        http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(type='http')
+        http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
+            http_type='http', org_name=module_manifest_org.name
+        )
         no_proxy = 'test.satellite.com'
         virtwho_config.http_proxy_id = http_proxy_id
         virtwho_config.no_proxy = no_proxy
         virtwho_config.update(['http_proxy_id', 'no_proxy'])
-        command = get_configure_command(virtwho_config.id)
-        deploy_configure_by_command(command, form_data['hypervisor_type'])
+        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+        deploy_configure_by_command(command, form_data['hypervisor_type'], org=virtwho_config.label)
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
         # Check HTTTPs Proxy option
-        https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy()
+        https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(
+            org_name=module_manifest_org.name
+        )
         virtwho_config.http_proxy_id = https_proxy_id
         virtwho_config.update(['http_proxy_id'])
-        deploy_configure_by_command(command, form_data['hypervisor_type'])
+        deploy_configure_by_command(command, form_data['hypervisor_type'], org=virtwho_config.label)
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_configure_organization_list(self, form_data, virtwho_config):
+    def test_positive_configure_organization_list(
+        self, module_manifest_org, form_data, virtwho_config
+    ):
         """Verify "GET /foreman_virt_who_configure/
 
         api/v2/organizations/:organization_id/configs"
@@ -348,8 +369,10 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        command = get_configure_command(virtwho_config.id)
-        deploy_configure_by_command(command, form_data['hypervisor_type'])
+        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+        deploy_configure_by_command(
+            command, form_data['hypervisor_type'], org=module_manifest_org.label
+        )
         search_result = virtwho_config.get_organization_configs(data={'per_page': '1000'})
         assert [item for item in search_result['results'] if item['name'] == form_data['name']]
         virtwho_config.delete()

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -332,7 +332,7 @@ class TestVirtWhoConfigforEsx:
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == '*'
         # Check HTTTP Proxy and No_PROXY option
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org_name=module_manifest_org.name
+            http_type='http', org=module_manifest_org
         )
         no_proxy = 'test.satellite.com'
         virtwho_config.http_proxy_id = http_proxy_id
@@ -344,7 +344,7 @@ class TestVirtWhoConfigforEsx:
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
         # Check HTTTPs Proxy option
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(
-            org_name=module_manifest_org.name
+            org=module_manifest_org
         )
         virtwho_config.http_proxy_id = https_proxy_id
         virtwho_config.update(['http_proxy_id'])

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -23,7 +23,6 @@ from nailgun import entities
 from robottelo.cli.host import Host
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -31,13 +30,8 @@ from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_option
 
 
-@pytest.fixture(scope='class')
-def default_org():
-    return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
-
-
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(module_manifest_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -45,7 +39,7 @@ def form_data(default_org, default_sat):
         'hypervisor_id': 'hostname',
         'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
         'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
-        'organization_id': default_org.id,
+        'organization_id': module_manifest_org.id,
         'filtering_mode': 'none',
         'satellite_url': default_sat.hostname,
         'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
@@ -61,7 +55,7 @@ def virtwho_config(form_data):
 
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
         :id: f5228e01-bb8d-4c8e-877e-cd8bc494f00e
@@ -73,9 +67,9 @@ class TestVirtWhoConfigforHyperv:
         :CaseImportance: High
         """
         assert virtwho_config.status == 'unknown'
-        command = get_configure_command(virtwho_config.id)
+        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True
+            command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = (
             entities.VirtWhoConfig()
@@ -95,7 +89,9 @@ class TestVirtWhoConfigforHyperv:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -111,7 +107,9 @@ class TestVirtWhoConfigforHyperv:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, module_manifest_org, form_data, virtwho_config
+    ):
         """Verify "GET /foreman_virt_who_configure/api/
 
         v2/configs/:id/deploy_script"
@@ -127,7 +125,10 @@ class TestVirtWhoConfigforHyperv:
         assert virtwho_config.status == 'unknown'
         script = virtwho_config.deploy_script()
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script['virt_who_config_script'], form_data['hypervisor_type'], debug=True
+            script['virt_who_config_script'],
+            form_data['hypervisor_type'],
+            debug=True,
+            org=module_manifest_org.label,
         )
         virt_who_instance = (
             entities.VirtWhoConfig()
@@ -147,7 +148,9 @@ class TestVirtWhoConfigforHyperv:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -163,7 +166,7 @@ class TestVirtWhoConfigforHyperv:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -181,8 +184,10 @@ class TestVirtWhoConfigforHyperv:
             virtwho_config.hypervisor_id = value
             virtwho_config.update(['hypervisor_id'])
             config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id)
-            deploy_configure_by_command(command, form_data['hypervisor_type'])
+            command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('hypervisor_id', config_file) == value
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -23,7 +23,6 @@ from nailgun import entities
 from robottelo.cli.host import Host
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -31,20 +30,15 @@ from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_option
 
 
-@pytest.fixture(scope='class')
-def default_org():
-    return entities.Organization().search(query={'search': 'name="Default Organization"'})[0]
-
-
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(module_manifest_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
         'interval': '60',
         'hypervisor_id': 'hostname',
         'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization_id': default_org.id,
+        'organization_id': module_manifest_org.id,
         'filtering_mode': 'none',
         'satellite_url': default_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
@@ -60,7 +54,7 @@ def virtwho_config(form_data):
 @pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
         :id: 97f776af-cbd0-4885-9a74-603a3bc01157
@@ -72,9 +66,9 @@ class TestVirtWhoConfigforKubevirt:
         :CaseImportance: High
         """
         assert virtwho_config.status == 'unknown'
-        command = get_configure_command(virtwho_config.id)
+        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True
+            command, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = (
             entities.VirtWhoConfig()
@@ -94,7 +88,9 @@ class TestVirtWhoConfigforKubevirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -110,7 +106,9 @@ class TestVirtWhoConfigforKubevirt:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, module_manifest_org, form_data, virtwho_config
+    ):
         """Verify "GET /foreman_virt_who_configure/api/
 
         v2/configs/:id/deploy_script"
@@ -126,7 +124,10 @@ class TestVirtWhoConfigforKubevirt:
         assert virtwho_config.status == 'unknown'
         script = virtwho_config.deploy_script()
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script['virt_who_config_script'], form_data['hypervisor-type'], debug=True
+            script['virt_who_config_script'],
+            form_data['hypervisor-type'],
+            debug=True,
+            org=module_manifest_org.label,
         )
         virt_who_instance = (
             entities.VirtWhoConfig()
@@ -146,7 +147,9 @@ class TestVirtWhoConfigforKubevirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -162,7 +165,7 @@ class TestVirtWhoConfigforKubevirt:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -180,8 +183,10 @@ class TestVirtWhoConfigforKubevirt:
             virtwho_config.hypervisor_id = value
             virtwho_config.update(['hypervisor_id'])
             config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id)
-            deploy_configure_by_command(command, form_data['hypervisor_type'])
+            command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('hypervisor_id', config_file) == value
         virtwho_config.delete()
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -309,7 +309,7 @@ class TestVirtWhoConfigforEsx:
         """
         # Check the https proxy option, update it via http proxy name
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(
-            org_name=module_manifest_org.name
+            org=module_manifest_org
         )
         no_proxy = 'test.satellite.com'
         VirtWhoConfig.update(
@@ -327,7 +327,7 @@ class TestVirtWhoConfigforEsx:
 
         # Check the http proxy option, update it via http proxy id
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org_name=module_manifest_org.name
+            http_type='http', org=module_manifest_org
         )
         VirtWhoConfig.update({'id': virtwho_config['id'], 'http-proxy-id': http_proxy_id})
         deploy_configure_by_command(

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -24,12 +24,10 @@ from fauxfactory import gen_string
 
 from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.host import Host
-from robottelo.cli.org import Org
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import create_http_proxy
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -42,7 +40,7 @@ from robottelo.virtwho_utils import virtwho_package_locked
 
 
 @pytest.fixture()
-def form_data(default_sat):
+def form_data(default_sat, module_manifest_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -50,7 +48,7 @@ def form_data(default_sat):
         'hypervisor-id': 'hostname',
         'hypervisor-type': settings.virtwho.esx.hypervisor_type,
         'hypervisor-server': settings.virtwho.esx.hypervisor_server,
-        'organization-id': 1,
+        'organization-id': module_manifest_org.id,
         'filtering-mode': 'none',
         'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.esx.hypervisor_username,
@@ -66,7 +64,7 @@ def virtwho_config(form_data):
 
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
         :id: 1885dd56-e3f9-43a7-af27-e496967b6256
@@ -78,9 +76,9 @@ class TestVirtWhoConfigforEsx:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'])
+        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True
+            command, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -98,7 +96,9 @@ class TestVirtWhoConfigforEsx:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -111,7 +111,9 @@ class TestVirtWhoConfigforEsx:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, module_manifest_org, form_data, virtwho_config
+    ):
         """Verify " hammer virt-who-config fetch"
 
         :id: 6aaffaeb-aaf2-42cf-b0dc-ca41a53d42a6
@@ -125,7 +127,7 @@ class TestVirtWhoConfigforEsx:
         assert virtwho_config['status'] == 'No Report Yet'
         script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True
+            script, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -143,7 +145,9 @@ class TestVirtWhoConfigforEsx:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -156,7 +160,7 @@ class TestVirtWhoConfigforEsx:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_debug_option(self, form_data, virtwho_config):
+    def test_positive_debug_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify debug option by hammer virt-who-config update"
 
         :id: c98bc518-828c-49ba-a644-542db3190263
@@ -177,14 +181,16 @@ class TestVirtWhoConfigforEsx:
         options = {'true': '1', 'false': '0', 'yes': '1', 'no': '0'}
         for key, value in sorted(options.items(), key=lambda item: item[0]):
             VirtWhoConfig.update({'id': virtwho_config['id'], 'debug': key})
-            command = get_configure_command(virtwho_config['id'])
-            deploy_configure_by_command(command, form_data['hypervisor-type'])
+            command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor-type'], org=module_manifest_org.label
+            )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
         VirtWhoConfig.delete({'name': new_name})
         assert not VirtWhoConfig.exists(search=('name', new_name))
 
     @pytest.mark.tier2
-    def test_positive_interval_option(self, form_data, virtwho_config):
+    def test_positive_interval_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify interval option by hammer virt-who-config update"
 
         :id: 5d558bca-534c-4bd4-b401-a0c362033c57
@@ -207,14 +213,16 @@ class TestVirtWhoConfigforEsx:
         }
         for key, value in sorted(options.items(), key=lambda item: int(item[0])):
             VirtWhoConfig.update({'id': virtwho_config['id'], 'interval': key})
-            command = get_configure_command(virtwho_config['id'])
-            deploy_configure_by_command(command, form_data['hypervisor-type'])
+            command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor-type'], org=module_manifest_org.label
+            )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 4e6bad11-2019-458b-a368-26ea95afc7f5
@@ -232,14 +240,16 @@ class TestVirtWhoConfigforEsx:
             result = VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'])
-            deploy_configure_by_command(command, form_data['hypervisor-type'])
+            command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor-type'], org=module_manifest_org.label
+            )
             assert get_configure_option('hypervisor_id', config_file) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_filter_option(self, form_data, virtwho_config):
+    def test_positive_filter_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify filter option by hammer virt-who-config update"
 
         :id: aaf45c5e-9504-47ce-8f25-b8073c2de036
@@ -257,14 +267,16 @@ class TestVirtWhoConfigforEsx:
         whitelist['filter-host-parents'] = regex
         blacklist['exclude-host-parents'] = regex
         config_file = get_configure_file(virtwho_config['id'])
-        command = get_configure_command(virtwho_config['id'])
+        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
         # Update Whitelist and check the result
         VirtWhoConfig.update(whitelist)
         result = VirtWhoConfig.info({'id': virtwho_config['id']})
         assert result['connection']['filtering'] == 'Whitelist'
         assert result['connection']['filtered-hosts'] == regex
         assert result['connection']['filter-host-parents'] == regex
-        deploy_configure_by_command(command, form_data['hypervisor-type'])
+        deploy_configure_by_command(
+            command, form_data['hypervisor-type'], org=module_manifest_org.label
+        )
         assert get_configure_option('filter_hosts', config_file) == regex
         assert get_configure_option('filter_host_parents', config_file) == regex
         # Update Blacklist and check the result
@@ -273,14 +285,16 @@ class TestVirtWhoConfigforEsx:
         assert result['connection']['filtering'] == 'Blacklist'
         assert result['connection']['excluded-hosts'] == regex
         assert result['connection']['exclude-host-parents'] == regex
-        deploy_configure_by_command(command, form_data['hypervisor-type'])
+        deploy_configure_by_command(
+            command, form_data['hypervisor-type'], org=module_manifest_org.label
+        )
         assert get_configure_option('exclude_hosts', config_file) == regex
         assert get_configure_option('exclude_host_parents', config_file) == regex
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, form_data, virtwho_config):
+    def test_positive_proxy_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify http_proxy option by hammer virt-who-config update"
 
         :id: 409d108e-e814-482b-93ed-09db89d21dda
@@ -294,7 +308,9 @@ class TestVirtWhoConfigforEsx:
         :BZ: 1902199
         """
         # Check the https proxy option, update it via http proxy name
-        https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy()
+        https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(
+            org_name=module_manifest_org.name
+        )
         no_proxy = 'test.satellite.com'
         VirtWhoConfig.update(
             {'id': virtwho_config['id'], 'http-proxy': https_proxy_name, 'no-proxy': no_proxy}
@@ -302,22 +318,30 @@ class TestVirtWhoConfigforEsx:
         result = VirtWhoConfig.info({'id': virtwho_config['id']})
         assert result['http-proxy']['http-proxy-name'] == https_proxy_name
         assert result['connection']['ignore-proxy'] == no_proxy
-        command = get_configure_command(virtwho_config['id'])
-        deploy_configure_by_command(command, form_data['hypervisor-type'])
+        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+        deploy_configure_by_command(
+            command, form_data['hypervisor-type'], org=module_manifest_org.label
+        )
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
 
         # Check the http proxy option, update it via http proxy id
-        http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(type='http')
+        http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
+            http_type='http', org_name=module_manifest_org.name
+        )
         VirtWhoConfig.update({'id': virtwho_config['id'], 'http-proxy-id': http_proxy_id})
-        deploy_configure_by_command(command, form_data['hypervisor-type'])
+        deploy_configure_by_command(
+            command, form_data['hypervisor-type'], org=module_manifest_org.label
+        )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
 
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_rhsm_option(self, form_data, virtwho_config, default_sat):
+    def test_positive_rhsm_option(
+        self, module_manifest_org, form_data, virtwho_config, default_sat
+    ):
         """Verify rhsm options in the configure file"
 
         :id: b5b93d4d-e780-41c0-9eaa-2407cc1dcc9b
@@ -331,8 +355,10 @@ class TestVirtWhoConfigforEsx:
         :CaseImportance: Medium
         """
         config_file = get_configure_file(virtwho_config['id'])
-        command = get_configure_command(virtwho_config['id'])
-        deploy_configure_by_command(command, form_data['hypervisor-type'])
+        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+        deploy_configure_by_command(
+            command, form_data['hypervisor-type'], org=module_manifest_org.label
+        )
         rhsm_username = get_configure_option('rhsm_username', config_file)
         assert not User.exists(search=('login', rhsm_username))
         assert get_configure_option('rhsm_hostname', config_file) == default_sat.hostname
@@ -341,7 +367,7 @@ class TestVirtWhoConfigforEsx:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_post_hypervisors(self, default_sat):
+    def test_positive_post_hypervisors(self, function_org, default_sat):
         """Post large json file to /rhsm/hypervisors"
 
         :id: e344c9d2-3538-4432-9a74-b025e9ef852d
@@ -357,9 +383,8 @@ class TestVirtWhoConfigforEsx:
 
         :BZ: 1637042, 1769680
         """
-        org = Org.info({'name': DEFAULT_ORG})
         data = hypervisor_json_create(hypervisors=100, guests=10)
-        url = f"{default_sat.url}/rhsm/hypervisors/{org['label']}"
+        url = f"{default_sat.url}/rhsm/hypervisors/{function_org.label}"
         auth = (settings.server.admin_username, settings.server.admin_password)
         result = requests.post(url, auth=auth, verify=False, json=data)
         if result.status_code != 200:
@@ -370,7 +395,9 @@ class TestVirtWhoConfigforEsx:
                 assert result.status_code == 200
 
     @pytest.mark.tier2
-    def test_positive_foreman_packages_protection(self, form_data, virtwho_config):
+    def test_positive_foreman_packages_protection(
+        self, module_manifest_org, form_data, virtwho_config
+    ):
         """foreman-protector should allow virt-who to be installed
 
         :id: 635ef99b-c5a3-4ac4-a0f1-09f7036d116e
@@ -388,8 +415,10 @@ class TestVirtWhoConfigforEsx:
         :BZ: 1783987
         """
         virtwho_package_locked()
-        command = get_configure_command(virtwho_config['id'])
-        deploy_configure_by_command(command, form_data['hypervisor-type'])
+        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+        deploy_configure_by_command(
+            command, form_data['hypervisor-type'], org=module_manifest_org.label
+        )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
         ]

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -23,7 +23,6 @@ from robottelo.cli.host import Host
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -32,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat):
+def form_data(default_sat, module_manifest_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -40,7 +39,7 @@ def form_data(default_sat):
         'hypervisor-id': 'hostname',
         'hypervisor-type': settings.virtwho.hyperv.hypervisor_type,
         'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
-        'organization-id': 1,
+        'organization-id': module_manifest_org.id,
         'filtering-mode': 'none',
         'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
@@ -56,7 +55,7 @@ def virtwho_config(form_data):
 
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
         :id: 7cc0ad4f-e185-4d63-a2f5-1cb0245faa6c
@@ -68,9 +67,9 @@ class TestVirtWhoConfigforHyperv:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'])
+        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True
+            command, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -82,7 +81,9 @@ class TestVirtWhoConfigforHyperv:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -95,7 +96,9 @@ class TestVirtWhoConfigforHyperv:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, module_manifest_org, form_data, virtwho_config
+    ):
         """Verify " hammer virt-who-config fetch"
 
         :id: 22dc8068-c843-4ca0-acbe-0b2aef8ece31
@@ -109,7 +112,7 @@ class TestVirtWhoConfigforHyperv:
         assert virtwho_config['status'] == 'No Report Yet'
         script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True
+            script, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -121,7 +124,9 @@ class TestVirtWhoConfigforHyperv:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -134,7 +139,7 @@ class TestVirtWhoConfigforHyperv:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 8e234492-33cb-4523-abb3-582626ad704c
@@ -151,8 +156,10 @@ class TestVirtWhoConfigforHyperv:
             result = VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'])
-            deploy_configure_by_command(command, form_data['hypervisor-type'])
+            command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor-type'], org=module_manifest_org.label
+            )
             assert get_configure_option('hypervisor_id', config_file) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -23,7 +23,6 @@ from robottelo.cli.host import Host
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
@@ -32,14 +31,14 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat):
+def form_data(default_sat, module_manifest_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
         'interval': '60',
         'hypervisor-id': 'hostname',
         'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization-id': 1,
+        'organization-id': module_manifest_org.id,
         'filtering-mode': 'none',
         'satellite-url': default_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
@@ -55,7 +54,7 @@ def virtwho_config(form_data):
 @pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
         :id: d0b109f5-2699-43e4-a6cd-d682204d97a7
@@ -67,9 +66,9 @@ class TestVirtWhoConfigforKubevirt:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'])
+        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True
+            command, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -81,7 +80,9 @@ class TestVirtWhoConfigforKubevirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -94,7 +95,9 @@ class TestVirtWhoConfigforKubevirt:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, module_manifest_org, form_data, virtwho_config
+    ):
         """Verify " hammer virt-who-config fetch"
 
         :id: 273df8e0-5ef5-47d9-9567-543157be7dd8
@@ -108,7 +111,7 @@ class TestVirtWhoConfigforKubevirt:
         assert virtwho_config['status'] == 'No Report Yet'
         script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True
+            script, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -120,7 +123,9 @@ class TestVirtWhoConfigforKubevirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': DEFAULT_ORG, 'search': sku})
+            subscriptions = Subscription.list(
+                {'organization': module_manifest_org.label, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -133,7 +138,7 @@ class TestVirtWhoConfigforKubevirt:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 57b89c7e-538e-4ab8-98b5-af4b9f587792
@@ -150,8 +155,10 @@ class TestVirtWhoConfigforKubevirt:
             result = VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'])
-            deploy_configure_by_command(command, form_data['hypervisor-type'])
+            command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+            deploy_configure_by_command(
+                command, form_data['hypervisor-type'], org=module_manifest_org.label
+            )
             assert get_configure_option('hypervisor_id', config_file) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -7,7 +7,7 @@ from robottelo.logging import logger
 
 
 @pytest.fixture(scope='module')
-def module_user(request, default_sat, module_org, module_location):
+def module_user(request, default_sat, module_manifest_org, default_location):
     """Creates admin user with default org set to module org and shares that
     user for all tests in the same test module. User's login contains test
     module name as a prefix.
@@ -21,8 +21,8 @@ def module_user(request, default_sat, module_org, module_location):
     logger.debug('Creating session user %r', login)
     user = default_sat.api.User(
         admin=True,
-        default_organization=module_org,
-        default_location=module_location,
+        default_organization=module_manifest_org,
+        default_location=default_location,
         description=f'created automatically by airgun for module "{test_module_name}"',
         login=login,
         password=password,

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -55,7 +55,7 @@ def form_data():
 
 class TestVirtwhoConfigforEsx:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, session, form_data):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: 44f93ec8-a59a-42a4-ab30-edc554b022b2
@@ -78,7 +78,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(name)
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True
+                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -92,7 +92,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, session, form_data):
+    def test_positive_deploy_configure_by_script(self, module_manifest_org, session, form_data):
         """Verify configure created and deployed with script.
 
         :id: d64332fb-a6e0-4864-9f8b-2406223fcdcc
@@ -115,7 +115,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(name)
             script = values['deploy']['script']
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True
+                script, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -129,7 +129,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_debug_option(self, session, form_data):
+    def test_positive_debug_option(self, module_manifest_org, session, form_data):
         """Verify debug checkbox and the value changes of VIRTWHO_DEBUG
 
         :id: adb435c4-d02b-47b6-89f5-dce9a4ff7939
@@ -147,19 +147,23 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+            config_command = get_configure_command(config_id, module_manifest_org.label)
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '1'
             session.virtwho_configure.edit(name, {'debug': False})
             results = session.virtwho_configure.read(name)
             assert results['overview']['debug'] is False
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '0'
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_interval_option(self, session, form_data):
+    def test_positive_interval_option(self, module_manifest_org, session, form_data):
         """Verify interval dropdown options and the value changes of VIRTWHO_INTERVAL.
 
         :id: 731f8361-38d4-40b9-9530-8d785d61eaab
@@ -177,7 +181,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
+            config_command = get_configure_command(config_id, module_manifest_org.label)
             intervals = {
                 'Every hour': '3600',
                 'Every 2 hours': '7200',
@@ -192,13 +196,15 @@ class TestVirtwhoConfigforEsx:
                 session.virtwho_configure.edit(name, {'interval': option})
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['interval'] == option
-                deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+                deploy_configure_by_command(
+                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                )
                 assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, session, form_data):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: cc494bd9-51d9-452a-bfa9-5cdcafef5197
@@ -216,7 +222,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
+            config_command = get_configure_command(config_id, module_manifest_org.label)
             config_file = get_configure_file(config_id)
             # esx and rhevm support hwuuid option
             values = ['uuid', 'hostname', 'hwuuid']
@@ -224,13 +230,15 @@ class TestVirtwhoConfigforEsx:
                 session.virtwho_configure.edit(name, {'hypervisor_id': value})
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['hypervisor_id'] == value
-                deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+                deploy_configure_by_command(
+                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                )
                 assert get_configure_option('hypervisor_id', config_file) == value
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_filtering_option(self, session, form_data):
+    def test_positive_filtering_option(self, module_manifest_org, session, form_data):
         """Verify Filtering dropdown options.
 
         :id: e17dda14-79cd-4cd2-8f29-60970b24a905
@@ -250,7 +258,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
+            config_command = get_configure_command(config_id, module_manifest_org.label)
             config_file = get_configure_file(config_id)
             regex = '.*redhat.com'
             whitelist = {'filtering': 'Whitelist', 'filtering_content.filter_hosts': regex}
@@ -263,7 +271,9 @@ class TestVirtwhoConfigforEsx:
             results = session.virtwho_configure.read(name)
             assert results['overview']['filter_hosts'] == regex
             assert results['overview']['filter_host_parents'] == regex
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert regex == get_configure_option('filter_hosts', config_file)
             assert regex == get_configure_option('filter_host_parents', config_file)
             # Update Blacklist and check the result
@@ -271,14 +281,16 @@ class TestVirtwhoConfigforEsx:
             results = session.virtwho_configure.read(name)
             assert results['overview']['exclude_hosts'] == regex
             assert results['overview']['exclude_host_parents'] == regex
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert regex == get_configure_option('exclude_hosts', config_file)
             assert regex == get_configure_option('exclude_host_parents', config_file)
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, session, form_data):
+    def test_positive_proxy_option(self, module_manifest_org, session, form_data):
         """Verify 'HTTP Proxy' and 'Ignore Proxy' options.
 
         :id: 6659d577-0135-4bf0-81af-14b930011536
@@ -290,28 +302,36 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        https_proxy, https_proxy_name, https_proxy_id = create_http_proxy()
-        http_proxy, http_proxy_name, http_proxy_id = create_http_proxy(type='http')
+        https_proxy, https_proxy_name, https_proxy_id = create_http_proxy(
+            org_name=module_manifest_org.name
+        )
+        http_proxy, http_proxy_name, http_proxy_id = create_http_proxy(
+            http_type='http', org_name=module_manifest_org.name
+        )
         name = gen_string('alpha')
         form_data['name'] = name
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
+            config_command = get_configure_command(config_id, module_manifest_org.label)
             no_proxy = 'test.satellite.com'
             # Check the https proxy and No_PROXY settings
             session.virtwho_configure.edit(name, {'proxy': https_proxy, 'no_proxy': no_proxy})
             results = session.virtwho_configure.read(name)
             assert results['overview']['proxy'] == https_proxy
             assert results['overview']['no_proxy'] == no_proxy
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy
             assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
             # Check the http proxy setting
             session.virtwho_configure.edit(name, {'proxy': http_proxy})
             results = session.virtwho_configure.read(name)
             assert results['overview']['proxy'] == http_proxy
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
@@ -352,7 +372,7 @@ class TestVirtwhoConfigforEsx:
                 assert sorted(assigned_permissions) == sorted(role_filters)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_configs_widget(self, session, form_data):
+    def test_positive_virtwho_configs_widget(self, module_manifest_org, session, form_data):
         """Check if Virt-who Configurations Status Widget is working in the Dashboard UI
 
         :id: 5d61ce00-a640-4823-89d4-7b1d02b50ea6
@@ -387,8 +407,10 @@ class TestVirtwhoConfigforEsx:
             assert values['latest_config'] == 'No configuration found'
             # Check the 'Status' changed after deployed the virt-who config
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, org_name)
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+            config_command = get_configure_command(config_id, module_manifest_org.label)
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             expected_values = [
                 {'Configuration Status': 'No Reports', 'Count': '0'},
@@ -405,7 +427,7 @@ class TestVirtwhoConfigforEsx:
             session.organization.delete(org_name)
 
     @pytest.mark.tier2
-    def test_positive_delete_configure(self, session, form_data):
+    def test_positive_delete_configure(self, module_manifest_org, session, form_data):
         """Verify when a config is deleted the associated user is deleted.
 
         :id: 0e66dcf6-dc64-4fb2-b8a9-518f5adfa800
@@ -425,8 +447,10 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+            config_command = get_configure_command(config_id, module_manifest_org.label)
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
@@ -434,7 +458,9 @@ class TestVirtwhoConfigforEsx:
             assert get_virtwho_status() == 'logerror'
 
     @pytest.mark.tier2
-    def test_positive_virtwho_reporter_role(self, session, test_name, form_data):
+    def test_positive_virtwho_reporter_role(
+        self, module_manifest_org, session, test_name, form_data
+    ):
         """Verify the virt-who reporter role can TRULY work.
 
         :id: cd235ab0-d89c-464b-98d6-9d090ac40d8f
@@ -463,7 +489,9 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.create(form_data)
             values = session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
-            deploy_configure_by_command(command, form_data['hypervisor_type'])
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Update the virt-who config file
             config_id = get_configure_id(config_name)
@@ -486,7 +514,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_viewer_role(self, session, test_name, form_data):
+    def test_positive_virtwho_viewer_role(self, module_manifest_org, session, test_name, form_data):
         """Verify the virt-who viewer role can TRULY work.
 
         :id: bf3be2e4-3853-41cc-9b3e-c8677f0b8c5f
@@ -515,7 +543,9 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.create(form_data)
             values = session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
-            deploy_configure_by_command(command, form_data['hypervisor_type'])
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Check the permissioin of Virt-who Viewer
             session.user.update(username, {'roles.resources.assigned': ['Virt-who Viewer']})
@@ -544,7 +574,9 @@ class TestVirtwhoConfigforEsx:
             assert not session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_manager_role(self, session, test_name, form_data):
+    def test_positive_virtwho_manager_role(
+        self, module_manifest_org, session, test_name, form_data
+    ):
         """Verify the virt-who manager role can TRULY work.
 
         :id: a72023fb-7b23-4582-9adc-c5227dc7859c
@@ -572,7 +604,9 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.create(form_data)
             values = session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
-            deploy_configure_by_command(command, form_data['hypervisor_type'])
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_manifest_org.label
+            )
             assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Check the permissioin of Virt-who Manager
             session.user.update(username, {'roles.resources.assigned': ['Virt-who Manager']})
@@ -586,7 +620,9 @@ class TestVirtwhoConfigforEsx:
                 # view_virt_who_config
                 values = newsession.virtwho_configure.read(new_virt_who_name)
                 command = values['deploy']['command']
-                deploy_configure_by_command(command, form_data['hypervisor_type'])
+                deploy_configure_by_command(
+                    command, form_data['hypervisor_type'], org=module_manifest_org.label
+                )
                 assert newsession.virtwho_configure.search(new_virt_who_name)[0]['Status'] == 'ok'
                 # edit_virt_who_config
                 modify_name = gen_string('alpha')
@@ -600,7 +636,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_overview_label_name(self, form_data, session):
+    def test_positive_overview_label_name(self, module_manifest_org, form_data, session):
         """Verify the label name on virt-who config Overview Page.
 
         :id: 21df8175-bb41-422e-a263-8677bc3a9565
@@ -616,7 +652,7 @@ class TestVirtwhoConfigforEsx:
         name = gen_string('alpha')
         form_data['name'] = name
         hypervisor_type = form_data['hypervisor_type']
-        http_proxy_url, proxy_name, proxy_id = create_http_proxy()
+        http_proxy_url, proxy_name, proxy_id = create_http_proxy(org_name=module_manifest_org)
         form_data['proxy'] = http_proxy_url
         form_data['no_proxy'] = 'test.satellite.com'
         regex = '.*redhat.com'
@@ -664,7 +700,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_last_checkin_status(self, form_data, session):
+    def test_positive_last_checkin_status(self, module_manifest_org, form_data, session):
         """Verify the Last Checkin status on Content Hosts Page.
 
         :id: 7448d482-d05c-4727-8980-176586e9e4a7
@@ -686,7 +722,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(name, widget_names='deploy.command')
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True
+                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             time_now = session.browser.get_client_datetime()
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -302,11 +302,9 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        https_proxy, https_proxy_name, https_proxy_id = create_http_proxy(
-            org_name=module_manifest_org.name
-        )
+        https_proxy, https_proxy_name, https_proxy_id = create_http_proxy(org=module_manifest_org)
         http_proxy, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org_name=module_manifest_org.name
+            http_type='http', org=module_manifest_org
         )
         name = gen_string('alpha')
         form_data['name'] = name
@@ -652,7 +650,7 @@ class TestVirtwhoConfigforEsx:
         name = gen_string('alpha')
         form_data['name'] = name
         hypervisor_type = form_data['hypervisor_type']
-        http_proxy_url, proxy_name, proxy_id = create_http_proxy(org_name=module_manifest_org)
+        http_proxy_url, proxy_name, proxy_id = create_http_proxy(org=module_manifest_org)
         form_data['proxy'] = http_proxy_url
         form_data['no_proxy'] = 'test.satellite.com'
         regex = '.*redhat.com'

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -44,7 +44,7 @@ def form_data():
 
 class TestVirtwhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, session, form_data):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: 16f6d8c3-332d-4e36-bc19-028955b2bbc4
@@ -67,7 +67,7 @@ class TestVirtwhoConfigforHyperv:
             values = session.virtwho_configure.read(name)
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True
+                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -81,7 +81,7 @@ class TestVirtwhoConfigforHyperv:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, session, form_data):
+    def test_positive_deploy_configure_by_script(self, module_manifest_org, session, form_data):
         """Verify configure created and deployed with script.
 
         :id: b0401417-3a6e-4a54-b8e8-22d290813da3
@@ -104,7 +104,7 @@ class TestVirtwhoConfigforHyperv:
             values = session.virtwho_configure.read(name)
             script = values['deploy']['script']
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True
+                script, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -118,7 +118,7 @@ class TestVirtwhoConfigforHyperv:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, session, form_data):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: f2efc018-d57e-4dc5-895e-53af320237de
@@ -136,14 +136,16 @@ class TestVirtwhoConfigforHyperv:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
+            config_command = get_configure_command(config_id, module_manifest_org.label)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:
                 session.virtwho_configure.edit(name, {'hypervisor_id': value})
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['hypervisor_id'] == value
-                deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+                deploy_configure_by_command(
+                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                )
                 assert get_configure_option('hypervisor_id', config_file) == value
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -42,7 +42,7 @@ def form_data():
 
 class TestVirtwhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, session, form_data):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: 7b2a1b08-f33c-44f4-ad2e-317b6c44b938
@@ -65,7 +65,7 @@ class TestVirtwhoConfigforKubevirt:
             values = session.virtwho_configure.read(name)
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True
+                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -79,7 +79,7 @@ class TestVirtwhoConfigforKubevirt:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, session, form_data):
+    def test_positive_deploy_configure_by_script(self, module_manifest_org, session, form_data):
         """Verify configure created and deployed with script.
 
         :id: b3903ccb-04cc-4867-b7ed-d5053d2bfe03
@@ -102,7 +102,7 @@ class TestVirtwhoConfigforKubevirt:
             values = session.virtwho_configure.read(name)
             script = values['deploy']['script']
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True
+                script, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -116,7 +116,7 @@ class TestVirtwhoConfigforKubevirt:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, session, form_data):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: 09826cc0-aa49-4355-8980-8097511eb7d7
@@ -134,14 +134,16 @@ class TestVirtwhoConfigforKubevirt:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
+            config_command = get_configure_command(config_id, module_manifest_org.label)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:
                 session.virtwho_configure.edit(name, {'hypervisor_id': value})
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['hypervisor_id'] == value
-                deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+                deploy_configure_by_command(
+                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                )
                 assert get_configure_option('hypervisor_id', config_file) == value
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -43,7 +43,7 @@ def form_data():
 
 class TestVirtwhoConfigforLibvirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, session, form_data):
+    def test_positive_deploy_configure_by_id(self, module_manifest_org, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: ae37ea79-f99c-4511-ace9-a7de26d6db40
@@ -66,7 +66,7 @@ class TestVirtwhoConfigforLibvirt:
             values = session.virtwho_configure.read(name)
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True
+                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -80,7 +80,7 @@ class TestVirtwhoConfigforLibvirt:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, session, form_data):
+    def test_positive_deploy_configure_by_script(self, module_manifest_org, session, form_data):
         """Verify configure created and deployed with script.
 
         :id: 3655a501-ab05-4724-945a-7f6e6878091d
@@ -103,7 +103,7 @@ class TestVirtwhoConfigforLibvirt:
             values = session.virtwho_configure.read(name)
             script = values['deploy']['script']
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True
+                script, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -117,7 +117,7 @@ class TestVirtwhoConfigforLibvirt:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, session, form_data):
+    def test_positive_hypervisor_id_option(self, module_manifest_org, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: b8b2b272-89f2-45d0-b922-6e988b20808b
@@ -135,14 +135,16 @@ class TestVirtwhoConfigforLibvirt:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id)
+            config_command = get_configure_command(config_id, module_manifest_org.label)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:
                 session.virtwho_configure.edit(name, {'hypervisor_id': value})
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['hypervisor_id'] == value
-                deploy_configure_by_command(config_command, form_data['hypervisor_type'])
+                deploy_configure_by_command(
+                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                )
                 assert get_configure_option('hypervisor_id', config_file) == value
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)


### PR DESCRIPTION
**Description**
Update the organization from `default_org` to `module_manifest_org` for virtwho plugin cases to fix failed cases. Those errors were imported from https://github.com/SatelliteQE/robottelo/pull/8993

**Test Result**
All test cases work fine locally.

