### PR TITLE
Sort generated ids for marker-based content host parametrization

### DIFF
--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -36,6 +36,7 @@ def pytest_generate_tests(metafunc):
         for ver in filtered_versions or settings.supportability.content_hosts.rhel.versions:
             rhel_params.append(dict(rhel_version=ver))
         if rhel_params:
+            rhel_params.sort(key=lambda r: str(r['rhel_version']))
             metafunc.parametrize(
                 'rhel_contenthost',
                 rhel_params,


### PR DESCRIPTION
This should help us resolve issues we're having with xdist collection. In the below examples, you can see that rhel8 and rhel7 swap places in test ordering. After the change, 7 comes before 8

before
![Screenshot from 2022-03-03 11-11-19](https://user-images.githubusercontent.com/6618303/156605442-282f726c-212d-4e32-b946-ea960b6c9b7f.png)

after
![Screenshot from 2022-03-03 11-11-07](https://user-images.githubusercontent.com/6618303/156605465-6c2e5f4e-59bd-4553-b981-5c8b2350b62a.png)

