### PR TITLE
Refactor tracer test to use rhel_contenthost fixture

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -51,6 +51,12 @@ REPOS:
   # which are essentially required for generating swid tags in RHEL8 content host.
   SWID_TOOLS_REPO: replace-with-swid-tools-repo
   FAKE_REPO_ZOO3: replace-with-zoo-fedorapeople-repo
+  MOCK_SERVICE_REPO_BASE: replace-with-repo-providing-robttelo-mock-service
+  MOCK_SERVICE_REPO:
+    RHEL7: "@format {this[repos].MOCK_SERVICE_REPO_BASE}/epel-7-x86_64/"
+    RHEL8: "@format {this[repos].MOCK_SERVICE_REPO_BASE}/epel-8-x86_64/"
+    RHEL9: "@format {this[repos].MOCK_SERVICE_REPO_BASE}/epel-9-x86_64/"
+  MOCK_SERVICE_RPM: "robottelo-mock-service"
 
 # Robottelo fixtures repos
   MODULE_STREAM_0:

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -6,10 +6,11 @@ All functions in this module will be treated as fixtures that apply the contenth
 """
 import pytest
 from broker import VMBroker
+from fauxfactory import gen_string
+from nailgun import entities
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import REPOS
 from robottelo.hosts import ContentHost
 
 
@@ -104,27 +105,66 @@ def registered_hosts(organization_ak_setup, content_hosts, default_sat):
 
 
 @pytest.fixture(scope="function")
-def katello_host_tools_host(setup_rhst_repo, rhel7_contenthost, default_sat):
-    """Register content host to Satellite and install katello-host-tools on the host,
-    based on hosts setup"""
-    rhel7_contenthost.install_katello_ca(default_sat)
-    rhel7_contenthost.register_contenthost(
-        setup_rhst_repo['org'].label,
-        setup_rhst_repo['ak'].name,
+def katello_host_tools_host(default_sat, module_org, rhel_contenthost):
+    """Register content host to Satellite and install katello-host-tools on the host."""
+    # prepare Product and appropriate Satellite Client repo on satellite
+    rhelver = rhel_contenthost.os_version.major
+    prod = entities.Product(
+        organization=module_org, name=f'rhel{rhelver}_{gen_string("alpha")}'
+    ).create()
+    sattools_repo = entities.Repository(
+        organization=module_org,
+        product=prod,
+        content_type='yum',
+        url=settings.repos['SATCLIENT_REPO'][f'RHEL{rhelver}'],
+    ).create()
+    sattools_repo.sync()
+    subs = entities.Subscription(organization=module_org, name=prod.name).search()
+    assert len(subs), f'Subscription for sat client product: {prod.name} was not found.'
+    sattools_sub = subs[0]
+
+    # finally, prepare the host end
+    rhel_contenthost.install_katello_ca(default_sat)
+    register = rhel_contenthost.register_contenthost(
+        org=module_org.label,
+        lce='Library',
+        name=f'{gen_string("alpha")}-{rhel_contenthost.hostname}',
+        force=True,
     )
-    assert rhel7_contenthost.subscribed
-    rhel7_contenthost.enable_repo(REPOS[setup_rhst_repo['repo_name']]['id'])
-    rhel7_contenthost.install_katello_host_tools()
-    yield rhel7_contenthost
+    assert register.status == 0, (
+        f'Failed to register the host: {rhel_contenthost.hostname}:'
+        'rc: {register.status}: {register.stderr}'
+    )
+    # attach product subscription to the host
+    rhel_contenthost.nailgun_host.bulk_add_subscriptions(
+        data={
+            "organization_id": module_org.id,
+            "included": {"ids": [rhel_contenthost.nailgun_host.id]},
+            "subscriptions": [{"id": sattools_sub.id, "quantity": 1}],
+        }
+    )
+    # refresh repository metadata
+    rhel_contenthost.execute('subscription-manager repos --list')
+    rhel_contenthost.install_katello_host_tools()
+    yield rhel_contenthost
 
 
 @pytest.fixture(scope="function")
 def katello_host_tools_tracer_host(katello_host_tools_host, default_sat):
     """Install katello-host-tools-tracer, add REx key and create custom
     repositories on the host"""
+    # create a custom, rhel version-specific OS repo
+    rhelver = katello_host_tools_host.os_version.major
+    if rhelver > 7:
+        katello_host_tools_host.create_custom_repos(**settings.repos[f'rhel{rhelver}_os'])
+    else:
+        katello_host_tools_host.create_custom_repos(
+            **{f'rhel{rhelver}_os': settings.repos[f'rhel{rhelver}_os']}
+        )
     katello_host_tools_host.install_tracer()
+    # enable REX
     katello_host_tools_host.add_rex_key(satellite=default_sat)
-    katello_host_tools_host.create_custom_rhel_repo_file_to_downgrade_packages()
+
     yield katello_host_tools_host
 
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -183,6 +183,8 @@ class ContentHost(Host):
         self.execute('subscription-manager clean')
 
     def teardown(self):
+        if self.nailgun_host:
+            self.nailgun_host.delete()
         self.unregister()
 
     def power_control(self, state=VmState.RUNNING, ensure=True):
@@ -417,6 +419,7 @@ class ContentHost(Host):
         consumerid=None,
         force=True,
         releasever=None,
+        name=None,
         username=settings.server.admin_username,
         password=settings.server.admin_password,
         auto_attach=False,
@@ -439,6 +442,7 @@ class ContentHost(Host):
         :param password: the user password
         :param auto_attach: automatically attach compatible subscriptions to
             this system.
+        :param name: name of the system to register, defaults to the hostname
         :return: SSHCommandResult instance filled with the result of the
             registration.
         """
@@ -467,6 +471,8 @@ class ContentHost(Host):
             cmd += f' --release {releasever}'
         if force:
             cmd += ' --force'
+        if name:
+            cmd += f' --name {name}'
         return self.execute(cmd)
 
     def unregister(self):
@@ -1044,15 +1050,6 @@ class ContentHost(Host):
         if cmd_result.status != 0:
             raise ContentHostError('There was an error installing katello-host-tools-tracer')
         self.execute('katello-tracer-upload')
-
-    def create_custom_rhel_repo_file_to_downgrade_packages(self):
-        """Create custom rhel repo file on client,
-        repo content is for older minor version, (current minor version - 1).
-        Please make sure that package you are looking for is inside minor version.
-        Usage: downgrade of package
-        """
-        baseurl = self.get_base_url_for_older_rhel_minor()
-        self.create_custom_repos(rhel=baseurl)
 
 
 class Capsule(ContentHost):

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -30,12 +30,31 @@ from fauxfactory import gen_mac
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
-from packaging import version
 from requests.exceptions import HTTPError
 
 from robottelo import datafactory
 from robottelo.api.utils import promote
 from robottelo.config import get_credentials
+from robottelo.config import settings
+
+
+@pytest.fixture(scope='function')
+def tracer_host(katello_host_tools_tracer_host):
+    # create a custom, rhel version-specific mock-service repo
+    rhelver = katello_host_tools_tracer_host.os_version.major
+    katello_host_tools_tracer_host.create_custom_repos(
+        **{f'mock_service_rhel{rhelver}': settings.repos['MOCK_SERVICE_REPO'][f'rhel{rhelver}']}
+    )
+    katello_host_tools_tracer_host.execute(f'yum -y install {settings.repos["MOCK_SERVICE_RPM"]}')
+    assert (
+        katello_host_tools_tracer_host.execute(
+            f'rpm -q {settings.repos["MOCK_SERVICE_RPM"]}'
+        ).status
+        == 0
+    )
+    katello_host_tools_tracer_host.execute(f'systemctl start {settings.repos["MOCK_SERVICE_RPM"]}')
+
+    yield katello_host_tools_tracer_host
 
 
 def update_smart_proxy(location, smart_proxy):
@@ -1487,33 +1506,44 @@ class TestHostTraces:
     """Tests for host tracer"""
 
     @pytest.mark.tier4
-    def test_positive_tracer_list_and_resolve(self, katello_host_tools_tracer_host):
+    @pytest.mark.rhel_ver_match('[^6].*')
+    def test_positive_tracer_list_and_resolve(self, tracer_host):
         """Install tracer on client, downgrade the service, check from the satellite
-        that tracer shows and resolves the problem
+        that tracer shows and resolves the problem. The test works with a package specified
+        in settings. This package is expected to install a systemd service which is expected
+        to log its version to /var/log/{package}/service.log.
+        The rpm is not supposed to start the service upon install.
 
         :id: 552fc212-536a-11ec-865d-98fa9b6ecd5a
 
-        :expectedresults: Tracer resolved the problem, the downgraded service was restarted
+        :expectedresults: Tracer detected and resolved the problem,
+            the affected service was restarted
 
         :parametrized: yes
 
         :CaseImportance: Medium
         """
-        # setup
-        client = katello_host_tools_tracer_host
-        host = entities.Host().search(query={'search': f'name = {client.hostname}'})[0]
-        package = 'rsyslog'
-        package_version = client.execute(f'rpm -q {package}')
-        assert package_version.status == 0
-        client.execute(f'yum -y downgrade {package}')
+        host = tracer_host.nailgun_host
+        package = settings.repos["MOCK_SERVICE_RPM"]
+        # mark the service log messages for later comparison and downgrade the pkg version
+        service_ver_log_old = tracer_host.execute(f'cat /var/log/{package}/service.log')
+        package_downgrade = tracer_host.execute(f'yum -y downgrade {package}')
+        assert package_downgrade.status == 0
+
+        # tracer should detect a new trace
         traces = host.traces(data={'host_id': host.id})
         assert (
             len(traces['results']) == 1
         ), f'only one trace trace should be found, there is: {traces["results"]}'
         assert package == traces['results'][0]['application']
+
+        # resolve traces and make sure that they disappear
         host.resolve_traces(data={'host_id': host.id, 'trace_ids': traces['results'][0]['id']})
         traces = host.traces(data={'host_id': host.id})
         assert not traces['results']
-        new_package_version = client.execute(f'rpm -q {package}')
-        assert new_package_version.status == 0
-        assert version.parse(package_version.stdout) > version.parse(new_package_version.stdout)
+
+        # verify on the host end, that the service was really restarted
+        service_ver_log_new = tracer_host.execute(f'cat /var/log/{package}/service.log')
+        assert (
+            service_ver_log_new != service_ver_log_old
+        ), f'The service {package} did not seem to be restarted'

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -29,7 +29,7 @@ from fauxfactory import gen_ipaddr
 from fauxfactory import gen_mac
 from fauxfactory import gen_string
 from nailgun import entities
-from packaging import version
+from wait_for import wait_for
 
 from robottelo.api.utils import promote
 from robottelo.cli.activationkey import ActivationKey
@@ -39,7 +39,6 @@ from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_fake_host
 from robottelo.cli.factory import make_host
 from robottelo.cli.factory import make_proxy
-from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.cli.factory import setup_org_for_a_rh_repo
 from robottelo.cli.host import Host
 from robottelo.cli.host import HostInterface
@@ -150,6 +149,25 @@ def function_user(function_host):
     ).create()
     yield {'user': user, 'password': user_password}
     user.delete()
+
+
+@pytest.fixture(scope='function')
+def tracer_host(katello_host_tools_tracer_host):
+    # create a custom, rhel version-specific mock-service repo
+    rhelver = katello_host_tools_tracer_host.os_version.major
+    katello_host_tools_tracer_host.create_custom_repos(
+        **{f'mock_service_rhel{rhelver}': settings.repos['MOCK_SERVICE_REPO'][f'rhel{rhelver}']}
+    )
+    katello_host_tools_tracer_host.execute(f'yum -y install {settings.repos["MOCK_SERVICE_RPM"]}')
+    assert (
+        katello_host_tools_tracer_host.execute(
+            f'rpm -q {settings.repos["MOCK_SERVICE_RPM"]}'
+        ).status
+        == 0
+    )
+    katello_host_tools_tracer_host.execute(f'systemctl start {settings.repos["MOCK_SERVICE_RPM"]}')
+
+    yield katello_host_tools_tracer_host
 
 
 def update_smart_proxy(location, smart_proxy):
@@ -1722,24 +1740,46 @@ def test_positive_provision_baremetal_with_uefi_secureboot():
     """
 
 
-@pytest.fixture(scope="module")
-def setup_custom_repo(setup_rhst_repo):
+@pytest.fixture(scope="function")
+def setup_custom_repo(module_org, katello_host_tools_host):
     """Create custom repository content"""
-    setup_org_for_a_custom_repo(
-        {
-            'url': settings.repos.yum_6.url,
-            'organization-id': setup_rhst_repo['org'].id,
-            'content-view-id': setup_rhst_repo['cv'].id,
-            'lifecycle-environment-id': setup_rhst_repo['lce'].id,
-            'activationkey-id': setup_rhst_repo['ak'].id,
+    custom_repo_url = settings.repos.yum_6.url
+    prod = entities.Product(organization=module_org, name=f'custom_{gen_string("alpha")}').create()
+    custom_repo = entities.Repository(
+        organization=module_org,
+        product=prod,
+        content_type='yum',
+        url=custom_repo_url,
+    ).create()
+    custom_repo.sync()
+    subs = entities.Subscription(organization=module_org, name=prod.name).search()
+    assert len(subs), f'Subscription for sat client product: {prod.name} was not found.'
+    custom_sub = subs[0]
+
+    katello_host_tools_host.nailgun_host.bulk_add_subscriptions(
+        data={
+            "organization_id": module_org.id,
+            "included": {"ids": [katello_host_tools_host.nailgun_host.id]},
+            "subscriptions": [{"id": custom_sub.id, "quantity": 1}],
         }
     )
-    return {
-        'ak': setup_rhst_repo['ak'],
-        'cv': setup_rhst_repo['cv'],
-        'lce': setup_rhst_repo['lce'],
-        'org': setup_rhst_repo['org'],
-    }
+    # refresh repository metadata
+    katello_host_tools_host.execute('subscription-manager repos --list')
+
+
+@pytest.fixture(scope="function")
+def yum_security_plugin(katello_host_tools_host):
+    """Enable yum-security-plugin if the distro version requires it.
+    Rhel6 yum version does not support updating of a specific advisory out of the box.
+    It requires the security plugin to be installed first
+    """
+    if katello_host_tools_host.os_version.major < 7:
+        katello_host_tools_host.create_custom_repos(
+            os_repo=settings.repos[f'rhel{katello_host_tools_host.os_version.major}_os']
+        )
+        katello_host_tools_host.execute('yum makecache')
+        yum_plugin_install = katello_host_tools_host.execute('yum -y install yum-plugin-security')
+        assert yum_plugin_install.status == 0, "Failed to install yum-plugin-security plugin"
 
 
 @pytest.mark.katello_host_tools
@@ -1820,12 +1860,17 @@ def test_positive_package_applicability(katello_host_tools_host, setup_custom_re
     client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     result = client.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
-    applicable_packages = Package.list(
-        {
-            'host-id': host_info['id'],
-            'packages-restrict-applicable': 'true',
-            'search': f'name={FAKE_1_CUSTOM_PACKAGE_NAME}',
-        }
+    applicable_packages, _ = wait_for(
+        lambda: Package.list(
+            {
+                'host-id': host_info['id'],
+                'packages-restrict-applicable': 'true',
+                'search': f'name={FAKE_1_CUSTOM_PACKAGE_NAME}',
+            }
+        ),
+        fail_condition=[],
+        timeout=120,
+        delay=5,
     )
     assert len(applicable_packages) == 1
     assert FAKE_2_CUSTOM_PACKAGE in applicable_packages[0]['filename']
@@ -1847,7 +1892,9 @@ def test_positive_package_applicability(katello_host_tools_host, setup_custom_re
 @pytest.mark.pit_client
 @pytest.mark.pit_server
 @pytest.mark.tier3
-def test_positive_erratum_applicability(katello_host_tools_host, setup_custom_repo):
+def test_positive_erratum_applicability(
+    katello_host_tools_host, setup_custom_repo, yum_security_plugin
+):
     """Ensure erratum applicability is functioning properly
 
     :id: 139de508-916e-4c91-88ad-b4973a6fa104
@@ -1874,13 +1921,20 @@ def test_positive_erratum_applicability(katello_host_tools_host, setup_custom_re
     host_info = Host.info({'name': client.hostname})
     client.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     result = client.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
-    assert result.status == 0
-    applicable_erratum = Host.errata_list({'host-id': host_info['id']})
-    applicable_erratum_ids = [
-        errata['erratum-id'] for errata in applicable_erratum if errata['installable'] == 'true'
+    applicable_errata, _ = wait_for(
+        lambda: Host.errata_list({'host-id': host_info['id']}),
+        handle_exception=True,
+        failure_condition=[],
+        timeout=120,
+        delay=5,
+    )
+    assert [
+        erratum
+        for erratum in applicable_errata
+        if erratum['installable'] == 'true'
+        and erratum['erratum-id'] == settings.repos.yum_6.errata[2]
     ]
-    assert settings.repos.yum_6.errata[2] in applicable_erratum_ids
-    # apply errata
+    # apply the erratum
     result = client.run(f'yum update -y --advisory {settings.repos.yum_6.errata[2]}')
     assert result.status == 0
     applicable_erratum = Host.errata_list({'host-id': host_info['id']})
@@ -1911,15 +1965,16 @@ def test_positive_apply_security_erratum(katello_host_tools_host, setup_custom_r
     client = katello_host_tools_host
     host_info = Host.info({'name': client.hostname})
     client.download_install_rpm(settings.repos.yum_6.url, FAKE_2_CUSTOM_PACKAGE)
-    # Check the system is up to date
-    result = client.run('yum update --security | grep "No packages needed for security"')
-    assert result.status == 0
-    # Downgrade walrus package
     client.run(f'yum downgrade -y {FAKE_2_CUSTOM_PACKAGE_NAME}')
     # Check that host has applicable errata
-    host_errata = Host.errata_list({'host-id': host_info['id']})
-    assert host_errata[0]['erratum-id'] == settings.repos.yum_6.errata[2]
-    assert host_errata[0]['installable'] == 'true'
+    host_erratum, _ = wait_for(
+        lambda: Host.errata_list({'host-id': host_info['id']})[0],
+        handle_exception=True,
+        timeout=120,
+        delay=5,
+    )
+    assert host_erratum['erratum-id'] == settings.repos.yum_6.errata[2]
+    assert host_erratum['installable'] == 'true'
     # Check the erratum becomes available
     result = client.run('yum update --assumeno --security | grep "No packages needed for security"')
     assert result.status == 1
@@ -1927,7 +1982,9 @@ def test_positive_apply_security_erratum(katello_host_tools_host, setup_custom_r
 
 @pytest.mark.katello_host_tools
 @pytest.mark.tier3
-def test_positive_install_package_via_rex(katello_host_tools_host, default_sat, setup_custom_repo):
+def test_positive_install_package_via_rex(
+    module_org, katello_host_tools_host, default_sat, setup_custom_repo
+):
     """Install a package to a host remotely using remote execution,
     install package using Katello SSH job template, host package list is used to verify that
 
@@ -1941,14 +1998,14 @@ def test_positive_install_package_via_rex(katello_host_tools_host, default_sat, 
     """
     client = katello_host_tools_host
     host_info = Host.info({'name': client.hostname})
-    client.configure_rex(satellite=default_sat, org=setup_custom_repo['org'], register=False)
+    client.configure_rex(satellite=default_sat, org=module_org, register=False)
     # Apply errata to the host collection using job invocation
     JobInvocation.create(
         {
             'feature': 'katello_package_install',
             'search-query': f'name ~ {client.hostname}',
             'inputs': f'package={FAKE_1_CUSTOM_PACKAGE}',
-            'organization-id': setup_custom_repo['org'].id,
+            'organization-id': module_org.id,
         }
     )
     result = client.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
@@ -2598,29 +2655,43 @@ def test_positive_dump_enc_yaml(default_sat):
 
 # -------------------------- HOST TRACE SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.tier3
-def test_positive_tracer_list_and_resolve(katello_host_tools_tracer_host, default_sat):
+@pytest.mark.rhel_ver_match('[^6].*')
+def test_positive_tracer_list_and_resolve(tracer_host):
     """Install tracer on client, downgrade the service, check from the satellite
-    that tracer shows and resolves the problem
+    that tracer shows and resolves the problem. The test works with a package specified
+    in settings. This package is expected to install a systemd service which is expected
+    to log its version to /var/log/{package}/service.log.
+    The rpm is not supposed to start the service upon install.
 
     :id: 81c83a2c-4b9d-11ec-a5b3-98fa9b6ecd5a
 
-    :expectedresults: Tracer resolved the problem, the downgraded service was restarted
+    :expectedresults: Tracer detected and resolved the problem, the affected service
+        was restarted
 
     :parametrized: yes
 
     :CaseImportance: Medium
     """
-    client = katello_host_tools_tracer_host
+    client = tracer_host
+    package = settings.repos["MOCK_SERVICE_RPM"]
     host_info = Host.info({'name': client.hostname})
-    package = 'rsyslog'
-    package_version = client.execute(f'rpm -q {package}')
-    assert package_version.status == 0
-    client.execute(f'yum -y downgrade {package}')
+
+    # mark the service log messages for later comparison and downgrade the pkg version
+    service_ver_log_old = tracer_host.execute(f'cat /var/log/{package}/service.log')
+    package_downgrade = tracer_host.execute(f'yum -y downgrade {package}')
+    assert package_downgrade.status == 0
+
+    # tracer should detect a new trace
     traces = HostTraces.list({'host-id': host_info['id']})[0]
     assert package == traces['application']
+
+    # resolve traces and make sure that they disappear
     HostTraces.resolve({'host-id': host_info['id'], 'trace-ids': traces['trace-id']})
     traces = HostTraces.list({'host-id': host_info['id']})
     assert not traces
-    new_package_version = client.execute(f'rpm -q {package}')
-    assert new_package_version.status == 0
-    assert version.parse(package_version.stdout) > version.parse(new_package_version.stdout)
+
+    # verify on the host end, that the service was really restarted
+    service_ver_log_new = tracer_host.execute(f'cat /var/log/{package}/service.log')
+    assert (
+        service_ver_log_new != service_ver_log_old
+    ), f'The service {package} did not seem to be restarted'


### PR DESCRIPTION
I refactored the test for tracer integration.
It is now using `rhel_contenthost` fixture so it is parametrized for all supported rhel versions.

Also, the logic of the test was fixed as the original version wasn't testing the host-side service state properly.

Thanks @ogajduse for writing the custom, mock service for the test.

tracer is supported since rhel7, so we're excluding rhel6 scenario:
```
$ pytest -k tracer_list  tests/foreman/api/test_host.py --collect-only
==== test session starts ====
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, xdist-2.5.0, ibutsu-2.0.2
collected 65 items / 62 deselected / 3 selected                                                                       

<Package api>
  <Module test_host.py>
    <Class TestHostTraces>
        <Function test_positive_tracer_list_and_resolve[rhel8]>
        <Function test_positive_tracer_list_and_resolve[rhel9]>
        <Function test_positive_tracer_list_and_resolve[rhel7]>

==== 3/65 tests collected (62 deselected) in 0.19s ====

```

results (rhel9 scenario failure is expected, since we don't have the rhel9 client repo yet):

```
$ pytest -k tracer_list  tests/foreman/api/test_host.py -n3
==== test session starts ====
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, reportportal-5.0.8, mock-3.6.1, xdist-2.5.0, ibutsu-2.0.2
gw0 [3] / gw1 [3] / gw2 [3]
..E                                                                                                             [100%]
==== ERRORS ====
...
'errors': ["404, message='Not Found', url=URL('https://dogfood...')
...

==== 2 passed, 1 error in 647.86s (0:10:47) ====
```