### PR TITLE
Fix sync-kickstart-repo-to-capsule test

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -364,6 +364,7 @@ REPOSET = {
     'rhst8': 'Red Hat Satellite Tools 6.9 for RHEL 8 x86_64 (RPMs)',
     'fdrh8': 'Fast Datapath for RHEL 8 x86_64 (RPMs)',
     'rhel8_bos_ks': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS (Kickstart)',
+    'rhel8_aps_ks': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream (Kickstart)',
 }
 
 NO_REPOS_AVAILABLE = "This system has no repositories available through subscriptions."
@@ -570,6 +571,15 @@ REPOS = {
         'product': PRDS['rhel8'],
         'distro': DISTRO_RHEL8,
         'key': 'rhel8_bos_ks',
+    },
+    'rhel8_aps_ks': {
+        'id': 'rhel-8-for-x86_64-appstream-kickstart',
+        'name': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart 8.5',
+        'version': '8.5',
+        'reposet': REPOSET['rhel8_bos_ks'],
+        'product': PRDS['rhel8'],
+        'distro': DISTRO_RHEL8,
+        'key': 'rhel8_aps_ks',
     },
 }
 

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1051,9 +1051,9 @@ class TestCapsuleContentManagement:
             basearch='x86_64',
             org_id=module_manifest_org.id,
             product=constants.PRDS['rhel8'],
-            repo=constants.REPOS['rhel8_bos_ks']['name'],
-            reposet=constants.REPOSET['rhel8_bos_ks'],
-            releasever='8.4',
+            reposet=constants.REPOSET['rhel8_aps_ks'],
+            repo=constants.REPOS['rhel8_aps_ks']['name'],
+            releasever=constants.REPOS['rhel8_aps_ks']['version'],
         )
         repo = entities.Repository(id=repo_id).read()
 
@@ -1102,7 +1102,7 @@ class TestCapsuleContentManagement:
         # Check for kickstart content on SAT and CAPS
         url_base = (
             f'pulp/content/{module_manifest_org.label}/{lce.label}/'
-            f'{cv.label}/content/dist/rhel8/8.4/x86_64/baseos/kickstart'
+            f'{cv.label}/content/dist/rhel8/8.5/x86_64/appstream/kickstart'
         )
 
         # Check kickstart specific files


### PR DESCRIPTION
The test is failing due to the same repository being already synced to the Satellite by another test (but same module_manifest_org):
```
E   requests.exceptions.HTTPError: 409 Client Error: Conflict for url: https://dhcp-3-176.vms.sat.rdu2.redhat.com:443/katello/api/v2/repository_sets/7421/enable
```
I could go with function scoped org and same repo, but I decided to test with another one.

Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_sync_kickstart_repo
=========================================================================== test session starts ===========================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, ibutsu-2.0.1, xdist-2.5.0, mock-3.6.1
collected 1 item                                                                                                                                                          

tests/foreman/api/test_contentmanagement.py .                                                                                                                       [100%]

===================================================================== 1 passed in 1270.46s (0:21:10) ======================================================================
```
It would be nice to have this cherry-picked into the 6.10 branch, if approved.
