### PR TITLE
Update virt-who cases to default_org

### DIFF
--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -31,14 +31,14 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(module_manifest_org, default_sat):
+def form_data(default_org, default_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
         'interval': '60',
         'hypervisor_id': 'hostname',
         'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization_id': module_manifest_org.id,
+        'organization_id': default_org.id,
         'filtering_mode': 'none',
         'satellite_url': default_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
@@ -54,7 +54,7 @@ def virtwho_config(form_data):
 @pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
         :id: 97f776af-cbd0-4885-9a74-603a3bc01157
@@ -66,9 +66,9 @@ class TestVirtWhoConfigforKubevirt:
         :CaseImportance: High
         """
         assert virtwho_config.status == 'unknown'
-        command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+        command = get_configure_command(virtwho_config.id, default_org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
+            command, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
         virt_who_instance = (
             entities.VirtWhoConfig()
@@ -88,9 +88,7 @@ class TestVirtWhoConfigforKubevirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list(
-                {'organization': module_manifest_org.label, 'search': sku}
-            )
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -106,9 +104,7 @@ class TestVirtWhoConfigforKubevirt:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, module_manifest_org, form_data, virtwho_config
-    ):
+    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
         """Verify "GET /foreman_virt_who_configure/api/
 
         v2/configs/:id/deploy_script"
@@ -127,7 +123,7 @@ class TestVirtWhoConfigforKubevirt:
             script['virt_who_config_script'],
             form_data['hypervisor-type'],
             debug=True,
-            org=module_manifest_org.label,
+            org=default_org.label,
         )
         virt_who_instance = (
             entities.VirtWhoConfig()
@@ -147,9 +143,7 @@ class TestVirtWhoConfigforKubevirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list(
-                {'organization': module_manifest_org.label, 'search': sku}
-            )
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -165,7 +159,7 @@ class TestVirtWhoConfigforKubevirt:
         assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
         """Verify hypervisor_id option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -183,9 +177,9 @@ class TestVirtWhoConfigforKubevirt:
             virtwho_config.hypervisor_id = value
             virtwho_config.update(['hypervisor_id'])
             config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_manifest_org.label)
+            command = get_configure_command(virtwho_config.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_manifest_org.label
+                command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
         virtwho_config.delete()

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, module_manifest_org):
+def form_data(default_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -39,7 +39,7 @@ def form_data(default_sat, module_manifest_org):
         'hypervisor-id': 'hostname',
         'hypervisor-type': settings.virtwho.hyperv.hypervisor_type,
         'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
-        'organization-id': module_manifest_org.id,
+        'organization-id': default_org.id,
         'filtering-mode': 'none',
         'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
@@ -55,7 +55,7 @@ def virtwho_config(form_data):
 
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
         :id: 7cc0ad4f-e185-4d63-a2f5-1cb0245faa6c
@@ -67,9 +67,9 @@ class TestVirtWhoConfigforHyperv:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+        command = get_configure_command(virtwho_config['id'], default_org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
+            command, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -81,9 +81,7 @@ class TestVirtWhoConfigforHyperv:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list(
-                {'organization': module_manifest_org.label, 'search': sku}
-            )
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -96,9 +94,7 @@ class TestVirtWhoConfigforHyperv:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, module_manifest_org, form_data, virtwho_config
-    ):
+    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
         :id: 22dc8068-c843-4ca0-acbe-0b2aef8ece31
@@ -112,7 +108,7 @@ class TestVirtWhoConfigforHyperv:
         assert virtwho_config['status'] == 'No Report Yet'
         script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
+            script, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -124,9 +120,7 @@ class TestVirtWhoConfigforHyperv:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list(
-                {'organization': module_manifest_org.label, 'search': sku}
-            )
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -139,7 +133,7 @@ class TestVirtWhoConfigforHyperv:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 8e234492-33cb-4523-abb3-582626ad704c
@@ -156,9 +150,9 @@ class TestVirtWhoConfigforHyperv:
             result = VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+            command = get_configure_command(virtwho_config['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_manifest_org.label
+                command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -31,14 +31,14 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, module_manifest_org):
+def form_data(default_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
         'interval': '60',
         'hypervisor-id': 'hostname',
         'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization-id': module_manifest_org.id,
+        'organization-id': default_org.id,
         'filtering-mode': 'none',
         'satellite-url': default_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
@@ -54,7 +54,7 @@ def virtwho_config(form_data):
 @pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
         :id: d0b109f5-2699-43e4-a6cd-d682204d97a7
@@ -66,9 +66,9 @@ class TestVirtWhoConfigforKubevirt:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+        command = get_configure_command(virtwho_config['id'], default_org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
+            command, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -80,9 +80,7 @@ class TestVirtWhoConfigforKubevirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list(
-                {'organization': module_manifest_org.label, 'search': sku}
-            )
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -95,9 +93,7 @@ class TestVirtWhoConfigforKubevirt:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, module_manifest_org, form_data, virtwho_config
-    ):
+    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
         :id: 273df8e0-5ef5-47d9-9567-543157be7dd8
@@ -111,7 +107,7 @@ class TestVirtWhoConfigforKubevirt:
         assert virtwho_config['status'] == 'No Report Yet'
         script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
+            script, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -123,9 +119,7 @@ class TestVirtWhoConfigforKubevirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list(
-                {'organization': module_manifest_org.label, 'search': sku}
-            )
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -138,7 +132,7 @@ class TestVirtWhoConfigforKubevirt:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 57b89c7e-538e-4ab8-98b5-af4b9f587792
@@ -155,9 +149,9 @@ class TestVirtWhoConfigforKubevirt:
             result = VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+            command = get_configure_command(virtwho_config['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_manifest_org.label
+                command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, module_manifest_org):
+def form_data(default_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -39,7 +39,7 @@ def form_data(default_sat, module_manifest_org):
         'hypervisor-id': 'hostname',
         'hypervisor-type': settings.virtwho.libvirt.hypervisor_type,
         'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
-        'organization-id': module_manifest_org.id,
+        'organization-id': default_org.id,
         'filtering-mode': 'none',
         'satellite-url': default_sat.hostname,
         'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
@@ -54,7 +54,7 @@ def virtwho_config(form_data):
 
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, module_manifest_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config deploy"
 
         :id: e66bf88a-bd4e-409a-91a8-bc5e005d95dd
@@ -66,9 +66,9 @@ class TestVirtWhoConfigforLibvirt:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+        command = get_configure_command(virtwho_config['id'], default_org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
+            command, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -80,9 +80,7 @@ class TestVirtWhoConfigforLibvirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list(
-                {'organization': module_manifest_org.label, 'search': sku}
-            )
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -95,9 +93,7 @@ class TestVirtWhoConfigforLibvirt:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, module_manifest_org, form_data, virtwho_config
-    ):
+    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
         """Verify " hammer virt-who-config fetch"
 
         :id: bd5c52ab-3dbd-4cf1-9837-b8eb6233f1cd
@@ -111,7 +107,7 @@ class TestVirtWhoConfigforLibvirt:
         assert virtwho_config['status'] == 'No Report Yet'
         script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
         hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True, org=module_manifest_org.label
+            script, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
         virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
             'status'
@@ -123,9 +119,7 @@ class TestVirtWhoConfigforLibvirt:
         ]
         for hostname, sku in hosts:
             host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list(
-                {'organization': module_manifest_org.label, 'search': sku}
-            )
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
@@ -138,7 +132,7 @@ class TestVirtWhoConfigforLibvirt:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, module_manifest_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 082a0eec-f024-4605-b876-a8959cf68e0c
@@ -155,9 +149,9 @@ class TestVirtWhoConfigforLibvirt:
             result = VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_manifest_org.label)
+            command = get_configure_command(virtwho_config['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_manifest_org.label
+                command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -7,7 +7,7 @@ from robottelo.logging import logger
 
 
 @pytest.fixture(scope='module')
-def module_user(request, default_sat, module_manifest_org, default_location):
+def module_user(request, default_sat, default_org, default_location):
     """Creates admin user with default org set to module org and shares that
     user for all tests in the same test module. User's login contains test
     module name as a prefix.
@@ -21,7 +21,7 @@ def module_user(request, default_sat, module_manifest_org, default_location):
     logger.debug('Creating session user %r', login)
     user = default_sat.api.User(
         admin=True,
-        default_organization=module_manifest_org,
+        default_organization=default_org,
         default_location=default_location,
         description=f'created automatically by airgun for module "{test_module_name}"',
         login=login,

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -55,7 +55,7 @@ def form_data():
 
 class TestVirtwhoConfigforEsx:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, module_manifest_org, session, form_data):
+    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: 44f93ec8-a59a-42a4-ab30-edc554b022b2
@@ -78,7 +78,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(name)
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -92,7 +92,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, module_manifest_org, session, form_data):
+    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
         """Verify configure created and deployed with script.
 
         :id: d64332fb-a6e0-4864-9f8b-2406223fcdcc
@@ -115,7 +115,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(name)
             script = values['deploy']['script']
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -129,7 +129,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_debug_option(self, module_manifest_org, session, form_data):
+    def test_positive_debug_option(self, default_org, session, form_data):
         """Verify debug checkbox and the value changes of VIRTWHO_DEBUG
 
         :id: adb435c4-d02b-47b6-89f5-dce9a4ff7939
@@ -147,23 +147,23 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                config_command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '1'
             session.virtwho_configure.edit(name, {'debug': False})
             results = session.virtwho_configure.read(name)
             assert results['overview']['debug'] is False
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                config_command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '0'
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_interval_option(self, module_manifest_org, session, form_data):
+    def test_positive_interval_option(self, default_org, session, form_data):
         """Verify interval dropdown options and the value changes of VIRTWHO_INTERVAL.
 
         :id: 731f8361-38d4-40b9-9530-8d785d61eaab
@@ -181,7 +181,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             intervals = {
                 'Every hour': '3600',
                 'Every 2 hours': '7200',
@@ -197,14 +197,14 @@ class TestVirtwhoConfigforEsx:
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['interval'] == option
                 deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                    config_command, form_data['hypervisor_type'], org=default_org.label
                 )
                 assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, module_manifest_org, session, form_data):
+    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: cc494bd9-51d9-452a-bfa9-5cdcafef5197
@@ -222,7 +222,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             # esx and rhevm support hwuuid option
             values = ['uuid', 'hostname', 'hwuuid']
@@ -231,14 +231,14 @@ class TestVirtwhoConfigforEsx:
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['hypervisor_id'] == value
                 deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                    config_command, form_data['hypervisor_type'], org=default_org.label
                 )
                 assert get_configure_option('hypervisor_id', config_file) == value
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_filtering_option(self, module_manifest_org, session, form_data):
+    def test_positive_filtering_option(self, default_org, session, form_data):
         """Verify Filtering dropdown options.
 
         :id: e17dda14-79cd-4cd2-8f29-60970b24a905
@@ -258,7 +258,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             regex = '.*redhat.com'
             whitelist = {'filtering': 'Whitelist', 'filtering_content.filter_hosts': regex}
@@ -272,7 +272,7 @@ class TestVirtwhoConfigforEsx:
             assert results['overview']['filter_hosts'] == regex
             assert results['overview']['filter_host_parents'] == regex
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                config_command, form_data['hypervisor_type'], org=default_org.label
             )
             assert regex == get_configure_option('filter_hosts', config_file)
             assert regex == get_configure_option('filter_host_parents', config_file)
@@ -282,7 +282,7 @@ class TestVirtwhoConfigforEsx:
             assert results['overview']['exclude_hosts'] == regex
             assert results['overview']['exclude_host_parents'] == regex
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                config_command, form_data['hypervisor_type'], org=default_org.label
             )
             assert regex == get_configure_option('exclude_hosts', config_file)
             assert regex == get_configure_option('exclude_host_parents', config_file)
@@ -290,7 +290,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, module_manifest_org, session, form_data):
+    def test_positive_proxy_option(self, default_org, session, form_data):
         """Verify 'HTTP Proxy' and 'Ignore Proxy' options.
 
         :id: 6659d577-0135-4bf0-81af-14b930011536
@@ -302,16 +302,16 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        https_proxy, https_proxy_name, https_proxy_id = create_http_proxy(org=module_manifest_org)
+        https_proxy, https_proxy_name, https_proxy_id = create_http_proxy(org=default_org)
         http_proxy, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org=module_manifest_org
+            http_type='http', org=default_org
         )
         name = gen_string('alpha')
         form_data['name'] = name
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             no_proxy = 'test.satellite.com'
             # Check the https proxy and No_PROXY settings
             session.virtwho_configure.edit(name, {'proxy': https_proxy, 'no_proxy': no_proxy})
@@ -319,7 +319,7 @@ class TestVirtwhoConfigforEsx:
             assert results['overview']['proxy'] == https_proxy
             assert results['overview']['no_proxy'] == no_proxy
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                config_command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy
             assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
@@ -328,7 +328,7 @@ class TestVirtwhoConfigforEsx:
             results = session.virtwho_configure.read(name)
             assert results['overview']['proxy'] == http_proxy
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                config_command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy
             session.virtwho_configure.delete(name)
@@ -370,7 +370,7 @@ class TestVirtwhoConfigforEsx:
                 assert sorted(assigned_permissions) == sorted(role_filters)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_configs_widget(self, module_manifest_org, session, form_data):
+    def test_positive_virtwho_configs_widget(self, default_org, session, form_data):
         """Check if Virt-who Configurations Status Widget is working in the Dashboard UI
 
         :id: 5d61ce00-a640-4823-89d4-7b1d02b50ea6
@@ -405,9 +405,9 @@ class TestVirtwhoConfigforEsx:
             assert values['latest_config'] == 'No configuration found'
             # Check the 'Status' changed after deployed the virt-who config
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                config_command, form_data['hypervisor_type'], org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             expected_values = [
@@ -425,7 +425,7 @@ class TestVirtwhoConfigforEsx:
             session.organization.delete(org_name)
 
     @pytest.mark.tier2
-    def test_positive_delete_configure(self, module_manifest_org, session, form_data):
+    def test_positive_delete_configure(self, default_org, session, form_data):
         """Verify when a config is deleted the associated user is deleted.
 
         :id: 0e66dcf6-dc64-4fb2-b8a9-518f5adfa800
@@ -445,9 +445,9 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                config_command, form_data['hypervisor_type'], org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             session.virtwho_configure.delete(name)
@@ -456,9 +456,7 @@ class TestVirtwhoConfigforEsx:
             assert get_virtwho_status() == 'logerror'
 
     @pytest.mark.tier2
-    def test_positive_virtwho_reporter_role(
-        self, module_manifest_org, session, test_name, form_data
-    ):
+    def test_positive_virtwho_reporter_role(self, default_org, session, test_name, form_data):
         """Verify the virt-who reporter role can TRULY work.
 
         :id: cd235ab0-d89c-464b-98d6-9d090ac40d8f
@@ -488,7 +486,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_manifest_org.label
+                command, form_data['hypervisor_type'], org=default_org.label
             )
             assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Update the virt-who config file
@@ -512,7 +510,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_viewer_role(self, module_manifest_org, session, test_name, form_data):
+    def test_positive_virtwho_viewer_role(self, default_org, session, test_name, form_data):
         """Verify the virt-who viewer role can TRULY work.
 
         :id: bf3be2e4-3853-41cc-9b3e-c8677f0b8c5f
@@ -542,7 +540,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_manifest_org.label
+                command, form_data['hypervisor_type'], org=default_org.label
             )
             assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Check the permissioin of Virt-who Viewer
@@ -572,9 +570,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_manager_role(
-        self, module_manifest_org, session, test_name, form_data
-    ):
+    def test_positive_virtwho_manager_role(self, default_org, session, test_name, form_data):
         """Verify the virt-who manager role can TRULY work.
 
         :id: a72023fb-7b23-4582-9adc-c5227dc7859c
@@ -603,7 +599,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_manifest_org.label
+                command, form_data['hypervisor_type'], org=default_org.label
             )
             assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Check the permissioin of Virt-who Manager
@@ -619,7 +615,7 @@ class TestVirtwhoConfigforEsx:
                 values = newsession.virtwho_configure.read(new_virt_who_name)
                 command = values['deploy']['command']
                 deploy_configure_by_command(
-                    command, form_data['hypervisor_type'], org=module_manifest_org.label
+                    command, form_data['hypervisor_type'], org=default_org.label
                 )
                 assert newsession.virtwho_configure.search(new_virt_who_name)[0]['Status'] == 'ok'
                 # edit_virt_who_config
@@ -634,7 +630,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_overview_label_name(self, module_manifest_org, form_data, session):
+    def test_positive_overview_label_name(self, default_org, form_data, session):
         """Verify the label name on virt-who config Overview Page.
 
         :id: 21df8175-bb41-422e-a263-8677bc3a9565
@@ -650,7 +646,7 @@ class TestVirtwhoConfigforEsx:
         name = gen_string('alpha')
         form_data['name'] = name
         hypervisor_type = form_data['hypervisor_type']
-        http_proxy_url, proxy_name, proxy_id = create_http_proxy(org=module_manifest_org)
+        http_proxy_url, proxy_name, proxy_id = create_http_proxy(org=default_org)
         form_data['proxy'] = http_proxy_url
         form_data['no_proxy'] = 'test.satellite.com'
         regex = '.*redhat.com'
@@ -698,7 +694,7 @@ class TestVirtwhoConfigforEsx:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_last_checkin_status(self, module_manifest_org, form_data, session):
+    def test_positive_last_checkin_status(self, default_org, form_data, session):
         """Verify the Last Checkin status on Content Hosts Page.
 
         :id: 7448d482-d05c-4727-8980-176586e9e4a7
@@ -720,7 +716,7 @@ class TestVirtwhoConfigforEsx:
             values = session.virtwho_configure.read(name, widget_names='deploy.command')
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             time_now = session.browser.get_client_datetime()
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -44,7 +44,7 @@ def form_data():
 
 class TestVirtwhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, module_manifest_org, session, form_data):
+    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: 16f6d8c3-332d-4e36-bc19-028955b2bbc4
@@ -67,7 +67,7 @@ class TestVirtwhoConfigforHyperv:
             values = session.virtwho_configure.read(name)
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -81,7 +81,7 @@ class TestVirtwhoConfigforHyperv:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, module_manifest_org, session, form_data):
+    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
         """Verify configure created and deployed with script.
 
         :id: b0401417-3a6e-4a54-b8e8-22d290813da3
@@ -104,7 +104,7 @@ class TestVirtwhoConfigforHyperv:
             values = session.virtwho_configure.read(name)
             script = values['deploy']['script']
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -118,7 +118,7 @@ class TestVirtwhoConfigforHyperv:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, module_manifest_org, session, form_data):
+    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: f2efc018-d57e-4dc5-895e-53af320237de
@@ -136,7 +136,7 @@ class TestVirtwhoConfigforHyperv:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:
@@ -144,7 +144,7 @@ class TestVirtwhoConfigforHyperv:
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['hypervisor_id'] == value
                 deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                    config_command, form_data['hypervisor_type'], org=default_org.label
                 )
                 assert get_configure_option('hypervisor_id', config_file) == value
             session.virtwho_configure.delete(name)

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -42,7 +42,7 @@ def form_data():
 
 class TestVirtwhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, module_manifest_org, session, form_data):
+    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: 7b2a1b08-f33c-44f4-ad2e-317b6c44b938
@@ -65,7 +65,7 @@ class TestVirtwhoConfigforKubevirt:
             values = session.virtwho_configure.read(name)
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -79,7 +79,7 @@ class TestVirtwhoConfigforKubevirt:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, module_manifest_org, session, form_data):
+    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
         """Verify configure created and deployed with script.
 
         :id: b3903ccb-04cc-4867-b7ed-d5053d2bfe03
@@ -102,7 +102,7 @@ class TestVirtwhoConfigforKubevirt:
             values = session.virtwho_configure.read(name)
             script = values['deploy']['script']
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -116,7 +116,7 @@ class TestVirtwhoConfigforKubevirt:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, module_manifest_org, session, form_data):
+    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: 09826cc0-aa49-4355-8980-8097511eb7d7
@@ -134,7 +134,7 @@ class TestVirtwhoConfigforKubevirt:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:
@@ -142,7 +142,7 @@ class TestVirtwhoConfigforKubevirt:
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['hypervisor_id'] == value
                 deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                    config_command, form_data['hypervisor_type'], org=default_org.label
                 )
                 assert get_configure_option('hypervisor_id', config_file) == value
             session.virtwho_configure.delete(name)

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -43,7 +43,7 @@ def form_data():
 
 class TestVirtwhoConfigforLibvirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, module_manifest_org, session, form_data):
+    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: ae37ea79-f99c-4511-ace9-a7de26d6db40
@@ -66,7 +66,7 @@ class TestVirtwhoConfigforLibvirt:
             values = session.virtwho_configure.read(name)
             command = values['deploy']['command']
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -80,7 +80,7 @@ class TestVirtwhoConfigforLibvirt:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, module_manifest_org, session, form_data):
+    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
         """Verify configure created and deployed with script.
 
         :id: 3655a501-ab05-4724-945a-7f6e6878091d
@@ -103,7 +103,7 @@ class TestVirtwhoConfigforLibvirt:
             values = session.virtwho_configure.read(name)
             script = values['deploy']['script']
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=module_manifest_org.label
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
@@ -117,7 +117,7 @@ class TestVirtwhoConfigforLibvirt:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, module_manifest_org, session, form_data):
+    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: b8b2b272-89f2-45d0-b922-6e988b20808b
@@ -135,7 +135,7 @@ class TestVirtwhoConfigforLibvirt:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, module_manifest_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:
@@ -143,7 +143,7 @@ class TestVirtwhoConfigforLibvirt:
                 results = session.virtwho_configure.read(name)
                 assert results['overview']['hypervisor_id'] == value
                 deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=module_manifest_org.label
+                    config_command, form_data['hypervisor_type'], org=default_org.label
                 )
                 assert get_configure_option('hypervisor_id', config_file) == value
             session.virtwho_configure.delete(name)


### PR DESCRIPTION
As now virt-who cases are running in our env, we would like to update the org of the virt-who cases to default_organization, so that we can debug easier and the cases would be more stable, Many thank.

All test case passed for libvirt and hyperv , esx hypervisors