### PR TITLE
Add simple script to display all validation errors

### DIFF
--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -1,0 +1,24 @@
+"""Usage: python scripts/validate_config.py"""
+from dynaconf.validator import ValidationError
+
+from robottelo.config import settings
+
+
+def binary_validation(validators):
+    settings.validators.clear()
+    settings.validators.extend(validators)
+    try:
+        settings.validators.validate()
+    except ValidationError as err:
+        if len(validators) == 1:
+            print(err)
+        else:
+            left, right = (
+                validators[: len(validators) // 2],
+                validators[len(validators) // 2 :],  # noqa: E203
+            )
+            binary_validation(left)
+            binary_validation(right)
+
+
+binary_validation(settings.validators[:])


### PR DESCRIPTION
Since dynaconf will only present the first validation error, chasing
down config issues can be difficult. With this script, you can see all
your validation errors.

example of a ton of config errors
```
$ python scripts/validate_config.py                                                                                 ST 1   helpers 
2022-02-22 09:12:12 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    certs.cert_file is required in env main
2022-02-22 09:12:12 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    certs.cert_file is required in env main
certs.cert_file is required in env main
container_repo.registry_url is required in env main
ec2.access_key is required in env main
git.ssh_port is required in env main
http_proxy.password is required in env main
ipa.basedn_ipa is required in env main
ldap.password is required in env main
open_ldap.password is required in env main
osp.image_os is required in env main
repos.rhel6_os cannot exists in env main
rhev.password is required in env main
rhsso.user_password is required in env main
vlan_networking.subnet is required in env main
combined validators failed vlan_networking.bridge is required in env main or vlan_networking.network is required in env main
vmware.username is required in env main
```