### PR TITLE
Update missing API endpoints for BZ 2028377

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -223,16 +223,19 @@ API_PATHS = {
     'content_export_incrementals': (
         '/katello/api/content_export_incrementals/version',
         '/katello/api/content_export_incrementals/library',
+        '/katello/api/content_export_incrementals/repository',
     ),
     'content_exports': (
         '/katello/api/content_exports',
         '/katello/api/content_exports/version',
         '/katello/api/content_exports/library',
+        '/katello/api/content_exports/repository',
     ),
     'content_imports': (
         '/katello/api/content_imports',
         '/katello/api/content_imports/version',
         '/katello/api/content_imports/library',
+        '/katello/api/content_imports/repository',
     ),
     'content_uploads': (
         '/katello/api/repositories/:repository_id/content_uploads',


### PR DESCRIPTION
Cherrypick of PR #9595

**Tests Results:**
```
(.robottelo) ➜  robottelo git:(fix-611-endpoints) ✗ pytest -q --disable-pytest-warnings tests/foreman/endtoend/test_api_endtoend.py::TestAvailableURLs::test_positive_get_links
.                                                                                                                                                        [100%]
1 passed, 3 warnings in 18.84s
```

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>