### PR TITLE
Add test for puppet bootstraping

### DIFF
--- a/tests/foreman/api/test_puppetbootstrap.py
+++ b/tests/foreman/api/test_puppetbootstrap.py
@@ -1,0 +1,96 @@
+"""Test class for puppet plugin CLI
+
+:Requirement: Puppet
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Puppet
+
+:Assignee: vsedmik
+
+:TestType: Functional
+
+:CaseImportance: Medium
+
+:Upstream: No
+"""
+import requests
+from fauxfactory import gen_string
+
+
+def test_positive_puppet_bootstrap(
+    session_puppet_enabled_sat,
+    session_puppet_enabled_proxy,
+    session_puppet_default_os,
+    module_puppet_org,
+    module_puppet_environment,
+):
+    """Test that provisioning template renders snippet for puppet bootstrapping.
+
+    :id: 71140e1a-6e4d-4110-bb2d-8d381f183d64
+
+    :setup:
+        1. Requires Satellite with http and templates feature enabled.
+
+    :steps:
+        1. Create a host providing puppet env, proxy and params.
+        2. Get rendered provisioning template using host's token.
+        3. Check the render contains puppet snippet in it.
+
+    :expectedresults:
+        1. Puppet snippet rendered in the provisioning template.
+
+    """
+    host_params = [
+        {
+            'name': 'enable-puppet7',
+            'value': 'True',
+            'parameter-type': 'boolean',
+        }
+    ]
+
+    host = session_puppet_enabled_sat.api.Host(
+        build=True,
+        environment=module_puppet_environment,
+        host_parameters_attributes=host_params,
+        organization=module_puppet_org,
+        operatingsystem=session_puppet_default_os,
+        puppet_proxy=session_puppet_enabled_proxy,
+        puppet_ca_proxy=session_puppet_enabled_proxy,
+        root_pass=gen_string('alphanumeric'),
+    ).create()
+
+    render = requests.get(
+        (
+            f'http://{session_puppet_enabled_sat.hostname}:8000/'
+            f'unattended/provision?token={host.token}'
+        ),
+    ).text
+
+    puppet_config = (
+        "if [ -f /usr/bin/dnf ]; then\n"
+        "  dnf -y install puppet-agent\n"
+        "else\n"
+        "  yum -t -y install puppet-agent\n"
+        "fi\n"
+        "\n"
+        "cat > /etc/puppetlabs/puppet/puppet.conf << EOF\n"
+        "[main]\n"
+        "\n"
+        "[agent]\n"
+        "pluginsync      = true\n"
+        "report          = true\n"
+        f"ca_server       = {session_puppet_enabled_proxy.name}\n"
+        f"certname        = {host.name}\n"
+        f"server          = {session_puppet_enabled_proxy.name}\n"
+        f"environment     = {module_puppet_environment.name}\n"
+    )
+    puppet_run = (
+        'puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime '
+        f'--tags no_such_tag --server {session_puppet_enabled_proxy.name}'
+    )
+
+    assert puppet_config in render
+    assert puppet_run in render


### PR DESCRIPTION
Adding test to verify that the rendered provisioning template contains the snippet for puppet bootstrapping.

Test result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_puppetbootstrap.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, ibutsu-2.0.2, xdist-2.5.0, reportportal-5.0.11, mock-3.6.1
collected 1 item                                                                                                                                                                                                                          

tests/foreman/api/test_puppetbootstrap.py .                                                                                                                                                                                         [100%]

===================================================================================================== 1 passed in 3109.77s (0:51:49) ======================================================================================================
```