### PR TITLE
Isolate rhel support, params, and deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ tests/foreman/pytest.ini
 /settings.local.yaml
 /settings*.local.yaml
 /conf/*.yaml
+!/conf/supportability.yaml
 
 # I don't know where those 2 files come from
 # but they are always there.

--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -1,13 +1,8 @@
 content_host:
-    deploy_workflow: workflow-name
+    deploy_workflow:
+        default:
+        rhel9: # example of workflow override for version
     default_rhel_version: 7
-    rhel_versions:
-      6: {}
-      7: {}
-      8: {}
-      9_compose:
-        deploy_workflow: deploy-rhel-cmp-template
-
     hardware:
         RHEL6:
             RELEASE: 6.10
@@ -21,7 +16,7 @@ content_host:
             RELEASE: 8.3
             MEMORY: 1536 MiB
             CORES: 1
-        RHEL9_compose:
+        RHEL9:
             RELEASE: 9.0
             COMPOSE: RHEL-9.0.0-20220118.1
             MEMORY: 1536 MiB

--- a/conf/supportability.yaml
+++ b/conf/supportability.yaml
@@ -1,0 +1,4 @@
+supportability:
+  content_hosts:
+    rhel:
+      versions: [6, 7, 8, 9]

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -18,11 +18,15 @@ def host_conf(request):
     conf = params = {}
     if hasattr(request, 'param'):
         params = request.param
-    conf['workflow'] = params.get('workflow', settings.content_host.deploy_workflow)
     _rhelver = f"rhel{params.get('rhel_version', settings.content_host.default_rhel_version)}"
     rhel_compose_id = settings.get(f"content_host.hardware.{_rhelver}.compose")
     if rhel_compose_id:
         conf['deploy_rhel_compose_id'] = rhel_compose_id
+    default_workflow = (
+        settings.content_host.deploy_workflow.get(_rhelver)
+        or settings.content_host.deploy_workflow.default
+    )
+    conf['workflow'] = params.get('workflow', default_workflow)
     conf['deploy_rhel_version'] = settings.content_host.hardware.get(_rhelver).release
     conf['memory'] = params.get('memory', settings.content_host.hardware.get(_rhelver).memory)
     conf['cores'] = params.get('cores', settings.content_host.hardware.get(_rhelver).cores)

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -15,7 +15,7 @@ def pytest_generate_tests(metafunc):
             list_params.extend(
                 [
                     setting_rhel_ver
-                    for setting_rhel_ver in settings.content_host.rhel_versions
+                    for setting_rhel_ver in settings.supportability.content_hosts.rhel.versions
                     if str(setting_rhel_ver) in str(matcher)
                 ]
             )
@@ -26,17 +26,15 @@ def pytest_generate_tests(metafunc):
             match_params.extend(
                 [
                     setting_rhel_ver
-                    for setting_rhel_ver in settings.content_host.rhel_versions
+                    for setting_rhel_ver in settings.supportability.content_hosts.rhel.versions
                     if re.fullmatch(str(matcher[0]), str(setting_rhel_ver))
                 ]
             )
         rhel_params = []
         filtered_versions = set(list_params + match_params)
-        for ver, data in settings.content_host.rhel_versions.items():
-            if ver in (filtered_versions or settings.content_host.rhel_versions):
-                # prefer version-specific deploy workflow before using the default one
-                workflow = data.get('deploy_workflow', settings.content_host.deploy_workflow)
-                rhel_params.append(dict(workflow=workflow, rhel_version=ver))
+        # default to all supported versions if no filters were found
+        for ver in filtered_versions or settings.supportability.content_hosts.rhel.versions:
+            rhel_params.append(dict(rhel_version=ver))
         if rhel_params:
             metafunc.parametrize(
                 'rhel_contenthost',

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -5,6 +5,9 @@ from robottelo.constants import VALID_GCE_ZONES
 
 
 VALIDATORS = dict(
+    supportability=[
+        Validator('supportability.content_hosts.rhel.versions', must_exist=True, is_type_of=list)
+    ],
     server=[
         Validator('server.hostname', default=''),
         Validator('server.hostnames', must_exist=True, is_type_of=list),
@@ -29,9 +32,8 @@ VALIDATORS = dict(
         Validator('server.ssh_password', default=None),
     ],
     content_host=[
-        Validator('content_host.rhel_versions', must_exist=True),
         Validator('content_host.default_rhel_version', must_exist=True),
-        Validator('content_host.deploy_workflow', must_exist=True),
+        Validator('content_host.deploy_workflow.default', must_exist=True),
     ],
     subscription=[
         Validator('subscription.rhn_username', must_exist=True),


### PR DESCRIPTION
The content host yaml was trying to do far too much with the
increasingly abstracted test generation for rhel versions.

This creates a new supportability.yaml, which is not a template but a
direct definition of the supported versions of RHEL for the current
master branch of robottelo. This will change when backported to 6.10,
and in future master commits.

Remove handling of the workflow selection during test generation. The
fixture being indirectly parametrized already has a function that deals
with processing host arguments used for deployment.

### Testing

Below is from a CI pipeline build to test this change. The collection of `tests/foreman/api` shows test cases using the rhel version specific content host fixtures and test_subscription.py shows an example of the abstracted `rhel_contenthost` fixture parametrized by the supported rhel versions.



```
 10:00:59  + py.test -rEfs --tb=short --durations=20 --durations-min=600.0 -n 1 --include-stubbed --junit-xml=sat-Critical-results.xml -o junit_suite_name=sat-Critical tests/foreman/api/test_subscription.py::test_positive_subscription_status_disabled
10:01:03  ============================= test session starts ==============================
10:01:03  platform linux -- Python 3.8.8, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
10:01:03  shared_function enabled - OFF - scope:  - storage: file
10:01:03  rootdir: /opt/app-root/src/robottelo, configfile: pyproject.toml
10:01:03  plugins: forked-1.4.0, ibutsu-2.0.2, mock-3.6.1, reportportal-5.0.11, services-2.2.1, xdist-2.5.0
10:01:03  gw0 I
10:01:07  gw0 [4]
10:01:07  
10:58:55  F..F                                                                     [100%]
10:58:55  =================================== FAILURES ===================================
10:58:55  ______________ test_positive_subscription_status_disabled[rhel6] _______________
10:58:55  [gw0] linux -- Python 3.8.8 /opt/app-root/bin/python3.8
10:58:55  tests/foreman/api/test_subscription.py:255: in test_positive_subscription_status_disabled
10:58:55      assert rhel_contenthost.subscribed
10:58:55  E   assert False
10:58:55  E    +  where False = <robottelo.hosts.ContentHost object at 0x7f18a6354b80>.subscribed
10:58:55  ______________ test_positive_subscription_status_disabled[rhel9] _______________
10:58:55  [gw0] linux -- Python 3.8.8 /opt/app-root/bin/python3.8
10:58:55  tests/foreman/api/test_subscription.py:255: in test_positive_subscription_status_disabled
10:58:55      assert rhel_contenthost.subscribed
10:58:55  E   assert False
10:58:55  E    +  where False = <robottelo.hosts.ContentHost object at 0x7f18b21350d0>.subscribed
10:58:55  --- generated xml file: /opt/app-root/src/robottelo/sat-Critical-results.xml ---
10:58:55  ============================= slowest 20 durations =============================
10:58:55  1742.77s setup    tests/foreman/api/test_subscription.py::test_positive_subscription_status_disabled[rhel6]
10:58:55  
10:58:55  (11 durations < 600s hidden.  Use -vv to show these durations.)
10:58:55  =========================== short test summary info ============================
10:58:55  FAILED tests/foreman/api/test_subscription.py::test_positive_subscription_status_disabled[rhel6]
10:58:55  FAILED tests/foreman/api/test_subscription.py::test_positive_subscription_status_disabled[rhel9]
10:58:55  =================== 2 failed, 2 passed in 3470.00s (0:57:49) ===================
```