### PR TITLE
Add parametrized token to all tests inheriting from rhel*_contenthost

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1140,6 +1140,8 @@ class TestCapsuleContentManagement:
             1. The container repo is successfully synced to the Capsule.
             2. The image is successfully pulled from Capsule to a host.
 
+        :parametrized: yes
+
         :CaseLevel: Integration
         """
         upstream_names = [
@@ -1247,6 +1249,8 @@ class TestCapsuleContentManagement:
         :expectedresults:
             1. The ansible-collection repo is successfully synced to the Capsule.
             2. The collection is successfully installed on the Content Host.
+
+        :parametrized: yes
 
         :CaseLevel: Integration
         """

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -240,6 +240,8 @@ def test_positive_install_in_host(
 
     :expectedresults: errata is installed in the host.
 
+    :parametrized: yes
+
     :CaseLevel: System
 
     :BZ: 1983043
@@ -293,6 +295,8 @@ def test_positive_install_multiple_in_host(
         installation
 
     :CaseImportance: Medium
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -553,6 +557,8 @@ def test_positive_get_count_for_host(setup_content_rhel6, rhel6_contenthost, def
 
     :CaseLevel: System
 
+    :parametrized: yes
+
     :CaseImportance: Medium
     """
     ak_name = setup_content_rhel6[0].name
@@ -592,6 +598,8 @@ def test_positive_get_applicable_for_host(setup_content_rhel6, rhel6_contenthost
     :expectedresults: The available errata is retrieved.
 
     :CaseLevel: System
+
+    :parametrized: yes
 
     :CaseImportance: Medium
     """
@@ -708,6 +716,8 @@ def test_positive_incremental_update_required(
 
     :expectedresults: Incremental update requirement is detected.
 
+    :parametrized: yes
+
     :CaseLevel: System
 
     :BZ: 2013093
@@ -818,6 +828,8 @@ def test_errata_installation_with_swidtags(
         module stream update
 
     :CaseAutomation: Automated
+
+    :parametrized: yes
 
     :CaseImportance: Critical
 
@@ -972,6 +984,8 @@ def test_apply_modular_errata_using_default_content_view(
     :expectedresults:  Errata enumeration works with module streams when using default Content View
 
     :CaseAutomation: Automated
+
+    :parametrized: yes
 
     :CaseLevel: System
     """

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1495,6 +1495,8 @@ class TestHostTraces:
 
         :expectedresults: Tracer resolved the problem, the downgraded service was restarted
 
+        :parametrized: yes
+
         :CaseImportance: Medium
         """
         # setup

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -272,6 +272,8 @@ def test_sca_end_to_end(
     :expectedresults: All tests pass and clients have access
         to repos without needing to add subscriptions
 
+    :parametrized: yes
+
     :CaseImportance: Critical
     """
     rhel7_contenthost.install_katello_ca(default_sat)
@@ -333,6 +335,8 @@ def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, functio
                         correctly without any failures
     :BZ: 1826515
 
+    :parametrized: yes
+
     :CaseImportance: High
     """
     repo = entities.Repository(
@@ -389,6 +393,8 @@ def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, defau
     :Assignee: dsynk
 
     :BZ: 1949353
+
+    :parametrized: yes
 
     :CaseImportance: High
     """

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -882,6 +882,8 @@ def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, default_sat
     :expectedresults: Multiple Activation keys are attached to a Content
         host
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     env = make_lifecycle_environment({'organization-id': module_org.id})
@@ -1592,8 +1594,9 @@ def test_positive_subscription_quantity_attached(module_org, rhel7_contenthost, 
         3. Attach a content host to the activation key.
         4. Verify 'ATTACHED' & 'QUANTITY' columns of 'hammer activation-key subscriptions'
 
-    :BZ: 1633094
+    :parametrized: yes
 
+    :BZ: 1633094
     """
     org = make_org()
     result = setup_org_for_a_rh_repo(

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -114,6 +114,8 @@ def test_positive_list_installable_updates(vm):
 
     :BZ: 1344049, 1498158
 
+    :parametrized: yes
+
     :CaseImportance: Critical
     """
     for _ in range(30):
@@ -152,6 +154,8 @@ def test_positive_erratum_installable(vm):
     :expectedresults: errata listed successfuly and is installable
 
     :BZ: 1344049, 1498158
+
+    :parametrized: yes
 
     :CaseImportance: Critical
     """
@@ -221,6 +225,8 @@ def test_negative_unregister_and_pull_content(vm):
     :expectedresults: Host can no longer retrieve content from satellite
 
     :CaseLevel: System
+
+    :parametrized: yes
 
     :CaseImportance: Critical
     """

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2259,6 +2259,8 @@ class TestContentView:
         :expectedresults: host subscribed to content view with user that has
             restricted permissions.
 
+        :parametrized: yes
+
         :CaseLevel: System
         """
         # Note: this test has been stubbed waitin for bug 1511481 resolution
@@ -2415,6 +2417,8 @@ class TestContentView:
 
         :expectedresults: host subscribed to content view with user that has
             restricted permissions.
+
+        :parametrized: yes
 
         :CaseLevel: System
         """

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1210,6 +1210,8 @@ class TestDockerClient:
             2. Register Docker-enabled client against Satellite 6.
 
         :expectedresults: Client can pull Docker images from server and run it.
+
+        :parametrized: yes
         """
         product = make_product_wait({'organization-id': module_org.id})
         repo = _repo(product['id'])
@@ -1272,6 +1274,8 @@ class TestDockerClient:
 
         :expectedresults: Client can search for docker images stored
             on Satellite instance
+
+        :parametrized: yes
         """
         pattern_prefix = gen_string('alpha', 5)
         registry_name_pattern = (
@@ -1372,6 +1376,8 @@ class TestDockerClient:
 
         :expectedresults: Client can pull in docker images stored
             on Satellite instance
+
+        :parametrized: yes
         """
         pattern_prefix = gen_string('alpha', 5)
         docker_upstream_name = CONTAINER_UPSTREAM_NAME
@@ -1472,8 +1478,10 @@ class TestDockerClient:
             7. upload the image to the new repo
 
         :expectedresults: Client can create a new image based off an existing
-            Docker image from a Satellite 6 instance, add a new package and
-            upload the modified image (plus layer) back to the Satellite 6.
+            Docker image from a Satellite instance, add a new package and
+            upload the modified image (plus layer) back to the Satellite.
+
+        :parametrized: yes
         """
         try:
             """

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1374,6 +1374,8 @@ def test_apply_errata_using_default_content_view(errata_host):
 
     :expectedresults: errata listed successfully and is installable
 
+    :parametrized: yes
+
     :CaseImportance: High
     """
     # check that package errata is applicable
@@ -1414,6 +1416,8 @@ def test_update_applicable_package_using_default_content_view(errata_host):
         3. Ensure the package is no longer applicable
 
     :expectedresults: after updating the package it is no longer shown as applicable
+
+    :parametrized: yes
 
     :CaseImportance: High
     """
@@ -1468,6 +1472,8 @@ def test_downgrade_applicable_package_using_default_content_view(errata_host):
         4. Ensure the package is now applicable
 
     :expectedresults: downgraded package shows as applicable
+
+    :parametrized: yes
 
     :CaseImportance: High
     """
@@ -1525,6 +1531,8 @@ def test_install_applicable_package_to_registerd_host(chost):
 
     :expectedresults: Installed package shows errata as applicable and installable
 
+    :parametrized: yes
+
     :CaseImportance: Medium
     """
     # Assert that the package is not applicable
@@ -1579,6 +1587,8 @@ def test_downgrading_package_shows_errata_from_library(errata_host, module_manif
         4. Ensure the errata is now applicable
 
     :expectedresults: errata shows as applicable
+
+    :parametrized: yes
 
     :CaseImportance: High
     """

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -671,6 +671,8 @@ def test_positive_register_with_no_ak(
 
     :expectedresults: Host successfully registered to appropriate org
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     rhel7_contenthost.install_katello_ca(default_sat)
@@ -689,6 +691,8 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel7_contenthos
     :id: 0af81129-cd69-4fa7-a128-9e8fcf2d03b1
 
     :expectedresults: host cannot be registered twice
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -755,6 +759,8 @@ def test_positive_list(module_ak_with_cv, module_lce, module_org, rhel7_contenth
 
     :expectedresults: Hosts are listed for the given org
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     rhel7_contenthost.install_katello_ca(default_sat)
@@ -779,6 +785,8 @@ def test_positive_list_by_last_checkin(
     :expectedresults: Hosts are listed for the given time period
 
     :BZ: 1285992
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -806,6 +814,8 @@ def test_positive_unregister(
     :expectedresults: Host is successfully unregistered. Unlike content
         host, host has not disappeared from list of hosts after
         unregistering.
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -1755,6 +1765,8 @@ def test_positive_report_package_installed_removed(katello_host_tools_host, setu
 
     :BZ: 1463809
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     client = katello_host_tools_host
@@ -1798,6 +1810,8 @@ def test_positive_package_applicability(katello_host_tools_host, setup_custom_re
         2. after step 5: applicable packages list is empty
 
     :BZ: 1463809
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -1852,6 +1866,8 @@ def test_positive_erratum_applicability(katello_host_tools_host, setup_custom_re
 
     :BZ: 1463809,1740790
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     client = katello_host_tools_host
@@ -1889,6 +1905,8 @@ def test_positive_apply_security_erratum(katello_host_tools_host, setup_custom_r
     :customerscenario: true
 
     :BZ: 1420671
+
+    :parametrized: yes
     """
     client = katello_host_tools_host
     host_info = Host.info({'name': client.hostname})
@@ -1918,6 +1936,8 @@ def test_positive_install_package_via_rex(katello_host_tools_host, default_sat, 
     :expectedresults: Package was installed
 
     :CaseLevel: System
+
+    :parametrized: yes
     """
     client = katello_host_tools_host
     host_info = Host.info({'name': client.hostname})
@@ -2107,6 +2127,8 @@ def test_positive_register(request, module_host_subscription, host_subscription_
 
     :expectedresults: host successfully registered
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     module_host_subscription.client = host_subscription_client
@@ -2155,6 +2177,8 @@ def test_positive_attach(request, module_host_subscription, host_subscription_cl
     :expectedresults: host successfully subscribed, subscription repository
         enabled, and repository package installed
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     module_host_subscription.client = host_subscription_client
@@ -2195,6 +2219,8 @@ def test_positive_attach_with_lce(module_host_subscription, host_subscription_cl
     :expectedresults: host successfully subscribed, subscription
         repository enabled, and repository package installed
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     module_host_subscription.client = host_subscription_client
@@ -2227,6 +2253,8 @@ def test_negative_without_attach(request, module_host_subscription, host_subscri
 
     :expectedresults: repository list is empty
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     module_host_subscription.client = host_subscription_client
@@ -2255,6 +2283,8 @@ def test_negative_without_attach_with_lce(module_host_subscription, host_subscri
     :id: fc469e70-a7cb-4fca-b0ea-3c9e3dfff849
 
     :expectedresults: repository not enabled on host
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -2313,6 +2343,8 @@ def test_positive_remove(request, module_host_subscription, host_subscription_cl
     :id: 3833c349-1f5b-41ac-bbac-2c1f33232d76
 
     :expectedresults: subscription successfully removed from host
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -2376,6 +2408,8 @@ def test_positive_auto_attach(request, module_host_subscription, host_subscripti
     :expectedresults: host successfully subscribed, subscription
         repository enabled, and repository package installed
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     module_host_subscription.client = host_subscription_client
@@ -2401,6 +2435,8 @@ def test_positive_unregister_host_subscription(module_host_subscription, host_su
     :id: 608f5b6d-4688-478e-8be8-e946771d5247
 
     :expectedresults: host subscription is unregistered
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -2446,6 +2482,8 @@ def test_syspurpose_end_to_end(module_host_subscription, host_subscription_clien
     :expectedresults: host is registered and system purpose values are correct.
 
     :CaseImportance: Critical
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -2567,6 +2605,8 @@ def test_positive_tracer_list_and_resolve(katello_host_tools_tracer_host, defaul
     :id: 81c83a2c-4b9d-11ec-a5b3-98fa9b6ecd5a
 
     :expectedresults: Tracer resolved the problem, the downgraded service was restarted
+
+    :parametrized: yes
 
     :CaseImportance: Medium
     """

--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -111,6 +111,8 @@ def test_positive_apply_errata(katello_agent_client):
 
     :expectedresults: Errata is scheduled for installation
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     sat = katello_agent_client['sat']
@@ -139,6 +141,8 @@ def test_positive_install_package(katello_agent_client):
 
     :expectedresults: Package was successfully installed
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     sat = katello_agent_client['sat']
@@ -158,6 +162,8 @@ def test_positive_remove_package(katello_agent_client):
     :id: 573dec11-8f14-411f-9e41-84426b0f23b5
 
     :expectedresults: Package was successfully removed
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -179,6 +185,8 @@ def test_positive_upgrade_package(katello_agent_client):
     :id: ad751c63-7175-40ae-8bc4-800462cd9c29
 
     :expectedresults: Package was successfully upgraded
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -202,6 +210,8 @@ def test_positive_upgrade_packages_all(katello_agent_client):
     :expectedresults: Packages (at least 1 with newer version available)
         were successfully upgraded
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     sat = katello_agent_client['sat']
@@ -222,6 +232,8 @@ def test_positive_install_and_remove_package_group(katello_agent_client):
 
     :expectedresults: Package group was successfully installed
         and removed
+
+    :parametrized: yes
 
     :CaseLevel: System
     """

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -770,6 +770,8 @@ def test_positive_generate_entitlements_report_multiple_formats(
 
     :BZ: 1830289
 
+    :parametrized: yes
+
     :customerscenario: true
     """
     client = rhel7_contenthost
@@ -831,6 +833,8 @@ def test_positive_schedule_entitlements_report(
 
     :expectedresults: report is scheduled and generated containing all the expected information
                       regarding entitlements.
+
+    :parametrized: yes
     """
     client = rhel7_contenthost
     client.install_katello_ca(default_sat)

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -274,6 +274,8 @@ def test_positive_auto_attach_disabled_golden_ticket(
 
     :BZ: 1718954
 
+    :parametrized: yes
+
     :CaseImportance: Medium
     """
     rhel7_contenthost_class.install_katello_ca(default_sat)

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1110,6 +1110,8 @@ class TestEndToEnd:
 
         :expectedresults: All tests should succeed and Content should be
             successfully fetched by client.
+
+        :parametrized: yes
         """
         # step 1: Create a new user with admin permissions
         login = gen_string('alphanumeric')

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -120,6 +120,8 @@ def test_positive_cli_end_to_end(fake_manifest_is_set, default_sat, rhel7_conten
 
     :expectedresults: All tests should succeed and Content should be
         successfully fetched by client.
+
+    :parametrized: yes
     """
     # step 1: Create a new user with admin permissions
     password = gen_alphanumeric()

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -178,6 +178,8 @@ def test_positive_noapply_api(module_manifest_org, module_cv, custom_repo, host,
     :expectedresults: Incremental update completed with no errors and
         Content view has a newer version
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     # Promote CV to new LCE

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -91,6 +91,8 @@ def test_positive_end_to_end_register(session, rhel7_contenthost, default_sat):
 
     :CaseLevel: System
 
+    :parametrized: yes
+
     :CaseImportance: High
     """
     org = entities.Organization().create()
@@ -867,6 +869,8 @@ def test_positive_add_host(session, module_org, rhel6_contenthost, default_sat):
 
     :expectedresults: Hosts are successfully associated to Activation key
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     ak = entities.ActivationKey(
@@ -900,6 +904,8 @@ def test_positive_delete_with_system(session, rhel6_contenthost, default_sat):
 
     :expectedresults: Activation key is deleted
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     name = gen_string('alpha')
@@ -926,7 +932,7 @@ def test_positive_delete_with_system(session, rhel6_contenthost, default_sat):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_negative_usage_limit(session, module_org, rhel6_contenthost, default_sat):
+def test_negative_usage_limit(session, module_org, default_sat):
     """Test that Usage limit actually limits usage
 
     :id: 9fe2d661-66f8-46a4-ae3f-0a9329494bdd
@@ -972,6 +978,8 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenth
     :id: 4d6b6b69-9d63-4180-af2e-a5d908f8adb7
 
     :expectedresults: Multiple Activation keys are attached to a system
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -1095,6 +1103,8 @@ def test_positive_service_level_subscription_with_custom_product(
            UI
 
     :BZ: 1394357
+
+    :parametrized: yes
 
     :CaseLevel: System
     """

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -155,6 +155,8 @@ def test_positive_end_to_end(session, default_location, repos_collection, vm):
 
     :CaseLevel: System
 
+    :parametrized: yes
+
     :CaseImportance: Critical
     """
     result = vm.run(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
@@ -237,6 +239,8 @@ def test_positive_end_to_end_bulk_update(session, default_location, vm):
 
     :BZ: 1712069
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     hc_name = gen_string('alpha')
@@ -298,6 +302,8 @@ def test_positive_search_by_subscription_status(session, default_location, vm):
 
     :BZ: 1406855, 1498827, 1495271
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     with session:
@@ -333,6 +339,8 @@ def test_positive_toggle_subscription_status(session, default_location, vm):
     :BZ: 1836868
 
     :CaseLevel: System
+
+    :parametrized: yes
 
     :CaseImportance: Medium
     """
@@ -371,6 +379,8 @@ def test_negative_install_package(session, default_location, vm):
 
     :expectedresults: Task finished with warning
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     with session:
@@ -389,6 +399,8 @@ def test_positive_remove_package(session, default_location, vm):
     :id: 86d8896b-06d9-4c99-937e-f3aa07b4eb69
 
     :expectedresults: Package was successfully removed
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -410,6 +422,8 @@ def test_positive_upgrade_package(session, default_location, vm):
     :id: 1969db93-e7af-4f5f-973d-23c222224db6
 
     :expectedresults: Package was successfully upgraded
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -433,6 +447,8 @@ def test_positive_install_package_group(session, default_location, vm):
 
     :expectedresults: Package group was successfully installed
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     with session:
@@ -455,6 +471,8 @@ def test_positive_remove_package_group(session, default_location, vm):
     :id: dbeea1f2-adf4-4ad8-a989-efad8ce21b98
 
     :expectedresults: Package group was successfully removed
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -483,6 +501,8 @@ def test_positive_search_errata_non_admin(
 
     :expectedresults: User can access errata page and proper errata is
         listed
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -521,6 +541,8 @@ def test_positive_ensure_errata_applicability_with_host_reregistered(session, de
     :expectedresults: errata is available in installable errata list
 
     :BZ: 1463818
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -564,6 +586,8 @@ def test_positive_host_re_registration_with_host_rename(
     :expectedresults: Re-registration should work as expected even after change in hostname
 
     :BZ: 1762793
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -614,6 +638,8 @@ def test_positive_check_ignore_facts_os_setting(session, default_location, vm, m
         to the setting values
 
     :BZ: 1155704
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -683,6 +709,8 @@ def test_positive_virt_who_hypervisor_subscription_status(
 
     :BZ: 1336924, 1860928
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     org = entities.Organization().create()
@@ -750,6 +778,8 @@ def test_module_stream_actions_on_content_host(session, default_location, vm_mod
     :id: 684e467e-b41c-4b95-8450-001abe85abe0
 
     :expectedresults: Remote execution for module actions should succeed.
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -858,6 +888,8 @@ def test_module_streams_customize_action(session, default_location, vm_module_st
 
     :CaseLevel: System
 
+    :parametrized: yes
+
     :CaseImportance: Medium
     """
     search_stream_version = '5.21'
@@ -905,6 +937,8 @@ def test_install_modular_errata(session, default_location, vm_module_streams):
     :id: 3b745562-7f97-4b58-98ec-844685f5c754
 
     :expectedresults: Modular Errata should get installed on content host.
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -970,6 +1004,8 @@ def test_module_status_update_from_content_host_to_satellite(
 
     :expectedresults: module stream status should get updated in Satellite
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     module_name = 'walrus'
@@ -1022,6 +1058,8 @@ def test_module_status_update_without_force_upload_package_profile(
     :expectedresults: module stream status should get updated in Satellite
 
     :CaseLevel: System
+
+    :parametrized: yes
 
     :CaseImportance: Medium
     """
@@ -1088,6 +1126,8 @@ def test_module_stream_update_from_satellite(session, default_location, vm_modul
 
     :expectedresults: module stream should get updated.
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     module_name = 'duck'
@@ -1152,6 +1192,8 @@ def test_syspurpose_attributes_empty(session, default_location, vm_module_stream
 
     :CaseLevel: System
 
+    :parametrized: yes
+
     :CaseImportance: High
     """
     with session:
@@ -1176,6 +1218,8 @@ def test_set_syspurpose_attributes_cli(session, default_location, vm_module_stre
     :expectedresults: Syspurpose attributes set for the content host
 
     :CaseLevel: System
+
+    :parametrized: yes
 
     :CaseImportance: High
     """
@@ -1206,6 +1250,8 @@ def test_unset_syspurpose_attributes_cli(session, default_location, vm_module_st
     :expectedresults: Syspurpose attributes are empty
 
     :CaseLevel: System
+
+    :parametrized: yes
 
     :CaseImportance: High
     """
@@ -1240,6 +1286,8 @@ def test_syspurpose_matched(session, default_location, vm_module_streams):
     :expectedresults: Syspurpose status is Matched
 
     :CaseLevel: System
+
+    :parametrized: yes
 
     :CaseImportance: High
     """
@@ -1297,6 +1345,8 @@ def test_syspurpose_mismatched(session, default_location, vm_module_streams):
     :expectedresults: Syspurpose status is 'Mismatched'
 
     :CaseLevel: System
+
+    :parametrized: yes
 
     :CaseImportance: High
     """
@@ -1421,6 +1471,8 @@ def test_content_access_after_stopped_foreman(
     :CaseComponent: Infrastructure
 
     :Assignee: lpramuk
+
+    :parametrized: yes
     """
     sat = foreman_service_teardown
     org = sat.api.Organization().create()

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2632,6 +2632,8 @@ def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthos
 
     :CaseLevel: Integration
 
+    :parametrized: yes
+
     :CaseImportance: High
     """
     org = entities.Organization().create()
@@ -3073,6 +3075,8 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, default
            updated package
 
     :CaseImportance: Medium
+
+    :parametrized: yes
 
     :CaseLevel: Integration
     """

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -214,6 +214,8 @@ def test_positive_user_access_with_host_filter(
 
     :BZ: 1417114
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     user_login = gen_string('alpha')

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -226,6 +226,8 @@ def test_end_to_end(session, module_org, module_repos_col, vm, default_sat):
     :expectedresults: Errata details are the same as expected, errata
         installation is successful
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     ERRATA_DETAILS = {
@@ -599,6 +601,8 @@ def test_positive_content_host_previous_env(session, module_org, module_repos_co
 
     :expectedresults: The errata from previous environments are displayed.
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     hostname = vm.hostname
@@ -641,6 +645,8 @@ def test_positive_content_host_library(session, module_org, vm):
     :Steps: Go to Content Hosts -> Select content host -> Errata Tab -> Select 'Library'.
 
     :expectedresults: The errata from Library are displayed.
+
+    :parametrized: yes
 
     :CaseLevel: System
     """

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1544,6 +1544,8 @@ def test_global_registration_with_capsule_host(
         4. open the global registration form and select the same capsule
         5. check host is registered successfully with selected capsule
 
+    :parametrized: yes
+
     :CaseAutomation: ManualOnly
     """
     client = rhel7_contenthost
@@ -1634,6 +1636,8 @@ def test_global_registration_with_gpg_repo_and_default_package(
         4. open the global registration form and update the gpg repo and key
         5. check host is registered successfully with installed same package
         6. check gpg repo is exist in registered host
+
+    :parametrized: yes
     """
     client = rhel7_contenthost
     repo_name = 'foreman_register'
@@ -1686,6 +1690,8 @@ def test_global_re_registration_host_with_force_ignore_error_options(
         3. open the global registration form and select --force and --Ignore Errors option
         4. registered the host with generated curl command
         5. re-register the same host again and check it is getting registered
+
+    :parametrized: yes
     """
     client = rhel7_contenthost
     with session:
@@ -1728,6 +1734,7 @@ def test_global_registration_token_restriction(
         1. open the global registration form and generate the curl token
         2. use that curl token to execute other api calls e.g. GET /hosts, /users
 
+    :parametrized: yes
     """
     client = rhel7_contenthost
     with session:

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -48,6 +48,8 @@ def test_positive_run_default_job_template_by_ip(session, module_org, module_rhe
 
     :expectedresults: Verify the job was successfully ran against the host
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     hostname = module_rhel_client_by_ip.hostname
@@ -83,6 +85,8 @@ def test_positive_run_custom_job_template_by_ip(session, module_org, module_rhel
         4. Run the job
 
     :expectedresults: Verify the job was successfully ran against the host
+
+    :parametrized: yes
 
     :CaseLevel: System
     """

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -54,6 +54,8 @@ def test_positive_run_default_job_template_by_ip(
 
     :expectedresults: Verify the job was successfully ran against the host
 
+    :parametrized: yes
+
     :CaseLevel: Integration
     """
     hostname = module_vm_client_by_ip.hostname
@@ -94,6 +96,8 @@ def test_positive_run_custom_job_template_by_ip(
         4. Run the job
 
     :expectedresults: Verify the job was successfully ran against the host
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -204,6 +208,8 @@ def test_positive_run_scheduled_job_template_by_ip(
 
         1. Verify the job was not immediately ran
         2. Verify the job was successfully ran after the designated time
+
+    :parametrized: yes
 
     :CaseLevel: System
     """

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -512,6 +512,8 @@ def test_positive_gen_entitlements_reports_multiple_formats(
     :expectedresults: reports are generated containing all the expected information
                       regarding Entitlements for each output format.
 
+    :parametrized: yes
+
     :CaseImportance: High
     """
     client = rhel7_contenthost

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -60,6 +60,8 @@ def test_rhcloud_insights_e2e(
 
     :customerscenario: true
 
+    :parametrized: yes
+
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
@@ -253,6 +255,8 @@ def test_host_details_page(
 
     :BZ: 1974578
 
+    :parametrized: yes
+
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
@@ -325,6 +329,8 @@ def test_rh_cloud_insights_clean_statuses(
 
     :BZ: 1962930
 
+    :parametrized: yes
+
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
@@ -384,6 +390,8 @@ def test_delete_host_having_insights_recommendation(
     :CaseImportance: Critical
 
     :BZ: 1860422, 1928652
+
+    :parametrized: yes
 
     :CaseAutomation: Automated
     """
@@ -471,6 +479,8 @@ def test_insights_tab_on_host_details_page(
     :CaseImportance: High
 
     :BZ: 1865876, 1879448
+
+    :parametrized: yes
 
     :CaseAutomation: Automated
     """

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -273,6 +273,8 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, def
 
     :BZ: 1366327
 
+    :parametrized: yes
+
     :CaseLevel: System
     """
     org = entities.Organization().create()
@@ -330,6 +332,8 @@ def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthos
            not empty and one of the consumed products exist
 
     :BZ: 1395788, 1506636, 1487317
+
+    :parametrized: yes
 
     :CaseLevel: System
     """
@@ -452,6 +456,8 @@ def test_positive_subscription_status_disabled_golden_ticket(
 
     :BZ: 1789924
 
+    :parametrized: yes
+
     :CaseImportance: Medium
     """
     rhel7_contenthost.install_katello_ca(default_sat)
@@ -487,6 +493,8 @@ def test_positive_candlepin_events_processed_by_STOMP(session, rhel7_contenthost
                       correctly without any failures
 
     :BZ: 1826515
+
+    :parametrized: yes
 
     :CaseImportance: High
     """

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -82,6 +82,8 @@ class TestScenarioREXCapsule:
         :expectedresults:
             1. Content host should create with pre-required details.
             2. REX job should run on it.
+
+        :parametrized: yes
         """
         sn = entities.Subnet(
             domain=self.vm_domain,
@@ -180,6 +182,8 @@ class TestScenarioREXSatellite:
         :expectedresults:
             1. It should create with pre-required details.
             2. REX job should run on it.
+
+        :parametrized: yes
         """
         sn = entities.Subnet(
             domain=self.vm_domain,


### PR DESCRIPTION
fixtures
These fixtures influencing the paramterization classification of dependent tests.
Adding the token accordingly.