### PR TITLE
foreman-maintain replaced to satellite-maintain

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -17,7 +17,7 @@ def init_settings():
 def foreman_service_teardown(satellite_host):
     """stop and restart of foreman service"""
     yield satellite_host
-    satellite_host.execute('foreman-maintain service start --only=foreman')
+    satellite_host.execute('satellite-maintain service start --only=foreman')
 
 
 @pytest.fixture

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -255,15 +255,15 @@ class Base:
             return cls._handle_response(response, ignore_stderr=ignore_stderr)
 
     @classmethod
-    def fm_execute(
+    def sm_execute(
         cls,
         command,
         hostname=None,
         timeout=None,
     ):
-        """Executes the foreman-maintain cli commands on the server via ssh"""
+        """Executes the satellite-maintain cli commands on the server via ssh"""
         client = get_client(hostname=hostname or cls.hostname)
-        result = client.execute(f'foreman-maintain {command}', timeout=timeout)
+        result = client.execute(f'satellite-maintain {command}', timeout=timeout)
         return result
 
     @classmethod

--- a/robottelo/cli/sm_backup.py
+++ b/robottelo/cli/sm_backup.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain backup [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain backup [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -18,14 +18,14 @@ from robottelo.cli.base import Base
 
 
 class Backup(Base):
-    """Manipulates Foreman-maintain's backup command"""
+    """Manipulates Satellite-maintain's backup command"""
 
     command_base = 'backup'
 
     @classmethod
     def run_backup(cls, backup_dir='/tmp/', backup_type='online', options=None, timeout=None):
-        """Build foreman-maintain backup online/offline/snapshot"""
+        """Build satellite-maintain backup online/offline/snapshot"""
         cls.command_sub = backup_type
         cls.command_end = backup_dir
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options), timeout=timeout)
+        return cls.sm_execute(cls._construct_command(options), timeout=timeout)

--- a/robottelo/cli/sm_health.py
+++ b/robottelo/cli/sm_health.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -18,27 +18,27 @@ from robottelo.cli.base import Base
 
 
 class Health(Base):
-    """Manipulates Foreman-maintain's health command"""
+    """Manipulates Satellite-maintain's health command"""
 
     command_base = 'health'
 
     @classmethod
     def check(cls, options=None):
-        """Build foreman-maintain health check"""
+        """Build satellite-maintain health check"""
         cls.command_sub = 'check'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def list(cls, options=None):
-        """Build foreman-maintain health list"""
+        """Build satellite-maintain health list"""
         cls.command_sub = 'list'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def list_tags(cls, options=None):
-        """Build foreman-maintain health list-tags"""
+        """Build satellite-maintain health list-tags"""
         cls.command_sub = 'list-tags'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))

--- a/robottelo/cli/sm_restore.py
+++ b/robottelo/cli/sm_restore.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain restore [OPTIONS] BACKUP_DIR
+    satellite-maintain restore [OPTIONS] BACKUP_DIR
 
 Parameters:
     BACKUP_DIR                    Path to backup directory to restore
@@ -16,14 +16,14 @@ from robottelo.cli.base import Base
 
 
 class Restore(Base):
-    """Manipulates Foreman-maintain's restore command"""
+    """Manipulates Satellite-maintain's restore command"""
 
     command_base = 'restore'
 
     @classmethod
     def run(cls, backup_dir='/tmp/', timeout='30m', options=None):
-        """Build foreman-maintain restore"""
+        """Build satellite-maintain restore"""
         # cls.command_sub = 'No subcommand for restore'
         cls.command_end = backup_dir
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options), timeout=timeout)
+        return cls.sm_execute(cls._construct_command(options), timeout=timeout)

--- a/robottelo/cli/sm_service.py
+++ b/robottelo/cli/sm_service.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain service [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain service [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -22,55 +22,55 @@ from robottelo.cli.base import Base
 
 
 class Service(Base):
-    """Manipulates Foreman-maintain's service command"""
+    """Manipulates Satellite-maintain's service command"""
 
     command_base = 'service'
 
     @classmethod
     def start(cls, options=None):
-        """Build foreman-maintain service start"""
+        """Build satellite-maintain service start"""
         cls.command_sub = 'start'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def stop(cls, options=None):
-        """Build foreman-maintain service stop"""
+        """Build satellite-maintain service stop"""
         cls.command_sub = 'stop'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def restart(cls, options=None):
-        """Build foreman-maintain service"""
+        """Build satellite-maintain service"""
         cls.command_sub = 'restart'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def status(cls, options=None):
-        """Build foreman-maintain service status"""
+        """Build satellite-maintain service status"""
         cls.command_sub = 'status'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def enable(cls, options=None):
-        """Build foreman-maintain service enable"""
+        """Build satellite-maintain service enable"""
         cls.command_sub = 'enable'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def disable(cls, options=None):
-        """Build foreman-maintain service disable"""
+        """Build satellite-maintain service disable"""
         cls.command_sub = 'disable'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def list(cls, options=None):
-        """Build foreman-maintain service list"""
+        """Build satellite-maintain service list"""
         cls.command_sub = 'list'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))

--- a/robottelo/cli/sm_upgrade.py
+++ b/robottelo/cli/sm_upgrade.py
@@ -1,6 +1,6 @@
 """
 Usage:
-    foreman-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
+    satellite-maintain upgrade [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters:
     SUBCOMMAND                    subcommand
@@ -18,27 +18,27 @@ from robottelo.cli.base import Base
 
 
 class Upgrade(Base):
-    """Manipulates Foreman-maintain's health command"""
+    """Manipulates Satellite-maintain's health command"""
 
     command_base = 'upgrade'
 
     @classmethod
     def list_versions(cls, options=None):
-        """Build foreman-maintain upgrade list-versions"""
+        """Build satellite-maintain upgrade list-versions"""
         cls.command_sub = 'list-versions'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def check(cls, options=None):
-        """Build foreman-maintain upgrade check"""
+        """Build satellite-maintain upgrade check"""
         cls.command_sub = 'check'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))
 
     @classmethod
     def run(cls, options=None):
-        """Build foreman-maintain upgrade run"""
+        """Build satellite-maintain upgrade run"""
         cls.command_sub = 'run'
         options = options or {}
-        return cls.fm_execute(cls._construct_command(options))
+        return cls.sm_execute(cls._construct_command(options))

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1104,12 +1104,12 @@ class Capsule(ContentHost):
 
     def restart_services(self):
         """Restart services, returning True if passed and stdout if not"""
-        result = self.execute('foreman-maintain service restart')
+        result = self.execute('satellite-maintain service restart')
         return True if result.status == 0 else result.stdout
 
     def check_services(self):
         error_msg = 'Some services are not running'
-        result = self.execute('foreman-maintain service status')
+        result = self.execute('satellite-maintain service status')
         if result.status == 0:
             return True
         for line in result.stdout.splitlines():

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -403,10 +403,10 @@ def get_hypervisor_info(hypervisor_type):
 
 def virtwho_package_locked():
     """
-    Uninstall virt-who package and lock the foreman-maintain packages.
+    Uninstall virt-who package and lock the satellite-maintain packages.
     """
-    runcmd('rpm -e virt-who; foreman-maintain packages lock')
-    result = runcmd('foreman-maintain packages is-locked')
+    runcmd('rpm -e virt-who; satellite-maintain packages lock')
+    result = runcmd('satellite-maintain packages is-locked')
     assert "Packages are locked" in result[1]
 
 

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -63,7 +63,7 @@ def test_positive_run_capsule_upgrade_playbook(capsule_configured, default_sat):
     result = default_sat.api.JobInvocation(id=job['id']).read()
     assert result.succeeded == 1
 
-    result = default_sat.execute('foreman-maintain health check')
+    result = default_sat.execute('satellite-maintain health check')
     assert result.status == 0
     for line in result.stdout:
         assert 'FAIL' not in line

--- a/tests/foreman/cli/test_puppetplugin.py
+++ b/tests/foreman/cli/test_puppetplugin.py
@@ -110,7 +110,7 @@ def test_positive_enable_disable_logic(destructive_sat, destructive_caps):
     assert_puppet_status(destructive_caps, expected=True)
 
     # Try to disable puppet on Satellite and check it failed.
-    result = destructive_sat.execute('foreman-maintain plugin purge-puppet')
+    result = destructive_sat.execute('satellite-maintain plugin purge-puppet')
     assert result.status == 1
     assert (
         f'The following proxies have Puppet feature: {destructive_caps.hostname}.' in result.stdout
@@ -118,14 +118,14 @@ def test_positive_enable_disable_logic(destructive_sat, destructive_caps):
 
     # Disable puppet on Capsule and check it succeeded.
     result = destructive_caps.execute(
-        'foreman-maintain plugin purge-puppet --remove-all-data', timeout='20m'
+        'satellite-maintain plugin purge-puppet --remove-all-data', timeout='20m'
     )
     assert result.status == 0
     assert_puppet_status(destructive_caps, expected=False)
 
     # Disable puppet on Satellite and check it succeeded.
     result = destructive_sat.execute(
-        'foreman-maintain plugin purge-puppet --remove-all-data', timeout='20m'
+        'satellite-maintain plugin purge-puppet --remove-all-data', timeout='20m'
     )
     assert result.status == 0
     assert_puppet_status(destructive_sat, expected=False)

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -224,7 +224,7 @@ def test_satellite_inventory_slice_variable():
         1. Register few content hosts with satellite.
         2. Set SATELLITE_INVENTORY_SLICE_SIZE=1 dynflow environment variable.
             See BZ#1945661#c1
-        3. Run "foreman-maintain service restart --only dynflow-sidekiq@worker-1"
+        3. Run "satellite-maintain service restart --only dynflow-sidekiq@worker-1"
         4. Generate inventory report.
 
     :expectedresults: Generated report had slice containing only one host.

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1334,7 +1334,7 @@ def test_positive_check_installer_services(default_sat):
 
     :steps:
         1. Run 'systemctl status <tomcat>' command to check tomcat service status on satellite.
-        2. Run 'foreman-maintain service status' command on satellite to check the satellite
+        2. Run 'satellite-maintain service status' command on satellite to check the satellite
             services.
         3. Run the 'hammer ping' command on satellite.
 

--- a/tests/foreman/longrun/test_remote_DB.py
+++ b/tests/foreman/longrun/test_remote_DB.py
@@ -117,7 +117,7 @@ def test_offline_backup_external_all_with_SSL():
 
     :id: dc452b72-66b8-4a69-adb1-da089a0d4942
 
-    :Steps: Run foreman-maintain backup offline
+    :Steps: Run satellite-maintain backup offline
 
     :expectedresults: Database backup created
 
@@ -132,7 +132,7 @@ def test_online_backup_external_all_with_SSL():
 
     :id: 2781aeb7-742e-4c95-ad57-c2d1c025bf90
 
-    :Steps: Run foreman-maintain backup online
+    :Steps: Run satellite-maintain backup online
 
     :expectedresults: Database backup created
 
@@ -147,7 +147,7 @@ def test_snapshot_backup_external_all_with_SSL():
 
     :id: e2d35b31-15ce-40da-bbbf-d302838d41b6
 
-    :Steps: Run foreman-maintain backup snapshot
+    :Steps: Run satellite-maintain backup snapshot
 
     :expectedresults: Database backup created
 
@@ -162,7 +162,7 @@ def test_restore_offline_backup_external_all_with_SSL():
 
     :id: c3e38e31-0058-48e9-b0f2-59788df64c38
 
-    :Steps: Run foreman-maintain restore - and provide it offline backup
+    :Steps: Run satellite-maintain restore - and provide it offline backup
 
     :expectedresults: Database backup restored
 
@@ -177,7 +177,7 @@ def test_restore_online_backup_external_all_with_SSL():
 
     :id: 5c724e98-af13-4d5f-ba2e-84c8767c0222
 
-    :Steps: Run foreman-maintain restore
+    :Steps: Run satellite-maintain restore
 
     :expectedresults: Database backup restored
 
@@ -192,7 +192,7 @@ def test_restore_snapshot_backup_external_all_with_SSL():
 
     :id: e6439ddf-4f5a-450d-8911-73082589105d
 
-    :Steps: Run foreman-maintain restore
+    :Steps: Run satellite-maintain restore
 
     :expectedresults: Database backup restored
 
@@ -228,7 +228,7 @@ def test_upgrade_satellite_eith_all_external_db_SSL():
     :Steps:
 
         1. Run satellite-installer with pulp, foreman and candlepin db options set
-        2. Upgrade with foreman-maintain
+        2. Upgrade with satellite-maintain
 
     :expectedresults:
 

--- a/tests/foreman/sys/test_foreman_service.py
+++ b/tests/foreman/sys/test_foreman_service.py
@@ -37,8 +37,8 @@ def test_positive_foreman_service_auto_restart(foreman_service_teardown):
     """
     sat = foreman_service_teardown
     sat.execute('systemctl stop foreman')
-    result = sat.execute('foreman-maintain service status --only=foreman')
+    result = sat.execute('satellite-maintain service status --only=foreman')
     assert result.status == 1
     assert 'not running (foreman)' in result.stdout
     assert sat.api.Organization().search(query={'search': f'name="{DEFAULT_ORG}"'})[0]
-    sat.execute('foreman-maintain service status --only=foreman')
+    sat.execute('satellite-maintain service status --only=foreman')

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -272,7 +272,7 @@ class TestKatelloCertsCheck:
             assert 'SSL certificate verification failed' not in result.stdout
             assert result.stdout.count('ok') == 7
             # assert all services are running
-            result = satellite.execute('foreman-maintain health check --label services-up -y')
+            result = satellite.execute('satellite-maintain health check --label services-up -y')
             assert result.status == 0, 'Not all services are running'
         finally:
             # revert to original certs
@@ -283,7 +283,7 @@ class TestKatelloCertsCheck:
             result = satellite.execute('hammer ping')
             assert result.status == 0, f'Hammer Ping failed:\n{result.stderr}'
             # assert all services are running
-            result = satellite.execute('foreman-maintain health check --label services-up -y')
+            result = satellite.execute('satellite-maintain health check --label services-up -y')
             assert result.status == 0, 'Not all services are running'
 
     @pytest.mark.destructive
@@ -335,7 +335,7 @@ class TestKatelloCertsCheck:
         assert 'SSL certificate verification failed' not in result.stdout
         assert result.stdout.count('ok') == 7
         # assert all services are running
-        result = rhel_vm.execute('foreman-maintain health check --label services-up -y')
+        result = rhel_vm.execute('satellite-maintain health check --label services-up -y')
         assert result.status == 0, 'Not all services are running'
 
     @pytest.mark.destructive
@@ -369,7 +369,7 @@ class TestKatelloCertsCheck:
         assert 'SSL certificate verification failed' not in result.stdout
         assert result.stdout.count('ok') == 8
         # assert all services are running
-        result = destructive_sat.execute('foreman-maintain health check --label services-up -y')
+        result = destructive_sat.execute('satellite-maintain health check --label services-up -y')
         assert result.status == 0, 'Not all services are running'
 
     @pytest.mark.destructive

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -1504,7 +1504,7 @@ def test_content_access_after_stopped_foreman(
     result = rhel7_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
     assert default_sat.execute('systemctl stop foreman').status == 0
-    result = default_sat.execute('foreman-maintain service status --only=foreman')
+    result = default_sat.execute('satellite-maintain service status --only=foreman')
     assert result.status == 1
     result = rhel7_contenthost.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
     assert result.status == 0

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -940,7 +940,7 @@ def test_single_sign_on_ldap_ipa_server(
     try:
         run_command(cmd='subscription-manager repos --enable rhel-7-server-optional-rpms')
         run_command(cmd='satellite-installer --foreman-ipa-authentication=true', timeout=800000)
-        run_command('foreman-maintain service restart', timeout=300000)
+        run_command('satellite-maintain service restart', timeout=300000)
         if is_open('BZ:1941997'):
             curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin'
         else:
@@ -952,7 +952,7 @@ def test_single_sign_on_ldap_ipa_server(
     finally:
         # resetting the settings to default for external auth
         run_command(cmd='satellite-installer --foreman-ipa-authentication=false', timeout=800000)
-        run_command('foreman-maintain service restart', timeout=300000)
+        run_command('satellite-maintain service restart', timeout=300000)
         run_command(
             cmd=f'ipa service-del HTTP/{default_sat.hostname}',
             hostname=settings.ipa.hostname,
@@ -1008,7 +1008,7 @@ def test_single_sign_on_ldap_ad_server(
     finally:
         # resetting the settings to default for external auth
         run_command(cmd='satellite-installer --foreman-ipa-authentication=false', timeout=800000)
-        run_command('foreman-maintain service restart', timeout=300000)
+        run_command('satellite-maintain service restart', timeout=300000)
 
 
 @pytest.mark.destructive

--- a/tests/upgrades/test_satellite_maintain.py
+++ b/tests/upgrades/test_satellite_maintain.py
@@ -1,4 +1,4 @@
-"""Test for Foreman-maintain related Upgrade Scenario's
+"""Test for Satellite-maintain related Upgrade Scenario's
 
 :Requirement: UpgradedSatellite
 
@@ -19,14 +19,14 @@
 import pytest
 
 
-class TestForemanMaintain:
+class TestSatelliteMaintain:
     """The test class contains pre-upgrade and post-upgrade scenarios to test
-    foreman-maintain utility
+    satellite-maintain utility
 
     Test Steps:
-        1. Before Satellite upgrade, Perform test for "foreman-maintain upgrade list-versions"
+        1. Before Satellite upgrade, Perform test for "satellite-maintain upgrade list-versions"
         2. Upgrade satellite/capsule.
-        3. Perform tests for foreman-maintain upgrade list-versions, after upgrade.
+        3. Perform tests for satellite-maintain upgrade list-versions, after upgrade.
         4. Check if tests passed.
     """
 
@@ -46,11 +46,11 @@ class TestForemanMaintain:
             satellite_version = satellite_version.stdout
         else:
             return [], [], None, None
-        forman_maintain_version = sat_obj.execute(
-            "foreman-maintain upgrade list-versions --disable-self-upgrade"
+        satellite_maintain_version = sat_obj.execute(
+            "satellite-maintain upgrade list-versions --disable-self-upgrade"
         )
         upgradeable_version = [
-            version for version in forman_maintain_version.stdout if version != ''
+            version for version in satellite_maintain_version.stdout if version != ''
         ]
         version_change = 0
         for version in upgradeable_version:
@@ -60,9 +60,9 @@ class TestForemanMaintain:
             y_version = ''
         else:
             major_version_change = True
-            y_version = list(set(forman_maintain_version) - set(satellite_version))[0].split('.')[
-                -1
-            ]
+            y_version = list(set(satellite_maintain_version) - set(satellite_version))[0].split(
+                '.'
+            )[-1]
 
         return satellite_version, upgradeable_version, major_version_change, y_version
 
@@ -97,14 +97,14 @@ class TestForemanMaintain:
         return zstream_version, next_version
 
     @pytest.mark.pre_upgrade
-    def test_pre_foreman_maintain_upgrade_list_versions(self, default_sat):
+    def test_pre_satellite_maintain_upgrade_list_versions(self, default_sat):
         """Pre-upgrade sceanrio that tests list of satellite version
         which satellite can be upgraded.
 
         :id: preupgrade-fc2c54b2-2663-11ea-b47c-48f17f1fc2e1
 
         :steps:
-            1. Run foreman-maintain upgrade list-versions
+            1. Run satellite-maintain upgrade list-versions
 
         :expectedresults: Versions should be current z-stream.
 
@@ -116,7 +116,7 @@ class TestForemanMaintain:
             y_version,
         ) = self.satellite_upgradable_version_list(default_sat)
         if satellite_version:
-            # In future If foreman-maintain packages update add before
+            # In future If satellite-maintain packages update add before
             # pre-upgrade test case execution then next version kind of
             # stuff check we can add it here.
             zstream_version, next_version = self.version_details(
@@ -127,14 +127,14 @@ class TestForemanMaintain:
         assert zstream_version in upgradable_version
 
     @pytest.mark.post_upgrade
-    def test_post_foreman_maintain_upgrade_list_versions(self, default_sat):
+    def test_post_satellite_maintain_upgrade_list_versions(self, default_sat):
         """Post-upgrade sceanrio that tests list of satellite version
         which satellite can be upgraded.
 
         :id: postupgrade-0bce689c-2664-11ea-b47c-48f17f1fc2e1
 
         :steps:
-            1. Run foreman-maintain upgrade list-versions.
+            1. Run satellite-maintain upgrade list-versions.
 
         :expectedresults: Versions should be next z-stream.
 


### PR DESCRIPTION
we should use downstream name for foreman-maintain and that is satellite maintain

I did rename files from `/robottello/cli/fm*` to `/robottelo/cli/sm*` and I didn't found any usages of these files in robotello, but it didn't feel quite right so maybe I just didn't found the usages or I need explanation why we use them. 

other usages of FM are in: `upgrade.yaml`  and `subscription.yaml`