### PR TITLE
Replace default_org.label using default_org name

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -147,7 +147,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             deploy_configure_by_command(
                 config_command, form_data['hypervisor_type'], org=default_org.label
             )
@@ -181,7 +181,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             intervals = {
                 'Every hour': '3600',
                 'Every 2 hours': '7200',
@@ -222,7 +222,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             # esx and rhevm support hwuuid option
             values = ['uuid', 'hostname', 'hwuuid']
@@ -258,7 +258,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             regex = '.*redhat.com'
             whitelist = {'filtering': 'Whitelist', 'filtering_content.filter_hosts': regex}
@@ -311,7 +311,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             no_proxy = 'test.satellite.com'
             # Check the https proxy and No_PROXY settings
             session.virtwho_configure.edit(name, {'proxy': https_proxy, 'no_proxy': no_proxy})
@@ -405,7 +405,7 @@ class TestVirtwhoConfigforEsx:
             assert values['latest_config'] == 'No configuration found'
             # Check the 'Status' changed after deployed the virt-who config
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             deploy_configure_by_command(
                 config_command, form_data['hypervisor_type'], org=default_org.label
             )
@@ -445,7 +445,7 @@ class TestVirtwhoConfigforEsx:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             deploy_configure_by_command(
                 config_command, form_data['hypervisor_type'], org=default_org.label
             )

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -136,7 +136,7 @@ class TestVirtwhoConfigforHyperv:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -134,7 +134,7 @@ class TestVirtwhoConfigforKubevirt:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -135,7 +135,7 @@ class TestVirtwhoConfigforLibvirt:
         with session:
             session.virtwho_configure.create(form_data)
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.label)
+            config_command = get_configure_command(config_id, default_org.name)
             config_file = get_configure_file(config_id)
             values = ['uuid', 'hostname']
             for value in values:


### PR DESCRIPTION
Hey,
Replace orgname using default_org name, because  "hammer -u XXX -p XXX virt-who-config deploy --id 53 --organization " using the org name, not the label name.

Cases Pass in hypervisior : ESX, hyperv, libvirt
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/ui/test_esx.py  -k test_positive_debug_option 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 15 items / 29 deselected / -14 selected                                                                                                                                                                 

tests/foreman/virtwho/ui/test_esx.py .                                                                                                                                                                      [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per430-09.gsslab.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1 passed, 29 deselected, 7 warnings in 215.78s (0:03:35) =============================================================================

(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/ui/test_esx.py -k test_positive_hypervisor_id_option;

=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 15 items / 29 deselected / -14 selected                                                                                                                                                                 

tests/foreman/virtwho/ui/test_esx.py .                                                                                                                                                                      [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per430-09.gsslab.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1 passed, 29 deselected, 7 warnings in 522.20s (0:08:42) =============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/ui/test_esx.py -k test_positive_filtering_option;
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 15 items / 29 deselected / -14 selected                                                                                                                                                                 

tests/foreman/virtwho/ui/test_esx.py .                                                                                                                                                                      [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_filtering_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_filtering_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_filtering_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_filtering_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per430-09.gsslab.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_filtering_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1 passed, 29 deselected, 7 warnings in 415.39s (0:06:55) =============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/ui/test_esx.py -k test_positive_proxy_option;
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 15 items / 29 deselected / -14 selected                                                                                                                                                                 

tests/foreman/virtwho/ui/test_esx.py .                                                                                                                                                                      [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per430-09.gsslab.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_proxy_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1 passed, 29 deselected, 11 warnings in 405.32s (0:06:45) ============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/ui/test_esx.py -k test_positive_delete_configure
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 15 items / 29 deselected / -14 selected                                                                                                                                                                 

tests/foreman/virtwho/ui/test_esx.py .                                                                                                                                                                      [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per430-09.gsslab.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_delete_configure
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1 passed, 29 deselected, 7 warnings in 216.60s (0:03:36) =============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/ui/test_hyperv.py  -k test_positive_hypervisor_id_option;
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 3 items / 5 deselected / -2 selected                                                                                                                                                                    

tests/foreman/virtwho/ui/test_hyperv.py 2022-05-06 10:44:06,789 [5704859]   WARN - #c.i.w.p.InstalledPackagesPanel - Cannot start process, the working directory '/home/yanpliu/gitrepo/robottelo/venv/bin' does not exist
.                                                                                                                                                                   [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_hyperv.py::TestVirtwhoConfigforHyperv::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_hyperv.py::TestVirtwhoConfigforHyperv::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_hyperv.py::TestVirtwhoConfigforHyperv::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_hyperv.py::TestVirtwhoConfigforHyperv::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per430-09.gsslab.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_hyperv.py::TestVirtwhoConfigforHyperv::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 5 deselected, 7 warnings in 398.45s (0:06:38) =============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/ui/test_libvirt.py  -k test_positive_hypervisor_id_option;
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 3 items / 5 deselected / -2 selected                                                                                                                                                                    

tests/foreman/virtwho/ui/test_libvirt.py .                                                                                                                                                                  [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_hypervisor_id_option
tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per430-09.gsslab.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_libvirt.py::TestVirtwhoConfigforLibvirt::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 5 deselected, 7 warnings in 548.13s (0:09:08) =============================================================================
```

