### PR TITLE
Test fixes for CR-GCE

### DIFF
--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -8,6 +8,7 @@ from nailgun import entities
 from wrapanapi.systems.google import GoogleCloudSystem
 
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_PTABLE
 from robottelo.errors import GCECertNotFoundError
 
 
@@ -20,6 +21,21 @@ def gce_cert(default_sat):
         json.dump(cert, f)
     default_sat.put(gce_cert_file, settings.gce.cert_path)
     if default_sat.execute(f'[ -f {settings.gce.cert_path} ]').status != 0:
+        raise GCECertNotFoundError(
+            f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
+        )
+    return cert
+
+
+@pytest.fixture(scope='session')
+def gce_cert_puppet(session_puppet_enabled_sat):
+    _, gce_cert_file = mkstemp(suffix='.json')
+    cert = json.loads(settings.gce.cert)
+    cert['local_path'] = gce_cert_file
+    with open(gce_cert_file, 'w') as f:
+        json.dump(cert, f)
+    session_puppet_enabled_sat.put(gce_cert_file, settings.gce.cert_path)
+    if session_puppet_enabled_sat.execute(f'[ -f {settings.gce.cert_path} ]').status != 0:
         raise GCECertNotFoundError(
             f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
         )
@@ -65,3 +81,30 @@ def module_gce_compute(module_org, module_location, gce_cert):
         location=[module_location],
     ).create()
     return gce_cr
+
+
+@pytest.fixture(scope='module')
+def module_gce_compute_puppet(
+    session_puppet_enabled_sat, module_puppet_org, module_puppet_loc, gce_cert_puppet
+):
+    gce_cr = session_puppet_enabled_sat.api.GCEComputeResource(
+        name=gen_string('alphanumeric'),
+        provider='GCE',
+        email=gce_cert_puppet['client_email'],
+        key_path=settings.gce.cert_path,
+        project=gce_cert_puppet['project_id'],
+        zone=settings.gce.zone,
+        organization=[module_puppet_org],
+        location=[module_puppet_loc],
+    ).create()
+    return gce_cr
+
+
+@pytest.fixture(scope='session')
+def session_puppet_default_partition_table(session_puppet_enabled_sat):
+    ptable = (
+        session_puppet_enabled_sat.api.PartitionTable()
+        .search(query={'search': f'name="{DEFAULT_PTABLE}"'})[0]
+        .read()
+    )
+    return ptable

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -36,7 +36,7 @@ def gce_cert_puppet(session_puppet_enabled_sat):
         json.dump(cert, f)
     session_puppet_enabled_sat.put(gce_cert_file, settings.gce.cert_path)
     if session_puppet_enabled_sat.execute(f'[ -f {settings.gce.cert_path} ]').status != 0:
-        raise GCECertNotFoundError(
+        pytest.fail(
             f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
         )
     return cert

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -337,7 +337,6 @@ class TestGCEHostProvisioningTestCase:
 
         Later in tests this host will be used to perform assertions
         """
-        import ipdb;ipdb.set_trace()
         host = session_puppet_enabled_sat.api.Host(
             architecture=session_puppet_default_architecture,
             compute_attributes=self.compute_attrs,


### PR DESCRIPTION
**Test results**

```
pytest  tests/foreman/api/test_computeresource_gce.py::TestGCEHostProvisioningTestCase
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-7.1.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.12, services-2.2.1, mock-3.7.0, forked-1.3.0, ibutsu-2.0.2, cov-3.0.0, xdist-2.5.0
collected 3 items                                                                                                                                                                                                 

tests/foreman/api/test_computeresource_gce.py ...                                                                                                                                                           [100%]
=================================================================================== 3 passed, 3 warnings in 3020.45s (0:50:20) ====================================================================================
```