### PR TITLE
Add :CaseComponent: to stubbed Ansible tests

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -284,6 +284,8 @@ def test_positive_ansible_job_check_mode(session):
 
     :CaseAutomation: NotAutomated
 
+    :CaseComponent: Ansible
+
     :assignee: dsynk
     """
 
@@ -306,6 +308,8 @@ def test_positive_ansible_config_report_failed_tasks_errors(session):
     :CaseLevel: System
 
     :CaseAutomation: NotAutomated
+
+    :CaseComponent: Ansible
 
     :assignee: dsynk
     """
@@ -331,6 +335,8 @@ def test_positive_ansible_config_report_changes_notice(session):
 
     :CaseAutomation: NotAutomated
 
+    :CaseComponent: Ansible
+
     :assignee: dsynk
     """
 
@@ -351,6 +357,8 @@ def test_positive_ansible_variables_imported_with_roles(session):
     :CaseLevel: System
 
     :CaseAutomation: NotAutomated
+
+    :CaseComponent: Ansible
 
     :assignee: dsynk
     """
@@ -373,6 +381,8 @@ def test_positive_roles_import_in_background(session):
 
     :CaseAutomation: NotAutomated
 
+    :CaseComponent: Ansible
+
     :assignee: dsynk
     """
 
@@ -394,6 +404,8 @@ def test_positive_ansible_roles_ignore_list(session):
     :CaseLevel: System
 
     :CaseAutomation: NotAutomated
+
+    :CaseComponent: Ansible
 
     :assignee: dsynk
     """
@@ -418,6 +430,8 @@ def test_positive_ansible_variables_installed_with_collection(session):
     :CaseLevel: System
 
     :CaseAutomation: NotAutomated
+
+    :CaseComponent: Ansible
 
     :assignee: dsynk
     """
@@ -445,6 +459,8 @@ def test_positive_install_ansible_collection_via_job_invocation(session):
 
     :CaseAutomation: NotAutomated
 
+    :CaseComponent: Ansible
+
     :assignee: dsynk
     """
 
@@ -469,6 +485,8 @@ def test_positive_set_ansible_role_order_per_host(session):
     :CaseLevel: System
 
     :CaseAutomation: NotAutomated
+
+    :CaseComponent: Ansible
 
     :assignee: dsynk
     """
@@ -497,6 +515,8 @@ def test_positive_set_ansible_role_order_per_hostgroup(session):
 
     :CaseAutomation: NotAutomated
 
+    :CaseComponent: Ansible
+
     :assignee: dsynk
     """
 
@@ -522,6 +542,8 @@ def test_positive_matcher_field_highlight(session):
     :CaseLevel: System
 
     :CaseAutomation: NotAutomated
+
+    :CaseComponent: Ansible
 
     :assignee: dsynk
     """


### PR DESCRIPTION
While reviewing my Tier 1 and 2 component test coverage, I realized that my stubbed Ansible tests did not have a `:CaseComponent:` assigned at the test level and were thus inheriting the `RemoteExecution` component from the test module. This PR adds the `Ansible` component to these stubbed tests.