### PR TITLE
removed dependancy for widgetastic as airgun takes care

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,9 +25,6 @@ tenacity==8.0.1
 testimony==2.2.0
 unittest2==1.1.0
 wait-for==1.2.0
-widgetastic.core==0.65
-widgetastic.patternfly==1.3.4
-widgetastic.patternfly4==0.22.3
 wrapanapi==3.5.11
 
 # Get airgun, nailgun and upgrade from master


### PR DESCRIPTION
Locally Tested 

```
> pip list | grep widgetastic
widgetastic.core                      0.65
widgetastic.patternfly                1.3.4
widgetastic.patternfly4               0.23.2.dev2+gcb3bf05
> pip list | grep selenium
selenium                              4.1.0
selenium-smart-locator                0.2.0
> pip list | grep airgun
airgun                                0.0.1
```