### PR TITLE
Puppet plugin fixture and tests

### DIFF
--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -3,6 +3,35 @@ import pytest
 from nailgun import entities
 
 from robottelo.config import settings
+from robottelo.helpers import InstallerCommand
+
+enable_satellite_cmd = InstallerCommand(
+    installer_args=[
+        'enable-foreman-plugin-puppet',
+        'enable-foreman-cli-puppet',
+        'enable-puppet',
+    ],
+    installer_opts={
+        'foreman-proxy-puppet': 'true',
+        'puppet-server': 'true',
+        'puppet-server-foreman-ssl-ca': '/etc/pki/katello/puppet/puppet_client_ca.crt',
+        'puppet-server-foreman-ssl-cert': '/etc/pki/katello/puppet/puppet_client.crt',
+        'puppet-server-foreman-ssl-key': '/etc/pki/katello/puppet/puppet_client.key',
+    },
+)
+
+enable_capsule_cmd = InstallerCommand(
+    installer_args=[
+        'enable-puppet',
+    ],
+    installer_opts={
+        'foreman-proxy-puppet': 'true',
+        'puppet-server': 'true',
+        'puppet-server-foreman-ssl-ca': '/etc/pki/katello/puppet/puppet_client_ca.crt',
+        'puppet-server-foreman-ssl-cert': '/etc/pki/katello/puppet/puppet_client.crt',
+        'puppet-server-foreman-ssl-key': '/etc/pki/katello/puppet/puppet_client.key',
+    },
+)
 
 
 @pytest.fixture(scope='session')
@@ -62,3 +91,12 @@ def module_puppet_classes(module_env_search, module_import_puppet_module):
             f'and environment = {module_env_search.name}'
         }
     )
+
+
+@pytest.fixture(scope='module')
+def module_puppet_enabled_sat(module_destructive_sat):
+    """Satellite with enabled puppet plugin"""
+    module_destructive_sat.register_to_dogfood()
+    result = module_destructive_sat.execute(enable_satellite_cmd.get_command(), timeout=900000)
+    assert result.status == 0
+    yield module_destructive_sat

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -1,6 +1,5 @@
 # Puppet Environment fixtures
 import pytest
-from nailgun import entities
 
 from robottelo.config import settings
 from robottelo.helpers import InstallerCommand
@@ -34,69 +33,84 @@ enable_capsule_cmd = InstallerCommand(
 )
 
 
-@pytest.fixture(scope='session')
-def default_puppet_environment(module_org):
-    environments = entities.Environment().search(
-        query=dict(search=f'organization_id={module_org.id}')
-    )
-    if environments:
-        return environments[0].read()
-
-
-@pytest.fixture(scope='module')
-def module_puppet_environment(module_org, module_location):
-    environment = entities.Environment(
-        organization=[module_org], location=[module_location]
-    ).create()
-    return entities.Environment(id=environment.id).read()
-
-
-@pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
-@pytest.fixture(scope='module')
-def module_import_puppet_module(default_sat):
-    """Returns custom puppet environment name that contains imported puppet module
-    and puppet class name."""
-    puppet_class = 'generic_1'
-    return {
-        'puppet_class': puppet_class,
-        'env': default_sat.create_custom_environment(repo=puppet_class),
-    }
-
-
-@pytest.fixture(scope='module')
-def module_env_search(module_org, module_location, module_import_puppet_module):
-    """Search for puppet environment created from module_import_puppet_module fixture.
-
-    Returns the puppet environment with updated organization and location.
-    """
-    env = (
-        entities.Environment()
-        .search(query={'search': f'name={module_import_puppet_module["env"]}'})[0]
-        .read()
-    )
-    env.location = [module_location]
-    env.organization = [module_org]
-    env.update(['location', 'organization'])
-    return env
-
-
-@pytest.fixture(scope='module')
-def module_puppet_classes(module_env_search, module_import_puppet_module):
-    """Returns puppet class based on following criteria:
-    Puppet environment from module_env_search and puppet class name.
-    """
-    return entities.PuppetClass().search(
-        query={
-            'search': f'name ~ {module_import_puppet_module["puppet_class"]} '
-            f'and environment = {module_env_search.name}'
-        }
-    )
-
-
 @pytest.fixture(scope='module')
 def module_puppet_enabled_sat(module_destructive_sat):
     """Satellite with enabled puppet plugin"""
     module_destructive_sat.register_to_dogfood()
     result = module_destructive_sat.execute(enable_satellite_cmd.get_command(), timeout=900000)
     assert result.status == 0
+    module_destructive_sat.execute('hammer -r')  # workaround for BZ#2039696
     yield module_destructive_sat
+
+
+@pytest.fixture(scope='module')
+def module_puppet_org(module_puppet_enabled_sat):
+    yield module_puppet_enabled_sat.api.Organization().create()
+
+
+@pytest.fixture(scope='module')
+def module_puppet_loc(module_puppet_enabled_sat):
+    yield module_puppet_enabled_sat.api.Location().create()
+
+
+@pytest.fixture(scope='session')
+def default_puppet_environment(module_puppet_org, module_puppet_enabled_sat):
+    environments = module_puppet_enabled_sat.api.Environment().search(
+        query=dict(search=f'organization_id={module_puppet_org.id}')
+    )
+    if environments:
+        return environments[0].read()
+
+
+@pytest.fixture(scope='module')
+def module_puppet_environment(module_puppet_org, module_puppet_loc, module_puppet_enabled_sat):
+    environment = module_puppet_enabled_sat.api.Environment(
+        organization=[module_puppet_org], location=[module_puppet_loc]
+    ).create()
+    return module_puppet_enabled_sat.api.Environment(id=environment.id).read()
+
+
+@pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
+@pytest.fixture(scope='module')
+def module_import_puppet_module(module_puppet_enabled_sat):
+    """Returns custom puppet environment name that contains imported puppet module
+    and puppet class name."""
+    puppet_class = 'generic_1'
+    return {
+        'puppet_class': puppet_class,
+        'env': module_puppet_enabled_sat.create_custom_environment(repo=puppet_class),
+    }
+
+
+@pytest.fixture(scope='module')
+def module_env_search(
+    module_puppet_org, module_puppet_loc, module_import_puppet_module, module_puppet_enabled_sat
+):
+    """Search for puppet environment created from module_import_puppet_module fixture.
+
+    Returns the puppet environment with updated organization and location.
+    """
+    env = (
+        module_puppet_enabled_sat.api.Environment()
+        .search(query={'search': f'name={module_import_puppet_module["env"]}'})[0]
+        .read()
+    )
+    env.location = [module_puppet_loc]
+    env.organization = [module_puppet_org]
+    env.update(['location', 'organization'])
+    return env
+
+
+@pytest.fixture(scope='module')
+def module_puppet_classes(
+    module_env_search, module_import_puppet_module, module_puppet_enabled_sat
+):
+    """Returns puppet class based on following criteria:
+    Puppet environment from module_env_search and puppet class name.
+    """
+    return module_puppet_enabled_sat.api.PuppetClass().search(
+        query={
+            'search': f'name ~ {module_import_puppet_module["puppet_class"]} '
+            f'and environment = {module_env_search.name}'
+        }
+    )

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -106,3 +106,12 @@ def module_destructive_sat(module_satellite_host):
     """Destructive tests require changing settings.server.hostname for now"""
     with module_satellite_host as sat:
         yield sat
+
+
+@pytest.fixture
+def destructive_caps(capsule_host, destructive_sat):
+    """Configure the capsule instance with the destructive satellite"""
+    capsule_host.install_katello_ca(destructive_sat)
+    capsule_host.register_contenthost()
+    capsule_host.capsule_setup(sat_host=destructive_sat)
+    yield capsule_host

--- a/robottelo/cli/environment.py
+++ b/robottelo/cli/environment.py
@@ -23,7 +23,7 @@ from robottelo.cli.base import Base
 class Environment(Base):
     """Manipulates Foreman's environments."""
 
-    command_base = 'environment'
+    command_base = 'puppet-environment'
 
     @classmethod
     def sc_params(cls, options=None):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -8,6 +8,7 @@ from tempfile import NamedTemporaryFile
 from urllib.parse import urljoin
 from urllib.parse import urlunsplit
 
+import requests
 from broker import VMBroker
 from broker.hosts import Host
 from dynaconf.vendor.box.exceptions import BoxKeyError
@@ -1091,6 +1092,10 @@ class Capsule(ContentHost):
             command_opts.update(cmd_kwargs)
             installer_obj = InstallerCommand(*cmd_args, **command_opts)
         return self.execute(installer_obj.get_command(), timeout=0)
+
+    def get_features(self):
+        """Get capsule features"""
+        return requests.get(f'https://{self.hostname}:9090/features', verify=False).text
 
     def capsule_setup(self, sat_host=None, **installer_kwargs):
         """Prepare the host and run the capsule installer"""

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -34,7 +34,7 @@ from robottelo.datafactory import valid_environments_list
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_environments_list()))
-def test_positive_create_with_name(name):
+def test_positive_create_with_name(name, module_puppet_enabled_sat):
     """Create an environment and provide a valid name.
 
     :id: 8869ccf8-a511-4fa7-ac36-11494e85f532
@@ -46,12 +46,14 @@ def test_positive_create_with_name(name):
 
     :CaseImportance: Critical
     """
-    env = entities.Environment(name=name).create()
+    env = module_puppet_enabled_sat.api.Environment(name=name).create()
     assert env.name == name
 
 
 @pytest.mark.tier1
-def test_positive_create_with_org_and_loc(module_org, module_location):
+def test_positive_create_with_org_and_loc(
+    module_puppet_org, module_puppet_loc, module_puppet_enabled_sat
+):
     """Create an environment and assign it to new organization.
 
     :id: de7e4132-5ca7-4b41-9af3-df075d31f8f4
@@ -61,18 +63,20 @@ def test_positive_create_with_org_and_loc(module_org, module_location):
 
     :CaseImportance: Critical
     """
-    env = entities.Environment(
-        name=gen_string('alphanumeric'), organization=[module_org], location=[module_location]
+    env = module_puppet_enabled_sat.api.Environment(
+        name=gen_string('alphanumeric'),
+        organization=[module_puppet_org],
+        location=[module_puppet_loc],
     ).create()
     assert len(env.organization) == 1
-    assert env.organization[0].id == module_org.id
+    assert env.organization[0].id == module_puppet_org.id
     assert len(env.location) == 1
-    assert env.location[0].id == module_location.id
+    assert env.location[0].id == module_puppet_loc.id
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_create_with_too_long_name(name):
+def test_negative_create_with_too_long_name(name, module_puppet_enabled_sat):
     """Create an environment and provide an invalid name.
 
     :id: e2654954-b3a1-4594-a487-bcd0cc8195ad
@@ -83,12 +87,12 @@ def test_negative_create_with_too_long_name(name):
 
     """
     with pytest.raises(HTTPError):
-        entities.Environment(name=name).create()
+        module_puppet_enabled_sat.api.Environment(name=name).create()
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_environments_list()))
-def test_negative_create_with_invalid_characters(name):
+def test_negative_create_with_invalid_characters(name, module_puppet_enabled_sat):
     """Create an environment and provide an illegal name.
 
     :id: 8ec57d04-4ce6-48b4-b7f9-79025019ad0f
@@ -99,12 +103,12 @@ def test_negative_create_with_invalid_characters(name):
 
     """
     with pytest.raises(HTTPError):
-        entities.Environment(name=name).create()
+        module_puppet_enabled_sat.api.Environment(name=name).create()
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(valid_environments_list()))
-def test_positive_update_name(module_puppet_environment, new_name):
+def test_positive_update_name(module_puppet_environment, new_name, module_puppet_enabled_sat):
     """Create environment entity providing the initial name, then
     update its name to another valid name.
 
@@ -115,12 +119,16 @@ def test_positive_update_name(module_puppet_environment, new_name):
     :expectedresults: Environment entity is created and updated properly
 
     """
-    env = entities.Environment(id=module_puppet_environment.id, name=new_name).update(['name'])
+    env = module_puppet_enabled_sat.api.Environment(
+        id=module_puppet_environment.id, name=new_name
+    ).update(['name'])
     assert env.name == new_name
 
 
 @pytest.mark.tier2
-def test_positive_update_and_remove(module_org, module_location):
+def test_positive_update_and_remove(
+    module_puppet_org, module_puppet_loc, module_puppet_enabled_sat
+):
     """Update environment and assign it to a new organization
     and location. Delete environment afterwards.
 
@@ -133,16 +141,16 @@ def test_positive_update_and_remove(module_org, module_location):
 
     :CaseLevel: Integration
     """
-    env = entities.Environment().create()
+    env = module_puppet_enabled_sat.api.Environment().create()
     assert len(env.organization) == 0
     assert len(env.location) == 0
-    env = entities.Environment(id=env.id, organization=[module_org]).update(['organization'])
+    env = entities.Environment(id=env.id, organization=[module_puppet_org]).update(['organization'])
     assert len(env.organization) == 1
-    assert env.organization[0].id, module_org.id
+    assert env.organization[0].id, module_puppet_org.id
 
-    env = entities.Environment(id=env.id, location=[module_location]).update(['location'])
+    env = entities.Environment(id=env.id, location=[module_puppet_loc]).update(['location'])
     assert len(env.location) == 1
-    assert env.location[0].id == module_location.id
+    assert env.location[0].id == module_puppet_loc.id
 
     env.delete()
     with pytest.raises(HTTPError):
@@ -151,7 +159,7 @@ def test_positive_update_and_remove(module_org, module_location):
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-def test_negative_update_name(module_puppet_environment, new_name):
+def test_negative_update_name(module_puppet_environment, new_name, module_puppet_enabled_sat):
     """Create environment entity providing the initial name, then
     try to update its name to invalid one.
 
@@ -163,7 +171,9 @@ def test_negative_update_name(module_puppet_environment, new_name):
 
     """
     with pytest.raises(HTTPError):
-        entities.Environment(id=module_puppet_environment.id, name=new_name).update(['name'])
+        module_puppet_enabled_sat.api.Environment(
+            id=module_puppet_environment.id, name=new_name
+        ).update(['name'])
 
 
 """Tests to see if the server returns the attributes it should.

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -19,12 +19,10 @@
 from random import choice
 
 import pytest
+from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.environment import Environment
-from robottelo.cli.factory import make_environment
-from robottelo.cli.scparams import SmartClassParameter
 from robottelo.config import settings
 from robottelo.datafactory import invalid_id_list
 from robottelo.datafactory import invalid_values_list
@@ -32,12 +30,17 @@ from robottelo.datafactory import parametrized
 
 
 @pytest.fixture(scope='module')
-def module_locations(default_sat):
-    return (default_sat.api.Location().create(), default_sat.api.Location().create())
+def module_locations(module_puppet_enabled_sat):
+    return (
+        module_puppet_enabled_sat.api.Location().create(),
+        module_puppet_enabled_sat.api.Location().create(),
+    )
 
 
 @pytest.mark.tier2
-def test_negative_list_with_parameters(module_org, module_locations):
+def test_negative_list_with_parameters(
+    module_puppet_org, module_locations, module_puppet_enabled_sat
+):
     """Test Environment List filtering parameters validation.
 
     :id: 97872953-e1aa-44bd-9ce0-a04bccbc9e94
@@ -49,25 +52,34 @@ def test_negative_list_with_parameters(module_org, module_locations):
 
     :BZ: 1337947
     """
-    make_environment({'organization-ids': module_org.id, 'location-ids': module_locations[0].id})
+    module_puppet_enabled_sat.cli.Environment.create(
+        {
+            'organization-ids': module_puppet_org.id,
+            'location-ids': module_locations[0].id,
+            'name': gen_alphanumeric(6),
+        }
+    )
+
     # Filter by non-existing location and existing organization
     with pytest.raises(CLIReturnCodeError):
-        Environment.list({'organization-id': module_org.id, 'location-id': gen_string('numeric')})
+        module_puppet_enabled_sat.cli.Environment.list(
+            {'organization-id': module_puppet_org.id, 'location-id': gen_string('numeric')}
+        )
     # Filter by non-existing organization and existing location
     with pytest.raises(CLIReturnCodeError):
-        Environment.list(
+        module_puppet_enabled_sat.cli.Environment.list(
             {'organization-id': gen_string('numeric'), 'location-id': module_locations[0].id}
         )
     # Filter by another location
-    results = Environment.list(
-        {'organization': module_org.name, 'location': module_locations[1].name}
+    results = module_puppet_enabled_sat.cli.Environment.list(
+        {'organization': module_puppet_org.name, 'location': module_locations[1].name}
     )
     assert len(results) == 0
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_name(name):
+def test_negative_create_with_name(name, module_puppet_enabled_sat):
     """Don't create an Environment with invalid data.
 
     :id: 8a4141b0-3bb9-47e5-baca-f9f027086d4c
@@ -79,12 +91,14 @@ def test_negative_create_with_name(name):
     :CaseImportance: Critical
     """
     with pytest.raises(CLIReturnCodeError):
-        Environment.create({'name': name})
+        module_puppet_enabled_sat.cli.Environment.create({'name': name})
 
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_CRUD_with_attributes(default_sat, module_org, module_locations):
+def test_positive_CRUD_with_attributes(
+    module_puppet_enabled_sat, module_puppet_org, module_locations
+):
     """Check if Environment with attributes can be created, updated and removed
 
     :id: d2187971-86b2-40c9-a93c-66f37691ae2b
@@ -101,61 +115,63 @@ def test_positive_CRUD_with_attributes(default_sat, module_org, module_locations
     """
     # Create with attributes
     env_name = gen_string('alpha')
-    environment = make_environment(
+    environment = module_puppet_enabled_sat.cli.Environment.create(
         {
             'location-ids': module_locations[0].id,
-            'organization-ids': module_org.id,
+            'organization-ids': module_puppet_org.id,
             'name': env_name,
         }
     )
     assert module_locations[0].name in environment['locations']
-    assert module_org.name in environment['organizations']
+    assert module_puppet_org.name in environment['organizations']
     assert env_name == environment['name']
 
     # List by name
-    result = Environment.list({'search': f'name={env_name}'})
+    result = module_puppet_enabled_sat.cli.Environment.list({'search': f'name={env_name}'})
     assert len(result) == 1
     assert result[0]['name'] == env_name
     # List by org loc id
-    results = Environment.list(
-        {'organization-id': module_org.id, 'location-id': module_locations[0].id}
+    results = module_puppet_enabled_sat.cli.Environment.list(
+        {'organization-id': module_puppet_org.id, 'location-id': module_locations[0].id}
     )
     assert env_name in [res['name'] for res in results]
     # List by org loc name
-    results = Environment.list(
-        {'organization': module_org.name, 'location': module_locations[0].name}
+    results = module_puppet_enabled_sat.cli.Environment.list(
+        {'organization': module_puppet_org.name, 'location': module_locations[0].name}
     )
     assert env_name in [res['name'] for res in results]
 
     # Update org and loc
-    new_org = default_sat.api.Organization().create()
-    Environment.update(
+    new_org = module_puppet_enabled_sat.api.Organization().create()
+    module_puppet_enabled_sat.cli.Environment.update(
         {
             'location-ids': module_locations[1].id,
             'organization-ids': new_org.id,
             'name': environment['name'],
         }
     )
-    env_info = Environment.info({'name': environment['name']})
+    env_info = module_puppet_enabled_sat.cli.Environment.info({'name': environment['name']})
     assert module_locations[1].name in env_info['locations']
     assert module_locations[0].name not in env_info['locations']
     assert new_org.name in env_info['organizations']
-    assert module_org.name not in env_info['organizations']
+    assert module_puppet_org.name not in env_info['organizations']
     # Update name
     new_env_name = gen_string('alpha')
-    Environment.update({'id': environment['id'], 'new-name': new_env_name})
-    env_info = Environment.info({'id': environment['id']})
+    module_puppet_enabled_sat.cli.Environment.update(
+        {'id': environment['id'], 'new-name': new_env_name}
+    )
+    env_info = module_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
     assert env_info['name'] == new_env_name
 
     # Delete
-    Environment.delete({'id': environment['id']})
+    module_puppet_enabled_sat.cli.Environment.delete({'id': environment['id']})
     with pytest.raises(CLIReturnCodeError):
-        Environment.info({'id': environment['id']})
+        module_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
-def test_negative_delete_by_id(entity_id):
+def test_negative_delete_by_id(entity_id, module_puppet_enabled_sat):
     """Create Environment then delete it by wrong ID
 
     :id: fe77920c-62fd-4e0e-b960-a940a1370d10
@@ -167,12 +183,12 @@ def test_negative_delete_by_id(entity_id):
     :CaseImportance: Medium
     """
     with pytest.raises(CLIReturnCodeError):
-        Environment.delete({'id': entity_id})
+        module_puppet_enabled_sat.cli.Environment.delete({'id': entity_id})
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-def test_negative_update_name(new_name):
+def test_negative_update_name(new_name, module_puppet_enabled_sat):
     """Update the Environment with invalid values
 
     :id: adc5ad73-0547-40f9-b4d4-649780cfb87a
@@ -182,10 +198,12 @@ def test_negative_update_name(new_name):
     :expectedresults: Environment is not updated
 
     """
-    environment = make_environment()
+    environment = module_puppet_enabled_sat.cli.Environment.create({'name': gen_string('alpha')})
     with pytest.raises(CLIReturnCodeError):
-        Environment.update({'id': environment['id'], 'new-name': new_name})
-    result = Environment.info({'id': environment['id']})
+        module_puppet_enabled_sat.cli.Environment.update(
+            {'id': environment['id'], 'new-name': new_name}
+        )
+    result = module_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
     assert environment['name'] == result['name']
 
 
@@ -194,7 +212,7 @@ def test_negative_update_name(new_name):
     not settings.robottelo.repos_hosting_url,
     reason='Missing repos_hosting_url',
 )
-def test_positive_sc_params(module_import_puppet_module):
+def test_positive_sc_params(module_import_puppet_module, module_puppet_enabled_sat):
     """Check if environment sc-param subcommand works passing
     an environment id
 
@@ -204,14 +222,16 @@ def test_positive_sc_params(module_import_puppet_module):
 
     """
     # Override one of the sc-params from puppet class
-    sc_params_list = SmartClassParameter.list(
+    sc_params_list = module_puppet_enabled_sat.cli.SmartClassParameter.list(
         {
-            'environment': module_import_puppet_module['env'],
+            'puppet-environment': module_import_puppet_module['env'],
             'search': f'puppetclass="{module_import_puppet_module["puppet_class"]}"',
         }
     )
     scp_id = choice(sc_params_list)['id']
-    SmartClassParameter.update({'id': scp_id, 'override': 1})
+    module_puppet_enabled_sat.cli.SmartClassParameter.update({'id': scp_id, 'override': 1})
     # Verify that affected sc-param is listed
-    env_scparams = Environment.sc_params({'environment': module_import_puppet_module['env']})
+    env_scparams = module_puppet_enabled_sat.cli.Environment.sc_params(
+        {'puppet-environment': module_import_puppet_module['env']}
+    )
     assert scp_id in [scp['id'] for scp in env_scparams]

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -18,21 +18,22 @@
 """
 import pytest
 
-from robottelo.cli.puppet import Puppet
 from robottelo.config import settings
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason="Missing repos_hosting_url")
-def test_positive_list_smart_class_parameters(module_import_puppet_module):
+def test_positive_list_smart_class_parameters(
+    module_import_puppet_module, module_puppet_enabled_sat
+):
     """List smart class parameters associated with the puppet class.
 
     :id: 56b370c2-8fc6-49be-9676-242178cc709a
 
     :expectedresults: Smart class parameters listed for the class.
     """
-    class_sc_parameters = Puppet.sc_params(
+    class_sc_parameters = module_puppet_enabled_sat.cli.Puppet.sc_params(
         {'puppet-class': module_import_puppet_module['puppet_class']}
     )
     assert len(class_sc_parameters) == 200

--- a/tests/foreman/cli/test_puppetplugin.py
+++ b/tests/foreman/cli/test_puppetplugin.py
@@ -1,0 +1,133 @@
+"""Test class for puppet plugin CLI
+
+:Requirement: Puppet
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Puppet
+
+:Assignee: vsedmik
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+
+from pytest_fixtures.component.puppet import enable_capsule_cmd
+from pytest_fixtures.component.puppet import enable_satellite_cmd
+
+
+puppet_cli_commands = [
+    'puppet-environment',
+    'puppet-class',
+    'config-group',
+    'host puppet-classes',
+    'host sc-params',
+    'hostgroup puppet-classes',
+    'hostgroup sc-params',
+]
+
+err_msg = 'Error: No such sub-command'
+
+
+@pytest.mark.skip_if_open("BZ:2034552")
+def test_positive_enable_disable_logic(destructive_sat, destructive_caps):
+    """Test puppet enable/disable logic on Satellite and Capsule
+
+    :id: a1909c3e-6d41-4235-97b1-4e8b64ee1a9e
+
+    :setup:
+        1. Satellite with registered external Capsule, both with disabled puppet.
+
+    :steps:
+        1. Check that puppet is disabled by default on both.
+        2. Try to enable puppet on Capsule and check it failed.
+        3. Enable puppet on Satellite and check it succeeded.
+        4. Enable puppet on Capsule and check it succeeded.
+        5. Try to disable puppet on Satellite and check it failed.
+        6. Disable puppet on Capsule and check it succeeded.
+        7. Disable puppet on Sastellite and check it succeeded.
+
+    :expectedresults:
+        1. Puppet is missing on disabled setup.
+        2. Puppet can't be enabled on Capsule when disabled on Satellite.
+        3. Puppet can be enabled with service running on Satellite, CLI commands were added.
+        4. Puppet can be enabled with service running on Capsule when enabled on Satellite.
+        5. Puppet can't be disabled on Satellite when enabled on Capsule.
+        6. Puppet can be disabled on Capsule
+        7. Puppet can be disabled on Satellite when disabled on Capsule.
+    """
+    # Check that puppet is disabled by default on both.
+    result = destructive_sat.execute('rpm -q puppetserver')
+    assert result.status == 1
+    assert 'package puppetserver is not installed' in result.stdout
+
+    for cmd in puppet_cli_commands:
+        result = destructive_sat.execute(f'hammer {cmd} --help')
+        assert result.status == 64
+        assert f"{err_msg} '{cmd.split()[-1]}'." in str(result.stderr)
+
+    result = destructive_caps.execute('rpm -q puppetserver')
+    assert result.status == 1
+    assert 'package puppetserver is not installed' in result.stdout
+
+    # Try to enable puppet on Capsule and check it failed.
+    result = destructive_caps.execute(enable_capsule_cmd.get_command(), timeout=900000)
+    assert result.status == 6  # == 6
+    assert 'failed to load one or more features (Puppet)' in result.stdout
+
+    # Enable puppet on Satellite and check it succeeded.
+    destructive_sat.register_to_dogfood()
+    result = destructive_sat.execute(enable_satellite_cmd.get_command(), timeout=900000)
+    assert result.status == 0
+    assert 'Success!' in result.stdout
+
+    result = destructive_sat.execute('rpm -q puppetserver')
+    assert result.status == 0
+    result = destructive_sat.execute('systemctl status puppetserver')
+    assert 'active (running)' in result.stdout
+
+    # TODO: an issue identified, DEVs investigating
+    # for cmd in puppet_commands:
+    #     result = destructive_sat.execute(f'hammer {cmd} --help')
+    #     assert result.status == 0
+
+    # Enable puppet on Capsule and check it succeeded.
+    result = destructive_caps.execute(enable_capsule_cmd.get_command(), timeout=900000)
+    assert result.status == 0
+    assert 'Success!' in result.stdout
+
+    result = destructive_caps.execute('rpm -q puppetserver')
+    assert result.status == 0
+    result = destructive_caps.execute('systemctl status puppetserver')
+    assert 'active (running)' in result.stdout
+
+    # Try to disable puppet on Satellite and check it failed.
+    result = destructive_sat.execute('foreman-maintain plugin purge-puppet')
+    assert result.status == 1
+    assert f'The following proxies have Puppet feature: {destructive_caps.hostname}.'
+
+    # Disable puppet on Capsule and check it succeeded.
+    result = destructive_caps.execute('foreman-maintain plugin purge-puppet')
+    assert result.status == 0
+
+    result = destructive_caps.execute('rpm -q puppetserver')
+    assert result.status == 1
+    assert 'package puppetserver is not installed' in result.stdout
+
+    # Disable puppet on Satellite and check it succeeded.
+    result = destructive_caps.execute('foreman-maintain plugin purge-puppet')
+    assert result.status == 0
+    result = destructive_sat.execute('rpm -q puppetserver')
+    assert result.status == 1
+    assert 'package puppetserver is not installed' in result.stdout
+
+    for cmd in puppet_cli_commands:
+        result = destructive_sat.execute(f'hammer {cmd} --help')
+        assert result.status == 64
+        assert f"{err_msg} '{cmd.split()[-1]}'." in str(result.stderr)


### PR DESCRIPTION
This PR adds:
- fixture for puppet-enabled Satellite
- fixture for `destructive_caps` (to be registered with `destructive_sat`)
- test for puppet enable/disable logic on both, Satellite and Capsule (waiting for BZ fix)
- test fixes in `cli/test_puppetclass`, `api/test_environment`, `cli/test_environment`

TODO:
- more puppet-related test fixes will follow in next PRs
