### PR TITLE
Add test to sync ansible-collection repo to capsule

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1035,6 +1035,12 @@ class Capsule(ContentHost):
     def url(self):
         return f'https://{self.hostname}'
 
+    @cached_property
+    def url_katello_ca_rpm(self):
+        """Return the Katello cert RPM URL"""
+        pub_url = urlunsplit(('http', self.hostname, 'pub/', '', ''))  # use url with https?
+        return urljoin(pub_url, 'katello-ca-consumer-latest.noarch.rpm')
+
     @property
     def rex_pub_key(self):
         return self.execute(f'cat {self.rex_key_path}').stdout.strip()
@@ -1208,12 +1214,6 @@ class Satellite(Capsule):
             return self.execute('rpm -q satellite').stdout.split('-')[1]
         else:
             return 'upstream'
-
-    @cached_property
-    def url_katello_ca_rpm(self):
-        """Return the Katello cert RPM URL"""
-        pub_url = urlunsplit(('http', self.hostname, 'pub/', '', ''))  # use url with https?
-        return urljoin(pub_url, 'katello-ca-consumer-latest.noarch.rpm')
 
     def capsule_certs_generate(self, capsule, cert_path=None, **extra_kwargs):
         """Generate capsule certs, returning the cert path and the installer command args"""


### PR DESCRIPTION
Adding a test to sync the _ansible-collection_ type repo to the Satellite, Capsule and consume it on a content host.

Test result on 6.10.1.1:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_sync_collection_repo
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, reportportal-5.0.8, ibutsu-1.16, mock-3.6.1
collected 1 item                                                                                                                                                          

tests/foreman/api/test_contentmanagement.py .                                                                                                                       [100%]
...
=============================================================== 1 passed, 3 warnings in 1422.45s (0:23:42) ================================================================
```