### PR TITLE
Adding test for FAM import/sync and run on Satellite

### DIFF
--- a/robottelo/cli/ansible.py
+++ b/robottelo/cli/ansible.py
@@ -18,8 +18,20 @@ class Ansible(Base):
 
     @classmethod
     def roles_import(cls, options=None):
-        """Import ansible roles"""
+        """DEPRECATED - Import ansible roles"""
         cls.command_sub = 'roles import'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def roles_sync(cls, options=None):
+        """Sync Ansible roles"""
+        cls.command_sub = 'roles sync'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def roles_delete(cls, options=None):
+        """Delete Ansible roles"""
+        cls.command_sub = 'roles delete'
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -54,6 +54,12 @@ class Host(Base):
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
+    def ansible_roles_assign(cls, options):
+        """Assigns the associated ansible-roles"""
+        cls.command_sub = 'ansible-roles assign'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
     def disassociate(cls, options):
         """Disassociate the host from a CR."""
         cls.command_sub = 'disassociate'

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2127,3 +2127,24 @@ FOREMAN_ANSIBLE_MODULES = [
 FAM_MODULE_PATH = (
     '/usr/share/ansible/collections/ansible_collections/redhat/satellite/plugins/modules'
 )
+
+RH_SAT_ROLES = [
+    'compute_profiles',
+    'compute_resources',
+    'content_credentials',
+    'content_rhel',
+    'content_view_publish',
+    'content_view_version_cleanup',
+    'content_views',
+    'convert2rhel',
+    'domains',
+    'hostgroups',
+    'lifecycle_environments',
+    'manifest',
+    'operatingsystems',
+    'organizations',
+    'provisioning_templates',
+    'repositories',
+    'settings',
+    'sync_plans',
+]


### PR DESCRIPTION
Test for ensuring users can import (sync is now the correct term) the FAM roles and attach them to a host to be ran. This test does not ensure that the play itself runs successfully. That would require changing vars for each role that's synced. For now I wanted coverage for syncing, assigning to a host, and running.

Results:
```
============================= test session starts ==============================
platform linux -- Python 3.9.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: [/home/gsulliva/Programming/robottelo](), configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, cov-2.12.1, xdist-2.5.0, ibutsu-2.0.2, mock-3.7.0, reportportal-5.0.11
collected 1 item

tests[/foreman/sys/test_fam.py]() .                                          [100%]

-------------- generated xml file: [/tmp/tmp-4631hms57w4TYCb6.xml]() ---------------
========================= 1 passed in 97.24s (0:01:37) =========================
```