### PR TITLE
[Nutanix_CLI_Support]: add new cases :test_positive_deploy_configure_by_script&test_positive_hypervisor_id_option

### DIFF
--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -24,7 +24,10 @@ from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.virtwho_utils import deploy_configure_by_command
+from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import get_configure_command
+from robottelo.virtwho_utils import get_configure_file
+from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
@@ -88,5 +91,70 @@ class TestVirtWhoConfigforNutanix:
                         break
             result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
             assert result.strip() == 'Subscription attached to the host successfully.'
+        VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+
+    @pytest.mark.tier2
+    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
+        """Verify "hammer virt-who-config fetch"
+
+        :id: d707fac0-f2b1-4493-b083-cf1edc231691
+
+        :expectedresults: Config can be created, fetch and deploy
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+        """
+        assert virtwho_config['status'] == 'No Report Yet'
+        script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script, form_data['hypervisor-type'], debug=True, org=default_org.label
+        )
+        virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
+            'status'
+        ]
+        assert virt_who_instance == 'OK'
+        hosts = [
+            (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
+            (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
+        ]
+        for hostname, sku in hosts:
+            host = Host.list({'search': hostname})[0]
+            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            vdc_id = subscriptions[0]['id']
+            if 'type=STACK_DERIVED' in sku:
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
+            assert result.strip() == 'Subscription attached to the host successfully.'
+        VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+
+    @pytest.mark.tier2
+    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
+        """Verify hypervisor_id option by hammer virt-who-config update"
+
+        :id: 565228cd-2124-41ed-89b7-84ec6ff77213
+
+        :expectedresults: hypervisor_id option can be updated.
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+        """
+        values = ['uuid', 'hostname']
+        for value in values:
+            VirtWhoConfig.update({'id': virtwho_config['id'], 'hypervisor-id': value})
+            result = VirtWhoConfig.info({'id': virtwho_config['id']})
+            assert result['connection']['hypervisor-id'] == value
+            config_file = get_configure_file(virtwho_config['id'])
+            command = get_configure_command(virtwho_config['id'], default_org.name)
+            deploy_configure_by_command(
+                command, form_data['hypervisor-type'], org=default_org.label
+            )
+            assert get_configure_option('hypervisor_id', config_file) == value
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -47,7 +47,7 @@ class TestVirtwhoConfigforHyperv:
     def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
         """Verify configure created and deployed with id.
 
-        :id: 16f6d8c3-332d-4e36-bc19-028955b2bbc4
+        :id: c8913398-c5c6-4f2c-bc53-0bbfb158b762
 
         :expectedresults:
             1. Config can be created and deployed by command


### PR DESCRIPTION
Add Nutanix CLI new cases:
- test_positive_deploy_configure_by_script
- test_positive_hypervisor_id_option

Test Results: PASS on Nutanix
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py -k test_positive_deploy_configure_by_script
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 3 items / 5 deselected / -2 selected                                                                                                                                                                    

tests/foreman/virtwho/cli/test_nutanix.py .                                                                                                                                                                 [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/cli/test_nutanix.py::TestVirtWhoConfigforNutanix::test_positive_deploy_configure_by_script
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 5 deselected, 3 warnings in 104.97s (0:01:44) =============================================================================
(
```
test_positive_deploy_configure_by_script  Test Results:
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py -k test_positive_hypervisor_id_option
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 3 items / 5 deselected / -2 selected                                                                                                                                                                    

tests/foreman/virtwho/cli/test_nutanix.py .                                                                                                                                                                 [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/cli/test_nutanix.py::TestVirtWhoConfigforNutanix::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 5 deselected, 3 warnings in 145.83s (0:02:25) =============================================================================

```