### PR TITLE
Remove codecoverage analysis

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -49,9 +49,6 @@ jobs:
           pytest --collect-only --disable-pytest-warnings -m pre_upgrade tests/upgrades/
           pytest --collect-only --disable-pytest-warnings -m post_upgrade tests/upgrades/
 
-      - name: Test Robottelo Coverage
-        run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo
-
       - name: Make Docs
         run: |
           make test-docstrings
@@ -60,12 +57,6 @@ jobs:
       - name: Analysis (git diff)
         if: failure()
         run: git diff
-
-      - name: Upload Codecov Coverage
-        uses: codecov/codecov-action@v1.0.13
-        with:
-          file: coverage.xml
-          name: ${{ github.run_id }}-py-${{ matrix.python-version }}
 
 
   robottelo_container:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -54,9 +54,6 @@ jobs:
           pytest --collect-only --disable-pytest-warnings -n 2 -m pre_upgrade tests/upgrades/
           pytest --collect-only --disable-pytest-warnings -n 2 -m post_upgrade tests/upgrades/
 
-      - name: Test Robottelo Coverage
-        run: pytest --cov --cov-config=.coveragerc --cov-report=xml tests/robottelo
-
       - name: Make Docs
         run: |
           make test-docstrings
@@ -65,9 +62,3 @@ jobs:
       - name: Analysis (git diff)
         if: failure()
         run: git diff
-
-      - name: Upload Codecov Coverage
-        uses: codecov/codecov-action@v1.0.13
-        with:
-          file: coverage.xml
-          name: ${{ github.run_id }}-py-${{ matrix.python-version }}


### PR DESCRIPTION
There is very little value for these reports in a project like robottelo
They detract from the overall effect of a PR's other checks
With that in mind, I'm removing code coverage checks with this PR until
further notice.