### PR TITLE
Fix tests failing for RHEL8 OS component on Satellite installed on RHL8

### DIFF
--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -4,6 +4,7 @@ from nailgun import entities
 
 from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
+from robottelo.constants import RHEL_8_MAJOR_VERSION
 
 
 @pytest.fixture(scope='session')
@@ -22,7 +23,7 @@ def default_os(
     if os is None:
         search_string = (
             f'name="RedHat" AND (major="{RHEL_6_MAJOR_VERSION}" '
-            f'OR major="{RHEL_7_MAJOR_VERSION}")'
+            f'OR major="{RHEL_7_MAJOR_VERSION}" OR major="{RHEL_8_MAJOR_VERSION}")'
         )
     else:
         version = os.split(' ')[1].split('.')


### PR DESCRIPTION
Many tests are failing for the `default_os` fixture where the Satellite is installed on RHEL8. Because it searches for default_os as `RHEL8` in satellite and we havent added that yet !

This PR adds that !