### PR TITLE
Robottelo/product.py Helpers refactor

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -83,3 +83,138 @@ def module_repository(os_path, module_product, module_target_sat):
     repo = module_target_sat.api.Repository(product=module_product, url=os_path).create()
     call_entity_method_with_timeout(module_target_sat.api.Repository(id=repo.id).sync, timeout=3600)
     return repo
+
+
+def _simplify_repos(request, repos):
+    """This is a helper function that transforms repos_collection related fixture parameters into
+    a list that can be passed to robottelo.host_helpers.RepositoryMixins.RepositoryCollection
+    class constructor arguments. It can create multiple repos with distro.
+
+    E.g: the parameters list to repos_collection fixture is:
+    [{
+        'distro': DISTRO_RHEL7,
+        'SatelliteToolsRepository': {},
+        'YumRepository': [{'url': settings.repos.yum_0.url},{'url': settings.repos.yum_6.url}]
+    }]
+
+    The fixture removes distro from the dict above and translates the remaining dictionary into
+    [
+        {'SatelliteToolsRepository': {}},
+        {'YumRepository': {'url': settings.repos.yum_0.url}},
+        {'YumRepository': {'url': settings.repos.yum_6.url}}
+    ]
+    Then the fixtures loop over it to create multiple repositories.
+
+    :returns: The tuple of distro of repositories(if given) and simplified repos
+    """
+    _repos = []
+    repo_distro = None
+    # Iterating over repository thats requested more than once
+    for repo_name, repo_options in repos.items():
+        if isinstance(repo_options, list):
+            [_repos.append({repo_name: options}) for options in repo_options]
+        else:
+            _repos.append({repo_name: repo_options})
+    # Fetching repo collection distro from the parameters separately
+    _repo_distro = list(filter(lambda _params: 'distro' in _params, _repos))
+    if _repo_distro:
+        repo_distro = _repos.pop(_repos.index(_repo_distro[0]))['distro']
+    # Use CDN and distro param values from its own param on test if
+    # not provided in repo_collection params
+    for index, repo in enumerate(_repos):
+        (repo_name, repo_params), *_ = repo.items()
+        for option in ['cdn', 'distro']:
+            if option in repo_params:
+                param_value = _repos[index][repo_name][option]
+                _repos[index][repo_name][option] = (
+                    request.getfixturevalue(option) if param_value == option else param_value
+                )
+    return repo_distro, _repos
+
+
+@pytest.fixture
+def repos_collection(request, target_sat):
+    """Use this fixture with parameters, in tests and fixtures, that needs to create multiple repos
+    and operate on bunch of those repositories using robottelo.host_helpers.RepositoryMixins repo
+    helper classes.
+
+    Remember:
+        1. This fixture uses CLI Endpoint to create repository collection.
+        2. The only parameter to this fixture should be a list of dicts of Repositories
+        with repo parameters.
+        3. To add distro to the repository(ies), You can either pass distro param in repository
+        dict in params list directly -OR- add distro key value to repos_collection repos and
+        its params list -OR- add distro pytest mark with multiple distros list.
+
+    Check various types of usage in following tests:
+        1. tests.foreman.ui.test_activationkey.test_positive_end_to_end_register
+            Where the distro param is added as a key value to a specific repository dict applies
+            to only that repository
+        2. tests.foreman.ui.test_contentview.test_positive_remove_cv_version_from_env
+            Where the distro key value is added with the list of repositories dicts applies to all
+            the repos in the list
+        3. tests.foreman.cli.test_vm_install_products_packages.test_vm_install_package
+            Where the cdn and distro are pytest marks and repos collection fixture uses values from
+            those marks to generate multitests based on distro and cdn combinations. To capture the
+            value of cdn / distro from pytest params in specific repo one has to add
+            `cdn` / 'distro' as value to cdn / distro arguments
+
+    """
+    repos = getattr(request, 'param', [])
+    repo_distro, repos = _simplify_repos(request, repos)
+    _repos_collection = target_sat.cli_factory.RepositoryCollection(
+        distro=repo_distro or request.getfixturevalue('distro'),
+        repositories=[
+            getattr(target_sat.cli_factory, repo_name)(**repo_params)
+            for repo in repos
+            for repo_name, repo_params in repo.items()
+        ],
+    )
+    return _repos_collection
+
+
+@pytest.fixture(scope='module')
+def module_repos_collection_with_setup(request, module_target_sat, module_org, module_lce):
+    """This fixture and its usage is very similar to repos_collection fixture above with extra
+    setup_content capabilities using module_org and module_lce fixtures
+
+    Remember:
+        1. One can not pass distro as pytest mark via test to this fixture since the conflict of
+        using function scoped distro fixture in module scoped this fixture arrives
+
+    """
+    repos = getattr(request, 'param', [])
+    repo_distro, repos = _simplify_repos(request, repos)
+    _repos_collection = module_target_sat.cli_factory.RepositoryCollection(
+        distro=repo_distro,
+        repositories=[
+            getattr(module_target_sat.cli_factory, repo_name)(**repo_params)
+            for repo in repos
+            for repo_name, repo_params in repo.items()
+        ],
+    )
+    _repos_collection.setup_content(module_org.id, module_lce.id)
+    return _repos_collection
+
+
+@pytest.fixture(scope='module')
+def module_repos_collection_with_manifest(request, module_target_sat, module_org, module_lce):
+    """This fixture and its usage is very similar to repos_collection fixture above with extra
+    setup_content and uploaded manifest capabilities using module_org and module_lce fixtures
+
+    Remember:
+        1. One can not pass distro as pytest mark via test to this fixture since the conflict of
+        using function scoped distro fixture in module scoped this fixture arrives
+    """
+    repos = getattr(request, 'param', [])
+    repo_distro, repos = _simplify_repos(request, repos)
+    _repos_collection = module_target_sat.cli_factory.RepositoryCollection(
+        distro=repo_distro,
+        repositories=[
+            getattr(module_target_sat.cli_factory, repo_name)(**repo_params)
+            for repo in repos
+            for repo_name, repo_params in repo.items()
+        ],
+    )
+    _repos_collection.setup_content(module_org.id, module_lce.id, upload_manifest=True)
+    return _repos_collection

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -330,6 +330,14 @@ MIRRORING_POLICIES = {
     'mirror_complete': "Complete Mirroring",
     'mirror_content_only': "Content Only",
 }
+
+PRODUCT_KEY_RHEL = 'rhel'
+PRODUCT_KEY_SAT_TOOLS = 'rhst'
+PRODUCT_KEY_SAT_CAPSULE = 'rhsc'
+PRODUCT_KEY_VIRT_AGENTS = 'rhva6'
+PRODUCT_KEY_CLOUD_FORMS_TOOLS = 'rhct6'
+PRODUCT_KEY_ANSIBLE_ENGINE = 'rhae2'
+
 HASH_TYPE = {'sha256': "SHA256", 'sha512': "SHA512", 'base64': "Base64", 'md5': "MD5"}
 
 REPO_TAB = {'rpms': "RPMs", 'kickstarts': "Kickstarts", 'isos': "ISOs", 'ostree': "OSTree"}

--- a/robottelo/errors.py
+++ b/robottelo/errors.py
@@ -19,3 +19,29 @@ class ImproperlyConfigured(Exception):
 
 class InvalidVaultURLForOIDC(Exception):
     """Raised if the vault doesnt allows OIDC login"""
+
+
+class RepositoryAlreadyDefinedError(Exception):
+    """Raised when a repository has already a predefined key"""
+
+
+class DistroNotSupportedError(Exception):
+    """Raised when using a non supported distro"""
+
+
+class RepositoryDataNotFound(Exception):
+    """Raised when repository data cannot be found for a predefined distro"""
+
+
+class OnlyOneOSRepositoryAllowed(Exception):
+    """Raised when trying to more than one OS repository to a collection"""
+
+
+class RepositoryAlreadyCreated(Exception):
+    """Raised when a repository content is already created and trying to launch
+    the create an other time"""
+
+
+class ReposContentSetupWasNotPerformed(Exception):
+    """Raised when trying to setup a VM but the repositories content was not
+    setup"""

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -29,6 +29,7 @@ from robottelo import manifests
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.config import settings
+from robottelo.host_helpers.repository_mixins import initiate_repo_helpers
 
 
 class CLIFactoryError(Exception):
@@ -246,6 +247,7 @@ class CLIFactory:
 
     def __init__(self, satellite):
         self._satellite = satellite
+        self.__dict__.update(initiate_repo_helpers(self._satellite))
 
     def __getattr__(self, name):
         """We intercept the usual attribute behavior on this class to emulate make_entity methods

--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -1,259 +1,37 @@
-"""Manage RH products repositories and custom repositories.
-
-The main purpose of this feature is to manage product repositories especially
-the RH one in the context of a special distro and cdn settings.
-
-The repository data creation became transparent when supplying only the target
-distro.
-
-Example Usage:
-
-We know that sat tool key = 'rhst'
-
-Working with generic repos.
-
-Generic repos has no way to guess the custom repo url in case of
-settings.robottelo.cdn = false , that why the GenericRHRepo without custom url always
-return cdn repo data::
-
-    sat_repo = GenericRHRepository(key=PRODUCT_KEY_SAT_TOOLS)
-    print(sat_repo.cdn) >> True
-    # today the default distro is rhel7
-    print(sat_repo.distro)  >> rhel7
-    print(sat_repo.data) >>
-    {
-    'arch': 'x86_64',
-    'cdn': True,
-    'product': 'Red Hat Enterprise Linux Server',
-    'releasever': None,
-    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
-    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
-    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'
-    }
-
-    # Generic CDN RH repository with specific distro "DISTRO_RHEL6"
-    sat_repo = GenericRHRepository(
-        distro=DISTRO_RHEL6, key=PRODUCT_KEY_SAT_TOOLS)
-
-    print(sat_repo.distro) >> rhel6
-    print(sat_repo.data)   >>
-    {
-    'arch': 'x86_64',
-    'cdn': True,
-    'product': 'Red Hat Enterprise Linux Server',
-    'releasever': None,
-    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 6 Server RPMs x86_64',
-    'repository-id': 'rhel-6-server-satellite-tools-6.2-rpms',
-    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs)'
-    }
-
-    # Generic RH repository with custom url
-    sat_repo = GenericRHRepository(
-        key=PRODUCT_KEY_SAT_TOOLS, url='http://sat-tools.example.com')
-
-    # because default settings.robottelo.cdn=False and we have a custom url
-    print(sat_repo.cdn) >> False
-    print(sat_repo.distro) >> rhel7
-    print(sat_repo.data) >>
-    {'cdn': False, 'url': 'http://sat-tools.example.com'}
-
-    # Generic RH repository with custom url and force cdn
-    sat_repo = GenericRHRepository(
-        key=PRODUCT_KEY_SAT_TOOLS,
-        url='http://sat-tools.example.com',
-        cdn=True
-    )
-    print(sat_repo.data) >>
-    {
-    'arch': 'x86_64',
-    'cdn': True,
-    'product': 'Red Hat Enterprise Linux Server',
-    'releasever': None,
-    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
-    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
-    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'
-    }
-
-    # We have created a SatelliteToolsRepository that automatically detect it's
-    # custom url in settings, so there no need to explicitly initialise with
-    # url, simply the distro is needed (in case of specific one), otherwise
-    # the default distro will be used.
-
-    # SatelliteToolsRepository RH repo use settings urls and cdn
-    sat_repo = SatelliteToolsRepository()
-    print(sat_repo.cdn) >> False
-    print(sat_repo.distro) >> rhel7
-    print(sat_repo.data) >>
-    {
-    'cdn': False,
-    # part of the url was hidden
-    'url': 'XXXXXXXXXXXXXXXXXXX/Tools_6_3_RHEL7/custom/'
-           'Satellite_Tools_6_3_Composes/Satellite_Tools_x86_64/'
-    }
-
-    # SatelliteToolsRepository RH repo use settings urls with 'force cdn')
-    sat_repo = SatelliteToolsRepository(cdn=True)
-    print(sat_repo.cdn >> True
-    print(sat_repo.distro >> rhel7
-    print(sat_repo.data >>
-    {
-    'arch': 'x86_64',
-    'cdn': True,
-    'product': 'Red Hat Enterprise Linux Server',
-    'releasever': None,
-    'repository': 'Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64',
-    'repository-id': 'rhel-7-server-satellite-tools-6.2-rpms',
-    'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 7 Server) (RPMs)'
-    }
-
-    # we can also indicate the distro, the same as for the generic one the
-    # data will be switched for that distro
-
-
-    # Working with RepositoryCollection using the default distro
-    repos_collection = RepositoryCollection(
-        repositories=[
-            RHELRepository(),
-            SatelliteToolsRepository(),
-            SatelliteCapsuleRepository(),
-            CustomYumRepository(url=settings.repos.yum_0.url)
-        ]
-    )
-
-    repos_collection.distro >> None
-    repos_collection.repos_data >>
-    [{'cdn': False,
-      'url': 'http://XXXXXXXXX/RHEL-7/7.4/Server/x86_64/os/'},
-     {'cdn': False,
-      'url': 'http://XXXXXXXXXXX/Tools_6_3_RHEL7/custom/'
-             'Satellite_Tools_6_3_Composes/Satellite_Tools_x86_64/'
-             },
-     {'cdn': False,
-      'url': 'http://XXXXXXXXXX/Satellite_6_3_RHEL7/custom/'
-             'Satellite_6_3_Composes/Satellite_6_3_RHEL7'
-             },
-     {'cdn': False, 'url': 'http://inecas.fedorapeople.org/fakerepos/zoo/'}
-    ]
-    repos_collection.need_subscription >> False
-
-    # Working with RepositoryCollection with force distro RHEL6 and force cdn
-    # on some repos
-    repos_collection = RepositoryCollection(
-        distro=DISTRO_RHEL6,
-        repositories=[
-            SatelliteToolsRepository(cdn=True),
-            SatelliteCapsuleRepository(),
-            YumRepository(url=settings.repos.yum_0.url)
-        ]
-    )
-    repos_collection.distro >> rhel6
-    repos_collection.repos_data >>
-    [
-        {'arch': 'x86_64',
-         'cdn': True,
-         'product': 'Red Hat Enterprise Linux Server',
-         'releasever': None,
-         'repository': 'Red Hat Satellite Tools 6.2 for RHEL 6 Server RPMs'
-                       ' x86_64',
-         'repository-id': 'rhel-6-server-satellite-tools-6.2-rpms',
-         'repository-set': 'Red Hat Satellite Tools 6.2 (for RHEL 6 Server)
-                           '(RPMs)'
-        },
-        {
-        'arch': 'x86_64',
-        'cdn': True,
-        'product': 'Red Hat Satellite Capsule',
-        'releasever': None,
-        'repository': 'Red Hat Satellite Capsule 6.2 for RHEL 6 Server RPMs '
-                      'x86_64',
-        'repository-id': 'rhel-6-server-satellite-capsule-6.2-rpms',
-        'repository-set': 'Red Hat Satellite Capsule 6.2 (for RHEL 6 Server) '
-                          '(RPMs)'
-        },
-        {'cdn': False, 'url': 'http://inecas.fedorapeople.org/fakerepos/zoo/'}
-    ]
-    repos_collection.need_subscription >> True
-    # Note: satellite capsule repo will query the server for a distro and if
-    # the same distro as the sat server is used will use the settings url
-    # (if cdn=False) else it will use the cdn one.
-
-    # Please consult the RepositoryCollection for some usage functions
-    # also test usage located at:
-    # tests/foreman/cli/test_vm_install_products_package.py
 """
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
+All the Repository classes in this module are supposed to use from sat_object.cli_factory object.
+The direct import of the repo classes in this module is prohibited !!!!!
+"""
+import inspect
+import sys
 
 from robottelo import constants
 from robottelo import manifests
-from robottelo.cli.activationkey import ActivationKey
-from robottelo.cli.contentview import ContentView
-from robottelo.cli.factory import make_activation_key
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_product_wait
-from robottelo.cli.factory import make_repository
-from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
-from robottelo.cli.org import Org
-from robottelo.cli.repository import Repository
-from robottelo.cli.repository_set import RepositorySet
-from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
-
-REPO_TYPE_YUM = constants.REPO_TYPE['yum']
-REPO_TYPE_DOCKER = constants.REPO_TYPE['docker']
-REPO_TYPE_OSTREE = constants.REPO_TYPE['ostree']
-
-DOWNLOAD_POLICY_ON_DEMAND = 'on_demand'
-DOWNLOAD_POLICY_IMMEDIATE = 'immediate'
-DOWNLOAD_POLICY_BACKGROUND = 'background'
-
-PRODUCT_KEY_RHEL = 'rhel'
-PRODUCT_KEY_SAT_TOOLS = 'rhst'
-PRODUCT_KEY_SAT_CAPSULE = 'rhsc'
-PRODUCT_KEY_VIRT_AGENTS = 'rhva6'
-PRODUCT_KEY_CLOUD_FORMS_TOOLS = 'rhct6'
-PRODUCT_KEY_ANSIBLE_ENGINE = 'rhae2'
-
-_server_distro = None  # type: str
+from robottelo.errors import DistroNotSupportedError
+from robottelo.errors import OnlyOneOSRepositoryAllowed
+from robottelo.errors import ReposContentSetupWasNotPerformed
+from robottelo.errors import RepositoryAlreadyCreated
+from robottelo.errors import RepositoryAlreadyDefinedError
+from robottelo.errors import RepositoryDataNotFound
 
 
-class RepositoryAlreadyDefinedError(Exception):
-    """Raised when a repository has already a predefined key"""
-
-
-class DistroNotSupportedError(Exception):
-    """Raised when using a non supported distro"""
-
-
-class RepositoryDataNotFound(Exception):
-    """Raised when repository data cannot be found for a predefined distro"""
-
-
-class OnlyOneOSRepositoryAllowed(Exception):
-    """Raised when trying to more than one OS repository to a collection"""
-
-
-class RepositoryAlreadyCreated(Exception):
-    """Raised when a repository content is already created and trying to launch
-    the create an other time"""
-
-
-class ReposContentSetupWasNotPerformed(Exception):
-    """Raised when trying to setup a VM but the repositories content was not
-    setup"""
+def initiate_repo_helpers(satellite):
+    return {
+        (name, type(name, (obj,), {'satellite': satellite}))
+        for name, obj in inspect.getmembers(sys.modules[__name__], inspect.isclass)
+        if obj.__module__ == __name__
+    }
 
 
 class BaseRepository:
     """Base repository class for custom and RH repositories"""
 
-    _url = None  # type: Optional[str]
-    _distro = None  # type: Optional[str]
-    _type = None  # type: Optional[str]
-    _repo_info = None  # type: Optional[Dict]
+    _url = None
+    _distro = None
+    _type = None
+    _repo_info = None
+    satellite = None
 
     def __init__(self, url=None, distro=None, content_type=None):
         self._url = url
@@ -262,15 +40,15 @@ class BaseRepository:
             self._type = content_type
 
     @property
-    def url(self):  # type: () -> Optional[str]
+    def url(self):
         return self._url
 
     @property
-    def cdn(self):  # type: () -> bool
+    def cdn(self):
         return False
 
     @property
-    def data(self):  # type: () -> Dict
+    def data(self):
         data = dict(url=self.url, cdn=self.cdn)
         content_type = self.content_type
         if content_type:
@@ -278,7 +56,7 @@ class BaseRepository:
         return data
 
     @property
-    def distro(self):  # type: () -> Optional[str]
+    def distro(self):
         """Return the current distro"""
         return self._distro
 
@@ -288,35 +66,36 @@ class BaseRepository:
         self._distro = value
 
     @property
-    def content_type(self):  # type: () -> str
+    def content_type(self):
         return self._type
 
     def __repr__(self):
         return f'<Repo type: {self.content_type}, url: {self.url}, object: {hex(id(self))}>'
 
     @property
-    def repo_info(self):  # type: () -> Optional[Dict]
+    def repo_info(self):
         return self._repo_info
 
     def create(
         self,
         organization_id,
         product_id,
-        download_policy=DOWNLOAD_POLICY_ON_DEMAND,
+        download_policy=None,
         synchronize=True,
     ):
-        # type: (int, int, str, bool) -> Dict
+        if download_policy:
+            download_policy = 'on_demand'
         """Create the repository for the supplied product id"""
         create_options = {
             'product-id': product_id,
             'content-type': self.content_type,
             'url': self.url,
         }
-        if self.content_type == REPO_TYPE_YUM and download_policy:
+        if self.content_type == constants.REPO_TYPE['yum'] and download_policy:
             create_options['download-policy'] = download_policy
-        if self.content_type == REPO_TYPE_OSTREE:
+        if self.content_type == constants.REPO_TYPE['ostree']:
             create_options['publish-via-http'] = 'false'
-        repo_info = make_repository(create_options)
+        repo_info = self.satellite.cli_factory.make_repository(create_options)
         self._repo_info = repo_info
         if synchronize:
             self.synchronize()
@@ -324,12 +103,11 @@ class BaseRepository:
 
     def synchronize(self):
         """Synchronize the repository"""
-        Repository.synchronize({'id': self.repo_info['id']}, timeout=4800000)
+        self.satellite.cli.Repository.synchronize({'id': self.repo_info['id']}, timeout=4800000)
 
     def add_to_content_view(self, organization_id, content_view_id):
-        # type: (int, int) -> None
         """Associate repository content to content-view"""
-        ContentView.add_repository(
+        self.satellite.cli.ContentView.add_repository(
             {
                 'id': content_view_id,
                 'organization-id': organization_id,
@@ -341,13 +119,13 @@ class BaseRepository:
 class YumRepository(BaseRepository):
     """Custom Yum repository"""
 
-    _type = REPO_TYPE_YUM  # type: str
+    _type = constants.REPO_TYPE['yum']
 
 
 class DockerRepository(BaseRepository):
     """Custom Docker repository"""
 
-    _type = REPO_TYPE_DOCKER  # type: str
+    _type = constants.REPO_TYPE['docker']
 
     def __init__(self, url=None, distro=None, upstream_name=None):
         self._upstream_name = upstream_name
@@ -358,7 +136,7 @@ class DockerRepository(BaseRepository):
         return self._upstream_name
 
     def create(self, organization_id, product_id, download_policy=None, synchronize=True):
-        repo_info = make_repository(
+        repo_info = self.satellite.cli_factory.make_repository(
             {
                 'product-id': product_id,
                 'content-type': self.content_type,
@@ -375,17 +153,17 @@ class DockerRepository(BaseRepository):
 class OSTreeRepository(BaseRepository):
     """Custom OSTree repository"""
 
-    _type = REPO_TYPE_OSTREE
+    _type = constants.REPO_TYPE['ostree']
 
 
 class GenericRHRepository(BaseRepository):
     """Generic RH repository"""
 
-    _type = REPO_TYPE_YUM
-    _distro = constants.DISTRO_DEFAULT  # type: str
-    _key = None  # type: str
-    _repo_data = None  # type: Dict
-    _url = None  # type: Optional[str]
+    _type = constants.REPO_TYPE['yum']
+    _distro = constants.DISTRO_DEFAULT
+    _key = None
+    _repo_data = None
+    _url = None
 
     def __init__(self, distro=None, key=None, cdn=False, url=None):
         super().__init__()
@@ -420,7 +198,7 @@ class GenericRHRepository(BaseRepository):
         return self._distro
 
     @distro.setter
-    def distro(self, distro):  # type: (str) -> None
+    def distro(self, distro):
         """Set a new distro value, we have to reinitialise the repo data also,
         if not found raise exception
         """
@@ -434,7 +212,7 @@ class GenericRHRepository(BaseRepository):
         self._distro = distro
         self._repo_data = repo_data
 
-    def _get_repo_data(self, distro=None):  # type: (Optional[str]) -> Dict
+    def _get_repo_data(self, distro=None):
         """Return the repo data as registered in constant module and bound
         to distro.
         """
@@ -450,21 +228,20 @@ class GenericRHRepository(BaseRepository):
         return repo_data
 
     @property
-    def repo_data(self):  # type: () -> Dict
+    def repo_data(self):
         if self._repo_data is not None:
             return self._repo_data
         self._repo_data = self._get_repo_data()
         return self._repo_data
 
     def _repo_is_distro(self, repo_data=None):
-        # type: (Optional[Dict]) -> bool
         """return whether the repo data is for an OS distro product repository"""
         if repo_data is None:
             repo_data = self.repo_data
         return bool(repo_data.get('distro_repository', False))
 
     @property
-    def is_distro_repository(self):  # type: () -> bool
+    def is_distro_repository(self):
         # whether the current repository is an OS distro product repository
         return self._repo_is_distro()
 
@@ -473,7 +250,7 @@ class GenericRHRepository(BaseRepository):
         return constants.DISTROS_MAJOR_VERSION[self.distro]
 
     @property
-    def distro_repository(self):  # type: () -> Optional[RHELRepository]
+    def distro_repository(self):
         """Return the OS distro repository object relied to this repository
 
         Suppose we have a repository for a product that must be installed on
@@ -501,13 +278,13 @@ class GenericRHRepository(BaseRepository):
         return None
 
     @property
-    def rh_repository_id(self):  # type: () -> Optional[str]
+    def rh_repository_id(self):
         if self.cdn:
             return self.repo_data.get('id')
         return None
 
     @property
-    def data(self):  # type: () -> Dict
+    def data(self):
         data = {}
         if self.cdn:
             data['product'] = self.repo_data.get('product')
@@ -536,23 +313,22 @@ class GenericRHRepository(BaseRepository):
         self,
         organization_id,
         product_id=None,
-        download_policy=DOWNLOAD_POLICY_ON_DEMAND,
+        download_policy='on_demand',
         synchronize=True,
     ):
-        # type: (int, Optional[int], Optional[str], Optional[bool]) -> Dict
         """Create an RH repository"""
         if not self.cdn and not self.url:
             raise ValueError('Can not handle Custom repository with url not supplied')
         if self.cdn:
             data = self.data
-            if not Repository.list(
+            if not self.satellite.cli.Repository.list(
                 {
                     'organization-id': organization_id,
                     'name': data['repository'],
                     'product': data['product'],
                 }
             ):
-                RepositorySet.enable(
+                self.satellite.cli.RepositorySet.enable(
                     {
                         'organization-id': organization_id,
                         'product': data['product'],
@@ -561,7 +337,7 @@ class GenericRHRepository(BaseRepository):
                         'releasever': data.get('releasever'),
                     }
                 )
-            repo_info = Repository.info(
+            repo_info = self.satellite.cli.Repository.info(
                 {
                     'organization-id': organization_id,
                     'name': data['repository'],
@@ -570,7 +346,9 @@ class GenericRHRepository(BaseRepository):
             )
             if download_policy:
                 # Set download policy
-                Repository.update({'download-policy': download_policy, 'id': repo_info['id']})
+                self.satellite.cli.Repository.update(
+                    {'download-policy': download_policy, 'id': repo_info['id']}
+                )
             self._repo_info = repo_info
             if synchronize:
                 self.synchronize()
@@ -582,7 +360,7 @@ class GenericRHRepository(BaseRepository):
 class RHELRepository(GenericRHRepository):
     """RHEL repository"""
 
-    _key = PRODUCT_KEY_RHEL
+    _key = constants.PRODUCT_KEY_RHEL
 
     @property
     def url(self):
@@ -592,17 +370,19 @@ class RHELRepository(GenericRHRepository):
 class SatelliteToolsRepository(GenericRHRepository):
     """Satellite Tools Repository"""
 
-    _key = PRODUCT_KEY_SAT_TOOLS
+    _key = constants.PRODUCT_KEY_SAT_TOOLS
 
     @property
     def url(self):
-        return settings.repos.sattools_repo[f'{PRODUCT_KEY_RHEL}{self.distro_major_version}']
+        return settings.repos.sattools_repo[
+            f'{constants.PRODUCT_KEY_RHEL}{self.distro_major_version}'
+        ]
 
 
 class SatelliteCapsuleRepository(GenericRHRepository):
     """Satellite capsule repository"""
 
-    _key = PRODUCT_KEY_SAT_CAPSULE
+    _key = constants.PRODUCT_KEY_SAT_CAPSULE
 
     @property
     def url(self):
@@ -614,31 +394,32 @@ class SatelliteCapsuleRepository(GenericRHRepository):
 class VirtualizationAgentsRepository(GenericRHRepository):
     """Virtualization Agents repository"""
 
-    _key = PRODUCT_KEY_VIRT_AGENTS
+    _key = constants.PRODUCT_KEY_VIRT_AGENTS
     _distro = constants.DISTRO_RHEL6
 
 
 class RHELCloudFormsTools(GenericRHRepository):
     _distro = constants.DISTRO_RHEL6
-    _key = PRODUCT_KEY_CLOUD_FORMS_TOOLS
+    _key = constants.PRODUCT_KEY_CLOUD_FORMS_TOOLS
 
 
 class RHELAnsibleEngineRepository(GenericRHRepository):
     """Red Hat Ansible Engine Repository"""
 
-    _key = PRODUCT_KEY_ANSIBLE_ENGINE
+    _key = constants.PRODUCT_KEY_ANSIBLE_ENGINE
 
 
 class RepositoryCollection:
     """Repository collection"""
 
-    _distro = None  # type: str
-    _org = None  # type: Dict
-    _items = []  # type: List[BaseRepository]
-    _repos_info = []  # type: List[Dict]
-    _custom_product_info = None  # type: Dict
-    _os_repo = None  # type: RHELRepository
-    _setup_content_data = None  # type: Dict[str, Dict]
+    _distro = None
+    _org = None
+    _items = []
+    _repos_info = []
+    _custom_product_info = None
+    _os_repo = None
+    _setup_content_data = None
+    satellite = None
 
     def __init__(self, distro=None, repositories=None):
 
@@ -654,11 +435,11 @@ class RepositoryCollection:
         self.add_items(repositories)
 
     @property
-    def distro(self):  # type: () -> str
+    def distro(self):
         return self._distro
 
     @property
-    def repos_info(self):  # type: () -> List[Dict]
+    def repos_info(self):
         return self._repos_info
 
     @property
@@ -666,11 +447,11 @@ class RepositoryCollection:
         return self._custom_product_info
 
     @property
-    def os_repo(self):  # type: () -> RHELRepository
+    def os_repo(self):
         return self._os_repo
 
     @os_repo.setter
-    def os_repo(self, repo):  # type: (RHELRepository) -> None
+    def os_repo(self, repo):
         if self.os_repo is not None:
             raise OnlyOneOSRepositoryAllowed('OS repo already added.(Only one OS repo allowed)')
         if not isinstance(repo, RHELRepository):
@@ -678,25 +459,25 @@ class RepositoryCollection:
         self._os_repo = repo
 
     @property
-    def repos_data(self):  # type: () -> List[Dict]
+    def repos_data(self):
         return [repo.data for repo in self]
 
     @property
-    def rh_repos(self):  # type: () -> List[BaseRepository]
+    def rh_repos(self):
         return [item for item in self if item.cdn]
 
     @property
-    def custom_repos(self):  # type: () -> List[BaseRepository]
+    def custom_repos(self):
         return [item for item in self if not item.cdn]
 
     @property
-    def rh_repos_info(self):  # type: () -> List[Dict]
+    def rh_repos_info(self):
         return [
             repo_info for repo_info in self._repos_info if repo_info['red-hat-repository'] == 'yes'
         ]
 
     @property
-    def custom_repos_info(self):  # type: () -> List[Dict]
+    def custom_repos_info(self):
         return [
             repo_info for repo_info in self._repos_info if repo_info['red-hat-repository'] == 'no'
         ]
@@ -706,7 +487,7 @@ class RepositoryCollection:
         return self._setup_content_data
 
     @property
-    def need_subscription(self):  # type: () -> bool
+    def need_subscription(self):
         if self.rh_repos:
             return True
         return False
@@ -745,8 +526,7 @@ class RepositoryCollection:
     def __iter__(self):
         yield from self._items
 
-    def setup(self, org_id, download_policy=DOWNLOAD_POLICY_ON_DEMAND, synchronize=True):
-        # type: (int, str, bool) -> Tuple[Dict, List[Dict]]
+    def setup(self, org_id, download_policy='on_demand', synchronize=True):
         """Setup the repositories on server.
 
         Recommended usage: repository only setup, for full content setup see
@@ -757,11 +537,16 @@ class RepositoryCollection:
         custom_product = None
         repos_info = []
         if any(not repo.cdn for repo in self):
-            custom_product = make_product_wait({'organization-id': org_id})
+            custom_product = self.satellite.cli_factory.make_product_wait(
+                {'organization-id': org_id}
+            )
         custom_product_id = custom_product['id'] if custom_product else None
         for repo in self:
             repo_info = repo.create(
-                org_id, custom_product_id, download_policy=download_policy, synchronize=synchronize
+                org_id,
+                custom_product_id,
+                download_policy=download_policy,
+                synchronize=synchronize,
             )
             repos_info.append(repo_info)
         self._custom_product_info = custom_product
@@ -769,41 +554,43 @@ class RepositoryCollection:
         return custom_product, repos_info
 
     def setup_content_view(self, org_id, lce_id=None):
-        # type: (int, int) -> Tuple[Dict, Dict]
         """Setup organization content view by adding all the repositories, publishing and promoting
         to lce if needed.
         """
         if lce_id is None:
-            lce = make_lifecycle_environment({'organization-id': org_id})
+            lce = self.satellite.cli_factory.make_lifecycle_environment({'organization-id': org_id})
         else:
-            lce = LifecycleEnvironment.info({'id': lce_id, 'organization-id': org_id})
-        content_view = make_content_view({'organization-id': org_id})
+            lce = self.satellite.cli.LifecycleEnvironment.info(
+                {'id': lce_id, 'organization-id': org_id}
+            )
+        content_view = self.satellite.cli_factory.make_content_view({'organization-id': org_id})
         # Add repositories to content view
         for repo in self:
             repo.add_to_content_view(org_id, content_view['id'])
         # Publish the content view
-        ContentView.publish({'id': content_view['id']})
+        self.satellite.cli.ContentView.publish({'id': content_view['id']})
         if lce['name'] != constants.ENVIRONMENT:
             # Get the latest content view version id
-            content_view_version = ContentView.info({'id': content_view['id']})['versions'][-1]
+            content_view_version = self.satellite.cli.ContentView.info({'id': content_view['id']})[
+                'versions'
+            ][-1]
             # Promote content view version to lifecycle environment
-            ContentView.version_promote(
+            self.satellite.cli.ContentView.version_promote(
                 {
                     'id': content_view_version['id'],
                     'organization-id': org_id,
                     'to-lifecycle-environment-id': lce['id'],
                 }
             )
-        content_view = ContentView.info({'id': content_view['id']})
+        content_view = self.satellite.cli.ContentView.info({'id': content_view['id']})
         return content_view, lce
 
-    @staticmethod
-    def setup_activation_key(org_id, content_view_id, lce_id, subscription_names=None):
-        # type: (int, int, int, Optional[List[str]]) -> Dict
-        """Create activation and associate content-view, lifecycle environment and subscriptions"""
+    def setup_activation_key(self, org_id, content_view_id, lce_id, subscription_names=None):
+        """Create activation and associate content-view,
+        lifecycle environment and subscriptions"""
         if subscription_names is None:
             subscription_names = []
-        activation_key = make_activation_key(
+        activation_key = self.satellite.cli_factory.make_activation_key(
             {
                 'organization-id': org_id,
                 'lifecycle-environment-id': lce_id,
@@ -812,14 +599,16 @@ class RepositoryCollection:
         )
         # Add subscriptions to activation-key
         # Get organization subscriptions
-        subscriptions = Subscription.list({'organization-id': org_id}, per_page=False)
+        subscriptions = self.satellite.cli.Subscription.list(
+            {'organization-id': org_id}, per_page=False
+        )
         added_subscription_names = []
         for subscription in subscriptions:
             if (
                 subscription['name'] in subscription_names
                 and subscription['name'] not in added_subscription_names
             ):
-                ActivationKey.add_subscription(
+                self.satellite.cli.ActivationKey.add_subscription(
                     {
                         'id': activation_key['id'],
                         'subscription-id': subscription['id'],
@@ -836,12 +625,13 @@ class RepositoryCollection:
             raise ValueError(f'Missing subscriptions: {missing_subscription_names}')
         return activation_key
 
-    @staticmethod
-    def organization_has_manifest(organization_id):
+    def organization_has_manifest(self, organization_id):
         """Check if an organization has a manifest, an organization has manifest if one of it's
         subscriptions have the account defined.
         """
-        subscriptions = Subscription.list({'organization-id': organization_id}, per_page=False)
+        subscriptions = self.satellite.cli.Subscription.list(
+            {'organization-id': organization_id}, per_page=False
+        )
         return any(bool(sub['account']) for sub in subscriptions)
 
     def setup_content(
@@ -849,10 +639,9 @@ class RepositoryCollection:
         org_id,
         lce_id,
         upload_manifest=False,
-        download_policy=DOWNLOAD_POLICY_ON_DEMAND,
+        download_policy='on_demand',
         rh_subscriptions=None,
     ):
-        # type: (int, int, bool, str, Optional[List[str]]) -> Dict[str, Any]
         """
         Setup content view and activation key of all the repositories.
 
@@ -891,14 +680,13 @@ class RepositoryCollection:
             repos=repos_info,
             lce=lce,
         )
-        self._org = Org.info({'id': org_id})
+        self._org = self.satellite.cli.Org.info({'id': org_id})
         self._setup_content_data = setup_content_data
         return setup_content_data
 
     def setup_virtual_machine(
         self,
         vm,
-        satellite,
         location_title=None,
         patch_os_release=False,
         install_katello_agent=True,
@@ -925,17 +713,17 @@ class RepositoryCollection:
         patch_os_release_distro = None
         if patch_os_release and self.os_repo:
             patch_os_release_distro = self.os_repo.distro
-        rh_repo_ids = []  # type: List[str]
+        rh_repo_ids = []
         if enable_rh_repos:
             rh_repo_ids = [getattr(repo, 'rh_repository_id') for repo in self.rh_repos]
-        repo_labels = []  # type: List[str]
+        repo_labels = []
         if enable_custom_repos:
             repo_labels = [
                 repo['label'] for repo in self.custom_repos_info if repo['content-type'] == 'yum'
             ]
 
         vm.contenthost_setup(
-            satellite,
+            self.satellite,
             self.organization['label'],
             location_title=location_title,
             rh_repo_ids=rh_repo_ids,

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -28,10 +28,6 @@ from robottelo.constants import DISTRO_RHEL6
 from robottelo.constants import DISTROS_SUPPORTED
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
 from robottelo.hosts import ContentHost
-from robottelo.products import DockerRepository
-from robottelo.products import RepositoryCollection
-from robottelo.products import SatelliteToolsRepository
-from robottelo.products import YumRepository
 
 
 @pytest.fixture
@@ -48,7 +44,21 @@ def lce(org):
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize('cdn', [True, False], ids=['cdn', 'no_cdn'])
 @pytest.mark.parametrize('distro', DISTROS_SUPPORTED)
-def test_vm_install_package(org, lce, distro, cdn, target_sat):
+@pytest.mark.parametrize(
+    'repos_collection',
+    [
+        {
+            'SatelliteToolsRepository': {'cdn': 'cdn', 'distro': 'distro'},
+            'YumRepository': {'url': settings.repos.yum_0.url},
+            'DockerRepository': {
+                'url': CONTAINER_REGISTRY_HUB,
+                'upstream_name': CONTAINER_UPSTREAM_NAME,
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_vm_install_package(repos_collection, org, lce, distro, cdn):
     """Install a package with all supported distros and cdn / non-cdn variants
 
     :id: b2a6065a-69f6-4805-a28b-eaaa812e0f4b
@@ -59,20 +69,12 @@ def test_vm_install_package(org, lce, distro, cdn, target_sat):
     """
     if distro == DISTRO_RHEL6:
         pytest.skip(f'{DISTRO_RHEL6!s} skipped until ELS subscriptions are in manifest.')
-    repos_collection = RepositoryCollection(
-        distro=distro,
-        repositories=[
-            SatelliteToolsRepository(cdn=cdn, distro=distro),
-            YumRepository(url=settings.repos.yum_0.url),
-            DockerRepository(url=CONTAINER_REGISTRY_HUB, upstream_name=CONTAINER_UPSTREAM_NAME),
-        ],
-    )
     # Create repos, content view, and activation key.
     repos_collection.setup_content(org['id'], lce['id'], upload_manifest=True)
     with Broker(nick=distro, host_classes={'host': ContentHost}) as host:
         # install katello-agent
         repos_collection.setup_virtual_machine(
-            host, target_sat, enable_custom_repos=True, install_katello_agent=False
+            host, enable_custom_repos=True, install_katello_agent=False
         )
         # install a package from custom repo
         result = host.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -38,8 +38,6 @@ from robottelo.config import settings
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 from robottelo.hosts import ContentHost
-from robottelo.products import RepositoryCollection
-from robottelo.products import SatelliteToolsRepository
 
 
 @pytest.mark.tier2
@@ -81,7 +79,12 @@ def test_positive_end_to_end_crud(session, module_org):
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_end_to_end_register(session, rhel7_contenthost, target_sat):
+@pytest.mark.parametrize(
+    'repos_collection',
+    [{'SatelliteToolsRepository': {'distro': constants.DISTRO_RHEL7}}],
+    indirect=True,
+)
+def test_positive_end_to_end_register(session, repos_collection, rhel7_contenthost, target_sat):
     """Create activation key and use it during content host registering
 
     :id: dfaecf6a-ba61-47e1-87c5-f8966a319b41
@@ -97,9 +100,6 @@ def test_positive_end_to_end_register(session, rhel7_contenthost, target_sat):
     """
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
-    repos_collection = RepositoryCollection(
-        distro=constants.DISTRO_RHEL7, repositories=[SatelliteToolsRepository()]
-    )
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
     ak_name = repos_collection.setup_content_data['activation_key']['name']
 

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -23,7 +23,6 @@ from robottelo import ssh
 from robottelo.api.utils import configure_provisioning
 from robottelo.api.utils import create_discovered_host
 from robottelo.libvirt_discovery import LibvirtGuest
-from robottelo.products import RHELRepository
 
 pytestmark = [pytest.mark.run_in_one_thread]
 
@@ -53,13 +52,13 @@ def discovery_location(module_location):
 
 
 @pytest.fixture(scope='module')
-def provisioning_env(discovery_org, discovery_location):
+def provisioning_env(module_target_sat, discovery_org, discovery_location):
     # Build PXE default template to get default PXE file
-    entities.ProvisioningTemplate().build_pxe_default()
+    module_target_sat.cli.ProvisioningTemplate().build_pxe_default()
     return configure_provisioning(
         org=discovery_org,
         loc=discovery_location,
-        os='Redhat {}'.format(RHELRepository().repo_data['version']),
+        os='Redhat {}'.format(module_target_sat.cli_factory.RHELRepository().repo_data['version']),
     )
 
 

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -27,20 +27,18 @@ from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.logging import logger
 from robottelo.manifests import original_manifest
 from robottelo.manifests import upload_manifest_locked
-from robottelo.products import RepositoryCollection
-from robottelo.products import YumRepository
 
 CUSTOM_REPO_ERRATA_ID = settings.repos.yum_0.errata[0]
 
 
 @pytest.fixture(scope='module')
-def module_repos_col(module_org, module_lce, module_target_sat, request):
+def module_repos_col(module_org, module_lce, module_target_sat, request, target_sat):
     upload_manifest_locked(org_id=module_org.id)
-    repos_collection = RepositoryCollection(
+    repos_collection = target_sat.cli_factory.RepositoryCollection(
         repositories=[
             # As Satellite Tools may be added as custom repo and to have a "Fully entitled" host,
             # force the host to consume an RH product with adding a cdn repo.
-            YumRepository(url=settings.repos.yum_0.url),
+            target_sat.cli_factory.YumRepository(url=settings.repos.yum_0.url),
         ],
     )
     repos_collection.setup_content(module_org.id, module_lce.id)
@@ -330,7 +328,9 @@ def test_positive_errata_view_organization_switch(
 
     :CaseLevel: Integration
     """
-    rc = RepositoryCollection(repositories=[YumRepository(settings.repos.yum_3.url)])
+    rc = target_sat.cli_factory.RepositoryCollection(
+        repositories=[target_sat.cli_factory.YumRepository(settings.repos.yum_3.url)]
+    )
     rc.setup_content(module_org.id, module_lce.id)
     with session:
         assert (

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -25,7 +25,6 @@ from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.constants import RPM_TO_UPLOAD
 from robottelo.helpers import get_data_file
-from robottelo.products import SatelliteToolsRepository
 
 
 @pytest.fixture(scope='module')
@@ -63,9 +62,9 @@ def module_yum_repo2(module_product):
 
 
 @pytest.fixture(scope='module')
-def module_rh_repo(module_org):
+def module_rh_repo(module_org, module_target_sat):
     manifests.upload_manifest_locked(module_org.id, manifests.clone())
-    rhst = SatelliteToolsRepository(cdn=True)
+    rhst = module_target_sat.cli_factory.SatelliteToolsRepository(cdn=True)
     repo_id = enable_rhrepo_and_fetchid(
         basearch=rhst.data['arch'],
         org_id=module_org.id,

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -42,10 +42,6 @@ from robottelo.constants.repos import ANSIBLE_GALAXY
 from robottelo.datafactory import gen_string
 from robottelo.helpers import read_data_file
 from robottelo.hosts import get_sat_version
-from robottelo.products import SatelliteToolsRepository
-
-# from robottelo.constants.repos import FEDORA26_OSTREE_REPO
-# from robottelo.constants.repos import FEDORA27_OSTREE_REPO
 
 
 @pytest.fixture(scope='module')
@@ -718,7 +714,7 @@ def test_positive_sync_ansible_collection_gallaxy_repo(session, module_prod):
 
 
 @pytest.mark.tier2
-def test_positive_reposet_disable(session):
+def test_positive_reposet_disable(session, target_sat):
     """Enable RH repo, sync it and then disable
 
     :id: de596c56-1327-49e8-86d5-a1ab907f26aa
@@ -729,7 +725,7 @@ def test_positive_reposet_disable(session):
     """
     org = entities.Organization().create()
     manifests.upload_manifest_locked(org.id)
-    sat_tools_repo = SatelliteToolsRepository(distro=DISTRO_RHEL7, cdn=True)
+    sat_tools_repo = target_sat.cli_factory.SatelliteToolsRepository(distro=DISTRO_RHEL7, cdn=True)
     repository_name = sat_tools_repo.data['repository']
     with session:
         session.organization.select(org.name)
@@ -759,7 +755,7 @@ def test_positive_reposet_disable(session):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
-def test_positive_reposet_disable_after_manifest_deleted(session):
+def test_positive_reposet_disable_after_manifest_deleted(session, target_sat):
     """Enable RH repo and sync it. Remove manifest and then disable
     repository
 
@@ -776,7 +772,7 @@ def test_positive_reposet_disable_after_manifest_deleted(session):
     org = entities.Organization().create()
     manifests.upload_manifest_locked(org.id)
     sub = entities.Subscription(organization=org)
-    sat_tools_repo = SatelliteToolsRepository(distro=DISTRO_RHEL7, cdn=True)
+    sat_tools_repo = target_sat.cli_factory.SatelliteToolsRepository(distro=DISTRO_RHEL7, cdn=True)
     repository_name = sat_tools_repo.data['repository']
     repository_name_orphaned = f'{repository_name} (Orphaned)'
     with session:
@@ -843,7 +839,7 @@ def test_positive_delete_random_docker_repo(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_delete_rhel_repo(session, module_org):
+def test_positive_delete_rhel_repo(session, module_org, target_sat):
     """Enable and sync a Red Hat Repository, and then delete it
 
     :id: e96f369d-3e58-4824-802e-0b7e99d6d207
@@ -858,7 +854,7 @@ def test_positive_delete_rhel_repo(session, module_org):
     """
 
     manifests.upload_manifest_locked(module_org.id)
-    sat_tools_repo = SatelliteToolsRepository(distro=DISTRO_RHEL7, cdn=True)
+    sat_tools_repo = target_sat.cli_factory.SatelliteToolsRepository(distro=DISTRO_RHEL7, cdn=True)
     repository_name = sat_tools_repo.data['repository']
     product_name = sat_tools_repo.data['product']
     with session:

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -37,8 +37,6 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.constants import VDC_SUBSCRIPTION_NAME
 from robottelo.constants import VIRT_WHO_HYPERVISOR_TYPES
-from robottelo.products import RepositoryCollection
-from robottelo.products import RHELAnsibleEngineRepository
 
 pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.skip_if_not_set('fake_manifest')]
 
@@ -298,8 +296,9 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, tar
     """
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
-    repos_collection = RepositoryCollection(
-        distro=DISTRO_RHEL7, repositories=[RHELAnsibleEngineRepository(cdn=True)]
+    repos_collection = target_sat.cli_factory.RepositoryCollection(
+        distro=DISTRO_RHEL7,
+        repositories=[target_sat.cli_factory.RHELAnsibleEngineRepository(cdn=True)],
     )
     product_name = repos_collection.rh_repos[0].data['product']
     repos_collection.setup_content(
@@ -359,7 +358,7 @@ def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthos
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
     provisioning_server = settings.libvirt.libvirt_hostname
-    rh_product_repository = RHELAnsibleEngineRepository(cdn=True)
+    rh_product_repository = target_sat.cli_factory.RHELAnsibleEngineRepository(cdn=True)
     product_name = rh_product_repository.data['product']
     # Create a new virt-who config
     virt_who_config = make_virt_who_config(

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -32,9 +32,6 @@ from robottelo.constants import REPO_TYPE
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.constants.repos import FEDORA27_OSTREE_REPO
-from robottelo.products import RepositoryCollection
-from robottelo.products import RHELCloudFormsTools
-from robottelo.products import SatelliteCapsuleRepository
 
 
 @pytest.fixture(scope='module')
@@ -76,7 +73,7 @@ def test_positive_sync_custom_repo(session, module_custom_product):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_sync_rh_repos(session, module_org_with_manifest):
+def test_positive_sync_rh_repos(session, target_sat, module_org_with_manifest):
     """Create Content RedHat Sync with two repos.
 
     :id: e30f6509-0b65-4bcc-a522-b4f3089d3911
@@ -85,10 +82,13 @@ def test_positive_sync_rh_repos(session, module_org_with_manifest):
 
     :CaseLevel: Integration
     """
-    repos = (SatelliteCapsuleRepository(cdn=True), RHELCloudFormsTools(cdn=True))
+    repos = (
+        target_sat.cli_factory.SatelliteCapsuleRepository(cdn=True),
+        target_sat.cli_factory.RHELCloudFormsTools(cdn=True),
+    )
     distros = [DISTRO_RHEL7, DISTRO_RHEL6]
     repo_collections = [
-        RepositoryCollection(distro=distro, repositories=[repo])
+        target_sat.cli_factory.RepositoryCollection(distro=distro, repositories=[repo])
         for distro, repo in zip(distros, repos)
     ]
     for repo_collection in repo_collections:


### PR DESCRIPTION
The PR contains:

- [x] Helper classes from `robottelo/products.py` are moved under `robottelo/host_helpers/repository_mixins.py`.
- [x] The helper classes from `robottelo/host_helpers/repository_mixins.py` are added to the cli_factory object so that repository helpers can be accessed from any sat object. E.g YumRepository can now be accessed as  `sat.cli_factory.YumRepository()`.
- [x] Since all the repo classes are mostly being used in the `RepositoryCollection` class, created the `repos_collection` fixture so that tests can use it with parameters. Also, some module-level fixtures are being created based on the usage in tests.
- [x] The test cases and some fixtures earlier using repo helpers from product.py are now moved to either use helpers from sat object or use fixtures depending on the test.
- [x] Extra: Constants and Error classes are moved to `constants.py` and `errors.py` respectively .
- [x] Docstrings for fixtures added for component owners to understand its usage.
- [x] Removed the `robottelo.products` module.
- [ ] **Pending (Will be done in separate PR)** : Move all repo helpers to use API endpoint from current CLI endpoint as per the facts gathering done for repo helpers usage. All the tests then will use repo helpers from `sat.api_factory` and `repo_collection` fixture will be using api endpoint.