### PR TITLE
Add token for github api calls

### DIFF
--- a/conf/git.yaml.template
+++ b/conf/git.yaml.template
@@ -4,3 +4,4 @@ GIT:
   SSH_PORT: 22
   HTTP_PORT: 80
   HOSTNAME: localhost
+  GITHUB_TOKEN:

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -171,7 +171,7 @@ class TestTemplateSyncTestCase:
         not_imported_count = [
             template['imported'] for template in filtered_imported_templates['message']['templates']
         ].count(False)
-        assert not_imported_count == 8
+        assert not_imported_count == 9
         ptemplates = entities.ProvisioningTemplate().search(
             query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
         )
@@ -180,10 +180,6 @@ class TestTemplateSyncTestCase:
             query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
         )
         assert len(ptables) == 1
-        jtemplates = entities.JobTemplate().search(
-            query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
-        )
-        assert len(jtemplates) == 1
         rtemplates = entities.ReportTemplate().search(
             query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
         )
@@ -922,7 +918,7 @@ class TestTemplateSyncTestCase:
         imported_count = [
             template['imported'] for template in imported_templates['message']['templates']
         ].count(True)
-        assert imported_count == 18  # Total Count
+        assert imported_count == 17  # Total Count
         # Export some filtered templates to local dir
         _, dir_path = create_import_export_local_dir
         exported_templates = entities.Template().exports(
@@ -931,7 +927,7 @@ class TestTemplateSyncTestCase:
         exported_count = [
             template['exported'] for template in exported_templates['message']['templates']
         ].count(True)
-        assert exported_count == 18
+        assert exported_count == 17
         assert 'name' in exported_templates['message']['templates'][0].keys()
         assert (
             default_sat.execute(
@@ -1100,6 +1096,7 @@ class TestTemplateSyncTestCase:
         )
         res = requests.get(
             url=f"{FOREMAN_TEMPLATE_IMPORT_API_URL}/git/trees/master",
+            headers={'Authorization': f'token {settings.git.github_token}'},
             params={'recursive': True},
         )
         res.raise_for_status()
@@ -1146,6 +1143,7 @@ class TestTemplateSyncTestCase:
         assert not output['message']['templates'][0]['imported']
         res = requests.get(
             url=f"{FOREMAN_TEMPLATE_IMPORT_API_URL}/contents/locked/robottelo_locked.erb",
+            headers={'Authorization': f'token {settings.git.github_token}'},
             params={'ref': 'locked'},
         )
         res.raise_for_status()
@@ -1196,6 +1194,7 @@ class TestTemplateSyncTestCase:
         assert output['message']['templates'][0]['changed']
         res = requests.get(
             url=f"{FOREMAN_TEMPLATE_IMPORT_API_URL}/contents/after_lock/robottelo_locked.erb",
+            headers={'Authorization': f'token {settings.git.github_token}'},
             params={'ref': 'locked'},
         )
         res.raise_for_status()


### PR DESCRIPTION
Unauthenticated users have limited access. Resulting into failing tests due to rate limits. Adding read-only token for github will remove rate limits and fix failing tests.

Updated numbers of templates: because of missing puppet module in sat7, some templates cannot be imported.

Test results:
```
pytest -v tests/foreman/api/test_templatesync.py
====================================================================== test session starts =======================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, xdist-2.5.0, ibutsu-2.0.2
collected 29 items                                                                                                                                               

tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_filtered_templates_from_git PASSED                                  [  3%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_import_filtered_templates_from_git_with_negate PASSED                               [  6%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_and_associate PASSED                                                [ 10%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_from_subdirectory PASSED                                            [ 13%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_filtered_templates_to_localdir PASSED                               [ 17%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_filtered_templates_negate PASSED                                    [ 20%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_and_import_with_metadata PASSED                                     [ 24%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_verbose[True] PASSED                                    [ 27%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_verbose[False] PASSED                                   [ 31%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_changed_key_true PASSED                                 [ 34%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_changed_key_false PASSED                                [ 37%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_name_key PASSED                                         [ 41%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_imported_key PASSED                                     [ 44%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_file_key PASSED                                         [ 48%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_corrupted_metadata PASSED                               [ 51%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_filtered_skip_message PASSED                            [ 55%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_no_name_error PASSED                                    [ 58%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_no_model_error PASSED                                   [ 62%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_json_output_blank_model_error PASSED                                [ 65%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_json_output PASSED                                                  [ 68%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_log_to_production PASSED                                            [ 72%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_log_to_production PASSED                                            [ 75%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_all_templates_to_repo[non_empty_repo-http] PASSED                   [ 79%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_all_templates_to_repo[non_empty_repo-ssh] PASSED                    [ 82%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_all_templates_to_repo[empty_repo-http] PASSED                       [ 86%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_export_all_templates_to_repo[empty_repo-ssh] PASSED                        [ 89%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_all_templates_from_repo PASSED                                      [ 93%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_negative_import_locked_template PASSED                                              [ 96%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_positive_import_locked_template PASSED                                              [100%]

========================================================== 29 passed, 0 warnings in 160.89s (0:02:40) ===========================================================
```