### PR TITLE
Fix puppetca

### DIFF
--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -4,32 +4,30 @@ import pytest
 from robottelo.config import settings
 from robottelo.helpers import InstallerCommand
 
+common_opts = {
+    'foreman-proxy-puppetca': 'true',
+    'foreman-proxy-content-puppet': 'true',
+    'foreman-proxy-puppet': 'true',
+    'puppet-server': 'true',
+    'puppet-server-foreman-ssl-ca': '/etc/pki/katello/puppet/puppet_client_ca.crt',
+    'puppet-server-foreman-ssl-cert': '/etc/pki/katello/puppet/puppet_client.crt',
+    'puppet-server-foreman-ssl-key': '/etc/pki/katello/puppet/puppet_client.key',
+}
+
 enable_satellite_cmd = InstallerCommand(
     installer_args=[
         'enable-foreman-plugin-puppet',
         'enable-foreman-cli-puppet',
         'enable-puppet',
     ],
-    installer_opts={
-        'foreman-proxy-puppet': 'true',
-        'puppet-server': 'true',
-        'puppet-server-foreman-ssl-ca': '/etc/pki/katello/puppet/puppet_client_ca.crt',
-        'puppet-server-foreman-ssl-cert': '/etc/pki/katello/puppet/puppet_client.crt',
-        'puppet-server-foreman-ssl-key': '/etc/pki/katello/puppet/puppet_client.key',
-    },
+    installer_opts=common_opts,
 )
 
 enable_capsule_cmd = InstallerCommand(
     installer_args=[
         'enable-puppet',
     ],
-    installer_opts={
-        'foreman-proxy-puppet': 'true',
-        'puppet-server': 'true',
-        'puppet-server-foreman-ssl-ca': '/etc/pki/katello/puppet/puppet_client_ca.crt',
-        'puppet-server-foreman-ssl-cert': '/etc/pki/katello/puppet/puppet_client.crt',
-        'puppet-server-foreman-ssl-key': '/etc/pki/katello/puppet/puppet_client.key',
-    },
+    installer_opts=common_opts,
 )
 
 

--- a/tests/foreman/cli/test_puppetplugin.py
+++ b/tests/foreman/cli/test_puppetplugin.py
@@ -38,6 +38,7 @@ err_msg = 'Error: No such sub-command'
 def assert_puppet_status(server, expected):
     result = server.get_features()
     assert ('puppet' in result) is expected
+    assert ('puppetca' in result) is expected
 
     result = server.execute('rpm -q puppetserver')
     assert (result.status == 0) is expected


### PR DESCRIPTION
Adding two forgotten args to set Puppet CA in fixture and assertion in test.

Tested locally with `test_positive_enable_disable_logic` and passes well until the known BZ#2034552 (disable on capsule) is hit.
