### PR TITLE
Refactor puppet_enabled_sat fixture

### DIFF
--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -31,29 +31,29 @@ enable_capsule_cmd = InstallerCommand(
 )
 
 
-@pytest.fixture(scope='module')
-def module_puppet_enabled_sat(module_destructive_sat):
+@pytest.fixture(scope='session')
+def session_puppet_enabled_sat(session_satellite_host):
     """Satellite with enabled puppet plugin"""
-    module_destructive_sat.register_to_dogfood()
-    result = module_destructive_sat.execute(enable_satellite_cmd.get_command(), timeout=900000)
+    session_satellite_host.register_to_dogfood()
+    result = session_satellite_host.execute(enable_satellite_cmd.get_command(), timeout='20m')
     assert result.status == 0
-    module_destructive_sat.execute('hammer -r')  # workaround for BZ#2039696
-    yield module_destructive_sat
+    session_satellite_host.execute('hammer -r')  # workaround for BZ#2039696
+    yield session_satellite_host
 
 
 @pytest.fixture(scope='module')
-def module_puppet_org(module_puppet_enabled_sat):
-    yield module_puppet_enabled_sat.api.Organization().create()
+def module_puppet_org(session_puppet_enabled_sat):
+    yield session_puppet_enabled_sat.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
-def module_puppet_loc(module_puppet_enabled_sat):
-    yield module_puppet_enabled_sat.api.Location().create()
+def module_puppet_loc(session_puppet_enabled_sat):
+    yield session_puppet_enabled_sat.api.Location().create()
 
 
 @pytest.fixture(scope='session')
-def default_puppet_environment(module_puppet_org, module_puppet_enabled_sat):
-    environments = module_puppet_enabled_sat.api.Environment().search(
+def default_puppet_environment(module_puppet_org, session_puppet_enabled_sat):
+    environments = session_puppet_enabled_sat.api.Environment().search(
         query=dict(search=f'organization_id={module_puppet_org.id}')
     )
     if environments:
@@ -61,35 +61,35 @@ def default_puppet_environment(module_puppet_org, module_puppet_enabled_sat):
 
 
 @pytest.fixture(scope='module')
-def module_puppet_environment(module_puppet_org, module_puppet_loc, module_puppet_enabled_sat):
-    environment = module_puppet_enabled_sat.api.Environment(
+def module_puppet_environment(module_puppet_org, module_puppet_loc, session_puppet_enabled_sat):
+    environment = session_puppet_enabled_sat.api.Environment(
         organization=[module_puppet_org], location=[module_puppet_loc]
     ).create()
-    return module_puppet_enabled_sat.api.Environment(id=environment.id).read()
+    return session_puppet_enabled_sat.api.Environment(id=environment.id).read()
 
 
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 @pytest.fixture(scope='module')
-def module_import_puppet_module(module_puppet_enabled_sat):
+def module_import_puppet_module(session_puppet_enabled_sat):
     """Returns custom puppet environment name that contains imported puppet module
     and puppet class name."""
     puppet_class = 'generic_1'
     return {
         'puppet_class': puppet_class,
-        'env': module_puppet_enabled_sat.create_custom_environment(repo=puppet_class),
+        'env': session_puppet_enabled_sat.create_custom_environment(repo=puppet_class),
     }
 
 
 @pytest.fixture(scope='module')
 def module_env_search(
-    module_puppet_org, module_puppet_loc, module_import_puppet_module, module_puppet_enabled_sat
+    module_puppet_org, module_puppet_loc, module_import_puppet_module, session_puppet_enabled_sat
 ):
     """Search for puppet environment created from module_import_puppet_module fixture.
 
     Returns the puppet environment with updated organization and location.
     """
     env = (
-        module_puppet_enabled_sat.api.Environment()
+        session_puppet_enabled_sat.api.Environment()
         .search(query={'search': f'name={module_import_puppet_module["env"]}'})[0]
         .read()
     )
@@ -101,12 +101,12 @@ def module_env_search(
 
 @pytest.fixture(scope='module')
 def module_puppet_classes(
-    module_env_search, module_import_puppet_module, module_puppet_enabled_sat
+    module_env_search, module_import_puppet_module, session_puppet_enabled_sat
 ):
     """Returns puppet class based on following criteria:
     Puppet environment from module_env_search and puppet class name.
     """
-    return module_puppet_enabled_sat.api.PuppetClass().search(
+    return session_puppet_enabled_sat.api.PuppetClass().search(
         query={
             'search': f'name ~ {module_import_puppet_module["puppet_class"]} '
             f'and environment = {module_env_search.name}'
@@ -114,10 +114,10 @@ def module_puppet_classes(
     )
 
 
-@pytest.fixture(scope='module', params=[True, False], ids=["puppet_enabled", "puppet_disabled"])
-def parametrized_puppet_sat(request, default_sat, module_puppet_enabled_sat):
+@pytest.fixture(scope='session', params=[True, False], ids=["puppet_enabled", "puppet_disabled"])
+def parametrized_puppet_sat(request, default_sat, session_puppet_enabled_sat):
     if request.param:
-        sat = module_puppet_enabled_sat
+        sat = session_puppet_enabled_sat
     else:
         sat = default_sat
     return {'sat': sat, 'enabled': request.param}

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -77,6 +77,14 @@ def module_satellite_host(satellite_factory):
     VMBroker(hosts=[new_sat]).checkin()
 
 
+@pytest.fixture(scope='session')
+def session_satellite_host(satellite_factory):
+    """A fixture that provides a Satellite based on config settings"""
+    new_sat = satellite_factory()
+    yield new_sat
+    VMBroker(hosts=[new_sat]).checkin()
+
+
 @pytest.fixture
 def capsule_host(capsule_factory):
     """A fixture that provides a Capsule based on config settings"""

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -22,7 +22,6 @@ http://theforeman.org/api/apidoc/v2/environments.html
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.api.utils import one_to_many_names
@@ -34,7 +33,7 @@ from robottelo.datafactory import valid_environments_list
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_environments_list()))
-def test_positive_create_with_name(name, module_puppet_enabled_sat):
+def test_positive_create_with_name(name, session_puppet_enabled_sat):
     """Create an environment and provide a valid name.
 
     :id: 8869ccf8-a511-4fa7-ac36-11494e85f532
@@ -46,13 +45,13 @@ def test_positive_create_with_name(name, module_puppet_enabled_sat):
 
     :CaseImportance: Critical
     """
-    env = module_puppet_enabled_sat.api.Environment(name=name).create()
+    env = session_puppet_enabled_sat.api.Environment(name=name).create()
     assert env.name == name
 
 
 @pytest.mark.tier1
 def test_positive_create_with_org_and_loc(
-    module_puppet_org, module_puppet_loc, module_puppet_enabled_sat
+    module_puppet_org, module_puppet_loc, session_puppet_enabled_sat
 ):
     """Create an environment and assign it to new organization.
 
@@ -63,7 +62,7 @@ def test_positive_create_with_org_and_loc(
 
     :CaseImportance: Critical
     """
-    env = module_puppet_enabled_sat.api.Environment(
+    env = session_puppet_enabled_sat.api.Environment(
         name=gen_string('alphanumeric'),
         organization=[module_puppet_org],
         location=[module_puppet_loc],
@@ -76,7 +75,7 @@ def test_positive_create_with_org_and_loc(
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
-def test_negative_create_with_too_long_name(name, module_puppet_enabled_sat):
+def test_negative_create_with_too_long_name(name, session_puppet_enabled_sat):
     """Create an environment and provide an invalid name.
 
     :id: e2654954-b3a1-4594-a487-bcd0cc8195ad
@@ -87,12 +86,12 @@ def test_negative_create_with_too_long_name(name, module_puppet_enabled_sat):
 
     """
     with pytest.raises(HTTPError):
-        module_puppet_enabled_sat.api.Environment(name=name).create()
+        session_puppet_enabled_sat.api.Environment(name=name).create()
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_environments_list()))
-def test_negative_create_with_invalid_characters(name, module_puppet_enabled_sat):
+def test_negative_create_with_invalid_characters(name, session_puppet_enabled_sat):
     """Create an environment and provide an illegal name.
 
     :id: 8ec57d04-4ce6-48b4-b7f9-79025019ad0f
@@ -103,12 +102,12 @@ def test_negative_create_with_invalid_characters(name, module_puppet_enabled_sat
 
     """
     with pytest.raises(HTTPError):
-        module_puppet_enabled_sat.api.Environment(name=name).create()
+        session_puppet_enabled_sat.api.Environment(name=name).create()
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(valid_environments_list()))
-def test_positive_update_name(module_puppet_environment, new_name, module_puppet_enabled_sat):
+def test_positive_update_name(module_puppet_environment, new_name, session_puppet_enabled_sat):
     """Create environment entity providing the initial name, then
     update its name to another valid name.
 
@@ -119,7 +118,7 @@ def test_positive_update_name(module_puppet_environment, new_name, module_puppet
     :expectedresults: Environment entity is created and updated properly
 
     """
-    env = module_puppet_enabled_sat.api.Environment(
+    env = session_puppet_enabled_sat.api.Environment(
         id=module_puppet_environment.id, name=new_name
     ).update(['name'])
     assert env.name == new_name
@@ -127,7 +126,7 @@ def test_positive_update_name(module_puppet_environment, new_name, module_puppet
 
 @pytest.mark.tier2
 def test_positive_update_and_remove(
-    module_puppet_org, module_puppet_loc, module_puppet_enabled_sat
+    module_puppet_org, module_puppet_loc, session_puppet_enabled_sat
 ):
     """Update environment and assign it to a new organization
     and location. Delete environment afterwards.
@@ -141,14 +140,18 @@ def test_positive_update_and_remove(
 
     :CaseLevel: Integration
     """
-    env = module_puppet_enabled_sat.api.Environment().create()
+    env = session_puppet_enabled_sat.api.Environment().create()
     assert len(env.organization) == 0
     assert len(env.location) == 0
-    env = entities.Environment(id=env.id, organization=[module_puppet_org]).update(['organization'])
+    env = session_puppet_enabled_sat.api.Environment(
+        id=env.id, organization=[module_puppet_org]
+    ).update(['organization'])
     assert len(env.organization) == 1
     assert env.organization[0].id, module_puppet_org.id
 
-    env = entities.Environment(id=env.id, location=[module_puppet_loc]).update(['location'])
+    env = session_puppet_enabled_sat.api.Environment(
+        id=env.id, location=[module_puppet_loc]
+    ).update(['location'])
     assert len(env.location) == 1
     assert env.location[0].id == module_puppet_loc.id
 
@@ -159,7 +162,7 @@ def test_positive_update_and_remove(
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(invalid_names_list()))
-def test_negative_update_name(module_puppet_environment, new_name, module_puppet_enabled_sat):
+def test_negative_update_name(module_puppet_environment, new_name, session_puppet_enabled_sat):
     """Create environment entity providing the initial name, then
     try to update its name to invalid one.
 
@@ -171,7 +174,7 @@ def test_negative_update_name(module_puppet_environment, new_name, module_puppet
 
     """
     with pytest.raises(HTTPError):
-        module_puppet_enabled_sat.api.Environment(
+        session_puppet_enabled_sat.api.Environment(
             id=module_puppet_environment.id, name=new_name
         ).update(['name'])
 

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -30,16 +30,16 @@ from robottelo.datafactory import parametrized
 
 
 @pytest.fixture(scope='module')
-def module_locations(module_puppet_enabled_sat):
+def module_locations(session_puppet_enabled_sat):
     return (
-        module_puppet_enabled_sat.api.Location().create(),
-        module_puppet_enabled_sat.api.Location().create(),
+        session_puppet_enabled_sat.api.Location().create(),
+        session_puppet_enabled_sat.api.Location().create(),
     )
 
 
 @pytest.mark.tier2
 def test_negative_list_with_parameters(
-    module_puppet_org, module_locations, module_puppet_enabled_sat
+    module_puppet_org, module_locations, session_puppet_enabled_sat
 ):
     """Test Environment List filtering parameters validation.
 
@@ -52,7 +52,7 @@ def test_negative_list_with_parameters(
 
     :BZ: 1337947
     """
-    module_puppet_enabled_sat.cli.Environment.create(
+    session_puppet_enabled_sat.cli.Environment.create(
         {
             'organization-ids': module_puppet_org.id,
             'location-ids': module_locations[0].id,
@@ -62,16 +62,16 @@ def test_negative_list_with_parameters(
 
     # Filter by non-existing location and existing organization
     with pytest.raises(CLIReturnCodeError):
-        module_puppet_enabled_sat.cli.Environment.list(
+        session_puppet_enabled_sat.cli.Environment.list(
             {'organization-id': module_puppet_org.id, 'location-id': gen_string('numeric')}
         )
     # Filter by non-existing organization and existing location
     with pytest.raises(CLIReturnCodeError):
-        module_puppet_enabled_sat.cli.Environment.list(
+        session_puppet_enabled_sat.cli.Environment.list(
             {'organization-id': gen_string('numeric'), 'location-id': module_locations[0].id}
         )
     # Filter by another location
-    results = module_puppet_enabled_sat.cli.Environment.list(
+    results = session_puppet_enabled_sat.cli.Environment.list(
         {'organization': module_puppet_org.name, 'location': module_locations[1].name}
     )
     assert len(results) == 0
@@ -79,7 +79,7 @@ def test_negative_list_with_parameters(
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-def test_negative_create_with_name(name, module_puppet_enabled_sat):
+def test_negative_create_with_name(name, session_puppet_enabled_sat):
     """Don't create an Environment with invalid data.
 
     :id: 8a4141b0-3bb9-47e5-baca-f9f027086d4c
@@ -91,13 +91,13 @@ def test_negative_create_with_name(name, module_puppet_enabled_sat):
     :CaseImportance: Critical
     """
     with pytest.raises(CLIReturnCodeError):
-        module_puppet_enabled_sat.cli.Environment.create({'name': name})
+        session_puppet_enabled_sat.cli.Environment.create({'name': name})
 
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_CRUD_with_attributes(
-    module_puppet_enabled_sat, module_puppet_org, module_locations
+    session_puppet_enabled_sat, module_puppet_org, module_locations
 ):
     """Check if Environment with attributes can be created, updated and removed
 
@@ -115,7 +115,7 @@ def test_positive_CRUD_with_attributes(
     """
     # Create with attributes
     env_name = gen_string('alpha')
-    environment = module_puppet_enabled_sat.cli.Environment.create(
+    environment = session_puppet_enabled_sat.cli.Environment.create(
         {
             'location-ids': module_locations[0].id,
             'organization-ids': module_puppet_org.id,
@@ -127,51 +127,51 @@ def test_positive_CRUD_with_attributes(
     assert env_name == environment['name']
 
     # List by name
-    result = module_puppet_enabled_sat.cli.Environment.list({'search': f'name={env_name}'})
+    result = session_puppet_enabled_sat.cli.Environment.list({'search': f'name={env_name}'})
     assert len(result) == 1
     assert result[0]['name'] == env_name
     # List by org loc id
-    results = module_puppet_enabled_sat.cli.Environment.list(
+    results = session_puppet_enabled_sat.cli.Environment.list(
         {'organization-id': module_puppet_org.id, 'location-id': module_locations[0].id}
     )
     assert env_name in [res['name'] for res in results]
     # List by org loc name
-    results = module_puppet_enabled_sat.cli.Environment.list(
+    results = session_puppet_enabled_sat.cli.Environment.list(
         {'organization': module_puppet_org.name, 'location': module_locations[0].name}
     )
     assert env_name in [res['name'] for res in results]
 
     # Update org and loc
-    new_org = module_puppet_enabled_sat.api.Organization().create()
-    module_puppet_enabled_sat.cli.Environment.update(
+    new_org = session_puppet_enabled_sat.api.Organization().create()
+    session_puppet_enabled_sat.cli.Environment.update(
         {
             'location-ids': module_locations[1].id,
             'organization-ids': new_org.id,
             'name': environment['name'],
         }
     )
-    env_info = module_puppet_enabled_sat.cli.Environment.info({'name': environment['name']})
+    env_info = session_puppet_enabled_sat.cli.Environment.info({'name': environment['name']})
     assert module_locations[1].name in env_info['locations']
     assert module_locations[0].name not in env_info['locations']
     assert new_org.name in env_info['organizations']
     assert module_puppet_org.name not in env_info['organizations']
     # Update name
     new_env_name = gen_string('alpha')
-    module_puppet_enabled_sat.cli.Environment.update(
+    session_puppet_enabled_sat.cli.Environment.update(
         {'id': environment['id'], 'new-name': new_env_name}
     )
-    env_info = module_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
+    env_info = session_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
     assert env_info['name'] == new_env_name
 
     # Delete
-    module_puppet_enabled_sat.cli.Environment.delete({'id': environment['id']})
+    session_puppet_enabled_sat.cli.Environment.delete({'id': environment['id']})
     with pytest.raises(CLIReturnCodeError):
-        module_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
+        session_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('entity_id', **parametrized(invalid_id_list()))
-def test_negative_delete_by_id(entity_id, module_puppet_enabled_sat):
+def test_negative_delete_by_id(entity_id, session_puppet_enabled_sat):
     """Create Environment then delete it by wrong ID
 
     :id: fe77920c-62fd-4e0e-b960-a940a1370d10
@@ -183,12 +183,12 @@ def test_negative_delete_by_id(entity_id, module_puppet_enabled_sat):
     :CaseImportance: Medium
     """
     with pytest.raises(CLIReturnCodeError):
-        module_puppet_enabled_sat.cli.Environment.delete({'id': entity_id})
+        session_puppet_enabled_sat.cli.Environment.delete({'id': entity_id})
 
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-def test_negative_update_name(new_name, module_puppet_enabled_sat):
+def test_negative_update_name(new_name, session_puppet_enabled_sat):
     """Update the Environment with invalid values
 
     :id: adc5ad73-0547-40f9-b4d4-649780cfb87a
@@ -198,12 +198,12 @@ def test_negative_update_name(new_name, module_puppet_enabled_sat):
     :expectedresults: Environment is not updated
 
     """
-    environment = module_puppet_enabled_sat.cli.Environment.create({'name': gen_string('alpha')})
+    environment = session_puppet_enabled_sat.cli.Environment.create({'name': gen_string('alpha')})
     with pytest.raises(CLIReturnCodeError):
-        module_puppet_enabled_sat.cli.Environment.update(
+        session_puppet_enabled_sat.cli.Environment.update(
             {'id': environment['id'], 'new-name': new_name}
         )
-    result = module_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
+    result = session_puppet_enabled_sat.cli.Environment.info({'id': environment['id']})
     assert environment['name'] == result['name']
 
 
@@ -212,7 +212,7 @@ def test_negative_update_name(new_name, module_puppet_enabled_sat):
     not settings.robottelo.repos_hosting_url,
     reason='Missing repos_hosting_url',
 )
-def test_positive_sc_params(module_import_puppet_module, module_puppet_enabled_sat):
+def test_positive_sc_params(module_import_puppet_module, session_puppet_enabled_sat):
     """Check if environment sc-param subcommand works passing
     an environment id
 
@@ -222,16 +222,16 @@ def test_positive_sc_params(module_import_puppet_module, module_puppet_enabled_s
 
     """
     # Override one of the sc-params from puppet class
-    sc_params_list = module_puppet_enabled_sat.cli.SmartClassParameter.list(
+    sc_params_list = session_puppet_enabled_sat.cli.SmartClassParameter.list(
         {
             'puppet-environment': module_import_puppet_module['env'],
             'search': f'puppetclass="{module_import_puppet_module["puppet_class"]}"',
         }
     )
     scp_id = choice(sc_params_list)['id']
-    module_puppet_enabled_sat.cli.SmartClassParameter.update({'id': scp_id, 'override': 1})
+    session_puppet_enabled_sat.cli.SmartClassParameter.update({'id': scp_id, 'override': 1})
     # Verify that affected sc-param is listed
-    env_scparams = module_puppet_enabled_sat.cli.Environment.sc_params(
+    env_scparams = session_puppet_enabled_sat.cli.Environment.sc_params(
         {'puppet-environment': module_import_puppet_module['env']}
     )
     assert scp_id in [scp['id'] for scp in env_scparams]

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -25,7 +25,7 @@ from robottelo.config import settings
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason="Missing repos_hosting_url")
 def test_positive_list_smart_class_parameters(
-    module_import_puppet_module, module_puppet_enabled_sat
+    module_import_puppet_module, session_puppet_enabled_sat
 ):
     """List smart class parameters associated with the puppet class.
 
@@ -33,7 +33,7 @@ def test_positive_list_smart_class_parameters(
 
     :expectedresults: Smart class parameters listed for the class.
     """
-    class_sc_parameters = module_puppet_enabled_sat.cli.Puppet.sc_params(
+    class_sc_parameters = session_puppet_enabled_sat.cli.Puppet.sc_params(
         {'puppet-class': module_import_puppet_module['puppet_class']}
     )
     assert len(class_sc_parameters) == 200


### PR DESCRIPTION
Changes:
1) Replaced destructive_sat with satellite_factory host in the puppet_enabled_sat fixture.
2) Rescoped the puppet_enabled_sat to the session level.

Test resuls:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_environment.py tests/foreman/cli/test_environment.py tests/foreman/cli/test_puppetclass.py tests/foreman/cli/test_classparameters.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, ibutsu-2.0.2, xdist-2.5.0, reportportal-5.0.11, mock-3.6.1
collected 68 items                                                                                                                                                                                                                        

tests/foreman/api/test_environment.py ..............................                                                                                                                                                                [ 44%]
tests/foreman/cli/test_environment.py ...........................                                                                                                                                                                   [ 83%]
tests/foreman/cli/test_puppetclass.py .                                                                                                                                                                                             [ 85%]
tests/foreman/cli/test_classparameters.py ..........                                                                                                                                                                                [100%]

============================================================================================== 68 passed, 83 warnings in 3336.56s (0:55:36) ===============================================================================================
```

TODO:
test with @tstrych's PR #9328