### PR TITLE
add rhel_contenthost-specific marks to filter os version parametrization

### DIFF
--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -1,3 +1,4 @@
+import re
 from inspect import getmembers
 from inspect import isfunction
 
@@ -6,19 +7,43 @@ from robottelo.config import settings
 
 def pytest_generate_tests(metafunc):
     if 'rhel_contenthost' in metafunc.fixturenames:
-        rhel_parameters = []
-        for ver in settings.content_host.rhel_versions.keys():
-            # prefer nick-specific deploy workflow before using the default one
-            workflow = settings.content_host.rhel_versions[ver].get(
-                'deploy_workflow', settings.content_host.deploy_workflow
+        function_marks = getattr(metafunc.function, 'pytestmark', [])
+        # process eventual rhel_version_list markers
+        matchers = [i.args for i in function_marks if i.name == 'rhel_ver_list']
+        list_params = []
+        for matcher in matchers:
+            list_params.extend(
+                [
+                    setting_rhel_ver
+                    for setting_rhel_ver in settings.content_host.rhel_versions
+                    if str(setting_rhel_ver) in str(matcher)
+                ]
             )
-            rhel_parameters.append(dict(workflow=workflow, rhel_version=ver))
-        metafunc.parametrize(
-            'rhel_contenthost',
-            rhel_parameters,
-            ids=[f'rhel{r["rhel_version"]}' for r in rhel_parameters],
-            indirect=True,
-        )
+        # process eventual rhel_version_match markers
+        matchers = [i.args for i in function_marks if i.name == 'rhel_ver_match']
+        match_params = []
+        for matcher in matchers:
+            match_params.extend(
+                [
+                    setting_rhel_ver
+                    for setting_rhel_ver in settings.content_host.rhel_versions
+                    if re.fullmatch(str(matcher[0]), str(setting_rhel_ver))
+                ]
+            )
+        rhel_params = []
+        filtered_versions = set(list_params + match_params)
+        for ver, data in settings.content_host.rhel_versions.items():
+            if ver in (filtered_versions or settings.content_host.rhel_versions):
+                # prefer version-specific deploy workflow before using the default one
+                workflow = data.get('deploy_workflow', settings.content_host.deploy_workflow)
+                rhel_params.append(dict(workflow=workflow, rhel_version=ver))
+        if rhel_params:
+            metafunc.parametrize(
+                'rhel_contenthost',
+                rhel_params,
+                ids=[f'rhel{r["rhel_version"]}' for r in rhel_params],
+                indirect=True,
+            )
 
 
 def pytest_configure(config):

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -16,6 +16,8 @@ def pytest_configure(config):
         "pit_client: PIT client scenario tests",
         "run_in_one_thread: Sequential tests",
         "build_sanity: Fast, basic tests that confirm build is ready for full test suite",
+        "rhel_ver_list: Filter rhel_contenthost versions by list",
+        "rhel_ver_match: Filter rhel_contenthost versions by regexp",
     ]
     markers.extend(module_markers())
     for marker in markers:


### PR DESCRIPTION
Adding 2 new marks to make RHEL version (or nick) filtering possible:

- `pytest.mark.rhel_nick_match('<regex pattern>')`
- `pytest.mark.rhel_nick_list([applicable, nick, list])`
(feel free to suggest more suitable names)

With nicks for various rhel versions configured in `content_host.yml` file, e.g.:

```yaml
content_host:
  deploy_workflow: deploy-base-rhel
  default_rhel_version: 7
  rhel_versions:
    6: {}
    7: {}
    8: {}
    9_compose:
      deploy_workflow: deploy-rhel-cmp-template
```

__Default behavior__
all tests using `rhel_contenthost` fixture (directly or indirectly) are being parametrized for each nick:

```bash
$ pytest -k "test_positive_subscription_status_disabled"  tests/foreman/api/test_subscription.py --collect-only
==== test session starts ====
...
<Package api>
  <Module test_subscription.py>
    <Function test_positive_subscription_status_disabled[rhel6]>
    <Function test_positive_subscription_status_disabled[rhel7]>
    <Function test_positive_subscription_status_disabled[rhel8]>
    <Function test_positive_subscription_status_disabled[rhel9_compose]>

==== 5/15 tests collected (10 deselected) in 0.04s ====

```

__Altered behavior__
Having the test decorated with one (or possibly more) of the introduced markers, e.g.:
```python
@pytest.mark.tier2
@pytest.mark.rhel_nick_list([8,'9_compose'])
def test_positive_subscription_status_disabled(
    module_ak, rhel_contenthost, module_org, default_sat
):
...
```
will only pick matching nicks and result in the following collection:
```bash
$ pytest -k "test_positive_subscription_status_disabled"  tests/foreman/api/test_subscription.py --collect-only
==== test session starts ====
...
<Package api>
  <Module test_subscription.py>
    <Function test_positive_subscription_status_disabled[rhel8]>
    <Function test_positive_subscription_status_disabled[rhel9_compose]>

=============================== 2/12 tests collected (10 deselected) in 0.03s ===============================
```
Using the regexp matching gives you more freedom in selecting just what you want (uses `re.fullmatch`):
```python
@pytest.mark.tier2
@pytest.mark.rhel_nick_match('[6,9].*') #for whatever crazy reason you might have for this
def test_positive_subscription_status_disabled(
    module_ak, rhel_contenthost, module_org, default_sat
):
...
```
results in:
```bash
$ pytest -k "test_positive_subscription_status_disabled"  tests/foreman/api/test_subscription.py --collect-only
==== test session starts ====
...
<Package api>
  <Module test_subscription.py>
    <Function test_positive_subscription_status_disabled[rhel6]>
    <Function test_positive_subscription_status_disabled[rhel9_compose]>

==== 2/12 tests collected (10 deselected) in 0.03s ====
```

The same approach can be used to define even more matcher marks (e.g. blacklist, ...)

merge preferably after:
https://github.com/SatelliteQE/robottelo/pull/9327