### PR TITLE
Fix configure_rhai_client for rhel8

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -26,6 +26,7 @@ LOCALES = (
 DISTRO_RHEL6 = "rhel6"
 DISTRO_RHEL7 = "rhel7"
 DISTRO_RHEL8 = "rhel8"
+DISTRO_RHEL9 = "rhel9"
 DISTRO_SLES11 = "sles11"
 DISTRO_SLES12 = "sles12"
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -710,13 +710,14 @@ class ContentHost(Host):
             constants.DISTRO_RHEL6: settings.repos.rhel6_os,
             constants.DISTRO_RHEL7: settings.repos.rhel7_os,
             constants.DISTRO_RHEL8: settings.repos.rhel8_os,
+            constants.DISTRO_RHEL9: settings.repos.rhel9_os,
         }
         rhel_repo = distro_repo_map.get(rhel_distro)
 
         if rhel_repo is None:
             raise ContentHostError(f'Missing RHEL repository configuration for {rhel_distro}.')
 
-        if rhel_distro == constants.DISTRO_RHEL8:
+        if rhel_distro not in (constants.DISTRO_RHEL6, constants.DISTRO_RHEL7):
             self.create_custom_repos(**rhel_repo)
         else:
             self.create_custom_repos(**{rhel_distro: rhel_repo})

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -716,7 +716,10 @@ class ContentHost(Host):
         if rhel_repo is None:
             raise ContentHostError(f'Missing RHEL repository configuration for {rhel_distro}.')
 
-        self.create_custom_repos(**{rhel_distro: rhel_repo})
+        if rhel_distro == constants.DISTRO_RHEL8:
+            self.create_custom_repos(**rhel_repo)
+        else:
+            self.create_custom_repos(**{rhel_distro: rhel_repo})
 
         # Install insights-client rpm
         if self.execute('yum install -y insights-client').status != 0:


### PR DESCRIPTION
`settings.repos.rhel8_os` has two repourl's(baseos and appstream), which causes `create_custom_repos` helper
to create an invalid repo on host.

Test result:
```
$ pytest tests/foreman/cli/test_rhcloud_insights.py -k test_positive_connection_option  
============================= test session starts ==============================
collected 2 items

tests/foreman/cli/test_rhcloud_insights.py ..                            [100%]

======================== 2 passed in 2763.80s (0:46:03) ========================
```
