### PR TITLE
Update capsule_setup to use DF repos for Capsule installation

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -88,8 +88,6 @@ def capsule_host(capsule_factory):
 @pytest.fixture
 def capsule_configured(capsule_host, default_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
-    capsule_host.install_katello_ca(default_sat)
-    capsule_host.register_contenthost()
     capsule_host.capsule_setup(sat_host=default_sat)
     yield capsule_host
 
@@ -111,7 +109,5 @@ def module_destructive_sat(module_satellite_host):
 @pytest.fixture
 def destructive_caps(capsule_host, destructive_sat):
     """Configure the capsule instance with the destructive satellite"""
-    capsule_host.install_katello_ca(destructive_sat)
-    capsule_host.register_contenthost()
     capsule_host.capsule_setup(sat_host=destructive_sat)
     yield capsule_host


### PR DESCRIPTION
Commited changes:
1) moved `register_to_dogfood` into Capsule class
2) updated `register_to_dogfood` to take `ak_type` param, added
   `rhel_release` to registration AK (for testing on other rhels)
3) updated `is_upstream` and `version` to work properly on CAPS and SAT
4) addded workaround for rhel8

Tested that it works for 6.10, 7.0 @ rhel7, 7.0 @ rhel8
