### PR TITLE
Small fix for GHA for on_push to 6.10.z

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -4,7 +4,7 @@ name: update_robottelo_image
 on:
   push:
     branches:
-      - master
+      - 6.10.z
 
 env:
     PYCURL_SSL_LIBRARY: openssl
@@ -16,6 +16,8 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9]
+    env:
+      SATELLITE_VERSION: '6.10'
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently, on push to 6.10.z branch being pushed to `robottelo:latest`, this will add a tag for 6.10.z in quay

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>