### PR TITLE
Check popover status of host for RH cloud related fields.

### DIFF
--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -280,7 +280,7 @@ def test_rhcloud_inventory_auto_upload_setting():
 
     :BZ: 1793017
 
-    :CaseAutomation: NotAutomated
+    :CaseAutomation: ManualOnly
     """
 
 

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -244,13 +244,16 @@ def test_host_details_page(
         4. Sync RH Cloud inventory status.
         5. Go to Hosts -> All Hosts
         6. Assert there is "Recommendations" column containing insights recommendation count.
-        7. Assert that host properties shows reporting inventory upload status.
-        8. Click on "Recommendations" tab.
+        7. Check popover status of host.
+        8. Assert that host properties shows reporting inventory upload status.
+        9. Click on "Recommendations" tab.
 
     :expectedresults:
         1. There's Insights column with number of recommendations.
-        2. Inventory upload status is present in host properties table.
-        3. Clicking on "Recommendations" tab takes user to Insights page with insights
+        2. Inventory upload status is displayed in popover status of host.
+        3. Insights registration status is displayed in popover status of host.
+        4. Inventory upload status is present in host properties table.
+        5. Clicking on "Recommendations" tab takes user to Insights page with insights
             recommendations selected for that host.
 
     :BZ: 1974578
@@ -291,6 +294,9 @@ def test_host_details_page(
             silent_failure=True,
             handle_exception=True,
         )
+        result = session.host.host_status(rhel8_insights_vm.hostname)
+        assert 'Insights: Reporting' in result
+        assert 'Inventory: Successfully uploaded to your RH cloud inventory' in result
         result = session.host.search(rhel8_insights_vm.hostname)[0]
         assert result['Name'] == rhel8_insights_vm.hostname
         assert int(result['Recommendations']) > 0

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -126,32 +126,6 @@ def test_rhcloud_inventory_e2e(
         assert len(host_profiles['installed_packages']) > 1
 
 
-@pytest.mark.stubbed
-def test_hosts_synchronization():
-    """Synchronize list of available hosts from cloud and mark them in Satellite
-
-    :id: 2f1bdd42-140d-46f8-bad5-299c54620ee8
-
-    :Steps:
-
-        1. Prepare machine and upload its data to Insights
-        2. Add Cloud API key in Satellite
-        3. In Satellite UI, Configure -> Inventory upload -> Sync inventory status
-        4. Assert content of toast message once synchronization finishes
-        5. Go to Hosts -> All Hosts and assert content of status popover
-        6. Open host page and assert status on "Properties" tab
-
-    :expectedresults:
-        1. Toast message contains number of hosts synchronized and missed
-        2. Presence in cloud is displayed in popover status of host
-        3. Presence in cloud is displayed in "Properties" tab on single host page
-
-    :BZ: 1865874
-
-    :CaseAutomation: NotAutomated
-    """
-
-
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_names(


### PR DESCRIPTION
This PR:
- Adds test scenario for popover status of host. It checks Insights registration and Inventory upload status.
- Removes `test_hosts_synchronization` because it's covered in other tests.
- Marks `test_rhcloud_inventory_auto_upload_setting` as `ManualOnly` because automatic inventory upload triggers once in 48 hours and it can't be changed from satellite.
- Depends on https://github.com/SatelliteQE/airgun/pull/664