### PR TITLE
bump black version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: pyupgrade
     args: [--py38-plus]
 - repo: https://github.com/psf/black
-  rev: 21.10b0
+  rev: 22.3.0
   hooks:
   - id: black
 - repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
Bumping _black_ version to _22.3.0_ where compatibility with _click_ is fixed - (https://github.com/psf/black/issues/2964)