### PR TITLE
fix search for infrastructure hosts

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -67,6 +67,7 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_hosts_list
 from robottelo.hosts import ContentHostError
+from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope="module")
@@ -843,14 +844,20 @@ def test_positive_list_infrastructure_hosts(
     Host.update({'name': default_sat.hostname, 'new-organization-id': module_org.id})
     # list satellite hosts
     hosts = Host.list({'search': 'infrastructure_facet.foreman=true'})
-    assert len(hosts) == 1
+    if is_open('BZ:1994685'):
+        assert len(hosts) == 2
+    else:
+        assert len(hosts) == 1
     hostnames = [host['name'] for host in hosts]
     assert rhel7_contenthost.hostname not in hostnames
     assert default_sat.hostname in hostnames
     # list capsule hosts
     hosts = Host.list({'search': 'infrastructure_facet.smart_proxy_id=1'})
     hostnames = [host['name'] for host in hosts]
-    assert len(hosts) == 1
+    if is_open('BZ:1994685'):
+        assert len(hosts) == 2
+    else:
+        assert len(hosts) == 1
     assert rhel7_contenthost.hostname not in hostnames
     assert default_sat.hostname in hostnames
 


### PR DESCRIPTION
The change hostname script does not clean the previous hostname form the host list -- BZ#1994685  This ghost host then shows up in the infrstructure host search results, causing failed assertions. This PR modifies the asserts to account for the problem until the bz is fixed