### PR TITLE
disabled and enabled puppet tests fixes in 7.0

### DIFF
--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -2,6 +2,7 @@
 import pytest
 
 from robottelo.config import settings
+from robottelo.constants import ENVIRONMENT
 from robottelo.constants import RHEL_6_MAJOR_VERSION
 from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.constants import RHEL_8_MAJOR_VERSION
@@ -152,3 +153,31 @@ def session_puppet_default_os(session_puppet_enabled_sat):
         .search(query={'search': search_string})[0]
         .read()
     )
+
+
+@pytest.fixture(scope='module')
+def module_puppet_published_cv(session_puppet_enabled_sat, module_puppet_org):
+    content_view = session_puppet_enabled_sat.api.ContentView(
+        organization=module_puppet_org
+    ).create()
+    content_view.publish()
+    return content_view.read()
+
+
+@pytest.fixture(scope='module')
+def module_puppet_lce_library(session_puppet_enabled_sat, module_puppet_org):
+    """Returns the Library lifecycle environment from chosen organization"""
+    return (
+        session_puppet_enabled_sat.api.LifecycleEnvironment()
+        .search(query={'search': f'name={ENVIRONMENT} and organization_id={module_puppet_org.id}'})[
+            0
+        ]
+        .read()
+    )
+
+
+@pytest.fixture(scope='module')
+def module_puppet_user(session_puppet_enabled_sat, module_puppet_org, module_puppet_loc):
+    return session_puppet_enabled_sat.api.User(
+        organization=[module_puppet_org], location=[module_puppet_loc]
+    ).create()

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -32,4 +32,5 @@ def module_markers():
         "host_parameter: Marks host parameter CLI tests",
         "katello_host_tools: Marks host CLI tests where katello host tools is installed on client",
         "host_subscription: Marks host subscription CLI tests",
+        "puppet_enabled: Marks CLI host tests with enabled puppet",
     ]

--- a/robottelo/host_helpers/__init__.py
+++ b/robottelo/host_helpers/__init__.py
@@ -1,3 +1,4 @@
+from robottelo.host_helpers.capsule_mixins import CapsuleInfo
 from robottelo.host_helpers.contenthost_mixins import SystemFacts
 from robottelo.host_helpers.contenthost_mixins import VersionedContent
 from robottelo.host_helpers.satellite_mixins import ContentInfo
@@ -5,6 +6,10 @@ from robottelo.host_helpers.satellite_mixins import Factories
 
 
 class ContentHostMixins(SystemFacts, VersionedContent):
+    pass
+
+
+class CapsuleMixins(CapsuleInfo):
     pass
 
 

--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -1,0 +1,95 @@
+import contextlib
+import random
+
+from robottelo.cli.proxy import CapsuleTunnelError
+from robottelo.logging import logger
+
+
+class CapsuleInfo:
+    """Miscellaneous Capsule helper methods"""
+
+    def get_available_capsule_port(self, port_pool=None):
+        """returns a list of unused ports dedicated for fake capsules
+        This calls an ss command on the server prompting for a port range. ss
+        returns a list of ports which have a PID assigned (a list of ports
+        which are already used). This function then substracts unavailable ports
+        from the other ones and returns one of available ones randomly.
+
+        :param port_pool: A list of ports used for fake capsules (for RHEL7+: don't
+            forget to set a correct selinux context before otherwise you'll get
+            Connection Refused error)
+
+        :return: Random available port from interval <9091, 9190>.
+        :rtype: int
+        """
+        if port_pool is None:
+            from robottelo.config import settings
+
+            port_pool_range = settings.fake_capsules.port_range
+            if isinstance(port_pool_range, str):
+                port_pool_range = tuple(port_pool_range.split('-'))
+            if isinstance(port_pool_range, tuple) and len(port_pool_range) == 2:
+                port_pool = range(int(port_pool_range[0]), int(port_pool_range[1]))
+            else:
+                raise TypeError(
+                    'Expected type of port_range is a tuple of 2 elements,'
+                    f'got {type(port_pool_range)} instead'
+                )
+        # returns a list of strings
+        ss_cmd = self.execute(
+            f"ss -tnaH sport ge {port_pool[0]} sport le {port_pool[-1]}"
+            " | awk '{n=split($4, p, \":\"); print p[n]}' | sort -u"
+        )
+        if ss_cmd.stderr[1]:
+            raise CapsuleTunnelError(
+                f'Failed to create ssh tunnel: Error getting port status: {ss_cmd.stderr}'
+            )
+        # converts a List of strings to a List of integers
+        try:
+            used_ports = map(
+                int, [val for val in ss_cmd.stdout.splitlines()[:-1] if val != 'Cannot stat file ']
+            )
+
+        except ValueError:
+            raise CapsuleTunnelError(
+                f'Failed parsing the port numbers from stdout: {ss_cmd.stdout.splitlines()[:-1]}'
+            )
+        try:
+            # take the list of available ports and return randomly selected one
+            return random.choice([port for port in port_pool if port not in used_ports])
+        except IndexError:
+            raise CapsuleTunnelError(
+                'Failed to create ssh tunnel: No more ports available for mapping'
+            )
+
+    @contextlib.contextmanager
+    def default_url_on_new_port(self, oldport, newport):
+        """Creates context where the default capsule is forwarded on a new port
+
+        :param int oldport: Port to be forwarded.
+        :param int newport: New port to be used to forward `oldport`.
+
+        :return: A string containing the new capsule URL with port.
+        :rtype: str
+
+        """
+        pre_ncat_procs = self.execute('pgrep ncat').stdout.splitlines()
+        with self.session.shell() as channel:
+            # if ncat isn't backgrounded, it prevents the channel from closing
+            command = f'ncat -kl -p {newport} -c "ncat {self.hostname} {oldport}" &'
+            logger.debug(f'Creating tunnel: {command}')
+            channel.send(command)
+            post_ncat_procs = self.execute('pgrep ncat').stdout.splitlines()
+            ncat_pid = set(post_ncat_procs).difference(set(pre_ncat_procs))
+            if not len(ncat_pid):
+                stderr = channel.get_exit_status()[1]
+                logger.debug(f'Tunnel failed: {stderr}')
+                # Something failed, so raise an exception.
+                raise CapsuleTunnelError(f'Starting ncat failed: {stderr}')
+            forward_url = f'https://{self.hostname}:{newport}'
+            logger.debug(f'Yielding capsule forward port url: {forward_url}')
+            try:
+                yield forward_url
+            finally:
+                logger.debug(f'Killing ncat pid: {ncat_pid}')
+                self.execute(f'kill {ncat_pid.pop()}')

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -3,7 +3,6 @@ This module is a more object oriented replacement for robottelo.cli.factory
 It is not meant to be used directly, but as part of a robottelo.hosts.Satellite instance
 example: my_satellite.cli_factory.make_org()
 """
-import contextlib
 import datetime
 import inspect
 import os
@@ -27,11 +26,9 @@ from fauxfactory import gen_url
 
 from robottelo import constants
 from robottelo import manifests
-from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.config import settings
-from robottelo.logging import logger
 
 
 class CLIFactoryError(Exception):
@@ -499,9 +496,9 @@ class CLIFactory:
         args = {'name': gen_alphanumeric()}
 
         if options is None or 'url' not in options:
-            newport = self.get_available_capsule_port()
+            newport = self._satellite.get_available_capsule_port()
             try:
-                with self.default_url_on_new_port(9090, newport) as url:
+                with self._satellite.default_url_on_new_port(9090, newport) as url:
                     args['url'] = url
                     return create_object(self._satellite.cli.Proxy, args, options)
             except CapsuleTunnelError as err:
@@ -1360,93 +1357,3 @@ class CLIFactory:
             data['lce'] = lce
 
         return data
-
-    def get_available_capsule_port(self, port_pool=None):
-        """returns a list of unused ports dedicated for fake capsules
-        This calls an ss command on the server prompting for a port range. ss
-        returns a list of ports which have a PID assigned (a list of ports
-        which are already used). This function then substracts unavailable ports
-        from the other ones and returns one of available ones randomly.
-
-        :param port_pool: A list of ports used for fake capsules (for RHEL7+: don't
-            forget to set a correct selinux context before otherwise you'll get
-            Connection Refused error)
-
-        :return: Random available port from interval <9091, 9190>.
-        :rtype: int
-        """
-        if port_pool is None:
-            port_pool_range = settings.fake_capsules.port_range
-            if type(port_pool_range) is str:
-                port_pool_range = tuple(port_pool_range.split('-'))
-            if type(port_pool_range) is tuple and len(port_pool_range) == 2:
-                port_pool = range(int(port_pool_range[0]), int(port_pool_range[1]))
-            else:
-                raise TypeError(
-                    'Expected type of port_range is a tuple of 2 elements,'
-                    f'got {type(port_pool_range)} instead'
-                )
-        # returns a list of strings
-        ss_cmd = self._satellite.execute(
-            f"ss -tnaH sport ge {port_pool[0]} sport le {port_pool[-1]}"
-            " | awk '{n=split($4, p, \":\"); print p[n]}' | sort -u"
-        )
-        if ss_cmd.stderr[1]:
-            raise CapsuleTunnelError(
-                f'Failed to create ssh tunnel: Error getting port status: {ss_cmd.stderr}'
-            )
-        # converts a List of strings to a List of integers
-        try:
-            print(ss_cmd)
-            used_ports = map(
-                int, [val for val in ss_cmd.stdout.splitlines()[:-1] if val != 'Cannot stat file ']
-            )
-
-        except ValueError:
-            raise CapsuleTunnelError(
-                f'Failed parsing the port numbers from stdout: {ss_cmd.stdout.splitlines()[:-1]}'
-            )
-        try:
-            # take the list of available ports and return randomly selected one
-            return random.choice([port for port in port_pool if port not in used_ports])
-        except IndexError:
-            raise CapsuleTunnelError(
-                'Failed to create ssh tunnel: No more ports available for mapping'
-            )
-
-    @contextlib.contextmanager
-    def default_url_on_new_port(self, oldport, newport):
-        """Creates context where the default capsule is forwarded on a new port
-
-        :param int oldport: Port to be forwarded.
-        :param int newport: New port to be used to forward `oldport`.
-
-        :return: A string containing the new capsule URL with port.
-        :rtype: str
-
-        """
-        domain = settings.server.hostname
-
-        client = ssh.get_client(hostname=self._satellite.hostname)
-        pre_ncat_procs = client.execute('pgrep ncat').stdout.splitlines()
-
-        with client.session.shell() as channel:
-            # if ncat isn't backgrounded, it prevents the channel from closing
-            command = f'ncat -kl -p {newport} -c "ncat {domain} {oldport}" &'
-            # broker 0.1.25 makes these debug messages redundant
-            logger.debug(f'Creating tunnel: {command}')
-            channel.send(command)
-            post_ncat_procs = client.execute('pgrep ncat').stdout.splitlines()
-            ncat_pid = set(post_ncat_procs).difference(set(pre_ncat_procs))
-            if not len(ncat_pid):
-                stderr = channel.get_exit_status()[1]
-                logger.debug(f'Tunnel failed: {stderr}')
-                # Something failed, so raise an exception.
-                raise CapsuleTunnelError(f'Starting ncat failed: {stderr}')
-            forward_url = f'https://{domain}:{newport}'
-            logger.debug(f'Yielding capsule forward port url: {forward_url}')
-            try:
-                yield forward_url
-            finally:
-                logger.debug(f'Killing ncat pid: {ncat_pid}')
-                client.execute(f'kill {ncat_pid.pop()}')

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -3,6 +3,7 @@ This module is a more object oriented replacement for robottelo.cli.factory
 It is not meant to be used directly, but as part of a robottelo.hosts.Satellite instance
 example: my_satellite.cli_factory.make_org()
 """
+import contextlib
 import datetime
 import inspect
 import os
@@ -26,8 +27,11 @@ from fauxfactory import gen_url
 
 from robottelo import constants
 from robottelo import manifests
+from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.config import settings
+from robottelo.logging import logger
 
 
 class CLIFactoryError(Exception):
@@ -500,7 +504,7 @@ class CLIFactory:
                 with self.default_url_on_new_port(9090, newport) as url:
                     args['url'] = url
                     return create_object(self._satellite.cli.Proxy, args, options)
-            except self._satellite.cli.CapsuleTunnelError as err:
+            except CapsuleTunnelError as err:
                 raise CLIFactoryError(f'Failed to create ssh tunnel: {err}')
         args['url'] = options['url']
         return create_object(self._satellite.cli.Proxy, args, options)
@@ -1356,3 +1360,93 @@ class CLIFactory:
             data['lce'] = lce
 
         return data
+
+    def get_available_capsule_port(self, port_pool=None):
+        """returns a list of unused ports dedicated for fake capsules
+        This calls an ss command on the server prompting for a port range. ss
+        returns a list of ports which have a PID assigned (a list of ports
+        which are already used). This function then substracts unavailable ports
+        from the other ones and returns one of available ones randomly.
+
+        :param port_pool: A list of ports used for fake capsules (for RHEL7+: don't
+            forget to set a correct selinux context before otherwise you'll get
+            Connection Refused error)
+
+        :return: Random available port from interval <9091, 9190>.
+        :rtype: int
+        """
+        if port_pool is None:
+            port_pool_range = settings.fake_capsules.port_range
+            if type(port_pool_range) is str:
+                port_pool_range = tuple(port_pool_range.split('-'))
+            if type(port_pool_range) is tuple and len(port_pool_range) == 2:
+                port_pool = range(int(port_pool_range[0]), int(port_pool_range[1]))
+            else:
+                raise TypeError(
+                    'Expected type of port_range is a tuple of 2 elements,'
+                    f'got {type(port_pool_range)} instead'
+                )
+        # returns a list of strings
+        ss_cmd = self._satellite.execute(
+            f"ss -tnaH sport ge {port_pool[0]} sport le {port_pool[-1]}"
+            " | awk '{n=split($4, p, \":\"); print p[n]}' | sort -u"
+        )
+        if ss_cmd.stderr[1]:
+            raise CapsuleTunnelError(
+                f'Failed to create ssh tunnel: Error getting port status: {ss_cmd.stderr}'
+            )
+        # converts a List of strings to a List of integers
+        try:
+            print(ss_cmd)
+            used_ports = map(
+                int, [val for val in ss_cmd.stdout.splitlines()[:-1] if val != 'Cannot stat file ']
+            )
+
+        except ValueError:
+            raise CapsuleTunnelError(
+                f'Failed parsing the port numbers from stdout: {ss_cmd.stdout.splitlines()[:-1]}'
+            )
+        try:
+            # take the list of available ports and return randomly selected one
+            return random.choice([port for port in port_pool if port not in used_ports])
+        except IndexError:
+            raise CapsuleTunnelError(
+                'Failed to create ssh tunnel: No more ports available for mapping'
+            )
+
+    @contextlib.contextmanager
+    def default_url_on_new_port(self, oldport, newport):
+        """Creates context where the default capsule is forwarded on a new port
+
+        :param int oldport: Port to be forwarded.
+        :param int newport: New port to be used to forward `oldport`.
+
+        :return: A string containing the new capsule URL with port.
+        :rtype: str
+
+        """
+        domain = settings.server.hostname
+
+        client = ssh.get_client(hostname=self._satellite.hostname)
+        pre_ncat_procs = client.execute('pgrep ncat').stdout.splitlines()
+
+        with client.session.shell() as channel:
+            # if ncat isn't backgrounded, it prevents the channel from closing
+            command = f'ncat -kl -p {newport} -c "ncat {domain} {oldport}" &'
+            # broker 0.1.25 makes these debug messages redundant
+            logger.debug(f'Creating tunnel: {command}')
+            channel.send(command)
+            post_ncat_procs = client.execute('pgrep ncat').stdout.splitlines()
+            ncat_pid = set(post_ncat_procs).difference(set(pre_ncat_procs))
+            if not len(ncat_pid):
+                stderr = channel.get_exit_status()[1]
+                logger.debug(f'Tunnel failed: {stderr}')
+                # Something failed, so raise an exception.
+                raise CapsuleTunnelError(f'Starting ncat failed: {stderr}')
+            forward_url = f'https://{domain}:{newport}'
+            logger.debug(f'Yielding capsule forward port url: {forward_url}')
+            try:
+                yield forward_url
+            finally:
+                logger.debug(f'Killing ncat pid: {ncat_pid}')
+                client.execute(f'kill {ncat_pid.pop()}')

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -36,6 +36,7 @@ from robottelo.constants import SATELLITE_VERSION
 from robottelo.helpers import get_data_file
 from robottelo.helpers import InstallerCommand
 from robottelo.helpers import validate_ssh_pub_key
+from robottelo.host_helpers import CapsuleMixins
 from robottelo.host_helpers import ContentHostMixins
 from robottelo.host_helpers import SatelliteMixins
 from robottelo.logging import logger
@@ -1063,7 +1064,7 @@ class ContentHost(Host, ContentHostMixins):
         self.execute('katello-tracer-upload')
 
 
-class Capsule(ContentHost):
+class Capsule(ContentHost, CapsuleMixins):
     rex_key_path = '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
 
     @property

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -76,48 +76,21 @@ def module_default_proxy(default_sat):
 
 
 @pytest.fixture(scope="function")
-def function_proxy():
-    proxy = make_proxy()
-    yield proxy
-    Proxy.delete({'id': proxy['id']})
-
-
-@pytest.fixture(scope="function")
-def function_host_content_source(
-    module_default_proxy, module_lce_library, module_org, module_published_cv
-):
-    host = make_fake_host(
-        {
-            'content-source-id': module_default_proxy['id'],
-            'content-view-id': module_published_cv.id,
-            'lifecycle-environment-id': module_lce_library.id,
-            'organization': module_org.name,
-        }
-    )
-    yield host
-    Host.delete({'id': host['id']})
-
-
-@pytest.fixture(scope="function")
-def function_host(module_default_proxy):
+def function_host():
     host_template = entities.Host()
     host_template.create_missing()
-    org_id = host_template.organization.id
-    loc_id = host_template.location.id
     # using CLI to create host
     host = make_host(
         {
             'architecture-id': host_template.architecture.id,
             'domain-id': host_template.domain.id,
-            'environment-id': host_template.environment.id,
-            'location-id': loc_id,
+            'location-id': host_template.location.id,
             'mac': host_template.mac,
             'medium-id': host_template.medium.id,
             'name': host_template.name,
             'operatingsystem-id': host_template.operatingsystem.id,
-            'organization-id': org_id,
+            'organization-id': host_template.organization.id,
             'partition-table-id': host_template.ptable.id,
-            'puppet-proxy-id': module_default_proxy['id'],
             'root-password': host_template.root_pass,
         }
     )
@@ -363,7 +336,6 @@ def test_positive_create_and_delete(module_lce_library, module_published_cv):
             'architecture-id': host.architecture.id,
             'content-view-id': module_published_cv.id,
             'domain-id': host.domain.id,
-            'environment-id': host.environment.id,
             'interface': interface,
             'lifecycle-environment-id': module_lce_library.id,
             'location-id': host.location.id,
@@ -450,34 +422,6 @@ def test_positive_crud_interface_by_id(default_location, default_org):
 
 
 @pytest.mark.host_create
-@pytest.mark.run_in_one_thread
-@pytest.mark.tier2
-def test_positive_create_and_update_with_content_source(
-    function_host_content_source, function_proxy, module_default_proxy
-):
-    """Create a host with content source specified and update content
-        source
-
-    :id: 5712f4db-3610-447d-b1da-0fe461577d59
-
-    :customerscenario: true
-
-    :BZ: 1260697, 1483252, 1313056, 1488465
-
-    :expectedresults: A host is created with expected content source
-        assigned and then content source is successfully updated
-
-    :CaseImportance: High
-    """
-    host = function_host_content_source
-    assert host['content-information']['content-source']['name'] == module_default_proxy['name']
-    new_content_source = function_proxy
-    Host.update({'id': host['id'], 'content-source-id': new_content_source['id']})
-    host = Host.info({'id': host['id']})
-    assert host['content-information']['content-source']['name'] == new_content_source['name']
-
-
-@pytest.mark.host_create
 @pytest.mark.tier2
 def test_negative_create_with_content_source(module_lce_library, module_org, module_published_cv):
     """Attempt to create a host with invalid content source specified
@@ -557,34 +501,6 @@ def test_positive_create_with_lce_and_cv(module_lce, module_org, module_promoted
     )
     assert new_host['content-information']['lifecycle-environment']['name'] == module_lce.name
     assert new_host['content-information']['content-view']['name'] == module_promoted_cv.name
-
-
-@pytest.mark.host_create
-@pytest.mark.tier1
-def test_positive_create_with_puppet_class_name(
-    module_env_search, module_location, module_org, module_puppet_classes, default_smart_proxy
-):
-    """Check if host can be created with puppet class name
-
-    :id: a65df36e-db4b-48d2-b0e1-5ccfbefd1e7a
-
-    :expectedresults: Host is created and has puppet class assigned
-
-    :CaseImportance: Critical
-    """
-    update_smart_proxy(module_location, default_smart_proxy)
-    host = make_fake_host(
-        {
-            'puppet-class-ids': [module_puppet_classes[0].id],
-            'environment': module_env_search.name,
-            'organization-id': module_org.id,
-            'location-id': module_location.id,
-            'puppet-ca-proxy-id': default_smart_proxy.id,
-            'puppet-proxy-id': default_smart_proxy.id,
-        }
-    )
-    host_classes = Host.puppetclasses({'host': host['name']})
-    assert module_puppet_classes[0].name in [puppet['name'] for puppet in host_classes]
 
 
 @pytest.mark.host_create
@@ -728,54 +644,16 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel7_contenthos
 
 
 @pytest.mark.host_create
-@pytest.mark.tier2
-def test_positive_list_scparams(
-    module_env_search, module_location, module_org, module_puppet_classes, default_smart_proxy
-):
-    """List all smart class parameters using host id
-
-    :id: 61814875-5ccd-4c04-a638-d36fe089d514
-
-    :expectedresults: Overridden sc-param from puppet
-        class are listed
-
-    :CaseLevel: Integration
-    """
-    update_smart_proxy(module_location, default_smart_proxy)
-    # Create hostgroup with associated puppet class
-    host = make_fake_host(
-        {
-            'puppet-class-ids': [module_puppet_classes[0].id],
-            'environment': module_env_search.name,
-            'organization-id': module_org.id,
-            'location-id': module_location.id,
-            'puppet-ca-proxy-id': default_smart_proxy.id,
-            'puppet-proxy-id': default_smart_proxy.id,
-        }
-    )
-
-    # Override one of the sc-params from puppet class
-    sc_params_list = SmartClassParameter.list(
-        {
-            'environment': module_env_search.name,
-            'search': f'puppetclass="{module_puppet_classes[0].name}"',
-        }
-    )
-    scp_id = choice(sc_params_list)['id']
-    SmartClassParameter.update({'id': scp_id, 'override': 1})
-    # Verify that affected sc-param is listed
-    host_scparams = Host.sc_params({'host': host['name']})
-    assert scp_id in [scp['id'] for scp in host_scparams]
-
-
-@pytest.mark.host_create
 @pytest.mark.tier3
-def test_positive_list(module_ak_with_cv, module_lce, module_org, rhel7_contenthost, default_sat):
-    """List hosts for a given org
+def test_positive_list_and_unregister(
+    module_ak_with_cv, module_lce, module_org, rhel7_contenthost, default_sat
+):
+    """List registered host for a given org and unregister the host
 
     :id: b9c056cd-11ca-4870-bac4-0ebc4a782cb0
 
-    :expectedresults: Hosts are listed for the given org
+    :expectedresults: Host is listed for the given org and host is successfully unregistered.
+        Unlike content host, host has not disappeared from list of hosts after unregistering.
 
     :parametrized: yes
 
@@ -784,8 +662,11 @@ def test_positive_list(module_ak_with_cv, module_lce, module_org, rhel7_contenth
     rhel7_contenthost.install_katello_ca(default_sat)
     rhel7_contenthost.register_contenthost(module_org.label, module_ak_with_cv.name)
     assert rhel7_contenthost.subscribed
-    hosts = Host.list({'organization-id': module_org.id, 'environment-id': module_lce.id})
-    assert len(hosts) >= 1
+    hosts = Host.list({'organization-id': module_org.id})
+    assert rhel7_contenthost.hostname in [host['name'] for host in hosts]
+    result = rhel7_contenthost.run('subscription-manager unregister')
+    assert result.status == 0
+    hosts = Host.list({'organization-id': module_org.id})
     assert rhel7_contenthost.hostname in [host['name'] for host in hosts]
 
 
@@ -855,44 +736,12 @@ def test_positive_list_infrastructure_hosts(
     assert default_sat.hostname in hostnames
 
 
-@pytest.mark.host_create
-@pytest.mark.tier3
-@pytest.mark.upgrade
-def test_positive_unregister(
-    module_ak_with_cv, module_lce, module_org, rhel7_contenthost, default_sat
-):
-    """Unregister a host
-
-    :id: c5ce988d-d0ea-4958-9956-5a4b039b285c
-
-    :expectedresults: Host is successfully unregistered. Unlike content
-        host, host has not disappeared from list of hosts after
-        unregistering.
-
-    :parametrized: yes
-
-    :CaseLevel: System
-    """
-    rhel7_contenthost.install_katello_ca(default_sat)
-    rhel7_contenthost.register_contenthost(module_org.label, module_ak_with_cv.name)
-    assert rhel7_contenthost.subscribed
-    hosts = Host.list({'organization-id': module_org.id, 'environment-id': module_lce.id})
-    assert len(hosts) >= 1
-    assert rhel7_contenthost.hostname in [host['name'] for host in hosts]
-    result = rhel7_contenthost.run('subscription-manager unregister')
-    assert result.status == 0
-    hosts = Host.list({'organization-id': module_org.id, 'environment-id': module_lce.id})
-    assert rhel7_contenthost.hostname in [host['name'] for host in hosts]
-
-
 @pytest.mark.skip_if_not_set('libvirt')
 @pytest.mark.host_create
 @pytest.mark.libvirt_discovery
 @pytest.mark.onprem_provisioning
 @pytest.mark.tier1
-def test_positive_create_using_libvirt_without_mac(
-    module_location, module_org, module_default_proxy
-):
+def test_positive_create_using_libvirt_without_mac(module_location, module_org):
     """Create a libvirt host and not specify a MAC address.
 
     :id: b003faa9-2810-4176-94d2-ea84bed248eb
@@ -913,14 +762,12 @@ def test_positive_create_using_libvirt_without_mac(
             'architecture-id': host.architecture.id,
             'compute-resource-id': compute_resource.id,
             'domain-id': host.domain.id,
-            'environment-id': host.environment.id,
             'location-id': host.location.id,
             'medium-id': host.medium.id,
             'name': host.name,
             'operatingsystem-id': host.operatingsystem.id,
             'organization-id': host.organization.id,
             'partition-table-id': host.ptable.id,
-            'puppet-proxy-id': module_default_proxy['id'],
             'root-password': host.root_pass,
         }
     )
@@ -1127,11 +974,6 @@ def test_positive_update_parameters_by_name(function_host, module_architecture, 
         query={'search': f'name="{function_host["organization"]}"'}
     )[0]
     new_domain = entities.Domain(location=[new_loc], organization=[organization]).create()
-    new_env = entities.Environment(
-        name=gen_string('alphanumeric'),
-        organization=[organization],
-        location=[new_loc],
-    ).create()
     p_table_name = function_host['operating-system']['partition-table']
     p_table = entities.PartitionTable().search(query={'search': f'name="{p_table_name}"'})
     new_os = entities.OperatingSystem(
@@ -1150,7 +992,6 @@ def test_positive_update_parameters_by_name(function_host, module_architecture, 
         {
             'architecture': module_architecture.name,
             'domain': new_domain.name,
-            'environment': new_env.name,
             'name': function_host['name'],
             'mac': new_mac,
             'medium-id': new_medium.id,
@@ -1164,7 +1005,6 @@ def test_positive_update_parameters_by_name(function_host, module_architecture, 
     assert host['location'] == new_loc.name
     assert host['network']['mac'] == new_mac
     assert host['network']['domain'] == new_domain.name
-    assert host['puppet-environment'] == new_env.name
     assert host['operating-system']['architecture'] == module_architecture.name
     assert host['operating-system']['operating-system'] == new_os.title
     assert host['operating-system']['medium'] == new_medium.name
@@ -1292,52 +1132,6 @@ def test_hammer_host_info_output(module_user):
     Host.update({'owner-id': module_user.id, 'id': '1'})
     result_info = Host.info(options={'id': '1', 'fields': 'Additional info'})
     assert int(result_info['additional-info']['owner-id']) == module_user.id
-
-
-@pytest.mark.host_update
-@pytest.mark.tier2
-def test_positive_update_host_owner_and_verify_puppet_class_name(
-    module_env_search,
-    module_org,
-    module_location,
-    module_puppet_classes,
-    module_user,
-    default_smart_proxy,
-):
-    """Update host owner and check puppet clases associated to the host
-
-    :id: 2b7dd148-914b-11eb-8a3a-98fa9b6ecd5a
-
-    :expectedresults: Host is updated with new owner
-        and puppet class is still assigned and shown
-
-    :CaseImportance: Medium
-
-    :BZ: 1851149, 1809952
-
-    :customerscenario: true
-    """
-    update_smart_proxy(module_location, default_smart_proxy)
-    host = make_fake_host(
-        {
-            'puppet-class-ids': [module_puppet_classes[0].id],
-            'environment': module_env_search.name,
-            'organization-id': module_org.id,
-            'location-id': module_location.id,
-            'puppet-ca-proxy-id': default_smart_proxy.id,
-            'puppet-proxy-id': default_smart_proxy.id,
-        }
-    )
-    host_classes = Host.puppetclasses({'host': host['name']})
-    assert module_puppet_classes[0].name in [puppet['name'] for puppet in host_classes]
-
-    Host.update({'id': host['id'], 'owner': module_user.login, 'owner-type': 'User'})
-    host = Host.info({'id': host['id']})
-    assert int(host['additional-info']['owner-id']) == module_user.id
-    assert host['additional-info']['owner-type'] == 'User'
-
-    host_classes = Host.puppetclasses({'host': host['name']})
-    assert module_puppet_classes[0].name in [puppet['name'] for puppet in host_classes]
 
 
 @pytest.mark.host_parameter
@@ -2731,3 +2525,217 @@ def test_positive_tracer_list_and_resolve(tracer_host):
     assert (
         service_ver_log_new != service_ver_log_old
     ), f'The service {package} did not seem to be restarted'
+
+
+# ---------------------------- PUPPET ENABLED IN INSTALLER TESTS -----------------------
+# @pytest.mark.puppet_enabled
+# @pytest.mark.tier1
+# def test_positive_host_with_puppet(
+#         module_puppet_org, module_puppet_loc, module_puppet_enabled_sat
+# ):
+#     """Create update read and delete host with puppet environment
+#
+#     :id: 8ae79fbe-79f4-11ec-80f5-98fa9b6ecd5a
+#
+#     :expectedresults: puppet environment
+#
+#     :CaseImportance: Critical
+#     """
+#     host_template = module_puppet_enabled_sat.api.entities.Host()
+#     host_template.create_missing()
+#     new_env = module_puppet_enabled_sat.api.entities.Environment(
+#         name=gen_string('alphanumeric'),
+#         organization=[module_puppet_org],
+#         location=[module_puppet_loc],
+#     ).create()
+#     host = make_host(
+#         {
+#             'architecture-id': host_template.architecture.id,
+#             'domain-id': host_template.domain.id,
+#             'environment-id': host_template.environment.id,
+#             'location-id': host_template.location.id,
+#             'mac': host_template.mac,
+#             'medium-id': host_template.medium.id,
+#             'name': host_template.name,
+#             'operatingsystem-id': host_template.operatingsystem.id,
+#             'organization-id': host_template.organization.id,
+#             'partition-table-id': host_template.ptable.id,
+#             'puppet-proxy-id': module_default_proxy['id'],
+#             'root-password': host_template.root_pass,
+#         }
+#     )
+#     module_puppet_enabled_sat.cli.Host.update(
+#         {
+#             'name': host.name,
+#             'environment': new_env.name,
+#         }
+#     )
+#     host = module_puppet_enabled_sat.cli.Host.info({'id': function_host['id']})
+#     assert host['puppet-environment'] == new_env.name
+#     module_puppet_enabled_sat.cli.Host.delete({'id': host['id']})
+
+
+@pytest.fixture(scope="function")
+def function_proxy():
+    proxy = make_proxy()
+    yield proxy
+    Proxy.delete({'id': proxy['id']})
+
+
+@pytest.fixture(scope="function")
+def function_host_content_source(
+    module_default_proxy, module_lce_library, module_org, module_published_cv
+):
+    host = make_fake_host(
+        {
+            'content-source-id': module_default_proxy['id'],
+            'content-view-id': module_published_cv.id,
+            'lifecycle-environment-id': module_lce_library.id,
+            'organization': module_org.name,
+        }
+    )
+    yield host
+    Host.delete({'id': host['id']})
+
+
+@pytest.mark.tier2
+@pytest.mark.puppet_enabled
+def test_positive_list_scparams(
+    module_env_search, module_location, module_org, module_puppet_classes, default_smart_proxy
+):
+    """List all smart class parameters using host id
+
+    :id: 61814875-5ccd-4c04-a638-d36fe089d514
+
+    :expectedresults: Overridden sc-param from puppet
+        class are listed
+
+    :CaseLevel: Integration
+    """
+    update_smart_proxy(module_location, default_smart_proxy)
+    # Create hostgroup with associated puppet class
+    host = make_fake_host(
+        {
+            'puppet-class-ids': [module_puppet_classes[0].id],
+            'environment': module_env_search.name,
+            'organization-id': module_org.id,
+            'location-id': module_location.id,
+            'puppet-ca-proxy-id': default_smart_proxy.id,
+            'puppet-proxy-id': default_smart_proxy.id,
+        }
+    )
+
+    # Override one of the sc-params from puppet class
+    sc_params_list = SmartClassParameter.list(
+        {
+            'environment': module_env_search.name,
+            'search': f'puppetclass="{module_puppet_classes[0].name}"',
+        }
+    )
+    scp_id = choice(sc_params_list)['id']
+    SmartClassParameter.update({'id': scp_id, 'override': 1})
+    # Verify that affected sc-param is listed
+    host_scparams = Host.sc_params({'host': host['name']})
+    assert scp_id in [scp['id'] for scp in host_scparams]
+
+
+@pytest.mark.puppet_enabled
+@pytest.mark.tier1
+def test_positive_create_with_puppet_class_name(
+    module_env_search, module_location, module_org, module_puppet_classes, default_smart_proxy
+):
+    """Check if host can be created with puppet class name
+
+    :id: a65df36e-db4b-48d2-b0e1-5ccfbefd1e7a
+
+    :expectedresults: Host is created and has puppet class assigned
+
+    :CaseImportance: Critical
+    """
+    update_smart_proxy(module_location, default_smart_proxy)
+    host = make_fake_host(
+        {
+            'puppet-class-ids': [module_puppet_classes[0].id],
+            'environment': module_env_search.name,
+            'organization-id': module_org.id,
+            'location-id': module_location.id,
+            'puppet-ca-proxy-id': default_smart_proxy.id,
+            'puppet-proxy-id': default_smart_proxy.id,
+        }
+    )
+    host_classes = Host.puppetclasses({'host': host['name']})
+    assert module_puppet_classes[0].name in [puppet['name'] for puppet in host_classes]
+
+
+@pytest.mark.puppet_enabled
+@pytest.mark.tier2
+def test_positive_update_host_owner_and_verify_puppet_class_name(
+    module_env_search,
+    module_org,
+    module_location,
+    module_puppet_classes,
+    module_user,
+    default_smart_proxy,
+):
+    """Update host owner and check puppet clases associated to the host
+
+    :id: 2b7dd148-914b-11eb-8a3a-98fa9b6ecd5a
+
+    :expectedresults: Host is updated with new owner
+        and puppet class is still assigned and shown
+
+    :CaseImportance: Medium
+
+    :BZ: 1851149, 1809952
+
+    :customerscenario: true
+    """
+    update_smart_proxy(module_location, default_smart_proxy)
+    host = make_fake_host(
+        {
+            'puppet-class-ids': [module_puppet_classes[0].id],
+            'environment': module_env_search.name,
+            'organization-id': module_org.id,
+            'location-id': module_location.id,
+            'puppet-ca-proxy-id': default_smart_proxy.id,
+            'puppet-proxy-id': default_smart_proxy.id,
+        }
+    )
+    host_classes = Host.puppetclasses({'host': host['name']})
+    assert module_puppet_classes[0].name in [puppet['name'] for puppet in host_classes]
+
+    Host.update({'id': host['id'], 'owner': module_user.login, 'owner-type': 'User'})
+    host = Host.info({'id': host['id']})
+    assert int(host['additional-info']['owner-id']) == module_user.id
+    assert host['additional-info']['owner-type'] == 'User'
+
+    host_classes = Host.puppetclasses({'host': host['name']})
+    assert module_puppet_classes[0].name in [puppet['name'] for puppet in host_classes]
+
+
+@pytest.mark.puppet_enabled
+@pytest.mark.run_in_one_thread
+@pytest.mark.tier2
+def test_positive_create_and_update_with_content_source(
+    function_host_content_source, function_proxy, module_default_proxy
+):
+    """Create a host with content source specified and update content
+        source
+
+    :id: 5712f4db-3610-447d-b1da-0fe461577d59
+
+    :customerscenario: true
+
+    :BZ: 1260697, 1483252, 1313056, 1488465
+
+    :expectedresults: A host is created with expected content source
+        assigned and then content source is successfully updated
+
+    :CaseImportance: High
+    """
+    host = function_host_content_source
+    assert host['content-information']['content-source']['name'] == module_default_proxy['name']
+    new_content_source = function_proxy
+    Host.update({'id': host['id'], 'content-source-id': new_content_source['id']})
+    host = Host.info({'id': host['id']})
+    assert host['content-information']['content-source']['name'] == new_content_source['name']


### PR DESCRIPTION
In progress. I would be glad if we can merge #9286 as soon as possible. Thanks

Merge only after #9286 and #9324

- [x] rebase on #9286 
- [x] tests with `@pytest.mark.puppet_enabled` based on desctructive sat and create new destrucitve fixtures
- [x] add marker 
- [x] proxy helpers refactored
- [x] `make_fake_host` based on destructive sat, #9324 
- [x] provide test results with enabled puppet once you are finisished


function host change
```
tests/foreman/cli/test_host.py::test_negative_add_parameter PASSED                     [  8%]
tests/foreman/cli/test_host.py::test_positive_parameter_crud PASSED                    [ 16%]
tests/foreman/cli/test_host.py::test_negative_update_mac PASSED                        [ 25%]
tests/foreman/cli/test_host.py::test_negative_update_name PASSED                       [ 33%]
tests/foreman/cli/test_host.py::test_positive_update_parameters_by_name PASSED         [ 41%]
tests/foreman/cli/test_host.py::test_positive_create_and_delete PASSED                 [ 50%]
tests/foreman/cli/test_host.py::test_positive_set_multi_line_and_with_spaces_parameter_value PASSED [ 58%]
tests/foreman/cli/test_host.py::test_negative_edit_parameter_by_non_admin_user PASSED  [ 66%]
tests/foreman/cli/test_host.py::test_positive_view_parameter_by_non_admin_user PASSED  [ 75%]
tests/foreman/cli/test_host.py::test_negative_view_parameter_by_non_admin_user PASSED  [ 83%]
tests/foreman/cli/test_host.py::test_negative_update_os PASSED                         [ 91%]
tests/foreman/cli/test_host.py::test_negative_update_arch PASSED                       [100%]
======================== 12 passed, 159 warnings in 556.81s (0:09:16) =======================
```

others:
```
tests/foreman/cli/test_host.py::test_positive_create_and_delete PASSED                 [100%]
=============================== 1 passed, 1 warning in 56.07s ================================
```


```
tests/foreman/cli/test_host.py::test_positive_list_and_unregister[rhel7_contenthost0] PASSED
=========== 1 passed, 53 deselected, 1 warning in 460.46s (0:07:40) ============
```
