### PR TITLE
rh_cloud test fix for package version.

### DIFF
--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -103,8 +103,10 @@ def test_rhcloud_inventory_api_e2e(
     # Assert Hostnames, IP addresses, and installed packages are present in report.
     json_data = get_report_data(local_report_path)
     json_meta_data = get_report_metadata(local_report_path)
-    package_version = rhcloud_sat_host.run('rpm -qa --qf "%{VERSION}" tfm-rubygem-foreman_rh_cloud')
-
+    prefix = 'tfm-' if rhcloud_sat_host.os_version.major < 8 else ''
+    package_version = rhcloud_sat_host.run(
+        f'rpm -qa --qf "%{{VERSION}}" {prefix}rubygem-foreman_rh_cloud'
+    )
     assert json_meta_data['source_metadata']['foreman_rh_cloud_version'] == str(package_version)
     assert json_meta_data['source'] == 'Satellite'
     hostnames = [host['fqdn'] for host in json_data['hosts']]


### PR DESCRIPTION
`Assertion was failing because of package version not getting collected because of different os versions `

**`Test result`** -

```
pytest -k test_rhcloud_inventory_api_e2e tests/foreman/api/test_rhcloud_inventory.py
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.8.6, pytest-7.1.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: reportportal-5.0.12, services-2.2.1, mock-3.7.0, forked-1.3.0, ibutsu-2.0.2, cov-3.0.0, xdist-2.5.0
collected 8 items / 7 deselected / 1 selected                                                                                                                                                                                                                                            

tests/foreman/api/test_rhcloud_inventory.py .                                                                                                                                                                                                                                     [100%]

================================================================================================================= 1 passed, 7 deselected, 1454.85s(0:24:14)==================================================================================================================
```

