### PR TITLE
Downgrade dynaconf

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 broker==0.1.35
 cryptography==36.0.2
 deepdiff==5.8.0
-dynaconf==3.1.8
+dynaconf==3.1.7
 fauxfactory==3.1.0
 Inflector==3.0.1
 jinja2==3.1.1


### PR DESCRIPTION
3.1.8 included dynaconf PR 729, which broke our envvar loading pattern.

The issue with 3.1.8 needs to be sorted, and the upgraded package can
come in with robottelo PR #9435