### PR TITLE
Fixed and improved Satellite Sync test cases

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -85,7 +85,7 @@ def export_cleanup_module(default_sat, module_org):
 def validate_filepath(sat_obj, org):
     """Checks the existence of certain files in a dir"""
     result = sat_obj.execute(
-        fr'find {EXPORT_DIR}{org.name} -type f \( -name "*.json" -o -name "*.txt" \)'
+        fr'find {EXPORT_DIR}{org.name} -type f \( -name "*.json" -o -name "*.tar.gz" \)'
     )
     return result.stdout
 
@@ -1361,14 +1361,11 @@ class TestContentViewSync:
         # Verify export directory is empty
         assert validate_filepath(default_sat, module_org) == ''
         # Export cv
-        export = ContentExport.completeVersion(
+        ContentExport.completeVersion(
             {'id': exporting_cvv_id['id'], 'organization-id': module_org.id}
         )
-        import_path = move_pulp_archive(default_sat, module_org, export['message'])
-
-        # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
-        assert result.stdout != ''
+        # Verify export directory is not empty
+        assert validate_filepath(default_sat, module_org) != ''
 
     @pytest.mark.tier3
     def test_postive_import_export_cv_with_file_content(


### PR DESCRIPTION
- changed component owner from @latran to @rmynar
- improved handling export and import archives (most failures were caused by garbage in these directories)
- new function `move_pulp_archive` that replaces recurring code and makes code more readable

```
$ pytest --disable-warnings tests/foreman/cli/test_satellitesync.py
=============================================================================== test session starts ===============================================================================
platform linux -- Python 3.10.4, pytest-7.1.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rmynar/rmynar/robottelo, configfile: pyproject.toml
plugins: cov-3.0.0, services-2.2.1, forked-1.4.0, mock-3.7.0, xdist-2.5.0, ibutsu-2.0.2, reportportal-5.0.12
collected 36 items / 16 deselected / 20 selected                                                                                                                                  

tests/foreman/cli/test_satellitesync.py ..............s.....                                                                                                                [100%]

===================================================== 19 passed, 1 skipped, 16 deselected, 22 warnings in 7266.37s (2:01:06) ======================================================
```