### PR TITLE
install_katello_ca does not raise ContentHostError

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -383,7 +383,7 @@ class ContentHost(Host, ContentHostMixins):
         # Checking the status here to verify katello-ca rpm is actually
         # present in the system
         if result.status != 0:
-            ContentHostError('Failed to download and install the katello-ca rpm')
+            raise ContentHostError('Failed to download and install the katello-ca rpm')
 
     def remove_katello_ca(self):
         """Removes katello-ca rpm from the broker virtual machine.


### PR DESCRIPTION
from automation logs:
```
[D 220505 08:27:12 hosts:88] <hostname> executing command: rpm -q katello-ca-consumer-sat_hostname
[D 220505 08:27:12 hosts:90] <hostname> command result:
    package katello-ca-consumer-sat_hostname is not installed
```
clearly this should fire the excteption as intended here:
```
        result = self.execute(f'rpm -q katello-ca-consumer-{satellite.hostname}')
        # Checking the status here to verify katello-ca rpm is actually
        # present in the system
        if result.status != 0:
            ContentHostError('Failed to download and install the katello-ca rpm')
```
...but it doesn't. I'll look out for possible cherry-pick
