### PR TITLE
rex against satellite permissions test

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -953,6 +953,11 @@ def make_job_invocation(options=None):
 
     :returns JobInvocation object
     """
+    return make_job_invocation_with_credentials(options)
+
+
+def make_job_invocation_with_credentials(options=None, credentials=None):
+    """Helper function to create Job Invocation with credentials"""
 
     args = {
         'async': None,
@@ -975,7 +980,8 @@ def make_job_invocation(options=None):
         'time-span': None,
     }
 
-    return create_object(JobInvocation, args, options)
+    jinv_cls = _entity_with_credentials(credentials, JobInvocation)
+    return create_object(jinv_cls, args, options)
 
 
 @cacheable


### PR DESCRIPTION
Rex jobs against Satellite are now limited by permission
result:
```
pytest tests/foreman/cli/test_remoteexecution.py -k test_positive_rex_against_satellite
================================================ test session starts ================================================
platform linux -- Python 3.10.2, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, configfile: pyproject.toml
plugins: forked-1.4.0, xdist-2.5.0, services-2.2.1, reportportal-5.0.11, mock-3.6.1, ibutsu-2.0.2
collected 21 items / 20 deselected / 1 selected                                                                     

tests/foreman/cli/test_remoteexecution.py .                                                                   [100%]
```