### PR TITLE
remove deploy_script to avoid affecting other deploy_configure_by_script

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -132,6 +132,7 @@ def virtwho_cleanup():
     runcmd("rm -f /var/run/virt-who.pid")
     runcmd("rm -f /var/log/rhsm/rhsm.log")
     runcmd("rm -rf /etc/virt-who.d/*")
+    runcmd("rm -rf /tmp/deploy_script.sh")
 
 
 def get_virtwho_status():


### PR DESCRIPTION
Hello,

To avoid not affecting the deploy_configure_by_script in other cases run, so add it in virtwho_cleanup() method.
Test Cases PASS: test_positive_deploy_configure_by_script for hypervisor libvirt/Esx/Hyperv

Thanks,
Yanping Liu