### PR TITLE
Fix cv failures

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2214,7 +2214,7 @@ def test_positive_edit_rh_custom_spin(session):
         distro=DISTRO_RHEL7, repositories=[SatelliteToolsRepository()]
     )
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
-    cv = entities.ContentView(id=repos_collection.setup_content_view['content_view']['id']).read()
+    cv = entities.ContentView(id=repos_collection.setup_content_data['content_view']['id']).read()
     with session:
         session.organization.select(org.name)
         session.contentviewfilter.create(
@@ -2654,7 +2654,9 @@ def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthos
 
 
 @pytest.mark.tier3
-def test_positive_delete_with_kickstart_repo_and_host_group(session, default_sat):
+def test_positive_delete_with_kickstart_repo_and_host_group(
+    session, default_sat, smart_proxy_location
+):
     """Check that Content View associated with kickstart repository and
     which is used by a host group can be removed from the system
 
@@ -2708,6 +2710,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(session, default_sat
     os = os.update(['architecture', 'ptable'])
     with session:
         session.organization.select(org.name)
+        session.location.select(smart_proxy_location.name)
         session.hostgroup.create(
             {
                 'host_group.name': hg_name,


### PR DESCRIPTION
These are tests that have been failing for a while.  Fixed them up.

Test results:
```
pytest tests/foreman/ui/test_contentview.py::test_positive_edit_rh_custom_spin

=========== 1 passed in 209.48s (0:03:29) ==========

pytest tests/foreman/ui/test_contentview.py::test_positive_delete_with_kickstart_repo_and_host_group

============ 1 passed in 292.77s (0:04:52) ==================
``