### PR TITLE
Remove libvirt_discovery tag for whole module

### DIFF
--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -48,8 +48,6 @@ from robottelo.constants import FOREMAN_PROVIDERS
 from robottelo.constants import LIBVIRT_RESOURCE_URL
 from robottelo.datafactory import parametrized
 
-pytestmark = pytest.mark.libvirt_discovery
-
 
 def valid_name_desc_data():
     """Random data for valid name and description"""


### PR DESCRIPTION
These tests should never have been marked as libvirt_discovery because they are not discovery tests