### PR TITLE
Pulp Task Clean-up testing

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -23,6 +23,7 @@ LOCALES = (
     'zh_TW',
 )
 
+DISTRO_RHEL5 = "rhel5"
 DISTRO_RHEL6 = "rhel6"
 DISTRO_RHEL7 = "rhel7"
 DISTRO_RHEL8 = "rhel8"
@@ -374,6 +375,16 @@ REPOSET = {
         'rhel8_aps': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream (Kickstart)',
         'rhel9': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Beta (Kickstart)',
     },
+    'rhel8_bos': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS RPMs 8',
+    'rhel8_aps': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream (RPMs)',
+    'rhel7_extra': 'Red Hat Enterprise Linux 7 Server - Extras (RPMs)',
+    'rhel7_optional': 'Red Hat Enterprise Linux 7 Server - Optional (RPMs)',
+    'rhel7_sup': 'Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)',
+    'rhst7_610': 'Red Hat Satellite Tools 6.10 (for RHEL 7 Server) (RPMs)',
+    'rhel6_optional': 'Red Hat Enterprise Linux 6 Server - Optional (RPMs)',
+    'rhel6_sup': 'Red Hat Enterprise Linux 6 Server - Supplementary (RPMs)',
+    'rhel5': 'Red Hat Enterprise Linux 5 Server (RPMs)',
+    'rhel5_sup': 'Red Hat Enterprise Linux 5 Server - Supplementary (RPMs)',
 }
 
 NO_REPOS_AVAILABLE = "This system has no repositories available through subscriptions."
@@ -456,6 +467,7 @@ REPOS = {
         'id': 'rhel-7-server-satellite-tools-6.4-rpms',
         'name': ('Red Hat Satellite Tools 6.4 for RHEL 7 Server RPMs x86_64'),
         'version': '6.4',
+        'releasever': None,
         'reposet': REPOSET['rhst7_64'],
         'product': PRDS['rhel'],
         'distro': DISTRO_RHEL7,
@@ -465,6 +477,7 @@ REPOS = {
         'id': 'rhel-7-server-satellite-tools-6.5-rpms',
         'name': ('Red Hat Satellite Tools 6.5 for RHEL 7 Server RPMs x86_64'),
         'version': '6.5',
+        'releasever': None,
         'reposet': REPOSET['rhst7_65'],
         'product': PRDS['rhel'],
         'distro': DISTRO_RHEL7,
@@ -474,6 +487,7 @@ REPOS = {
         'id': 'rhel-7-server-satellite-tools-6.6-rpms',
         'name': ('Red Hat Satellite Tools 6.6 for RHEL 7 Server RPMs x86_64'),
         'version': '6.6',
+        'releasever': None,
         'reposet': REPOSET['rhst7_66'],
         'product': PRDS['rhel'],
         'distro': DISTRO_RHEL7,
@@ -483,6 +497,7 @@ REPOS = {
         'id': 'rhel-7-server-satellite-tools-6.7-rpms',
         'name': ('Red Hat Satellite Tools 6.7 for RHEL 7 Server RPMs x86_64'),
         'version': '6.7',
+        'releasever': None,
         'reposet': REPOSET['rhst7_67'],
         'product': PRDS['rhel'],
         'distro': DISTRO_RHEL7,
@@ -555,17 +570,11 @@ REPOS = {
     'rhdt7': {
         'name': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7 Server x86_64')
     },
-    'rhscl7': {
-        'id': 'rhel-server-rhscl-7-rpms',
-        'name': (
-            'Red Hat Software Collections RPMs for Red Hat Enterprise'
-            ' Linux 7 Server x86_64 7Server'
-        ),
-    },
     'rhae2': {
         'id': 'rhel-7-server-ansible-2.9-rpms',
         'name': 'Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server x86_64',
         'version': '2.9',
+        'releasever': None,
         'arch': 'x86_64',
         'reposet': REPOSET['rhae2'],
         'product': PRDS['rhae'],
@@ -623,7 +632,122 @@ REPOS = {
             'distro': DISTRO_RHEL9,
         },
     },
+    'rhel8_bos': {
+        'id': 'rhel-8-for-x86_64-baseos-rpms',
+        'name': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS RPMs 8',
+        'version': '8',
+        'reposet': REPOSET['rhel8_bos'],
+        'product': PRDS['rhel8'],
+        'distro': DISTRO_RHEL8,
+        'key': 'rhel8_bos',
+    },
+    'rhel8_aps': {
+        'id': 'rhel-8-for-x86_64-appstream-rpms',
+        'name': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs 8',
+        'releasever': '8',
+        'version': '8',
+        'reposet': REPOSET['rhel8_aps'],
+        'product': PRDS['rhel8'],
+        'distro': DISTRO_RHEL8,
+        'key': 'rhel8_aps',
+    },
+    'rhel7_optional': {
+        'id': 'rhel-7-server-optional-rpms',
+        'name': 'Red Hat Enterprise Linux 7 Server - Optional RPMs x86_64 7Server',
+        'releasever': '7Server',
+        'version': '7',
+        'reposet': REPOSET['rhel7_optional'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL7,
+        'key': 'rhel7_optional',
+    },
+    'rhel7_extra': {
+        'id': 'rhel-7-server-extras-rpms',
+        'name': 'Red Hat Enterprise Linux 7 Server - Extras RPMs x86_64',
+        'releasever': '7',
+        'version': '7',
+        'reposet': REPOSET['rhel7_extra'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL7,
+        'key': 'rhel7_extra',
+    },
+    'rhel7_sup': {
+        'id': 'rhel-7-server-supplementary-rpms',
+        'name': 'Red Hat Enterprise Linux 7 Server - Supplementary RPMs x86_64 7Server',
+        'releasever': '7Server',
+        'version': '7',
+        'reposet': REPOSET['rhel7_sup'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL7,
+        'key': 'rhel7_sup',
+    },
+    'rhel6_optional': {
+        'id': 'rhel-6-server-optional-rpms',
+        'name': 'Red Hat Enterprise Linux 6 Server - Optional RPMs x86_64 6Server',
+        'releasever': '6Server',
+        'version': '6',
+        'reposet': REPOSET['rhel6_optional'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL6,
+        'key': 'rhel6_optional',
+    },
+    'rhel6_sup': {
+        'id': 'rhel-6-server-supplementary-rpms',
+        'name': 'Red Hat Enterprise Linux 6 Server - Supplementary RPMs x86_64 6Server',
+        'releasever': '6Server',
+        'version': '6',
+        'reposet': REPOSET['rhel6_sup'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL6,
+        'key': 'rhel6_sup',
+    },
+    'rhel5': {
+        'id': 'rhel-5-server-rpms',
+        'name': 'Red Hat Enterprise Linux 5 Server RPMs x86_64 5Server',
+        'releasever': '5Server',
+        'version': '5',
+        'reposet': REPOSET['rhel5'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL5,
+        'key': 'rhel5',
+    },
+    'rhel5_sup': {
+        'id': 'rhel-5-server-supplementary-rpms',
+        'name': 'Red Hat Enterprise Linux 5 Server - Supplementary RPMs x86_64 5Server',
+        'releasever': '5Server',
+        'version': '5',
+        'reposet': REPOSET['rhel5_sup'],
+        'product': PRDS['rhel'],
+        'distro': DISTRO_RHEL5,
+        'key': 'rhel5_sup',
+    },
+    'rhscl7': {
+        'id': 'rhel-server-rhscl-7-rpms',
+        'name': (
+            'Red Hat Software Collections RPMs for Red Hat Enterprise'
+            ' Linux 7 Server x86_64 7Server'
+        ),
+        'releasever': '7Server',
+        'version': '7',
+        'reposet': REPOSET['rhscl7'],
+        'product': PRDS['rhscl'],
+        'distro': DISTRO_RHEL7,
+        'key': 'rhscl7',
+    },
 }
+
+BULK_REPO_LIST = [
+    REPOS['rhel6_optional'],
+    REPOS['rhel6_sup'],
+    REPOS['rhel5_sup'],
+    REPOS['rhel7_optional'],
+    REPOS['rhel7_sup'],
+    REPOS['rhel7'],
+    REPOS['rhel6'],
+    REPOS['rhel5'],
+    REPOS['rhscl7'],
+    REPOS['rhel8_aps'],
+]
 
 DISTRO_REPOS = {
     # DISTRO_RHEL6: REPOS['rhel6'],
@@ -764,7 +888,9 @@ REP_TEM_APPLIED_ERRATA_INPUT = {
     'Include Last Reboot': {'yes': 'yes', 'no': 'no'},
 }
 CONTAINER_REGISTRY_HUB = 'https://mirror.gcr.io'
+RH_CONTAINER_REGISTRY_HUB = 'https://registry.redhat.io/'
 CONTAINER_UPSTREAM_NAME = 'library/busybox'
+DOCKER_REPO_UPSTREAM_NAME = 'openshift3/logging-elasticsearch'
 CONTAINER_RH_REGISTRY_UPSTREAM_NAME = 'openshift3/ose-metrics-hawkular-openshift-agent'
 CONTAINER_CLIENTS = ['docker', 'podman']
 CUSTOM_LOCAL_FOLDER = '/var/lib/pulp/imports/myrepo/'

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -23,12 +23,16 @@ from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from fauxfactory import gen_utf8
 from nailgun import entities
+from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 
+from robottelo import constants
 from robottelo import manifests
 from robottelo.api.utils import apply_package_filter
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import promote
+from robottelo.api.utils import upload_manifest
+from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
 from robottelo.constants import CUSTOM_RPM_SHA_512_FEED_COUNT
@@ -731,11 +735,10 @@ class TestContentViewPublishPromote:
         comp_content_view_info = comp_content_view.version[0].read()
         assert comp_content_view_info.package_count == 36
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
+    @pytest.mark.tier4
     @pytest.mark.destructive
     @pytest.mark.run_in_one_thread
-    def test_positive_reboot_recover_cv_publish(self):
+    def test_positive_reboot_recover_cv_publish(self, destructive_sat):
         """Reboot the Satellite during publish and resume publishing
 
         :id: cceae727-81db-40a4-9c26-05ca6e93464e
@@ -749,8 +752,62 @@ class TestContentViewPublishPromote:
 
         :CaseImportance: High
 
-        :CaseAutomation: NotAutomated
+        :CaseAutomation: Automated
         """
+        org = entities.Organization().create()
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
+        rhel7_extra = enable_rhrepo_and_fetchid(
+            basearch='x86_64',
+            org_id=org.id,
+            product=constants.PRDS['rhel'],
+            repo=constants.REPOS['rhel7_extra']['name'],
+            reposet=constants.REPOSET['rhel7_extra'],
+            releasever=None,
+        )
+        rhel7_optional = enable_rhrepo_and_fetchid(
+            basearch='x86_64',
+            org_id=org.id,
+            product=constants.PRDS['rhel'],
+            repo=constants.REPOS['rhel7_optional']['name'],
+            reposet=constants.REPOSET['rhel7_optional'],
+            releasever=constants.REPOS['rhel7_optional']['releasever'],
+        )
+        rhel7_sup = enable_rhrepo_and_fetchid(
+            basearch='x86_64',
+            org_id=org.id,
+            product=constants.PRDS['rhel'],
+            repo=constants.REPOS['rhel7_sup']['name'],
+            reposet=constants.REPOSET['rhel7_sup'],
+            releasever=constants.REPOS['rhel7_sup']['releasever'],
+        )
+        rhel7_extra = entities.Repository(id=rhel7_extra).read()
+        rhel7_optional = entities.Repository(id=rhel7_optional).read()
+        rhel7_sup = entities.Repository(id=rhel7_sup).read()
+        for repo in [rhel7_extra, rhel7_optional, rhel7_sup]:
+            repo.sync(timeout=1200)
+        cv = entities.ContentView(
+            organization=org,
+            solve_dependencies=True,
+            repository=[rhel7_extra, rhel7_sup, rhel7_optional],
+        ).create()
+        try:
+            publish_task = cv.publish(synchronous=False)
+            destructive_sat.power_control(state='reboot', ensure=True)
+            wait_for_tasks(
+                search_query=(f'id = {publish_task["id"]}'),
+                search_rate=30,
+                max_tries=60,
+            )
+        except TaskFailedError:
+            entities.ForemanTask().bulk_resume(data={"task_ids": [publish_task['id']]})
+            wait_for_tasks(
+                search_query=(f'id = {publish_task["id"]}'),
+                search_rate=30,
+                max_tries=60,
+            )
+        task_status = entities.ForemanTask(id=publish_task['id']).poll()
+        assert task_status['result'] == 'success'
 
 
 class TestContentViewUpdate:

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -16,6 +16,7 @@
 
 :Upstream: No
 """
+import re
 import tempfile
 import time
 from string import punctuation
@@ -38,6 +39,7 @@ from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
+from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import repos as repo_constants
 from robottelo.datafactory import parametrized
@@ -1369,9 +1371,8 @@ class TestRepositorySync:
         """
         pass
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier1
-    def test_positive_bulk_cancel_sync(self):
+    @pytest.mark.tier3
+    def test_positive_bulk_cancel_sync(self, default_sat, module_manifest_org):
         """Bulk cancel 10+ repository syncs
 
         :id: f9bb1c95-d60f-4c93-b32e-09d58ebce80e
@@ -1379,20 +1380,57 @@ class TestRepositorySync:
         :steps:
             1. Add 10+ repos and sync all of them
             2. Cancel all of the syncs
-            3. Check /var/log/foreman/production.log and /var/log/messages
+            3. Check Foreman Tasks and /var/log/messages
 
         :expectedresults: All the syncs stop successfully.
 
         :CaseImportance: High
 
-        :CaseAutomation: NotAutomated
+        :CaseAutomation: Automated
         """
+        repo_ids = []
+        for repo in constants.BULK_REPO_LIST:
+            repo_id = enable_rhrepo_and_fetchid(
+                basearch='x86_64',
+                org_id=module_manifest_org.id,
+                product=repo['product'],
+                repo=repo['name'],
+                reposet=repo['reposet'],
+                releasever=repo['releasever'],
+            )
+            repo_ids.append(repo_id)
+            rh_repo = entities.Repository(id=repo_id).read()
+            rh_repo.download_policy = 'immediate'
+            rh_repo = rh_repo.update()
+        sync_ids = []
+        for repo_id in repo_ids:
+            sync_task = entities.Repository(id=repo_id).sync(synchronous=False)
+            sync_ids.append(sync_task['id'])
+        entities.ForemanTask().bulk_cancel(data={"task_ids": sync_ids[0:5]})
+        # Give some time for sync cancels to calm down
+        time.sleep(30)
+        entities.ForemanTask().bulk_cancel(data={"task_ids": sync_ids[5:]})
+        for sync_id in sync_ids:
+            sync_result = entities.ForemanTask(id=sync_id).poll(canceled=True)
+            assert (
+                'Task canceled' in sync_result['humanized']['errors']
+                or 'No content added' in sync_result['humanized']['output']
+            )
+            # Find correlating pulp task using Foreman Task id
+            prod_log_out = default_sat.execute(
+                f'grep {sync_id} /var/log/foreman/production.log'
+            ).stdout.splitlines()[0]
+            correlation_id = re.search(r'\[I\|bac\|\w{8}\]', prod_log_out).group()[7:15]
+            # Assert the cancelation was executed in Pulp
+            result = default_sat.execute(
+                f'grep "{correlation_id}" /var/log/messages | grep "Canceling task"'
+            )
+            assert result.status == 0
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier4
+    @pytest.mark.tier3
     @pytest.mark.destructive
     @pytest.mark.run_in_one_thread
-    def test_positive_reboot_recover_sync(self):
+    def test_positive_reboot_recover_sync(self, destructive_sat):
         """Reboot during repo sync and resume the sync when the Satellite is online
 
         :id: 4f746e28-444c-4688-b92b-778a6e58d614
@@ -1406,8 +1444,37 @@ class TestRepositorySync:
 
         :CaseImportance: High
 
-        :CaseAutomation: NotAutomated
+        :CaseAutomation: Automated
         """
+        org = entities.Organization().create()
+        with manifests.clone() as manifest:
+            upload_manifest(org.id, manifest.content)
+        rhel7_extra = enable_rhrepo_and_fetchid(
+            basearch='x86_64',
+            org_id=org.id,
+            product=constants.PRDS['rhel'],
+            repo=constants.REPOS['rhel7_extra']['name'],
+            reposet=constants.REPOSET['rhel7_extra'],
+            releasever=None,
+        )
+        rhel7_extra = entities.Repository(id=rhel7_extra).read()
+        sync_task = rhel7_extra.sync(synchronous=False)
+        destructive_sat.power_control(state='reboot', ensure=True)
+        try:
+            wait_for_tasks(
+                search_query=(f'id = {sync_task["id"]}'),
+                search_rate=15,
+                max_tries=10,
+            )
+        except TaskFailedError:
+            sync_task = rhel7_extra.sync(synchronous=False)
+            wait_for_tasks(
+                search_query=(f'id = {sync_task["id"]}'),
+                search_rate=15,
+                max_tries=10,
+            )
+        task_status = entities.ForemanTask(id=sync_task['id']).poll()
+        assert task_status['result'] == 'success'
 
 
 class TestDockerRepository:
@@ -1474,9 +1541,24 @@ class TestDockerRepository:
         repo.sync()
         assert repo.read().content_counts['docker_manifest'] >= 1
 
-    @pytest.mark.stubbed
     @pytest.mark.tier3
-    def test_positive_cancel_docker_repo_sync(self):
+    @pytest.mark.parametrize(
+        'repo_options',
+        **datafactory.parametrized(
+            {
+                'large_repo': {
+                    'content_type': 'docker',
+                    'docker_upstream_name': constants.DOCKER_REPO_UPSTREAM_NAME,
+                    'name': gen_string('alphanumeric', 10),
+                    'url': constants.RH_CONTAINER_REGISTRY_HUB,
+                    'upstream_username': settings.subscription.rhn_username,
+                    'upstream_password': settings.subscription.rhn_password,
+                }
+            }
+        ),
+        indirect=True,
+    )
+    def test_positive_cancel_docker_repo_sync(self, repo):
         """Cancel a large, syncing Docker-type repository
 
         :id: 86534979-be49-40ad-8290-05ac71c801b2
@@ -1494,8 +1576,15 @@ class TestDockerRepository:
 
         :CaseImportance: High
 
-        :CaseAutomation: NotAutomated
+        :CaseAutomation: Automated
         """
+        sync_task = repo.sync(synchronous=False)
+        # Need to wait for sync to actually start up
+        time.sleep(2)
+        entities.ForemanTask().bulk_cancel(data={"task_ids": [sync_task['id']]})
+        sync_task = entities.ForemanTask(id=sync_task['id']).poll(canceled=True)
+        assert 'Task canceled' in sync_task['humanized']['errors']
+        assert 'No content added' in sync_task['humanized']['output']
 
     @pytest.mark.tier2
     @pytest.mark.parametrize(


### PR DESCRIPTION
These tests are related to testing how Pulp 3 handles task clean up on cancel/shutdown. For `test_positive_reboot_recover_cv_publish` the long setup is necessary to ensure AT has enough time to reboot the Satellite before the publish finishes. I had to use `time.sleep` more than I'd like, because of how canceling tasks and rebooting is dependent on timing. When using the API to get this timing right, I wanted to ensure all processes had started / stopped before moving on, since cancels and resumes are not necessarily immediate.

These tests also depends on https://github.com/SatelliteQE/nailgun/pull/810 and https://github.com/SatelliteQE/nailgun/pull/809 as the first one adds the ability to cancel and resume tasks, while the second temporarily solves an issue with reading repositories.

Results:
```
============================= test session starts ==============================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, cov-2.12.1, xdist-2.5.0, ibutsu-2.0.1
collected 1 item

tests/foreman/api/test_contentview.py .                                  [100%]

-------------- generated xml file: /tmp/tmp-5241KiVKrkToMfnh.xml ---------------
======================== 1 passed in 1656.96s (0:27:36) ========================

============================= test session starts ==============================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, cov-2.12.1, xdist-2.5.0, ibutsu-2.0.1
collected 3 items                                                                                                                                                           

tests/foreman/api/test_repository.py ...                                    [100%]

============================= warnings summary ==============================
tests/foreman/api/test_repository.py: 99 warnings
  /home/gsulliva/Programming/venvrobottelo/lib64/python3.9/site-packages/urllib3/connectionpool.py:981: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dhcp-3-13.vms.sat.rdu2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/warnings.html
==================== 3 passed, 99 warnings in 666.46s (0:11:06) =====================
```