### PR TITLE
Add sleep time after get virtwho status to get the complete mapping info in rhsm.log

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -220,12 +220,12 @@ def _get_hypervisor_mapping(hypervisor_type):
     :raises: VirtWhoError: If hypervisor_name is None.
     :return: hypervisor_name and guest_name
     """
-    logs, _ = wait_for(
-        get_rhsm_log,
-        fail_condition=lambda logs: "Host-to-guest mapping being sent to" not in logs,
+    wait_for(
+        lambda: 'Host-to-guest mapping being sent to' in get_rhsm_log(),
         timeout=10,
         delay=2,
     )
+    logs = get_rhsm_log()
     mapping = list()
     entry = None
     guest_name, guest_uuid = get_guest_info(hypervisor_type)

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -140,7 +140,7 @@ def get_virtwho_status():
     """
     _, logs = runcmd('cat /var/log/rhsm/rhsm.log')
     error = len(re.findall(r'\[.*ERROR.*\]', logs))
-    ret, stdout = runcmd('systemctl status virt-who')
+    ret, stdout = runcmd('systemctl status virt-who; sleep 10')
     running_stauts = ['is running', 'Active: active (running)']
     stopped_status = ['is stopped', 'Active: inactive (dead)']
     if ret != 0:


### PR DESCRIPTION
Hey,
Will get the mapping info after get virtwho status, because of the network issue, it did not get the complete mapping info after restart virtwho immediately. so add sleep time can get the full mapping info.

Cases pass for hypervisor libvirt, esx, kubevirt, hyperv.