### PR TITLE
Add test to check that OS was created after KS sync

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -26,6 +26,7 @@ LOCALES = (
 DISTRO_RHEL6 = "rhel6"
 DISTRO_RHEL7 = "rhel7"
 DISTRO_RHEL8 = "rhel8"
+DISTRO_RHEL9 = "rhel9"
 DISTRO_SLES11 = "sles11"
 DISTRO_SLES12 = "sles12"
 
@@ -340,6 +341,7 @@ PRDS = {
     'rhscl': 'Red Hat Software Collections (for RHEL Server)',
     'rhae': 'Red Hat Ansible Engine',
     'rhel8': 'Red Hat Enterprise Linux for x86_64',
+    'rhel9': 'Red Hat Enterprise Linux for x86_64 Beta',
 }
 
 REPOSET = {
@@ -365,8 +367,13 @@ REPOSET = {
     'rhae2': 'Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server',
     'rhst8': 'Red Hat Satellite Tools 6.9 for RHEL 8 x86_64 (RPMs)',
     'fdrh8': 'Fast Datapath for RHEL 8 x86_64 (RPMs)',
-    'rhel8_bos_ks': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS (Kickstart)',
-    'rhel8_aps_ks': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream (Kickstart)',
+    'kickstart': {
+        'rhel6': 'Red Hat Enterprise Linux 6 Server (Kickstart)',
+        'rhel7': 'Red Hat Enterprise Linux 7 Server (Kickstart)',
+        'rhel8': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS (Kickstart)',
+        'rhel8_aps': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream (Kickstart)',
+        'rhel9': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Beta (Kickstart)',
+    },
 }
 
 NO_REPOS_AVAILABLE = "This system has no repositories available through subscriptions."
@@ -574,23 +581,47 @@ REPOS = {
         'distro': DISTRO_RHEL8,
         'key': 'rhst',
     },
-    'rhel8_bos_ks': {
-        'id': 'rhel-8-for-x86_64-baseos-kickstart',
-        'name': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8.4',
-        'version': '8.4',
-        'reposet': REPOSET['rhel8_bos_ks'],
-        'product': PRDS['rhel8'],
-        'distro': DISTRO_RHEL8,
-        'key': 'rhel8_bos_ks',
-    },
-    'rhel8_aps_ks': {
-        'id': 'rhel-8-for-x86_64-appstream-kickstart',
-        'name': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart 8.5',
-        'version': '8.5',
-        'reposet': REPOSET['rhel8_bos_ks'],
-        'product': PRDS['rhel8'],
-        'distro': DISTRO_RHEL8,
-        'key': 'rhel8_aps_ks',
+    'kickstart': {
+        'rhel6': {
+            'id': 'rhel-6-server-kickstart',
+            'name': 'Red Hat Enterprise Linux 6 Server Kickstart x86_64 6.10',
+            'version': '6.10',
+            'reposet': REPOSET['kickstart']['rhel6'],
+            'product': PRDS['rhel'],
+            'distro': DISTRO_RHEL6,
+        },
+        'rhel7': {
+            'id': 'rhel-7-server-kickstart',
+            'name': 'Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.9',
+            'version': '7.9',
+            'reposet': REPOSET['kickstart']['rhel7'],
+            'product': PRDS['rhel'],
+            'distro': DISTRO_RHEL7,
+        },
+        'rhel8': {
+            'id': 'rhel-8-for-x86_64-baseos-kickstart',
+            'name': 'Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8.4',
+            'version': '8.4',
+            'reposet': REPOSET['kickstart']['rhel8'],
+            'product': PRDS['rhel8'],
+            'distro': DISTRO_RHEL8,
+        },
+        'rhel8_aps': {
+            'id': 'rhel-8-for-x86_64-appstream-kickstart',
+            'name': 'Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart 8.5',
+            'version': '8.5',
+            'reposet': REPOSET['kickstart']['rhel8_aps'],
+            'product': PRDS['rhel8'],
+            'distro': DISTRO_RHEL8,
+        },
+        'rhel9': {
+            'id': 'rhel-9-for-x86_64-baseos-beta-kickstart',
+            'name': 'Red Hat Enterprise Linux 9 for x86_64 - BaseOS Beta Kickstart',
+            'version': '9.0',
+            'reposet': REPOSET['kickstart']['rhel9'],
+            'product': PRDS['rhel9'],
+            'distro': DISTRO_RHEL9,
+        },
     },
 }
 

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -114,13 +114,14 @@ class TestSatelliteContentManagement:
 
         :BZ: 1687801
         """
+        distro = 'rhel8'
         rh_repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_manifest_org.id,
-            product=constants.PRDS['rhel8'],
-            repo=constants.REPOS['rhel8_bos_ks']['name'],
-            reposet=constants.REPOSET['rhel8_bos_ks'],
-            releasever='8.4',
+            product=constants.REPOS['kickstart'][distro]['product'],
+            reposet=constants.REPOSET['kickstart'][distro],
+            repo=constants.REPOS['kickstart'][distro]['name'],
+            releasever=constants.REPOS['kickstart'][distro]['version'],
         )
         rh_repo = entities.Repository(id=rh_repo_id).read()
         rh_repo.sync()
@@ -136,6 +137,41 @@ class TestSatelliteContentManagement:
         assert rh_repo.content_counts['package'] > 0
         assert rh_repo.content_counts['package_group'] > 0
         assert rh_repo.content_counts['rpm'] > 0
+
+    @pytest.mark.parametrize(
+        'distro', [f'rhel{ver}' for ver in settings.supportability.content_hosts.rhel.versions]
+    )
+    def test_positive_sync_kickstart_check_os(self, module_manifest_org, distro):
+        """Sync rhel KS repo and assert that OS was created
+
+        :id: f84bcf1b-717e-40e7-82ee-000eead45249
+
+        :Parametrized: Yes
+
+        :steps:
+            1. Enable and sync a kickstart repo.
+            2. Check that OS with corresponding version.
+
+        :expectedresults:
+            1. OS with corresponding version was created.
+
+        """
+        repo_id = enable_rhrepo_and_fetchid(
+            basearch='x86_64',
+            org_id=module_manifest_org.id,
+            product=constants.REPOS['kickstart'][distro]['product'],
+            reposet=constants.REPOSET['kickstart'][distro],
+            repo=constants.REPOS['kickstart'][distro]['name'],
+            releasever=constants.REPOS['kickstart'][distro]['version'],
+        )
+        rh_repo = entities.Repository(id=repo_id).read()
+        rh_repo.sync()
+
+        major, minor = constants.REPOS['kickstart'][distro]['version'].split('.')
+        os = entities.OperatingSystem().search(
+            query={'search': f'name="RedHat" AND major="{major}" AND minor="{minor}"'}
+        )
+        assert len(os)
 
     @pytest.mark.tier2
     def test_positive_mirror_on_sync(self, default_sat):
@@ -1047,13 +1083,14 @@ class TestCapsuleContentManagement:
 
         :BZ: 1992329
         """
+        distro = 'rhel8_aps'
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_manifest_org.id,
-            product=constants.PRDS['rhel8'],
-            reposet=constants.REPOSET['rhel8_aps_ks'],
-            repo=constants.REPOS['rhel8_aps_ks']['name'],
-            releasever=constants.REPOS['rhel8_aps_ks']['version'],
+            product=constants.REPOS['kickstart'][distro]['product'],
+            reposet=constants.REPOSET['kickstart'][distro],
+            repo=constants.REPOS['kickstart'][distro]['name'],
+            releasever=constants.REPOS['kickstart'][distro]['version'],
         )
         repo = entities.Repository(id=repo_id).read()
 


### PR DESCRIPTION
Proposed changes:
1) Adding a test to check that appropriate OS is created automatically after KS repo sync.
2) Fixed other KS-related tests to use the new constants.

Note: It seems that repo.read() does not return `package` in `content_counts` anymore (`rpm`, `package_group`, etc. stayed). For this reason all tests using `repo.content_counts['package']` are failing and need to be fixed, rather in a different PR. For this PR I verified that kickstart repo enable+sync worked for them.
CC @latran 

Results:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_check_os
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, ibutsu-2.0.2, xdist-2.5.0, reportportal-5.0.11, mock-3.6.1
collected 4 items                                                                                                                                                                                                                         

tests/foreman/api/test_contentmanagement.py ....                                                                                                                                                                                    [100%]

=============================================================================================== 4 passed, 73 warnings in 542.17s (0:09:02) ================================================================================================
```