### PR TITLE
[6.10.z] Fix import order in ui/test_reporttemplates.py

### DIFF
--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -19,8 +19,8 @@
 import csv
 import json
 import os
-from pathlib import PurePath
 from pathlib import Path
+from pathlib import PurePath
 
 import pytest
 import yaml


### PR DESCRIPTION
GHA merge checks fail for 6.10.z, and blocks image builds in the Quay repository
https://github.com/SatelliteQE/robottelo/actions/runs/1922606568

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>