### PR TITLE
Fix puppet cli

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -253,7 +253,8 @@ class CLIFactory:
         These are all basic cases where the make method just need some default values.
         For more complex make methods, we define them in methods below.
         """
-        if fields := ENTITY_FIELDS.get(name.replace('make_', '')):
+        fields = ENTITY_FIELDS.get(name.replace('make_', ''))
+        if isinstance(fields, dict):
             # someone is attempting to use a make_<entity> method
             if setup := fields.get('_setup'):
                 # check for an evaluate _setup fields
@@ -270,6 +271,8 @@ class CLIFactory:
             # evaluate functions that provide default values
             fields = self._evaluate_functions(fields)
             return partial(create_object, entity_cls, fields)
+        else:
+            raise CLIFactoryError(f'unknown factory method name: {name.replace("make_", "")}')
 
     def _evaluate_function(self, function):
         """Some functions may require an instance reference"""
@@ -1174,7 +1177,7 @@ class CLIFactory:
             # Create the current resource type role permissions
             options = {'role-id': role_id}
             options.update(permission_data)
-            self.make_filter(options=options)
+            self.make_filter(options)
 
     def setup_cdn_and_custom_repositories(
         self, org_id, repos, download_policy='on_demand', synchronize=True

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -17,10 +17,6 @@
 import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import add_role_permissions
-from robottelo.cli.factory import make_hostgroup
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_user
 from robottelo.config import settings
 from robottelo.datafactory import gen_string
 
@@ -93,7 +89,7 @@ class TestSmartClassParameters:
             environment=module_puppet['env'].name,
         ).create()
         host.add_puppetclass(data={'puppetclass_id': module_puppet['class']['id']})
-        hostgroup = make_hostgroup(
+        hostgroup = session_puppet_enabled_sat.cli_factory.make_hostgroup(
             {
                 'puppet-environment-id': module_puppet['env'].id,
                 'puppet-class-ids': module_puppet['class']['id'],
@@ -154,9 +150,14 @@ class TestSmartClassParameters:
                 ]
             },
         }
-        user = make_user({'admin': '0', 'password': password})
-        role = make_role()
-        add_role_permissions(role['id'], required_user_permissions)
+        user = session_puppet_enabled_sat.cli_factory.make_user(
+            {'admin': '0', 'password': password}
+        )
+        role = session_puppet_enabled_sat.cli_factory.make_role()
+        session_puppet_enabled_sat.cli_factory.add_role_permissions(
+            role['id'], required_user_permissions
+        )
+
         # Add the created and initiated role with permissions to user
         session_puppet_enabled_sat.cli.User.add_role({'id': user['id'], 'role-id': role['id']})
         sc_params = session_puppet_enabled_sat.cli.SmartClassParameter.with_user(


### PR DESCRIPTION
Rebased on #9560, this PR only fixes 2 tests failing since snap 18 (`test_positive_list` and `test_positive_list_with_non_admin_user`, see just 4d14fa7) rather due to changes in cli factory.

Test results:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/cli/test_classparameters.py
============================================ test session starts ============================================
platform linux -- Python 3.9.9, pytest-7.1.2, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, mock-3.7.0, lazy-fixture-0.6.3, ibutsu-2.0.2, reportportal-5.1.1, xdis
collected 10 items

tests/foreman/cli/test_classparameters.py ..........                                                  [100%]

================================ 10 passed, 35 warnings in 294.99s (0:04:54) ================================
```