### PR TITLE
Fixing test case with mirroring policy

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -138,14 +138,14 @@ class TestSatelliteContentManagement:
         assert rh_repo.content_counts['rpm'] > 0
 
     @pytest.mark.tier2
-    def test_positive_mirror_on_sync(self, default_sat):
-        """Assert that the content of a repository with 'Mirror on Sync' enabled
+    def test_positive_mirroring_policy(self, default_sat):
+        """Assert that the content of a repository with 'Mirroring Policy' enabled
         is restored properly after resync.
 
         :id: cbf1c781-cb96-4b4a-bae2-15c9f5be5e50
 
         :steps:
-            1. Create and sync a repo with 'Mirror on Sync' enabled.
+            1. Create and sync a repo with 'Mirroring Policy - mirror complete enabled.
             2. Remove all packages from the repo and upload another one.
             3. Resync the repo again.
             4. Check the content was restored properly.
@@ -161,7 +161,10 @@ class TestSatelliteContentManagement:
         org = entities.Organization().create()
         prod = entities.Product(organization=org).create()
         repo = entities.Repository(
-            download_policy='immediate', mirror_on_sync=True, product=prod, url=repo_url
+            download_policy='immediate',
+            mirroring_policy='mirror_complete',
+            product=prod,
+            url=repo_url,
         ).create()
         repo.sync()
         repo = repo.read()
@@ -336,7 +339,7 @@ class TestCapsuleContentManagement:
         repo = entities.Repository(
             product=product,
             checksum_type='sha256',
-            mirror_on_sync=False,
+            mirroring_policy='additive',
             download_policy='immediate',
         ).create()
         lce = entities.LifecycleEnvironment(organization=org).create()
@@ -816,7 +819,10 @@ class TestCapsuleContentManagement:
         org = entities.Organization().create()
         prod = entities.Product(organization=org).create()
         repo = entities.Repository(
-            download_policy='on_demand', mirror_on_sync=True, product=prod, url=repo_url
+            download_policy='on_demand',
+            mirroring_policy='mirror_complete',
+            product=prod,
+            url=repo_url,
         ).create()
         lce = entities.LifecycleEnvironment(organization=org).create()
         # Associate the lifecycle environment with the capsule
@@ -906,7 +912,10 @@ class TestCapsuleContentManagement:
         org = entities.Organization().create()
         prod = entities.Product(organization=org).create()
         repo = entities.Repository(
-            download_policy='on_demand', mirror_on_sync=True, product=prod, url=repo_url
+            download_policy='on_demand',
+            mirror_on_sync='mirror_complete',
+            product=prod,
+            url=repo_url,
         ).create()
         lce = entities.LifecycleEnvironment(organization=org).create()
         # Update capsule's download policy to on_demand to match repository's


### PR DESCRIPTION
Some failed test cases in contentmanagement that needs to be updated due to mirroring policy change.  This is for 6.10.z