### PR TITLE
clean deploy_script and delete host before register to avoid can not register different org

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -132,6 +132,7 @@ def virtwho_cleanup():
     runcmd("rm -f /var/run/virt-who.pid")
     runcmd("rm -f /var/log/rhsm/rhsm.log")
     runcmd("rm -rf /etc/virt-who.d/*")
+    runcmd("rm -rf /tmp/deploy_script.sh")
 
 
 def get_virtwho_status():
@@ -266,6 +267,9 @@ def deploy_configure_by_command(command, hypervisor_type, debug=False, org='Defa
     :param str org: Organization Label
     """
     virtwho_cleanup()
+    guest_name, guest_uuid = get_guest_info(hypervisor_type)
+    if Host.list({'search': guest_name}):
+        Host.delete({'name': guest_name})
     register_system(get_system(hypervisor_type), org=org)
     ret, stdout = runcmd(command)
     if ret != 0 or 'Finished successfully' not in stdout:

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -405,10 +405,8 @@ class TestVirtwhoConfigforEsx:
             assert values['latest_config'] == 'No configuration found'
             # Check the 'Status' changed after deployed the virt-who config
             config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.name)
-            deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
-            )
+            config_command = get_configure_command(config_id, org_name)
+            deploy_configure_by_command(config_command, form_data['hypervisor_type'], org=org_name)
             assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             expected_values = [
                 {'Configuration Status': 'No Reports', 'Count': '0'},


### PR DESCRIPTION
Hey,
1. Delete  host before register
Add delete host before register to avoid not affect other cases meet the error "XXX is currently registered to a different org".

2.  Update orgname for case test_positive_virtwho_configs_widget
As the virtwhoconfig is created in an non-default_org, so deploy should be in the same org not the default_org.

3. Remove   deploy_script to avoid affecting other deploy_configure_by_script

Test Cases PASS: test_positive_deploy_configure_by_script for hypervisor libvirt/Esx/Hyperv
 test_positive_virtwho_configs_widget Test Results:PASS

```
(robottelo_vv) [yanpliu@yanpliu robottelo]$  pytest tests/foreman/virtwho/ui/test_esx.py -k test_positive_virtwho_configs_widget
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 15 items / 29 deselected / -14 selected                                                                                                                                                                 

tests/foreman/virtwho/ui/test_esx.py .                                                                                                                                                                      [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_virtwho_configs_widget
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_virtwho_configs_widget
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_virtwho_configs_widget
tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_virtwho_configs_widget
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_esx.py::TestVirtwhoConfigforEsx::test_positive_virtwho_configs_widget
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1 passed, 29 deselected, 7 warnings in 326.99s (0:05:26) =============================================================================

```

Satellite6.10.z PR have already fixed these issues.
https://github.com/SatelliteQE/robottelo/pull/9534
https://github.com/SatelliteQE/robottelo/pull/9532