### PR TITLE
Deploy Arguments Lowered

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -10,7 +10,8 @@ from robottelo.hosts import Satellite
 def _resolve_deploy_args(args_dict):
     for key, val in args_dict.items():
         if isinstance(val, str) and val.startswith('this.'):
-            args_dict[key] = settings.get(val.replace('this.', ''))
+            # Args transformed into small letters and existing capital args removed
+            args_dict[key.lower()] = settings.get(args_dict.pop(key).replace('this.', ''))
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
# Problem:

satellite_factory fixture is trying to checkout satellite of version 6.1 instead of 6.10 and with unaccepted `CAPITALIZED` broker checkout deploy arguments.

Both capitalization and versioning need to be fixed.

This is causing PRT and importance tests to fail that using satellite_factory fixture OR `settings.server.deploy_arguments` conf.

Since the deploy arguments were wrong, 6.10 test was ending up checking out 7.0 satellite version as its the latest ver.

#  Solution

1. The capitalization is being fixed in this PR.
2. Double quoting the `6.10` version in server.conf so that dynaconf wont covert it to float (6.1) in CI PR.