### PR TITLE
Solved an issue with Satellite objects modifying classes

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1237,7 +1237,9 @@ class Satellite(Capsule, SatelliteMixins):
         for name, obj in entities.__dict__.items():
             try:
                 if Entity in obj.mro():
-                    setattr(self._api, name, inject_config(obj, self.nailgun_cfg))
+                    #  create a copy of the class and inject our server config into the __init__
+                    new_cls = type(name, (obj,), {})
+                    setattr(self._api, name, inject_config(new_cls, self.nailgun_cfg))
             except AttributeError:
                 # not everything has an mro method, we don't care about them
                 pass
@@ -1260,9 +1262,9 @@ class Satellite(Capsule, SatelliteMixins):
                 for name, obj in cli_module.__dict__.items():
                     try:
                         if Base in obj.mro():
-                            # set our hostname as a class attribute
-                            obj.hostname = self.hostname
-                            setattr(self._cli, name, obj)
+                            # create a copy of the class and set our hostname as a class attribute
+                            new_cls = type(name, (obj,), {'hostname': self.hostname})
+                            setattr(self._cli, name, new_cls)
                     except AttributeError:
                         # not everything has an mro method, we don't care about them
                         pass


### PR DESCRIPTION
The Satellite object's api and cli attributes nest entity classes from
their respective places. These classes were intended to provide
isolation between the main testing satellite and Satellite object
instances.
However, the previous implementation modified the entity classes that
the rest of the framework used as well instead of creating copies of the
classes specific to that Satellite object.
This change fixes that by copying the classes (through on-demand
subclassing) to ensure there is true isolation.