### PR TITLE
Add rh_cloud insights end-to-end test for RHEL 9

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -3,9 +3,6 @@ from broker.broker import VMBroker
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import DISTRO_RHEL7
-from robottelo.constants import DISTRO_RHEL8
-from robottelo.constants import DISTRO_RHEL9
 from robottelo.helpers import file_downloader
 
 
@@ -77,7 +74,7 @@ def rhcloud_registered_hosts(organization_ak_setup, content_hosts, rhcloud_sat_h
             satellite=rhcloud_sat_host,
             activation_key=ak.name,
             org=org.label,
-            rhel_distro=DISTRO_RHEL7,
+            rhel_distro=f"rhel{vm.os_version.major}",
         )
         assert vm.subscribed
     return content_hosts
@@ -85,26 +82,16 @@ def rhcloud_registered_hosts(organization_ak_setup, content_hosts, rhcloud_sat_h
 
 @pytest.fixture
 def rhel_insights_vm(rhcloud_sat_host, organization_ak_setup, rhel_contenthost):
-    """A module-level fixture to create rhel8 content host registered with insights."""
-    distro_repo_map = {
-        7: DISTRO_RHEL7,
-        8: DISTRO_RHEL8,
-        9: DISTRO_RHEL9,
-    }
+    """A module-level fixture to create rhel content host registered with insights."""
+    # settings.supportability.content_hosts.rhel.versions
     org, ak = organization_ak_setup
     rhel_contenthost.configure_rex(satellite=rhcloud_sat_host, org=org, register=False)
     rhel_contenthost.configure_rhai_client(
         satellite=rhcloud_sat_host,
         activation_key=ak.name,
         org=org.label,
-        rhel_distro=distro_repo_map.get(rhel_contenthost.os_version.major),
+        rhel_distro=f"rhel{rhel_contenthost.os_version.major}",
     )
-    # Create a vulnerability which can be remediated
-    rhel_contenthost.run('chmod 777 /etc/ssh/sshd_config;insights-client')
-    if rhel_contenthost.os_version.major == 8:
-        rhel_contenthost.run(
-            'dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client'
-        )
     yield rhel_contenthost
 
 

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -99,18 +99,13 @@ def rhel_insights_vm(rhcloud_sat_host, organization_ak_setup, rhel_contenthost):
         org=org.label,
         rhel_distro=distro_repo_map.get(rhel_contenthost.os_version.major),
     )
-    yield rhel_contenthost
-
-
-@pytest.fixture
-def fixable_rhel_vm(rhel_insights_vm):
-    """A function-level fixture to create dnf related insights recommendation for rhel8 host."""
-
-    rhel_insights_vm.run('chmod 777 /etc/ssh/sshd_config;insights-client')
-    if rhel_insights_vm.os_version.major == 8:
-        rhel_insights_vm.run(
+    # Create a vulnerability which can be remediated
+    rhel_contenthost.run('chmod 777 /etc/ssh/sshd_config;insights-client')
+    if rhel_contenthost.os_version.major == 8:
+        rhel_contenthost.run(
             'dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client'
         )
+    yield rhel_contenthost
 
 
 @pytest.fixture

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -83,8 +83,8 @@ def rhcloud_registered_hosts(organization_ak_setup, content_hosts, rhcloud_sat_h
     return content_hosts
 
 
-@pytest.fixture(scope='module')
-def rhel_insights_vm(rhcloud_sat_host, organization_ak_setup, module_rhel_contenthost):
+@pytest.fixture
+def rhel_insights_vm(rhcloud_sat_host, organization_ak_setup, rhel_contenthost):
     """A module-level fixture to create rhel8 content host registered with insights."""
     distro_repo_map = {
         7: DISTRO_RHEL7,
@@ -92,14 +92,14 @@ def rhel_insights_vm(rhcloud_sat_host, organization_ak_setup, module_rhel_conten
         9: DISTRO_RHEL9,
     }
     org, ak = organization_ak_setup
-    module_rhel_contenthost.configure_rex(satellite=rhcloud_sat_host, org=org, register=False)
-    module_rhel_contenthost.configure_rhai_client(
+    rhel_contenthost.configure_rex(satellite=rhcloud_sat_host, org=org, register=False)
+    rhel_contenthost.configure_rhai_client(
         satellite=rhcloud_sat_host,
         activation_key=ak.name,
         org=org.label,
-        rhel_distro=distro_repo_map.get(module_rhel_contenthost.os_version.major),
+        rhel_distro=distro_repo_map.get(rhel_contenthost.os_version.major),
     )
-    yield module_rhel_contenthost
+    yield rhel_contenthost
 
 
 @pytest.fixture

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -43,6 +43,15 @@ def rhel_contenthost(request):
         yield host
 
 
+@pytest.fixture(scope='module')
+def module_rhel_contenthost(rhel_contenthost):
+    """A module-level fixture that provides a content host object parametrized"""
+    # Request should be parametrized through pytest_fixtures.fixture_markers
+    # unpack params dict
+    with VMBroker(**host_conf(rhel_contenthost), host_classes={'host': ContentHost}) as host:
+        yield host
+
+
 @pytest.fixture(params=[{'rhel_version': '7'}])
 def rhel7_contenthost(request):
     """A function-level fixture that provides a rhel7 content host object"""

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -43,15 +43,6 @@ def rhel_contenthost(request):
         yield host
 
 
-@pytest.fixture(scope='module')
-def module_rhel_contenthost(rhel_contenthost):
-    """A module-level fixture that provides a content host object parametrized"""
-    # Request should be parametrized through pytest_fixtures.fixture_markers
-    # unpack params dict
-    with VMBroker(**host_conf(rhel_contenthost), host_classes={'host': ContentHost}) as host:
-        yield host
-
-
 @pytest.fixture(params=[{'rhel_version': '7'}])
 def rhel7_contenthost(request):
     """A function-level fixture that provides a rhel7 content host object"""

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -30,7 +30,7 @@ from robottelo.constants import DISTRO_RHEL8
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-@pytest.mark.rhel_ver_list([8, 9])
+@pytest.mark.rhel_ver_list([9])
 def test_rhcloud_insights_e2e(
     rhel_insights_vm, organization_ak_setup, unset_rh_cloud_token, rhcloud_sat_host, fixable_rhel_vm
 ):

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -32,7 +32,10 @@ from robottelo.constants import DISTRO_RHEL8
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_list([8, 9])
 def test_rhcloud_insights_e2e(
-    rhel_insights_vm, organization_ak_setup, unset_rh_cloud_token, rhcloud_sat_host
+    rhel_insights_vm,
+    organization_ak_setup,
+    unset_rh_cloud_token,
+    rhcloud_sat_host,
 ):
     """Synchronize hits data from cloud, verify it is displayed in Satellite and run remediation.
 
@@ -64,6 +67,8 @@ def test_rhcloud_insights_e2e(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
+    # Create a vulnerability which can be remediated
+    rhel_insights_vm.run('chmod 777 /etc/ssh/sshd_config;insights-client')
     query = 'Decreased security: OpenSSH config permissions'
     job_query = (
         f'Remote action: Insights remediations for selected issues on {rhel_insights_vm.hostname}'
@@ -222,7 +227,10 @@ def test_host_sorting_based_on_recommendation_count():
 @pytest.mark.tier2
 @pytest.mark.rhel_ver_list([8])
 def test_host_details_page(
-    rhel_insights_vm, organization_ak_setup, set_rh_cloud_token, rhcloud_sat_host
+    rhel_insights_vm,
+    organization_ak_setup,
+    set_rh_cloud_token,
+    rhcloud_sat_host,
 ):
     """Test host details page for host having insights recommendations.
 
@@ -254,6 +262,8 @@ def test_host_details_page(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
+    # Create a vulnerability which can be remediated
+    rhel_insights_vm.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client')
     # Sync inventory status
     inventory_sync = rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_inventory_sync()
     wait_for(
@@ -295,6 +305,7 @@ def test_host_details_page(
             == 'Successfully uploaded to your RH cloud inventory clear'
         )
         recommendations = session.host.read_insights_recommendations(rhel_insights_vm.hostname)
+        assert len(recommendations), 'No recommendations were found'
         assert recommendations[0]['Hostname'] == rhel_insights_vm.hostname
         assert int(result['Recommendations']) == len(recommendations)
 
@@ -394,6 +405,8 @@ def test_delete_host_having_insights_recommendation(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
+    # Create a vulnerability which can be remediated
+    rhel_insights_vm.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client')
     # Sync inventory status
     inventory_sync = rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_inventory_sync()
     wait_for(
@@ -474,6 +487,8 @@ def test_insights_tab_on_host_details_page(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
+    # Create a vulnerability which can be remediated
+    rhel_insights_vm.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client')
     dnf_issue = (
         'The dnf installs lower versions of packages when the '
         '"best" option is not present in the /etc/dnf/dnf.conf'


### PR DESCRIPTION
This PR parameterizes `test_rhcloud_insights_e2e` to run for RHEL 8 and  RHEL 9.