### PR TITLE
Fix puppet class teardown

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1382,6 +1382,34 @@ class Satellite(Capsule, SatelliteMixins):
         smart_proxy.import_puppetclasses()
         return env_name
 
+    def destroy_custom_environment(self, env_name):
+        """Remove custom environment including installed modules."""
+        self.execute(f'rm -rf /etc/puppetlabs/code/environments/{env_name}/')
+        smart_proxy = (
+            self.api.SmartProxy().search(query={'search': f'name={self.hostname}'})[0].read()
+        )
+        smart_proxy.import_puppetclasses()
+
+    def delete_puppet_class(self, puppetclass_name):
+        """Delete puppet class and its subclasses."""
+        # Find puppet class
+        puppet_classes = self.api.PuppetClass().search(
+            query={'search': f'name = "{puppetclass_name}"'}
+        )
+        # And all subclasses
+        puppet_classes.extend(
+            self.api.PuppetClass().search(query={'search': f'name ~ "{puppetclass_name}::"'})
+        )
+        for puppet_class in puppet_classes:
+            # Search and remove puppet class from affected hostgroups
+            for hostgroup in puppet_class.read().hostgroup:
+                hostgroup.delete_puppetclass(data={'puppetclass_id': puppet_class.id})
+            # Search and remove puppet class from affected hosts
+            for host in self.api.Host().search(query={'search': f'class={puppet_class.name}'}):
+                host.delete_puppetclass(data={'puppetclass_id': puppet_class.id})
+            # Remove puppet class entity
+            puppet_class.delete()
+
     @contextmanager
     def hammer_api_timeout(self, timeout=-1):
         """Set hammer API request timeout on Satellite

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -23,7 +23,6 @@ from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from requests import HTTPError
 
-from robottelo.api.utils import delete_puppet_class
 from robottelo.config import settings
 from robottelo.datafactory import filtered_datapoint
 from robottelo.datafactory import parametrized
@@ -74,7 +73,8 @@ def module_puppet(session_puppet_enabled_sat):
         .read()
     )
     yield {'env': env, 'class': puppet_class, 'sc_params': sc_params_list}
-    delete_puppet_class(puppet_class.name)
+    session_puppet_enabled_sat.delete_puppet_class(puppet_class.name)
+    session_puppet_enabled_sat.destroy_custom_environment(env_name)
 
 
 @pytest.mark.run_in_one_thread
@@ -612,3 +612,4 @@ class TestSmartClassParameters:
         ).create()
         hostgroup.add_puppetclass(data={'puppetclass_id': module_puppet['class'].id})
         assert len(sc_param.read().override_values) == 0
+        hostgroup.delete()

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -16,7 +16,6 @@
 """
 import pytest
 
-from robottelo.api.utils import delete_puppet_class
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import add_role_permissions
 from robottelo.cli.factory import make_hostgroup
@@ -46,7 +45,8 @@ def module_puppet(session_puppet_enabled_sat, module_puppet_org, module_puppet_l
         .read()
     )
     yield {'env': env, 'class': puppet_class}
-    delete_puppet_class(puppet_class['name'])
+    session_puppet_enabled_sat.delete_puppet_class(puppet_class['name'])
+    session_puppet_enabled_sat.destroy_custom_environment(env_name)
 
 
 @pytest.fixture(scope='module')

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -23,8 +23,6 @@ from nailgun import entities
 from upgrade_tests.helpers.scenarios import create_dict
 from upgrade_tests.helpers.scenarios import get_entity_data
 
-from robottelo.api.utils import delete_puppet_class
-
 
 def _valid_sc_parameters_data():
     """Returns a list of valid smart class parameter types and values"""
@@ -75,11 +73,11 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
         create_dict(scenario_ents)
 
     @pytest.fixture(scope="class")
-    def _clean_scenario(self, request):
+    def _clean_scenario(self, request, default_sat):
         @request.addfinalizer
         def _cleanup():
             puppet_class = get_entity_data(self.__class__.__name__)['puppet_class']
-            delete_puppet_class(puppet_class)
+            default_sat.delete_puppet_class(puppet_class)
 
     def _validate_value(self, data, sc_param):
         """The helper function to validate the parameter actual and expected


### PR DESCRIPTION
Some classparameters tests are failing in teardown because `api.utils.delete_puppet_class()` is leveraged there, which runs against the `default_sat` where puppet is not enabled.
As we are going to refactor the api utils anyway, I'm moving this method into `Satellite` class so that it can be run against the appropriate sat.

Tests result:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_classparameters.py
========================================== test session starts ==========================================
platform linux -- Python 3.9.9, pytest-7.1.2, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, mock-3.7.0, lazy-fixture-0.6.3, ibutsu-2.0.2, xdist-2.5.0, reportp
collected 29 items

tests/foreman/api/test_classparameters.py .............................                          [100%]

============================ 29 passed, 110 warnings in 1690.15s (0:28:10) ==============================
```
