### PR TITLE
[Fix again][Revisit #9341] the checks failing for assertions in pip

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -33,7 +33,7 @@ jobs:
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          # pip install -U pip
+          pip install -U pip==21.3.1
           pip uninstall -y pycurl
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-optional.txt

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          # pip install -U pip
+          pip install -U pip==21.3.1
           pip uninstall -y pycurl
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-optional.txt

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -32,7 +32,7 @@ jobs:
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          pip install -U pip
+          pip install -U pip==21.3.1
           pip uninstall -y pycurl
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-optional.txt

--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -33,6 +33,14 @@ REPOS:
     RHEL7: replace-with-rhel7-http-link
     RHEL8: replace-with-rhel8-http-link
     RHEL9: replace-with-rhel9-http-link
+  # Satellite's utils repos, and it works for 7.0 and onwards
+  SATUTILS_REPO:
+  # Satellite's client repos, and it works for 7.0 and onwards
+  SATCLIENT_REPO:
+    RHEL6:
+    RHEL7:
+    RHEL8:
+    RHEL9:
   # Downstream Satellite-maintain repo
   SATMAINTENANCE_REPO: replace-with-sat-maintain-repo
   # Software Collection Repo


### PR DESCRIPTION
We are still seeing this issue even though we removed pip update in https://github.com/SatelliteQE/robottelo/pull/9341 . 

So as per discussions on https://github.com/readthedocs/readthedocs.org/issues/8864 and https://github.com/pypa/pip/issues/10851 I am proposing to pin the pip upgrade to 21.3.1. 

I am also adding a fix for missing `SATUTILS_REPO` and `SATCLINT_REPO` keys missing in `repo.yaml` config.