### PR TITLE
Fix cli user/usergroup tests

### DIFF
--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -58,7 +58,6 @@ class TestUser:
         saved on sat. roles is a dict so keys are role's id respective value is
         the role itself
         """
-        settings.configure()
         include_list = [gen_string("alphanumeric", 100)]
 
         def roles_helper():


### PR DESCRIPTION
`settings.configure` was used as a workaround for some configuration issues back then
This change fixes failing cli User and Usergroup tests 