### PR TITLE
Fix cli classparameters tests

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1320,7 +1320,7 @@ class Satellite(Capsule):
             f'--target-dir /etc/puppetlabs/code/environments/{env_name}/modules/'
         )
         smart_proxy = (
-            entities.SmartProxy().search(query={'search': f'name={self.hostname}'})[0].read()
+            self.api.SmartProxy().search(query={'search': f'name={self.hostname}'})[0].read()
         )
         smart_proxy.import_puppetclasses()
         return env_name


### PR DESCRIPTION
Tests results:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/cli/test_classparameters.py
======================================================================================= test session starts =======================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, ibutsu-2.0.2, xdist-2.5.0, reportportal-5.0.11, mock-3.6.1
collected 10 items                                                                                                                                                                                                                        

tests/foreman/cli/test_classparameters.py ..........                                                                                                                                        [100%]
========================================================================== 10 passed, 31 warnings in 2829.78s (0:47:09) ===========================================================================