### PR TITLE
Added tests to satellitesync

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1485,8 +1485,8 @@ class TestContentViewSync:
 
             1. Create custom product and custom repo with ansible collection
             2. Sync repo
-            4. Export library and import into another satellite
-            5. Check imported library has ansible collection in it
+            3. Export library and import into another satellite
+            4. Check imported library has ansible collection in it
 
         :expectedresults:  Imported library should have the ansible collection present in the
             imported product


### PR DESCRIPTION
```
$ pytest tests/foreman/cli/test_satellitesync.py -k test_postive_import_export_ansible_collection_repo
========================================================================= test session starts =========================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rmynar/rmynar/robottelo, configfile: pytest.ini
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, mock-3.6.1, reportportal-5.0.8, ibutsu-1.16
collected 36 items / 35 deselected / 1 selected                                                                                                                       

tests/foreman/cli/test_satellitesync.py .                                                                                                                       [100%]

============================================================ 1 passed, 35 deselected in 142.16s (0:02:22) =============================================================
$ pytest tests/foreman/cli/test_satellitesync.py -k test_negative_import_redhat_cv_without_manifest
========================================================================= test session starts =========================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rmynar/rmynar/robottelo, configfile: pytest.ini
plugins: forked-1.3.0, services-2.2.1, xdist-2.4.0, mock-3.6.1, reportportal-5.0.8, ibutsu-1.16
collected 36 items / 35 deselected / 1 selected                                                                                                                       

tests/foreman/cli/test_satellitesync.py .                                                                                                                       [100%]

============================================================ 1 passed, 35 deselected in 172.79s (0:02:52) =============================================================
```