### PR TITLE
Sanitize junit xml from escape sequences

### DIFF
--- a/scripts/polarion-test-run-upload.sh
+++ b/scripts/polarion-test-run-upload.sh
@@ -71,6 +71,7 @@ POLARION_SELECTOR="name=Satellite 6"
 TEST_RUN_GROUP_ID="$(echo ${TEST_RUN_ID} | cut -d' ' -f2 | cut -d'-' -f1)"
 
 set -x
+sed -i 's/\x1b/ESC/g' "${JUNIT_FILE}"
 betelgeuse ${TOKEN_PREFIX} test-run \
     --custom-fields "isautomated=true" \
     --custom-fields "arch=x8664" \


### PR DESCRIPTION
Colored installer output (default) corrupts Junit XML file with binary chars used in escape sequences.

Fixes:
```
+ betelgeuse test-run --custom-fields isautomated=true --custom-fields arch=x8664 --custom-fields variant=server --response-property 'name=Satellite 6' --test-run-title 'Satellite 6.11-15.0 rhel7 upgrade' --test-run-id 'Satellite 6.11-15.0 rhel7 upgrade' --test-run-group-id 6.11 --status inprogress upgrade-all-tiers-results.xml tests/foreman rhsat6_machine RHSAT6 upgrade-all-tiers-results.xml
Traceback (most recent call last):
  File "/opt/app-root/bin/betelgeuse", line 8, in <module>
    sys.exit(cli())
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/opt/app-root/lib64/python3.8/site-packages/betelgeuse/__init__.py", line 841, in test_run
    testsuite = ElementTree.parse(junit_path).getroot()
  File "/usr/lib64/python3.8/xml/etree/ElementTree.py", line 1202, in parse
    tree.parse(source, parser)
  File "/usr/lib64/python3.8/xml/etree/ElementTree.py", line 595, in parse
    self._root = parser._parse_whole(source)
xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 109225, column 913
```