### PR TITLE
[Nutanix Support]: Add CLI new case:test_positive_deploy_configure_by_id

### DIFF
--- a/conf/virtwho.yaml.template
+++ b/conf/virtwho.yaml.template
@@ -5,7 +5,7 @@ VIRTWHO:
         # The SKU ID for virtual vdc
         VDC_VIRTUAL:
     ESX:
-        # The hypervisor type, one of the values: esx, hyperv, rhevm, libvirt, kubevirt
+        # The hypervisor type, one of the values: esx, hyperv, rhevm, libvirt, kubevirt, ahv
         HYPERVISOR_TYPE: esx
         # The hostname or ip or other values for hypervisor server, depends on the type
         HYPERVISOR_SERVER:
@@ -54,6 +54,16 @@ VIRTWHO:
         HYPERVISOR_USERNAME:
         HYPERVISOR_PASSWORD:
         HYPERVISOR_CONFIG_FILE:
+        GUEST:
+        GUEST_PORT:
+        GUEST_USERNAME:
+        GUEST_PASSWORD:
+    AHV:
+        HYPERVISOR_TYPE: ahv
+        HYPERVISOR_SERVER:
+        HYPERVISOR_USERNAME:
+        HYPERVISOR_PASSWORD:
+        PRISM_FLAVOR:
         GUEST:
         GUEST_PORT:
         GUEST_USERNAME:

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -38,7 +38,10 @@ def get_system(system_type):
         ('satellite', 'esx', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv').
     :raises: VirtWhoError: If wrong ``system_type`` specified.
     """
-    if system_type in ['esx', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv']:
+    hypervisor_list = ['esx', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv']
+    system_type_list = ['satellite']
+    system_type_list.extend(hypervisor_list)
+    if system_type in hypervisor_list:
         return {
             'hostname': getattr(settings.virtwho, system_type).guest,
             'username': getattr(settings.virtwho, system_type).guest_username,
@@ -53,19 +56,7 @@ def get_system(system_type):
         }
     else:
         raise VirtWhoError(
-            '"{}" system type is not supported. Please use one of {}'.format(
-                system_type,
-                (
-                    'satellite',
-                    'default_org',
-                    'xen',
-                    'hyperv',
-                    'rhevm',
-                    'libvirt',
-                    'kubevirt',
-                    'ahv',
-                ),
-            )
+            f'"{system_type}" system type is not supported. Please use one of {system_type_list}'
         )
 
 
@@ -218,7 +209,7 @@ def _get_hypervisor_mapping(logs, hypervisor_type):
     """Analysing rhsm.log and get to know: what is the hypervisor_name
     for the specific guest.
     :param str logs: the output of rhsm.log.
-    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt. ahv
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt, ahv
     :raises: VirtWhoError: If hypervisor_name is None.
     :return: hypervisor_name and guest_name
     """

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -35,10 +35,10 @@ def get_system(system_type):
     """Return a dict account for ssh connect.
 
     :param str system_type: The type of the system, should be one of
-        ('satellite', 'default_org', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv').
+        ('satellite', 'esx', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv').
     :raises: VirtWhoError: If wrong ``system_type`` specified.
     """
-    if system_type in ['default_org', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv']:
+    if system_type in ['esx', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv']:
         return {
             'hostname': getattr(settings.virtwho, system_type).guest,
             'username': getattr(settings.virtwho, system_type).guest_username,

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -35,10 +35,10 @@ def get_system(system_type):
     """Return a dict account for ssh connect.
 
     :param str system_type: The type of the system, should be one of
-        ('satellite', 'esx', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt').
+        ('satellite', 'default_org', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv').
     :raises: VirtWhoError: If wrong ``system_type`` specified.
     """
-    if system_type in ['esx', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt']:
+    if system_type in ['default_org', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt', 'ahv']:
         return {
             'hostname': getattr(settings.virtwho, system_type).guest,
             'username': getattr(settings.virtwho, system_type).guest_username,
@@ -54,7 +54,17 @@ def get_system(system_type):
     else:
         raise VirtWhoError(
             '"{}" system type is not supported. Please use one of {}'.format(
-                system_type, ('satellite', 'esx', 'xen', 'hyperv', 'rhevm', 'libvirt', 'kubevirt')
+                system_type,
+                (
+                    'satellite',
+                    'default_org',
+                    'xen',
+                    'hyperv',
+                    'rhevm',
+                    'libvirt',
+                    'kubevirt',
+                    'ahv',
+                ),
             )
         )
 
@@ -208,7 +218,7 @@ def _get_hypervisor_mapping(logs, hypervisor_type):
     """Analysing rhsm.log and get to know: what is the hypervisor_name
     for the specific guest.
     :param str logs: the output of rhsm.log.
-    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt. ahv
     :raises: VirtWhoError: If hypervisor_name is None.
     :return: hypervisor_name and guest_name
     """
@@ -242,7 +252,7 @@ def _get_hypervisor_mapping(logs, hypervisor_type):
 
 def deploy_validation(hypervisor_type):
     """Checkout the deploy result
-    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt, ahv
     :raises: VirtWhoError: If failed to start virt-who servcie.
     :ruturn: hypervisor_name and guest_name
     """
@@ -262,7 +272,7 @@ def deploy_configure_by_command(command, hypervisor_type, debug=False, org='Defa
 
     :param str command: get the command by UI/CLI/API, it should be like:
         `hammer virt-who-config deploy --id 1 --organization-id 1`
-    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt, ahv
     :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
     :param str org: Organization Label
     """
@@ -283,7 +293,7 @@ def deploy_configure_by_script(
 ):
     """Deploy and run virt-who service by the shell script.
     :param str script_content: get the script by UI or API.
-    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt, ahv
     :param bool debug: if VIRTWHO_DEBUG=1, this option should be True.
     :param str org: Organization Label
     """

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -1,0 +1,92 @@
+"""Test class for Virtwho Configure CLI
+
+:Requirement: Virt-whoConfigurePlugin
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Virt-whoConfigurePlugin
+
+:Assignee: yanpliu
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+from fauxfactory import gen_string
+
+from robottelo.cli.host import Host
+from robottelo.cli.subscription import Subscription
+from robottelo.cli.virt_who_config import VirtWhoConfig
+from robottelo.config import settings
+from robottelo.virtwho_utils import deploy_configure_by_command
+from robottelo.virtwho_utils import get_configure_command
+
+
+@pytest.fixture()
+def form_data(default_sat, default_org):
+    form = {
+        'name': gen_string('alpha'),
+        'debug': 1,
+        'interval': '60',
+        'hypervisor-id': 'hostname',
+        'hypervisor-type': settings.virtwho.ahv.hypervisor_type,
+        'hypervisor-server': settings.virtwho.ahv.hypervisor_server,
+        'organization-id': default_org.id,
+        'filtering-mode': 'none',
+        'satellite-url': default_sat.hostname,
+        'hypervisor-username': settings.virtwho.ahv.hypervisor_username,
+        'hypervisor-password': settings.virtwho.ahv.hypervisor_password,
+        'prism-flavor': settings.virtwho.ahv.prism_flavor,
+    }
+    return form
+
+
+@pytest.fixture()
+def virtwho_config(form_data):
+    return VirtWhoConfig.create(form_data)['general-information']
+
+
+class TestVirtWhoConfigforNutanix:
+    @pytest.mark.tier2
+    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
+        """Verify " hammer virt-who-config deploy"
+
+        :id: 129d8e57-b4fc-4d95-ad33-5aa6ec6fb146
+
+        :expectedresults: Config can be created and deployed
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+        """
+        assert virtwho_config['status'] == 'No Report Yet'
+        command = get_configure_command(virtwho_config['id'], default_org.name)
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data['hypervisor-type'], debug=True, org=default_org.label
+        )
+        virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
+            'status'
+        ]
+        assert virt_who_instance == 'OK'
+        hosts = [
+            (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
+            (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
+        ]
+        for hostname, sku in hosts:
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            vdc_id = subscriptions[0]['id']
+            if 'type=STACK_DERIVED' in sku:
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
+            assert result.strip() == 'Subscription attached to the host successfully.'
+        VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -54,7 +54,7 @@ def virtwho_config(form_data):
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
-        """Verify " hammer virt-who-config deploy"
+        """Verify "hammer virt-who-config deploy"
 
         :id: 129d8e57-b4fc-4d95-ad33-5aa6ec6fb146
 


### PR DESCRIPTION
Hey,
Automation Nutanix CLI test case: verify hammer virt-who-config deploy.
Case Run: PASS
Test Results:
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/cli/test_nutanix.py  -k test_positive_deploy_configure_by_id -s
2022-05-13 15:57:19 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    server.version.release is required in env main
2022-05-13 15:57:19 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    server.version.release is required in env main
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
......
.

================================================================================================ warnings summary =================================================================================================
.
.
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 1 deselected, 3 warnings in 193.91s (0:03:13) =============================================================================

```