### PR TITLE
Skip katello-agent tests from automation

### DIFF
--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -28,6 +28,7 @@ from robottelo.helpers import InstallerCommand
 pytestmark = [
     pytest.mark.run_in_one_thread,
     pytest.mark.skip_if_not_set('clients', 'fake_manifest'),
+    pytest.mark.destructive,
 ]
 
 


### PR DESCRIPTION
Katello-agent tests fail due to https://github.com/SatelliteQE/robottelo/pull/9320 , not sure what is a plan to fix this for destructive tests.
Meanwhile, marking this tests destructive to skip this from importance pipelines, which will save 1 destructive_sat checkout

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>