### PR TITLE
#9215 package_install with ReX

### DIFF
--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -126,10 +126,13 @@ class Host(Base):
         return facts
 
     @classmethod
-    def package_install(cls, options):
+    def package_install(cls, hosts='', package=''):
         """Install packages remotely."""
-        cls.command_sub = 'package install'
-        return cls.execute(cls._construct_command(options), output_format='csv')
+
+        return cls.execute(
+            f'job-invocation create --feature katello_package_install'
+            f' --search-query "{hosts}" --inputs "package={package}"'
+        )
 
     @classmethod
     def package_list(cls, options):

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -908,12 +908,17 @@ def test_positive_generate_hostpkgcompare(
             hosts_info.append(Host.info({'name': client.hostname}))
             client.enable_repo(REPOS['rhst7']['id'])
             client.install_katello_agent()
+            # Add ReX key
+            client.add_rex_key(satellite=default_sat)
         hosts_info.sort(key=lambda host: host['name'])
 
         host1, host2 = hosts_info
-        Host.package_install({'host-id': host1['id'], 'packages': FAKE_0_CUSTOM_PACKAGE_NAME})
-        Host.package_install({'host-id': host1['id'], 'packages': FAKE_1_CUSTOM_PACKAGE})
-        Host.package_install({'host-id': host2['id'], 'packages': FAKE_2_CUSTOM_PACKAGE})
+        Host.package_install(hosts=f"id={host1['id']}", package=FAKE_0_CUSTOM_PACKAGE_NAME)
+        Host.package_install(hosts=f"id={host1['id']}", package=FAKE_1_CUSTOM_PACKAGE)
+        Host.package_install(hosts=f"id={host2['id']}", package=FAKE_2_CUSTOM_PACKAGE)
+        # Host.package_install({'host-id': host1['id'], 'packages': FAKE_0_CUSTOM_PACKAGE_NAME})
+        # Host.package_install({'host-id': host1['id'], 'packages': FAKE_1_CUSTOM_PACKAGE})
+        # Host.package_install({'host-id': host2['id'], 'packages': FAKE_2_CUSTOM_PACKAGE})
 
         result = ReportTemplate.generate(
             {

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -916,9 +916,6 @@ def test_positive_generate_hostpkgcompare(
         Host.package_install(hosts=f"id={host1['id']}", package=FAKE_0_CUSTOM_PACKAGE_NAME)
         Host.package_install(hosts=f"id={host1['id']}", package=FAKE_1_CUSTOM_PACKAGE)
         Host.package_install(hosts=f"id={host2['id']}", package=FAKE_2_CUSTOM_PACKAGE)
-        # Host.package_install({'host-id': host1['id'], 'packages': FAKE_0_CUSTOM_PACKAGE_NAME})
-        # Host.package_install({'host-id': host1['id'], 'packages': FAKE_1_CUSTOM_PACKAGE})
-        # Host.package_install({'host-id': host2['id'], 'packages': FAKE_2_CUSTOM_PACKAGE})
 
         result = ReportTemplate.generate(
             {


### PR DESCRIPTION
This needs discussion before getting merged.
This is intended to fix #9215 where a method that is being deprecated is being used for package installation, resulting to a failure. I decided to fix this by the way recommended in the error message, that is, by using remote execution. I decided to not stick to backwards compatibility since it would make the function usage less straightforward for the future and it shouldn't be hard to fix all usages of this function in this repo.
The fix is in `host.py` and an example of the required changes per usage are in `test_reporttemplates.py`.
Things to consider:
- Is it ok to make this backwards incompatible?
- Should all the invocations of the function be used as part of this PR, or as a separate PR?
- Is it a good decision to use ReX, as recommended?
- Is it ok that `add_rex_key` must be called beforehand or should it be called as part of `package_install` function? If the latter, it would require the function to obtain a host object.