### PR TITLE
Make "default_sat" fixture usage more cooperative

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Collect Tests with xdist
         run: |
-          pytest --collect-only --disable-pytest-warnings -n 2 tests/foreman/ tests/robottelo/
-          pytest --collect-only --disable-pytest-warnings -n 2 -m pre_upgrade tests/upgrades/
-          pytest --collect-only --disable-pytest-warnings -n 2 -m post_upgrade tests/upgrades/
+          pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 tests/foreman/ tests/robottelo/
+          pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 -m pre_upgrade tests/upgrades/
+          pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 -m post_upgrade tests/upgrades/
 
       - name: Make Docs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ tests/foreman/pytest.ini
 /settings.local.yaml
 /settings*.local.yaml
 /conf/*.yaml
+/conf/*.conf
 !/conf/supportability.yaml
 
 # I don't know where those 2 files come from

--- a/pytest_fixtures/component/domain.py
+++ b/pytest_fixtures/component/domain.py
@@ -4,8 +4,8 @@ from nailgun import entities
 
 
 @pytest.fixture(scope='session')
-def default_domain(default_sat, default_smart_proxy):
-    domain_name = default_sat.hostname.partition('.')[-1]
+def default_domain(session_target_sat, default_smart_proxy):
+    domain_name = session_target_sat.hostname.partition('.')[-1]
     dom = entities.Domain().search(query={'search': f'name={domain_name}'})[0]
     dom.dns = default_smart_proxy
     dom.update(['dns'])

--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -13,10 +13,10 @@ from robottelo.helpers import get_data_file
 
 
 @pytest.fixture(scope="session")
-def tailoring_file_path(default_sat):
+def tailoring_file_path(session_target_sat):
     """Return Tailoring file path."""
     local = get_data_file(OSCAP_TAILORING_FILE)
-    default_sat.put(
+    session_target_sat.put(
         local_path=get_data_file(OSCAP_TAILORING_FILE),
         remote_path=f'/tmp/{OSCAP_TAILORING_FILE}',
     )
@@ -24,10 +24,10 @@ def tailoring_file_path(default_sat):
 
 
 @pytest.fixture(scope="session")
-def oscap_content_path(default_sat):
+def oscap_content_path(session_target_sat):
     """Download scap content from satellite and return local path of it."""
     local_file = robottelo_tmp_dir.joinpath(PurePath(settings.oscap.content_path).name)
-    default_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
+    session_target_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
     return local_file
 
 

--- a/pytest_fixtures/component/provision_azure.py
+++ b/pytest_fixtures/component/provision_azure.py
@@ -25,9 +25,9 @@ def azurerm_settings():
 
 
 @pytest.fixture(scope='module')
-def module_azurerm_cr(azurerm_settings, module_org, module_location, default_sat):
+def module_azurerm_cr(azurerm_settings, module_org, module_location, module_target_sat):
     """Create AzureRM Compute Resource"""
-    azure_cr = default_sat.api.AzureRMComputeResource(
+    azure_cr = module_target_sat.api.AzureRMComputeResource(
         name=gen_string('alpha'),
         provider='AzureRm',
         tenant=azurerm_settings['tenant'],
@@ -64,11 +64,11 @@ def module_azurerm_cr_puppet(
 def module_azurerm_finishimg(
     default_architecture,
     default_os,
-    default_sat,
+    module_target_sat,
     module_azurerm_cr,
 ):
     """Creates Finish Template image on AzureRM Compute Resource"""
-    finish_image = default_sat.api.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),
@@ -103,10 +103,10 @@ def module_azurerm_byos_finishimg(
     default_architecture,
     default_os,
     module_azurerm_cr,
-    default_sat,
+    module_target_sat,
 ):
     """Creates BYOS Finish Template image on AzureRM Compute Resource"""
-    finish_image = default_sat.api.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),
@@ -140,11 +140,11 @@ def module_azurerm_byos_finishimg_puppet(
 def module_azurerm_cloudimg(
     default_architecture,
     default_os,
-    default_sat,
+    module_target_sat,
     module_azurerm_cr,
 ):
     """Creates cloudinit image on AzureRM Compute Resource"""
-    finish_image = default_sat.api.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),
@@ -180,11 +180,11 @@ def module_azurerm_cloudimg_puppet(
 def module_azurerm_gallery_finishimg(
     default_architecture,
     default_os,
-    default_sat,
+    module_target_sat,
     module_azurerm_cr,
 ):
     """Creates Shared Gallery Finish Template image on AzureRM Compute Resource"""
-    finish_image = default_sat.api.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),
@@ -218,11 +218,11 @@ def module_azurerm_gallery_finishimg_puppet(
 def module_azurerm_custom_finishimg(
     default_architecture,
     default_os,
-    default_sat,
+    module_target_sat,
     module_azurerm_cr,
 ):
     """Creates Custom Finish Template image on AzureRM Compute Resource"""
-    finish_image = default_sat.api.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -13,14 +13,14 @@ from robottelo.errors import GCECertNotFoundError
 
 
 @pytest.fixture(scope='session')
-def gce_cert(default_sat):
+def gce_cert(session_target_sat):
     _, gce_cert_file = mkstemp(suffix='.json')
     cert = json.loads(settings.gce.cert)
     cert['local_path'] = gce_cert_file
     with open(gce_cert_file, 'w') as f:
         json.dump(cert, f)
-    default_sat.put(gce_cert_file, settings.gce.cert_path)
-    if default_sat.execute(f'[ -f {settings.gce.cert_path} ]').status != 0:
+    session_target_sat.put(gce_cert_file, settings.gce.cert_path)
+    if session_target_sat.execute(f'[ -f {settings.gce.cert_path} ]').status != 0:
         raise GCECertNotFoundError(
             f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
         )

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -130,11 +130,11 @@ def module_puppet_classes(
 
 
 @pytest.fixture(scope='session', params=[True, False], ids=["puppet_enabled", "puppet_disabled"])
-def parametrized_puppet_sat(request, default_sat, session_puppet_enabled_sat):
+def parametrized_puppet_sat(request, session_target_sat, session_puppet_enabled_sat):
     if request.param:
         sat = session_puppet_enabled_sat
     else:
-        sat = default_sat
+        sat = session_target_sat
     return {'sat': sat, 'enabled': request.param}
 
 

--- a/pytest_fixtures/component/smartproxy.py
+++ b/pytest_fixtures/component/smartproxy.py
@@ -23,14 +23,14 @@ def import_puppet_classes(default_smart_proxy):
 
 
 @pytest.fixture(scope='module')
-def module_fake_proxy(request, default_sat):
+def module_fake_proxy(request, module_target_sat):
     """Create a Proxy and register the cleanup function"""
     args = {'name': gen_string(str_type='alpha')}
     newport = get_available_capsule_port()
     try:
         with default_url_on_new_port(9090, newport) as url:
             args['url'] = url
-            proxy = default_sat.api.SmartProxy(**args).create()
+            proxy = module_target_sat.api.SmartProxy(**args).create()
             yield proxy
             capsule_cleanup(proxy.id)
     except CapsuleTunnelError as err:

--- a/pytest_fixtures/component/subscription.py
+++ b/pytest_fixtures/component/subscription.py
@@ -2,34 +2,36 @@ import pytest
 
 
 @pytest.fixture(scope='session')
-def clean_rhsm(default_sat):
+def clean_rhsm(session_target_sat):
     """removes pre-existing candlepin certs and resets RHSM."""
-    default_sat.remove_katello_ca()
+    session_target_sat.remove_katello_ca()
 
 
 @pytest.fixture(scope='module')
-def subscribe_satellite(clean_rhsm, default_sat):
+def subscribe_satellite(clean_rhsm, module_target_sat):
     """subscribe satellite to cdn"""
     from robottelo.config import settings
 
-    if default_sat.os_version.major < 8:
-        release_version = f'{default_sat.os_version.major}Server'
+    if module_target_sat.os_version.major < 8:
+        release_version = f'{module_target_sat.os_version.major}Server'
     else:
-        release_version = f'{default_sat.os_version.major}'
-    default_sat.register_contenthost(
+        release_version = f'{module_target_sat.os_version.major}'
+    module_target_sat.register_contenthost(
         org=None,
         lce=None,
         username=settings.subscription.rhn_username,
         password=settings.subscription.rhn_password,
         releasever=release_version,
     )
-    result = default_sat.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[0]
+    result = module_target_sat.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[
+        0
+    ]
     if 'Successfully attached a subscription' in result.stdout:
-        default_sat.enable_repo(
-            f'rhel-{default_sat.os_version.major}-server-extras-rpms', force=True
+        module_target_sat.enable_repo(
+            f'rhel-{module_target_sat.os_version.major}-server-extras-rpms', force=True
         )
         yield
     else:
         pytest.fail('Failed to attach system to pool. Aborting Test!.')
-    default_sat.unregister()
-    default_sat.remove_katello_ca()
+    module_target_sat.unregister()
+    module_target_sat.remove_katello_ca()

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -71,10 +71,12 @@ def module_gt_manifest_org():
 
 
 @pytest.fixture(scope='module')
-def smart_proxy_location(module_org, default_sat):
+def smart_proxy_location(module_org, module_target_sat):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
-        entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
+        entities.SmartProxy()
+        .search(query={'search': f'name={module_target_sat.hostname}'})[0]
+        .read()
     )
     smart_proxy.location.append(entities.Location(id=location.id))
     smart_proxy.update(['location'])

--- a/pytest_fixtures/component/templatesync.py
+++ b/pytest_fixtures/component/templatesync.py
@@ -8,7 +8,7 @@ from robottelo.logging import logger
 
 
 @pytest.fixture()
-def create_import_export_local_dir(default_sat):
+def create_import_export_local_dir(target_sat):
     """Creates a local directory inside root_dir on satellite from where the templates will
         be imported from or exported to.
 
@@ -20,7 +20,7 @@ def create_import_export_local_dir(default_sat):
     root_dir = FOREMAN_TEMPLATE_ROOT_DIR
     dir_path = f'{root_dir}/{dir_name}'
     # Creating the directory and set the write context
-    result = default_sat.execute(
+    result = target_sat.execute(
         f'mkdir -p {dir_path} && '
         f'chown foreman -R {root_dir} && '
         f'restorecon -R -v {root_dir} && '
@@ -33,25 +33,27 @@ def create_import_export_local_dir(default_sat):
             f"Failed to create local dir or set SELinux context. Error output: {result.stderr}"
         )
     # Copying the file to new directory to be modified by tests
-    default_sat.execute(f'cp example_template.erb {dir_path}')
+    target_sat.execute(f'cp example_template.erb {dir_path}')
     yield dir_name, dir_path
-    default_sat.execute(f'rm -rf {dir_path}')
+    target_sat.execute(f'rm -rf {dir_path}')
 
 
 @pytest.fixture(scope='session')
-def git_port(default_sat):
+def git_port(session_target_sat):
     """Allow port for git service"""
-    default_sat.execute(f'semanage port -a -t http_port_t -p tcp {settings.git.http_port}')
-    default_sat.execute(f'semanage port -a -t ssh_port_t -p tcp {settings.git.ssh_port}')
+    session_target_sat.execute(f'semanage port -a -t http_port_t -p tcp {settings.git.http_port}')
+    session_target_sat.execute(f'semanage port -a -t ssh_port_t -p tcp {settings.git.ssh_port}')
 
 
 @pytest.fixture(scope='session')
-def git_pub_key(default_sat, git_port):
+def git_pub_key(session_target_sat, git_port):
     """Copy ssh public key to git service"""
     git = settings.git
     key_path = '/usr/share/foreman/.ssh'
-    default_sat.execute(f'sudo -u foreman ssh-keygen -q -t rsa -f {key_path}/id_rsa -N "" <<<y')
-    key = default_sat.execute(f'cat {key_path}/id_rsa.pub').stdout.strip()
+    session_target_sat.execute(
+        f'sudo -u foreman ssh-keygen -q -t rsa -f {key_path}/id_rsa -N "" <<<y'
+    )
+    key = session_target_sat.execute(f'cat {key_path}/id_rsa.pub').stdout.strip()
     title = gen_string('alpha')
     auth = (git.username, git.password)
     url = f'http://{git.hostname}:{git.http_port}'
@@ -63,7 +65,7 @@ def git_pub_key(default_sat, git_port):
     res.raise_for_status()
     id = res.json()['id']
     # add ssh key to known host
-    default_sat.execute(
+    session_target_sat.execute(
         f'ssh-keyscan -t rsa -p {git.ssh_port} {git.hostname} > {key_path}/known_hosts'
     )
     yield

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -94,42 +94,42 @@ def content_hosts(request):
 
 
 @pytest.fixture(scope='module')
-def registered_hosts(organization_ak_setup, content_hosts, default_sat):
+def registered_hosts(organization_ak_setup, content_hosts, module_target_sat):
     """Fixture that registers content hosts to Satellite, based on rh_cloud setup"""
     org, ak = organization_ak_setup
     for vm in content_hosts:
-        vm.install_katello_ca(default_sat)
+        vm.install_katello_ca(module_target_sat)
         vm.register_contenthost(org.label, ak.name)
-        vm.add_rex_key(default_sat)
+        vm.add_rex_key(module_target_sat)
         assert vm.subscribed
     return content_hosts
 
 
-@pytest.fixture(scope="function")
-def katello_host_tools_host(default_sat, module_org, rhel_contenthost):
+@pytest.fixture
+def katello_host_tools_host(target_sat, module_org, rhel_contenthost):
     """Register content host to Satellite and install katello-host-tools on the host."""
     repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
-    register_host_custom_repo(default_sat, module_org, rhel_contenthost, [repo])
+    register_host_custom_repo(target_sat, module_org, rhel_contenthost, [repo])
     rhel_contenthost.install_katello_host_tools()
     yield rhel_contenthost
 
 
-@pytest.fixture(scope="function")
-def cockpit_host(default_sat, module_org, rhel_contenthost):
+@pytest.fixture
+def cockpit_host(target_sat, module_org, rhel_contenthost):
     """Register content host to Satellite and install cockpit on the host."""
     rhelver = rhel_contenthost.os_version.major
     if rhelver > 7:
         repo = [settings.repos[f'rhel{rhelver}_os']['baseos']]
     else:
         repo = [settings.repos['rhel7_os'], settings.repos['rhel7_extras']]
-    register_host_custom_repo(default_sat, module_org, rhel_contenthost, repo)
+    register_host_custom_repo(target_sat, module_org, rhel_contenthost, repo)
     rhel_contenthost.execute(f"hostnamectl set-hostname {rhel_contenthost.hostname} --static")
     rhel_contenthost.install_cockpit()
-    rhel_contenthost.add_rex_key(satellite=default_sat)
+    rhel_contenthost.add_rex_key(satellite=target_sat)
     yield rhel_contenthost
 
 
-def register_host_custom_repo(default_sat, module_org, rhel_contenthost, repo_urls):
+def register_host_custom_repo(target_sat, module_org, rhel_contenthost, repo_urls):
     """Register content host to Satellite and sync repos"""
     # prepare Product and appropriate Satellite Client repo on satellite
     rhelver = rhel_contenthost.os_version.major
@@ -149,7 +149,7 @@ def register_host_custom_repo(default_sat, module_org, rhel_contenthost, repo_ur
     subscription = subs[0]
 
     # finally, prepare the host end
-    rhel_contenthost.install_katello_ca(default_sat)
+    rhel_contenthost.install_katello_ca(target_sat)
     register = rhel_contenthost.register_contenthost(
         org=module_org.label,
         lce='Library',
@@ -173,14 +173,14 @@ def register_host_custom_repo(default_sat, module_org, rhel_contenthost, repo_ur
 
 
 @pytest.fixture
-def rex_contenthost(katello_host_tools_host, default_sat):
+def rex_contenthost(katello_host_tools_host, target_sat):
     """Fixture that enables remote execution on the host"""
-    katello_host_tools_host.add_rex_key(satellite=default_sat)
+    katello_host_tools_host.add_rex_key(satellite=target_sat)
     yield katello_host_tools_host
 
 
-@pytest.fixture(scope="function")
-def katello_host_tools_tracer_host(rex_contenthost, default_sat):
+@pytest.fixture
+def katello_host_tools_tracer_host(rex_contenthost, target_sat):
     """Install katello-host-tools-tracer, create custom
     repositories on the host"""
     # create a custom, rhel version-specific OS repo
@@ -196,9 +196,9 @@ def katello_host_tools_tracer_host(rex_contenthost, default_sat):
 
 
 @pytest.fixture
-def container_contenthost(rhel7_contenthost, default_sat):
+def container_contenthost(rhel7_contenthost, target_sat):
     """Fixture that installs docker on the content host"""
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
 
     repos = {
         'server': settings.repos.rhel7_os,

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -37,7 +37,7 @@ class TestAzureRMComputeResourceTestCase:
     @pytest.mark.upgrade
     @pytest.mark.tier1
     def test_positive_crud_azurerm_cr(
-        self, module_org, module_location, azurerm_settings, default_sat
+        self, module_org, module_location, azurerm_settings, target_sat
     ):
         """Create, Read, Update and Delete AzureRM compute resources
 
@@ -51,7 +51,7 @@ class TestAzureRMComputeResourceTestCase:
         """
         # Create CR
         cr_name = gen_string('alpha')
-        compresource = default_sat.api.AzureRMComputeResource(
+        compresource = target_sat.api.AzureRMComputeResource(
             name=cr_name,
             provider='AzureRm',
             tenant=azurerm_settings['tenant'],
@@ -80,7 +80,7 @@ class TestAzureRMComputeResourceTestCase:
 
         # Delete CR
         compresource.delete()
-        assert not default_sat.api.AzureRMComputeResource().search(
+        assert not target_sat.api.AzureRMComputeResource().search(
             query={'search': f'name={new_cr_name}'}
         )
 

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -86,9 +86,9 @@ def module_gce_finishimg_puppet(
 
 
 @pytest.fixture(scope='class')
-def gce_domain(module_org, module_location, default_smart_proxy, default_sat):
+def gce_domain(module_org, module_location, default_smart_proxy, target_sat):
     """Sets Domain for GCE Host Provisioning"""
-    _, _, dom = default_sat.hostname.partition('.')
+    _, _, dom = target_sat.hostname.partition('.')
     domain = entities.Domain().search(query={'search': f'name="{dom}"'})
     domain = domain[0].read()
     domain.location.append(module_location)

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -87,7 +87,7 @@ class TestSatelliteContentManagement:
         assert response, f"Repository {repo} failed to sync."
 
     @pytest.mark.tier4
-    def test_positive_sync_kickstart_repo(self, module_manifest_org, default_sat):
+    def test_positive_sync_kickstart_repo(self, module_manifest_org, target_sat):
         """No encoding gzip errors on kickstart repositories
         sync.
 
@@ -129,7 +129,7 @@ class TestSatelliteContentManagement:
         rh_repo.download_policy = 'immediate'
         rh_repo = rh_repo.update(['download_policy'])
         call_entity_method_with_timeout(rh_repo.sync, timeout=600)
-        result = default_sat.execute(
+        result = target_sat.execute(
             'grep pulp /var/log/messages | grep failed | grep encoding | grep gzip'
         )
         assert result.status == 1
@@ -174,7 +174,7 @@ class TestSatelliteContentManagement:
         assert len(os)
 
     @pytest.mark.tier2
-    def test_positive_mirroring_policy(self, default_sat):
+    def test_positive_mirroring_policy(self, target_sat):
         """Assert that the content of a repository with 'Mirror Policy' enabled
         is restored properly after resync.
 
@@ -230,7 +230,7 @@ class TestSatelliteContentManagement:
 
     @pytest.mark.tier3
     def test_positive_allow_reregistration_when_dmi_uuid_changed(
-        self, module_org, rhel_contenthost, default_sat
+        self, module_org, rhel_contenthost, target_sat
     ):
         """Register a content host with a custom DMI UUID, unregistering it, change
         the DMI UUID, and re-registering it again
@@ -247,15 +247,15 @@ class TestSatelliteContentManagement:
         """
         uuid_1 = str(uuid.uuid1())
         uuid_2 = str(uuid.uuid4())
-        rhel_contenthost.install_katello_ca(default_sat)
-        default_sat.execute(
+        rhel_contenthost.install_katello_ca(target_sat)
+        target_sat.execute(
             f'echo \'{{"dmi.system.uuid": "{uuid_1}"}}\' > /etc/rhsm/facts/uuid.facts'
         )
         result = rhel_contenthost.register_contenthost(module_org.label, lce=constants.ENVIRONMENT)
         assert result.status == 0
         result = rhel_contenthost.execute('subscription-manager clean')
         assert result.status == 0
-        default_sat.execute(
+        target_sat.execute(
             f'echo \'{{"dmi.system.uuid": "{uuid_2}"}}\' > /etc/rhsm/facts/uuid.facts'
         )
         result = rhel_contenthost.register_contenthost(module_org.label, lce=constants.ENVIRONMENT)
@@ -498,7 +498,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_updated_repo(
-        self, default_sat, capsule_configured, function_org, function_product
+        self, target_sat, capsule_configured, function_org, function_product
     ):
         """Sync a custom repo with no upstream url but uploaded content to the Capsule via promoted CV,
         update content of the repo, publish and promote the CV again, resync the Capsule.
@@ -592,7 +592,7 @@ class TestCapsuleContentManagement:
 
         # Check the content is synced on the Capsule side properly
         sat_repo_url = form_repo_url(
-            default_sat,
+            target_sat,
             org=function_org.label,
             lce=lce.label,
             cv=cv.label,
@@ -614,7 +614,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_capsule_sync(self, capsule_configured, default_sat):
+    def test_positive_capsule_sync(self, capsule_configured, target_sat):
         """Create repository, add it to lifecycle environment, assign lifecycle
         environment with a capsule, sync repository, sync it once again, update
         repository (add 1 new package), sync repository once again.
@@ -692,7 +692,7 @@ class TestCapsuleContentManagement:
         # Assert that the content published on the capsule is exactly the
         # same as in repository on satellite
         sat_repo_url = form_repo_url(
-            default_sat,
+            target_sat,
             org=org.label,
             lce=lce.label,
             cv=cv.label,
@@ -862,7 +862,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_on_demand_sync(self, capsule_configured, default_sat):
+    def test_positive_on_demand_sync(self, capsule_configured, target_sat):
         """Create a repository with 'on_demand' policy, add it to a CV,
         promote to an 'on_demand' Capsule's LCE, check artifacts were created,
         download a published package, assert it matches the source.
@@ -958,7 +958,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_update_with_immediate_sync(self, capsule_configured, default_sat):
+    def test_positive_update_with_immediate_sync(self, capsule_configured, target_sat):
         """Create a repository with on_demand download policy, associate it
         with capsule, sync repo, update download policy to immediate, sync once
         more.
@@ -1106,7 +1106,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_sync_kickstart_repo(
-        self, module_manifest_org, default_sat, capsule_configured
+        self, module_manifest_org, target_sat, capsule_configured
     ):
         """Sync kickstart repository to the capsule.
 
@@ -1186,12 +1186,12 @@ class TestCapsuleContentManagement:
 
         # Check kickstart specific files
         for file in constants.KICKSTART_CONTENT:
-            sat_file = md5_by_url(f'{default_sat.url}/{url_base}/{file}')
+            sat_file = md5_by_url(f'{target_sat.url}/{url_base}/{file}')
             caps_file = md5_by_url(f'{capsule_configured.url}/{url_base}/{file}')
             assert sat_file == caps_file
 
         # Check packages
-        sat_pkg_url = f'{default_sat.url}/{url_base}/Packages/'
+        sat_pkg_url = f'{target_sat.url}/{url_base}/Packages/'
         caps_pkg_url = f'{capsule_configured.url}/{url_base}/Packages/'
         sat_pkgs = get_repo_files_by_url(sat_pkg_url)
         caps_pkgs = get_repo_files_by_url(caps_pkg_url)
@@ -1201,7 +1201,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients')
     def test_positive_sync_container_repo_end_to_end(
-        self, default_sat, capsule_configured, container_contenthost, module_org, module_product
+        self, target_sat, capsule_configured, container_contenthost, module_org, module_product
     ):
         """Sync container repositories with schema1, schema2,
         and both of them to the capsule and pull them to a
@@ -1312,7 +1312,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_collection_repo(
-        self, default_sat, module_lce_library, module_product, capsule_configured, rhel7_contenthost
+        self, target_sat, module_lce_library, module_product, capsule_configured, rhel7_contenthost
     ):
         """Sync ansible-collection repo to the Capsule, consume it on a host.
 
@@ -1383,7 +1383,7 @@ class TestCapsuleContentManagement:
         result = rhel7_contenthost.execute('yum -y install ansible')
         assert result.status == 0
 
-        repo_path = repo.full_path.replace(default_sat.hostname, capsule_configured.hostname)
+        repo_path = repo.full_path.replace(target_sat.hostname, capsule_configured.hostname)
         coll_path = './collections'
         cfg = (
             '[defaults]\n'
@@ -1410,7 +1410,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_file_repo(
-        self, default_sat, capsule_configured, module_org, module_product
+        self, target_sat, capsule_configured, module_org, module_product
     ):
         """Sync file-type repository to the capsule.
 
@@ -1481,7 +1481,7 @@ class TestCapsuleContentManagement:
 
         # Check for content on SAT and CAPS
         sat_repo_url = form_repo_url(
-            default_sat,
+            target_sat,
             org=module_org.label,
             lce=lce.label,
             cv=cv.label,

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -689,7 +689,7 @@ class TestContentViewPublishPromote:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    def test_composite_content_view_with_same_repos(self, module_org, default_sat):
+    def test_composite_content_view_with_same_repos(self, module_org, target_sat):
         """Create a Composite Content View with content views having same yum repo.
         Add filter on the content views and check the package count for composite content view
         should not be changed.
@@ -738,7 +738,7 @@ class TestContentViewPublishPromote:
     @pytest.mark.tier4
     @pytest.mark.destructive
     @pytest.mark.run_in_one_thread
-    def test_positive_reboot_recover_cv_publish(self, destructive_sat):
+    def test_positive_reboot_recover_cv_publish(self, target_sat):
         """Reboot the Satellite during publish and resume publishing
 
         :id: cceae727-81db-40a4-9c26-05ca6e93464e
@@ -793,7 +793,7 @@ class TestContentViewPublishPromote:
         ).create()
         try:
             publish_task = cv.publish(synchronous=False)
-            destructive_sat.power_control(state='reboot', ensure=True)
+            target_sat.power_control(state='reboot', ensure=True)
             wait_for_tasks(
                 search_query=(f'id = {publish_task["id"]}'),
                 search_rate=30,

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -975,7 +975,7 @@ def test_negative_update_os():
 
 @pytest.mark.tier3
 def test_positive_read_content_source_id(
-    module_org, module_location, module_lce, module_published_cv, default_sat
+    module_org, module_location, module_lce, module_published_cv, target_sat
 ):
     """Read the host content_source_id attribute from the read request
     response
@@ -991,7 +991,7 @@ def test_positive_read_content_source_id(
 
     :CaseLevel: System
     """
-    proxy = entities.SmartProxy().search(query={'url': f'{default_sat.url}:9090'})[0].read()
+    proxy = entities.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0].read()
     promote(module_published_cv.version[0], environment_id=module_lce.id)
     host = entities.Host(
         organization=module_org,
@@ -1011,7 +1011,7 @@ def test_positive_read_content_source_id(
 
 @pytest.mark.tier3
 def test_positive_update_content_source_id(
-    module_org, module_location, module_lce, module_published_cv, default_sat
+    module_org, module_location, module_lce, module_published_cv, target_sat
 ):
     """Read the host content_source_id attribute from the update request
     response
@@ -1027,9 +1027,9 @@ def test_positive_update_content_source_id(
 
     :CaseLevel: System
     """
-    proxy = default_sat.api.SmartProxy().search(query={'url': f'{default_sat.url}:9090'})[0]
+    proxy = target_sat.api.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0]
     promote(module_published_cv.version[0], environment_id=module_lce.id)
-    host = default_sat.api.Host(
+    host = target_sat.api.Host(
         organization=module_org,
         location=module_location,
         content_facet_attributes={

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -396,7 +396,7 @@ def test_negative_create_with_invalid_name(module_org, name):
 
 
 @pytest.mark.tier1
-def test_positive_add_remove_subscription(module_org, module_ak_cv_lce, default_sat):
+def test_positive_add_remove_subscription(module_org, module_ak_cv_lce, target_sat):
     """Try to bulk add and remove a subscription to members of a host collection.
 
     :id: c4ec5727-eb25-452e-a91f-87cafb16666b
@@ -430,7 +430,7 @@ def test_positive_add_remove_subscription(module_org, module_ak_cv_lce, default_
     # Create and register VMs as members of Host Collection
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}, _count=2) as hosts:
         for client in hosts:
-            client.install_katello_ca(default_sat)
+            client.install_katello_ca(target_sat)
             client.register_contenthost(module_org.label, module_ak_cv_lce.name)
         # Read host_collection back from Satellite to get host_ids
         host_collection = module_ak_cv_lce.host_collection[0].read()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -307,7 +307,7 @@ class TestOrganizationUpdate:
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
-    def test_positive_add_and_remove_smart_proxy(self, default_sat):
+    def test_positive_add_and_remove_smart_proxy(self, target_sat):
         """Add a smart proxy to an organization
 
         :id: e21de720-3fa2-429b-bd8e-b6a48a13146d
@@ -319,15 +319,15 @@ class TestOrganizationUpdate:
         :CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxy = default_sat.api.SmartProxy().search(
-            query={'search': f'url = {default_sat.url}:9090'}
+        smart_proxy = target_sat.api.SmartProxy().search(
+            query={'search': f'url = {target_sat.url}:9090'}
         )
         # Check that proxy is found and unpack it from the list
         assert len(smart_proxy) > 0
         smart_proxy = smart_proxy[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
-        org = default_sat.api.Organization().create()
+        org = target_sat.api.Organization().create()
         org.smart_proxy = []
         org = org.update(['smart_proxy'])
         # Verify smart proxy was actually removed

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -39,11 +39,11 @@ class TestPermission:
     """Tests for the ``permissions`` path."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def create_permissions(self, default_sat):
+    def create_permissions(self, class_target_sat):
         # workaround for setting class variables
         cls = type(self)
         cls.permissions = PERMISSIONS.copy()
-        if default_sat.is_upstream:
+        if class_target_sat.is_upstream:
             cls.permissions[None].extend(cls.permissions.pop('DiscoveryRule'))
             cls.permissions[None].remove('app_root')
             cls.permissions[None].remove('attachments')
@@ -52,14 +52,14 @@ class TestPermission:
             cls.permissions[None].remove('view_cases')
             cls.permissions[None].remove('view_log_viewer')
 
-        result = default_sat.execute('rpm -qa | grep rubygem-foreman_openscap')
+        result = class_target_sat.execute('rpm -qa | grep rubygem-foreman_openscap')
         if result.status != 0:
             cls.permissions.pop('ForemanOpenscap::Policy')
             cls.permissions.pop('ForemanOpenscap::ScapContent')
             cls.permissions[None].remove('destroy_arf_reports')
             cls.permissions[None].remove('view_arf_reports')
             cls.permissions[None].remove('create_arf_reports')
-        result = default_sat.execute('rpm -qa | grep rubygem-foreman_remote_execution')
+        result = class_target_sat.execute('rpm -qa | grep rubygem-foreman_remote_execution')
         if result.status != 0:
             cls.permissions.pop('JobInvocation')
             cls.permissions.pop('JobTemplate')

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -27,7 +27,7 @@ CAPSULE_TARGET_VERSION = '6.10.z'
 
 
 @pytest.mark.tier4
-def test_positive_run_capsule_upgrade_playbook(capsule_configured, default_sat):
+def test_positive_run_capsule_upgrade_playbook(capsule_configured, target_sat):
     """Run Capsule Upgrade playbook against an External Capsule
 
     :id: 9ec6903d-2bb7-46a5-8002-afc74f06d83b
@@ -41,13 +41,13 @@ def test_positive_run_capsule_upgrade_playbook(capsule_configured, default_sat):
     :CaseImportance: Medium
     """
     template_id = (
-        default_sat.api.JobTemplate()
+        target_sat.api.JobTemplate()
         .search(query={'search': 'name="Capsule Upgrade Playbook"'})[0]
         .id
     )
 
-    capsule_configured.add_rex_key(satellite=default_sat)
-    job = default_sat.api.JobInvocation().run(
+    capsule_configured.add_rex_key(satellite=target_sat)
+    job = target_sat.api.JobInvocation().run(
         synchronous=False,
         data={
             'job_template_id': template_id,
@@ -60,23 +60,23 @@ def test_positive_run_capsule_upgrade_playbook(capsule_configured, default_sat):
         },
     )
     wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
-    result = default_sat.api.JobInvocation(id=job['id']).read()
+    result = target_sat.api.JobInvocation(id=job['id']).read()
     assert result.succeeded == 1
 
-    result = default_sat.execute('satellite-maintain health check')
+    result = target_sat.execute('satellite-maintain health check')
     assert result.status == 0
     for line in result.stdout:
         assert 'FAIL' not in line
 
-    result = default_sat.api.SmartProxy(
-        id=default_sat.api.SmartProxy(name=default_sat.hostname).search()[0].id
+    result = target_sat.api.SmartProxy(
+        id=target_sat.api.SmartProxy(name=target_sat.hostname).search()[0].id
     ).refresh()
     feature_list = [feat['name'] for feat in result['features']]
     assert {'Container_Gateway', 'Dynflow', 'SSH', 'Pulpcore', 'Templates'}.issubset(feature_list)
 
 
 @pytest.mark.destructive
-def test_negative_run_capsule_upgrade_playbook_on_satellite(default_sat):
+def test_negative_run_capsule_upgrade_playbook_on_satellite(target_sat):
     """Run Capsule Upgrade playbook against the Satellite itself
 
     :id: 99462a11-5133-415d-ba64-4354da539a34
@@ -90,16 +90,16 @@ def test_negative_run_capsule_upgrade_playbook_on_satellite(default_sat):
 
     :CaseImportance: Medium
     """
-    sat = default_sat.nailgun_host
+    sat = target_sat.nailgun_host
     template_id = (
-        default_sat.api.JobTemplate()
+        target_sat.api.JobTemplate()
         .search(query={'search': 'name="Capsule Upgrade Playbook"'})[0]
         .id
     )
 
-    default_sat.add_rex_key(satellite=default_sat)
+    target_sat.add_rex_key(satellite=target_sat)
     with pytest.raises(TaskFailedError) as error:
-        default_sat.api.JobInvocation().run(
+        target_sat.api.JobInvocation().run(
             data={
                 'job_template_id': template_id,
                 'inputs': {
@@ -111,12 +111,12 @@ def test_negative_run_capsule_upgrade_playbook_on_satellite(default_sat):
             }
         )
     assert 'A sub task failed' in error.value.args[0]
-    job = default_sat.api.JobInvocation().search(
+    job = target_sat.api.JobInvocation().search(
         query={'search': f'host={sat.name},status=failed,description="Capsule Upgrade Playbook"'}
     )[0]
     response = client.get(
-        f'{default_sat.url}/api/job_invocations/{job.id}/hosts/{sat.id}',
-        auth=(default_sat.username, default_sat.password),
+        f'{target_sat.url}/api/job_invocations/{job.id}/hosts/{sat.id}',
+        auth=(target_sat.username, target_sat.password),
         verify=False,
     )
     assert 'This playbook cannot be executed on a Satellite server.' in response.text

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -475,7 +475,7 @@ def test_negative_nonauthor_of_report_cant_download_it():
 
 
 @pytest.mark.tier3
-def test_positive_generate_entitlements_report(setup_content, default_sat):
+def test_positive_generate_entitlements_report(setup_content, target_sat):
     """Generate a report using the Subscription - Entitlement Report template.
 
     :id: 722e8802-367b-4399-bcaa-949daab26632
@@ -494,7 +494,7 @@ def test_positive_generate_entitlements_report(setup_content, default_sat):
     """
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         ak, org = setup_content
-        vm.install_katello_ca(default_sat)
+        vm.install_katello_ca(target_sat)
         vm.register_contenthost(org.label, ak.name)
         assert vm.subscribed
         rt = (
@@ -514,7 +514,7 @@ def test_positive_generate_entitlements_report(setup_content, default_sat):
 
 
 @pytest.mark.tier3
-def test_positive_schedule_entitlements_report(setup_content, default_sat):
+def test_positive_schedule_entitlements_report(setup_content, target_sat):
     """Schedule a report using the Subscription - Entitlement Report template.
 
     :id: 5152c518-b0da-4c27-8268-2be78289249f
@@ -533,7 +533,7 @@ def test_positive_schedule_entitlements_report(setup_content, default_sat):
     """
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         ak, org = setup_content
-        vm.install_katello_ca(default_sat)
+        vm.install_katello_ca(target_sat)
         vm.register_contenthost(org.label, ak.name)
         assert vm.subscribed
         rt = (

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -175,13 +175,13 @@ class TestCannedRole:
             'loc': entities.Location().create(),
         }
 
-    @pytest.fixture(scope='function')
-    def create_ldap(self, ad_data, default_sat, module_location, module_org):
+    @pytest.fixture
+    def create_ldap(self, ad_data, target_sat, module_location, module_org):
         """Fetch necessary properties from settings and Create ldap auth source"""
         ad_data = ad_data()
         authsource_name = gen_string('alpha')
         yield dict(
-            sat_url=default_sat.url,
+            sat_url=target_sat.url,
             ldap_user_name=ad_data['ldap_user_name'],
             ldap_user_passwd=ad_data['ldap_user_passwd'],
             authsource=entities.AuthSourceLDAP(
@@ -203,7 +203,7 @@ class TestCannedRole:
                 location=[module_location],
             ).create(),
         )
-        for user in default_sat.api.User().search(
+        for user in target_sat.api.User().search(
             query={'search': f'login={ad_data["ldap_user_name"]}'}
         ):
             user.delete()
@@ -548,7 +548,7 @@ class TestCannedRole:
 
     @pytest.mark.tier3
     def test_negative_access_entities_from_org_admin(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """User can not access resources in taxonomies assigned to role if
         its own taxonomies are not same as its role
@@ -572,14 +572,14 @@ class TestCannedRole:
         domain = self.create_domain(
             orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id]
         )
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         # Getting the domain from user
         with pytest.raises(HTTPError):
             entities.Domain(sc, id=domain.id).read()
 
     @pytest.mark.tier3
     def test_negative_access_entities_from_user(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """User can not access resources within its own taxonomies if assigned
         role does not have permissions for user taxonomies
@@ -603,7 +603,7 @@ class TestCannedRole:
         domain = self.create_domain(
             orgs=[filter_taxonomies['org'].id], locs=[filter_taxonomies['loc'].id]
         )
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         # Getting the domain from user
         with pytest.raises(HTTPError):
             entities.Domain(sc, id=domain.id).read()
@@ -936,7 +936,7 @@ class TestCannedRole:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_user_group_users_access_as_org_admin(self, role_taxonomies, default_sat):
+    def test_positive_user_group_users_access_as_org_admin(self, role_taxonomies, target_sat):
         """Users in usergroup can have access to the resources in taxonomies if
         the taxonomies of Org Admin role is same
 
@@ -994,7 +994,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc'].id],
         ).create()
         for login, password in ((userone_login, userone_pass), (usertwo_login, usertwo_pass)):
-            sc = ServerConfig(auth=(login, password), url=default_sat.url, verify=False)
+            sc = ServerConfig(auth=(login, password), url=target_sat.url, verify=False)
             try:
                 entities.Domain(sc).search(
                     query={
@@ -1042,7 +1042,7 @@ class TestCannedRole:
 
     @pytest.mark.tier2
     def test_negative_assign_org_admin_to_user_group(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """Users in usergroup can not have access to the resources in
         taxonomies if the taxonomies of Org Admin role is not same
@@ -1074,13 +1074,13 @@ class TestCannedRole:
         assert user_group.name == ug_name
         dom = self.create_domain(orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id])
         for user in [user_one, user_two]:
-            sc = self.user_config(user, default_sat)
+            sc = self.user_config(user, target_sat)
             with pytest.raises(HTTPError):
                 entities.Domain(sc, id=dom.id).read()
 
     @pytest.mark.tier2
     def test_negative_assign_taxonomies_by_org_admin(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """Org Admin doesn't have permissions to assign org to any of
         its entities
@@ -1123,7 +1123,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         # Getting the domain from user1
         dom = entities.Domain(sc, id=dom.id).read()
         dom.organization = [filter_taxonomies['org']]
@@ -1164,7 +1164,7 @@ class TestCannedRole:
 
     @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_with_org_admin(
-        self, role_taxonomies, default_sat
+        self, role_taxonomies, target_sat
     ):
         """Super Admin can access entities in taxonomies assigned to Org Admin
 
@@ -1183,7 +1183,7 @@ class TestCannedRole:
         :CaseLevel: Integration
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         # Creating resource
         dom_name = gen_string('alpha')
         dom = entities.Domain(
@@ -1205,7 +1205,7 @@ class TestCannedRole:
 
     @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_without_org_admin(
-        self, role_taxonomies, default_sat
+        self, role_taxonomies, target_sat
     ):
         """Super Admin can access entities in taxonomies assigned to Org Admin
         after deleting Org Admin role/user
@@ -1226,7 +1226,7 @@ class TestCannedRole:
         :CaseLevel: Integration
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         # Creating resource
         dom_name = gen_string('alpha')
         dom = entities.Domain(
@@ -1254,7 +1254,7 @@ class TestCannedRole:
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_negative_create_roles_by_org_admin(self, role_taxonomies, default_sat):
+    def test_negative_create_roles_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin doesnt have permissions to create new roles
 
         :id: 806ecc16-0dc7-405b-90d3-0584eced27a3
@@ -1282,7 +1282,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         role_name = gen_string('alpha')
         with pytest.raises(HTTPError):
             entities.Role(
@@ -1293,7 +1293,7 @@ class TestCannedRole:
             ).create()
 
     @pytest.mark.tier1
-    def test_negative_modify_roles_by_org_admin(self, role_taxonomies, default_sat):
+    def test_negative_modify_roles_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin has no permissions to modify existing roles
 
         :id: 93ad9d7d-afad-4403-84a9-d59cc2ddfa58
@@ -1310,7 +1310,7 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_role = entities.Role().create()
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         test_role = entities.Role(sc, id=test_role.id).read()
         with pytest.raises(HTTPError):
             test_role.organization = [role_taxonomies['org']]
@@ -1318,7 +1318,7 @@ class TestCannedRole:
             test_role.update(['organization', 'location'])
 
     @pytest.mark.tier2
-    def test_negative_admin_permissions_to_org_admin(self, role_taxonomies, default_sat):
+    def test_negative_admin_permissions_to_org_admin(self, role_taxonomies, target_sat):
         """Org Admin has no access to Super Admin user
 
         :id: cdebf9a8-35c2-4730-8423-de47a2c15ff5
@@ -1347,13 +1347,13 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         with pytest.raises(HTTPError):
             entities.User(sc, id=1).read()
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_create_user_by_org_admin(self, role_taxonomies, default_sat):
+    def test_positive_create_user_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin can create new users
 
         :id: f4edbe25-3ee6-46d6-8fca-a04f6ddc8eed
@@ -1392,7 +1392,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc_user = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc_user = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         user_login = gen_string('alpha')
         user_pass = gen_string('alphanumeric')
         user = entities.User(
@@ -1411,7 +1411,7 @@ class TestCannedRole:
             assert location.name == name
 
     @pytest.mark.tier2
-    def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies, default_sat):
+    def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies, target_sat):
         """Org Admin can access users inside its taxonomies
 
         :id: c43275de-e0ff-4a22-b103-391a5ab81874
@@ -1433,7 +1433,7 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_user = self.create_simple_user(filter_taxos=role_taxonomies)
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         try:
             entities.User(sc, id=test_user.id).read()
         except HTTPError as err:
@@ -1441,7 +1441,7 @@ class TestCannedRole:
 
     @pytest.mark.skip_if_open('BZ:1825698')
     @pytest.mark.tier2
-    def test_positive_create_nested_location(self, role_taxonomies, default_sat):
+    def test_positive_create_nested_location(self, role_taxonomies, target_sat):
         """Org Admin can create nested locations
 
         :id: 971bc909-96a5-4614-b254-04a51c708432
@@ -1473,14 +1473,14 @@ class TestCannedRole:
         )
         user.role = [org_admin]
         user = user.update(['role'])
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         name = gen_string('alphanumeric')
         location = entities.Location(sc, name=name, parent=role_taxonomies['loc'].id).create()
         assert location.name == name
 
     @pytest.mark.tier2
     def test_negative_access_users_outside_org_admin_taxonomies(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """Org Admin can not access users outside its taxonomies
 
@@ -1503,12 +1503,12 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_user = self.create_simple_user(filter_taxos=filter_taxonomies)
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         with pytest.raises(HTTPError):
             entities.User(sc, id=test_user.id).read()
 
     @pytest.mark.tier1
-    def test_negative_create_taxonomies_by_org_admin(self, role_taxonomies, default_sat):
+    def test_negative_create_taxonomies_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin cannot define/create organizations but can create
             locations
 
@@ -1537,7 +1537,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         with pytest.raises(HTTPError):
             entities.Organization(sc, name=gen_string('alpha')).create()
         try:
@@ -1550,7 +1550,7 @@ class TestCannedRole:
     @pytest.mark.upgrade
     @pytest.mark.tier1
     def test_positive_access_all_global_entities_by_org_admin(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """Org Admin can access all global entities in any taxonomies
         regardless of its own assigned taxonomies
@@ -1580,7 +1580,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc'], filter_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         try:
             for entity in [
                 entities.Architecture,

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -33,13 +33,15 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
-def module_proxy_attrs(default_sat):
+def module_proxy_attrs(module_target_sat):
     """Find a ``SmartProxy``.
 
     Every Satellite has a built-in smart proxy, so searching for an
     existing smart proxy should always succeed.
     """
-    smart_proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})
+    smart_proxy = entities.SmartProxy().search(
+        query={'search': f'url = {module_target_sat.url}:9090'}
+    )
     # Check that proxy is found and unpack it from the list
     assert len(smart_proxy) > 0, "No smart proxy is found"
     smart_proxy = smart_proxy[0]

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -185,7 +185,7 @@ def test_negative_upload():
 
 
 @pytest.mark.tier2
-def test_positive_delete_manifest_as_another_user(function_org, default_sat):
+def test_positive_delete_manifest_as_another_user(function_org, target_sat):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
 
@@ -200,7 +200,7 @@ def test_positive_delete_manifest_as_another_user(function_org, default_sat):
     :CaseImportance: Medium
     """
     user1_password = gen_string('alphanumeric')
-    user1 = default_sat.api.User(
+    user1 = target_sat.api.User(
         admin=True,
         password=user1_password,
         organization=[function_org],
@@ -208,11 +208,11 @@ def test_positive_delete_manifest_as_another_user(function_org, default_sat):
     ).create()
     sc1 = ServerConfig(
         auth=(user1.login, user1_password),
-        url=default_sat.url,
+        url=target_sat.url,
         verify=False,
     )
     user2_password = gen_string('alphanumeric')
-    user2 = default_sat.api.User(
+    user2 = target_sat.api.User(
         admin=True,
         password=user2_password,
         organization=[function_org],
@@ -220,7 +220,7 @@ def test_positive_delete_manifest_as_another_user(function_org, default_sat):
     ).create()
     sc2 = ServerConfig(
         auth=(user2.login, user2_password),
-        url=default_sat.url,
+        url=target_sat.url,
         verify=False,
     )
     # use the first admin to upload a manifest
@@ -236,9 +236,7 @@ def test_positive_delete_manifest_as_another_user(function_org, default_sat):
 
 
 @pytest.mark.tier2
-def test_positive_subscription_status_disabled(
-    module_ak, rhel_contenthost, module_org, default_sat
-):
+def test_positive_subscription_status_disabled(module_ak, rhel_contenthost, module_org, target_sat):
     """Verify that Content host Subscription status is set to 'Disabled'
      for a golden ticket manifest
 
@@ -252,7 +250,7 @@ def test_positive_subscription_status_disabled(
 
     :CaseImportance: Medium
     """
-    rhel_contenthost.install_katello_ca(default_sat)
+    rhel_contenthost.install_katello_ca(target_sat)
     rhel_contenthost.register_contenthost(module_org.label, module_ak.name)
     assert rhel_contenthost.subscribed
     host_content = entities.Host(id=rhel_contenthost.nailgun_host.id).read_raw().content
@@ -262,9 +260,7 @@ def test_positive_subscription_status_disabled(
 @pytest.mark.tier2
 @pytest.mark.pit_client
 @pytest.mark.pit_server
-def test_sca_end_to_end(
-    module_ak, rhel7_contenthost, module_org, rh_repo, custom_repo, default_sat
-):
+def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custom_repo, target_sat):
     """Perform end to end testing for Simple Content Access Mode
 
     :id: c6c4b68c-a506-46c9-bd1d-22e4c1926ef8
@@ -278,7 +274,7 @@ def test_sca_end_to_end(
 
     :CaseImportance: Critical
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(module_org.label, module_ak.name)
     assert rhel7_contenthost.subscribed
     # Check to see if Organization is in SCA Mode
@@ -315,7 +311,7 @@ def test_sca_end_to_end(
 
 
 @pytest.mark.tier2
-def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, function_org, default_sat):
+def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, function_org, target_sat):
     """Verify that Candlepin events are being read and processed by
         attaching subscriptions, validating host subscriptions status,
         and viewing processed and failed Candlepin events
@@ -352,7 +348,7 @@ def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, functio
         environment=entities.LifecycleEnvironment(id=function_org.library.id),
         auto_attach=True,
     ).create()
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(function_org.name, ak.name)
     host = entities.Host().search(query={'search': f'name={rhel7_contenthost.hostname}'})
     host_id = host[0].id
@@ -373,7 +369,7 @@ def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, functio
     assert '0 Failed' in response['message']
 
 
-def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, default_sat):
+def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, target_sat):
     """Verify that a content host with an expired SCA cert can
         re-register successfully
 
@@ -411,7 +407,7 @@ def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, defau
     ).create()
     # registering the content host with no content enabled/synced in the org
     # should create a client SCA cert with no content
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org=module_org.label, activation_key=ak.name)
     assert rhel7_contenthost.subscribed
     rhel7_contenthost.unregister()

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -589,7 +589,7 @@ class TestSshKeyInUser:
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_ssh_key_in_host_enc(self, default_sat):
+    def test_positive_ssh_key_in_host_enc(self, target_sat):
         """SSH key appears in host ENC output
 
         :id: 4b70a950-e777-4b2d-a83d-29279715fe6d
@@ -611,7 +611,7 @@ class TestSshKeyInUser:
         ssh_key = gen_ssh_keypairs()[1]
         entities.SSHKey(user=user, name=gen_string('alpha'), key=ssh_key).create()
         host = entities.Host(owner=user, owner_type='User', organization=org, location=loc).create()
-        sshkey_updated_for_host = f'{ssh_key} {user.login}@{default_sat.hostname}'
+        sshkey_updated_for_host = f'{ssh_key} {user.login}@{target_sat.hostname}'
         host_enc_key = host.enc()['data']['parameters']['ssh_authorized_keys']
         assert sshkey_updated_for_host == host_enc_key[0]
 
@@ -621,18 +621,18 @@ class TestActiveDirectoryUser:
     """Implements the LDAP auth User Tests with Active Directory"""
 
     @pytest.fixture(scope='module')
-    def create_ldap(self, ad_data, default_sat):
+    def create_ldap(self, ad_data, module_target_sat):
         """Fetch necessary properties from settings and Create ldap auth source"""
-        org = default_sat.api.Organization().create()
-        loc = default_sat.api.Location(organization=[org]).create()
+        org = module_target_sat.api.Organization().create()
+        loc = module_target_sat.api.Location(organization=[org]).create()
         ad_data = ad_data()
         yield dict(
             org=org,
             loc=loc,
-            sat_url=default_sat.url,
+            sat_url=module_target_sat.url,
             ldap_user_name=ad_data['ldap_user_name'],
             ldap_user_passwd=ad_data['ldap_user_passwd'],
-            authsource=default_sat.api.AuthSourceLDAP(
+            authsource=module_target_sat.api.AuthSourceLDAP(
                 onthefly_register=True,
                 account=ad_data['ldap_user_name'],
                 account_password=ad_data['ldap_user_passwd'],
@@ -651,7 +651,7 @@ class TestActiveDirectoryUser:
                 organization=[org],
             ).create(),
         )
-        for user in default_sat.api.User().search(
+        for user in module_target_sat.api.User().search(
             query={'search': f'login={ad_data["ldap_user_name"]}'}
         ):
             user.delete()
@@ -762,10 +762,10 @@ class TestFreeIPAUser:
     """Implements the LDAP auth User Tests with FreeIPA"""
 
     @pytest.fixture(scope='class')
-    def create_ldap(self, default_sat):
+    def create_ldap(self, class_target_sat):
         """Fetch necessary properties from settings and Create ldap auth source"""
-        org = default_sat.api.Organization().create()
-        loc = default_sat.api.Location(organization=[org]).create()
+        org = class_target_sat.api.Organization().create()
+        loc = class_target_sat.api.Location(organization=[org]).create()
         ldap_user_name = settings.ipa.username
         ldap_user_passwd = settings.ipa.password
         username = settings.ipa.user
@@ -774,9 +774,9 @@ class TestFreeIPAUser:
             loc=loc,
             ldap_user_name=ldap_user_name,
             ldap_user_passwd=ldap_user_passwd,
-            sat_url=default_sat.url,
+            sat_url=class_target_sat.url,
             username=username,
-            authsource=default_sat.api.AuthSourceLDAP(
+            authsource=class_target_sat.api.AuthSourceLDAP(
                 onthefly_register=True,
                 account=ldap_user_name,
                 account_password=ldap_user_passwd,
@@ -795,7 +795,7 @@ class TestFreeIPAUser:
                 organization=[org],
             ).create(),
         )
-        for user in default_sat.api.User().search(query={'search': f'login={username}'}):
+        for user in class_target_sat.api.User().search(query={'search': f'login={username}'}):
             user.delete()
 
     @pytest.mark.tier3

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -587,7 +587,7 @@ def test_negative_update_usage_limit(module_org):
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_usage_limit(module_org, default_sat):
+def test_positive_usage_limit(module_org, target_sat):
     """Test that Usage limit actually limits usage
 
     :id: 00ded856-e939-4140-ac84-91b6a8643623
@@ -622,10 +622,10 @@ def test_positive_usage_limit(module_org, default_sat):
     )
     with VMBroker(nick=DISTRO_RHEL7, host_classes={'host': ContentHost}, _count=2) as clients:
         vm1, vm2 = clients
-        vm1.install_katello_ca(default_sat)
+        vm1.install_katello_ca(target_sat)
         vm1.register_contenthost(module_org.label, new_ak['name'])
         assert vm1.subscribed
-        vm2.install_katello_ca(default_sat)
+        vm2.install_katello_ca(target_sat)
         result = vm2.register_contenthost(module_org.label, new_ak['name'])
         assert not vm2.subscribed
         assert result.status == 70
@@ -873,7 +873,7 @@ def test_positive_delete_subscription(module_manifest_org):
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, default_sat):
+def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, target_sat):
     """Check if multiple Activation keys can be attached to a
     Content host
 
@@ -901,7 +901,7 @@ def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, default_sat
         )
         for _ in range(2)
     ]
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     for i in range(2):
         rhel7_contenthost.register_contenthost(module_org.label, new_aks[i]['name'])
         assert rhel7_contenthost.subscribed
@@ -1205,7 +1205,7 @@ def test_update_ak_with_syspurpose_values(module_org, module_manifest_org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_positive_add_subscription_by_id(module_org, default_sat):
+def test_positive_add_subscription_by_id(module_org, target_sat):
     """Test that subscription can be added to activation key
 
     :id: b884be1c-b35d-440a-9a9d-c854c83e10a7
@@ -1225,7 +1225,7 @@ def test_positive_add_subscription_by_id(module_org, default_sat):
     :BZ: 1463685
     """
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     org_id = make_org()['id']
     ackey_id = make_activation_key({'organization-id': org_id})['id']
     Subscription.upload({'file': manifest.filename, 'organization-id': org_id})
@@ -1578,8 +1578,7 @@ def test_positive_view_subscriptions_by_non_admin_user(module_manifest_org):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-@pytest.mark.skip_if_not_set('repos_hosting_url')
-def test_positive_subscription_quantity_attached(module_org, rhel7_contenthost, default_sat):
+def test_positive_subscription_quantity_attached(module_org, rhel7_contenthost, target_sat):
     """Check the Quantity and Attached fields of 'hammer activation-key subscriptions'
 
     see https://bugzilla.redhat.com/show_bug.cgi?id=1633094
@@ -1620,7 +1619,7 @@ def test_positive_subscription_quantity_attached(module_org, rhel7_contenthost, 
     )
     subs = Subscription.list({'organization-id': org['id']}, per_page=False)
     subs_lookup = {s['id']: s for s in subs}
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org['label'], activation_key=ak['name'])
     assert rhel7_contenthost.subscribed
 

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -71,7 +71,7 @@ def non_admin_user():
 
 
 @pytest.mark.tier1
-def test_positive_create_session(admin_user, default_sat):
+def test_positive_create_session(admin_user, target_sat):
     """Check if user stays authenticated with session enabled
 
     :id: fcee7f5f-1040-41a9-bf17-6d0c24a93e22
@@ -90,7 +90,7 @@ def test_positive_create_session(admin_user, default_sat):
     try:
         idle_timeout = Settings.list({'search': 'name=idle_timeout'})[0]['value']
         Settings.set({'name': 'idle_timeout', 'value': 1})
-        result = configure_sessions(default_sat)
+        result = configure_sessions(target_sat)
         assert result == 0, 'Failed to configure hammer sessions'
         AuthLogin.basic({'username': admin_user['login'], 'password': password})
         result = Auth.with_user().status()
@@ -110,7 +110,7 @@ def test_positive_create_session(admin_user, default_sat):
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_disable_session(admin_user, default_sat):
+def test_positive_disable_session(admin_user, target_sat):
     """Check if user logs out when session is disabled
 
     :id: 38ee0d85-c2fe-4cac-a992-c5dbcec11031
@@ -125,7 +125,7 @@ def test_positive_disable_session(admin_user, default_sat):
     :expectedresults: The session is terminated
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -133,7 +133,7 @@ def test_positive_disable_session(admin_user, default_sat):
     # list organizations without supplying credentials
     assert Org.with_user().list()
     # disabling sessions
-    result = configure_sessions(satellite=default_sat, enable=False)
+    result = configure_sessions(satellite=target_sat, enable=False)
     assert result == 0, 'Failed to configure hammer sessions'
     result = Auth.with_user().status()
     assert NOTCONF_MSG.format(admin_user['login']) in result[0]['message']
@@ -142,7 +142,7 @@ def test_positive_disable_session(admin_user, default_sat):
 
 
 @pytest.mark.tier1
-def test_positive_log_out_from_session(admin_user, default_sat):
+def test_positive_log_out_from_session(admin_user, target_sat):
     """Check if session is terminated when user logs out
 
     :id: 0ba05f2d-7b83-4b0c-a04c-80e62b7c4cf2
@@ -157,7 +157,7 @@ def test_positive_log_out_from_session(admin_user, default_sat):
     :expectedresults: The session is terminated
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -172,7 +172,7 @@ def test_positive_log_out_from_session(admin_user, default_sat):
 
 
 @pytest.mark.tier1
-def test_positive_change_session(admin_user, non_admin_user, default_sat):
+def test_positive_change_session(admin_user, non_admin_user, target_sat):
     """Change from existing session to a different session
 
     :id: b6ea6f3c-fcbd-4e7b-97bd-f3e0e6b9da8f
@@ -189,7 +189,7 @@ def test_positive_change_session(admin_user, non_admin_user, default_sat):
     :expectedresults: The session is altered
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -203,7 +203,7 @@ def test_positive_change_session(admin_user, non_admin_user, default_sat):
 
 
 @pytest.mark.tier1
-def test_positive_session_survives_unauthenticated_call(admin_user, default_sat):
+def test_positive_session_survives_unauthenticated_call(admin_user, target_sat):
     """Check if session stays up after unauthenticated call
 
     :id: 8bc304a0-70ea-489c-9c3f-ea8343c5284c
@@ -220,14 +220,14 @@ def test_positive_session_survives_unauthenticated_call(admin_user, default_sat)
     :expectedresults: The session is unchanged
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
     assert LOGEDIN_MSG.format(admin_user['login']) in result[0]['message']
     # list organizations without supplying credentials
     Org.with_user().list()
-    result = default_sat.execute('hammer ping')
+    result = target_sat.execute('hammer ping')
     assert result.status == 0, 'Failed to run hammer ping'
     result = Auth.with_user().status()
     assert LOGEDIN_MSG.format(admin_user['login']) in result[0]['message']
@@ -235,7 +235,7 @@ def test_positive_session_survives_unauthenticated_call(admin_user, default_sat)
 
 
 @pytest.mark.tier1
-def test_positive_session_survives_failed_login(admin_user, non_admin_user, default_sat):
+def test_positive_session_survives_failed_login(admin_user, non_admin_user, target_sat):
     """Check if session stays up after failed login attempt
 
     :id: 6c4d5c4c-eff0-411b-829f-0c2f2ec26132
@@ -252,7 +252,7 @@ def test_positive_session_survives_failed_login(admin_user, non_admin_user, defa
     :expectedresults: The session is unchanged
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -268,7 +268,7 @@ def test_positive_session_survives_failed_login(admin_user, non_admin_user, defa
 
 
 @pytest.mark.tier1
-def test_positive_session_preceeds_saved_credentials(admin_user, default_sat):
+def test_positive_session_preceeds_saved_credentials(admin_user, target_sat):
     """Check if enabled session is mutually exclusive with
     saved credentials in hammer config
 
@@ -293,7 +293,7 @@ def test_positive_session_preceeds_saved_credentials(admin_user, default_sat):
     try:
         idle_timeout = Settings.list({'search': 'name=idle_timeout'})[0]['value']
         Settings.set({'name': 'idle_timeout', 'value': 1})
-        result = configure_sessions(satellite=default_sat, add_default_creds=True)
+        result = configure_sessions(satellite=target_sat, add_default_creds=True)
         assert result == 0, 'Failed to configure hammer sessions'
         AuthLogin.basic({'username': admin_user['login'], 'password': password})
         result = Auth.with_user().status()
@@ -311,7 +311,7 @@ def test_positive_session_preceeds_saved_credentials(admin_user, default_sat):
 
 
 @pytest.mark.tier1
-def test_negative_no_credentials(default_sat):
+def test_negative_no_credentials(target_sat):
     """Attempt to execute command without authentication
 
     :id: 8a3b5c68-1027-450f-997c-c5630218f49f
@@ -320,7 +320,7 @@ def test_negative_no_credentials(default_sat):
 
     :CaseImportance: High
     """
-    result = configure_sessions(satellite=default_sat, enable=False)
+    result = configure_sessions(satellite=target_sat, enable=False)
     assert result == 0, 'Failed to configure hammer sessions'
     result = Auth.with_user().status()
     assert NOTCONF_MSG in result[0]['message']
@@ -329,7 +329,7 @@ def test_negative_no_credentials(default_sat):
 
 
 @pytest.mark.tier1
-def test_negative_no_permissions(admin_user, non_admin_user, default_sat):
+def test_negative_no_permissions(admin_user, non_admin_user, target_sat):
     """Attempt to execute command out of user's permissions
 
     :id: 756f666f-270a-4b02-b587-a2ab09b7d46c
@@ -339,7 +339,7 @@ def test_negative_no_permissions(admin_user, non_admin_user, default_sat):
     :CaseImportance: High
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': non_admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -351,7 +351,7 @@ def test_negative_no_permissions(admin_user, non_admin_user, default_sat):
 
 @pytest.mark.destructive
 @pytest.mark.tier1
-def test_positive_password_reset(destructive_sat):
+def test_positive_password_reset(target_sat):
     """Reset admin password using foreman rake and update the hammer config.
     verify the reset password is working.
 
@@ -362,17 +362,17 @@ def test_positive_password_reset(destructive_sat):
     :CaseImportance: High
 
     """
-    result = destructive_sat.execute('foreman-rake permissions:reset')
+    result = target_sat.execute('foreman-rake permissions:reset')
     assert result.status == 0
     reset_password = result.stdout.strip().split('password: ')[1]
-    result = destructive_sat.execute(
+    result = target_sat.execute(
         f'''sed -i -e '/username/d;/password/d;/use_sessions/d' {HAMMER_CONFIG};\
         echo '  :use_sessions: true' >> {HAMMER_CONFIG}'''
     )
     assert result.status == 0
-    destructive_sat.cli.AuthLogin.basic(
+    target_sat.cli.AuthLogin.basic(
         {'username': settings.server.admin_username, 'password': reset_password}
     )
-    result = destructive_sat.cli.Auth.with_user().status()
+    result = target_sat.cli.Auth.with_user().status()
     assert LOGEDIN_MSG.format(settings.server.admin_username) in result[0]['message']
-    assert destructive_sat.cli.Org.with_user().list()
+    assert target_sat.cli.Org.with_user().list()

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -24,7 +24,7 @@ from robottelo.hosts import ContentHost
 
 @pytest.mark.tier1
 def test_positive_register(
-    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv, default_sat
+    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv, target_sat
 ):
     """System is registered
 
@@ -44,17 +44,17 @@ def test_positive_register(
 
     :CaseImportance: Critical
     """
-    hg = default_sat.api.HostGroup(location=[module_location], organization=[module_org]).create()
+    hg = target_sat.api.HostGroup(location=[module_location], organization=[module_org]).create()
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         # assure system is not registered
         result = vm.execute('subscription-manager identity')
         # result will be 1 if not registered
         assert result.status == 1
         assert vm.execute(
-            f'curl -o /root/bootstrap.py "http://{default_sat.hostname}/pub/bootstrap.py" '
+            f'curl -o /root/bootstrap.py "http://{target_sat.hostname}/pub/bootstrap.py" '
         )
         assert vm.execute(
-            f'python /root/bootstrap.py -s {default_sat.hostname} -o {module_org.name}'
+            f'python /root/bootstrap.py -s {target_sat.hostname} -o {module_org.name}'
             f' -L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             ' --skip puppet --skip foreman'
         )
@@ -64,7 +64,7 @@ def test_positive_register(
         assert result.status == 0
         # register system once again
         assert vm.execute(
-            f'python /root/bootstrap.py -s "{default_sat.hostname}" -o {module_org.name} '
+            f'python /root/bootstrap.py -s "{target_sat.hostname}" -o {module_org.name} '
             f'-L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             '--skip puppet --skip foreman '
         )

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -75,14 +75,14 @@ def vm(
     module_gt_manifest_org,
     module_ak,
     rhel7_contenthost_module,
-    default_sat,
+    module_target_sat,
 ):
     # python-psutil obsoleted by python2-psutil, install older python2-psutil for errata test.
     rhel7_contenthost_module.run(
         'rpm -Uvh https://download.fedoraproject.org/pub/epel/7/x86_64/Packages/p/'
         'python2-psutil-5.6.7-1.el7.x86_64.rpm'
     )
-    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.install_katello_ca(module_target_sat)
     rhel7_contenthost_module.register_contenthost(module_gt_manifest_org.label, module_ak.name)
     host = entities.Host().search(query={'search': f'name={rhel7_contenthost_module.hostname}'})
     host_id = host[0].id
@@ -170,7 +170,7 @@ def test_positive_erratum_installable(vm):
 
 
 @pytest.mark.tier2
-def test_negative_rct_not_shows_golden_ticket_enabled(default_sat):
+def test_negative_rct_not_shows_golden_ticket_enabled(target_sat):
     """Assert restricted manifest has no Golden Ticket enabled .
 
     :id: 754c1be7-468e-4795-bcf9-258a38f3418b
@@ -190,14 +190,14 @@ def test_negative_rct_not_shows_golden_ticket_enabled(default_sat):
     # upload organization manifest with org environment access disabled
     manifest = manifests.clone()
     manifests.upload_manifest_locked(org.id, manifest, interface=manifests.INTERFACE_CLI)
-    result = default_sat.execute(f'rct cat-manifest {manifest.filename}')
+    result = target_sat.execute(f'rct cat-manifest {manifest.filename}')
     assert result.status == 0
     assert 'Content Access Mode: Simple Content Access' not in result.stdout
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_rct_shows_golden_ticket_enabled(module_gt_manifest_org, default_sat):
+def test_positive_rct_shows_golden_ticket_enabled(module_gt_manifest_org, target_sat):
     """Assert unrestricted manifest has Golden Ticket enabled .
 
     :id: 0c6e2f88-1a86-4417-9248-d7bd20584197
@@ -211,7 +211,7 @@ def test_positive_rct_shows_golden_ticket_enabled(module_gt_manifest_org, defaul
 
     :CaseImportance: Medium
     """
-    result = default_sat.execute(f'rct cat-manifest {module_gt_manifest_org.manifest_filename}')
+    result = target_sat.execute(f'rct cat-manifest {module_gt_manifest_org.manifest_filename}')
     assert result.status == 0
     assert 'Content Access Mode: Simple Content Access' in result.stdout
 

--- a/tests/foreman/cli/test_contentcredentials.py
+++ b/tests/foreman/cli/test_contentcredentials.py
@@ -271,7 +271,7 @@ def test_positive_update_name(new_name, module_org):
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 @pytest.mark.tier1
-def test_positive_update_key(name, module_org, default_sat):
+def test_positive_update_key(name, module_org, target_sat):
     """Create gpg key with valid name and valid gpg key via file
     import then update its gpg key file
 
@@ -289,7 +289,7 @@ def test_positive_update_key(name, module_org, default_sat):
     local_key = create_gpg_key_file(content)
     assert gpg_key, 'GPG Key file must be created'
     key = f'/tmp/{gen_alphanumeric()}'
-    default_sat.put(local_key, key)
+    target_sat.put(local_key, key)
     ContentCredential.update(
         {'path': key, 'name': gpg_key['name'], 'organization-id': module_org.id}
     )

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2221,7 +2221,7 @@ class TestContentView:
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
     def test_positive_sub_host_with_restricted_user_perm_at_custom_loc(
-        self, module_org, rhel7_contenthost, default_sat
+        self, module_org, rhel7_contenthost, target_sat
     ):
         """Attempt to subscribe a host with restricted user permissions and
         custom location.
@@ -2367,7 +2367,7 @@ class TestContentView:
         # assert that this is the same content view
         assert content_view['name'] == user_content_view['name']
         # create a client host and register it with the created user
-        rhel7_contenthost.install_katello_ca(default_sat)
+        rhel7_contenthost.install_katello_ca(target_sat)
         rhel7_contenthost.register_contenthost(
             org['label'],
             lce=f'{env["name"]}/{content_view["name"]}',
@@ -2382,7 +2382,7 @@ class TestContentView:
 
     @pytest.mark.tier3
     def test_positive_sub_host_with_restricted_user_perm_at_default_loc(
-        self, module_org, rhel7_contenthost, default_sat
+        self, module_org, rhel7_contenthost, target_sat
     ):
         """Attempt to subscribe a host with restricted user permissions and
         default location.
@@ -2524,7 +2524,7 @@ class TestContentView:
         # assert that this is the same content view
         assert content_view['name'] == user_content_view['name']
         # create a client host and register it with the created user
-        rhel7_contenthost.install_katello_ca(default_sat)
+        rhel7_contenthost.install_katello_ca(target_sat)
         rhel7_contenthost.register_contenthost(
             org['label'],
             lce='/'.join([env['name'], content_view['name']]),
@@ -4129,7 +4129,7 @@ class TestContentViewFileRepo:
 
     @pytest.mark.skip_if_open('BZ:1610309')
     @pytest.mark.tier3
-    def test_positive_arbitrary_file_repo_addition(self, module_org, module_product, default_sat):
+    def test_positive_arbitrary_file_repo_addition(self, module_org, module_product, target_sat):
         """Check a File Repository with Arbitrary File can be added to a
         Content View
 
@@ -4154,7 +4154,7 @@ class TestContentViewFileRepo:
         :BZ: 1610309, 1908465
         """
         repo = self.make_file_repository_upload_contents(
-            module_org, module_product, satellite=default_sat
+            module_org, module_product, satellite=target_sat
         )
         cv = cli_factory.make_content_view({'organization-id': module_org.id})
         # Associate repo to CV with names.
@@ -4171,7 +4171,7 @@ class TestContentViewFileRepo:
 
     @pytest.mark.skip_if_open('BZ:1908465')
     @pytest.mark.tier3
-    def test_positive_arbitrary_file_repo_removal(self, module_org, module_product, default_sat):
+    def test_positive_arbitrary_file_repo_removal(self, module_org, module_product, target_sat):
         """Check a File Repository with Arbitrary File can be removed from a
         Content View
 
@@ -4196,7 +4196,7 @@ class TestContentViewFileRepo:
         """
         cv = cli_factory.make_content_view({'organization-id': module_org.id})
         repo = self.make_file_repository_upload_contents(
-            module_org, module_product, satellite=default_sat
+            module_org, module_product, satellite=target_sat
         )
         ContentView.add_repository(
             {'id': cv['id'], 'repository-id': repo['id'], 'organization-id': module_org.id}
@@ -4232,7 +4232,7 @@ class TestContentViewFileRepo:
         """
 
     @pytest.mark.tier3
-    def test_positive_arbitrary_file_repo_promotion(self, module_org, module_product, default_sat):
+    def test_positive_arbitrary_file_repo_promotion(self, module_org, module_product, target_sat):
         """Check arbitrary files availability for Content view version after
         content-view promotion.
 
@@ -4260,7 +4260,7 @@ class TestContentViewFileRepo:
 
         cv = cli_factory.make_content_view({'organization-id': module_org.id})
         repo = self.make_file_repository_upload_contents(
-            module_product, module_product, satellite=default_sat
+            module_product, module_product, satellite=target_sat
         )
         ContentView.add_repository(
             {'id': cv['id'], 'repository-id': repo['id'], 'organization-id': module_org.id}
@@ -4283,7 +4283,7 @@ class TestContentViewFileRepo:
         assert repo['name'] in expected_repo
 
     @pytest.mark.tier3
-    def test_positive_katello_repo_rpms_max_int(self, default_sat):
+    def test_positive_katello_repo_rpms_max_int(self, target_sat):
         """Checking that datatype for katello_repository_rpms table is a
         bigint for id for a closed loop bz.
 
@@ -4297,7 +4297,7 @@ class TestContentViewFileRepo:
 
         :BZ: 1793701
         """
-        result = default_sat.execute(
+        result = target_sat.execute(
             'sudo -u postgres psql -d foreman -c "\\d katello_repository_rpms"'
         )
         assert 'id|bigint' in result.stdout.splitlines()[3].replace(' ', '')

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -50,7 +50,7 @@ def _assertdiscoveredhost(hostname):
 
 @pytest.mark.skip_if_not_set('vlan_networking')
 @pytest.fixture(scope='class')
-def foreman_discovery(default_sat):
+def foreman_discovery(target_sat):
     """Steps to Configure foreman discovery
 
     1. Build PXE default template
@@ -63,10 +63,10 @@ def foreman_discovery(default_sat):
     # Build PXE default template to get default PXE file
     Template.build_pxe_default()
     # let's just modify the timeouts to speed things up
-    default_sat.execute(
+    target_sat.execute(
         "sed -ie 's/TIMEOUT [[:digit:]]\\+/TIMEOUT 1/g' /var/lib/tftpboot/pxelinux.cfg/default"
     )
-    default_sat.execute(
+    target_sat.execute(
         "sed -ie '/APPEND initrd/s/$/ fdi.countdown=1/' /var/lib/tftpboot/pxelinux.cfg/default"
     )
 

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -83,7 +83,7 @@ def format_commands_diff(commands_diff):
 
 
 @pytest.mark.upgrade
-def test_positive_all_options(default_sat):
+def test_positive_all_options(target_sat):
     """check all provided options for every hammer command
 
     :id: 1203ab9f-896d-4039-a166-9e2d36925b5b
@@ -93,7 +93,7 @@ def test_positive_all_options(default_sat):
     :CaseImportance: Critical
     """
     differences = {}
-    raw_output = default_sat.execute('hammer full-help').stdout
+    raw_output = target_sat.execute('hammer full-help').stdout
     commands = re.split(r'.*\n(?=hammer.*\n^[-]+)', raw_output, flags=re.M)
     commands.pop(0)  # remove "Hammer CLI help" line
     for raw_command in commands:
@@ -132,7 +132,7 @@ def test_positive_all_options(default_sat):
 
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
-def test_positive_disable_hammer_defaults(default_sat):
+def test_positive_disable_hammer_defaults(target_sat):
     """Verify hammer disable defaults command.
 
     :id: d0b65f36-b91f-4f2f-aaf8-8afda3e23708
@@ -154,26 +154,26 @@ def test_positive_disable_hammer_defaults(default_sat):
     try:
         Defaults.add({'param-name': 'organization_id', 'param-value': default_org['id']})
         # list templates for BZ#1368173
-        result = default_sat.execute('hammer job-template list')
+        result = target_sat.execute('hammer job-template list')
         assert result.status == 0
         # Verify --organization-id is not required to pass if defaults are set
-        result = default_sat.execute('hammer product list')
+        result = target_sat.execute('hammer product list')
         assert result.status == 0
         # Verify product list fail without using defaults
-        result = default_sat.execute('hammer --no-use-defaults product list')
+        result = target_sat.execute('hammer --no-use-defaults product list')
         assert result.status != 0
         assert default_product_name not in result.stdout
         # Verify --organization-id is not required to pass if defaults are set
-        result = default_sat.execute('hammer --use-defaults product list')
+        result = target_sat.execute('hammer --use-defaults product list')
         assert result.status == 0
         assert default_product_name in result.stdout
     finally:
         Defaults.delete({'param-name': 'organization_id'})
-        result = default_sat.execute('hammer defaults list')
+        result = target_sat.execute('hammer defaults list')
         assert default_org['id'] not in result.stdout
 
 
-def test_positive_check_debug_log_levels(default_sat):
+def test_positive_check_debug_log_levels(target_sat):
     """Enabling debug log level in candlepin via hammer logging
 
     :id: 029c80f1-2bc5-494e-a04a-7d6beb0f769a
@@ -188,12 +188,12 @@ def test_positive_check_debug_log_levels(default_sat):
     """
     Admin.logging({'all': True, 'level-debug': True})
     # Verify value of `log4j.logger.org.candlepin` as `DEBUG`
-    result = default_sat.execute('grep DEBUG /etc/candlepin/candlepin.conf')
+    result = target_sat.execute('grep DEBUG /etc/candlepin/candlepin.conf')
     assert result.status == 0
     assert 'log4j.logger.org.candlepin = DEBUG' in result.stdout
 
     Admin.logging({"all": True, "level-production": True})
     # Verify value of `log4j.logger.org.candlepin` as `WARN`
-    result = default_sat.execute('grep WARN /etc/candlepin/candlepin.conf')
+    result = target_sat.execute('grep WARN /etc/candlepin/candlepin.conf')
     assert result.status == 0
     assert 'log4j.logger.org.candlepin = WARN' in result.stdout

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -68,9 +68,9 @@ from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope="module")
-def module_default_proxy(default_sat):
+def module_default_proxy(module_target_sat):
     """Use the default installation smart proxy"""
-    return default_sat.cli.Proxy.list({'search': f'url = {default_sat.url}:9090'})[0]
+    return module_target_sat.cli.Proxy.list({'search': f'url = {module_target_sat.url}:9090'})[0]
 
 
 @pytest.fixture(scope="function")
@@ -595,7 +595,7 @@ def test_positive_katello_and_openscap_loaded():
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_register_with_no_ak(
-    module_lce, module_org, module_promoted_cv, rhel7_contenthost, default_sat
+    module_lce, module_org, module_promoted_cv, rhel7_contenthost, target_sat
 ):
     """Register host to satellite without activation key
 
@@ -607,7 +607,7 @@ def test_positive_register_with_no_ak(
 
     :CaseLevel: System
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(
         module_org.label,
         lce=f'{module_lce.label}/{module_promoted_cv.label}',
@@ -617,7 +617,7 @@ def test_positive_register_with_no_ak(
 
 @pytest.mark.cli_host_create
 @pytest.mark.tier3
-def test_negative_register_twice(module_ak_with_cv, module_org, rhel7_contenthost, default_sat):
+def test_negative_register_twice(module_ak_with_cv, module_org, rhel7_contenthost, target_sat):
     """Attempt to register a host twice to Satellite
 
     :id: 0af81129-cd69-4fa7-a128-9e8fcf2d03b1
@@ -628,7 +628,7 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel7_contenthos
 
     :CaseLevel: System
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(module_org.label, module_ak_with_cv.name)
     assert rhel7_contenthost.subscribed
     result = rhel7_contenthost.register_contenthost(
@@ -644,7 +644,7 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel7_contenthos
 @pytest.mark.cli_host_create
 @pytest.mark.tier3
 def test_positive_list_and_unregister(
-    module_ak_with_cv, module_lce, module_org, rhel7_contenthost, default_sat
+    module_ak_with_cv, module_lce, module_org, rhel7_contenthost, target_sat
 ):
     """List registered host for a given org and unregister the host
 
@@ -657,7 +657,7 @@ def test_positive_list_and_unregister(
 
     :CaseLevel: System
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(module_org.label, module_ak_with_cv.name)
     assert rhel7_contenthost.subscribed
     hosts = Host.list({'organization-id': module_org.id})
@@ -671,7 +671,7 @@ def test_positive_list_and_unregister(
 @pytest.mark.cli_host_create
 @pytest.mark.tier3
 def test_positive_list_by_last_checkin(
-    module_lce, module_org, module_promoted_cv, rhel7_contenthost, default_sat
+    module_lce, module_org, module_promoted_cv, rhel7_contenthost, target_sat
 ):
     """List all content hosts using last checkin criteria
 
@@ -687,7 +687,7 @@ def test_positive_list_by_last_checkin(
 
     :CaseLevel: System
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(
         module_org.label,
         lce=f'{module_lce.label}/{module_promoted_cv.label}',
@@ -701,7 +701,7 @@ def test_positive_list_by_last_checkin(
 @pytest.mark.cli_host_create
 @pytest.mark.tier3
 def test_positive_list_infrastructure_hosts(
-    module_lce, module_org, module_promoted_cv, rhel7_contenthost, default_sat
+    module_lce, module_org, module_promoted_cv, rhel7_contenthost, target_sat
 ):
     """List infrasturcture hosts (Satellite and Capsule)
 
@@ -713,13 +713,13 @@ def test_positive_list_infrastructure_hosts(
 
     :CaseLevel: System
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(
         module_org.label,
         lce=f'{module_lce.label}/{module_promoted_cv.label}',
     )
     assert rhel7_contenthost.subscribed
-    Host.update({'name': default_sat.hostname, 'new-organization-id': module_org.id})
+    Host.update({'name': target_sat.hostname, 'new-organization-id': module_org.id})
     # list satellite hosts
     hosts = Host.list({'search': 'infrastructure_facet.foreman=true'})
     if is_open('BZ:1994685'):
@@ -728,7 +728,7 @@ def test_positive_list_infrastructure_hosts(
         assert len(hosts) == 1
     hostnames = [host['name'] for host in hosts]
     assert rhel7_contenthost.hostname not in hostnames
-    assert default_sat.hostname in hostnames
+    assert target_sat.hostname in hostnames
     # list capsule hosts
     hosts = Host.list({'search': 'infrastructure_facet.smart_proxy_id=1'})
     hostnames = [host['name'] for host in hosts]
@@ -737,7 +737,7 @@ def test_positive_list_infrastructure_hosts(
     else:
         assert len(hosts) == 1
     assert rhel7_contenthost.hostname not in hostnames
-    assert default_sat.hostname in hostnames
+    assert target_sat.hostname in hostnames
 
 
 @pytest.mark.skip_if_not_set('libvirt')
@@ -1817,7 +1817,7 @@ def test_positive_apply_security_erratum(katello_host_tools_host, setup_custom_r
 @pytest.mark.cli_katello_host_tools
 @pytest.mark.tier3
 def test_positive_install_package_via_rex(
-    module_org, katello_host_tools_host, default_sat, setup_custom_repo
+    module_org, katello_host_tools_host, target_sat, setup_custom_repo
 ):
     """Install a package to a host remotely using remote execution,
     install package using Katello SSH job template, host package list is used to verify that
@@ -1832,7 +1832,7 @@ def test_positive_install_package_via_rex(
     """
     client = katello_host_tools_host
     host_info = Host.info({'name': client.hostname})
-    client.configure_rex(satellite=default_sat, org=module_org, register=False)
+    client.configure_rex(satellite=target_sat, org=module_org, register=False)
     # Apply errata to the host collection using job invocation
     JobInvocation.create(
         {
@@ -1895,8 +1895,8 @@ def host_subscription(module_ak, module_cv, module_lce, module_org):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.fixture(scope="function")
-def host_subscription_client(rhel7_contenthost, default_sat):
-    rhel7_contenthost.install_katello_ca(default_sat)
+def host_subscription_client(rhel7_contenthost, target_sat):
+    rhel7_contenthost.install_katello_ca(target_sat)
     yield rhel7_contenthost
 
 
@@ -2441,7 +2441,7 @@ def test_syspurpose_end_to_end(module_host_subscription, host_subscription_clien
 
 # -------------------------- HOST ERRATA SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.tier1
-def test_positive_errata_list_of_sat_server(default_sat):
+def test_positive_errata_list_of_sat_server(target_sat):
     """Check if errata list doesn't raise exception. Check BZ for details.
 
     :id: 6b22f0c0-9c4b-11e6-ab93-68f72889dc7f
@@ -2452,14 +2452,14 @@ def test_positive_errata_list_of_sat_server(default_sat):
 
     :CaseImportance: Critical
     """
-    hostname = default_sat.execute('hostname').stdout.strip()
+    hostname = target_sat.execute('hostname').stdout.strip()
     host = Host.info({'name': hostname})
     assert isinstance(Host.errata_list({'host-id': host['id']}), list)
 
 
 # -------------------------- HOST ENC SUBCOMMAND SCENARIOS -------------------------
 @pytest.mark.tier1
-def test_positive_dump_enc_yaml(default_sat):
+def test_positive_dump_enc_yaml(target_sat):
     """Dump host's ENC YAML. Check BZ for details.
 
     :id: 50bf2530-788c-4710-a382-d034d73d5d4d
@@ -2472,9 +2472,9 @@ def test_positive_dump_enc_yaml(default_sat):
 
     :CaseImportance: Critical
     """
-    enc_dump = Host.enc_dump({'name': default_sat.hostname})
-    assert f'fqdn: {default_sat.hostname}' in enc_dump
-    assert f'ip: {default_sat.ip_addr}' in enc_dump
+    enc_dump = Host.enc_dump({'name': target_sat.hostname})
+    assert f'fqdn: {target_sat.hostname}' in enc_dump
+    assert f'ip: {target_sat.ip_addr}' in enc_dump
     assert 'ssh-rsa' in enc_dump
 
 

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -275,7 +275,7 @@ def test_positive_copy_by_id(module_org):
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_register_host_ak_with_host_collection(module_org, module_ak_with_cv, default_sat):
+def test_positive_register_host_ak_with_host_collection(module_org, module_ak_with_cv, target_sat):
     """Attempt to register a host using activation key with host collection
 
     :id: 62459e8a-0cfa-44ff-b70c-7f55b4757d66
@@ -302,7 +302,7 @@ def test_positive_register_host_ak_with_host_collection(module_org, module_ak_wi
     )
 
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as client:
-        client.install_katello_ca(default_sat)
+        client.install_katello_ca(target_sat)
         # register the client host with the current activation key
         client.register_contenthost(module_org.name, activation_key=module_ak_with_cv.name)
         assert client.subscribed

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -55,11 +55,11 @@ pc_name = 'generic_1'
 
 
 @pytest.fixture(scope='module')
-def env(module_org, module_location, default_sat):
+def env(module_org, module_location, module_target_sat):
     """Return the puppet environment."""
 
-    env_name = default_sat.create_custom_environment(repo=pc_name)
-    env = default_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
+    env_name = module_target_sat.create_custom_environment(repo=pc_name)
+    env = module_target_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
     env.location = [module_location]
     env.organization = [module_org]
     env.update(['location', 'organization'])
@@ -73,9 +73,9 @@ def puppet_classes(env):
 
 
 @pytest.fixture(scope='module')
-def content_source(default_sat):
+def content_source(module_target_sat):
     """Return the proxy."""
-    return Proxy.list({'search': f'url = {default_sat.url}:9090'})[0]
+    return Proxy.list({'search': f'url = {module_target_sat.url}:9090'})[0]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -33,20 +33,20 @@ pytestmark = [
 
 
 @pytest.fixture(scope='module')
-def sat_with_katello_agent(module_destructive_sat):
-    """Enable katello-agent on destructive_sat"""
-    module_destructive_sat.register_to_dogfood()
+def sat_with_katello_agent(module_target_sat):
+    """Enable katello-agent on target_sat"""
+    module_target_sat.register_to_dogfood()
     # Enable katello-agent from satellite-installer
-    result = module_destructive_sat.install(
+    result = module_target_sat.install(
         InstallerCommand('foreman-proxy-content-enable-katello-agent true')
     )
     assert result.status == 0
     # Verify katello-agent is enabled
-    result = module_destructive_sat.install(
+    result = module_target_sat.install(
         InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
     )
     assert 'true' in result.stdout
-    yield module_destructive_sat
+    yield module_target_sat
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -451,7 +451,7 @@ class TestRHSSOAuthSource:
         run_command(f"echo '  :use_sessions: {'true' if enable else 'false'}' >> {HAMMER_CONFIG}")
 
     @pytest.fixture()
-    def rh_sso_hammer_auth_setup(self, destructive_sat, request):
+    def rh_sso_hammer_auth_setup(self, target_sat, request):
         """rh_sso hammer setup before running the auth login tests"""
         self.configure_hammer_session()
         client_config = {'publicClient': 'true'}
@@ -469,7 +469,7 @@ class TestRHSSOAuthSource:
     @pytest.mark.destructive
     def test_rhsso_login_using_hammer(
         self,
-        destructive_sat,
+        target_sat,
         enable_external_auth_rhsso,
         rhsso_setting_setup,
         rh_sso_hammer_auth_setup,
@@ -482,7 +482,7 @@ class TestRHSSOAuthSource:
 
         :CaseImportance: High
         """
-        result = destructive_sat.cli.AuthLogin.oauth(
+        result = target_sat.cli.AuthLogin.oauth(
             {
                 'oidc-token-endpoint': get_oidc_token_endpoint(),
                 'oidc-client-id': get_oidc_client_id(),
@@ -491,19 +491,19 @@ class TestRHSSOAuthSource:
             }
         )
         assert f"Successfully logged in as '{settings.rhsso.rhsso_user}'." == result[0]['message']
-        result = destructive_sat.cli.Auth.with_user(
+        result = target_sat.cli.Auth.with_user(
             username=settings.rhsso.rhsso_user, password=settings.rhsso.rhsso_password
         ).status()
         assert (
             f"Session exists, currently logged in as '{settings.rhsso.rhsso_user}'."
             == result[0]['message']
         )
-        task_list = destructive_sat.cli.Task.with_user(
+        task_list = target_sat.cli.Task.with_user(
             username=settings.rhsso.rhsso_user, password=settings.rhsso.rhsso_password
         ).list()
         assert len(task_list) >= 0
         with pytest.raises(CLIReturnCodeError) as error:
-            destructive_sat.cli.Role.with_user(
+            target_sat.cli.Role.with_user(
                 username=settings.rhsso.rhsso_user, password=settings.rhsso.rhsso_password
             ).list()
         assert 'Missing one of the required permissions' in error.value.message

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -37,7 +37,7 @@ from robottelo.logging import logger
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_foreman_core(default_sat):
+def test_positive_logging_from_foreman_core(target_sat):
     """Check that GET command to Hosts API is logged and has request ID.
 
     :id: 0785260d-cb81-4351-a7cb-d7841335e2de
@@ -51,16 +51,16 @@ def test_positive_logging_from_foreman_core(default_sat):
     source_log = '/var/log/foreman/production.log'
     test_logfile = '/var/tmp/logfile_from_foreman_core'
     # get the number of lines in the source log before the test
-    line_count_start = line_count(source_log, default_sat)
+    line_count_start = line_count(source_log, target_sat)
     # hammer command for this test
-    result = default_sat.execute('hammer host list')
+    result = target_sat.execute('hammer host list')
     assert result.status == 0, f'Non-zero status for host list: {result.stderr}'
     # get the number of lines in the source log after the test
-    line_count_end = line_count(source_log, default_sat)
+    line_count_end = line_count(source_log, target_sat)
     # get the log lines of interest, put them in test_logfile
-    cut_lines(line_count_start, line_count_end, source_log, test_logfile, default_sat)
+    cut_lines(line_count_start, line_count_end, source_log, test_logfile, target_sat)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile)
+    target_sat.get(remote_path=test_logfile)
     # search the log file extract for the line with GET to host API
     with open(test_logfile) as logfile:
         for line in logfile:
@@ -76,7 +76,7 @@ def test_positive_logging_from_foreman_core(default_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_foreman_proxy(default_sat):
+def test_positive_logging_from_foreman_proxy(target_sat):
     """Check PUT to Smart Proxy API to refresh the features is logged and has request ID.
 
     :id: 0ecd8406-6cf1-4520-b8b6-8a164a1e60c2
@@ -93,22 +93,22 @@ def test_positive_logging_from_foreman_proxy(default_sat):
     source_log_2 = '/var/log/foreman-proxy/proxy.log'
     test_logfile_2 = '/var/tmp/logfile_2_from_proxy'
     # get the number of lines in the source logs before the test
-    line_count_start_1 = line_count(source_log_1, default_sat)
-    line_count_start_2 = line_count(source_log_2, default_sat)
+    line_count_start_1 = line_count(source_log_1, target_sat)
+    line_count_start_2 = line_count(source_log_2, target_sat)
     # hammer command for this test
-    result = default_sat.execute('hammer proxy refresh-features --id 1')
+    result = target_sat.execute('hammer proxy refresh-features --id 1')
     assert result.status == 0, f'Non-zero status for host list: {result.stderr}'
     # get the number of lines in the source logs after the test
-    line_count_end_1 = line_count(source_log_1, default_sat)
-    line_count_end_2 = line_count(source_log_2, default_sat)
+    line_count_end_1 = line_count(source_log_1, target_sat)
+    line_count_end_2 = line_count(source_log_2, target_sat)
     # get the log lines of interest, put them in test_logfile_1
-    cut_lines(line_count_start_1, line_count_end_1, source_log_1, test_logfile_1, default_sat)
+    cut_lines(line_count_start_1, line_count_end_1, source_log_1, test_logfile_1, target_sat)
     # get the log lines of interest, put them in test_logfile_2
-    cut_lines(line_count_start_2, line_count_end_2, source_log_2, test_logfile_2, default_sat)
+    cut_lines(line_count_start_2, line_count_end_2, source_log_2, test_logfile_2, target_sat)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile_1)
+    target_sat.get(remote_path=test_logfile_1)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile_2)
+    target_sat.get(remote_path=test_logfile_2)
     # search the log file extract for the line with PUT to host API
     with open(test_logfile_1) as logfile:
         for line in logfile:
@@ -135,7 +135,7 @@ def test_positive_logging_from_foreman_proxy(default_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_candlepin(module_org, default_sat):
+def test_positive_logging_from_candlepin(module_org, target_sat):
     """Check logging after manifest upload.
 
     :id: 8c06e501-52d7-4baf-903e-7de9caffb066
@@ -151,20 +151,20 @@ def test_positive_logging_from_candlepin(module_org, default_sat):
     # regex for a version 4 UUID (8-4-4-12 format)
     regex = r"\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b"
     # get the number of lines in the source log before the test
-    line_count_start = line_count(source_log, default_sat)
+    line_count_start = line_count(source_log, target_sat)
     # command for this test
     with manifests.clone() as manifest:
         with NamedTemporaryFile(dir=robottelo_tmp_dir) as content_file:
             content_file.write(manifest.content.read())
             content_file.seek(0)
-            default_sat.put(local_path=content_file.name, remote_path=manifest.filename)
+            target_sat.put(local_path=content_file.name, remote_path=manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': module_org.id})
     # get the number of lines in the source log after the test
-    line_count_end = line_count(source_log, default_sat)
+    line_count_end = line_count(source_log, target_sat)
     # get the log lines of interest, put them in test_logfile
-    cut_lines(line_count_start, line_count_end, source_log, test_logfile, default_sat)
+    cut_lines(line_count_start, line_count_end, source_log, test_logfile, target_sat)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile)
+    target_sat.get(remote_path=test_logfile)
     # search the log file extract for the line with POST to candlepin API
     with open(test_logfile) as logfile:
         for line in logfile:
@@ -180,7 +180,7 @@ def test_positive_logging_from_candlepin(module_org, default_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_dynflow(module_org, default_sat):
+def test_positive_logging_from_dynflow(module_org, target_sat):
     """Check POST to repositories API is logged while enabling a repo \
         and it has the request ID.
 
@@ -197,16 +197,16 @@ def test_positive_logging_from_dynflow(module_org, default_sat):
     product = entities.Product(organization=module_org).create()
     repo_name = gen_string('alpha')
     # get the number of lines in the source log before the test
-    line_count_start = line_count(source_log, default_sat)
+    line_count_start = line_count(source_log, target_sat)
     # command for this test
     new_repo = entities.Repository(name=repo_name, product=product).create()
     logger.info(f'Created Repo {new_repo.name} for dynflow log test')
     # get the number of lines in the source log after the test
-    line_count_end = line_count(source_log, default_sat)
+    line_count_end = line_count(source_log, target_sat)
     # get the log lines of interest, put them in test_logfile
-    cut_lines(line_count_start, line_count_end, source_log, test_logfile, default_sat)
+    cut_lines(line_count_start, line_count_end, source_log, test_logfile, target_sat)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile)
+    target_sat.get(remote_path=test_logfile)
     # search the log file extract for the line with POST to to repositories API
     with open(test_logfile) as logfile:
         for line in logfile:
@@ -221,7 +221,7 @@ def test_positive_logging_from_dynflow(module_org, default_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_pulp3(module_org, default_sat):
+def test_positive_logging_from_pulp3(module_org, target_sat):
     """
     Verify Pulp3 logs are getting captured using pulp3 correlation ID
 
@@ -253,12 +253,12 @@ def test_positive_logging_from_pulp3(module_org, default_sat):
     Product.synchronize({'id': product['id'], 'organization-id': module_org.id})
     Repository.synchronize({'id': repo['id']})
     # Get the id of repository sync from task
-    task_out = default_sat.execute(
+    task_out = target_sat.execute(
         "hammer task list | grep -F \'Synchronize repository {\"text\"=>\"repository\'"
     ).stdout.splitlines()[0][:8]
-    prod_log_out = default_sat.execute(f'grep  {task_out} {source_log}').stdout.splitlines()[0]
+    prod_log_out = target_sat.execute(f'grep  {task_out} {source_log}').stdout.splitlines()[0]
     # Get correlation id of pulp from production logs
     pulp_correlation_id = re.search(r'\[I\|bac\|\w{8}\]', prod_log_out).group()[7:15]
     # verify pulp correlation id in message
-    message_log = default_sat.execute(f'cat {test_logfile} | grep {pulp_correlation_id}')
+    message_log = target_sat.execute(f'cat {test_logfile} | grep {pulp_correlation_id}')
     assert message_log.status == 0

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -119,7 +119,7 @@ class TestTailoringFiles:
         assert name in [tailoringfile['name'] for tailoringfile in result]
 
     @pytest.mark.tier1
-    def test_negative_create_with_invalid_file(self, default_sat):
+    def test_negative_create_with_invalid_file(self, target_sat):
         """Create Tailoring files with invalid file
 
         :id: 86f5ce13-856c-4e58-997f-fa21093edd04
@@ -132,7 +132,7 @@ class TestTailoringFiles:
 
         :CaseImportance: Medium
         """
-        default_sat.put(get_data_file(SNIPPET_DATA_FILE), f'/tmp/{SNIPPET_DATA_FILE}')
+        target_sat.put(get_data_file(SNIPPET_DATA_FILE), f'/tmp/{SNIPPET_DATA_FILE}')
         name = gen_string('alphanumeric')
         with pytest.raises(CLIFactoryError):
             make_tailoringfile({'name': name, 'scap-file': f'/tmp/{SNIPPET_DATA_FILE}'})
@@ -179,7 +179,7 @@ class TestTailoringFiles:
 
     @pytest.mark.skip_if_open("BZ:1857572")
     @pytest.mark.tier2
-    def test_positive_download_tailoring_file(self, tailoring_file_path, default_sat):
+    def test_positive_download_tailoring_file(self, tailoring_file_path, target_sat):
 
         """Download the tailoring file from satellite
 
@@ -204,7 +204,7 @@ class TestTailoringFiles:
         assert tailoring_file['name'] == name
         result = TailoringFiles.download_tailoring_file({'name': name, 'path': '/var/tmp/'})
         assert file_path in result
-        result = default_sat.execute(f'find {file_path} 2> /dev/null')
+        result = target_sat.execute(f'find {file_path} 2> /dev/null')
         assert result.status == 0
         assert file_path == result.stdout.strip()
 

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -21,7 +21,7 @@ import pytest
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_ping(default_sat):
+def test_positive_ping(target_sat):
     """hammer ping return code
 
     :id: dfa3ab4f-a64f-4a96-8c7f-d940df22b8bf
@@ -33,7 +33,7 @@ def test_positive_ping(default_sat):
 
     :expectedresults: hammer ping returns a right return code
     """
-    result = default_sat.execute('hammer ping')
+    result = target_sat.execute('hammer ping')
     assert result.stderr[1].decode() == ''
 
     status_count = 0
@@ -57,7 +57,7 @@ def test_positive_ping(default_sat):
 
 
 @pytest.mark.destructive
-def test_negative_ping_fail_status_code(default_sat):
+def test_negative_ping_fail_status_code(target_sat):
     """Negative test to verify non-zero status code of ping fail
 
     :id: 8f8675aa-df52-11eb-9353-b0a460e02491
@@ -71,9 +71,9 @@ def test_negative_ping_fail_status_code(default_sat):
     :expectedresults: Hammer ping fails and returns non-zero(1) status code.
 
     """
-    command_out = default_sat.execute('satellite-maintain service stop --only tomcat.service')
+    command_out = target_sat.execute('satellite-maintain service stop --only tomcat.service')
     assert command_out.status == 0
-    result = default_sat.execute("hammer ping")
+    result = target_sat.execute("hammer ping")
     assert result.status == 1
-    command_out = default_sat.execute('satellite-maintain service start --only tomcat.service')
+    command_out = target_sat.execute('satellite-maintain service start --only tomcat.service')
     assert command_out.status == 0

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -174,7 +174,7 @@ def test_negative_create_with_label(label, module_org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_product_list_with_default_settings(module_org, default_sat):
+def test_product_list_with_default_settings(module_org, target_sat):
     """Listing product of an organization apart from default organization using hammer
      does not return output if a defaults settings are applied on org.
 
@@ -205,14 +205,14 @@ def test_product_list_with_default_settings(module_org, default_sat):
         )
 
     Defaults.add({'param-name': 'organization_id', 'param-value': org_id})
-    result = default_sat.cli.Defaults.list(per_page=False)
+    result = target_sat.cli.Defaults.list(per_page=False)
     assert any([res['value'] == org_id for res in result if res['parameter'] == 'organization_id'])
 
     try:
         # Verify --organization-id is not required to pass if defaults are set
-        result = default_sat.cli.Product.list()
+        result = target_sat.cli.Product.list()
         assert any([res['name'] == default_product_name for res in result])
-        result = default_sat.cli.Repository.list()
+        result = target_sat.cli.Repository.list()
         assert any([res['product'] == default_product_name for res in result])
 
         # verify that defaults setting should not affect other entities
@@ -223,7 +223,7 @@ def test_product_list_with_default_settings(module_org, default_sat):
 
     finally:
         Defaults.delete({'param-name': 'organization_id'})
-        result = default_sat.cli.Defaults.list(per_page=False)
+        result = target_sat.cli.Defaults.list(per_page=False)
         assert not [res for res in result if res['parameter'] == 'organization_id']
 
 

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -19,7 +19,7 @@ from robottelo.config import settings
 
 @pytest.mark.tier1
 def test_upgrade_katello_ca_consumer_rpm(
-    module_org, module_location, default_sat, rhel7_contenthost
+    module_org, module_location, target_sat, rhel7_contenthost
 ):
     """After updating the consumer cert the rhsm.conf file still points to Satellite host name
     and not Red Hat CDN for subscription.
@@ -44,21 +44,21 @@ def test_upgrade_katello_ca_consumer_rpm(
 
     :BZ: 1791503
     """
-    consumer_cert_name = f'katello-ca-consumer-{default_sat.hostname}'
+    consumer_cert_name = f'katello-ca-consumer-{target_sat.hostname}'
     consumer_cert_src = f'{consumer_cert_name}-1.0-1.src.rpm'
     new_consumer_cert_rpm = f'{consumer_cert_name}-1.0-2.noarch.rpm'
     spec_file = f'{consumer_cert_name}.spec'
     vm = rhel7_contenthost
     # Install consumer cert and check server URL in /etc/rhsm/rhsm.conf
     assert vm.execute(
-        f'rpm -Uvh "http://{default_sat.hostname}/pub/{consumer_cert_name}-1.0-1.noarch.rpm"'
+        f'rpm -Uvh "http://{target_sat.hostname}/pub/{consumer_cert_name}-1.0-1.noarch.rpm"'
     )
     # Check server URL is not Red Hat CDN's "subscription.rhsm.redhat.com"
     result = vm.execute('grep ^hostname /etc/rhsm/rhsm.conf')
     assert 'subscription.rhsm.redhat.com' not in result.stdout
-    assert default_sat.hostname in result.stdout
+    assert target_sat.hostname in result.stdout
     # Get consumer cert source file
-    assert vm.execute(f'curl -O "http://{default_sat.hostname}/pub/{consumer_cert_src}"')
+    assert vm.execute(f'curl -O "http://{target_sat.hostname}/pub/{consumer_cert_src}"')
     # Install repo for build tools
     vm.create_custom_repos(rhel7=settings.repos.rhel7_os)
     result = vm.execute('[ -s "/etc/yum.repos.d/rhel7.repo" ]')
@@ -77,7 +77,7 @@ def test_upgrade_katello_ca_consumer_rpm(
     # Check server URL is not Red Hat CDN's "subscription.rhsm.redhat.com"
     result = vm.execute('grep ^hostname /etc/rhsm/rhsm.conf')
     assert 'subscription.rhsm.redhat.com' not in result.stdout
-    assert default_sat.hostname in result.stdout
+    assert target_sat.hostname in result.stdout
     # Register as final check
     vm.register_contenthost(module_org.label)
     result = vm.execute('subscription-manager identity')

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -25,12 +25,12 @@ from robottelo.cli.report import ConfigReport
 
 
 @pytest.fixture(scope='module', autouse=True)
-def run_puppet_agent(default_sat):
+def run_puppet_agent(module_target_sat):
     """Retrieves the client configuration from the puppet master and
     applies it to the local host. This is required to make sure
     that we have reports available.
     """
-    default_sat.execute('puppet agent -t')
+    module_target_sat.execute('puppet agent -t')
 
 
 @pytest.mark.tier1

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -67,11 +67,11 @@ from robottelo.hosts import ContentHost
 
 
 @pytest.fixture(scope='module')
-def local_org(default_sat):
+def local_org(module_target_sat):
     """Create org with CLI factory and upload cloned manifest"""
     org = make_org()
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        module_target_sat.put(manifest, manifest.filename)
     return org
 
 
@@ -752,7 +752,7 @@ def test_positive_generate_ansible_template():
 
 @pytest.mark.tier3
 def test_positive_generate_entitlements_report_multiple_formats(
-    local_org, local_ak, local_subscription, rhel7_contenthost, default_sat
+    local_org, local_ak, local_subscription, rhel7_contenthost, target_sat
 ):
     """Generate an report using the Subscription - Entitlement Report template
     in html, yaml, and csv format.
@@ -775,7 +775,7 @@ def test_positive_generate_entitlements_report_multiple_formats(
     :customerscenario: true
     """
     client = rhel7_contenthost
-    client.install_katello_ca(default_sat)
+    client.install_katello_ca(target_sat)
     client.register_contenthost(local_org['label'], local_ak['name'])
     assert client.subscribed
     result_html = ReportTemplate.generate(
@@ -817,7 +817,7 @@ def test_positive_generate_entitlements_report_multiple_formats(
 
 @pytest.mark.tier3
 def test_positive_schedule_entitlements_report(
-    local_org, local_ak, local_subscription, rhel7_contenthost, default_sat
+    local_org, local_ak, local_subscription, rhel7_contenthost, target_sat
 ):
     """Schedule an report using the Subscription - Entitlement Report template in csv format.
 
@@ -837,7 +837,7 @@ def test_positive_schedule_entitlements_report(
     :parametrized: yes
     """
     client = rhel7_contenthost
-    client.install_katello_ca(default_sat)
+    client.install_katello_ca(target_sat)
     client.register_contenthost(local_org['label'], local_ak['name'])
     assert client.subscribed
     scheduled_csv = ReportTemplate.schedule(
@@ -860,7 +860,7 @@ def test_positive_schedule_entitlements_report(
 
 @pytest.mark.tier3
 def test_positive_generate_hostpkgcompare(
-    local_org, local_ak, local_content_view, local_environment, default_sat
+    local_org, local_ak, local_content_view, local_environment, target_sat
 ):
     """Generate 'Host - compare content hosts packages' report
 
@@ -906,7 +906,7 @@ def test_positive_generate_hostpkgcompare(
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}, _count=2) as hosts:
         for client in hosts:
             # Create RHEL hosts via broker and register content host
-            client.install_katello_ca(default_sat)
+            client.install_katello_ca(target_sat)
             # Register content host, install katello-agent
             client.register_contenthost(local_org['label'], local_ak['name'])
             assert client.subscribed

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -569,7 +569,7 @@ class TestRepository:
             assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
-    def test_positive_create_repo_with_new_organization_and_location(self, default_sat):
+    def test_positive_create_repo_with_new_organization_and_location(self, target_sat):
         """Check if error is thrown when creating a Repo with a new Organization and Location.
 
         :id: 9ea4f2a9-f339-4215-b301-cd39c6b5c474
@@ -597,7 +597,7 @@ class TestRepository:
             }
         )
 
-        result = default_sat.execute(
+        result = target_sat.execute(
             "cat /var/log/foreman/production.log | "
             "grep \"undefined method `id' for nil:NilClass (NoMethodError)\""
         )
@@ -1165,7 +1165,7 @@ class TestRepository:
         indirect=True,
     )
     def test_positive_synchronize_rpm_repo_ignore_SRPM(
-        self, module_org, module_product, repo, default_sat
+        self, module_org, module_product, repo, target_sat
     ):
         """Synchronize yum repository with ignore SRPM
 
@@ -1498,7 +1498,7 @@ class TestRepository:
         assert repo['content-counts']['packages'] == '0'
 
     @pytest.mark.tier1
-    def test_positive_upload_content(self, repo, default_sat):
+    def test_positive_upload_content(self, repo, target_sat):
         """Create repository and upload content
 
         :id: eb0ec599-2bf1-483a-8215-66652f948d67
@@ -1513,9 +1513,7 @@ class TestRepository:
 
         :CaseImportance: Critical
         """
-        default_sat.put(
-            local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}"
-        )
+        target_sat.put(local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}")
         result = Repository.upload_content(
             {
                 'name': repo['name'],
@@ -1533,7 +1531,7 @@ class TestRepository:
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
         indirect=True,
     )
-    def test_positive_upload_content_to_file_repo(self, repo, default_sat):
+    def test_positive_upload_content_to_file_repo(self, repo, target_sat):
         """Create file repository and upload content to it
 
         :id: 5e24b416-2928-4533-96cf-6bffbea97a95
@@ -1552,7 +1550,7 @@ class TestRepository:
         # Verify it has finished
         new_repo = Repository.info({'id': repo['id']})
         assert int(new_repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT
-        default_sat.put(
+        target_sat.put(
             local_path=get_data_file(OS_TEMPLATE_DATA_FILE),
             remote_path=f"/tmp/{OS_TEMPLATE_DATA_FILE}",
         )
@@ -1727,7 +1725,7 @@ class TestRepository:
         assert len(repos) == 0
 
     @pytest.mark.tier2
-    def test_positive_upload_remove_srpm_content(self, repo, default_sat):
+    def test_positive_upload_remove_srpm_content(self, repo, target_sat):
         """Create repository, upload and remove an SRPM content
 
         :id: 706dc3e2-dacb-4fdd-8eef-5715ce498888
@@ -1742,7 +1740,7 @@ class TestRepository:
 
         :BZ: 1378442
         """
-        default_sat.put(
+        target_sat.put(
             local_path=get_data_file(SRPM_TO_UPLOAD), remote_path=f"/tmp/{SRPM_TO_UPLOAD}"
         )
         # Upload SRPM
@@ -1770,7 +1768,7 @@ class TestRepository:
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
-    def test_positive_srpm_list_end_to_end(self, repo, default_sat):
+    def test_positive_srpm_list_end_to_end(self, repo, target_sat):
         """Create repository,  upload, list and remove an SRPM content
 
         :id: 98ad4228-f2e5-438a-9210-5ce6561769f2
@@ -1786,7 +1784,7 @@ class TestRepository:
 
         :CaseImportance: High
         """
-        default_sat.put(
+        target_sat.put(
             local_path=get_data_file(SRPM_TO_UPLOAD), remote_path=f"/tmp/{SRPM_TO_UPLOAD}"
         )
         # Upload SRPM
@@ -2237,7 +2235,7 @@ class TestSRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
     )
-    def test_positive_sync(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with SRPMs
 
         :id: eb69f840-122d-4180-b869-1bd37518480c
@@ -2247,7 +2245,7 @@ class TestSRPMRepository:
         :expectedresults: srpms can be listed in repository
         """
         Repository.synchronize({'id': repo['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
             f"/custom/{module_product.label}/{repo['label']}/Packages/t/ | grep .src.rpm"
         )
@@ -2259,7 +2257,7 @@ class TestSRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_cv(self, module_org, module_product, repo, default_sat):
+    def test_positive_sync_publish_cv(self, module_org, module_product, repo, target_sat):
         """Synchronize repository with SRPMs, add repository to content view
         and publish content view
 
@@ -2273,7 +2271,7 @@ class TestSRPMRepository:
         cv = make_content_view({'organization-id': module_org.id})
         ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': cv['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/content_views/"
             f"{cv['label']}/1.0/custom/{module_product.label}/{repo['label']}/Packages/t/"
             " | grep .src.rpm"
@@ -2287,7 +2285,7 @@ class TestSRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with SRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
@@ -2306,7 +2304,7 @@ class TestSRPMRepository:
         content_view = ContentView.info({'id': cv['id']})
         cvv = content_view['versions'][0]
         ContentView.version_promote({'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/{lce['label']}/"
             f"{cv['label']}/custom/{module_product.label}/{repo['label']}/Packages/t"
             " | grep .src.rpm"
@@ -2376,9 +2374,7 @@ class TestAnsibleCollectionRepository:
         ids=['ansible_galaxy'],
         indirect=True,
     )
-    def test_positive_export_ansible_collection(
-        self, repo, module_org, module_product, default_sat
-    ):
+    def test_positive_export_ansible_collection(self, repo, module_org, module_product, target_sat):
         """Export ansible collection between organizations
 
         :id: 4858227e-1669-476d-8da3-4e6bfb6b7e2a
@@ -2396,10 +2392,8 @@ class TestAnsibleCollectionRepository:
         assert repo['sync']['status'] == 'Success'
         # export
         result = ContentExport.completeLibrary({'organization-id': module_org.id})
-        default_sat.execute(
-            f'cp -r /var/lib/pulp/exports/{module_org.name} /var/lib/pulp/imports/.'
-        )
-        default_sat.execute('chown -R pulp:pulp /var/lib/pulp/imports')
+        target_sat.execute(f'cp -r /var/lib/pulp/exports/{module_org.name} /var/lib/pulp/imports/.')
+        target_sat.execute('chown -R pulp:pulp /var/lib/pulp/imports')
         export_metadata = result['message'].split()[1]
         # import
         import_path = export_metadata.replace('/metadata.json', '').replace('exports', 'imports')
@@ -2413,7 +2407,7 @@ class TestAnsibleCollectionRepository:
         ]
         assert len(ac_content) > 0
         repo = Repository.info({'name': ac_content[0]['repo-name'], 'product-id': prod['id']})
-        result = default_sat.execute(f'curl {repo["published-at"]}')
+        result = target_sat.execute(f'curl {repo["published-at"]}')
         assert "available_versions" in result.stdout
 
     @pytest.mark.tier2
@@ -2433,7 +2427,7 @@ class TestAnsibleCollectionRepository:
         indirect=True,
     )
     def test_positive_sync_ansible_collection_from_satellite(
-        self, repo, module_org, module_product, default_sat
+        self, repo, module_org, module_product, target_sat
     ):
         """Sync ansible collection from another organization
 
@@ -2478,7 +2472,7 @@ class TestMD5Repository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_MD5_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, target_sat):
         """Synchronize MD5 signed repository with add repository to content view,
         publish and promote content view to lifecycle environment
 
@@ -2514,7 +2508,7 @@ class TestDRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
     )
-    def test_positive_sync(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with DRPMs
 
         :id: a645966c-750b-40ef-a264-dc3bb632b9fd
@@ -2524,7 +2518,7 @@ class TestDRPMRepository:
         :expectedresults: drpms can be listed in repository
         """
         Repository.synchronize({'id': repo['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
             f"/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
@@ -2536,7 +2530,7 @@ class TestDRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_cv(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync_publish_cv(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with DRPMs, add repository to content view
         and publish content view
 
@@ -2550,7 +2544,7 @@ class TestDRPMRepository:
         cv = make_content_view({'organization-id': module_org.id})
         ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': cv['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/content_views/"
             f"{cv['label']}/1.0/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
@@ -2563,7 +2557,7 @@ class TestDRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with DRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
@@ -2582,7 +2576,7 @@ class TestDRPMRepository:
         content_view = ContentView.info({'id': cv['id']})
         cvv = content_view['versions'][0]
         ContentView.version_promote({'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/{lce['label']}"
             f"/{cv['label']}/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
@@ -2788,7 +2782,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
         indirect=True,
     )
-    def test_positive_upload_file_to_file_repo(self, repo_options, repo, default_sat):
+    def test_positive_upload_file_to_file_repo(self, repo_options, repo, target_sat):
         """Check arbitrary file can be uploaded to File Repository
 
         :id: 134d668d-bd63-4475-bf7b-b899bb9fb7bb
@@ -2805,9 +2799,7 @@ class TestFileRepository:
 
         :CaseImportance: Critical
         """
-        default_sat.put(
-            local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}"
-        )
+        target_sat.put(local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}")
         result = Repository.upload_content(
             {
                 'name': repo['name'],
@@ -2851,7 +2843,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
         indirect=True,
     )
-    def test_positive_remove_file(self, repo, default_sat):
+    def test_positive_remove_file(self, repo, target_sat):
         """Check arbitrary file can be removed from File Repository
 
         :id: 07ca9c8d-e764-404e-866d-30d8cd2ca2b6
@@ -2869,9 +2861,7 @@ class TestFileRepository:
 
         :CaseImportance: Critical
         """
-        default_sat.put(
-            local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}"
-        )
+        target_sat.put(local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}")
         result = Repository.upload_content(
             {
                 'name': repo['name'],
@@ -2934,7 +2924,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': f'file://{CUSTOM_LOCAL_FOLDER}'}]),
         indirect=True,
     )
-    def test_positive_file_repo_local_directory_sync(self, repo, default_sat):
+    def test_positive_file_repo_local_directory_sync(self, repo, target_sat):
         """Check an entire local directory can be synced to File Repository
 
         :id: ee91ecd2-2f07-4678-b782-95a7e7e57159
@@ -2956,8 +2946,8 @@ class TestFileRepository:
         :CaseImportance: Critical
         """
         # Making Setup For Creating Local Directory using Pulp Manifest
-        default_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
-        default_sat.execute(
+        target_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
+        target_sat.execute(
             f'wget -P {CUSTOM_LOCAL_FOLDER} -r -np -nH --cut-dirs=5 -R "index.html*" '
             f'{CUSTOM_FILE_REPO}'
         )
@@ -2971,7 +2961,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': f'file://{CUSTOM_LOCAL_FOLDER}'}]),
         indirect=True,
     )
-    def test_positive_symlinks_sync(self, repo, default_sat):
+    def test_positive_symlinks_sync(self, repo, target_sat):
         """Check symlinks can be synced to File Repository
 
         :id: b0b0a725-b754-450b-bc0d-572d0294307a
@@ -2994,12 +2984,12 @@ class TestFileRepository:
         :CaseAutomation: Automated
         """
         # Downloading the pulp repository into Satellite Host
-        default_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
-        default_sat.execute(
+        target_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
+        target_sat.execute(
             f'wget -P {CUSTOM_LOCAL_FOLDER} -r -np -nH --cut-dirs=5 -R "index.html*" '
             f'{CUSTOM_FILE_REPO}'
         )
-        default_sat.execute(f'ln -s {CUSTOM_LOCAL_FOLDER} /{gen_string("alpha")}')
+        target_sat.execute(f'ln -s {CUSTOM_LOCAL_FOLDER} /{gen_string("alpha")}')
 
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
@@ -3011,7 +3001,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
         indirect=True,
     )
-    def test_file_repo_contains_only_newer_file(self, repo_options, repo, default_sat):
+    def test_file_repo_contains_only_newer_file(self, repo_options, repo, target_sat):
         """
             Check that a file-type repo contains only the newer of
             two versions of a file with the same name.
@@ -3034,7 +3024,7 @@ class TestFileRepository:
         :parametrized: yes
         """
         text_file_name = f'test-{gen_string("alpha", 5)}.txt'.lower()
-        default_sat.execute(f'echo "First File" > /tmp/{text_file_name}')
+        target_sat.execute(f'echo "First File" > /tmp/{text_file_name}')
         result = Repository.upload_content(
             {
                 'name': repo['name'],
@@ -3052,7 +3042,7 @@ class TestFileRepository:
         )
         assert text_file_name == filesearch[0].name
         # Create new version of the file by changing the text
-        default_sat.execute(f'echo "Second File" > /tmp/{text_file_name}')
+        target_sat.execute(f'echo "Second File" > /tmp/{text_file_name}')
         result = Repository.upload_content(
             {
                 'name': repo['name'],

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -118,10 +118,10 @@ def org():
 
 
 @pytest.fixture
-def manifest_org(org, default_sat):
+def manifest_org(org, target_sat):
     """Upload a manifest to the organization."""
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     Subscription.upload({'file': manifest.filename, 'organization-id': org['id']})
     return org
 

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -70,7 +70,7 @@ class TestRepositoryExport:
 
     @pytest.mark.tier3
     def test_positive_export_complete_version_custom_repo(
-        self, default_sat, export_cleanup, module_org
+        self, target_sat, export_cleanup, module_org
     ):
         """Export a custom repository via complete version
 
@@ -106,15 +106,15 @@ class TestRepositoryExport:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export content view
         ContentExport.completeVersion({'id': cvv['id'], 'organization-id': module_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat) != ''
+        assert validate_filepath(target_sat) != ''
 
     @pytest.mark.tier3
     def test_positive_export_incremental_version_custom_repo(
-        self, default_sat, export_cleanup, module_org
+        self, target_sat, export_cleanup, module_org
     ):
         """Export custom repo via incremental export
 
@@ -150,16 +150,16 @@ class TestRepositoryExport:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export complete first, then incremental
         ContentExport.completeVersion({'id': cvv['id'], 'organization-id': module_org.id})
         ContentExport.incrementalVersion({'id': cvv['id'], 'organization-id': module_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat) != ''
+        assert validate_filepath(target_sat) != ''
 
     @pytest.mark.tier3
     def test_positive_export_complete_library_custom_repo(
-        self, function_org, export_cleanup_library, default_sat
+        self, function_org, export_cleanup_library, target_sat
     ):
         """Export custom repo via complete library export
 
@@ -190,15 +190,15 @@ class TestRepositoryExport:
         )
         ContentView.publish({'id': cv['id']})
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export content view
         ContentExport.completeLibrary({'organization-id': function_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat) != ''
+        assert validate_filepath(target_sat) != ''
 
     @pytest.mark.tier3
     def test_positive_export_incremental_library_custom_repo(
-        self, export_cleanup_library, function_org, default_sat
+        self, export_cleanup_library, function_org, target_sat
     ):
         """Export custom repo via incremental library export
 
@@ -230,19 +230,17 @@ class TestRepositoryExport:
         )
         ContentView.publish({'id': cv['id']})
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export complete library, then export incremental
         ContentExport.completeLibrary({'organization-id': function_org.id})
         ContentExport.incrementalLibrary({'organization-id': function_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat) != ''
+        assert validate_filepath(target_sat) != ''
 
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_export_complete_version_rh_repo(
-        self, default_sat, export_cleanup, module_org
-    ):
+    def test_positive_export_complete_version_rh_repo(self, target_sat, export_cleanup, module_org):
         """Export RedHat repo via complete version
 
         :id: e17898db-ca92-4121-a723-0d4b3cf120eb
@@ -255,7 +253,7 @@ class TestRepositoryExport:
         # Enable RH repository
         cv_name = gen_string('alpha')
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': module_org.id})
         RepositorySet.enable(
             {
@@ -290,17 +288,17 @@ class TestRepositoryExport:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export content view
         ContentExport.completeVersion({'id': cvv['id'], 'organization-id': module_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat) != ''
+        assert validate_filepath(target_sat) != ''
 
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_complete_library_rh_repo(
-        self, export_cleanup_library, function_org, default_sat
+        self, export_cleanup_library, function_org, target_sat
     ):
         """Export RedHat repo via complete library
 
@@ -314,7 +312,7 @@ class TestRepositoryExport:
         # Enable RH repository
         cv_name = gen_string('alpha')
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': function_org.id})
         RepositorySet.enable(
             {
@@ -346,11 +344,11 @@ class TestRepositoryExport:
         )
         ContentView.publish({'id': cv['id']})
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export content view
         ContentExport.completeLibrary({'organization-id': function_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat) != ''
+        assert validate_filepath(target_sat) != ''
 
 
 @pytest.fixture(scope='class')
@@ -382,19 +380,19 @@ def class_export_entities(module_org):
 
 
 @pytest.fixture(scope='function')
-def export_cleanup_library(default_sat, function_org):
+def export_cleanup_library(target_sat, function_org):
     """Deletes dir for library export"""
     yield
     # Deletes directory created for library export test
-    assert default_sat.execute(f'rm -rf {EXPORT_DIR}/{function_org.name}').stdout == ''
+    assert target_sat.execute(f'rm -rf {EXPORT_DIR}/{function_org.name}').stdout == ''
 
 
 @pytest.fixture(scope='function')
-def export_cleanup(default_sat, module_org):
+def export_cleanup(target_sat, module_org):
     """Deletes dir for version export"""
     yield
     # Deletes directory created for CV export Test
-    assert default_sat.execute(f'rm -rf {EXPORT_DIR}/{module_org.name}').stdout == ''
+    assert target_sat.execute(f'rm -rf {EXPORT_DIR}/{module_org.name}').stdout == ''
 
 
 def validate_filepath(sat_obj):
@@ -520,7 +518,7 @@ class TestContentViewSync:
         class_export_entities,
         config_export_import_settings,
         export_cleanup,
-        default_sat,
+        target_sat,
         module_org,
     ):
         """Export the CV and import it.  Ensure that all content is same from
@@ -560,7 +558,7 @@ class TestContentViewSync:
         exported_packages = Package.list({'content-view-version-id': export_cvv_id})
         assert len(exported_packages)
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export cv
         path = ContentExport.completeVersion(
             {'id': export_cvv_id, 'organization-id': module_org.id}
@@ -568,18 +566,18 @@ class TestContentViewSync:
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
         # Move export files to import location and set permission
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import files and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -610,7 +608,7 @@ class TestContentViewSync:
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_export_import_default_org_view(
-        self, export_cleanup_library, function_org, config_export_import_settings, default_sat
+        self, export_cleanup_library, function_org, config_export_import_settings, target_sat
     ):
         """Export Default Organization View version contents in directory and Import them.
 
@@ -678,13 +676,13 @@ class TestContentViewSync:
         cv_packages = Package.list({'content-view-version-id': default_cvv_id})
         assert len(cv_packages)
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export complete library
         path = ContentExport.completeLibrary({'organization-id': function_org.id})
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert result.stdout != ''
         # Verify 'export-library' is created and packages are there
         export_lib_cv = ContentView.info(
@@ -698,17 +696,17 @@ class TestContentViewSync:
         assert len(cv_packages)
         assert exported_lib_packages == cv_packages
         # Verify export directory is not empty
-        assert validate_filepath(default_sat) != ''
+        assert validate_filepath(target_sat) != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on and set download policy to immediate
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
         # Move export files to import location and set permission
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import and verify content of library
         ContentImport.library({'organization-id': importing_org['id'], 'path': import_path})
@@ -726,7 +724,7 @@ class TestContentViewSync:
         class_export_entities,
         export_cleanup,
         config_export_import_settings,
-        default_sat,
+        target_sat,
         module_org,
     ):
         """CV Version with filtered contents is the only one that gets exported and imported
@@ -789,7 +787,7 @@ class TestContentViewSync:
         export_packages = Package.list({'content-view-version-id': exporting_cvv_id})
         assert len(export_packages) == 1
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export cv
         path = ContentExport.completeVersion(
             {'id': exporting_cvv_id, 'organization-id': module_org.id}
@@ -797,18 +795,18 @@ class TestContentViewSync:
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert result.stdout != ''
         # Import section
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
         # Move export files to import location and set permission
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import file and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -827,7 +825,7 @@ class TestContentViewSync:
         class_export_entities,
         export_cleanup,
         config_export_import_settings,
-        default_sat,
+        target_sat,
         module_org,
     ):
         """Export promoted CV version contents in directory and Import them.
@@ -866,7 +864,7 @@ class TestContentViewSync:
         exported_packages = Package.list({'content-view-version-id': promoted_cvv_id})
         assert len(exported_packages)
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export cv
         path = ContentExport.completeVersion(
             {'id': export_cvv_id, 'organization-id': module_org.id}
@@ -874,18 +872,18 @@ class TestContentViewSync:
         # Grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
         # Move export files to import location and set permission
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -906,7 +904,7 @@ class TestContentViewSync:
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_export_import_redhat_cv(
-        self, export_cleanup, config_export_import_settings, function_org, default_sat
+        self, export_cleanup, config_export_import_settings, function_org, target_sat
     ):
         """Export CV version redhat contents in directory and Import them
 
@@ -940,7 +938,7 @@ class TestContentViewSync:
         # Setup rhel repo
         cv_name = gen_string('alpha')
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': function_org.id})
         RepositorySet.enable(
             {
@@ -975,23 +973,23 @@ class TestContentViewSync:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export cv
         path = ContentExport.completeVersion({'id': cvv['id'], 'organization-id': function_org.id})
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert len(result.stdout) > 1
         exported_packages = Package.list({'content-view-version-id': cvv['id']})
         assert len(exported_packages)
         # importing portion
         importing_org = make_org()
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'/{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         manifests.upload_manifest_locked(
             importing_org['id'], interface=manifests.INTERFACE_CLI, timeout=7200000
@@ -1029,7 +1027,7 @@ class TestContentViewSync:
         self,
         export_cleanup,
         config_export_import_settings,
-        default_sat,
+        target_sat,
         function_org,
     ):
         """Export CV version redhat contents in directory and Import them
@@ -1064,7 +1062,7 @@ class TestContentViewSync:
         cv_name = gen_string('alpha')
 
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': function_org.id})
         RepositorySet.enable(
             {
@@ -1105,17 +1103,17 @@ class TestContentViewSync:
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert len(result.stdout) > 1
         exported_packages = Package.list({'content-view-version-id': cvv['id']})
         assert len(exported_packages)
         # importing portion
         importing_org = make_org()
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import and verify content
         manifests.upload_manifest_locked(
@@ -1156,7 +1154,7 @@ class TestContentViewSync:
         class_export_entities,
         export_cleanup,
         config_export_import_settings,
-        default_sat,
+        target_sat,
         module_org,
     ):
         """Import the same cv twice
@@ -1180,7 +1178,7 @@ class TestContentViewSync:
         export_cvv_id = class_export_entities['exporting_cvv_id']
         export_cv_name = class_export_entities['exporting_cv_name']
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export cv
         path = ContentExport.completeVersion(
             {'id': export_cvv_id, 'organization-id': module_org.id}
@@ -1188,17 +1186,17 @@ class TestContentViewSync:
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import section
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -1313,7 +1311,7 @@ class TestContentViewSync:
 
     @pytest.mark.tier3
     def test_postive_export_cv_with_mixed_content_repos(
-        self, class_export_entities, export_cleanup, default_sat, module_org
+        self, class_export_entities, export_cleanup, target_sat, module_org
     ):
         """Exporting CV version having yum and non-yum(docker) is successful
 
@@ -1384,19 +1382,19 @@ class TestContentViewSync:
         exported_packages = Package.list({'content-view-version-id': exporting_cvv_id['id']})
         assert len(exported_packages)
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export cv
         path = ContentExport.completeVersion(
             {'id': exporting_cvv_id['id'], 'organization-id': module_org.id}
         )
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert result.stdout != ''
 
     @pytest.mark.tier3
     def test_postive_import_export_cv_with_file_content(
-        self, default_sat, config_export_import_settings, export_cleanup, module_org
+        self, target_sat, config_export_import_settings, export_cleanup, module_org
     ):
         """Exporting and Importing cv with file content
 
@@ -1442,7 +1440,7 @@ class TestContentViewSync:
         exported_files = File.list({'content-view-version-id': exporting_cvv_id})
         assert len(exported_files)
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export cv
         path = ContentExport.completeVersion(
             {'id': exporting_cvv_id, 'organization-id': module_org.id}
@@ -1450,18 +1448,18 @@ class TestContentViewSync:
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
         # Move export files to import location and set permission
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import files and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -1475,7 +1473,7 @@ class TestContentViewSync:
 
     @pytest.mark.tier3
     def test_postive_import_export_ansible_collection_repo(
-        self, default_sat, config_export_import_settings, export_cleanup, function_org
+        self, target_sat, config_export_import_settings, export_cleanup, function_org
     ):
         """Exporting and Importing library with ansible collection
 
@@ -1510,18 +1508,18 @@ class TestContentViewSync:
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
         # Move export files to import location and set permission
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import files and verify content
         ContentImport.library({'organization-id': importing_org['id'], 'path': import_path})
@@ -1539,7 +1537,7 @@ class TestContentViewSync:
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.mark.tier3
     def test_negative_import_redhat_cv_without_manifest(
-        self, export_cleanup, config_export_import_settings, function_org, default_sat
+        self, export_cleanup, config_export_import_settings, function_org, target_sat
     ):
         """Redhat content can't be imported into satellite/organization without manifest
 
@@ -1563,7 +1561,7 @@ class TestContentViewSync:
         # Setup rhel repo
         cv_name = gen_string('alpha')
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': function_org.id})
         RepositorySet.enable(
             {
@@ -1598,21 +1596,21 @@ class TestContentViewSync:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat) == ''
+        assert validate_filepath(target_sat) == ''
         # Export cv
         path = ContentExport.completeVersion({'id': cvv['id'], 'organization-id': function_org.id})
         # grab export dir and check all exported files are there
         export_dir = os.path.dirname(path['message'])
         export_folder = os.path.split(export_dir)
-        result = default_sat.execute(f'ls {export_dir}')
+        result = target_sat.execute(f'ls {export_dir}')
         assert len(result.stdout) > 1
         # importing portion
         importing_org = make_org()
-        default_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
         import_path = f'/{IMPORT_DIR}{export_folder[1]}'
-        default_sat.execute(f'chown -R pulp:pulp {import_path}')
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -425,7 +425,7 @@ def test_negative_update_send_welcome_email(value):
 @pytest.mark.tier3
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['failed_login_attempts_limit'], indirect=True)
-def test_positive_failed_login_attempts_limit(setting_update, default_sat):
+def test_positive_failed_login_attempts_limit(setting_update, target_sat):
     """automate brute force protection limit configurable function
 
     :id: f95407ed-451b-4387-ac9b-2959ae2f51ae
@@ -453,12 +453,12 @@ def test_positive_failed_login_attempts_limit(setting_update, default_sat):
     """
     username = settings.server.admin_username
     password = settings.server.admin_password
-    assert default_sat.execute(f'hammer -u {username} -p {password} user list').status == 0
+    assert target_sat.execute(f'hammer -u {username} -p {password} user list').status == 0
     Settings.set({'name': 'failed_login_attempts_limit', 'value': '5'})
     for _ in range(5):
-        assert default_sat.execute(f'hammer -u {username} -p BAD_PASS user list').status == 129
-    assert default_sat.execute(f'hammer -u {username} -p {password} user list').status == 129
+        assert target_sat.execute(f'hammer -u {username} -p BAD_PASS user list').status == 129
+    assert target_sat.execute(f'hammer -u {username} -p {password} user list').status == 129
     sleep(301)
-    assert default_sat.execute(f'hammer -u {username} -p {password} user list').status == 0
+    assert target_sat.execute(f'hammer -u {username} -p {password} user list').status == 0
     Settings.set({'name': 'failed_login_attempts_limit', 'value': '0'})
     assert Settings.info({'name': 'failed_login_attempts_limit'})['value'] == '0'

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -179,7 +179,7 @@ def test_positive_subscription_list(function_org, manifest_clone_upload):
 
 
 @pytest.mark.tier2
-def test_positive_delete_manifest_as_another_user(default_sat):
+def test_positive_delete_manifest_as_another_user(target_sat):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
 
@@ -204,7 +204,7 @@ def test_positive_delete_manifest_as_another_user(default_sat):
     ).create()
     # use the first admin to upload a manifest
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     Subscription.with_user(username=user1.login, password=user1_password).upload(
         {'file': manifest.filename, 'organization-id': org.id}
     )
@@ -261,7 +261,7 @@ def test_positive_candlepin_events_processed_by_STOMP():
 
 @pytest.mark.tier2
 def test_positive_auto_attach_disabled_golden_ticket(
-    module_org, golden_ticket_host_setup, rhel7_contenthost_class, default_sat
+    module_org, golden_ticket_host_setup, rhel7_contenthost_class, target_sat
 ):
     """Verify that Auto-Attach is disabled or "Not Applicable"
     when a host organization is in Simple Content Access mode (Golden Ticket)
@@ -279,7 +279,7 @@ def test_positive_auto_attach_disabled_golden_ticket(
 
     :CaseImportance: Medium
     """
-    rhel7_contenthost_class.install_katello_ca(default_sat)
+    rhel7_contenthost_class.install_katello_ca(target_sat)
     rhel7_contenthost_class.register_contenthost(module_org.label, golden_ticket_host_setup['name'])
     assert rhel7_contenthost_class.subscribed
     host = Host.list({'search': rhel7_contenthost_class.hostname})

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -565,7 +565,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_rh_product_past_sync_date(default_sat):
+def test_positive_synchronize_rh_product_past_sync_date(target_sat):
     """Create a sync plan with past datetime as a sync date, add a
     RH product and verify the product gets synchronized on the next sync
     occurrence
@@ -582,7 +582,7 @@ def test_positive_synchronize_rh_product_past_sync_date(default_sat):
     delay = 2 * 60
     org = make_org()
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     Subscription.upload({'file': manifest.filename, 'organization-id': org['id']})
     RepositorySet.enable(
         {
@@ -633,7 +633,7 @@ def test_positive_synchronize_rh_product_past_sync_date(default_sat):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_rh_product_future_sync_date(default_sat):
+def test_positive_synchronize_rh_product_future_sync_date(target_sat):
     """Create a sync plan with sync date in a future and sync one RH
     product with it automatically.
 
@@ -650,7 +650,7 @@ def test_positive_synchronize_rh_product_future_sync_date(default_sat):
     guardtime = 180  # do not start test less than 2 mins before the next sync event
     org = make_org()
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     Subscription.upload({'file': manifest.filename, 'organization-id': org['id']})
     RepositorySet.enable(
         {

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -359,7 +359,7 @@ class TestSshKeyInUser:
         assert ssh_name not in [i['name'] for i in result]
 
     @pytest.mark.tier1
-    def test_positive_create_ssh_key_super_admin_from_file(self, default_sat):
+    def test_positive_create_ssh_key_super_admin_from_file(self, target_sat):
         """SSH Key can be added to Super Admin user from file
 
         :id: b865d0ae-6317-475c-a6da-600615b71eeb
@@ -370,7 +370,7 @@ class TestSshKeyInUser:
         :CaseImportance: Critical
         """
         ssh_name = gen_string('alpha')
-        result = default_sat.execute(f"echo '{self.ssh_key}' > test_key.pub")
+        result = target_sat.execute(f"echo '{self.ssh_key}' > test_key.pub")
         assert result.status == 0, 'key file not created'
         User.ssh_keys_add({'user': 'admin', 'key-file': 'test_key.pub', 'name': ssh_name})
         result = User.ssh_keys_list({'user': 'admin'})
@@ -383,7 +383,7 @@ class TestPersonalAccessToken:
     """Implement personal access token for the users"""
 
     @pytest.mark.tier2
-    def test_personal_access_token_admin_user(self, default_sat):
+    def test_personal_access_token_admin_user(self, target_sat):
         """Personal access token for admin user
 
         :id: f2d3813f-e477-4b6b-8507-246b08fcb3b4
@@ -407,16 +407,16 @@ class TestPersonalAccessToken:
             action="create", options={'name': token_name, 'user-id': user['id']}
         )
         token_value = result[0]['message'].split(':')[-1]
-        curl_command = f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
-        command_output = default_sat.execute(curl_command)
+        curl_command = f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
+        command_output = target_sat.execute(curl_command)
         assert user['login'] in command_output.stdout
         assert user['email'] in command_output.stdout
         User.access_token(action="revoke", options={'name': token_name, 'user-id': user['id']})
-        command_output = default_sat.execute(curl_command)
+        command_output = target_sat.execute(curl_command)
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout
 
     @pytest.mark.tier2
-    def test_positive_personal_access_token_user_with_role(self, default_sat):
+    def test_positive_personal_access_token_user_with_role(self, target_sat):
         """Personal access token for user with a role
 
         :id: b9fe7ddd-d1e4-4d76-9966-d223b02768ec
@@ -444,18 +444,18 @@ class TestPersonalAccessToken:
             action="create", options={'name': token_name, 'user-id': user['id']}
         )
         token_value = result[0]['message'].split(':')[-1]
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
         )
         assert user['login'] in command_output.stdout
         assert user['email'] in command_output.stdout
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/dashboard'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/dashboard'
         )
         assert 'Access denied' in command_output.stdout
 
     @pytest.mark.tier2
-    def test_expired_personal_access_token(self, default_sat):
+    def test_expired_personal_access_token(self, target_sat):
         """Personal access token expired for the user.
 
         :id: cb07b096-aba4-4a95-9a15-5413f32b597b
@@ -482,19 +482,19 @@ class TestPersonalAccessToken:
             options={'name': token_name, 'user-id': user['id'], 'expires-at': datetime_expire},
         )
         token_value = result[0]['message'].split(':')[-1]
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
         )
         assert user['login'] in command_output.stdout
         assert user['email'] in command_output.stdout
         sleep(20)
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/hosts'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/hosts'
         )
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout
 
     @pytest.mark.tier2
-    def test_custom_personal_access_token_role(self, default_sat):
+    def test_custom_personal_access_token_role(self, target_sat):
         """Personal access token for non admin user with custom role
 
         :id: dcbd22df-2641-4d3e-a1ad-76f36642e31b
@@ -530,13 +530,13 @@ class TestPersonalAccessToken:
             action="create", options={'name': token_name, 'user-id': user['id']}
         )
         token_value = result[0]['message'].split(':')[-1]
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
         )
         assert user['login'] in command_output.stdout
         assert user['email'] in command_output.stdout
         User.access_token(action="revoke", options={'name': token_name, 'user-id': user['id']})
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
         )
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -48,7 +48,7 @@ def lce(org):
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize('cdn', [True, False], ids=['cdn', 'no_cdn'])
 @pytest.mark.parametrize('distro', DISTROS_SUPPORTED)
-def test_vm_install_package(org, lce, distro, cdn, default_sat):
+def test_vm_install_package(org, lce, distro, cdn, target_sat):
     """Install a package with all supported distros and cdn / non-cdn variants
 
     :id: b2a6065a-69f6-4805-a28b-eaaa812e0f4b
@@ -72,7 +72,7 @@ def test_vm_install_package(org, lce, distro, cdn, default_sat):
     with VMBroker(nick=distro, host_classes={'host': ContentHost}) as host:
         # install katello-agent
         repos_collection.setup_virtual_machine(
-            host, default_sat, enable_custom_repos=True, install_katello_agent=False
+            host, target_sat, enable_custom_repos=True, install_katello_agent=False
         )
         # install a package from custom repo
         result = host.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1056,7 +1056,7 @@ class TestEndToEnd:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    def test_positive_end_to_end(self, fake_manifest_is_set, default_sat, rhel7_contenthost):
+    def test_positive_end_to_end(self, fake_manifest_is_set, target_sat, rhel7_contenthost):
         """Perform end to end smoke tests using RH and custom repos.
 
         1. Create a new user with admin permissions
@@ -1206,7 +1206,7 @@ class TestEndToEnd:
         # step 2.18: Provision a client
         # TODO this isn't provisioning through satellite as intended
         # Note it wasn't well before the change that added this todo
-        rhel7_contenthost.install_katello_ca(default_sat)
+        rhel7_contenthost.install_katello_ca(target_sat)
         # Register client with foreman server using act keys
         rhel7_contenthost.register_contenthost(org.label, activation_key_name)
         assert rhel7_contenthost.subscribed

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -92,7 +92,7 @@ def test_positive_cli_find_admin_user():
 @pytest.mark.tier4
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_cli_end_to_end(fake_manifest_is_set, default_sat, rhel7_contenthost):
+def test_positive_cli_end_to_end(fake_manifest_is_set, target_sat, rhel7_contenthost):
     """Perform end to end smoke tests using RH and custom repos.
 
     1. Create a new user with admin permissions
@@ -134,7 +134,7 @@ def test_positive_cli_end_to_end(fake_manifest_is_set, default_sat, rhel7_conten
     # step 2.2: Clone and upload manifest
     if fake_manifest_is_set:
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': org['id']})
 
     # step 2.3: Create a new lifecycle environment
@@ -329,7 +329,7 @@ def test_positive_cli_end_to_end(fake_manifest_is_set, default_sat, rhel7_conten
     # step 2.18: Provision a client
     # TODO this isn't provisioning through satellite as intended
     # Note it wasn't well before the change that added this todo
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     # Register client with foreman server using act keys
     rhel7_contenthost.register_contenthost(org['label'], activation_key['name'])
     assert rhel7_contenthost.subscribed

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -64,7 +64,7 @@ def register_satellite(sat):
     params,
     ids=['isc_dhcp', 'infoblox_dhcp', 'infoblox_dns'],
 )
-def test_plugin_installation(destructive_sat, command_args, command_opts, rpm_command):
+def test_plugin_installation(target_sat, command_args, command_opts, rpm_command):
     """Check that external DNS and DHCP plugins install correctly
 
     :id: c75aa5f3-870a-4f4a-9d7a-0a871b47fd6f
@@ -79,11 +79,11 @@ def test_plugin_installation(destructive_sat, command_args, command_opts, rpm_co
 
     :BZ: 1994490, 2000237
     """
-    register_satellite(destructive_sat)
+    register_satellite(target_sat)
     installer_obj = InstallerCommand(command_args, **command_opts)
-    command_output = destructive_sat.execute(installer_obj.get_command())
+    command_output = target_sat.execute(installer_obj.get_command())
     assert 'Success!' in command_output.stdout
-    rpm_result = destructive_sat.execute(rpm_command)
+    rpm_result = target_sat.execute(rpm_command)
     assert rpm_result.status == 0
 
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -140,10 +140,10 @@ def host(
     custom_repo,
     module_ak,
     module_cv,
-    default_sat,
+    module_target_sat,
 ):
     # Create client machine and register it to satellite with rhel_7_partial_ak
-    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.install_katello_ca(module_target_sat)
     # Register, enable tools repo and install katello-host-tools.
     rhel7_contenthost_module.register_contenthost(module_manifest_org.label, module_ak.name)
     rhel7_contenthost_module.enable_repo(REPOS['rhst7']['id'])

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -75,9 +75,9 @@ def fetch_scap_and_profile_id(scap_name, scap_profile):
 
 
 @pytest.fixture(scope='module')
-def default_proxy(default_sat):
+def default_proxy(module_target_sat):
     """Returns default capsule/proxy id"""
-    proxy = Proxy.list({'search': default_sat.hostname})[0]
+    proxy = Proxy.list({'search': module_target_sat.hostname})[0]
     p_features = set(proxy.get('features').split(', '))
     if {'Ansible', 'Openscap'}.issubset(p_features):
         proxy_id = proxy.get('id')
@@ -140,7 +140,7 @@ def update_scap_content(module_org):
 @pytest.mark.tier4
 @pytest.mark.parametrize('distro', [DISTRO_RHEL6, DISTRO_RHEL7, DISTRO_RHEL8])
 def test_positive_oscap_run_via_ansible(
-    module_org, default_proxy, content_view, lifecycle_env, distro, default_sat
+    module_org, default_proxy, content_view, lifecycle_env, distro, target_sat
 ):
     """End-to-End Oscap run via ansible
 
@@ -211,7 +211,7 @@ def test_positive_oscap_run_via_ansible(
         target_memory=OSCAP_TARGET_MEMORY,
     ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
-        vm.install_katello_ca(default_sat)
+        vm.install_katello_ca(target_sat)
         vm.register_contenthost(module_org.name, ak_name[distro])
         assert vm.subscribed
         Host.set_parameter(
@@ -226,7 +226,7 @@ def test_positive_oscap_run_via_ansible(
             vm.create_custom_repos(**rhel_repo)
         else:
             vm.create_custom_repos(**{distro: rhel_repo})
-        vm.add_rex_key(satellite=default_sat)
+        vm.add_rex_key(satellite=target_sat)
         Host.update(
             {
                 'name': vm.hostname.lower(),
@@ -262,7 +262,7 @@ def test_positive_oscap_run_via_ansible(
 
 @pytest.mark.tier4
 def test_positive_oscap_run_via_ansible_bz_1814988(
-    module_org, default_proxy, content_view, lifecycle_env, default_sat
+    module_org, default_proxy, content_view, lifecycle_env, target_sat
 ):
     """End-to-End Oscap run via ansible
 
@@ -326,7 +326,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
         target_memory=OSCAP_TARGET_MEMORY,
     ) as vm:
         host_name, _, host_domain = vm.hostname.partition('.')
-        vm.install_katello_ca(default_sat)
+        vm.install_katello_ca(target_sat)
         vm.register_contenthost(module_org.name, ak_name[DISTRO_RHEL7])
         assert vm.subscribed
         Host.set_parameter(
@@ -345,7 +345,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
             '--fetch-remote-resources --results-arf results.xml '
             '/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml',
         )
-        vm.add_rex_key(satellite=default_sat)
+        vm.add_rex_key(satellite=target_sat)
         Host.update(
             {
                 'name': vm.hostname.lower(),

--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -20,7 +20,7 @@ import pytest
 
 
 @pytest.mark.tier2
-def test_positive_setup_dynflow(default_sat):
+def test_positive_setup_dynflow(target_sat):
     """Set dynflow parameters, restart it and check it adheres to them
 
     :id: a5aaab5e-bc18-453e-a284-64aef752ec88
@@ -37,5 +37,5 @@ def test_positive_setup_dynflow(default_sat):
     ]
     # if thread count is not respected or the process is not running, this should timeout
     # how is this a test? Nothing is asserted.
-    default_sat.execute(' && '.join(commands))
-    default_sat.execute("systemctl stop 'dynflow-sidekiq@test'; rm /etc/foreman/dynflow/test.yml")
+    target_sat.execute(' && '.join(commands))
+    target_sat.execute("systemctl stop 'dynflow-sidekiq@test'; rm /etc/foreman/dynflow/test.yml")

--- a/tests/foreman/sys/test_foreman_rake.py
+++ b/tests/foreman/sys/test_foreman_rake.py
@@ -18,7 +18,7 @@ import pytest
 @pytest.mark.destructive
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_katello_reimport(destructive_sat):
+def test_positive_katello_reimport(target_sat):
     """Close loop bug for running katello:reimport.  Making sure
     that katello:reimport works and doesn't throw an error.
 
@@ -37,6 +37,6 @@ def test_positive_katello_reimport(destructive_sat):
     :customerscenario: true
     """
 
-    result = destructive_sat.execute('foreman-rake katello:reimport')
+    result = target_sat.execute('foreman-rake katello:reimport')
     assert 'NoMethodError:' not in result.stdout
     assert 'rake aborted!' not in result.stdout

--- a/tests/foreman/sys/test_hooks.py
+++ b/tests/foreman/sys/test_hooks.py
@@ -33,21 +33,21 @@ pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.destructive]
 
 
 @pytest.fixture(scope='function')
-def logger_hook(default_org, default_sat):
+def logger_hook(default_org, target_sat):
     """Create logger script to be executed via hooks"""
-    default_sat.execute(
+    target_sat.execute(
         '''printf '#!/bin/sh\necho "$(date): Executed $1 hook'''
         + f''' on object $2" > {LOGS_DIR}' > {SCRIPT_PATH}'''
     )
-    default_sat.execute(f'chmod 774 {SCRIPT_PATH}')
-    default_sat.execute(f'chown foreman:foreman {SCRIPT_PATH}')
-    default_sat.execute(f'restorecon -RvF {HOOKS_DIR}')
+    target_sat.execute(f'chmod 774 {SCRIPT_PATH}')
+    target_sat.execute(f'chown foreman:foreman {SCRIPT_PATH}')
+    target_sat.execute(f'restorecon -RvF {HOOKS_DIR}')
     yield
 
-    default_sat.execute(f'rm -rf {HOOKS_DIR}/*')
+    target_sat.execute(f'rm -rf {HOOKS_DIR}/*')
 
 
-def test_positive_host_hooks(logger_hook, default_sat):
+def test_positive_host_hooks(logger_hook, target_sat):
     """Create hooks to be executed on host create, update and destroy
 
     :id: 4fe35fda-1524-44f7-9221-96d1aeafc75c
@@ -69,15 +69,15 @@ def test_positive_host_hooks(logger_hook, default_sat):
     destroy_event = 'destroy'
     for event in [create_event, destroy_event, update_event]:
         hook_dir = f'{HOOKS_DIR}/host/managed/{event}'
-        default_sat.execute(f'mkdir -p {hook_dir}')
-        default_sat.execute(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
-    result = default_sat.execute('systemctl restart httpd')
+        target_sat.execute(f'mkdir -p {hook_dir}')
+        target_sat.execute(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
+    result = target_sat.execute('systemctl restart httpd')
     assert result.status == 0
 
     # delete host, check logs for hook activity
     host = entities.Host(name=host_name).create()
     assert host.name == f'{host_name}.{host.domain.read().name}'
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(create_event, host_name) in result.stdout
 
@@ -86,7 +86,7 @@ def test_positive_host_hooks(logger_hook, default_sat):
     host.ip = new_ip
     host = host.update(['ip'])
     assert host.ip == new_ip
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(update_event, host_name) in result.stdout
 
@@ -94,12 +94,12 @@ def test_positive_host_hooks(logger_hook, default_sat):
     host.delete()
     with pytest.raises(HTTPError):
         host.read()
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(destroy_event, host_name) in result.stdout
 
 
-def test_positive_hostgroup_hooks(logger_hook, default_org, default_sat):
+def test_positive_hostgroup_hooks(logger_hook, default_org, target_sat):
     """Create hooks to be executed on hostgroup create, udpdate and destroy
 
     :id: 7e935dec-e4fe-47d8-be02-8c687a99ae7a
@@ -122,15 +122,15 @@ def test_positive_hostgroup_hooks(logger_hook, default_org, default_sat):
     destroy_event = 'before_destroy'
     for event in [create_event, update_event, destroy_event]:
         hook_dir = f'{HOOKS_DIR}/hostgroup/{event}'
-        default_sat.execute(f'mkdir -p {hook_dir}')
-        default_sat.execute(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
-    result = default_sat.execute('systemctl restart httpd')
+        target_sat.execute(f'mkdir -p {hook_dir}')
+        target_sat.execute(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
+    result = target_sat.execute('systemctl restart httpd')
     assert result.status == 0
 
     # create hg, check logs for hook activity
     hg = entities.HostGroup(name=hg_name, organization=[default_org.id]).create()
     assert hg.name == hg_name
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(create_event, hg_name) in result.stdout
 
@@ -139,7 +139,7 @@ def test_positive_hostgroup_hooks(logger_hook, default_org, default_sat):
     hg.architecture = new_arch
     hg = hg.update(['architecture'])
     assert hg.architecture.read().name == new_arch.name
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(update_event, hg_name) in result.stdout
 
@@ -147,6 +147,6 @@ def test_positive_hostgroup_hooks(logger_hook, default_org, default_sat):
     hg.delete()
     with pytest.raises(HTTPError):
         hg.read()
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(destroy_event, hg_name) in result.stdout

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -21,7 +21,7 @@ import pytest
 
 
 @pytest.mark.upgrade
-def test_selinux_status(default_sat):
+def test_selinux_status(target_sat):
     """Test SELinux status.
 
     :id: 43218070-ac5e-4679-b74a-3e2bcb497a0a
@@ -30,10 +30,10 @@ def test_selinux_status(default_sat):
 
     """
     # check SELinux is enabled
-    result = default_sat.execute('getenforce')
+    result = target_sat.execute('getenforce')
     assert 'Enforcing' in result.stdout
     # check there are no SELinux denials
-    result = default_sat.execute('ausearch --input-logs -m avc -ts today --raw')
+    result = target_sat.execute('ausearch --input-logs -m avc -ts today --raw')
     assert result.status == 1
 
 
@@ -47,7 +47,7 @@ def test_selinux_status(default_sat):
         '/var/lib/pulp/tmp',
     ],
 )
-def test_pulp_directory_exists(default_sat, directory):
+def test_pulp_directory_exists(target_sat, directory):
     """Check Pulp3 directories are present.
 
     :id: 96a64932-9e89-4063-9d5b-55c811375361
@@ -58,11 +58,11 @@ def test_pulp_directory_exists(default_sat, directory):
 
     """
     # check pulp3 directories present
-    assert default_sat.execute(f'test -d {directory}').status == 0, f'{directory} must exist.'
+    assert target_sat.execute(f'test -d {directory}').status == 0, f'{directory} must exist.'
 
 
 @pytest.mark.upgrade
-def test_pulp_service_definitions(default_sat):
+def test_pulp_service_definitions(target_sat):
     """Test systemd settings for Pulp3 file system layout.
 
     :id: e584faea-dede-4895-8d7f-411cb074f6c0
@@ -71,15 +71,15 @@ def test_pulp_service_definitions(default_sat):
 
     """
     # check pulpcore settings
-    result = default_sat.execute('systemctl cat pulpcore-content.socket')
+    result = target_sat.execute('systemctl cat pulpcore-content.socket')
     assert result.status == 0
     assert 'ListenStream=/run/pulpcore-content.sock' in result.stdout
-    result = default_sat.execute('systemctl cat pulpcore-content.service')
+    result = target_sat.execute('systemctl cat pulpcore-content.service')
     assert result.status == 0
     assert 'Requires=pulpcore-content.socket' in result.stdout
-    result = default_sat.execute('systemctl cat pulpcore-api.service')
+    result = target_sat.execute('systemctl cat pulpcore-api.service')
     assert result.status == 0
     assert 'Requires=pulpcore-api.socket' in result.stdout
     # check pulp3 configuration file present
-    result = default_sat.execute('test -f /etc/pulp/settings.py')
+    result = target_sat.execute('test -f /etc/pulp/settings.py')
     assert result.status == 0

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -39,7 +39,7 @@ class TestRenameHost:
 
     @pytest.mark.skip_if_open("BZ:1925616")
     @pytest.mark.destructive
-    def test_positive_rename_satellite(self, module_org, module_product, destructive_sat):
+    def test_positive_rename_satellite(self, module_org, module_product, target_sat):
         """run katello-change-hostname on Satellite server
 
         :id: 9944bfb1-1440-4820-ada8-2e219f09c0be
@@ -72,50 +72,50 @@ class TestRenameHost:
         """
         username = settings.server.admin_username
         password = settings.server.admin_password
-        old_hostname = destructive_sat.execute('hostname').stdout
+        old_hostname = target_sat.execute('hostname').stdout
         new_hostname = f'new-{old_hostname}'
         # create installation medium with hostname in path
         medium_path = f'http://{old_hostname}/testpath-{gen_string("alpha")}/os/'
         medium = entities.Media(organization=[module_org], path_=medium_path).create()
         repo = entities.Repository(product=module_product, name='testrepo').create()
-        result = destructive_sat.execute(
+        result = target_sat.execute(
             f'satellite-change-hostname {new_hostname} -y -u {username} -p {password}',
             timeout=1200000,
         )
         assert result.status == 0, 'unsuccessful rename'
         assert BCK_MSG in result.stdout
         # services running after rename?
-        result = destructive_sat.execute('hammer ping')
+        result = target_sat.execute('hammer ping')
         assert result.status == 0, 'services did not start properly'
         # basic hostname check
-        result = destructive_sat.execute('hostname')
+        result = target_sat.execute('hostname')
         assert result.status == 0
         assert new_hostname in result.stdout, 'hostname left unchanged'
         # check default capsule
-        result = destructive_sat.execute(
+        result = target_sat.execute(
             f'hammer -u {username} -p {password} --output json capsule info --name {new_hostname}'
         )
         assert result.status == 0, 'internal capsule not renamed correctly'
         assert hammer.parse_json(result.stdout)['url'] == f"https://{new_hostname}:9090"
         # check old consumer certs were deleted
-        result = destructive_sat.execute(f'rpm -qa | grep ^{old_hostname}')
+        result = target_sat.execute(f'rpm -qa | grep ^{old_hostname}')
         assert result.status == 1, 'old consumer certificates not removed'
         # check new consumer certs were created
-        result = destructive_sat.execute(f'rpm -qa | grep ^{new_hostname}')
+        result = target_sat.execute(f'rpm -qa | grep ^{new_hostname}')
         assert result.status == 0, 'new consumer certificates not created'
         # check if installation media paths were updated
-        result = destructive_sat.execute(
+        result = target_sat.execute(
             f'hammer -u {username} -p {password} --output json medium info --id {medium.id}'
         )
         assert result.status == 0
         assert new_hostname in hammer.parse_json(result.stdout)['path']
         # check answer file for instances of old hostname
         ans_f = '/etc/foreman-installer/scenarios.d/satellite-answers.yaml'
-        result = destructive_sat.execute(f'grep " {old_hostname}" {ans_f}')
+        result = target_sat.execute(f'grep " {old_hostname}" {ans_f}')
         assert result.status == 1, 'old hostname was not correctly replaced in answers.yml'
 
         # check repository published at path
-        result = destructive_sat.execute(
+        result = target_sat.execute(
             f'hammer -u {username} -p {password} --output json repository info --id {repo.id}'
         )
         assert result.status == 0
@@ -124,7 +124,7 @@ class TestRenameHost:
         ), 'repository published path not updated correctly'
 
         # check for any other occurences of old hostname
-        result = destructive_sat.execute(f'grep " {old_hostname}" /etc/* -r')
+        result = target_sat.execute(f'grep " {old_hostname}" /etc/* -r')
         assert result.status == 1, 'there are remaining instances of the old hostname'
 
         repo.sync()
@@ -134,7 +134,7 @@ class TestRenameHost:
         cv.publish()
 
     @pytest.mark.destructive
-    def test_negative_rename_sat_to_invalid_hostname(self, destructive_sat):
+    def test_negative_rename_sat_to_invalid_hostname(self, target_sat):
         """change to invalid hostname on Satellite server
 
         :id: 385fad60-3990-42e0-9436-4ebb71918125
@@ -148,19 +148,19 @@ class TestRenameHost:
         """
         username = settings.server.admin_username
         password = settings.server.admin_password
-        original_name = destructive_sat.hostname
+        original_name = target_sat.hostname
         hostname = gen_string('alpha')
-        result = destructive_sat.execute(
+        result = target_sat.execute(
             f'satellite-change-hostname -y {hostname} -u {username} -p {password}'
         )
         assert result.status == 1
         assert BAD_HN_MSG.format(hostname) in result.stdout
         # assert no changes were made
-        result = destructive_sat.execute('hostname')
+        result = target_sat.execute('hostname')
         assert original_name == result.stdout, "Invalid hostame assigned"
 
     @pytest.mark.destructive
-    def test_negative_rename_sat_no_credentials(self, destructive_sat):
+    def test_negative_rename_sat_no_credentials(self, target_sat):
         """change hostname without credentials on Satellite server
 
         :id: ed4f7611-33c9-455f-8557-507cc59ede92
@@ -172,18 +172,18 @@ class TestRenameHost:
 
         :CaseAutomation: Automated
         """
-        original_name = destructive_sat.hostname
+        original_name = target_sat.hostname
         hostname = gen_string('alpha')
-        result = destructive_sat.execute(f'satellite-change-hostname -y {hostname}')
+        result = target_sat.execute(f'satellite-change-hostname -y {hostname}')
         assert result.status == 1
         assert NO_CREDS_MSG in result.stdout
         # assert no changes were made
-        result = destructive_sat.execute('hostname')
+        result = target_sat.execute('hostname')
         assert original_name == result.stdout, "Invalid hostame assigned"
 
     @pytest.mark.skip_if_open("BZ:1925616")
     @pytest.mark.destructive
-    def test_negative_rename_sat_wrong_passwd(self, destructive_sat):
+    def test_negative_rename_sat_wrong_passwd(self, target_sat):
         """change hostname with wrong password on Satellite server
 
         :id: e6d84c5b-4bb1-4400-8022-d01cc9216936
@@ -196,10 +196,10 @@ class TestRenameHost:
         :CaseAutomation: Automated
         """
         username = settings.server.admin_username
-        original_name = destructive_sat.hostname
+        original_name = target_sat.hostname
         new_hostname = f'new-{original_name}'
         password = gen_string('alpha')
-        result = destructive_sat.execute(
+        result = target_sat.execute(
             f'satellite-change-hostname -y {new_hostname} -u {username} -p {password}'
         )
         assert result.status == 1
@@ -207,7 +207,7 @@ class TestRenameHost:
 
     @pytest.mark.stubbed
     @pytest.mark.destructive
-    def test_positive_rename_capsule(self, destructive_sat):
+    def test_positive_rename_capsule(self, target_sat):
         """run katello-change-hostname on Capsule
 
         :id: 4aa9fd86-bba9-49e4-a67a-8685e1ab5a74
@@ -239,7 +239,7 @@ class TestRenameHost:
         password = settings.server.admin_password
         # the rename part of the test, not necessary to run from robottelo
         hostname = gen_string('alpha')
-        result = destructive_sat.execute(
+        result = target_sat.execute(
             'satellite-change-hostname '
             f'-y -u {username} -p {password} '
             '--disable-system-checks '

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -81,7 +81,7 @@ def test_positive_end_to_end_crud(session, module_org):
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_end_to_end_register(session, rhel7_contenthost, default_sat):
+def test_positive_end_to_end_register(session, rhel7_contenthost, target_sat):
     """Create activation key and use it during content host registering
 
     :id: dfaecf6a-ba61-47e1-87c5-f8966a319b41
@@ -103,7 +103,7 @@ def test_positive_end_to_end_register(session, rhel7_contenthost, default_sat):
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
     ak_name = repos_collection.setup_content_data['activation_key']['name']
 
-    repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
     with session:
         session.organization.select(org.name)
         chost = session.contenthost.read(rhel7_contenthost.hostname, widget_names='details')
@@ -857,7 +857,7 @@ def test_positive_add_docker_repo_ccv(session, module_org):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_positive_add_host(session, module_org, rhel6_contenthost, default_sat):
+def test_positive_add_host(session, module_org, rhel6_contenthost, target_sat):
     """Test that hosts can be associated to Activation Keys
 
     :id: 886e9ea5-d917-40e0-a3b1-41254c4bf5bf
@@ -880,7 +880,7 @@ def test_positive_add_host(session, module_org, rhel6_contenthost, default_sat):
         organization=module_org,
     ).create()
 
-    rhel6_contenthost.install_katello_ca(default_sat)
+    rhel6_contenthost.install_katello_ca(target_sat)
     rhel6_contenthost.register_contenthost(module_org.label, ak.name)
     assert rhel6_contenthost.subscribed
     with session:
@@ -893,7 +893,7 @@ def test_positive_add_host(session, module_org, rhel6_contenthost, default_sat):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_positive_delete_with_system(session, rhel6_contenthost, default_sat):
+def test_positive_delete_with_system(session, rhel6_contenthost, target_sat):
     """Delete an Activation key which has registered systems
 
     :id: 86cd070e-cf46-4bb1-b555-e7cb42e4dc9f
@@ -924,7 +924,7 @@ def test_positive_delete_with_system(session, rhel6_contenthost, default_sat):
         )
         assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.add_subscription(name, product_name)
-        rhel6_contenthost.install_katello_ca(default_sat)
+        rhel6_contenthost.install_katello_ca(target_sat)
         rhel6_contenthost.register_contenthost(org.label, name)
         assert rhel6_contenthost.subscribed
         session.activationkey.delete(name)
@@ -933,7 +933,7 @@ def test_positive_delete_with_system(session, rhel6_contenthost, default_sat):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_negative_usage_limit(session, module_org, default_sat):
+def test_negative_usage_limit(session, module_org, target_sat):
     """Test that Usage limit actually limits usage
 
     :id: 9fe2d661-66f8-46a4-ae3f-0a9329494bdd
@@ -959,10 +959,10 @@ def test_negative_usage_limit(session, module_org, default_sat):
         assert ak['details']['hosts_limit'] == hosts_limit
     with VMBroker(nick='rhel6', host_classes={'host': ContentHost}, _count=2) as hosts:
         vm1, vm2 = hosts
-        vm1.install_katello_ca(default_sat)
+        vm1.install_katello_ca(target_sat)
         vm1.register_contenthost(module_org.label, name)
         assert vm1.subscribed
-        vm2.install_katello_ca(default_sat)
+        vm2.install_katello_ca(target_sat)
         result = vm2.register_contenthost(module_org.label, name)
         assert not vm2.subscribed
         assert len(result.stderr)
@@ -973,7 +973,7 @@ def test_negative_usage_limit(session, module_org, default_sat):
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
-def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenthost, default_sat):
+def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenthost, target_sat):
     """Check if multiple Activation keys can be attached to a system
 
     :id: 4d6b6b69-9d63-4180-af2e-a5d908f8adb7
@@ -1017,7 +1017,7 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenth
             ]
             assert product_name in subscriptions
         # Create VM
-        rhel6_contenthost.install_katello_ca(default_sat)
+        rhel6_contenthost.install_katello_ca(target_sat)
         rhel6_contenthost.register_contenthost(module_org.label, ','.join([key_1_name, key_2_name]))
         assert rhel6_contenthost.subscribed
         # Assert the content-host association with activation keys
@@ -1031,7 +1031,7 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenth
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_host_associations(session, default_sat):
+def test_positive_host_associations(session, target_sat):
     """Register few hosts with different activation keys and ensure proper
     data is reflected under Associations > Content Hosts tab
 
@@ -1058,10 +1058,10 @@ def test_positive_host_associations(session, default_sat):
     ).create()
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}, _count=2) as hosts:
         vm1, vm2 = hosts
-        vm1.install_katello_ca(default_sat)
+        vm1.install_katello_ca(target_sat)
         vm1.register_contenthost(org.label, ak1.name)
         assert vm1.subscribed
-        vm2.install_katello_ca(default_sat)
+        vm2.install_katello_ca(target_sat)
         vm2.register_contenthost(org.label, ak2.name)
         assert vm2.subscribed
         with session:
@@ -1078,7 +1078,7 @@ def test_positive_host_associations(session, default_sat):
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_service_level_subscription_with_custom_product(
-    session, rhel7_contenthost, default_sat
+    session, rhel7_contenthost, target_sat
 ):
     """Subscribe a host to activation key with Premium service level and with
     custom product
@@ -1130,7 +1130,7 @@ def test_positive_service_level_subscription_with_custom_product(
     activation_key.service_level = 'Premium'
     activation_key = activation_key.update(['service_level'])
 
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org.label, activation_key=activation_key.name)
     assert rhel7_contenthost.subscribed
     result = rhel7_contenthost.run('subscription-manager list --consumed')

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2588,7 +2588,7 @@ def test_positive_publish_with_repo_with_disabled_http(session, module_org):
 
 @pytest.mark.upgrade
 @pytest.mark.tier2
-def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthost, default_sat):
+def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthost, target_sat):
     """Attempt to subscribe a host to content view with custom repository
 
     :id: 715db997-707b-4868-b7cc-b6977fd6ac04
@@ -2610,7 +2610,7 @@ def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthos
         repositories=[SatelliteToolsRepository(), YumRepository(url=settings.repos.yum_0.url)],
     )
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
-    repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
     assert rhel7_contenthost.subscribed
     with session:
         session.organization.select(org.name)
@@ -2624,7 +2624,7 @@ def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthos
 
 @pytest.mark.tier3
 def test_positive_delete_with_kickstart_repo_and_host_group(
-    session, default_sat, smart_proxy_location
+    session, target_sat, smart_proxy_location
 ):
     """Check that Content View associated with kickstart repository and
     which is used by a host group can be removed from the system
@@ -2642,7 +2642,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(
     :CaseImportance: High
     """
     hg_name = gen_string('alpha')
-    sat_hostname = default_sat.hostname
+    sat_hostname = target_sat.hostname
     org = entities.Organization().create()
     # Create a new Lifecycle environment
     lc_env = entities.LifecycleEnvironment(organization=org).create()
@@ -2944,7 +2944,7 @@ def test_positive_rh_mixed_content_end_to_end(session, module_prod, module_org):
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_errata_inc_update_list_package(session, default_sat):
+def test_positive_errata_inc_update_list_package(session, target_sat):
     """Publish incremental update with a new errata for a custom repo
 
     :BZ: 1489778
@@ -3005,7 +3005,7 @@ def test_positive_errata_inc_update_list_package(session, default_sat):
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_composite_child_inc_update(session, rhel7_contenthost, default_sat):
+def test_positive_composite_child_inc_update(session, rhel7_contenthost, target_sat):
     """Incremental update with a new errata on a child content view should
     trigger incremental update of parent composite content view
 
@@ -3083,7 +3083,7 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, default
         f'hammer activation-key add-subscription --id {ak_id} '
         f'--subscription {product.name} --organization-id {org.id}'
     )
-    result = default_sat.execute(command)
+    result = target_sat.execute(command)
     assert result.status == 0
     # Create composite cv
     composite_cv = entities.ContentView(composite=True, organization=org).create()
@@ -3100,7 +3100,7 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, default
     entities.ActivationKey(
         id=content_data['activation_key']['id'], content_view=composite_cv
     ).update(['content_view'])
-    repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
     result = rhel7_contenthost.run(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
     with session:
@@ -3745,7 +3745,7 @@ def test_positive_depsolve_with_module_errata(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_filter_by_pkg_group_name(session, module_org, default_sat):
+def test_positive_filter_by_pkg_group_name(session, module_org, target_sat):
     """Publish a filtered version of a Content View, filtering on the package group's name.
 
     :id: c7021f46-0168-44f7-a863-4aa34533efdb
@@ -3761,10 +3761,10 @@ def test_positive_filter_by_pkg_group_name(session, module_org, default_sat):
     package_group = 'birds'
     expected_packages = [('cockateel'), ('duck'), ('penguin'), ('stork')]
     create_sync_custom_repo(module_org.id, repo_name=repo_name)
-    repo = default_sat.api.Repository(name=repo_name).search(
+    repo = target_sat.api.Repository(name=repo_name).search(
         query={'organization_id': module_org.id}
     )[0]
-    cv = default_sat.api.ContentView(organization=module_org, repository=[repo]).create()
+    cv = target_sat.api.ContentView(organization=module_org, repository=[repo]).create()
     with session:
         session.contentviewfilter.create(
             cv.name,

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -194,7 +194,7 @@ def test_positive_task_status(session):
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_user_access_with_host_filter(
-    test_name, module_location, rhel7_contenthost, default_sat
+    test_name, module_location, rhel7_contenthost, target_sat
 ):
     """Check if user with necessary host permissions can access dashboard
     and required widgets are rendered with proper values
@@ -250,7 +250,7 @@ def test_positive_user_access_with_host_filter(
         )
         repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
         repos_collection.setup_virtual_machine(
-            rhel7_contenthost, default_sat, location_title=module_location.name
+            rhel7_contenthost, target_sat, location_title=module_location.name
         )
         result = rhel7_contenthost.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
         assert result.status == 0

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -131,7 +131,7 @@ def test_create_with_config_group(session, module_org, module_location):
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_create_with_puppet_class(session, module_org, module_location, default_sat):
+def test_create_with_puppet_class(session, module_org, module_location, target_sat):
     """Create new host group with assigned puppet class to it
 
     :id: 166ca6a6-c0f7-4fa0-a3f2-b0d6980cf50d
@@ -142,8 +142,8 @@ def test_create_with_puppet_class(session, module_org, module_location, default_
     """
     name = gen_string('alpha')
     pc_name = 'generic_1'
-    env_name = default_sat.create_custom_environment(repo=pc_name)
-    env = default_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
+    env_name = target_sat.create_custom_environment(repo=pc_name)
+    env = target_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
     env = entities.Environment(
         id=env.id,
         location=[module_location],
@@ -187,7 +187,7 @@ def test_positive_create_new_host():
 
 
 def test_positive_nested_host_groups(
-    session, module_org, module_lce, module_published_cv, module_ak_cv_lce, default_sat
+    session, module_org, module_lce, module_published_cv, module_ak_cv_lce, target_sat
 ):
     """Verify create, update and delete operation for nested host-groups
 
@@ -209,8 +209,8 @@ def test_positive_nested_host_groups(
     parent_hg_name = gen_string('alpha')
     child_hg_name = gen_string('alpha')
     description = gen_string('alpha')
-    architecture = default_sat.api.Architecture().create()
-    os = default_sat.api.OperatingSystem(architecture=[architecture]).create()
+    architecture = target_sat.api.Architecture().create()
+    os = target_sat.api.OperatingSystem(architecture=[architecture]).create()
     os_name = f'{os.name} {os.major}'
     with session:
         # Create parent host-group with default lce and content view
@@ -224,7 +224,7 @@ def test_positive_nested_host_groups(
                 'operating_system.operating_system': os_name,
             }
         )
-        assert default_sat.api.HostGroup().search(query={'search': f'name={parent_hg_name}'})
+        assert target_sat.api.HostGroup().search(query={'search': f'name={parent_hg_name}'})
 
         # Create nested host group
         session.hostgroup.create(
@@ -233,7 +233,7 @@ def test_positive_nested_host_groups(
                 'host_group.name': child_hg_name,
             }
         )
-        assert default_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})
+        assert target_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})
         child_hostgroup_values = session.hostgroup.read(f'{parent_hg_name}/{child_hg_name}')
         assert parent_hg_name in child_hostgroup_values['host_group']['parent_name']
         assert ENVIRONMENT in child_hostgroup_values['host_group']['lce']
@@ -255,4 +255,4 @@ def test_positive_nested_host_groups(
 
         # Delete nested host group
         session.hostgroup.delete(f'{parent_hg_name}/{child_hg_name}')
-        assert not default_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})
+        assert not target_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -24,9 +24,9 @@ from robottelo.datafactory import gen_string
 
 
 @pytest.fixture
-def module_rhel_client_by_ip(module_org, smart_proxy_location, rhel7_contenthost, default_sat):
+def module_rhel_client_by_ip(module_org, smart_proxy_location, rhel7_contenthost, target_sat):
     """Setup a broker rhel client to be used in remote execution by ip"""
-    rhel7_contenthost.configure_rex(satellite=default_sat, org=module_org)
+    rhel7_contenthost.configure_rex(satellite=target_sat, org=module_org)
     update_vm_host_location(rhel7_contenthost, location_id=smart_proxy_location.id)
     yield rhel7_contenthost
 

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -21,7 +21,7 @@ from fauxfactory import gen_string
 
 
 @pytest.mark.tier2
-def test_positive_end_to_end(session, module_org, module_location, default_sat):
+def test_positive_end_to_end(session, module_org, module_location, target_sat):
     """Perform end to end testing for Job Template component.
 
     :id: 2e0e31c5-e557-4151-83f9-21820c9cb1be
@@ -207,7 +207,7 @@ def test_positive_end_to_end(session, module_org, module_location, default_sat):
             editor_view_option='Preview',
             widget_names='template.template_editor.editor',
         )
-        assert default_sat.hostname in template_values['template']['template_editor']['editor']
+        assert target_sat.hostname in template_values['template']['template_editor']['editor']
         session.jobtemplate.clone(template_new_name, {'template.name': template_clone_name})
         assert session.jobtemplate.search(template_clone_name)[0]['Name'] == template_clone_name
         for name in (template_new_name, template_clone_name):

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -52,7 +52,7 @@ pytestmark = [pytest.mark.run_in_one_thread]
 EXTERNAL_GROUP_NAME = 'foobargroup'
 
 
-def set_certificate_in_satellite(server_type, default_sat, hostname=None):
+def set_certificate_in_satellite(server_type, target_sat, hostname=None):
     """update the cert settings in satellite based on type of ldap server"""
     if server_type == 'IPA':
         idm_cert_path_url = os.path.join(settings.ipa.hostname, 'ipa/config/ca.crt')
@@ -60,22 +60,22 @@ def set_certificate_in_satellite(server_type, default_sat, hostname=None):
             file_url=idm_cert_path_url,
             local_path=CERT_PATH,
             file_name='ipa.crt',
-            hostname=default_sat.hostname,
+            hostname=target_sat.hostname,
         )
     elif server_type == 'AD':
         assert hostname is not None
-        default_sat.execute('yum -y --disableplugin=foreman-protector install cifs-utils')
+        target_sat.execute('yum -y --disableplugin=foreman-protector install cifs-utils')
         command = r'mount -t cifs -o username=administrator,pass={0} //{1}/c\$ /mnt'
-        default_sat.execute(command.format(settings.ldap.password, hostname))
-        result = default_sat.execute(
+        target_sat.execute(command.format(settings.ldap.password, hostname))
+        result = target_sat.execute(
             f'cp /mnt/Users/Administrator/Desktop/satqe-QE-SAT6-AD-CA.cer {CERT_PATH}'
         )
         if result.status != 0:
             raise AssertionError('Failed to copy the AD server certificate at right path')
-    result = default_sat.execute(f'update-ca-trust extract && restorecon -R {CERT_PATH}')
+    result = target_sat.execute(f'update-ca-trust extract && restorecon -R {CERT_PATH}')
     if result.status != 0:
         raise AssertionError('Failed to update and trust the certificate')
-    result = default_sat.execute('systemctl restart httpd')
+    result = target_sat.execute('systemctl restart httpd')
     if result.status != 0:
         raise AssertionError(f'Failed to restart the httpd after applying {server_type} cert')
 
@@ -275,7 +275,7 @@ def test_positive_create_org_and_loc(session, ldap_auth_source, ldap_tear_down):
 @pytest.mark.parametrize('ldap_auth_source', ['AD_2016', 'AD_2019', 'IPA'], indirect=True)
 @pytest.mark.destructive
 def test_positive_create_with_https(
-    session, subscribe_satellite, test_name, ldap_auth_source, ldap_tear_down, default_sat
+    session, subscribe_satellite, test_name, ldap_auth_source, ldap_tear_down, target_sat
 ):
     """Create LDAP auth_source for IDM with HTTPS.
 
@@ -298,11 +298,11 @@ def test_positive_create_with_https(
     """
     ldap_data, auth_source = ldap_auth_source
     if ldap_data['auth_type'] == 'ipa':
-        set_certificate_in_satellite(server_type='IPA', default_sat=default_sat)
+        set_certificate_in_satellite(server_type='IPA', target_sat=target_sat)
         username = settings.ipa.user
     else:
         set_certificate_in_satellite(
-            server_type='AD', default_sat=default_sat, hostname=ldap_data['ldap_hostname']
+            server_type='AD', target_sat=target_sat, hostname=ldap_data['ldap_hostname']
         )
         username = settings.ldap.username
     org = entities.Organization().create()
@@ -923,7 +923,7 @@ def test_negative_login_user_with_invalid_password_otp(
 
 @pytest.mark.destructive
 def test_single_sign_on_ldap_ipa_server(
-    subscribe_satellite, enroll_idm_and_configure_external_auth, ldap_tear_down, default_sat
+    subscribe_satellite, enroll_idm_and_configure_external_auth, ldap_tear_down, target_sat
 ):
     """Verify the single sign-on functionality with external authentication
 
@@ -942,23 +942,23 @@ def test_single_sign_on_ldap_ipa_server(
         run_command(cmd='satellite-installer --foreman-ipa-authentication=true', timeout=800000)
         run_command('satellite-maintain service restart', timeout=300000)
         if is_open('BZ:1941997'):
-            curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin'
+            curl_command = f'curl -k -u : --negotiate {target_sat.url}/users/extlogin'
         else:
-            curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin/'
+            curl_command = f'curl -k -u : --negotiate {target_sat.url}/users/extlogin/'
         result = run_command(curl_command)
         assert 'redirected' in result
-        assert f'{default_sat.url}/hosts' in result
+        assert f'{target_sat.url}/hosts' in result
         assert 'You are being' in result
     finally:
         # resetting the settings to default for external auth
         run_command(cmd='satellite-installer --foreman-ipa-authentication=false', timeout=800000)
         run_command('satellite-maintain service restart', timeout=300000)
         run_command(
-            cmd=f'ipa service-del HTTP/{default_sat.hostname}',
+            cmd=f'ipa service-del HTTP/{target_sat.hostname}',
             hostname=settings.ipa.hostname,
         )
         run_command(
-            cmd=f'ipa host-del {default_sat.hostname}',
+            cmd=f'ipa host-del {target_sat.hostname}',
             hostname=settings.ipa.hostname,
         )
 
@@ -968,7 +968,7 @@ def test_single_sign_on_ldap_ipa_server(
 )
 @pytest.mark.destructive
 def test_single_sign_on_ldap_ad_server(
-    subscribe_satellite, enroll_ad_and_configure_external_auth, default_sat
+    subscribe_satellite, enroll_ad_and_configure_external_auth, target_sat
 ):
     """Verify the single sign-on functionality with external authentication
 
@@ -999,12 +999,12 @@ def test_single_sign_on_ldap_ad_server(
         # create the kerberos ticket for authentication
         run_command(f'echo {settings.ldap.password} | kinit {settings.ldap.username}')
         if is_open('BZ:1941997'):
-            curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin'
+            curl_command = f'curl -k -u : --negotiate {target_sat.url}/users/extlogin'
         else:
-            curl_command = f'curl -k -u : --negotiate {default_sat.url}/users/extlogin/'
+            curl_command = f'curl -k -u : --negotiate {target_sat.url}/users/extlogin/'
         result = run_command(curl_command)
         assert 'redirected' in result
-        assert f'{default_sat.url}/hosts' in result
+        assert f'{target_sat.url}/hosts' in result
     finally:
         # resetting the settings to default for external auth
         run_command(cmd='satellite-installer --foreman-ipa-authentication=false', timeout=800000)

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -34,7 +34,7 @@ CUSTOM_REPO_ERRATA_ID = settings.repos.yum_0.errata[0]
 
 
 @pytest.fixture(scope='module')
-def module_repos_col(module_org, module_lce, default_sat, request):
+def module_repos_col(module_org, module_lce, module_target_sat, request):
     upload_manifest_locked(org_id=module_org.id)
     repos_collection = RepositoryCollection(
         repositories=[
@@ -49,7 +49,7 @@ def module_repos_col(module_org, module_lce, default_sat, request):
     @request.addfinalizer
     def _cleanup():
         try:
-            default_sat.api.Subscription(organization=module_org).delete_manifest(
+            module_target_sat.api.Subscription(organization=module_org).delete_manifest(
                 data={'organization_id': module_org.id}
             )
         except Exception:
@@ -315,7 +315,7 @@ def test_positive_download_debug_cert_after_refresh(session):
 
 @pytest.mark.tier2
 def test_positive_errata_view_organization_switch(
-    session, module_org, module_lce, module_repos_col, default_sat
+    session, module_org, module_lce, module_repos_col, target_sat
 ):
     """Verify no errata list visible on Organization switch
 

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -26,18 +26,18 @@ from robottelo.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def oscap_content_path(default_sat):
+def oscap_content_path(module_target_sat):
     _, file_name = os.path.split(settings.oscap.content_path)
 
     local_file = robottelo_tmp_dir.joinpath(file_name)
-    default_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
+    module_target_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
     return local_file
 
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(
-    session, oscap_content_path, default_sat, default_org, default_location
+    session, oscap_content_path, target_sat, default_org, default_location
 ):
     """Perform end to end testing for openscap content component
 

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -386,7 +386,7 @@ def test_positive_autocomplete(session):
 
 @pytest.mark.tier2
 def test_positive_schedule_generation_and_get_mail(
-    session, module_manifest_org, module_location, default_sat
+    session, module_manifest_org, module_location, target_sat
 ):
     """Schedule generating a report. Request the result be sent via e-mail.
 
@@ -435,11 +435,11 @@ def test_positive_schedule_generation_and_get_mail(
         f'send "q\\r"\n'
     )
 
-    assert default_sat.execute(f"expect -c '{expect_script}'").status == 0
-    default_sat.get(remote_path=str(gzip_path), local_path=str(local_gzip_file))
+    assert target_sat.execute(f"expect -c '{expect_script}'").status == 0
+    target_sat.get(remote_path=str(gzip_path), local_path=str(local_gzip_file))
     assert os.system(f'gunzip {local_gzip_file}') == 0
     data = json.loads(local_file.read_text())
-    subscription_search = default_sat.api.Subscription(organization=module_manifest_org).search()
+    subscription_search = target_sat.api.Subscription(organization=module_manifest_org).search()
     assert len(data) >= len(subscription_search) > 0
     keys_expected = [
         'Account number',
@@ -496,7 +496,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
 
 @pytest.mark.tier3
 def test_positive_gen_entitlements_reports_multiple_formats(
-    session, setup_content, rhel7_contenthost, default_sat
+    session, setup_content, rhel7_contenthost, target_sat
 ):
     """Generate reports using the Entitlements template in html, yaml, json, and csv format.
 
@@ -520,7 +520,7 @@ def test_positive_gen_entitlements_reports_multiple_formats(
     :CaseImportance: High
     """
     client = rhel7_contenthost
-    client.install_katello_ca(default_sat)
+    client.install_katello_ca(target_sat)
     module_org, ak = setup_content
     client.register_contenthost(module_org.label, ak.name)
     assert client.subscribed

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -477,7 +477,7 @@ def test_failed_inventory_upload():
 
 
 @pytest.mark.tier2
-def test_rhcloud_inventory_without_manifest(session, module_org, default_sat):
+def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
     """Verify that proper error message is given when no manifest is imported in an organization.
 
     :id: 1d90bb24-2380-4653-8ed6-a084fce66d1e
@@ -501,7 +501,7 @@ def test_rhcloud_inventory_without_manifest(session, module_org, default_sat):
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(module_org.name)
         wait_for(
-            lambda: default_sat.api.ForemanTask()
+            lambda: target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -353,7 +353,7 @@ def test_negative_update_email_delivery_method_smtp():
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_update_email_delivery_method_sendmail(session, default_sat):
+def test_positive_update_email_delivery_method_sendmail(session, target_sat):
     """Updating Sendmail params on Email tab
 
     :id: c774e713-9640-402d-8987-c3509e918eb6
@@ -392,7 +392,7 @@ def test_positive_update_email_delivery_method_sendmail(session, default_sat):
     }
     mail_config_new_params = {
         "delivery_method": "Sendmail",
-        "email_reply_address": f"root@{default_sat.hostname}",
+        "email_reply_address": f"root@{target_sat.hostname}",
         "email_subject_prefix": [gen_string('alpha')],
         "sendmail_location": "/usr/sbin/sendmail",
         "send_welcome_email": "Yes",
@@ -405,7 +405,7 @@ def test_positive_update_email_delivery_method_sendmail(session, default_sat):
                 session.settings.update(mail_content, mail_content_value)
             test_mail_response = session.settings.send_test_mail(property_name)[0]
             assert test_mail_response == "Email was sent successfully"
-            assert default_sat.execute(command).status == 0
+            assert target_sat.execute(command).status == 0
         finally:
             for key, value in mail_config_default_param.items():
                 setting_cleanup(setting_name=key, setting_value=value.value)

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -23,15 +23,17 @@ from robottelo.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def module_dom(default_sat, module_org, module_location):
-    d = default_sat.api.Domain(organization=[module_org.id], location=[module_location.id]).create()
+def module_dom(module_target_sat, module_org, module_location):
+    d = module_target_sat.api.Domain(
+        organization=[module_org.id], location=[module_location.id]
+    ).create()
     yield d.read()
     d.delete()
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, default_sat, module_dom):
+def test_positive_end_to_end(session, module_target_sat, module_dom):
     """Perform end to end testing for subnet component in ipv6 network
 
     :id: f77031c9-2ca8-44db-8afa-d0212aeda540
@@ -59,7 +61,7 @@ def test_positive_end_to_end(session, default_sat, module_dom):
                 'domains.resources.assigned': [module_dom.name],
             }
         )
-        sn = default_sat.api.Subnet().search(query={'search': f'name={name}'})
+        sn = module_target_sat.api.Subnet().search(query={'search': f'name={name}'})
         assert sn, f'Subnet {sn} expected to exist, but it is not listed'
         sn = sn[0]
         subnet_values = session.subnet.read(name, widget_names=['subnet', 'domains'])
@@ -78,6 +80,6 @@ def test_positive_end_to_end(session, default_sat, module_dom):
         sn.domain = []
         sn.update(['domain'])
         session.subnet.delete(new_name)
-        assert not default_sat.api.Subnet().search(
+        assert not module_target_sat.api.Subnet().search(
             query={'search': f'name={new_name}'}
         ), 'The subnet was supposed to be deleted'

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -244,7 +244,7 @@ def test_positive_access_manifest_as_another_admin_user(test_name):
 
 
 @pytest.mark.tier3
-def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, default_sat):
+def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, target_sat):
     """Ensure that Virtual Datacenters subscription provided products is
     not empty and that a consumed product exist in content products.
 
@@ -287,7 +287,7 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, def
         org.id, lce.id, upload_manifest=True, rh_subscriptions=[DEFAULT_SUBSCRIPTION_NAME]
     )
     rhel7_contenthost.contenthost_setup(
-        default_sat,
+        target_sat,
         org.label,
         activation_key=repos_collection.setup_content_data['activation_key']['name'],
         install_katello_agent=False,
@@ -307,7 +307,7 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, def
 
 @pytest.mark.skip_if_not_set('libvirt')
 @pytest.mark.tier3
-def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthost, default_sat):
+def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthost, target_sat):
     """Ensure that Virtual Data Centers guest subscription Provided
     Products and Content Products are not empty.
 
@@ -353,7 +353,7 @@ def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthos
     )
     # configure virtual machine and setup virt-who service
     virt_who_data = rhel7_contenthost.virt_who_hypervisor_config(
-        default_sat,
+        target_sat,
         virt_who_config['general-information']['id'],
         org_id=org.id,
         lce_id=lce.id,
@@ -443,7 +443,7 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(session):
 
 @pytest.mark.tier3
 def test_positive_subscription_status_disabled_golden_ticket(
-    session, golden_ticket_host_setup, rhel7_contenthost, default_sat
+    session, golden_ticket_host_setup, rhel7_contenthost, target_sat
 ):
     """Verify that Content host Subscription status is set to 'Disabled'
      for a golden ticket manifest
@@ -460,7 +460,7 @@ def test_positive_subscription_status_disabled_golden_ticket(
 
     :CaseImportance: Medium
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     org, ak = golden_ticket_host_setup
     rhel7_contenthost.register_contenthost(org.label, ak.name)
     assert rhel7_contenthost.subscribed
@@ -473,7 +473,7 @@ def test_positive_subscription_status_disabled_golden_ticket(
 
 
 @pytest.mark.tier2
-def test_positive_candlepin_events_processed_by_STOMP(session, rhel7_contenthost, default_sat):
+def test_positive_candlepin_events_processed_by_STOMP(session, rhel7_contenthost, target_sat):
     """Verify that Candlepin events are being read and processed by
        attaching subscriptions, validating host subscriptions status,
        and viewing processed and failed Candlepin events
@@ -507,7 +507,7 @@ def test_positive_candlepin_events_processed_by_STOMP(session, rhel7_contenthost
         organization=org,
         environment=entities.LifecycleEnvironment(id=org.library.id),
     ).create()
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org.name, ak.name)
     with session:
         session.organization.select(org_name=org.name)

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -96,7 +96,7 @@ def test_positive_import_templates(session, templates_org, templates_loc):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_export_templates(session, create_import_export_local_dir, default_sat):
+def test_positive_export_templates(session, create_import_export_local_dir, target_sat):
     """Export the satellite templates to local directory
 
     :id: 1c24cf51-7198-48aa-a70a-8c0441333374
@@ -135,10 +135,10 @@ def test_positive_export_templates(session, create_import_export_local_dir, defa
         )
         assert export_title == f'Export to {FOREMAN_TEMPLATE_ROOT_DIR} as user {session._user}'
     exported_file = f'{dir_path}/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb'
-    result = default_sat.execute(f'find {exported_file} -type f')
+    result = target_sat.execute(f'find {exported_file} -type f')
     assert result.status == 0
     search_string = f'name: {export_template}'
-    result = default_sat.execute(f"grep -F '{search_string}' {exported_file}")
+    result = target_sat.execute(f"grep -F '{search_string}' {exported_file}")
     assert result.status == 0
 
 

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -32,7 +32,7 @@ from robottelo.constants import ROLES
 @pytest.mark.tier2
 @pytest.mark.pit_server
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, default_sat, test_name, module_org, module_location):
+def test_positive_end_to_end(session, target_sat, test_name, module_org, module_location):
     """Perform end to end testing for user component
 
     :id: 2794fdd0-cfe3-4f1a-aa5f-25b2d211ae12
@@ -53,7 +53,7 @@ def test_positive_end_to_end(session, default_sat, test_name, module_org, module
     description = gen_string('alphanumeric')
     language = 'en'
     timezone = '(GMT+00:00) UTC'
-    role = default_sat.api.Role().create().name
+    role = target_sat.api.Role().create().name
     with session:
         # Create new user and validate its values
         session.user.create(
@@ -107,7 +107,7 @@ def test_positive_end_to_end(session, default_sat, test_name, module_org, module
 
 
 @pytest.mark.tier2
-def test_positive_create_with_multiple_roles(session, default_sat):
+def test_positive_create_with_multiple_roles(session, target_sat):
     """Create User with multiple roles
 
     :id: d3cc4434-25ca-4465-8878-42495390c17b
@@ -122,7 +122,7 @@ def test_positive_create_with_multiple_roles(session, default_sat):
     role2 = gen_string('alpha')
     password = gen_string('alpha')
     for role in [role1, role2]:
-        default_sat.api.Role(name=role).create()
+        target_sat.api.Role(name=role).create()
     with session:
         session.user.create(
             {
@@ -166,7 +166,7 @@ def test_positive_create_with_all_roles(session):
 
 
 @pytest.mark.tier2
-def test_positive_create_with_multiple_orgs(session, default_sat):
+def test_positive_create_with_multiple_orgs(session, target_sat):
     """Create User associated to multiple Orgs
 
     :id: d74c0284-3995-4a4a-8746-00858282bf5d
@@ -180,7 +180,7 @@ def test_positive_create_with_multiple_orgs(session, default_sat):
     org_name2 = gen_string('alpha')
     password = gen_string('alpha')
     for org_name in [org_name1, org_name2]:
-        default_sat.api.Organization(name=org_name).create()
+        target_sat.api.Organization(name=org_name).create()
     with session:
         session.organization.select(org_name=DEFAULT_ORG)
         session.user.create(
@@ -202,7 +202,7 @@ def test_positive_create_with_multiple_orgs(session, default_sat):
 
 
 @pytest.mark.tier2
-def test_positive_update_with_multiple_roles(session, default_sat):
+def test_positive_update_with_multiple_roles(session, target_sat):
     """Update User with multiple roles
 
     :id: 127fb368-09fd-4f10-8319-566a1bcb5cd2
@@ -212,7 +212,7 @@ def test_positive_update_with_multiple_roles(session, default_sat):
     :CaseLevel: Integration
     """
     name = gen_string('alpha')
-    role_names = [default_sat.api.Role().create().name for _ in range(3)]
+    role_names = [target_sat.api.Role().create().name for _ in range(3)]
     password = gen_string('alpha')
     with session:
         session.user.create(
@@ -257,7 +257,7 @@ def test_positive_update_with_all_roles(session):
 
 
 @pytest.mark.tier2
-def test_positive_update_orgs(session, default_sat):
+def test_positive_update_orgs(session, target_sat):
     """Assign a User to multiple Orgs
 
     :id: a207188d-1ad1-4ff1-9906-bae1d91104fd
@@ -268,7 +268,7 @@ def test_positive_update_orgs(session, default_sat):
     """
     name = gen_string('alpha')
     password = gen_string('alpha')
-    org_names = [default_sat.api.Organization().create().name for _ in range(3)]
+    org_names = [target_sat.api.Organization().create().name for _ in range(3)]
     with session:
         session.organization.select(org_name=random.choice(org_names))
         session.user.create(
@@ -287,7 +287,7 @@ def test_positive_update_orgs(session, default_sat):
 
 @pytest.mark.tier2
 def test_positive_create_product_with_limited_user_permission(
-    session, default_sat, test_name, module_org, module_location
+    session, target_sat, test_name, module_org, module_location
 ):
     """A user with all permissions in Product and Repositories should be able to
     create a new product
@@ -309,10 +309,10 @@ def test_positive_create_product_with_limited_user_permission(
     product_name = gen_string('alpha')
     product_label = gen_string('alpha')
     product_description = gen_string('alpha')
-    role = default_sat.api.Role().create()
+    role = target_sat.api.Role().create()
     # Calling Products and Repositoy to get all the permissions in it
     create_role_permissions(role, {'Katello::Product': PERMISSIONS['Katello::Product']})
-    default_sat.api.User(
+    target_sat.api.User(
         default_organization=module_org,
         organization=[module_org],
         firstname='sample',

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -33,7 +33,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -43,7 +43,7 @@ def form_data(default_org, default_sat):
         'hypervisor_server': settings.virtwho.esx.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'hypervisor_username': settings.virtwho.esx.hypervisor_username,
         'hypervisor_password': settings.virtwho.esx.hypervisor_password,
     }

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_org, default_sat):
         'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
         'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
     }

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -40,7 +40,7 @@ def form_data(default_org, default_sat):
         'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_org, default_sat):
         'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -40,7 +40,7 @@ from robottelo.virtwho_utils import virtwho_package_locked
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -50,7 +50,7 @@ def form_data(default_sat, default_org):
         'hypervisor-server': settings.virtwho.esx.hypervisor_server,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'hypervisor-username': settings.virtwho.esx.hypervisor_username,
         'hypervisor-password': settings.virtwho.esx.hypervisor_password,
     }
@@ -323,7 +323,7 @@ class TestVirtWhoConfigforEsx:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_rhsm_option(self, default_org, form_data, virtwho_config, default_sat):
+    def test_positive_rhsm_option(self, default_org, form_data, virtwho_config, target_sat):
         """Verify rhsm options in the configure file"
 
         :id: b5b93d4d-e780-41c0-9eaa-2407cc1dcc9b
@@ -341,13 +341,13 @@ class TestVirtWhoConfigforEsx:
         deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
         rhsm_username = get_configure_option('rhsm_username', config_file)
         assert not User.exists(search=('login', rhsm_username))
-        assert get_configure_option('rhsm_hostname', config_file) == default_sat.hostname
+        assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
         assert get_configure_option('rhsm_prefix', config_file) == '/rhsm'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_post_hypervisors(self, function_org, default_sat):
+    def test_positive_post_hypervisors(self, function_org, target_sat):
         """Post large json file to /rhsm/hypervisors"
 
         :id: e344c9d2-3538-4432-9a74-b025e9ef852d
@@ -364,7 +364,7 @@ class TestVirtWhoConfigforEsx:
         :BZ: 1637042, 1769680
         """
         data = hypervisor_json_create(hypervisors=100, guests=10)
-        url = f"{default_sat.url}/rhsm/hypervisors/{function_org.label}"
+        url = f"{target_sat.url}/rhsm/hypervisors/{function_org.label}"
         auth = (settings.server.admin_username, settings.server.admin_password)
         result = requests.post(url, auth=auth, verify=False, json=data)
         if result.status_code != 200:

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_sat, default_org):
         'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
         'hypervisor-password': settings.virtwho.hyperv.hypervisor_password,
     }

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -40,7 +40,7 @@ def form_data(default_sat, default_org):
         'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_sat, default_org):
         'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -7,7 +7,7 @@ from robottelo.logging import logger
 
 
 @pytest.fixture(scope='module')
-def module_user(request, default_sat, default_org, default_location):
+def module_user(request, target_sat, default_org, default_location):
     """Creates admin user with default org set to module org and shares that
     user for all tests in the same test module. User's login contains test
     module name as a prefix.
@@ -19,7 +19,7 @@ def module_user(request, default_sat, default_org, default_location):
     login = f'{test_module_name}_{gen_string("alphanumeric")}'
     password = gen_string('alphanumeric')
     logger.debug('Creating session user %r', login)
-    user = default_sat.api.User(
+    user = target_sat.api.User(
         admin=True,
         default_organization=default_org,
         default_location=default_location,

--- a/tests/upgrades/scenario_workers.py
+++ b/tests/upgrades/scenario_workers.py
@@ -14,13 +14,13 @@ _json_file = 'upgrade_workers.json'
 json_file = Path(_json_file)
 
 
-def save_worker_hostname(test_name, default_sat):
+def save_worker_hostname(test_name, target_sat):
     data = {}
     if json_file.exists():
         data = json.loads(json_file.read_text())
     # Removing the parameter name from test name before save
     test_name = test_name.split('[')[0] if '[' in test_name else test_name
-    data.update({test_name: default_sat.hostname})
+    data.update({test_name: target_sat.hostname})
     json_file.write_text(json.dumps(data))
 
 
@@ -35,10 +35,10 @@ def get_worker_hostname_from_testname(test_name, shared_workers):
 
 
 @pytest.fixture(autouse=True)
-def save_pre_upgrade_worker_hostname(request, default_sat):
+def save_pre_upgrade_worker_hostname(request, target_sat):
     """Saves the worker id of pre_upgrade test in json"""
     if request.node.get_closest_marker('pre_upgrade'):
-        save_worker_hostname(request.node.name, default_sat)
+        save_worker_hostname(request.node.name, target_sat)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -52,7 +52,7 @@ class TestCapsuleSync:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_user_scenario_capsule_sync(self, request, default_sat, default_org):
+    def test_pre_user_scenario_capsule_sync(self, request, target_sat, default_org):
         """Pre-upgrade scenario that creates and sync repository with
         rpm in satellite which will be synced in post upgrade scenario.
 
@@ -76,17 +76,17 @@ class TestCapsuleSync:
         )
         prod_name = f"{pre_test_name}_prod"
         cv_name = f"{pre_test_name}_cv"
-        repo_url = f'http://{default_sat.hostname}/pub/{repo_name}'
-        ak = default_sat.api.ActivationKey(organization=default_org.id).search(
+        repo_url = f'http://{target_sat.hostname}/pub/{repo_name}'
+        ak = target_sat.api.ActivationKey(organization=default_org.id).search(
             query={'search': f'name={activation_key}'}
         )[0]
         ak_env = ak.environment.read()
 
-        product = default_sat.api.Product(name=prod_name, organization=default_org.id).create()
+        product = target_sat.api.Product(name=prod_name, organization=default_org.id).create()
         create_repo(rpm1, repo_path)
-        repo = default_sat.api.Repository(product=product.id, name=repo_name, url=repo_url).create()
+        repo = target_sat.api.Repository(product=product.id, name=repo_name, url=repo_url).create()
         repo.sync()
-        content_view = default_sat.api.ContentView(
+        content_view = target_sat.api.ContentView(
             name=cv_name, organization=default_org.id
         ).create()
         content_view.repository = [repo]
@@ -98,7 +98,7 @@ class TestCapsuleSync:
 
     @pytest.mark.post_upgrade(depend_on=test_pre_user_scenario_capsule_sync)
     def test_post_user_scenario_capsule_sync(
-        self, request, dependent_scenario_name, default_sat, default_org
+        self, request, dependent_scenario_name, target_sat, default_org
     ):
         """Post-upgrade scenario that sync capsule from satellite and then
         verifies if the repo/rpm of pre-upgrade scenario is synced to capsule
@@ -123,24 +123,24 @@ class TestCapsuleSync:
             settings.upgrade.capsule_ak[settings.upgrade.os]
             or settings.upgrade.custom_capsule_ak[settings.upgrade.os]
         )
-        ak = default_sat.api.ActivationKey(organization=default_org.id).search(
+        ak = target_sat.api.ActivationKey(organization=default_org.id).search(
             query={'search': f'name={activation_key}'}
         )[0]
-        repo = default_sat.api.Repository(organization=default_org.id).search(
+        repo = target_sat.api.Repository(organization=default_org.id).search(
             query={'search': f'name={pre_test_name}_repo'}
         )[0]
-        product = default_sat.api.Product(organization=default_org.id).search(
+        product = target_sat.api.Product(organization=default_org.id).search(
             query={'search': f'name={pre_test_name}_prod'}
         )[0]
         env_name = ak.environment.read()
         org_name = env_name.organization.read_json()['label']
 
-        content_view = default_sat.api.ContentView(organization=f'{default_org.id}').search(
+        content_view = target_sat.api.ContentView(organization=f'{default_org.id}').search(
             query={'search': f'name={pre_test_name}_cv'}
         )[0]
-        capsule = default_sat.api.SmartProxy().search(query={'search': f'name={cap_host}'})[0]
+        capsule = target_sat.api.SmartProxy().search(query={'search': f'name={cap_host}'})[0]
         call_entity_method_with_timeout(
-            default_sat.api.Capsule(id=capsule.id).content_sync, timeout=3600
+            target_sat.api.Capsule(id=capsule.id).content_sync, timeout=3600
         )
         result = execute(
             lambda: run(
@@ -160,7 +160,7 @@ class TestCapsuleSyncNewRepo:
     """
 
     @pytest.mark.post_upgrade
-    def test_post_user_scenario_capsule_sync_yum_repo(self, request, default_sat, default_org):
+    def test_post_user_scenario_capsule_sync_yum_repo(self, request, target_sat, default_org):
         """Post-upgrade scenario that creates and sync repository with
         rpm, sync capsule with satellite and verifies if the repo/rpm in
         satellite is synced to capsule.
@@ -186,20 +186,20 @@ class TestCapsuleSyncNewRepo:
             or settings.upgrade.custom_capsule_ak[settings.upgrade.os]
         )
         cap_host = settings.upgrade.capsule_hostname
-        ak = default_sat.api.ActivationKey(organization=default_org.id).search(
+        ak = target_sat.api.ActivationKey(organization=default_org.id).search(
             query={'search': f'name={activation_key}'}
         )[0]
         ak_env = ak.environment.read()
-        repo_url = f'http://{default_sat.hostname}/pub/{repo_name}/'
-        product = default_sat.api.Product(organization=default_org.id).create()
+        repo_url = f'http://{target_sat.hostname}/pub/{repo_name}/'
+        product = target_sat.api.Product(organization=default_org.id).create()
         repo_path = f'/var/www/html/pub/{repo_name}/'
         create_repo(rpm2, repo_path)
 
-        repo = default_sat.api.Repository(
+        repo = target_sat.api.Repository(
             product=product.id, name=f'{repo_name}', url=repo_url
         ).create()
         repo.sync()
-        content_view = default_sat.api.ContentView(organization=default_org.id).create()
+        content_view = target_sat.api.ContentView(organization=default_org.id).create()
         content_view.repository = [repo]
         content_view = content_view.update(['repository'])
         content_view.publish()

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -54,7 +54,7 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
     """
 
     @pytest.fixture(scope="class")
-    def _setup_scenario(self, default_sat):
+    def _setup_scenario(self, target_sat):
         """Import some parametrized puppet classes. This is required to make
         sure that we have smart class variable available.
         Read all available smart class parameters for imported puppet class to
@@ -62,7 +62,7 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
         """
         self.org = entities.Organization().create()
         repo = 'api_test_classparameters'
-        env_name = default_sat.create_custom_environment(repo=repo)
+        env_name = target_sat.create_custom_environment(repo=repo)
         self.puppet_class = entities.PuppetClass().search(
             query={'search': f'name = "{repo}" and environment = "{env_name}"'}
         )[0]
@@ -73,11 +73,11 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
         create_dict(scenario_ents)
 
     @pytest.fixture(scope="class")
-    def _clean_scenario(self, request, default_sat):
+    def _clean_scenario(self, request, class_target_sat):
         @request.addfinalizer
         def _cleanup():
             puppet_class = get_entity_data(self.__class__.__name__)['puppet_class']
-            default_sat.delete_puppet_class(puppet_class)
+            class_target_sat.delete_puppet_class(puppet_class)
 
     def _validate_value(self, data, sc_param):
         """The helper function to validate the parameter actual and expected

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -30,7 +30,7 @@ class TestContentView:
     """
 
     @pytest.mark.pre_upgrade
-    def test_cv_preupgrade_scenario(self, request, default_sat):
+    def test_cv_preupgrade_scenario(self, request, target_sat):
         """Pre-upgrade scenario that creates content-view with various repositories.
 
         :id: preupgrade-a4ebbfa1-106a-4962-9c7c-082833879ae8
@@ -56,7 +56,7 @@ class TestContentView:
 
         remote_file_path = f"/tmp/{RPM_TO_UPLOAD}"
 
-        default_sat.put(get_data_file(RPM_TO_UPLOAD), remote_file_path)
+        target_sat.put(get_data_file(RPM_TO_UPLOAD), remote_file_path)
         with open(f'{get_data_file(RPM_TO_UPLOAD)}', "rb") as content:
             file_repository.upload_content(files={'content': content})
         assert RPM_TO_UPLOAD in file_repository.files()["results"][0]['name']

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -50,13 +50,13 @@ class TestScenarioPositiveGCEHostComputeResource:
     """
 
     @pytest.fixture(scope='class')
-    def arch_os_domain(self, default_sat):
-        arch = default_sat.api.Architecture().search(query={'search': 'name=x86_64'})[0]
-        os = default_sat.api.OperatingSystem().search(
+    def arch_os_domain(self, class_target_sat):
+        arch = class_target_sat.api.Architecture().search(query={'search': 'name=x86_64'})[0]
+        os = class_target_sat.api.OperatingSystem().search(
             query={'search': 'family=Redhat and major=7'}
         )[0]
 
-        domain_name = default_sat.hostname.split('.', 1)[1]
+        domain_name = class_target_sat.hostname.split('.', 1)[1]
         return namedtuple('ArchOsDomain', ['arch', 'os', 'domain'])(arch, os, domain_name)
 
     @pytest.fixture(scope='class')
@@ -115,7 +115,7 @@ class TestScenarioPositiveGCEHostComputeResource:
         assert gce_img.name == 'autoupgrade_gce_img'
 
     @pytest.mark.post_upgrade(depend_on=test_pre_create_gce_cr_and_host)
-    def test_post_create_gce_cr_and_host(self, default_sat, arch_os_domain, delete_host):
+    def test_post_create_gce_cr_and_host(self, target_sat, arch_os_domain, delete_host):
         """Host provisioned using preupgrade GCE CR
 
         :id: postupgrade-ef82143d-efef-49b2-9702-93d67ef6804c
@@ -147,7 +147,7 @@ class TestScenarioPositiveGCEHostComputeResource:
             'image_id': LATEST_RHEL7_GCE_IMG_UUID,
         }
         # Host Provisioning Tests
-        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with target_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
             gce_hst = entities.Host(
                 name=hostname,
                 organization=org,

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -48,7 +48,7 @@ class TestScenarioPerformanceTuning:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_performance_tuning_apply(self, default_sat):
+    def test_pre_performance_tuning_apply(self, target_sat):
         """In preupgrade scenario we apply the medium tuning size.
 
         :id: preupgrade-83404326-20b7-11ea-a370-48f17f1fc2e1
@@ -63,27 +63,27 @@ class TestScenarioPerformanceTuning:
 
         """
         try:
-            default_sat.get(
+            target_sat.get(
                 local_path="custom-hiera-before-upgrade.yaml",
                 remote_path="/etc/foreman-installer/custom-hiera.yaml",
             )
             installer_obj = InstallerCommand(tuning='medium')
-            command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
+            command_output = target_sat.execute(installer_obj.get_command(), timeout='30m')
             assert 'Success!' in command_output.stdout
             installer_obj = InstallerCommand(help='tuning')
-            command_output = default_sat.execute(installer_obj.get_command())
+            command_output = target_sat.execute(installer_obj.get_command())
             assert 'default: "medium"' in command_output.stdout
 
         except Exception as exp:
             logger.critical(exp)
             installer_obj = InstallerCommand(tuning='default')
-            command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
+            command_output = target_sat.execute(installer_obj.get_command(), timeout='30m')
             assert 'Success!' in command_output.stdout
             assert 'default: "default"' in command_output.stdout
             raise
 
     @pytest.mark.post_upgrade(depend_on=test_pre_performance_tuning_apply)
-    def test_post_performance_tuning_apply(self, default_sat):
+    def test_post_performance_tuning_apply(self, target_sat):
         """In postupgrade scenario, we verify the set tuning parameters and custom-hiera.yaml
         file's content.
 
@@ -101,16 +101,16 @@ class TestScenarioPerformanceTuning:
 
         """
         installer_obj = InstallerCommand(help='tuning')
-        command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
+        command_output = target_sat.execute(installer_obj.get_command(), timeout='30m')
         assert 'default: "medium"' in command_output.stdout
-        default_sat.get(
+        target_sat.get(
             local_path="custom-hiera-after-upgrade.yaml",
             remote_path="/etc/foreman-installer/custom-hiera.yaml",
         )
         assert filecmp.cmp('custom-hiera-before-upgrade.yaml', 'custom-hiera-after-upgrade.yaml')
         installer_obj = InstallerCommand(tuning='default')
-        command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
+        command_output = target_sat.execute(installer_obj.get_command(), timeout='30m')
         assert 'Success!' in command_output.stdout
         installer_obj = InstallerCommand(help='tuning')
-        command_output = default_sat.execute(installer_obj.get_command())
+        command_output = target_sat.execute(installer_obj.get_command())
         assert 'default: "default"' in command_output.stdout

--- a/tests/upgrades/test_puppet.py
+++ b/tests/upgrades/test_puppet.py
@@ -23,9 +23,9 @@ from robottelo.hosts import Capsule
 
 
 @pytest.fixture(scope='module', params=[True, False], ids=["satellite", "capsule"])
-def upgrade_server(request, default_sat):
+def upgrade_server(request, module_target_sat):
     if request.param:
-        return default_sat
+        return module_target_sat
     else:
         return Capsule(settings.upgrade.capsule_hostname)
 
@@ -64,7 +64,7 @@ class TestPuppet:
         assert 'active (running)' in result.stdout
 
     @pytest.mark.post_upgrade
-    def test_post_puppet_reporting(self, default_sat):
+    def test_post_puppet_reporting(self, target_sat):
         """Test that puppet is reporting to Satellite after the upgrade.
 
         :id:   postupgrade-cdc4f6cc-23d8-4b4a-bd94-5c86b3072828
@@ -83,7 +83,7 @@ class TestPuppet:
         result = default_caps.execute('puppet agent -t')
         assert result.status == 0
 
-        result = default_sat.cli.ConfigReport.list(
+        result = target_sat.cli.ConfigReport.list(
             {'search': f'host={default_caps.hostname},origin=Puppet'}
         )
         assert len(result)

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -166,7 +166,7 @@ class TestScenarioREXSatellite:
 
     @pytest.mark.pre_upgrade
     def test_pre_scenario_remoteexecution_satellite(
-        self, request, compute_resource_setup, default_location, rhel7_contenthost, default_sat
+        self, request, compute_resource_setup, default_location, rhel7_contenthost, target_sat
     ):
         """Run REX job on client registered with Satellite
 
@@ -195,7 +195,7 @@ class TestScenarioREXSatellite:
             organization=[self.org.id],
             remote_execution_proxy=[entities.SmartProxy(id=1)],
         ).create()
-        rhel7_contenthost.configure_rex(satellite=default_sat, org=self.org, by_ip=False)
+        rhel7_contenthost.configure_rex(satellite=target_sat, org=self.org, by_ip=False)
         host = rhel7_contenthost.nailgun_host
         host[0].subnet = sn
         host[0].update(['subnet'])

--- a/tests/upgrades/test_satellite_maintain.py
+++ b/tests/upgrades/test_satellite_maintain.py
@@ -97,7 +97,7 @@ class TestSatelliteMaintain:
         return zstream_version, next_version
 
     @pytest.mark.pre_upgrade
-    def test_pre_satellite_maintain_upgrade_list_versions(self, default_sat):
+    def test_pre_satellite_maintain_upgrade_list_versions(self, target_sat):
         """Pre-upgrade sceanrio that tests list of satellite version
         which satellite can be upgraded.
 
@@ -114,7 +114,7 @@ class TestSatelliteMaintain:
             upgradable_version,
             major_version_change,
             y_version,
-        ) = self.satellite_upgradable_version_list(default_sat)
+        ) = self.satellite_upgradable_version_list(target_sat)
         if satellite_version:
             # In future If satellite-maintain packages update add before
             # pre-upgrade test case execution then next version kind of
@@ -127,7 +127,7 @@ class TestSatelliteMaintain:
         assert zstream_version in upgradable_version
 
     @pytest.mark.post_upgrade
-    def test_post_satellite_maintain_upgrade_list_versions(self, default_sat):
+    def test_post_satellite_maintain_upgrade_list_versions(self, target_sat):
         """Post-upgrade sceanrio that tests list of satellite version
         which satellite can be upgraded.
 
@@ -144,7 +144,7 @@ class TestSatelliteMaintain:
             upgradable_version,
             major_version_change,
             y_version,
-        ) = self.satellite_upgradable_version_list(default_sat)
+        ) = self.satellite_upgradable_version_list(target_sat)
         if satellite_version:
             zstream_version, next_version = self.version_details(
                 satellite_version[0], major_version_change, y_version, upgrade_stage="post-upgrade"

--- a/tests/upgrades/test_satellitesync.py
+++ b/tests/upgrades/test_satellitesync.py
@@ -74,7 +74,7 @@ class TestSatelliteSync:
         indirect=True,
     )
     def test_post_version_cv_export_import(
-        self, request, set_importing_org, dependent_scenario_name, default_sat
+        self, request, set_importing_org, dependent_scenario_name, target_sat
     ):
         """After upgrade, content view version import and export works on the existing content
          view(that we created before the upgrade).
@@ -111,7 +111,7 @@ class TestSatelliteSync:
         ContentView.version_export({'export-dir': f'{export_base}', 'id': exporting_cvv_id})
         exported_tar = f'{export_base}/export-{exporting_cv.name}-{exporting_cvv_version}.tar'
 
-        result = default_sat.execute(f'[ -f {exported_tar} ]')
+        result = target_sat.execute(f'[ -f {exported_tar} ]')
         assert result.status == 0
 
         exported_packages = Package.list({'content-view-version-id': exporting_cvv_id})
@@ -125,7 +125,7 @@ class TestSatelliteSync:
         imported_packages = Package.list({'content-view-version-id': importing_cvv[0].id})
         assert len(imported_packages) > 0
         assert len(exported_packages) == len(imported_packages)
-        default_sat.execute(f'rm -rf {export_base}/*')
+        target_sat.execute(f'rm -rf {export_base}/*')
         exporting_cv_json = exporting_cv.read_json()
         importing_cv_json = importing_cv.read_json()
         exporting_cv_env_id = exporting_cv_json['environments'][0]['id']

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -92,7 +92,7 @@ class TestSubscriptionAutoAttach:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_subscription_scenario_autoattach(self, request, default_sat):
+    def test_pre_subscription_scenario_autoattach(self, request, target_sat):
         """Create content host and register with Satellite
 
         :id: preupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
@@ -148,7 +148,7 @@ class TestSubscriptionAutoAttach:
 
     @pytest.mark.post_upgrade(depend_on=test_pre_subscription_scenario_autoattach)
     def test_post_subscription_scenario_autoattach(
-        self, request, dependent_scenario_name, default_sat
+        self, request, dependent_scenario_name, target_sat
     ):
         """Run subscription auto-attach on pre-upgrade content host registered
         with Satellite.

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -32,7 +32,7 @@ class TestUserGroupMembership:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_create_usergroup_with_ldap_user(self, request, default_sat):
+    def test_pre_create_usergroup_with_ldap_user(self, request, target_sat):
         """Create Usergroup in preupgrade version.
 
         :id: preupgrade-4b11d883-f523-4f38-b65a-650ecd90335c
@@ -44,7 +44,7 @@ class TestUserGroupMembership:
 
         :expectedresults: The usergroup, with ldap user as member, should be created successfully.
         """
-        authsource = default_sat.api.AuthSourceLDAP(
+        authsource = target_sat.api.AuthSourceLDAP(
             onthefly_register=True,
             account=settings.ldap.username,
             account_password=settings.ldap.password,
@@ -63,14 +63,14 @@ class TestUserGroupMembership:
         assert authsource.name == request.node.name + "_server"
         sc = ServerConfig(
             auth=(settings.ldap.username, settings.ldap.password),
-            url=default_sat.url,
+            url=target_sat.url,
             verify=False,
         )
 
         with pytest.raises(HTTPError):
             entities.User(sc).search()
-        user_group = default_sat.api.UserGroup(name=request.node.name + "_user_group").create()
-        user = default_sat.api.User().search(query={'search': f'login={settings.ldap.username}'})[0]
+        user_group = target_sat.api.UserGroup(name=request.node.name + "_user_group").create()
+        user = target_sat.api.User().search(query={'search': f'login={settings.ldap.username}'})[0]
         user_group.user = [user]
         user_group = user_group.update(['user'])
         assert user.login == user_group.user[0].read().login

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -37,7 +37,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture
-def form_data(default_sat):
+def form_data(target_sat):
     esx = settings.virtwho.esx
     return {
         'debug': 1,
@@ -46,7 +46,7 @@ def form_data(default_sat):
         'hypervisor_type': esx.hypervisor_type,
         'hypervisor_server': esx.hypervisor_server,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'hypervisor_username': esx.hypervisor_username,
         'hypervisor_password': esx.hypervisor_password,
         'name': 'preupgrade_virt_who',


### PR DESCRIPTION
In this change, I replace all current usage of the default_sat fixture
with a new target_sat fixture. This new fixture can provide the original
default_sat object as well as dynamically provision new Satellite
instances when needed. This is initially used to replace all uses of the
destructive_sat fixture to also use the new target_sat. It achieves this
by looking for the destructive marker; when attached to a downstream
test, all fixtures in the chain will then use the destructive target_sat
instance.
Other satellite types (like fips) could be similarly controlled in this
way.