### PR TITLE
Update pip in GHA, rollback PR #9341

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -33,7 +33,7 @@ jobs:
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          # pip install -U pip
+          pip install -U pip
           pip uninstall -y pycurl
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-optional.txt

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          # pip install -U pip
+          pip install -U pip
           pip uninstall -y pycurl
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-optional.txt

--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -33,6 +33,14 @@ REPOS:
     RHEL7: replace-with-rhel7-http-link
     RHEL8: replace-with-rhel8-http-link
     RHEL9: replace-with-rhel9-http-link
+  # Satellite's utils repos, and it works for 7.0 and onwards
+  SATUTILS_REPO: replace-with-utils-repository-url
+  # Satellite's client repos, and it works for 7.0 and onwards
+  SATCLIENT_REPO:
+    RHEL6: replace-with-rhel6-http-link
+    RHEL7: replace-with-rhel7-http-link
+    RHEL8: replace-with-rhel8-http-link
+    RHEL9: replace-with-rhel9-http-link
   # Downstream Satellite-maintain repo
   SATMAINTENANCE_REPO: replace-with-sat-maintain-repo
   # Software Collection Repo


### PR DESCRIPTION
**Description:**
1. Upstream pypa/pip issue[pypa/pip/pull/10867] for pip22 is solved, for which we temporarily disabled updating pip in GHA
2. Tests collection for `tests/upgrades` fails in GHA for recently added SATUTILS_REPO and SATCLIENT_REPO variables, check https://github.com/SatelliteQE/satellite6-upgrade/pull/521

Tested here: https://github.com/Gauravtalreja1/robottelo/pull/2