### PR TITLE
expand content_host.yml to support custom deploy workflows per nick

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -11,7 +11,7 @@ CAPSULE:
     # internal, ga, beta
     SOURCE: "internal"
     # The base os rhel version where the capsule installed
-    # RHEL_VERSION: 
+    # RHEL_VERSION:
   # The Ansible Tower workflow used to deploy a capsule
   DEPLOY_WORKFLOW: deploy-sat-capsule
   # Dictionary of arguments which should be passed along to the deploy workflow

--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -2,9 +2,12 @@ content_host:
     deploy_workflow: workflow-name
     default_rhel_version: 7
     rhel_versions:
-        - 6
-        - 7
-        - 8
+      6: {}
+      7: {}
+      8: {}
+      9_compose:
+        deploy_workflow: deploy-rhel-cmp-template
+
     hardware:
         RHEL6:
             RELEASE: 6.10
@@ -16,5 +19,10 @@ content_host:
             CORES: 1
         RHEL8:
             RELEASE: 8.3
+            MEMORY: 1536 MiB
+            CORES: 1
+        RHEL9_compose:
+            RELEASE: 9.0
+            compose: RHEL-9.0.0-20220118.1
             MEMORY: 1536 MiB
             CORES: 1

--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -23,6 +23,6 @@ content_host:
             CORES: 1
         RHEL9_compose:
             RELEASE: 9.0
-            compose: RHEL-9.0.0-20220118.1
+            COMPOSE: RHEL-9.0.0-20220118.1
             MEMORY: 1536 MiB
             CORES: 1

--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -2,7 +2,7 @@ REPOS:
   SATELLITE_VERSION_UNDR: "@jinja {{this.robottelo.satellite_version | replace('.', '_')}}"
   # RHEL major version can be used by some repositories to frame their repository URL for
   # extended RHEL versions.
-  RHEL_MAJOR_VERSION: "@jinja {{this.server.version.rhel_version | int}}" 
+  RHEL_MAJOR_VERSION: "@jinja {{this.server.version.rhel_version | int}}"
   # Provide link to RHEL6,7,8 & 9 repo here, as puppet rpm requires packages from
   # those repos and syncing the entire repo on the fly would take longer for
   # tests to run. Specify the *.repo link to an internal repo for tests to execute properly.

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -22,8 +22,8 @@ def host_conf(request):
     _rhelver = f"rhel{params.get('rhel_version', settings.content_host.default_rhel_version)}"
     rhel_compose_id = settings.get(f"content_host.hardware.{_rhelver}.compose")
     if rhel_compose_id:
-        conf['rhel_compose_id'] = rhel_compose_id
-    conf['rhel_version'] = settings.content_host.hardware.get(_rhelver).release
+        conf['deploy_rhel_compose_id'] = rhel_compose_id
+    conf['deploy_rhel_version'] = settings.content_host.hardware.get(_rhelver).release
     conf['memory'] = params.get('memory', settings.content_host.hardware.get(_rhelver).memory)
     conf['cores'] = params.get('cores', settings.content_host.hardware.get(_rhelver).cores)
     return conf

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -6,10 +6,13 @@ from robottelo.config import settings
 
 def pytest_generate_tests(metafunc):
     if 'rhel_contenthost' in metafunc.fixturenames:
-        rhel_parameters = [
-            dict(workflow=settings.content_host.deploy_workflow, rhel_version=ver)
-            for ver in settings.content_host.rhel_versions
-        ]
+        rhel_parameters = []
+        for ver in settings.content_host.rhel_versions.keys():
+            # prefer nick-specific deploy workflow before using the default one
+            workflow = settings.content_host.rhel_versions[ver].get(
+                'deploy_workflow', settings.content_host.deploy_workflow
+            )
+            rhel_parameters.append(dict(workflow=workflow, rhel_version=ver))
         metafunc.parametrize(
             'rhel_contenthost',
             rhel_parameters,


### PR DESCRIPTION
Partially Addresses: SAT-7681

Please, merge together with the backports:
- 6.10.z: https://github.com/SatelliteQE/robottelo/pull/9336
- 6.9.z:  https://github.com/SatelliteQE/robottelo/pull/9335

This allows us to define custom deploy workflow per individual OS version entry - this is needed as Compose versions are using different naming and thus different deploy workflow.
A sample usage can be seen in the updated `content_host.yml.sample`
