### PR TITLE
Fix puppet class import on a fake-capsule

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -37,6 +37,20 @@ def proxy_port_range(default_sat):
             default_sat.execute(f'semanage port -a -t websm_port_t -p tcp {port_pool_range}')
 
 
+@pytest.fixture(autouse=False, scope='session')
+def puppet_proxy_port_range(session_puppet_enabled_sat):
+    """Assigns port range for fake_capsules on puppet_enabled_sat"""
+    if session_puppet_enabled_sat:
+        port_pool_range = settings.fake_capsules.port_range
+        if (
+            session_puppet_enabled_sat.execute(f'semanage port -l | grep {port_pool_range}').status
+            != 0
+        ):
+            session_puppet_enabled_sat.execute(
+                f'semanage port -a -t websm_port_t -p tcp {port_pool_range}'
+            )
+
+
 @pytest.fixture(scope='session')
 def install_cockpit_plugin(default_sat):
     default_sat.register_to_dogfood()

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -231,7 +231,7 @@ def test_positive_refresh_features(request):
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier2
-def test_positive_import_puppet_classes(request):
+def test_positive_import_puppet_classes(session_puppet_enabled_sat, puppet_proxy_port_range):
     """Import puppet classes from proxy
 
     :id: 385efd1b-6146-47bf-babf-0127ce5955ed
@@ -242,14 +242,18 @@ def test_positive_import_puppet_classes(request):
 
     :BZ: 1398695
     """
-    new_port = get_available_capsule_port()
-    with default_url_on_new_port(9090, new_port) as url:
-        proxy = _create_smart_proxy(request, url=url)
-        result = proxy.import_puppetclasses()
-        assert (
-            "Successfully updated environment and puppetclasses from "
-            "the on-disk puppet installation"
-        ) in result['message']
+    with session_puppet_enabled_sat:
+        new_port = get_available_capsule_port()
+        with default_url_on_new_port(9090, new_port) as url:
+            proxy = entities.SmartProxy(url=url).create()
+            result = proxy.import_puppetclasses()
+            assert (
+                "Successfully updated environment and puppetclasses from "
+                "the on-disk puppet installation"
+            ) in result['message'] or "No changes to your environments detected" in result[
+                'message'
+            ]
+        entities.SmartProxy(id=proxy.id).delete()
 
 
 """Tests to see if the server returns the attributes it should.

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -178,7 +178,7 @@ def test_positive_refresh_features_by_name(request):
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier1
-def test_positive_import_puppet_classes(request):
+def test_positive_import_puppet_classes(session_puppet_enabled_sat, puppet_proxy_port_range):
     """Import puppet classes from proxy
 
     :id: 42e3a9c0-62e1-4049-9667-f3c0cdfe0b04
@@ -188,10 +188,12 @@ def test_positive_import_puppet_classes(request):
     :CaseLevel: Component
 
     """
-    port = get_available_capsule_port()
-    with default_url_on_new_port(9090, port) as url:
-        proxy = _make_proxy(request, {'url': url})
-        Proxy.import_classes({'id': proxy['id']})
+    with session_puppet_enabled_sat:
+        port = get_available_capsule_port()
+        with default_url_on_new_port(9090, port) as url:
+            proxy = make_proxy({'url': url})
+            Proxy.import_classes({'id': proxy['id']})
+        Proxy.delete({'id': proxy['id']})
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
Just redirecting the test cases to be run against the puppet-enabled instance.

Test results:
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/cli/test_capsule.py tests/foreman/api/test_smartproxy.py
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.9, pytest-7.1.2, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, mock-3.7.0, lazy-fixture-0.6.3, ibutsu-2.0.2, reportportal-5.1.1, xdist-2.5.0
collected 45 items / 9 deselected / 36 selected                                                                                                                                                                                           

tests/foreman/cli/test_capsule.py .......F......FF...                                                                                                                                                                               [ 52%]
tests/foreman/api/test_smartproxy.py .......F.........                                                                                                                                                                              [100%]
========================================================================================================= short test summary info =========================================================================================================
FAILED tests/foreman/cli/test_capsule.py::test_positive_create_with_name[html] - robottelo.cli.factory.CLIFactoryError: Failed to create Proxy with data:
FAILED tests/foreman/cli/test_capsule.py::test_positive_delete_by_id[html] - robottelo.cli.factory.CLIFactoryError: Failed to create Proxy with data:
FAILED tests/foreman/cli/test_capsule.py::test_positive_update_name - robottelo.cli.base.CLIReturnCodeError: CLIReturnCodeError(status=70, stderr='Could not update the proxy:\n  Value expected but found :lt\n', msg='Command "proxy u...
FAILED tests/foreman/api/test_smartproxy.py::test_positive_create_with_name[html] - requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://dhcp-3-38.vms.sat.rdu2.redhat.com:443/api/v2/smart_proxies
=================================================================================== 4 failed, 32 passed, 9 deselected, 52 warnings in 627.43s (0:10:27) ===================================================================================
```
Tests being fixed by this PR pass, all remaining failures relate to this single BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2084661
