### PR TITLE
unskip effective user rex test

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -141,7 +141,6 @@ class TestRemoteExecution:
         search = Task.list_tasks({'search': f'id={task["id"]}'})
         assert search[0]['action'] == task['action']
 
-    @pytest.mark.skip_if_open('BZ:1804685')
     @pytest.mark.tier3
     @pytest.mark.pit_client
     @pytest.mark.pit_server
@@ -151,7 +150,7 @@ class TestRemoteExecution:
 
         :id: 0cd75cab-f699-47e6-94d3-4477d2a94bb7
 
-        :BZ: 1451675
+        :BZ: 1451675, 1804685
 
         :expectedresults: Verify the job was successfully run under the
             effective user identity on host


### PR DESCRIPTION
The bz was closed wontfix, but the failure no longer occurs (--foreman-proxy-plugin-remote-execution-ssh-async-ssh is set to false by default), checked for rhel7:

```
pytest tests/foreman/cli/test_remoteexecution.py -k test_positive_run_job_effective_user_by_ip

==================================================== test session starts =====================================================
                                                                   

tests/foreman/cli/test_remoteexecution.py .                                                                            [100%]
```
