### PR TITLE
[6.9.z] remove pit_client from 1 non-compliant test

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -636,7 +636,6 @@ class TestAnsibleREX:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    @pytest.mark.pit_client
     @pytest.mark.pit_server
     @pytest.mark.parametrize(
         'fixture_vmsetup',


### PR DESCRIPTION
The test  does not use the proper VM fixtures so it ignores the PIT deploy workflow. Thus it provides VM running incorrect rhel version.

backport of 99b70756a965db1af0dfb770814033d71c8cb774