### PR TITLE
Moving wt.exceptions imports to airgun

### DIFF
--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -20,10 +20,10 @@ import random
 
 import pytest
 from airgun.exceptions import DisabledWidgetError
+from airgun.exceptions import NoSuchElementException
 from airgun.session import Session
 from fauxfactory import gen_string
 from nailgun import entities
-from widgetastic.exceptions import NoSuchElementException
 
 from robottelo.constants import BOOKMARK_ENTITIES
 from robottelo.helpers import get_nailgun_config

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -24,11 +24,11 @@ from random import randint
 
 import pytest
 from airgun.exceptions import InvalidElementStateException
+from airgun.exceptions import NoSuchElementException
 from airgun.session import Session
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
 from productmd.common import parse_nvra
-from widgetastic.exceptions import NoSuchElementException
 
 from robottelo import constants
 from robottelo import manifests

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -25,11 +25,11 @@ import re
 import pytest
 import yaml
 from airgun.exceptions import DisabledWidgetError
+from airgun.exceptions import NoSuchElementException
 from airgun.session import Session
 from broker.broker import VMBroker
 from nailgun import entities
 from wait_for import wait_for
-from widgetastic.exceptions import NoSuchElementException
 
 from robottelo import constants
 from robottelo import manifests


### PR DESCRIPTION
This goes with airgun PR: https://github.com/SatelliteQE/airgun/pull/672

We don't have widgetastic as a direct dependency, the import should be coming from airgun.

## Checks

Checks will fail until 672 is merged and the import is available. 

I've tested the import locally with the correct version installed. Robottelo-runner check should also have correct version of airgun installed and will not hit any import errors.