### PR TITLE
Fixing hostname execute order

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -243,7 +243,7 @@ class Base:
         )
         response = ssh.command(
             cmd.encode('utf-8'),
-            hostname=hostname or settings.server.hostname or cls.hostname,
+            hostname=hostname or cls.hostname or settings.server.hostname,
             output_format=output_format,
             timeout=timeout,
         )


### PR DESCRIPTION
In our CLI Base.py class, the execute command is deferring to `settings.server.hostname` before `cls.hostname` which causes failures for anyone trying to execute CLI commands on a Satellite checked out during test runtime.

Example point of failure:
```python
def test_positive_os_list_with_default_organization_set(satellite_host):
    ...
    satellite_host.cli.Defaults.add({'param-name': 'organization', 'param-value': DEFAULT_ORG})
    ...
```
```
============================= test session starts ==============================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, cov-2.12.1, ibutsu-2.0.1, xdist-2.5.0
collected 1 item

tests/foreman/cli/test_operatingsystem.py .                              [100%]

-------------- generated xml file: /tmp/tmp-26830fOn4jiE85JkL.xml --------------
======================== 1 passed in 224.50s (0:03:44) =========================
```