### PR TITLE
Initial RemoteDB config and foreman-maintain CLI's

### DIFF
--- a/conf/remotedb.yaml.template
+++ b/conf/remotedb.yaml.template
@@ -1,0 +1,21 @@
+REMOTEDB:
+  # Unconfigured Satellite hostname
+  SERVER: <server>
+  # PostgreSQL DB Server
+  DB_SERVER: <db_server>
+  # Databases
+  foreman:
+    username: foreman
+    db_name: foreman
+  candlepin:
+    username: candlepin
+    db_name: candlepin
+  pulp:
+    username: pulp
+    db_name: pulpcore
+  # Common databases passwords
+  db_password:
+  # SSL connection for Satellite and database server
+  SSL: ON
+  # DB port
+  PORT: 5432

--- a/conftest.py
+++ b/conftest.py
@@ -30,6 +30,7 @@ pytest_plugins = [
     'pytest_fixtures.component.host',
     'pytest_fixtures.component.hostgroup',
     'pytest_fixtures.component.lce',
+    'pytest_fixtures.component.maintain',
     'pytest_fixtures.component.os',
     'pytest_fixtures.component.oscap',
     'pytest_fixtures.component.provision_azure',

--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -1,0 +1,16 @@
+# Satellite-maintain fixtures
+import pytest
+from broker import VMBroker
+
+from robottelo.config import settings
+from robottelo.hosts import Satellite
+
+
+@pytest.fixture(scope='module')
+def sat_maintain(satellite_factory):
+    if settings.remotedb.server:
+        yield Satellite(settings.remotedb.server)
+    else:
+        sat = satellite_factory()
+        yield sat
+        VMBroker(hosts=[sat]).checkin()

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -66,6 +66,7 @@ class Base:
 
     command_base = None  # each inherited instance should define this
     command_sub = None  # specific to instance, like: create, update, etc.
+    command_end = None  # extending commands like for directory to pass
     command_requires_org = False  # True when command requires organization-id
     hostname = None  # Now used for Satellite class hammer execution
     logger = logger
@@ -253,6 +254,20 @@ class Base:
             return cls._handle_response(response, ignore_stderr=ignore_stderr)
 
     @classmethod
+    def fm_execute(
+        cls,
+        command,
+        hostname=None,
+        timeout=None,
+    ):
+        """Executes the foreman-maintain cli commands on the server via ssh"""
+        from robottelo.ssh import get_client
+
+        client = get_client(hostname=hostname or cls.hostname)
+        result = client.execute(f'foreman-maintain {command}', timeout=timeout)
+        return result
+
+    @classmethod
     def exists(cls, options=None, search=None):
         """Search for an entity using the query ``search[0]="search[1]"``
 
@@ -405,6 +420,6 @@ class Base:
                 if isinstance(val, list):
                     val = ','.join(str(el) for el in val)
                 tail += f' --{key}="{val}"'
-        cmd = f"{cls.command_base} {cls.command_sub or ''} {tail.strip()}"
+        cmd = f"{cls.command_base} {cls.command_sub or ''} {tail.strip()} {cls.command_end or ''}"
 
         return cmd

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -7,6 +7,7 @@ from robottelo import ssh
 from robottelo.cli import hammer
 from robottelo.config import settings
 from robottelo.logging import logger
+from robottelo.ssh import get_client
 
 
 class CLIError(Exception):
@@ -261,8 +262,6 @@ class Base:
         timeout=None,
     ):
         """Executes the foreman-maintain cli commands on the server via ssh"""
-        from robottelo.ssh import get_client
-
         client = get_client(hostname=hostname or cls.hostname)
         result = client.execute(f'foreman-maintain {command}', timeout=timeout)
         return result

--- a/robottelo/cli/fm_backup.py
+++ b/robottelo/cli/fm_backup.py
@@ -1,0 +1,32 @@
+"""
+Usage:
+    foreman-maintain backup [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands:
+    online                        Keep services online during backup
+    offline                       Shut down services to preserve consistent backup
+    snapshot                      Use snapshots of the databases to create backup
+
+Options:
+    -h, --help                    print help
+"""
+from robottelo.cli.base import Base
+
+
+class Backup(Base):
+    """Manipulates Foreman-maintain's backup command"""
+
+    command_base = "backup"
+
+    @classmethod
+    def run_backup(cls, options=None, backup_dir='/tmp/', backup_type='online', timeout=None):
+        """Build foreman-maintain backup online/offline/snapshot"""
+        cls.command_sub = backup_type
+        cls.command_end = backup_dir
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options), timeout=timeout)

--- a/robottelo/cli/fm_backup.py
+++ b/robottelo/cli/fm_backup.py
@@ -20,13 +20,12 @@ from robottelo.cli.base import Base
 class Backup(Base):
     """Manipulates Foreman-maintain's backup command"""
 
-    command_base = "backup"
+    command_base = 'backup'
 
     @classmethod
-    def run_backup(cls, options=None, backup_dir='/tmp/', backup_type='online', timeout=None):
+    def run_backup(cls, backup_dir='/tmp/', backup_type='online', options=None, timeout=None):
         """Build foreman-maintain backup online/offline/snapshot"""
         cls.command_sub = backup_type
         cls.command_end = backup_dir
-        if options is None:
-            options = {}
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options), timeout=timeout)

--- a/robottelo/cli/fm_health.py
+++ b/robottelo/cli/fm_health.py
@@ -1,0 +1,47 @@
+"""
+Usage:
+    foreman-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands:
+    list                          List the checks based on criteria
+    list-tags                     List the tags to use for filtering checks
+    check                         Run the health checks against the system
+
+Options:
+    -h, --help                    print help
+"""
+from robottelo.cli.base import Base
+
+
+class Health(Base):
+    """Manipulates Foreman-maintain's health command"""
+
+    command_base = "health"
+
+    @classmethod
+    def check(cls, options=None):
+        """Build foreman-maintain health check"""
+        cls.command_sub = "check"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def list(cls, options=None):
+        """Build foreman-maintain health list"""
+        cls.command_sub = "list"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def list_tags(cls, options=None):
+        """Build foreman-maintain health list-tags"""
+        cls.command_sub = "list-tags"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))

--- a/robottelo/cli/fm_health.py
+++ b/robottelo/cli/fm_health.py
@@ -20,28 +20,25 @@ from robottelo.cli.base import Base
 class Health(Base):
     """Manipulates Foreman-maintain's health command"""
 
-    command_base = "health"
+    command_base = 'health'
 
     @classmethod
     def check(cls, options=None):
         """Build foreman-maintain health check"""
-        cls.command_sub = "check"
-        if options is None:
-            options = {}
+        cls.command_sub = 'check'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
     def list(cls, options=None):
         """Build foreman-maintain health list"""
-        cls.command_sub = "list"
-        if options is None:
-            options = {}
+        cls.command_sub = 'list'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
     def list_tags(cls, options=None):
         """Build foreman-maintain health list-tags"""
-        cls.command_sub = "list-tags"
-        if options is None:
-            options = {}
+        cls.command_sub = 'list-tags'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))

--- a/robottelo/cli/fm_restore.py
+++ b/robottelo/cli/fm_restore.py
@@ -18,13 +18,12 @@ from robottelo.cli.base import Base
 class Restore(Base):
     """Manipulates Foreman-maintain's restore command"""
 
-    command_base = "restore"
+    command_base = 'restore'
 
     @classmethod
-    def run(cls, options=None, backup_dir='/tmp/', timeout='30m'):
+    def run(cls, backup_dir='/tmp/', timeout='30m', options=None):
         """Build foreman-maintain restore"""
         # cls.command_sub = 'No subcommand for restore'
         cls.command_end = backup_dir
-        if options is None:
-            options = {}
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options), timeout=timeout)

--- a/robottelo/cli/fm_restore.py
+++ b/robottelo/cli/fm_restore.py
@@ -1,0 +1,30 @@
+"""
+Usage:
+    foreman-maintain restore [OPTIONS] BACKUP_DIR
+
+Parameters:
+    BACKUP_DIR                    Path to backup directory to restore
+
+Options:
+    -y, --assumeyes               Automatically answer yes for all questions
+    -w, --whitelist whitelist     Comma-separated list of labels of steps to be skipped
+    -f, --force                   Force steps that would be skipped as they were already run
+    -i, --incremental             Restore an incremental backup
+    -h, --help                    print help
+"""
+from robottelo.cli.base import Base
+
+
+class Restore(Base):
+    """Manipulates Foreman-maintain's restore command"""
+
+    command_base = "restore"
+
+    @classmethod
+    def run(cls, options=None, backup_dir='/tmp/', timeout='30m'):
+        """Build foreman-maintain restore"""
+        # cls.command_sub = 'No subcommand for restore'
+        cls.command_end = backup_dir
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options), timeout=timeout)

--- a/robottelo/cli/fm_service.py
+++ b/robottelo/cli/fm_service.py
@@ -24,60 +24,53 @@ from robottelo.cli.base import Base
 class Service(Base):
     """Manipulates Foreman-maintain's service command"""
 
-    command_base = "service"
+    command_base = 'service'
 
     @classmethod
-    def service_start(cls, options=None):
+    def start(cls, options=None):
         """Build foreman-maintain service start"""
-        cls.command_sub = "start"
-        if options is None:
-            options = {}
+        cls.command_sub = 'start'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
-    def service_stop(cls, options=None):
+    def stop(cls, options=None):
         """Build foreman-maintain service stop"""
-        cls.command_sub = "stop"
-        if options is None:
-            options = {}
+        cls.command_sub = 'stop'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
-    def service_restart(cls, options=None):
+    def restart(cls, options=None):
         """Build foreman-maintain service"""
-        cls.command_sub = "restart"
-        if options is None:
-            options = {}
+        cls.command_sub = 'restart'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
-    def service_status(cls, options=None):
+    def status(cls, options=None):
         """Build foreman-maintain service status"""
-        cls.command_sub = "status"
-        if options is None:
-            options = {}
+        cls.command_sub = 'status'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
-    def service_enable(cls, options=None):
+    def enable(cls, options=None):
         """Build foreman-maintain service enable"""
-        cls.command_sub = "enable"
-        if options is None:
-            options = {}
+        cls.command_sub = 'enable'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
-    def service_disable(cls, options=None):
+    def disable(cls, options=None):
         """Build foreman-maintain service disable"""
-        cls.command_sub = "disable"
-        if options is None:
-            options = {}
+        cls.command_sub = 'disable'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
-    def service_list(cls, options=None):
+    def list(cls, options=None):
         """Build foreman-maintain service list"""
-        cls.command_sub = "list"
-        if options is None:
-            options = {}
+        cls.command_sub = 'list'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))

--- a/robottelo/cli/fm_service.py
+++ b/robottelo/cli/fm_service.py
@@ -1,0 +1,83 @@
+"""
+Usage:
+    foreman-maintain service [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands:
+    start                         Start applicable services
+    stop                          Stop applicable services
+    restart                       Restart applicable services
+    status                        Get statuses of applicable services
+    list                          List applicable services
+    enable                        Enable applicable services
+    disable                       Disable applicable services
+
+Options:
+    -h, --help                    print help
+"""
+from robottelo.cli.base import Base
+
+
+class Service(Base):
+    """Manipulates Foreman-maintain's service command"""
+
+    command_base = "service"
+
+    @classmethod
+    def service_start(cls, options=None):
+        """Build foreman-maintain service start"""
+        cls.command_sub = "start"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def service_stop(cls, options=None):
+        """Build foreman-maintain service stop"""
+        cls.command_sub = "stop"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def service_restart(cls, options=None):
+        """Build foreman-maintain service"""
+        cls.command_sub = "restart"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def service_status(cls, options=None):
+        """Build foreman-maintain service status"""
+        cls.command_sub = "status"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def service_enable(cls, options=None):
+        """Build foreman-maintain service enable"""
+        cls.command_sub = "enable"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def service_disable(cls, options=None):
+        """Build foreman-maintain service disable"""
+        cls.command_sub = "disable"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def service_list(cls, options=None):
+        """Build foreman-maintain service list"""
+        cls.command_sub = "list"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))

--- a/robottelo/cli/fm_upgrade.py
+++ b/robottelo/cli/fm_upgrade.py
@@ -1,0 +1,47 @@
+"""
+Usage:
+    foreman-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands:
+    list-versions                 List versions this system is upgradable to
+    check                         Run pre-upgrade checks before upgrading to specified version
+    run                           Run full upgrade to a specified version
+
+Options:
+    -h, --help                    print help
+"""
+from robottelo.cli.base import Base
+
+
+class Upgrade(Base):
+    """Manipulates Foreman-maintain's health command"""
+
+    command_base = "upgrade"
+
+    @classmethod
+    def list_versions(cls, options=None):
+        """Build foreman-maintain upgrade list-versions"""
+        cls.command_sub = "list-versions"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def check(cls, options=None):
+        """Build foreman-maintain upgrade check"""
+        cls.command_sub = "check"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))
+
+    @classmethod
+    def run(cls, options=None):
+        """Build foreman-maintain upgrade run"""
+        cls.command_sub = "run"
+        if options is None:
+            options = {}
+        return cls.fm_execute(cls._construct_command(options))

--- a/robottelo/cli/fm_upgrade.py
+++ b/robottelo/cli/fm_upgrade.py
@@ -20,28 +20,25 @@ from robottelo.cli.base import Base
 class Upgrade(Base):
     """Manipulates Foreman-maintain's health command"""
 
-    command_base = "upgrade"
+    command_base = 'upgrade'
 
     @classmethod
     def list_versions(cls, options=None):
         """Build foreman-maintain upgrade list-versions"""
-        cls.command_sub = "list-versions"
-        if options is None:
-            options = {}
+        cls.command_sub = 'list-versions'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
     def check(cls, options=None):
         """Build foreman-maintain upgrade check"""
-        cls.command_sub = "check"
-        if options is None:
-            options = {}
+        cls.command_sub = 'check'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))
 
     @classmethod
     def run(cls, options=None):
         """Build foreman-maintain upgrade run"""
-        cls.command_sub = "run"
-        if options is None:
-            options = {}
+        cls.command_sub = 'run'
+        options = options or {}
         return cls.fm_execute(cls._construct_command(options))

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -279,6 +279,22 @@ VALIDATORS = dict(
             must_exist=True,
         )
     ],
+    remotedb=[
+        Validator(
+            'remotedb.server',
+            'remotedb.db_server',
+            'remotedb.common_db_password',
+            must_exist=False,
+        ),
+        Validator('remotedb.foreman.username', default='foreman'),
+        Validator('remotedb.foreman.db_name', default='foreman'),
+        Validator('remotedb.candlepin.username', default='candlepin'),
+        Validator('remotedb.candlepin.db_name', default='candlepin'),
+        Validator('remotedb.pulp.username', default='pulp'),
+        Validator('remotedb.pulp.db_name', default='pulpcore'),
+        Validator('remotedb.ssl', default=True),
+        Validator('remotedb.port', default=5432),
+    ],
     shared_function=[
         Validator('shared_function.storage', is_in=('file', 'redis'), default='file'),
         Validator('shared_function.share_timeout', lte=86400, default=86400),


### PR DESCRIPTION
**Description:**
1. Initial RemoteDB configuration for setup and upgrade, which will be used by @vsedmik in https://github.com/SatelliteQE/robottelo/pull/9201
2. Add CLI support for generating foreman-maintain commands in robottelo, with some CLI's.

Related MR:
satelliteqe-jenkins: MR#454