### PR TITLE
Fix list comprehension of org help command

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -86,15 +86,15 @@ def test_verify_bugzilla_1078866():
     # org list --help:
     result = Org.list({'help': True}, output_format=None)
     # get list of lines and check they all are unique
-    lines = [line for line in result if line != '' and '----' not in line]
+    lines = [line.strip() for line in result.splitlines() if line and '----' not in line]
     assert len(set(lines)) == len(lines)
 
     # org info --help:info returns more lines (obviously), ignore exception
     result = Org.info({'help': True}, output_format=None)
 
     # get list of lines and check they all are unique
-    lines = [line for line in result['options']]
-    assert len(set(lines)) == len(lines)
+    lines = [line for line in result['options'] if '----' not in line]
+    assert len(set(lines)) == len(lines) - 1
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
The org list command has been failing due to list comprehension.

Note that line 97 uses `len(lines) - 1` to account for `description` appearing twice, but in separate section so it's still valid.  Not sure how to handle that or to just completely remove it from the list.  Any thought is appreciated.

Result:
```
pytest tests/foreman/cli/test_organization.py -k test_verify_bugzilla_1078866
================= 1 passed, 36 deselected in 17.89s ============
```