### PR TITLE
Temporarily Stop Updating pip

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -33,7 +33,7 @@ jobs:
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          pip install -U pip
+          # pip install -U pip
           pip uninstall -y pycurl
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-optional.txt

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          pip install -U pip
+          # pip install -U pip
           pip uninstall -y pycurl
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-optional.txt


### PR DESCRIPTION
pip 22 is currently having issues with dependency installation (https://github.com/pypa/pip/issues/10851)
until it is resolved, we should disable explicit updating. if it takes longer to resolve, then we may need to explicitly enforce pip 21.3.1