### PR TITLE
Update missing API endpoints for 6.10.z

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -228,16 +228,19 @@ API_PATHS = {
     'content_export_incrementals': (
         '/katello/api/content_export_incrementals/version',
         '/katello/api/content_export_incrementals/library',
+        '/katello/api/content_export_incrementals/repository',
     ),
     'content_exports': (
         '/katello/api/content_exports',
         '/katello/api/content_exports/version',
         '/katello/api/content_exports/library',
+        '/katello/api/content_exports/repository',
     ),
     'content_imports': (
         '/katello/api/content_imports',
         '/katello/api/content_imports/version',
         '/katello/api/content_imports/library',
+        '/katello/api/content_imports/repository',
     ),
     'content_uploads': (
         '/katello/api/repositories/:repository_id/content_uploads',


### PR DESCRIPTION
**Description:**
Update missing API endpoints introduced by [BZ 2059388](https://bugzilla.redhat.com/show_bug.cgi?id=2059388)

**Tests Results:**
```
(.robottelo) ➜  robottelo git:(fix-610-endpoints) ✗ pytest -q --disable-pytest-warnings tests/foreman/endtoend/test_api_endtoend.py::TestAvailableURLs::test_positive_get_links
.                                                                                                                                                        [100%]
1 passed, 3 warnings in 12.59s
```
Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>