### PR TITLE
Removing a puppet test case that was failing in 6.10

### DIFF
--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2541,40 +2541,6 @@ def test_positive_search_composite(session):
 
 
 @pytest.mark.tier3
-@pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_publish_with_force_puppet_env(session, module_import_puppet_module):
-    """Check that puppet environment will be created automatically once
-    content view that contains puppet module is published, no matter
-    whether 'Force Puppet' option is enabled or disabled for that content
-    view
-    Check that puppet environment will be created automatically once content
-    view without puppet module is published, only if 'Force Puppet' option is
-    enabled
-
-    :id: af553367-e621-41e8-86cb-091ba7ba6c0a
-
-    :customerscenario: true
-
-    :expectedresults: puppet environment is created only in expected cases
-
-    :BZ: 1437110
-
-    :CaseLevel: Integration
-
-    :CaseImportance: High
-    """
-    puppet_env_name = module_import_puppet_module['env']
-    with session:
-        for force_value in [True, False]:
-            cv_name = gen_string('alpha')
-            session.contentview.create({'name': cv_name})
-            session.contentview.update(cv_name, {'details.force_puppet': force_value})
-            result = session.contentview.publish(cv_name)
-            assert result['Version'] == VERSION
-            assert session.puppetenvironment.search(puppet_env_name) == puppet_env_name
-
-
-@pytest.mark.tier3
 def test_positive_publish_with_repo_with_disabled_http(session, module_org):
     """Attempt to publish content view with repository that set
     'publish via http' to False


### PR DESCRIPTION
This test case is no longer applicable after discussing with vlad.  Removing for so it gives a better automation result.