### PR TITLE
Add test coverage for BZ#1876220

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -45,9 +45,10 @@ def proxy_port_range(default_sat):
 
 
 @pytest.fixture
-def install_cockpit_plugin(default_sat):
-    default_sat.register_to_dogfood()
-    default_sat.install_cockpit()
+def cockpit_sat(destructive_sat):
+    destructive_sat.register_to_dogfood()
+    destructive_sat.install_cockpit()
+    yield destructive_sat
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
**Test results:**

```
$ pytest -k test_positive_cockpit tests/foreman/ui/test_host.py
========================================= test session starts ============================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sganar/satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, reportportal-5.0.8, forked-1.3.0, ibutsu-2.0.1, cov-3.0.0, xdist-2.5.0
collected 36 items / 35 deselected / 1 selected                                                                                                  

tests/foreman/ui/test_host.py .                                                                                                            [100%]

================================= 1 passed, 35 deselected in 1451.19s (0:24:11) ===============================
```