### PR TITLE
encapsulate the cockpit sat installer under the Sat class

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -47,19 +47,7 @@ def proxy_port_range(default_sat):
 @pytest.fixture
 def install_cockpit_plugin(default_sat):
     default_sat.register_to_dogfood()
-    cmd_result = default_sat.execute(
-        'foreman-installer --enable-foreman-plugin-remote-execution-cockpit', timeout='30m'
-    )
-    if cmd_result.status != 0:
-        raise SatelliteHostError(
-            f'Error during cockpit installation, installation output: {cmd_result.stdout}'
-        )
-    cmd_result = default_sat.execute(
-        f'sshpass -p "{settings.server.ssh_password}" ssh-copy-id \
-        -i ~foreman-proxy/.ssh/id_rsa_foreman_proxy -o StrictHostKeyChecking=no localhost'
-    )
-    if cmd_result.status != 0:
-        raise SatelliteHostError(f'Error during ssh-copy-id, command output: {cmd_result.stdout}')
+    default_sat.install_cockpit()
 
 
 @pytest.fixture(scope='session')

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1374,3 +1374,13 @@ class Satellite(Capsule):
             raise SatelliteHostError(
                 f'Error during registration, command output: {cmd_result.stdout}'
             )
+
+    def install_cockpit(self):
+        cmd_result = self.execute(
+            'satellite-installer --enable-foreman-plugin-remote-execution-cockpit', timeout='30m'
+        )
+        if cmd_result.status != 0:
+            raise SatelliteHostError(
+                f'Error during cockpit installation, installation output: {cmd_result.stdout}'
+            )
+        self.add_rex_key(self)


### PR DESCRIPTION
addressing #8852 
where the install_cockpit_plugin should be moved under sat class. 

the register to dogfood was already moved.

I will rather have fixture in the test than two setup lines in this case:
```
deafult_sat.register_to_dogfood()
default_sat.install_cockpit_plugin()
```

but `satellite-installer` command in `pytest/sys` still feels weird but I don't know if there is a better place let me know if you think so :smile: 