### PR TITLE
[6.10 cherry-pick] Skipping manifest refresh tests/setup

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -57,7 +57,8 @@ def organization_ak_setup(rhcloud_sat_host, rhcloud_manifest_org):
         auto_attach=True,
     ).create()
     subscription = rhcloud_sat_host.api.Subscription(organization=rhcloud_manifest_org)
-    subscription.refresh_manifest(data={'organization_id': rhcloud_manifest_org.id})
+    # Disabling due to an issue with manifest refreshes. Is this refresh actually needed?
+    # subscription.refresh_manifest(data={'organization_id': rhcloud_manifest_org.id})
     default_subscription = subscription.search(
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -96,6 +96,7 @@ def test_positive_create():
         upload_manifest(org.id, manifest.content)
 
 
+@pytest.mark.skip('Skipping due to manifest refresh issues')
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier1
 def test_positive_refresh(request):
@@ -116,6 +117,7 @@ def test_positive_refresh(request):
     assert sub.search()
 
 
+@pytest.mark.skip('Skipping due to manifest refresh issues')
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier1
 def test_positive_create_after_refresh(function_org):

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -141,6 +141,7 @@ def test_positive_manifest_history(function_org, manifest_clone_upload):
     assert f'{function_org.name} file imported successfully.' in ''.join(history)
 
 
+@pytest.mark.skip('Skipping due to manifest refresh issues')
 @pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_manifest_refresh(function_org):

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -264,6 +264,7 @@ def test_positive_delete_with_manifest_lces(session):
         assert not session.organization.search(org.name)
 
 
+@pytest.mark.skip('Skipping due to manifest refresh issues')
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -36,6 +36,7 @@ class TestManifestScenarioRefresh:
     The scenario to test the refresh of a manifest created before upgrade.
     """
 
+    @pytest.mark.skip('Skipping due to manifest refresh issues')
     @pytest.mark.pre_upgrade
     def test_pre_manifest_scenario_refresh(self, request):
         """Before upgrade, upload & refresh the manifest.
@@ -57,6 +58,7 @@ class TestManifestScenarioRefresh:
         sub.refresh_manifest(data={'organization_id': org.id})
         assert len(sub.search()) > 0
 
+    @pytest.mark.skip('Skipping due to manifest refresh issues')
     @pytest.mark.post_upgrade(depend_on=test_pre_manifest_scenario_refresh)
     def test_post_manifest_scenario_refresh(self, request, dependent_scenario_name):
         """After upgrade, Check the manifest refresh and delete functionality.


### PR DESCRIPTION
Due to a change in the way manifests are handled in the portal, we need
to avoid refreshing manifests.
This change skips a number of tests and disables manifest refresh
behavior in a fixture that had dozens of downstream tests.