### PR TITLE
Fixing BZ Authorization

### DIFF
--- a/robottelo/utils/issue_handlers/bugzilla.py
+++ b/robottelo/utils/issue_handlers/bugzilla.py
@@ -245,9 +245,9 @@ def get_data_bz(bz_numbers, cached_data=None):  # pragma: no cover
         f"{settings.bugzilla.url}/rest/bug",
         params={
             "id": ",".join(set(bz_numbers)),
-            "api_key": settings.bugzilla.api_key,
             "include_fields": ",".join(bz_fields),
         },
+        headers={"Authorization": f"api_key:{settings.bugzilla.api_key}"},
     )
     response.raise_for_status()
     data = response.json().get('bugs')


### PR DESCRIPTION
BZ API Key authorization now requires using the `Authorization` header. Email said API Keys will be invalidated, but mine is working so far.

Test Result:
```
============================= test session starts ==============================
platform linux -- Python 3.9.10, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: [/home/gsulliva/Programming/robottelo](), configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, cov-2.12.1, xdist-2.5.0, ibutsu-2.0.2, mock-3.7.0, reportportal-5.0.11
collected 1 item

tests[/foreman/api/test_repository.py]() s                                   [100%]

-------------- generated xml file: [/tmp/tmp-563397B0P4L0Gerg.xml]() ---------------
============================= 1 skipped in 42.42s ==============================
```