### PR TITLE
[6.9] reverting rex refactoring cherry-pick

### DIFF
--- a/conf/supportability.yaml
+++ b/conf/supportability.yaml
@@ -1,4 +1,4 @@
 supportability:
   content_hosts:
     rhel:
-      versions: [6, 7,'7_fips', 8, '8_fips']
+      versions: [6, 7, 8]


### PR DESCRIPTION
https://github.com/SatelliteQE/robottelo/pull/9404 was merged without running the cli/remote_execution.py module, even though the tests were directly affected by the changes -- causing the whole module to fail in 6.9 runs. 

the cherry-pick of https://github.com/SatelliteQE/robottelo/pull/9388 didn't apply cleanly as the pytest_fixtures/core/contenthosts.py does not exist in this branch, but even if it did, the actual fixture depends on other fixtures that are not part of the cherry-pick, etc. etc., it's a snowball.

Therefore reverting the module to the original state, I believe it shouldn't have been altered by 9404 anyway  