### PR TITLE
[6.9.z] Sanitize junit xml from escape sequences

### DIFF
--- a/scripts/polarion-test-run-upload.sh
+++ b/scripts/polarion-test-run-upload.sh
@@ -71,6 +71,7 @@ POLARION_SELECTOR="name=Satellite 6"
 TEST_RUN_GROUP_ID="$(echo ${TEST_RUN_ID} | cut -d' ' -f2 | cut -d'-' -f1)"
 
 set -x
+sed -i 's/\x1b/ESC/g' "${JUNIT_FILE}"
 betelgeuse ${TOKEN_PREFIX} test-run \
     --custom-fields "isautomated=true" \
     --custom-fields "arch=x8664" \


### PR DESCRIPTION
Cherrypicks #9501 to `6.9.z`