### PR TITLE
Assign location to the host when registering using subscription-manager

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -790,6 +790,7 @@ class ContentHost(Host, ContentHostMixins):
         self,
         satellite,
         org_label,
+        location_title=None,
         rh_repo_ids=None,
         repo_labels=None,
         product_label=None,
@@ -812,6 +813,8 @@ class ContentHost(Host, ContentHostMixins):
         """
         rh_repo_ids = rh_repo_ids or []
         repo_labels = repo_labels or []
+        if location_title:
+            self.set_facts({'locations.facts': {'foreman_location': str(location_title)}})
         self.install_katello_ca(satellite)
         result = self.register_contenthost(org_label, activation_key=activation_key, lce=lce)
         if not self.subscribed:

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -899,7 +899,7 @@ class RepositoryCollection:
         self,
         vm,
         satellite,
-        location=None,
+        location_title=None,
         patch_os_release=False,
         install_katello_agent=True,
         enable_rh_repos=True,
@@ -934,12 +934,10 @@ class RepositoryCollection:
                 repo['label'] for repo in self.custom_repos_info if repo['content-type'] == 'yum'
             ]
 
-        if location:
-            vm.set_facts({'locations.facts': {'foreman_location': str(location.name)}})
-
         vm.contenthost_setup(
             satellite,
             self.organization['label'],
+            location_title=location_title,
             rh_repo_ids=rh_repo_ids,
             repo_labels=repo_labels,
             product_label=self.custom_product['label'] if self.custom_product else None,

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -899,6 +899,7 @@ class RepositoryCollection:
         self,
         vm,
         satellite,
+        location=None,
         patch_os_release=False,
         install_katello_agent=True,
         enable_rh_repos=True,
@@ -932,6 +933,12 @@ class RepositoryCollection:
             repo_labels = [
                 repo['label'] for repo in self.custom_repos_info if repo['content-type'] == 'yum'
             ]
+
+        if location:
+            vm.execute(
+                f'echo {{\\"foreman_location\\":\\"{location.name}\\"}} '
+                '> /etc/rhsm/facts/location.facts'
+            )
 
         vm.contenthost_setup(
             satellite,

--- a/robottelo/products.py
+++ b/robottelo/products.py
@@ -935,10 +935,7 @@ class RepositoryCollection:
             ]
 
         if location:
-            vm.execute(
-                f'echo {{\\"foreman_location\\":\\"{location.name}\\"}} '
-                '> /etc/rhsm/facts/location.facts'
-            )
+            vm.set_facts({'locations.facts': {'foreman_location': str(location.name)}})
 
         vm.contenthost_setup(
             satellite,

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -250,7 +250,7 @@ def test_positive_user_access_with_host_filter(
         )
         repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
         repos_collection.setup_virtual_machine(
-            rhel7_contenthost, default_sat, location=module_location
+            rhel7_contenthost, default_sat, location_title=module_location.name
         )
         result = rhel7_contenthost.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
         assert result.status == 0

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -243,13 +243,15 @@ def test_positive_user_access_with_host_filter(
     ).create()
     with Session(test_name, user=user_login, password=user_password) as session:
         assert session.dashboard.read('HostConfigurationStatus')['total_count'] == 0
-        assert len(session.dashboard.read('LatestErrata')) == 0
+        assert len(session.dashboard.read('LatestErrata')['erratas']) == 0
         repos_collection = RepositoryCollection(
             distro=DISTRO_RHEL7,
             repositories=[SatelliteToolsRepository(), YumRepository(url=settings.repos.yum_6.url)],
         )
         repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
-        repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+        repos_collection.setup_virtual_machine(
+            rhel7_contenthost, default_sat, location=module_location
+        )
         result = rhel7_contenthost.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
         assert result.status == 0
         hostname = rhel7_contenthost.hostname


### PR DESCRIPTION
Host needs to be assigned to a location in order to be displayed on the
All Hosts page in the UI. There is no other way to assign the location
that would not require an extra call to the Satellite after the host is
registered.

The way I implemented it, RHSM just picks the custom fact and Satellite
honros it and assigns the host to the location.

Only thing I am not sure is the placement of the custom fact creation.
I am open to placing it anywhere else where it makes sense.

This PR needs to be merged along with SatelliteQE/airgun#691.

Thank you @LadislavVasina1 for helping me debugging it!

```
$ pytest tests/foreman/ui/test_dashboard.py::test_positive_user_access_with_host_filter[rhel7_contenthost0]============================================================= test session starts =============================================================
platform linux -- Python 3.10.2, pytest-7.1.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ogajduse/repos/robottelo, configfile: pyproject.toml
plugins: forked-1.4.0, xdist-2.5.0, services-2.2.1, reportportal-5.0.12, mock-3.7.0, ibutsu-2.0.2
collected 1 item

tests/foreman/ui/test_dashboard.py .                                                                                                    [100%]

============================================================== warnings summary ===============================================================
tests/foreman/ui/test_dashboard.py::test_positive_user_access_with_host_filter[rhel7_contenthost0]
  /home/ogajduse/.virtualenvs/robottelo/lib/python3.10/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: executable_path has been deprecated, please pass in a Service object
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== 1 passed, 1 warning in 687.69s (0:11:27) ===================================================
```