### PR TITLE
Add inital support for RHEL9

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -1,23 +1,27 @@
 REPOS:
   SATELLITE_VERSION_UNDR: "@jinja {{this.robottelo.satellite_version | replace('.', '_')}}"
-  # Rhel major version would be used by some repositories to frame their repository URL for
-  # extended Rhel versions.
+  # RHEL major version can be used by some repositories to frame their repository URL for
+  # extended RHEL versions.
   RHEL_MAJOR_VERSION: "@jinja {{this.server.version.rhel_release[0]}}"
-  # Provide link to rhel6/7/8 repo here, as puppet rpm would require packages from
-  # RHEL 6/7/8 repo and syncing the entire repo on the fly would take longer for
-  # tests to run Specify the *.repo link to an internal repo for tests to execute properly
+  # Provide link to RHEL6,7,8 & 9 repo here, as puppet rpm requires packages from
+  # those repos and syncing the entire repo on the fly would take longer for
+  # tests to run. Specify the *.repo link to an internal repo for tests to execute properly.
   RHEL_REPO_HOST: http://rhel_repo.example.com
   RHEL6_REPO: '@format {this[repos].rhel_repo_host}/pub/rhel6.repo'
   RHEL7_REPO: '@format {this[repos].rhel_repo_host}/pub/rhel7.repo'
   RHEL8_REPO: '@format {this[repos].rhel_repo_host}/pub/rhel8.repo'
+  RHEL9_REPO: '@format {this[repos].rhel_repo_host}/pub/rhel9.repo'
   SATELLITE_REPO: replace-with-repo-link
-  # Provide link to rhel6/7/8 repositories URL as we need all OS packages in order
+  # Provide link to RHEL6,7,8 & 9 repositories URL as we need all OS packages in order
   # to have real installation media for provisioning procedure
   RHEL6_OS: replace-with-rhel6-os-http-link
   RHEL7_OS: replace-with-rhel7-os-http-link
   RHEL8_OS:
     BASEOS: replace-with-rhel8-os-baseos-http-link
     APPSTREAM: replace-with-rhel8-os-appstream-http-link
+  RHEL9_OS:
+    BASEOS: replace-with-rhel9-os-baseos-http-link
+    APPSTREAM: replace-with-rhel9-os-appstream-http-link
   RHEL7_OPTIONAL: replace-with-rhel7-optional-url
   RHEL7_EXTRAS: replace-with-rhel7-extras-url
   # If capsule and satellite tools repositories available related packages will
@@ -28,6 +32,7 @@ REPOS:
     RHEL6: replace-with-rhel6-http-link
     RHEL7: replace-with-rhel7-http-link
     RHEL8: replace-with-rhel8-http-link
+    RHEL9: replace-with-rhel9-http-link
   # Downstream Satellite-maintain repo
   SATMAINTENANCE_REPO: replace-with-sat-maintain-repo
   # Software Collection Repo

--- a/conf/upgrade.yaml.template
+++ b/conf/upgrade.yaml.template
@@ -10,17 +10,20 @@ UPGRADE:
     RHEL6:
     RHEL7:
     RHEL8:
+    RHEL9:
   # RHEL6 & RHEL7's client will only be available when we spawn the VM using upgrade template,
   # it is used in content host upgrade.
   CLIENT_AK:
     RHEL6: "clientak_rhel6"
     RHEL7: "clientak_rhel7"
     RHEL8: "clientak_rhel8"
+    RHEL9: "clientak_rhel9"
   # Custom capsule activation key
   CUSTOM_CAPSULE_AK:
     RHEL6:
     RHEL7:
     RHEL8:
+    RHEL9:
   # Upgrade codebase supports these types of upgrade only.
   PRODUCTS:
     - "satellite"
@@ -49,6 +52,7 @@ UPGRADE:
     RHEL6:
     RHEL7:
     RHEL8:
+    RHEL9:
   # System Reboot after upgrade
   SATELLITE_CAPSULE_SETUP_REBOOT: true
   # Upgrade with http-proxy


### PR DESCRIPTION
Hello

RHEL9 hardware support is coming for broker and CI, hence this PR adding RHEL9 to  templates.
I do not want to add RHEL9 to constants until component owners have tested that. I have been caught out before by people  adding the latest RHEL major version in every where in robo constants file.

