### PR TITLE
Fix sat-sync test case failure

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -896,7 +896,7 @@ class TestContentViewSync:
             {'name': import_cv_name, 'organization-id': importing_org['id']}
         )['versions']
         assert len(importing_cvv_id) >= 1
-        imported_packages = Package.list({'content-view-version-id': importing_cv_id['id']})
+        imported_packages = Package.list({'content-view-version-id': importing_cvv_id[0]['id']})
         assert len(imported_packages)
         assert len(exported_packages) == len(imported_packages)
         # Verify the LCE is in Library


### PR DESCRIPTION
Previous test was using the incorrect id.  Fixing it to use the correct
cvv-id.

Test result:
```
pytest tests/foreman/cli/test_satellitesync.py::TestContentViewSync::test_positive_export_import_promoted_cv

================ 1 passed in 170.23s (0:02:50) =============
```