### PR TITLE
Fixing package version for incremental update test

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -43,8 +43,8 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.role import Role
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE_NAME
 from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
+from robottelo.constants import FAKE_2_CUSTOM_PACKAGE_NAME
 from robottelo.datafactory import generate_strings_list
 from robottelo.datafactory import invalid_names_list
 from robottelo.datafactory import parametrized
@@ -3770,8 +3770,8 @@ class TestContentView:
         cli_factory.make_content_view_filter_rule(
             {
                 'content-view-filter-id': cvf['filter-id'],
-                'name': FAKE_1_CUSTOM_PACKAGE_NAME,
-                'version': 0.71,
+                'name': FAKE_2_CUSTOM_PACKAGE_NAME,
+                'version': 5.21,
             }
         )
         ContentView.publish({'id': content_view['id']})
@@ -3784,7 +3784,7 @@ class TestContentView:
         # Inc update output format is pretty weird - list of dicts where each
         # key's value is actual line from stdout
         result = [line.strip() for line_dict in result for line in line_dict.values()]
-        assert FAKE_2_CUSTOM_PACKAGE in [line.strip() for line in result]
+        assert FAKE_2_CUSTOM_PACKAGE not in [line.strip() for line in result]
         content_view = ContentView.info({'id': content_view['id']})
         assert '1.1' in [cvv_['version'] for cvv_ in content_view['versions']]
 


### PR DESCRIPTION
We found some discrepancies between errata package versions in the yum_0 and yum_1 repositories. yum_0 has a Sea_Erratum that uses walrus-0.71 while yum_1's Sea_Erratum has walrus-5.21. Since this test is using yum_1 we need to first add a filter rule for walrus-5.21 and then assert it is not in the incremental update.

```
============================= test session starts ==============================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, cov-2.12.1, ibutsu-2.0.1, xdist-2.5.0
collected 1 item

tests/foreman/cli/test_contentview.py .                                  [100%]

-------------- generated xml file: /tmp/tmp-12585Nv87mT1Zpc3E.xml --------------
========================= 1 passed in 94.86s (0:01:34) =========================
```