### PR TITLE
Remove use of nested Satellite context manager

### DIFF
--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -56,28 +56,27 @@ def katello_agent_repos(sat_with_katello_agent):
     lce = sat.api.LifecycleEnvironment(organization=org).create()
     cv = sat.api.ContentView(organization=org).create()
     ak = sat.api.ActivationKey(environment=lce, organization=org).create()
-    with sat:
-        setup_org_for_a_rh_repo(
-            {
-                'product': constants.PRDS['rhel'],
-                'repository-set': constants.REPOSET['rhst7'],
-                'repository': constants.REPOS['rhst7']['name'],
-                'organization-id': org.id,
-                'content-view-id': cv.id,
-                'lifecycle-environment-id': lce.id,
-                'activationkey-id': ak.id,
-            }
-        )
-        # Create custom repository content
-        setup_org_for_a_custom_repo(
-            {
-                'url': settings.repos.yum_1.url,
-                'organization-id': org.id,
-                'content-view-id': cv.id,
-                'lifecycle-environment-id': lce.id,
-                'activationkey-id': ak.id,
-            }
-        )
+    setup_org_for_a_rh_repo(
+        {
+            'product': constants.PRDS['rhel'],
+            'repository-set': constants.REPOSET['rhst7'],
+            'repository': constants.REPOS['rhst7']['name'],
+            'organization-id': org.id,
+            'content-view-id': cv.id,
+            'lifecycle-environment-id': lce.id,
+            'activationkey-id': ak.id,
+        }
+    )
+    # Create custom repository content
+    setup_org_for_a_custom_repo(
+        {
+            'url': settings.repos.yum_1.url,
+            'organization-id': org.id,
+            'content-view-id': cv.id,
+            'lifecycle-environment-id': lce.id,
+            'activationkey-id': ak.id,
+        }
+    )
     return {
         'ak': ak,
         'cv': cv,


### PR DESCRIPTION
This test uses a nested Satellite context manager, resulting in an
unclean exit.
This change just removes the nested use, but does not address any
potential downstream test failures