### PR TITLE
test_errata fix api and cli

### DIFF
--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -108,6 +108,12 @@ class Host(Base):
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
+    def errata_recalculate(cls, options):
+        """Recalculate errata on a content host"""
+        cls.command_sub = 'errata recalculate'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def facts(cls, options=None):
         """
         List all fact values.


### PR DESCRIPTION
1. Fix for API and CLI tests. Mostly changing the job invocation task labels and searchquery.
2. Removed 1 API test as the corresponding BZ is moved to CLOSED WONTFIX