### PR TITLE
Test fix for container management-content

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2492,7 +2492,6 @@ class TestTokenAuthContainerRepository:
         """
         container_repo = getattr(settings.container_repo.registries, repo_key)
         for docker_repo_name in container_repo.repos_to_sync:
-
             repo_options = dict(
                 content_type='docker',
                 docker_upstream_name=docker_repo_name,
@@ -2500,7 +2499,7 @@ class TestTokenAuthContainerRepository:
                 upstream_username=container_repo.username,
                 upstream_password=container_repo.password,
                 url=container_repo.url,
-                docker_tags_whitelist=['latest'],
+                include_tags=['latest'],
             )
             repo_options['organization'] = module_org
             repo_options['product'] = module_product


### PR DESCRIPTION
Fixes the issue of whitelisting the tags 
Nailgun PR  - https://github.com/SatelliteQE/nailgun/pull/828

`Test results`

```
pytest -k test_positive_tag_whitelist tests/foreman/api/test_repository.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-7.1.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.12, services-2.2.1, mock-3.7.0, forked-1.3.0, ibutsu-2.0.2, cov-3.0.0, xdist-2.5.0
collected 163 items / 161 deselected / 2 selected                                                                                                                                                                 

tests/foreman/api/test_repository.py ..                                                                                                                                                                     [100%]

============================================================================ 2 passed, 161 deselected, 6 warnings in 103.03s (0:01:43) ============================================================================

```
