### PR TITLE
Satellite Endpoints user properties

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,6 +13,7 @@ pytest_plugins = [
     'pytest_plugins.metadata_markers',
     'pytest_plugins.settings_skip',
     'pytest_plugins.rerun_rp.rerun_rp',
+    'pytest_plugins.fspath_plugins',
     # Fixtures
     'pytest_fixtures.core.broker',
     'pytest_fixtures.core.contenthosts',

--- a/pytest_plugins/fspath_plugins.py
+++ b/pytest_plugins/fspath_plugins.py
@@ -1,0 +1,16 @@
+# File System related Collection Modification/Addition to test cases
+import re
+
+
+def pytest_collection_modifyitems(session, items, config):
+    endpoint_regex = re.compile(
+        # To match the endpoint in the fspath
+        r'^.*/(?P<endpoint>\S*)/test_.*.py$',
+        re.IGNORECASE,
+    )
+    for item in items:
+        if item.nodeid.startswith('tests/robottelo/') or item.nodeid.startswith('tests/upgrades/'):
+            continue
+
+        endpoint = endpoint_regex.findall(item.location[0])[0]
+        item.user_properties.append(('endpoint', endpoint))


### PR DESCRIPTION
The endpoint user property of tests depends on the `item.location` to filter the tests in ibutsu/RP based on api/cli/ui/endtoend/installer/longrun/sys endpoints for a specific compoenent/user(other metadatas) etc.