### PR TITLE
Add tests for puppet availability on upgraded setup

### DIFF
--- a/robottelo/cli/report.py
+++ b/robottelo/cli/report.py
@@ -1,7 +1,7 @@
 """
 Usage::
 
-    hammer report [OPTIONS] SUBCOMMAND [ARG] ...
+    hammer config-report [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters::
 
@@ -18,9 +18,9 @@ Subcommands::
 from robottelo.cli.base import Base
 
 
-class Report(Base):
+class ConfigReport(Base):
     """
-    Manipulates Foreman's reports.
+    Manipulates Foreman's config reports.
     """
 
-    command_base = 'report'
+    command_base = 'config-report'

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -21,7 +21,7 @@ import random
 import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.report import Report
+from robottelo.cli.report import ConfigReport
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -43,11 +43,11 @@ def test_positive_info():
 
     :CaseImportance: Critical
     """
-    result = Report.list()
+    result = ConfigReport.list()
     assert len(result) > 0
     # Grab a random report
     report = random.choice(result)
-    result = Report.info({'id': report['id']})
+    result = ConfigReport.info({'id': report['id']})
     assert report['id'] == result['id']
 
 
@@ -62,10 +62,10 @@ def test_positive_delete_by_id():
 
     :CaseImportance: Critical
     """
-    result = Report.list()
+    result = ConfigReport.list()
     assert len(result) > 0
     # Grab a random report
     report = random.choice(result)
-    Report.delete({'id': report['id']})
+    ConfigReport.delete({'id': report['id']})
     with pytest.raises(CLIReturnCodeError):
-        Report.info({'id': report['id']})
+        ConfigReport.info({'id': report['id']})

--- a/tests/upgrades/test_puppet.py
+++ b/tests/upgrades/test_puppet.py
@@ -1,0 +1,89 @@
+"""Test for Remote Execution related Upgrade Scenario's
+
+:Requirement: UpgradedSatellite
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Puppet
+
+:Assignee: vsedmik
+
+:TestType: Functional
+
+:CaseImportance: Medium
+
+:Upstream: No
+"""
+import pytest
+
+from robottelo.config import settings
+from robottelo.hosts import Capsule
+
+
+@pytest.fixture(scope='module', params=[True, False], ids=["satellite", "capsule"])
+def upgrade_server(request, default_sat):
+    if request.param:
+        return default_sat
+    else:
+        return Capsule(settings.upgrade.capsule_hostname)
+
+
+class TestPuppet:
+    """
+    Test puppet availability on the upgraded setup.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_post_puppet_active(self, upgrade_server):
+        """Test that puppet remains active after the upgrade on both,
+        Satellite and Capsule.
+
+        :id: postupgrade-6360e928-ba0f-41a7-9aaa-bea87cb6342d
+
+        :steps:
+            1. Check for capsule features.
+            2. Check for puppetserver status.
+
+        :expectedresults:
+            1. Puppet and Puppetca features are enabled.
+            2. Puppetserver is installed and runnning.
+
+        :parametrized: yes
+
+        """
+        result = upgrade_server.get_features()
+        assert 'puppet' in result
+        assert 'puppetca' in result
+
+        result = upgrade_server.execute('rpm -q puppetserver')
+        assert result.status == 0
+
+        result = upgrade_server.execute('systemctl status puppetserver')
+        assert 'active (running)' in result.stdout
+
+    @pytest.mark.post_upgrade
+    def test_post_puppet_reporting(self, default_sat):
+        """Test that puppet is reporting to Satellite after the upgrade.
+
+        :id:   postupgrade-cdc4f6cc-23d8-4b4a-bd94-5c86b3072828
+
+        :steps:
+            1. Run puppet agent on the registered Capsule.
+            2. On Satellite, read puppet-originated Config reports for the Capsule host.
+
+        :expectedresults:
+            1. Puppet agent run succeeds.
+            2. At least one Config report exists (was created) for the Capsule.
+
+        """
+        default_caps = Capsule(settings.upgrade.capsule_hostname)
+
+        result = default_caps.execute('puppet agent -t')
+        assert result.status == 0
+
+        result = default_sat.cli.ConfigReport.list(
+            {'search': f'host={default_caps.hostname},origin=Puppet'}
+        )
+        assert len(result)


### PR DESCRIPTION
Puppet is supposed to remain enabled on the upgraded setup, so I'm adding tests to check it in upgrades.
I've also updated Report to ConfigReport in CLI as the original is deprecated:
```
[root@sat ~]# hammer report --help
report command is deprecated and will be removed in one of the future versions. Please use config-report command instead.
```

Tests results against upgraded setup:
```
(venv39) [vsedmik@localhost robottelo]$ pytest -m post_upgrade tests/upgrades/test_puppet.py
================================================================================= test session starts =================================================================================
platform linux -- Python 3.9.9, pytest-7.1.1, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, mock-3.7.0, lazy-fixture-0.6.3, ibutsu-2.0.2, xdist-2.5.0, reportportal-5.0.12
collected 3 items                                                                                                                                                                     

tests/upgrades/test_puppet.py ...                                                                                                                                               [100%]

============================================================================ 3 passed, 1 warning in 29.50s ============================================================================
```