### PR TITLE
Add test for importing templates with puppet

### DIFF
--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -112,3 +112,12 @@ def module_puppet_classes(
             f'and environment = {module_env_search.name}'
         }
     )
+
+
+@pytest.fixture(scope='module', params=[True, False], ids=["puppet_enabled", "puppet_disabled"])
+def parametrized_puppet_sat(request, default_sat, module_puppet_enabled_sat):
+    if request.param:
+        sat = module_puppet_enabled_sat
+    else:
+        sat = default_sat
+    return {'sat': sat, 'enabled': request.param}

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -186,6 +186,44 @@ class TestTemplateSyncTestCase:
         assert len(rtemplates) == 1
 
     @pytest.mark.tier2
+    def test_import_template_with_puppet(self, parametrized_puppet_sat):
+        """Importing puppet templates with enabled/disabled puppet module
+
+        :Steps:
+            1. Have enabled(disabled) puppet module
+            2. Import template containing puppet
+            3. Check if template was imported
+
+        :expectedresults:
+            Template was (not) imported
+
+        :id: 9ab46883-a3a7-4d2c-9a79-3d574bfd2ad8
+
+        :parametrized: yes
+
+        :CaseImportance: Medium
+        """
+        prefix = gen_string('alpha')
+        api_template = parametrized_puppet_sat['sat'].api.Template()
+        filtered_imported_templates = api_template.imports(
+            data={
+                'repo': FOREMAN_TEMPLATE_IMPORT_URL,
+                'branch': 'automation',
+                'dirname': 'import/job_templates/',
+                'filter': 'jenkins Start OpenSCAP scans',
+                'force': True,
+                'prefix': prefix,
+            }
+        )
+        not_imported_count = [
+            template['imported'] for template in filtered_imported_templates['message']['templates']
+        ].count(False)
+        if parametrized_puppet_sat['enabled']:
+            assert not_imported_count == 1
+        else:
+            assert not_imported_count == 2
+
+    @pytest.mark.tier2
     def test_positive_import_and_associate(
         self,
         create_import_export_local_dir,


### PR DESCRIPTION
Follow-up for #9326

Adding test for importing templates with puppet on sat with puppet enabled and puppet disabled.

Test results:
```
pytest -v tests/foreman/api/test_templatesync.py -k test_import_template_with_puppet
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1 -- /home/pdragun/.virtualenvs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pdragun/Documents/robottelo, configfile: pyproject.toml
plugins: cov-2.12.1, forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, xdist-2.5.0, ibutsu-2.0.2
collected 31 items / 29 deselected / 2 selected                                                                                                                                                                                              

tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_import_template_with_puppet[puppet_enabled] PASSED                                                                                                              [ 50%]
tests/foreman/api/test_templatesync.py::TestTemplateSyncTestCase::test_import_template_with_puppet[puppet_disabled] PASSED                                                                                                             [100%]

========================================================================================== 2 passed, 29 deselected, 1 warning in 2705.35s (0:45:05) ==========================================================================================
```