### PR TITLE
fixed test_positive_copy_subscription

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1333,7 +1333,7 @@ def test_positive_copy_subscription(module_manifest_org):
         {'name': new_name, 'organization-id': module_manifest_org.id}
     )
     # Verify that the subscription copied over
-    assert subscription_result[0]['name'] in result[3]  # subscription name  # subscription list
+    assert subscription_result[0]['name'] in result  # subscription name  # subscription list
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
tests.foreman.cli.test_activationkey.test_positive_copy_subscription was failing due indexing a large string value. Assertion now just checks copied activation key has the same subscription as "parent" key.