### PR TITLE
new simple  ui test host introduced

### DIFF
--- a/robottelo/ui/utils.py
+++ b/robottelo/ui/utils.py
@@ -22,7 +22,6 @@ def create_fake_host(
         'host.location': host.location.name,
         'host.lce': ENVIRONMENT,
         'host.content_view': DEFAULT_CV,
-        'host.puppet_environment': host.environment.name,
         'operating_system.architecture': host.architecture.name,
         'operating_system.operating_system': os_name,
         'operating_system.media_type': 'All Media',

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2343,3 +2343,26 @@ def test_positive_cockpit(session, default_sat):
         ), 'cockpit page shows hostname {} instead of {}'.format(
             hostname_inside_cockpit, default_sat.hostname
         )
+
+
+@pytest.mark.tier4
+def test_positive_read_details_page_from_new_ui(session, module_host_template):
+    """Create new Host and read all its content through details page
+
+    :id: ef0c5942-9049-11ec-8029-98fa9b6ecd5a
+
+    :expectedresults: Host is created and has expected content
+
+    :CaseLevel: System
+    """
+    interface_id = gen_string('alpha')
+    with session:
+        host_name = create_fake_host(session, module_host_template, interface_id)
+        assert session.host_new.search(host_name)[0]['Name'] == host_name
+        values = session.host_new.get_details(host_name)
+        assert values['Overview']['HostStatusCard']['status'] == 'All Statuses are OK'
+        assert (
+            values['Overview']['DetailsCard']['details']['mac_address'] == module_host_template.mac
+        )
+        assert values['Overview']['DetailsCard']['details']['host_owner'] == values['current_user']
+        assert values['Overview']['DetailsCard']['details']['comment'] == 'Host with fake data'


### PR DESCRIPTION
============================= test session starts ==============================
collected 37 items / 36 deselected / 1 selected

tests/foreman/ui/test_host.py::test_positive_read_details_page_from_new_ui
================= 1 passed, 36 deselected in 152.00s (0:02:32) =================