### PR TITLE
katello-ca installation for rhel8,9 fips hosts

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -376,7 +376,11 @@ class ContentHost(Host, ContentHostMixins):
         :raises robottelo.hosts.ContentHostError: If katello-ca wasn't
             installed.
         """
-        self.execute(f'rpm -Uvh {satellite.url_katello_ca_rpm}')
+        self.execute(
+            f'curl --insecure --output katello-ca-consumer-latest.noarch.rpm \
+                    {satellite.url_katello_ca_rpm}'
+        )
+        self.execute('rpm -Uvh katello-ca-consumer-latest.noarch.rpm')
         # Not checking the status here, as rpm could be installed before
         # and installation may fail
         result = self.execute(f'rpm -q katello-ca-consumer-{satellite.hostname}')


### PR DESCRIPTION
With system-wide crypto policies, fips enabled rhel8 and 9 hosts seem to be less forgiving than rhel7_fips. In this case, rpm -Uvh pulling straight from the url would be aborted with `curl: (60) SSL certificate problem: self signed certificate in certificate chain`. The proposed variant succeeds on these fips hosts.