### PR TITLE
Fix for User tests

### DIFF
--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -750,7 +750,6 @@ class TestActiveDirectoryUser:
             entities.LibvirtComputeResource,
             entities.OVirtComputeResource,
             entities.VMWareComputeResource,
-            entities.ConfigGroup,
             entities.Errata,
             entities.OperatingSystem,
         ]:
@@ -872,7 +871,6 @@ class TestFreeIPAUser:
             entities.LibvirtComputeResource,
             entities.OVirtComputeResource,
             entities.VMWareComputeResource,
-            entities.ConfigGroup,
             entities.Errata,
             entities.OperatingSystem,
         ]:

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -51,7 +51,7 @@ def test_positive_end_to_end(session, default_sat, test_name, module_org, module
     password = gen_string('alpha')
     email = gen_email()
     description = gen_string('alphanumeric')
-    language = 'English (United States)'
+    language = 'en'
     timezone = '(GMT+00:00) UTC'
     role = default_sat.api.Role().create().name
     with session:


### PR DESCRIPTION
**`Test results:`**
```
$ pytest -k test_positive_access_entities_from_ldap_org_admin tests/foreman/api/test_user.py 
========================================= test session starts ====================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sganar/satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, forked-1.3.0, ibutsu-2.0.2, reportportal-5.0.11, cov-3.0.0, xdist-2.5.0
collected 144 items / 143 deselected / 1 selected                                                                                                                                                                                                                                        

tests/foreman/api/test_user.py .                                                                                                                                                                                                                                                   [100%]

================================== 1 passed, 143 deselected in 76.55s (0:01:16) ===============================================
```
```
$ pytest -k test_positive_access_entities_from_ipa_org_admin tests/foreman/api/test_user.py 
======================================== test session starts ======================================================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sganar/satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, forked-1.3.0, ibutsu-2.0.2, reportportal-5.0.11, cov-3.0.0, xdist-2.5.0
collected 144 items / 143 deselected / 1 selected                                                                                                                                                                                                                                        

tests/foreman/api/test_user.py .                                                                                                                                                                                                                                                   [100%]

=================================== 1 passed, 143 deselected in 61.98s (0:01:01) =================================================================
```
```
$ pytest -k test_positive_end_to_end tests/foreman/ui/test_user.py 
======================================= test session starts ===========================================================
platform linux -- Python 3.8.6, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sganar/satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, forked-1.3.0, ibutsu-2.0.2, reportportal-5.0.11, cov-3.0.0, xdist-2.5.0
collected 11 items / 10 deselected / 1 selected                                                                                                                                                                                                                                          

tests/foreman/ui/test_user.py .                                                                                                                                                                                                                                                    [100%]

================================= 1 passed, 10 deselected in 606.41s (0:10:06) ===========================================
```
Depends on : https://github.com/SatelliteQE/airgun/pull/689