### PR TITLE
Fix api, cli and ui tests related to Openscap

### DIFF
--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -32,7 +32,7 @@ def oscap_content_path(default_sat):
 
 
 @pytest.fixture(scope="module")
-def scap_content(import_ansible_roles, import_puppet_classes):
+def scap_content(import_ansible_roles):
     title = f"rhel-content-{gen_string('alpha')}"
     scap_info = make_scapcontent({'title': title, 'scap-file': f'{settings.oscap.content_path}'})
     scap_id = scap_info['id']

--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -22,23 +22,11 @@ from nailgun import entities
 from robottelo.datafactory import gen_string
 
 
-@pytest.fixture(scope="module")
-def module_location(module_location):
-    yield module_location
-    module_location.delete()
-
-
-@pytest.fixture(scope="module")
-def module_org(module_org):
-    yield module_org
-    module_org.delete()
-
-
 class TestTailoringFile:
     """Implements Tailoring Files tests in API."""
 
     @pytest.mark.tier1
-    def test_positive_crud_tailoringfile(self, module_org, module_location, tailoring_file_path):
+    def test_positive_crud_tailoringfile(self, default_org, default_location, tailoring_file_path):
         """Perform end to end testing for oscap tailoring files component
 
         :id: 2441988f-2054-49f7-885e-3675336f712f
@@ -53,14 +41,14 @@ class TestTailoringFile:
         scap = entities.TailoringFile(
             name=name,
             scap_file=tailoring_file_path['local'],
-            organization=[module_org],
-            location=[module_location],
+            organization=[default_org],
+            location=[default_location],
         ).create()
         assert entities.TailoringFile().search(query={'search': f'name={name}'})
         result = entities.TailoringFile(id=scap.id).read()
         assert result.name == name
-        assert result.location[0].id == module_location.id
-        assert result.organization[0].id == module_org.id
+        assert result.location[0].id == default_location.id
+        assert result.organization[0].id == default_org.id
         scap = entities.TailoringFile(
             id=scap.id, name=new_name, original_filename=f'{original_filename}'
         ).update()

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -21,24 +21,12 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 
-@pytest.fixture(scope="module")
-def module_location(module_location):
-    yield module_location
-    module_location.delete()
-
-
-@pytest.fixture(scope="module")
-def module_org(module_org):
-    yield module_org
-    module_org.delete()
-
-
 class TestOscapPolicy:
     """Implements Oscap Policy tests in API."""
 
     @pytest.mark.tier1
     def test_positive_crud_scap_policy(
-        self, module_org, module_location, scap_content, tailoring_file
+        self, default_org, default_location, scap_content, tailoring_file
     ):
         """Perform end to end testing for oscap policy component
 
@@ -54,12 +42,12 @@ class TestOscapPolicy:
         new_name = gen_string('alpha')
         description = gen_string('alpha')
         hostgroup = entities.HostGroup(
-            location=[module_location], organization=[module_org]
+            location=[default_location], organization=[default_org]
         ).create()
         # Create new oscap policy with assigned content and tailoring file
         policy = entities.CompliancePolicies(
             name=name,
-            deploy_by='puppet',
+            deploy_by='ansible',
             description=description,
             scap_content_id=scap_content["scap_id"],
             scap_content_profile_id=scap_content["scap_profile_id"],
@@ -68,12 +56,12 @@ class TestOscapPolicy:
             period="monthly",
             day_of_month="5",
             hostgroup=[hostgroup],
-            location=[module_location],
-            organization=[module_org],
+            location=[default_location],
+            organization=[default_org],
         ).create()
         assert entities.CompliancePolicies().search(query={'search': f'name="{name}"'})
         # Check that created entity has expected values
-        assert policy.deploy_by == 'puppet'
+        assert policy.deploy_by == 'ansible'
         assert policy.name == name
         assert policy.description == description
         assert str(policy.scap_content_id) == str(scap_content["scap_id"])
@@ -82,8 +70,8 @@ class TestOscapPolicy:
         assert policy.period == "monthly"
         assert int(policy.day_of_month) == 5
         assert str(policy.hostgroup[0].id) == str(hostgroup.id)
-        assert str(policy.organization[0].id) == str(module_org.id)
-        assert str(policy.location[0].id) == str(module_location.id)
+        assert str(policy.organization[0].id) == str(default_org.id)
+        assert str(policy.location[0].id) == str(default_location.id)
         # Update oscap policy with new name
         policy = entities.CompliancePolicies(id=policy.id, name=new_name).update()
         assert policy.name == new_name

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -467,7 +467,7 @@ class TestOpenScap:
         scap_policy = make_scap_policy(
             {
                 'name': name,
-                'deploy-by': 'puppet',
+                'deploy-by': 'ansible',
                 'scap-content-id': scap_content["scap_id"],
                 'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
@@ -504,7 +504,7 @@ class TestOpenScap:
             make_scap_policy(
                 {
                     'name': name,
-                    'deploy-by': 'puppet',
+                    'deploy-by': 'ansible',
                     'scap-content-id': scap_content["scap_id"],
                     'scap-content-profile-id': scap_content["scap_profile_id"],
                     'period': OSCAP_PERIOD['weekly'].lower(),
@@ -536,7 +536,7 @@ class TestOpenScap:
         with pytest.raises(CLIFactoryError):
             make_scap_policy(
                 {
-                    'deploy-by': 'puppet',
+                    'deploy-by': 'ansible',
                     'scap-content-profile-id': scap_content["scap_profile_id"],
                     'period': OSCAP_PERIOD['weekly'].lower(),
                     'weekday': OSCAP_WEEKDAY['friday'].lower(),
@@ -571,7 +571,7 @@ class TestOpenScap:
         scap_policy = make_scap_policy(
             {
                 'name': name,
-                'deploy-by': 'puppet',
+                'deploy-by': 'ansible',
                 'scap-content-id': scap_content["scap_id"],
                 'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
@@ -620,7 +620,7 @@ class TestOpenScap:
         assert scap_policy['deployment-option'] == 'ansible'
         assert scap_policy['hostgroups'][0] == hostgroup['name']
 
-    @pytest.mark.parametrize('deploy', **parametrized(['manual', 'puppet', 'ansible']))
+    @pytest.mark.parametrize('deploy', **parametrized(['manual', 'ansible']))
     @pytest.mark.upgrade
     @pytest.mark.tier2
     def test_positive_associate_scap_policy_with_tailoringfiles(
@@ -706,7 +706,7 @@ class TestOpenScap:
         with pytest.raises(CLIReturnCodeError):
             Scapcontent.info({'name': scap_policy['name']})
 
-    @pytest.mark.parametrize('deploy', **parametrized(['manual', 'puppet', 'ansible']))
+    @pytest.mark.parametrize('deploy', **parametrized(['manual', 'ansible']))
     @pytest.mark.upgrade
     @pytest.mark.tier2
     def test_positive_scap_policy_end_to_end(self, deploy, scap_content):
@@ -794,7 +794,7 @@ class TestOpenScap:
         scap_policy = make_scap_policy(
             {
                 'name': name,
-                'deploy-by': 'puppet',
+                'deploy-by': 'ansible',
                 'scap-content-id': scap_content["scap_id"],
                 'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
@@ -803,7 +803,7 @@ class TestOpenScap:
             }
         )
         assert scap_policy['hostgroups'][0] == hostgroup['name']
-        assert scap_policy['deployment-option'] == 'puppet'
+        assert scap_policy['deployment-option'] == 'ansible'
         new_hostgroup = make_hostgroup()
         Scappolicy.update(
             {'id': scap_policy['id'], 'deploy-by': 'ansible', 'hostgroups': new_hostgroup['name']}
@@ -840,7 +840,7 @@ class TestOpenScap:
         scap_policy = make_scap_policy(
             {
                 'name': name,
-                'deploy-by': 'puppet',
+                'deploy-by': 'ansible',
                 'scap-content-id': scap_content["scap_id"],
                 'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
@@ -887,7 +887,7 @@ class TestOpenScap:
         scap_policy = make_scap_policy(
             {
                 'name': name,
-                'deploy-by': 'puppet',
+                'deploy-by': 'ansible',
                 'scap-content-id': scap_content["scap_id"],
                 'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),
@@ -933,7 +933,7 @@ class TestOpenScap:
         scap_policy = make_scap_policy(
             {
                 'name': name,
-                'deploy-by': 'puppet',
+                'deploy-by': 'ansible',
                 'scap-content-id': scap_content["scap_id"],
                 'scap-content-profile-id': scap_content["scap_profile_id"],
                 'period': OSCAP_PERIOD['weekly'].lower(),


### PR DESCRIPTION
Openscap tests fails if no capsule with Openscap feature is available in org and loc. Default capsule is associated with Default org and loc and has openscap feature.

Test result:

```
$ pytest tests/foreman/cli/test_oscap_tailoringfiles.py
============================= test session starts ==============================
collected 24 items / 4 deselected / 20 selected

tests/foreman/cli/test_oscap_tailoringfiles.py ....................      [100%]

================= 20 passed, 4 deselected in 249.66s (0:04:09) =================
```
```
$ pytest tests/foreman/cli/test_oscap.py 
============================= test session starts ==============================
collected 71 items / 3 deselected / 68 selected

tests/foreman/cli/test_oscap.py ........................................ [ 58%]
............................                                             [100%]

========== 68 passed, 3 deselected, 24 warnings in 1381.52s (0:23:01) ==========
```
```
$ pytest tests/foreman/api/test_oscap_tailoringfiles.py
============================= test session starts ==============================
collected 1 item

tests/foreman/api/test_oscap_tailoringfiles.py .                         [100%]

======================= 1 passed, 12 warnings in 26.05s ========================
```
```
$ pytest tests/foreman/api/test_oscappolicy.py
============================= test session starts ==============================
collected 1 item

tests/foreman/api/test_oscappolicy.py .                                  [100%]

================== 1 passed, 22 warnings in 90.47s (0:01:30) ===================
```
```
$ pytest tests/foreman/ui/test_oscaptailoringfile.py
============================= test session starts ==============================
collected 4 items / 3 deselected / 1 selected

tests/foreman/ui/test_oscaptailoringfile.py .                            [100%]

=========== 1 passed, 3 deselected, 9 warnings in 250.17s (0:04:10) ============
```
```
$ pytest tests/foreman/ui/test_oscapcontent.py 
============================= test session starts ==============================
collected 2 items

tests/foreman/ui/test_oscapcontent.py ..                                 [100%]

================== 2 passed, 8 warnings in 1524.83s (0:25:24) ==================
```