### PR TITLE
Metadata markers

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -10,6 +10,8 @@ CAPSULE:
     # The source of Capsule packages. Can be one of:
     # internal, ga, beta
     SOURCE: "internal"
+    # The base os rhel version where the capsule installed
+    # RHEL_VERSION: 
   # The Ansible Tower workflow used to deploy a capsule
   DEPLOY_WORKFLOW: deploy-sat-capsule
   # Dictionary of arguments which should be passed along to the deploy workflow

--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -2,7 +2,7 @@ REPOS:
   SATELLITE_VERSION_UNDR: "@jinja {{this.robottelo.satellite_version | replace('.', '_')}}"
   # RHEL major version can be used by some repositories to frame their repository URL for
   # extended RHEL versions.
-  RHEL_MAJOR_VERSION: "@jinja {{this.server.version.rhel_release[0]}}"
+  RHEL_MAJOR_VERSION: "@jinja {{this.server.version.rhel_version | int}}" 
   # Provide link to RHEL6,7,8 & 9 repo here, as puppet rpm requires packages from
   # those repos and syncing the entire repo on the fly would take longer for
   # tests to run. Specify the *.repo link to an internal repo for tests to execute properly.

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -8,12 +8,11 @@ SERVER:
     # RELEASE: populate with satellite version
     # The snap version currently testing (if applicable)
     # SNAP:
-    # The RHEL Base OS Version(x.y) where the Satellite is installed
-    # RHEL_VERSION:
     # The source of Satellite packages. Can be one of:
     # internal, ga, beta
     SOURCE: "internal"
-    RHEL_RELEASE: '7'
+    # The RHEL Base OS Version(x.y) where the Satellite is installed
+    RHEL_VERSION: '7'
   # run-on-one - All xdist runners default to the first satellite
   # balance - xdist runners will be split between available satellites
   # on-demand - any xdist runner without a satellite will have a new one provisioned.

--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -4,7 +4,9 @@ import re
 
 import pytest
 
+from robottelo.config import settings
 from robottelo.hosts import get_sat_rhel_version
+from robottelo.hosts import get_sat_version
 from robottelo.logging import collection_logger as logger
 
 FMT_XUNIT_TIME = '%Y-%m-%dT%H:%M:%S'
@@ -72,6 +74,8 @@ def pytest_collection_modifyitems(session, items, config):
     """
     # get RHEL version of the satellite
     rhel_version = get_sat_rhel_version().base_version
+    sat_version = get_sat_version().base_version
+    snap_version = settings.server.version.get('snap', '')
 
     # split the option string and handle no option, single option, multiple
     # config.getoption(default) doesn't work like you think it does, hence or ''
@@ -112,6 +116,8 @@ def pytest_collection_modifyitems(session, items, config):
         for marker in item.iter_markers():
             item.user_properties.append((marker.name, next(iter(marker.args), None)))
         item.user_properties.append(("BaseOS", rhel_version))
+        item.user_properties.append(("SatelliteVersion", sat_version))
+        item.user_properties.append(("SnapVersion", snap_version))
         item.user_properties.append(
             ("start_time", datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME))
         )

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -67,8 +67,8 @@ def get_sat_rhel_version():
     try:
         rhel_version = Satellite().os_version
     except (AuthenticationError, ContentHostError, BoxKeyError):
-        if hasattr(settings.server.version, 'rhel_release'):
-            rhel_version = str(settings.server.version.rhel_release)
+        if hasattr(settings.server.version, 'rhel_version'):
+            rhel_version = str(settings.server.version.rhel_version)
         elif hasattr(settings.robottelo, 'rhel_version'):
             rhel_version = settings.robottelo.rhel_version
     return Version(rhel_version)


### PR DESCRIPTION
Updated and added Metadata Markers:
1. Removed RHEL_RELEASE from server.yaml.template to use RHEL_VERSION only.
2. Added Metadata for Satellite Version and Snap Version in metadata markers