### PR TITLE
[6.10 cherry-pick] Make "default_sat" fixture usage more cooperative

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Collect Tests with xdist
         run: |
-          pytest --collect-only --disable-pytest-warnings -n 2 tests/foreman/ tests/robottelo/
-          pytest --collect-only --disable-pytest-warnings -n 2 -m pre_upgrade tests/upgrades/
-          pytest --collect-only --disable-pytest-warnings -n 2 -m post_upgrade tests/upgrades/
+          pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 tests/foreman/ tests/robottelo/
+          pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 -m pre_upgrade tests/upgrades/
+          pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 -m post_upgrade tests/upgrades/
 
       - name: Make Docs
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ logs/**
 
 .pytest_cache/
 tests/foreman/pytest.ini
+ven*/
 
 # For pytest --bz-cache generated file
 **/bz_cache.json
@@ -71,6 +72,7 @@ tests/foreman/pytest.ini
 /settings.local.yaml
 /settings*.local.yaml
 /conf/*.yaml
+/conf/*.conf
 !/conf/supportability.yaml
 
 # I don't know where those 2 files come from

--- a/pytest_fixtures/component/domain.py
+++ b/pytest_fixtures/component/domain.py
@@ -4,8 +4,8 @@ from nailgun import entities
 
 
 @pytest.fixture(scope='session')
-def default_domain(default_sat, default_smart_proxy):
-    domain_name = default_sat.hostname.partition('.')[-1]
+def default_domain(session_target_sat, default_smart_proxy):
+    domain_name = session_target_sat.hostname.partition('.')[-1]
     dom = entities.Domain().search(query={'search': f'name={domain_name}'})[0]
     dom.dns = default_smart_proxy
     dom.update(['dns'])

--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -13,10 +13,10 @@ from robottelo.helpers import get_data_file
 
 
 @pytest.fixture(scope="session")
-def tailoring_file_path(default_sat):
+def tailoring_file_path(session_target_sat):
     """Return Tailoring file path."""
     local = get_data_file(OSCAP_TAILORING_FILE)
-    default_sat.put(
+    session_target_sat.put(
         local_path=get_data_file(OSCAP_TAILORING_FILE),
         remote_path=f'/tmp/{OSCAP_TAILORING_FILE}',
     )
@@ -24,10 +24,10 @@ def tailoring_file_path(default_sat):
 
 
 @pytest.fixture(scope="session")
-def oscap_content_path(default_sat):
+def oscap_content_path(session_target_sat):
     """Download scap content from satellite and return local path of it."""
     local_file = robottelo_tmp_dir.joinpath(PurePath(settings.oscap.content_path).name)
-    default_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
+    session_target_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
     return local_file
 
 

--- a/pytest_fixtures/component/provision_azure.py
+++ b/pytest_fixtures/component/provision_azure.py
@@ -1,7 +1,6 @@
 # Azure CR Fixtures
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 from wrapanapi import AzureSystem
 
 from robottelo.config import settings
@@ -26,9 +25,9 @@ def azurerm_settings():
 
 
 @pytest.fixture(scope='module')
-def module_azurerm_cr(azurerm_settings, module_org, module_location):
+def module_azurerm_cr(azurerm_settings, module_org, module_location, module_target_sat):
     """Create AzureRM Compute Resource"""
-    azure_cr = entities.AzureRMComputeResource(
+    azure_cr = module_target_sat.api.AzureRMComputeResource(
         name=gen_string('alpha'),
         provider='AzureRm',
         tenant=azurerm_settings['tenant'],
@@ -43,9 +42,33 @@ def module_azurerm_cr(azurerm_settings, module_org, module_location):
 
 
 @pytest.fixture(scope='module')
-def module_azurerm_finishimg(default_architecture, default_os, module_azurerm_cr):
+def module_azurerm_cr_puppet(
+    azurerm_settings, module_puppet_org, module_puppet_loc, session_puppet_enabled_sat
+):
+    """Create AzureRM Compute Resource"""
+    azure_cr = session_puppet_enabled_sat.api.AzureRMComputeResource(
+        name=gen_string('alpha'),
+        provider='AzureRm',
+        tenant=azurerm_settings['tenant'],
+        app_ident=azurerm_settings['app_ident'],
+        sub_id=azurerm_settings['sub_id'],
+        secret_key=azurerm_settings['secret'],
+        region=azurerm_settings['region'],
+        organization=[module_puppet_org],
+        location=[module_puppet_loc],
+    ).create()
+    return azure_cr
+
+
+@pytest.fixture(scope='module')
+def module_azurerm_finishimg(
+    default_architecture,
+    default_os,
+    module_target_sat,
+    module_azurerm_cr,
+):
     """Creates Finish Template image on AzureRM Compute Resource"""
-    finish_image = entities.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),
@@ -57,9 +80,33 @@ def module_azurerm_finishimg(default_architecture, default_os, module_azurerm_cr
 
 
 @pytest.fixture(scope='module')
-def module_azurerm_byos_finishimg(default_architecture, default_os, module_azurerm_cr):
+def module_azurerm_finishimg_puppet(
+    session_puppet_default_architecture,
+    session_puppet_default_os,
+    session_puppet_enabled_sat,
+    module_azurerm_cr_puppet,
+):
+    """Creates Finish Template image on AzureRM Compute Resource"""
+    finish_image = session_puppet_enabled_sat.api.Image(
+        architecture=session_puppet_default_architecture,
+        compute_resource=module_azurerm_cr_puppet,
+        name=gen_string('alpha'),
+        operatingsystem=session_puppet_default_os,
+        username=settings.azurerm.username,
+        uuid=AZURERM_RHEL7_FT_IMG_URN,
+    ).create()
+    return finish_image
+
+
+@pytest.fixture(scope='module')
+def module_azurerm_byos_finishimg(
+    default_architecture,
+    default_os,
+    module_azurerm_cr,
+    module_target_sat,
+):
     """Creates BYOS Finish Template image on AzureRM Compute Resource"""
-    finish_image = entities.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),
@@ -71,9 +118,33 @@ def module_azurerm_byos_finishimg(default_architecture, default_os, module_azure
 
 
 @pytest.fixture(scope='module')
-def module_azurerm_cloudimg(default_architecture, default_os, module_azurerm_cr):
+def module_azurerm_byos_finishimg_puppet(
+    session_puppet_default_architecture,
+    session_puppet_default_os,
+    module_azurerm_cr_puppet,
+    session_puppet_enabled_sat,
+):
+    """Creates BYOS Finish Template image on AzureRM Compute Resource"""
+    finish_image = session_puppet_enabled_sat.api.Image(
+        architecture=session_puppet_default_architecture,
+        compute_resource=module_azurerm_cr_puppet,
+        name=gen_string('alpha'),
+        operatingsystem=session_puppet_default_os,
+        username=settings.azurerm.username,
+        uuid=AZURERM_RHEL7_FT_BYOS_IMG_URN,
+    ).create()
+    return finish_image
+
+
+@pytest.fixture(scope='module')
+def module_azurerm_cloudimg(
+    default_architecture,
+    default_os,
+    module_target_sat,
+    module_azurerm_cr,
+):
     """Creates cloudinit image on AzureRM Compute Resource"""
-    finish_image = entities.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),
@@ -86,9 +157,34 @@ def module_azurerm_cloudimg(default_architecture, default_os, module_azurerm_cr)
 
 
 @pytest.fixture(scope='module')
-def module_azurerm_gallery_finishimg(default_architecture, default_os, module_azurerm_cr):
+def module_azurerm_cloudimg_puppet(
+    session_puppet_default_architecture,
+    session_puppet_default_os,
+    session_puppet_enabled_sat,
+    module_azurerm_cr_puppet,
+):
+    """Creates cloudinit image on AzureRM Compute Resource"""
+    finish_image = session_puppet_enabled_sat.api.Image(
+        architecture=session_puppet_default_architecture,
+        compute_resource=module_azurerm_cr_puppet,
+        name=gen_string('alpha'),
+        operatingsystem=session_puppet_default_os,
+        username=settings.azurerm.username,
+        uuid=AZURERM_RHEL7_UD_IMG_URN,
+        user_data=True,
+    ).create()
+    return finish_image
+
+
+@pytest.fixture(scope='module')
+def module_azurerm_gallery_finishimg(
+    default_architecture,
+    default_os,
+    module_target_sat,
+    module_azurerm_cr,
+):
     """Creates Shared Gallery Finish Template image on AzureRM Compute Resource"""
-    finish_image = entities.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),
@@ -100,9 +196,33 @@ def module_azurerm_gallery_finishimg(default_architecture, default_os, module_az
 
 
 @pytest.fixture(scope='module')
-def module_azurerm_custom_finishimg(default_architecture, default_os, module_azurerm_cr):
+def module_azurerm_gallery_finishimg_puppet(
+    session_puppet_default_architecture,
+    session_puppet_default_os,
+    session_puppet_enabled_sat,
+    module_azurerm_cr_puppet,
+):
+    """Creates Shared Gallery Finish Template image on AzureRM Compute Resource"""
+    finish_image = session_puppet_enabled_sat.api.Image(
+        architecture=session_puppet_default_architecture,
+        compute_resource=module_azurerm_cr_puppet,
+        name=gen_string('alpha'),
+        operatingsystem=session_puppet_default_os,
+        username=settings.azurerm.username,
+        uuid=AZURERM_RHEL7_FT_GALLERY_IMG_URN,
+    ).create()
+    return finish_image
+
+
+@pytest.fixture(scope='module')
+def module_azurerm_custom_finishimg(
+    default_architecture,
+    default_os,
+    module_target_sat,
+    module_azurerm_cr,
+):
     """Creates Custom Finish Template image on AzureRM Compute Resource"""
-    finish_image = entities.Image(
+    finish_image = module_target_sat.api.Image(
         architecture=default_architecture,
         compute_resource=module_azurerm_cr,
         name=gen_string('alpha'),

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -12,14 +12,14 @@ from robottelo.errors import GCECertNotFoundError
 
 
 @pytest.fixture(scope='session')
-def gce_cert(default_sat):
+def gce_cert(session_target_sat):
     _, gce_cert_file = mkstemp(suffix='.json')
     cert = json.loads(settings.gce.cert)
     cert['local_path'] = gce_cert_file
     with open(gce_cert_file, 'w') as f:
         json.dump(cert, f)
-    default_sat.put(gce_cert_file, settings.gce.cert_path)
-    if default_sat.execute(f'[ -f {settings.gce.cert_path} ]').status != 0:
+    session_target_sat.put(gce_cert_file, settings.gce.cert_path)
+    if session_target_sat.execute(f'[ -f {settings.gce.cert_path} ]').status != 0:
         raise GCECertNotFoundError(
             f"The GCE certificate in path {settings.gce.cert_path} is not found in satellite."
         )

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -24,13 +24,13 @@ def module_puppet_environment(module_org, module_location):
 
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 @pytest.fixture(scope='module')
-def module_import_puppet_module(default_sat):
+def module_import_puppet_module(module_target_sat):
     """Returns custom puppet environment name that contains imported puppet module
     and puppet class name."""
     puppet_class = 'generic_1'
     return {
         'puppet_class': puppet_class,
-        'env': default_sat.create_custom_environment(repo=puppet_class),
+        'env': module_target_sat.create_custom_environment(repo=puppet_class),
     }
 
 

--- a/pytest_fixtures/component/smartproxy.py
+++ b/pytest_fixtures/component/smartproxy.py
@@ -23,14 +23,14 @@ def import_puppet_classes(default_smart_proxy):
 
 
 @pytest.fixture(scope='module')
-def module_fake_proxy(request, default_sat):
+def module_fake_proxy(request, module_target_sat):
     """Create a Proxy and register the cleanup function"""
     args = {'name': gen_string(str_type='alpha')}
     newport = get_available_capsule_port()
     try:
         with default_url_on_new_port(9090, newport) as url:
             args['url'] = url
-            proxy = default_sat.api.SmartProxy(**args).create()
+            proxy = module_target_sat.api.SmartProxy(**args).create()
             yield proxy
             capsule_cleanup(proxy.id)
     except CapsuleTunnelError as err:

--- a/pytest_fixtures/component/subscription.py
+++ b/pytest_fixtures/component/subscription.py
@@ -1,6 +1,5 @@
 import pytest
 
-from robottelo.config import settings
 from robottelo.rhsso_utils import run_command
 
 
@@ -11,32 +10,36 @@ def unsubscribe():
 
 
 @pytest.fixture(scope='session')
-def clean_rhsm():
+def clean_rhsm(session_target_sat):
     """removes pre-existing candlepin certs and resets RHSM."""
-    # removing the katello-ca-consumer
-    run_command('rpm -qa | grep katello-ca-consumer | xargs -r rpm -e')
+    session_target_sat.remove_katello_ca()
 
 
-@pytest.fixture(scope='session')
-def subscribe_satellite(clean_rhsm, default_sat):
+@pytest.fixture(scope='module')
+def subscribe_satellite(clean_rhsm, module_target_sat):
     """subscribe satellite to cdn"""
-    run_command(
-        'subscription-manager register --force --user={} --password={} {}'.format(
-            settings.subscription.rhn_username,
-            settings.subscription.rhn_password,
-            # set release to "7Server" currently with this scope
-            f'--release="{default_sat.os_version.major}Server"',
-        )
+    from robottelo.config import settings
+
+    if module_target_sat.os_version.major < 8:
+        release_version = f'{module_target_sat.os_version.major}Server'
+    else:
+        release_version = f'{module_target_sat.os_version.major}'
+    module_target_sat.register_contenthost(
+        org=None,
+        lce=None,
+        username=settings.subscription.rhn_username,
+        password=settings.subscription.rhn_password,
+        releasever=release_version,
     )
-    has_success_msg = 'Successfully attached a subscription'
-    attach_cmd = f'subscription-manager attach --pool={settings.subscription.rhn_poolid}'
-    result = run_command(attach_cmd)
-    if has_success_msg in result:
-        run_command(
-            f'subscription-manager repos --enable \
-                    "rhel-{default_sat.os_version.major}-server-extras-rpms"'
+    result = module_target_sat.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[
+        0
+    ]
+    if 'Successfully attached a subscription' in result.stdout:
+        module_target_sat.enable_repo(
+            f'rhel-{module_target_sat.os_version.major}-server-extras-rpms', force=True
         )
         yield
     else:
-        pytest.fail("Failed to attach system to pool. Aborting Test!.")
-    unsubscribe()
+        pytest.fail('Failed to attach system to pool. Aborting Test!.')
+    module_target_sat.unregister()
+    module_target_sat.remove_katello_ca()

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -71,10 +71,12 @@ def module_gt_manifest_org():
 
 
 @pytest.fixture(scope='module')
-def smart_proxy_location(module_org, default_sat):
+def smart_proxy_location(module_org, module_target_sat):
     location = entities.Location(organization=[module_org]).create()
     smart_proxy = (
-        entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
+        entities.SmartProxy()
+        .search(query={'search': f'name={module_target_sat.hostname}'})[0]
+        .read()
     )
     smart_proxy.location.append(entities.Location(id=location.id))
     smart_proxy.update(['location'])

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import pytest
 from broker import VMBroker
 from wait_for import wait_for
@@ -15,10 +17,45 @@ def _resolve_deploy_args(args_dict):
 
 
 @pytest.fixture(scope='session')
-def default_sat(align_to_satellite):
+def _default_sat(align_to_satellite):
     """Returns a Satellite object for settings.server.hostname"""
     if settings.server.hostname:
         return Satellite()
+
+
+@contextmanager
+def _target_sat_imp(request, _default_sat, satellite_factory):
+    """This is the actual working part of the following target_sat fixtures"""
+    if request.node.get_closest_marker(name='destructive'):
+        new_sat = satellite_factory()
+        yield new_sat
+        VMBroker(hosts=[new_sat]).checkin()
+    else:
+        yield _default_sat
+
+
+@pytest.fixture
+def target_sat(request, _default_sat, satellite_factory):
+    with _target_sat_imp(request, _default_sat, satellite_factory) as sat:
+        yield sat
+
+
+@pytest.fixture(scope='module')
+def module_target_sat(request, _default_sat, satellite_factory):
+    with _target_sat_imp(request, _default_sat, satellite_factory) as sat:
+        yield sat
+
+
+@pytest.fixture(scope='session')
+def session_target_sat(request, _default_sat, satellite_factory):
+    with _target_sat_imp(request, _default_sat, satellite_factory) as sat:
+        yield sat
+
+
+@pytest.fixture(scope='class')
+def class_target_sat(request, _default_sat, satellite_factory):
+    with _target_sat_imp(request, _default_sat, satellite_factory) as sat:
+        yield sat
 
 
 @pytest.fixture(scope='session')
@@ -86,23 +123,7 @@ def capsule_host(capsule_factory):
 
 
 @pytest.fixture
-def capsule_configured(capsule_host, default_sat):
+def capsule_configured(capsule_host, target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
-    capsule_host.install_katello_ca(default_sat)
-    capsule_host.register_contenthost()
-    capsule_host.capsule_setup(sat_host=default_sat)
+    capsule_host.capsule_setup(sat_host=target_sat)
     yield capsule_host
-
-
-@pytest.fixture
-def destructive_sat(satellite_host):
-    """Destructive tests require changing settings.server.hostname for now"""
-    with satellite_host as sat:
-        yield sat
-
-
-@pytest.fixture(scope='module')
-def module_destructive_sat(module_satellite_host):
-    """Destructive tests require changing settings.server.hostname for now"""
-    with module_satellite_host as sat:
-        yield sat

--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -14,38 +14,54 @@ def foreman_service_teardown(satellite_host):
 
 
 @pytest.fixture
-def allow_repo_discovery(default_sat):
+def allow_repo_discovery(target_sat):
     """Set SELinux boolean to allow Rails to connect to non-standard ports."""
-    default_sat.execute('setsebool foreman_rails_can_connect_all on')
+    target_sat.execute('setsebool foreman_rails_can_connect_all on')
     yield
-    default_sat.execute('setsebool foreman_rails_can_connect_all off')
+    target_sat.execute('setsebool foreman_rails_can_connect_all off')
 
 
 @pytest.fixture(autouse=True, scope="session")
-def relax_bfa(default_sat):
+def relax_bfa(session_target_sat):
     """Relax BFA protection against failed login attempts"""
-    if default_sat:
-        default_sat.cli.Settings.set({'name': 'failed_login_attempts_limit', 'value': '0'})
+    if session_target_sat:
+        session_target_sat.cli.Settings.set({'name': 'failed_login_attempts_limit', 'value': '0'})
 
 
 @pytest.fixture(autouse=True, scope='session')
-def proxy_port_range(default_sat):
+def proxy_port_range(session_target_sat):
     """Assigns port range for fake_capsules"""
-    if default_sat:
+    if session_target_sat:
         port_pool_range = settings.fake_capsules.port_range
-        if default_sat.execute(f'semanage port -l | grep {port_pool_range}').status != 0:
-            default_sat.execute(f'semanage port -a -t websm_port_t -p tcp {port_pool_range}')
+        if session_target_sat.execute(f'semanage port -l | grep {port_pool_range}').status != 0:
+            session_target_sat.execute(f'semanage port -a -t websm_port_t -p tcp {port_pool_range}')
 
 
 @pytest.fixture
-def cockpit_sat(destructive_sat):
-    destructive_sat.register_to_dogfood()
-    destructive_sat.install_cockpit()
-    yield destructive_sat
+def cockpit_sat(target_sat):
+    target_sat.register_to_dogfood()
+    target_sat.install_cockpit()
+    yield target_sat
 
 
 @pytest.fixture(scope='session')
-def block_fake_repo_access(default_sat):
+def install_cockpit_plugin(session_target_sat):
+    session_target_sat.register_to_dogfood()
+    session_target_sat.install_cockpit()
+    # TODO remove this change when we start using new host detail view
+    setting_object = session_target_sat.api.Setting().search(
+        query={'search': 'name=host_details_ui'}
+    )[0]
+    old_value = setting_object.value
+    setting_object.value = False
+    setting_object.update({'value'})
+    yield
+    setting_object.value = old_value
+    setting_object.update({'value'})
+
+
+@pytest.fixture(scope='session')
+def block_fake_repo_access(session_target_sat):
     """Block traffic to given port used by fake repo"""
     repo_server_name = '.'.join(
         urlparse(settings.robottelo.REPOS_HOSTING_URL).netloc.split(':')[:1]
@@ -53,20 +69,20 @@ def block_fake_repo_access(default_sat):
     repo_server_port = '.'.join(
         urlparse(settings.robottelo.REPOS_HOSTING_URL).netloc.split(':')[1:]
     )
-    cmd_result = default_sat.execute(f'nc -z {repo_server_name} {repo_server_port}')
+    cmd_result = session_target_sat.execute(f'nc -z {repo_server_name} {repo_server_port}')
     if cmd_result.status != 0:
         raise SatelliteHostError(
             f'Error, port {repo_server_name} {repo_server_port} incorrect or already blocked.'
         )
-    default_sat.execute(
+    session_target_sat.execute(
         'firewall-cmd --direct --add-rule ipv4 filter OUTPUT 0 -p tcp -m tcp'
         f' --dport={repo_server_port} -j DROP'
     )
-    cmd_result = default_sat.execute(f'nc -z {repo_server_name} {repo_server_port}')
+    cmd_result = session_target_sat.execute(f'nc -z {repo_server_name} {repo_server_port}')
     if cmd_result.status != 1:
         raise SatelliteHostError(f'Error, port {repo_server_name} {repo_server_port} not blocked.')
     yield
-    default_sat.execute(
+    session_target_sat.execute(
         'firewall-cmd --direct --remove-rule ipv4 filter OUTPUT 0 -p tcp -m tcp'
         f' --dport={repo_server_port} -j DROP'
     )

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -60,9 +60,9 @@ def invalid_sc_parameters_data():
 
 
 @pytest.fixture(scope='module')
-def module_puppet(default_sat):
+def module_puppet(module_target_sat):
     puppet_class = 'api_test_classparameters'
-    env_name = default_sat.create_custom_environment(repo=puppet_class)
+    env_name = module_target_sat.create_custom_environment(repo=puppet_class)
     puppet_class = entities.PuppetClass().search(
         query={'search': f'name = "{puppet_class}" and environment = "{env_name}"'}
     )[0]

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -37,7 +37,9 @@ class TestAzureRMComputeResourceTestCase:
 
     @pytest.mark.upgrade
     @pytest.mark.tier1
-    def test_positive_crud_azurerm_cr(self, module_org, module_location, azurerm_settings):
+    def test_positive_crud_azurerm_cr(
+        self, module_org, module_location, azurerm_settings, target_sat
+    ):
         """Create, Read, Update and Delete AzureRM compute resources
 
         :id: da081a1f-9614-4918-91cb-c900c40ac121
@@ -50,7 +52,7 @@ class TestAzureRMComputeResourceTestCase:
         """
         # Create CR
         cr_name = gen_string('alpha')
-        compresource = entities.AzureRMComputeResource(
+        compresource = target_sat.api.AzureRMComputeResource(
             name=cr_name,
             provider='AzureRm',
             tenant=azurerm_settings['tenant'],
@@ -79,7 +81,9 @@ class TestAzureRMComputeResourceTestCase:
 
         # Delete CR
         compresource.delete()
-        assert not entities.AzureRMComputeResource().search(query={'search': f'name={new_cr_name}'})
+        assert not target_sat.api.AzureRMComputeResource().search(
+            query={'search': f'name={new_cr_name}'}
+        )
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
@@ -221,7 +225,7 @@ class TestAzureRMHostProvisioningTestCase:
     @pytest.fixture(scope='class')
     def class_host_ft(
         self,
-        default_sat,
+        class_target_sat,
         azurermclient,
         module_azurerm_finishimg,
         module_azurerm_cr,
@@ -238,7 +242,9 @@ class TestAzureRMHostProvisioningTestCase:
         Later in tests this host will be used to perform assertions
         """
 
-        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with class_target_sat.skip_yum_update_during_provisioning(
+            template='Kickstart default finish'
+        ):
             host = entities.Host(
                 architecture=default_architecture,
                 build=True,
@@ -370,7 +376,7 @@ class TestAzureRMUserDataProvisioning:
     @pytest.fixture(scope='class')
     def class_host_ud(
         self,
-        default_sat,
+        class_target_sat,
         azurermclient,
         module_azurerm_cloudimg,
         module_azurerm_cr,
@@ -387,7 +393,9 @@ class TestAzureRMUserDataProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with class_target_sat.skip_yum_update_during_provisioning(
+            template='Kickstart default finish'
+        ):
             host = entities.Host(
                 architecture=default_architecture,
                 build=True,
@@ -523,7 +531,7 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
     @pytest.fixture(scope='class')
     def class_host_gallery_ft(
         self,
-        default_sat,
+        class_target_sat,
         azurermclient,
         module_azurerm_gallery_finishimg,
         module_azurerm_cr,
@@ -540,7 +548,9 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with class_target_sat.skip_yum_update_during_provisioning(
+            template='Kickstart default finish'
+        ):
             host = entities.Host(
                 architecture=default_architecture,
                 build=True,
@@ -649,7 +659,7 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
     @pytest.fixture(scope='class')
     def class_host_custom_ft(
         self,
-        default_sat,
+        class_target_sat,
         azurermclient,
         module_azurerm_custom_finishimg,
         module_azurerm_cr,
@@ -666,7 +676,9 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
         Later in tests this host will be used to perform assertions
         """
 
-        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with class_target_sat.skip_yum_update_during_provisioning(
+            template='Kickstart default finish'
+        ):
             host = entities.Host(
                 architecture=default_architecture,
                 build=True,

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -66,9 +66,9 @@ def module_gce_finishimg(
 
 
 @pytest.fixture(scope='class')
-def gce_domain(module_org, module_location, default_smart_proxy, default_sat):
+def gce_domain(module_org, module_location, default_smart_proxy, target_sat):
     """Sets Domain for GCE Host Provisioning"""
-    _, _, dom = default_sat.hostname.partition('.')
+    _, _, dom = target_sat.hostname.partition('.')
     domain = entities.Domain().search(query={'search': f'name="{dom}"'})
     domain = domain[0].read()
     domain.location.append(module_location)

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -87,7 +87,7 @@ class TestSatelliteContentManagement:
         assert response, f"Repository {repo} failed to sync."
 
     @pytest.mark.tier4
-    def test_positive_sync_kickstart_repo(self, module_manifest_org, default_sat):
+    def test_positive_sync_kickstart_repo(self, module_manifest_org, target_sat):
         """No encoding gzip errors on kickstart repositories
         sync.
 
@@ -128,7 +128,7 @@ class TestSatelliteContentManagement:
         rh_repo.download_policy = 'immediate'
         rh_repo = rh_repo.update(['download_policy'])
         call_entity_method_with_timeout(rh_repo.sync, timeout=600)
-        result = default_sat.execute(
+        result = target_sat.execute(
             'grep pulp /var/log/messages | grep failed | grep encoding | grep gzip'
         )
         assert result.status == 1
@@ -139,8 +139,8 @@ class TestSatelliteContentManagement:
         assert rh_repo.content_counts['rpm'] > 0
 
     @pytest.mark.tier2
-    def test_positive_mirroring_policy(self, default_sat):
-        """Assert that the content of a repository with 'Mirroring Policy' enabled
+    def test_positive_mirroring_policy(self, target_sat):
+        """Assert that the content of a repository with 'Mirror Policy' enabled
         is restored properly after resync.
 
         :id: cbf1c781-cb96-4b4a-bae2-15c9f5be5e50
@@ -430,7 +430,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_updated_repo(
-        self, default_sat, capsule_configured, function_org, function_product
+        self, target_sat, capsule_configured, function_org, function_product
     ):
         """Sync a custom repo with no upstream url but uploaded content to the Capsule via promoted CV,
         update content of the repo, publish and promote the CV again, resync the Capsule.
@@ -524,7 +524,7 @@ class TestCapsuleContentManagement:
 
         # Check the content is synced on the Capsule side properly
         sat_repo_url = form_repo_url(
-            default_sat,
+            target_sat,
             org=function_org.label,
             lce=lce.label,
             cv=cv.label,
@@ -546,7 +546,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_capsule_sync(self, capsule_configured, default_sat):
+    def test_positive_capsule_sync(self, capsule_configured, target_sat):
         """Create repository, add it to lifecycle environment, assign lifecycle
         environment with a capsule, sync repository, sync it once again, update
         repository (add 1 new package), sync repository once again.
@@ -624,7 +624,7 @@ class TestCapsuleContentManagement:
         # Assert that the content published on the capsule is exactly the
         # same as in repository on satellite
         sat_repo_url = form_repo_url(
-            default_sat,
+            target_sat,
             org=org.label,
             lce=lce.label,
             cv=cv.label,
@@ -794,7 +794,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_on_demand_sync(self, capsule_configured, default_sat):
+    def test_positive_on_demand_sync(self, capsule_configured, target_sat):
         """Create a repository with 'on_demand' policy, add it to a CV,
         promote to an 'on_demand' Capsule's LCE, check artifacts were created,
         download a published package, assert it matches the source.
@@ -890,7 +890,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_update_with_immediate_sync(self, capsule_configured, default_sat):
+    def test_positive_update_with_immediate_sync(self, capsule_configured, target_sat):
         """Create a repository with on_demand download policy, associate it
         with capsule, sync repo, update download policy to immediate, sync once
         more.
@@ -1038,7 +1038,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_sync_kickstart_repo(
-        self, module_manifest_org, default_sat, capsule_configured
+        self, module_manifest_org, target_sat, capsule_configured
     ):
         """Sync kickstart repository to the capsule.
 
@@ -1117,12 +1117,12 @@ class TestCapsuleContentManagement:
 
         # Check kickstart specific files
         for file in constants.KICKSTART_CONTENT:
-            sat_file = md5_by_url(f'{default_sat.url}/{url_base}/{file}')
+            sat_file = md5_by_url(f'{target_sat.url}/{url_base}/{file}')
             caps_file = md5_by_url(f'{capsule_configured.url}/{url_base}/{file}')
             assert sat_file == caps_file
 
         # Check packages
-        sat_pkg_url = f'{default_sat.url}/{url_base}/Packages/'
+        sat_pkg_url = f'{target_sat.url}/{url_base}/Packages/'
         caps_pkg_url = f'{capsule_configured.url}/{url_base}/Packages/'
         sat_pkgs = get_repo_files_by_url(sat_pkg_url)
         caps_pkgs = get_repo_files_by_url(caps_pkg_url)
@@ -1132,7 +1132,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients')
     def test_positive_sync_container_repo_end_to_end(
-        self, default_sat, capsule_configured, container_contenthost, module_org, module_product
+        self, target_sat, capsule_configured, container_contenthost, module_org, module_product
     ):
         """Sync container repositories with schema1, schema2,
         and both of them to the capsule and pull them to a
@@ -1241,7 +1241,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_collection_repo(
-        self, default_sat, module_lce_library, module_product, capsule_configured, rhel7_contenthost
+        self, target_sat, module_lce_library, module_product, capsule_configured, rhel7_contenthost
     ):
         """Sync ansible-collection repo to the Capsule, consume it on a host.
 
@@ -1310,7 +1310,7 @@ class TestCapsuleContentManagement:
         result = rhel7_contenthost.execute('yum -y install ansible')
         assert result.status == 0
 
-        repo_path = repo.full_path.replace(default_sat.hostname, capsule_configured.hostname)
+        repo_path = repo.full_path.replace(target_sat.hostname, capsule_configured.hostname)
         coll_path = './collections'
         cfg = (
             '[defaults]\n'
@@ -1337,7 +1337,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_file_repo(
-        self, default_sat, capsule_configured, module_org, module_product
+        self, target_sat, capsule_configured, module_org, module_product
     ):
         """Sync file-type repository to the capsule.
 
@@ -1408,7 +1408,7 @@ class TestCapsuleContentManagement:
 
         # Check for content on SAT and CAPS
         sat_repo_url = form_repo_url(
-            default_sat,
+            target_sat,
             org=module_org.label,
             lce=lce.label,
             cv=cv.label,
@@ -1436,7 +1436,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier3
     def test_positive_allow_reregistration_when_dmi_uuid_changed(
-        self, module_org, rhel_contenthost, default_sat
+        self, module_org, rhel_contenthost, target_sat
     ):
         """Register a content host with a custom DMI UUID, unregistering it, change
         the DMI UUID, and re-registering it again
@@ -1453,15 +1453,15 @@ class TestCapsuleContentManagement:
         """
         uuid_1 = str(uuid.uuid1())
         uuid_2 = str(uuid.uuid4())
-        rhel_contenthost.install_katello_ca(default_sat)
-        default_sat.execute(
+        rhel_contenthost.install_katello_ca(target_sat)
+        target_sat.execute(
             f'echo \'{{"dmi.system.uuid": "{uuid_1}"}}\' > /etc/rhsm/facts/uuid.facts'
         )
         result = rhel_contenthost.register_contenthost(module_org.label, lce=constants.ENVIRONMENT)
         assert result.status == 0
         result = rhel_contenthost.execute('subscription-manager clean')
         assert result.status == 0
-        default_sat.execute(
+        target_sat.execute(
             f'echo \'{{"dmi.system.uuid": "{uuid_2}"}}\' > /etc/rhsm/facts/uuid.facts'
         )
         result = rhel_contenthost.register_contenthost(module_org.label, lce=constants.ENVIRONMENT)

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -685,7 +685,7 @@ class TestContentViewPublishPromote:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    def test_composite_content_view_with_same_repos(self, module_org, default_sat):
+    def test_composite_content_view_with_same_repos(self, module_org, target_sat):
         """Create a Composite Content View with content views having same yum repo.
         Add filter on the content views and check the package count for composite content view
         should not be changed.

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -17,7 +17,6 @@
 :Upstream: No
 """
 # For ease of use hc refers to host-collection throughout this document
-from datetime import datetime
 from time import sleep
 
 import pytest
@@ -32,7 +31,6 @@ from robottelo.api.utils import upload_manifest
 from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.cli.factory import setup_org_for_a_rh_repo
-from robottelo.cli.job_invocation import JobInvocation
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.hosts import ContentHost
@@ -170,7 +168,7 @@ def _fetch_available_errata(module_org, host, expected_amount, timeout=120):
 
 @pytest.mark.upgrade
 @pytest.mark.tier3
-def test_positive_install_in_hc(module_org, activation_key, custom_repo, default_sat):
+def test_positive_install_in_hc(module_org, activation_key, custom_repo, target_sat):
     """Install errata in a host-collection
 
     :id: 6f0242df-6511-4c0f-95fc-3fa32c63a064
@@ -189,10 +187,10 @@ def test_positive_install_in_hc(module_org, activation_key, custom_repo, default
         nick=constants.DISTRO_RHEL7, host_classes={'host': ContentHost}, _count=2
     ) as clients:
         for client in clients:
-            client.install_katello_ca(default_sat)
+            client.install_katello_ca(target_sat)
             client.register_contenthost(module_org.label, activation_key.name)
             assert client.subscribed
-            client.add_rex_key(satellite=default_sat)
+            client.add_rex_key(satellite=target_sat)
         host_ids = [client.nailgun_host.id for client in clients]
         _install_package(
             module_org,
@@ -200,35 +198,31 @@ def test_positive_install_in_hc(module_org, activation_key, custom_repo, default
             host_ids=host_ids,
             package_name=constants.FAKE_1_CUSTOM_PACKAGE,
         )
-        host_collection = default_sat.api.HostCollection(organization=module_org).create()
+        host_collection = target_sat.api.HostCollection(organization=module_org).create()
         host_ids = [client.nailgun_host.id for client in clients]
         host_collection.host_ids = host_ids
         host_collection = host_collection.update(['host_ids'])
-        host_collection_query = f'host_collection_id = {host_collection.id}'
-        JobInvocation.create(
-            {
+        task_id = target_sat.api.JobInvocation().run(
+            data={
                 'feature': 'katello_errata_install',
                 'inputs': f'errata=\'{CUSTOM_REPO_ERRATA_ID}\'',
-                'search-query': host_collection_query,
+                'search-query': f'host_collection_id = {host_collection.id}',
                 'organization-id': f'{module_org.id}',
             }
+        )['id']
+        wait_for_tasks(
+            search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
+            search_rate=20,
+            max_tries=10,
         )
         for client in clients:
-            wait_for_tasks(
-                search_query=(
-                    'label = Actions::Katello::Host::UploadProfiles'
-                    f' and resource_id = {client.nailgun_host.id}'
-                ),
-                search_rate=15,
-                max_tries=10,
-            )
             result = client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}')
             assert result.status == 0
 
 
 @pytest.mark.tier3
 def test_positive_install_in_host(
-    module_org, activation_key, custom_repo, rhel7_contenthost, default_sat
+    module_org, activation_key, custom_repo, rhel7_contenthost, target_sat
 ):
     """Install errata in a host
 
@@ -244,7 +238,7 @@ def test_positive_install_in_host(
 
     :BZ: 1983043
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(module_org.label, activation_key.name)
     assert rhel7_contenthost.subscribed
     host_id = rhel7_contenthost.nailgun_host.id
@@ -254,8 +248,8 @@ def test_positive_install_in_host(
         host_ids=[host_id],
         package_name=constants.FAKE_1_CUSTOM_PACKAGE,
     )
-    rhel7_contenthost.add_rex_key(satellite=default_sat)
-    default_sat.api.JobInvocation().run(
+    rhel7_contenthost.add_rex_key(satellite=target_sat)
+    task_id = target_sat.api.JobInvocation().run(
         data={
             'feature': 'katello_errata_install',
             'inputs': {'errata': f'{CUSTOM_REPO_ERRATA_ID}'},
@@ -263,13 +257,10 @@ def test_positive_install_in_host(
             'search_query': f'name = {rhel7_contenthost.hostname}',
             'organization_id': module_org.id,
         },
-    )
+    )['id']
     wait_for_tasks(
-        search_query=(
-            'label = Actions::Katello::Host::UploadProfiles'
-            f' and resource_id = {rhel7_contenthost.nailgun_host.id}'
-        ),
-        search_rate=15,
+        search_query=f'label = Actions::Katello::Host::UploadProfiles and resource_id = {task_id}',
+        search_rate=20,
         max_tries=10,
     )
     _validate_package_installed([rhel7_contenthost], constants.FAKE_2_CUSTOM_PACKAGE)
@@ -277,7 +268,7 @@ def test_positive_install_in_host(
 
 @pytest.mark.tier3
 def test_positive_install_multiple_in_host(
-    module_org, activation_key, custom_repo, rhel7_contenthost, default_sat
+    module_org, activation_key, custom_repo, rhel7_contenthost, target_sat
 ):
     """For a host with multiple applicable errata install one and ensure
     the rest of errata is still available
@@ -296,7 +287,7 @@ def test_positive_install_multiple_in_host(
 
     :CaseLevel: System
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(module_org.label, activation_key.name)
     assert rhel7_contenthost.subscribed
     host = rhel7_contenthost.nailgun_host
@@ -307,24 +298,19 @@ def test_positive_install_multiple_in_host(
     host = host.read()
     applicable_errata_count = host.content_facet_attributes['errata_counts']['total']
     assert applicable_errata_count > 1
-    rhel7_contenthost.add_rex_key(satellite=default_sat)
+    rhel7_contenthost.add_rex_key(satellite=target_sat)
     for errata in settings.repos.yum_9.errata[1:4]:
-        timestamp = (datetime.utcnow()).strftime('%Y-%m-%d %H:%M')
-        JobInvocation.create(
-            {
+        task_id = target_sat.api.JobInvocation().run(
+            data={
                 'feature': 'katello_errata_install',
                 'inputs': f'errata=\'{errata}\'',
                 'search-query': f'name = {rhel7_contenthost.hostname}',
                 'organization-id': f'{module_org.id}',
             }
-        )
+        )['id']
         wait_for_tasks(
-            search_query=(
-                'label = Actions::Katello::Host::UploadProfiles'
-                f' and resource_id = {rhel7_contenthost.nailgun_host.id}'
-                f' and started_at >= "{timestamp}"'
-            ),
-            search_rate=15,
+            search_query=f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}',
+            search_rate=20,
             max_tries=10,
         )
         host = host.read()
@@ -334,7 +320,7 @@ def test_positive_install_multiple_in_host(
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_list(module_org, custom_repo, default_sat):
+def test_positive_list(module_org, custom_repo, target_sat):
     """View all errata specific to repository
 
     :id: 1efceabf-9821-4804-bacf-2213ac0c7550
@@ -348,9 +334,9 @@ def test_positive_list(module_org, custom_repo, default_sat):
 
     :CaseLevel: System
     """
-    repo1 = default_sat.api.Repository(id=custom_repo['repository-id']).read()
-    repo2 = default_sat.api.Repository(
-        product=default_sat.api.Product().create(), url=settings.repos.yum_3.url
+    repo1 = target_sat.api.Repository(id=custom_repo['repository-id']).read()
+    repo2 = target_sat.api.Repository(
+        product=target_sat.api.Product().create(), url=settings.repos.yum_3.url
     ).create()
     repo2.sync()
     repo1_errata_ids = [
@@ -368,7 +354,7 @@ def test_positive_list(module_org, custom_repo, default_sat):
 
 
 @pytest.mark.tier3
-def test_positive_list_updated(module_org, custom_repo, default_sat):
+def test_positive_list_updated(module_org, custom_repo, target_sat):
     """View all errata in an Org sorted by Updated
 
     :id: 560d6584-70bd-4d1b-993a-cc7665a9e600
@@ -381,9 +367,9 @@ def test_positive_list_updated(module_org, custom_repo, default_sat):
 
     :CaseLevel: System
     """
-    repo = default_sat.api.Repository(id=custom_repo['repository-id']).read()
+    repo = target_sat.api.Repository(id=custom_repo['repository-id']).read()
     assert repo.sync()['result'] == 'success'
-    erratum_list = default_sat.api.Errata(repository=repo).search(
+    erratum_list = target_sat.api.Errata(repository=repo).search(
         query={'order': 'updated ASC', 'per_page': '1000'}
     )
     updated = [errata.updated for errata in erratum_list]
@@ -391,7 +377,7 @@ def test_positive_list_updated(module_org, custom_repo, default_sat):
 
 
 @pytest.mark.tier3
-def test_positive_sorted_issue_date_and_filter_by_cve(module_org, custom_repo, default_sat):
+def test_positive_sorted_issue_date_and_filter_by_cve(module_org, custom_repo, target_sat):
     """Sort by issued date and filter errata by CVE
 
     :id: a921d4c2-8d3d-4462-ba6c-fbd4b898a3f2
@@ -412,7 +398,7 @@ def test_positive_sorted_issue_date_and_filter_by_cve(module_org, custom_repo, d
     assert issued == sorted(issued)
 
     # Errata is filtered by CVE
-    erratum_list = default_sat.api.Errata(repository=custom_repo['repository-id']).search(
+    erratum_list = target_sat.api.Errata(repository=custom_repo['repository-id']).search(
         query={'order': 'cve DESC', 'per_page': '1000'}
     )
     # Most of Errata don't have any CVEs. Removing empty CVEs from results
@@ -537,7 +523,7 @@ def setup_content_rhel6():
 
 
 @pytest.mark.tier3
-def test_positive_get_count_for_host(setup_content_rhel6, rhel6_contenthost, default_sat):
+def test_positive_get_count_for_host(setup_content_rhel6, rhel6_contenthost, target_sat):
     """Available errata count when retrieving Host
 
     :id: 2f35933f-8026-414e-8f75-7f4ec048faae
@@ -559,7 +545,7 @@ def test_positive_get_count_for_host(setup_content_rhel6, rhel6_contenthost, def
     org_label = setup_content_rhel6[1].label
     org_id = setup_content_rhel6[1].id
     sub_list = setup_content_rhel6[2]
-    rhel6_contenthost.install_katello_ca(default_sat)
+    rhel6_contenthost.install_katello_ca(target_sat)
     rhel6_contenthost.register_contenthost(org_label, ak_name)
     assert rhel6_contenthost.subscribed
     pool_id = rhel6_contenthost.subscription_manager_get_pool(sub_list=sub_list)
@@ -578,7 +564,7 @@ def test_positive_get_count_for_host(setup_content_rhel6, rhel6_contenthost, def
 
 @pytest.mark.upgrade
 @pytest.mark.tier3
-def test_positive_get_applicable_for_host(setup_content_rhel6, rhel6_contenthost, default_sat):
+def test_positive_get_applicable_for_host(setup_content_rhel6, rhel6_contenthost, target_sat):
     """Get applicable errata ids for a host
 
     :id: 51d44d51-eb3f-4ee4-a1df-869629d427ac
@@ -598,7 +584,7 @@ def test_positive_get_applicable_for_host(setup_content_rhel6, rhel6_contenthost
     ak_name = setup_content_rhel6[0].name
     org_label = setup_content_rhel6[1].label
     org_id = setup_content_rhel6[1].id
-    rhel6_contenthost.install_katello_ca(default_sat)
+    rhel6_contenthost.install_katello_ca(target_sat)
     rhel6_contenthost.register_contenthost(org_label, ak_name)
     assert rhel6_contenthost.subscribed
     pool_id = rhel6_contenthost.subscription_manager_get_pool(sub_list=setup_content_rhel6[2])
@@ -682,7 +668,7 @@ def test_positive_incremental_update_required(
     custom_repo,
     rh_repo,
     rhel7_contenthost,
-    default_sat,
+    target_sat,
 ):
     """Given a set of hosts and errata, check for content view version
     and environments that need updating."
@@ -712,7 +698,7 @@ def test_positive_incremental_update_required(
 
     :BZ: 2013093
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(module_org.label, activation_key.name)
     assert rhel7_contenthost.subscribed
     rhel7_contenthost.enable_repo(constants.REPOS['rhst7']['id'])
@@ -795,7 +781,7 @@ def _validate_swid_tags_installed(module_org, vm, module_name):
 @pytest.mark.upgrade
 @pytest.mark.pit_client
 def test_errata_installation_with_swidtags(
-    module_org, module_lce, repos_collection, rhel8_contenthost, default_sat
+    module_org, module_lce, repos_collection, rhel8_contenthost, target_sat
 ):
     """Verify errata installation with swid_tags and swid tags get updated after
     module stream update.
@@ -833,11 +819,11 @@ def test_errata_installation_with_swidtags(
         }
     )
     repos_collection.setup_virtual_machine(
-        rhel8_contenthost, default_sat, install_katello_agent=False
+        rhel8_contenthost, target_sat, install_katello_agent=False
     )
 
     # install older module stream
-    rhel8_contenthost.add_rex_key(satellite=default_sat)
+    rhel8_contenthost.add_rex_key(satellite=target_sat)
     _set_prerequisites_for_swid_repos(module_org, vm=rhel8_contenthost)
     _run_remote_command_on_content_host(
         module_org, f'dnf -y module install {module_name}:0:{version}', rhel8_contenthost
@@ -949,7 +935,7 @@ def test_apply_modular_errata_using_default_content_view(
     rhel8_contenthost,
     rhel8_module_ak,
     rhel8_custom_repo_cv,
-    default_sat,
+    target_sat,
 ):
     """
     Registering a RHEL8 system to the default content view with no modules enabled results in
@@ -979,7 +965,7 @@ def test_apply_modular_errata_using_default_content_view(
     stream = '0'
     version = '20180704244205'
 
-    rhel8_contenthost.install_katello_ca(default_sat)
+    rhel8_contenthost.install_katello_ca(target_sat)
     rhel8_contenthost.register_contenthost(module_manifest_org.label, rhel8_module_ak.name)
     assert rhel8_contenthost.subscribed
     host = rhel8_contenthost.nailgun_host

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -314,7 +314,7 @@ def test_positive_create_with_inherited_params(module_org, module_location):
 
 
 @pytest.mark.tier1
-def test_positive_create_and_update_with_puppet_proxy(default_sat):
+def test_positive_create_and_update_with_puppet_proxy(target_sat):
     """Create a host with puppet proxy specified and then create new host without specified
     puppet proxy and update the new host with the same puppet proxy
 
@@ -325,19 +325,17 @@ def test_positive_create_and_update_with_puppet_proxy(default_sat):
     :CaseImportance: Critical
     """
     # TODO Define the default capsule/SP port + URL on hosts.Capsule
-    proxy = default_sat.api.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[
-        0
-    ]
-    host = default_sat.api.Host(puppet_proxy=proxy).create()
+    proxy = target_sat.api.SmartProxy().search(query={'search': f'url = {target_sat.url}:9090'})[0]
+    host = target_sat.api.Host(puppet_proxy=proxy).create()
     assert host.puppet_proxy.read().name == proxy.name
-    new_host = default_sat.api.Host().create()
+    new_host = target_sat.api.Host().create()
     new_host.puppet_proxy = proxy
     new_host = new_host.update(['puppet_proxy'])
     assert new_host.puppet_proxy.read().name == proxy.name
 
 
 @pytest.mark.tier1
-def test_positive_create_with_puppet_ca_proxy(default_sat):
+def test_positive_create_with_puppet_ca_proxy(target_sat):
     """Create a host with puppet CA proxy specified and then create new host without specified
      puppet CA proxy and update the new host with the same puppet CA proxy
 
@@ -347,7 +345,7 @@ def test_positive_create_with_puppet_ca_proxy(default_sat):
 
     :CaseImportance: Critical
     """
-    proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[0]
+    proxy = entities.SmartProxy().search(query={'search': f'url = {target_sat.url}:9090'})[0]
     host = entities.Host(puppet_ca_proxy=proxy).create()
     assert host.puppet_ca_proxy.read().name == proxy.name
     new_host = entities.Host().create()
@@ -943,7 +941,7 @@ def test_negative_update_os():
 
 @pytest.mark.tier3
 def test_positive_read_content_source_id(
-    module_org, module_location, module_lce, module_published_cv, default_sat
+    module_org, module_location, module_lce, module_published_cv, target_sat
 ):
     """Read the host content_source_id attribute from the read request
     response
@@ -959,7 +957,7 @@ def test_positive_read_content_source_id(
 
     :CaseLevel: System
     """
-    proxy = entities.SmartProxy().search(query={'url': f'{default_sat.url}:9090'})[0].read()
+    proxy = entities.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0].read()
     promote(module_published_cv.version[0], environment_id=module_lce.id)
     host = entities.Host(
         organization=module_org,
@@ -979,7 +977,7 @@ def test_positive_read_content_source_id(
 
 @pytest.mark.tier3
 def test_positive_update_content_source_id(
-    module_org, module_location, module_lce, module_published_cv, default_sat
+    module_org, module_location, module_lce, module_published_cv, target_sat
 ):
     """Read the host content_source_id attribute from the update request
     response
@@ -995,9 +993,9 @@ def test_positive_update_content_source_id(
 
     :CaseLevel: System
     """
-    proxy = default_sat.api.SmartProxy().search(query={'url': f'{default_sat.url}:9090'})[0]
+    proxy = target_sat.api.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0]
     promote(module_published_cv.version[0], environment_id=module_lce.id)
-    host = default_sat.api.Host(
+    host = target_sat.api.Host(
         organization=module_org,
         location=module_location,
         content_facet_attributes={
@@ -1318,7 +1316,7 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
 
 
 @pytest.mark.tier1
-def test_positive_read_puppet_proxy_name(default_sat):
+def test_positive_read_puppet_proxy_name(target_sat):
     """Read a hostgroup created with puppet proxy and inspect server's
     response
 
@@ -1330,14 +1328,14 @@ def test_positive_read_puppet_proxy_name(default_sat):
 
     :CaseImportance: Critical
     """
-    proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[0]
+    proxy = entities.SmartProxy().search(query={'search': f'url = {target_sat.url}:9090'})[0]
     host = entities.Host(puppet_proxy=proxy).create().read_json()
     assert 'puppet_proxy_name' in host
     assert proxy.name == host['puppet_proxy_name']
 
 
 @pytest.mark.tier1
-def test_positive_read_puppet_ca_proxy_name(default_sat):
+def test_positive_read_puppet_ca_proxy_name(target_sat):
     """Read a hostgroup created with puppet ca proxy and inspect server's
     response
 
@@ -1349,7 +1347,7 @@ def test_positive_read_puppet_ca_proxy_name(default_sat):
 
     :CaseImportance: Critical
     """
-    proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})[0]
+    proxy = entities.SmartProxy().search(query={'search': f'url = {target_sat.url}:9090'})[0]
     host = entities.Host(puppet_ca_proxy=proxy).create().read_json()
     assert 'puppet_ca_proxy_name' in host
     assert proxy.name == host['puppet_ca_proxy_name']

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -396,7 +396,7 @@ def test_negative_create_with_invalid_name(module_org, name):
 
 
 @pytest.mark.tier1
-def test_positive_add_remove_subscription(module_org, module_ak_cv_lce, default_sat):
+def test_positive_add_remove_subscription(module_org, module_ak_cv_lce, target_sat):
     """Try to bulk add and remove a subscription to members of a host collection.
 
     :id: c4ec5727-eb25-452e-a91f-87cafb16666b
@@ -430,7 +430,7 @@ def test_positive_add_remove_subscription(module_org, module_ak_cv_lce, default_
     # Create and register VMs as members of Host Collection
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}, _count=2) as hosts:
         for client in hosts:
-            client.install_katello_ca(default_sat)
+            client.install_katello_ca(target_sat)
             client.register_contenthost(module_org.label, module_ak_cv_lce.name)
         # Read host_collection back from Satellite to get host_ids
         host_collection = module_ak_cv_lce.host_collection[0].read()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -307,7 +307,7 @@ class TestOrganizationUpdate:
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
-    def test_positive_add_and_remove_smart_proxy(self, default_sat):
+    def test_positive_add_and_remove_smart_proxy(self, target_sat):
         """Add a smart proxy to an organization
 
         :id: e21de720-3fa2-429b-bd8e-b6a48a13146d
@@ -319,15 +319,15 @@ class TestOrganizationUpdate:
         :CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
-        smart_proxy = default_sat.api.SmartProxy().search(
-            query={'search': f'url = {default_sat.url}:9090'}
+        smart_proxy = target_sat.api.SmartProxy().search(
+            query={'search': f'url = {target_sat.url}:9090'}
         )
         # Check that proxy is found and unpack it from the list
         assert len(smart_proxy) > 0
         smart_proxy = smart_proxy[0]
         # By default, newly created organization uses built-in smart proxy,
         # so we need to remove it first
-        org = default_sat.api.Organization().create()
+        org = target_sat.api.Organization().create()
         org.smart_proxy = []
         org = org.update(['smart_proxy'])
         # Verify smart proxy was actually removed

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -39,11 +39,11 @@ class TestPermission:
     """Tests for the ``permissions`` path."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def create_permissions(self, default_sat):
+    def create_permissions(self, class_target_sat):
         # workaround for setting class variables
         cls = type(self)
         cls.permissions = PERMISSIONS.copy()
-        if default_sat.is_upstream:
+        if class_target_sat.is_upstream:
             cls.permissions[None].extend(cls.permissions.pop('DiscoveryRule'))
             cls.permissions[None].remove('app_root')
             cls.permissions[None].remove('attachments')
@@ -52,14 +52,14 @@ class TestPermission:
             cls.permissions[None].remove('view_cases')
             cls.permissions[None].remove('view_log_viewer')
 
-        result = default_sat.execute('rpm -qa | grep rubygem-foreman_openscap')
+        result = class_target_sat.execute('rpm -qa | grep rubygem-foreman_openscap')
         if result.status != 0:
             cls.permissions.pop('ForemanOpenscap::Policy')
             cls.permissions.pop('ForemanOpenscap::ScapContent')
             cls.permissions[None].remove('destroy_arf_reports')
             cls.permissions[None].remove('view_arf_reports')
             cls.permissions[None].remove('create_arf_reports')
-        result = default_sat.execute('rpm -qa | grep rubygem-foreman_remote_execution')
+        result = class_target_sat.execute('rpm -qa | grep rubygem-foreman_remote_execution')
         if result.status != 0:
             cls.permissions.pop('JobInvocation')
             cls.permissions.pop('JobTemplate')

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -475,7 +475,7 @@ def test_negative_nonauthor_of_report_cant_download_it():
 
 
 @pytest.mark.tier3
-def test_positive_generate_entitlements_report(setup_content, default_sat):
+def test_positive_generate_entitlements_report(setup_content, target_sat):
     """Generate a report using the Subscription - Entitlement Report template.
 
     :id: 722e8802-367b-4399-bcaa-949daab26632
@@ -494,7 +494,7 @@ def test_positive_generate_entitlements_report(setup_content, default_sat):
     """
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         ak, org = setup_content
-        vm.install_katello_ca(default_sat)
+        vm.install_katello_ca(target_sat)
         vm.register_contenthost(org.label, ak.name)
         assert vm.subscribed
         rt = (
@@ -514,7 +514,7 @@ def test_positive_generate_entitlements_report(setup_content, default_sat):
 
 
 @pytest.mark.tier3
-def test_positive_schedule_entitlements_report(setup_content, default_sat):
+def test_positive_schedule_entitlements_report(setup_content, target_sat):
     """Schedule a report using the Subscription - Entitlement Report template.
 
     :id: 5152c518-b0da-4c27-8268-2be78289249f
@@ -533,7 +533,7 @@ def test_positive_schedule_entitlements_report(setup_content, default_sat):
     """
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         ak, org = setup_content
-        vm.install_katello_ca(default_sat)
+        vm.install_katello_ca(target_sat)
         vm.register_contenthost(org.label, ak.name)
         assert vm.subscribed
         rt = (

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1139,7 +1139,7 @@ class TestRepository:
         ),
         indirect=True,
     )
-    def test_positive_access_protected_repository(self, module_org, repo, default_sat):
+    def test_positive_access_protected_repository(self, module_org, repo, target_sat):
         """Access protected/https repository data file URL using organization
         debug certificate
 
@@ -1160,7 +1160,7 @@ class TestRepository:
         repo.sync()
         repo_data_file_url = urljoin(repo.full_path, 'repodata/repomd.xml')
         # ensure the url is based on the protected base server URL
-        assert repo_data_file_url.startswith(default_sat.url)
+        assert repo_data_file_url.startswith(target_sat.url)
         # try to access repository data without organization debug certificate
         response = client.get(repo_data_file_url, verify=False)
         assert response.status_code == 403
@@ -1186,7 +1186,7 @@ class TestRepository:
         ),
         indirect=True,
     )
-    def test_positive_access_unprotected_repository(self, module_org, repo, default_sat):
+    def test_positive_access_unprotected_repository(self, module_org, repo, target_sat):
         """Access files in unprotected repository over HTTP and HTTPS
 
         :id: 43fe24c8-7a50-4d38-8259-b23e5ed5800a
@@ -1202,7 +1202,7 @@ class TestRepository:
         repo.sync()
         repo_data_file_url = urljoin(repo.full_path, 'repodata/repomd.xml')
         # ensure the repo url is based on the base server URL
-        assert repo_data_file_url.startswith(default_sat.url)
+        assert repo_data_file_url.startswith(target_sat.url)
         # try to access repository data without organization debug certificate
         response = client.get(repo_data_file_url, verify=False)
         assert response.status_code == 200
@@ -1580,7 +1580,7 @@ class TestDockerRepository:
         indirect=True,
     )
     def test_negative_synchronize_private_registry_no_passwd(
-        self, repo_options, module_product, default_sat
+        self, repo_options, module_product, target_sat
     ):
         """Create and try to sync a Docker-type repository from a private
         registry providing empty password and the sync must fail with
@@ -1602,7 +1602,7 @@ class TestDockerRepository:
         with pytest.raises(
             HTTPError,
             match='422 Client Error: Unprocessable Entity for url: '
-            f'{default_sat.url}:443/katello/api/v2/repositories',
+            f'{target_sat.url}:443/katello/api/v2/repositories',
         ):
             entities.Repository(**repo_options).create()
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -511,7 +511,7 @@ class TestCannedRole:
 
     @pytest.mark.tier3
     def test_negative_access_entities_from_org_admin(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """User can not access resources in taxonomies assigned to role if
         its own taxonomies are not same as its role
@@ -535,14 +535,14 @@ class TestCannedRole:
         domain = self.create_domain(
             orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id]
         )
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         # Getting the domain from user
         with pytest.raises(HTTPError):
             entities.Domain(sc, id=domain.id).read()
 
     @pytest.mark.tier3
     def test_negative_access_entities_from_user(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """User can not access resources within its own taxonomies if assigned
         role does not have permissions for user taxonomies
@@ -566,7 +566,7 @@ class TestCannedRole:
         domain = self.create_domain(
             orgs=[filter_taxonomies['org'].id], locs=[filter_taxonomies['loc'].id]
         )
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         # Getting the domain from user
         with pytest.raises(HTTPError):
             entities.Domain(sc, id=domain.id).read()
@@ -899,7 +899,7 @@ class TestCannedRole:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_user_group_users_access_as_org_admin(self, role_taxonomies, default_sat):
+    def test_positive_user_group_users_access_as_org_admin(self, role_taxonomies, target_sat):
         """Users in usergroup can have access to the resources in taxonomies if
         the taxonomies of Org Admin role is same
 
@@ -957,7 +957,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc'].id],
         ).create()
         for login, password in ((userone_login, userone_pass), (usertwo_login, usertwo_pass)):
-            sc = ServerConfig(auth=(login, password), url=default_sat.url, verify=False)
+            sc = ServerConfig(auth=(login, password), url=target_sat.url, verify=False)
             try:
                 entities.Domain(sc).search(
                     query={
@@ -1005,7 +1005,7 @@ class TestCannedRole:
 
     @pytest.mark.tier2
     def test_negative_assign_org_admin_to_user_group(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """Users in usergroup can not have access to the resources in
         taxonomies if the taxonomies of Org Admin role is not same
@@ -1037,13 +1037,13 @@ class TestCannedRole:
         assert user_group.name == ug_name
         dom = self.create_domain(orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id])
         for user in [user_one, user_two]:
-            sc = self.user_config(user, default_sat)
+            sc = self.user_config(user, target_sat)
             with pytest.raises(HTTPError):
                 entities.Domain(sc, id=dom.id).read()
 
     @pytest.mark.tier2
     def test_negative_assign_taxonomies_by_org_admin(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """Org Admin doesn't have permissions to assign org to any of
         its entities
@@ -1086,7 +1086,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         # Getting the domain from user1
         dom = entities.Domain(sc, id=dom.id).read()
         dom.organization = [filter_taxonomies['org']]
@@ -1127,7 +1127,7 @@ class TestCannedRole:
 
     @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_with_org_admin(
-        self, role_taxonomies, default_sat
+        self, role_taxonomies, target_sat
     ):
         """Super Admin can access entities in taxonomies assigned to Org Admin
 
@@ -1146,7 +1146,7 @@ class TestCannedRole:
         :CaseLevel: Integration
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         # Creating resource
         dom_name = gen_string('alpha')
         dom = entities.Domain(
@@ -1168,7 +1168,7 @@ class TestCannedRole:
 
     @pytest.mark.tier2
     def test_positive_taxonomies_control_to_superadmin_without_org_admin(
-        self, role_taxonomies, default_sat
+        self, role_taxonomies, target_sat
     ):
         """Super Admin can access entities in taxonomies assigned to Org Admin
         after deleting Org Admin role/user
@@ -1189,7 +1189,7 @@ class TestCannedRole:
         :CaseLevel: Integration
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         # Creating resource
         dom_name = gen_string('alpha')
         dom = entities.Domain(
@@ -1217,7 +1217,7 @@ class TestCannedRole:
 
     @pytest.mark.tier1
     @pytest.mark.upgrade
-    def test_negative_create_roles_by_org_admin(self, role_taxonomies, default_sat):
+    def test_negative_create_roles_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin doesnt have permissions to create new roles
 
         :id: 806ecc16-0dc7-405b-90d3-0584eced27a3
@@ -1245,7 +1245,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         role_name = gen_string('alpha')
         with pytest.raises(HTTPError):
             entities.Role(
@@ -1256,7 +1256,7 @@ class TestCannedRole:
             ).create()
 
     @pytest.mark.tier1
-    def test_negative_modify_roles_by_org_admin(self, role_taxonomies, default_sat):
+    def test_negative_modify_roles_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin has no permissions to modify existing roles
 
         :id: 93ad9d7d-afad-4403-84a9-d59cc2ddfa58
@@ -1273,7 +1273,7 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_role = entities.Role().create()
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         test_role = entities.Role(sc, id=test_role.id).read()
         with pytest.raises(HTTPError):
             test_role.organization = [role_taxonomies['org']]
@@ -1281,7 +1281,7 @@ class TestCannedRole:
             test_role.update(['organization', 'location'])
 
     @pytest.mark.tier2
-    def test_negative_admin_permissions_to_org_admin(self, role_taxonomies, default_sat):
+    def test_negative_admin_permissions_to_org_admin(self, role_taxonomies, target_sat):
         """Org Admin has no access to Super Admin user
 
         :id: cdebf9a8-35c2-4730-8423-de47a2c15ff5
@@ -1310,13 +1310,13 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         with pytest.raises(HTTPError):
             entities.User(sc, id=1).read()
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_create_user_by_org_admin(self, role_taxonomies, default_sat):
+    def test_positive_create_user_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin can create new users
 
         :id: f4edbe25-3ee6-46d6-8fca-a04f6ddc8eed
@@ -1355,7 +1355,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc_user = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc_user = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         user_login = gen_string('alpha')
         user_pass = gen_string('alphanumeric')
         user = entities.User(
@@ -1374,7 +1374,7 @@ class TestCannedRole:
             assert location.name == name
 
     @pytest.mark.tier2
-    def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies, default_sat):
+    def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies, target_sat):
         """Org Admin can access users inside its taxonomies
 
         :id: c43275de-e0ff-4a22-b103-391a5ab81874
@@ -1396,7 +1396,7 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_user = self.create_simple_user(filter_taxos=role_taxonomies)
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         try:
             entities.User(sc, id=test_user.id).read()
         except HTTPError as err:
@@ -1404,7 +1404,7 @@ class TestCannedRole:
 
     @pytest.mark.skip_if_open('BZ:1825698')
     @pytest.mark.tier2
-    def test_positive_create_nested_location(self, role_taxonomies, default_sat):
+    def test_positive_create_nested_location(self, role_taxonomies, target_sat):
         """Org Admin can create nested locations
 
         :id: 971bc909-96a5-4614-b254-04a51c708432
@@ -1436,14 +1436,14 @@ class TestCannedRole:
         )
         user.role = [org_admin]
         user = user.update(['role'])
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         name = gen_string('alphanumeric')
         location = entities.Location(sc, name=name, parent=role_taxonomies['loc'].id).create()
         assert location.name == name
 
     @pytest.mark.tier2
     def test_negative_access_users_outside_org_admin_taxonomies(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """Org Admin can not access users outside its taxonomies
 
@@ -1466,12 +1466,12 @@ class TestCannedRole:
         """
         user = self.create_org_admin_user(role_taxos=role_taxonomies, user_taxos=role_taxonomies)
         test_user = self.create_simple_user(filter_taxos=filter_taxonomies)
-        sc = self.user_config(user, default_sat)
+        sc = self.user_config(user, target_sat)
         with pytest.raises(HTTPError):
             entities.User(sc, id=test_user.id).read()
 
     @pytest.mark.tier1
-    def test_negative_create_taxonomies_by_org_admin(self, role_taxonomies, default_sat):
+    def test_negative_create_taxonomies_by_org_admin(self, role_taxonomies, target_sat):
         """Org Admin cannot define/create organizations but can create
             locations
 
@@ -1500,7 +1500,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         with pytest.raises(HTTPError):
             entities.Organization(sc, name=gen_string('alpha')).create()
         if not is_open("BZ:1825698"):
@@ -1514,7 +1514,7 @@ class TestCannedRole:
     @pytest.mark.upgrade
     @pytest.mark.tier1
     def test_positive_access_all_global_entities_by_org_admin(
-        self, role_taxonomies, filter_taxonomies, default_sat
+        self, role_taxonomies, filter_taxonomies, target_sat
     ):
         """Org Admin can access all global entities in any taxonomies
         regardless of its own assigned taxonomies
@@ -1544,7 +1544,7 @@ class TestCannedRole:
             location=[role_taxonomies['loc'], filter_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=default_sat.url, verify=False)
+        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
         try:
             for entity in [
                 entities.Architecture,

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -33,13 +33,15 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
-def module_proxy_attrs(default_sat):
+def module_proxy_attrs(module_target_sat):
     """Find a ``SmartProxy``.
 
     Every Satellite has a built-in smart proxy, so searching for an
     existing smart proxy should always succeed.
     """
-    smart_proxy = entities.SmartProxy().search(query={'search': f'url = {default_sat.url}:9090'})
+    smart_proxy = entities.SmartProxy().search(
+        query={'search': f'url = {module_target_sat.url}:9090'}
+    )
     # Check that proxy is found and unpack it from the list
     assert len(smart_proxy) > 0, "No smart proxy is found"
     smart_proxy = smart_proxy[0]

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -185,7 +185,7 @@ def test_negative_upload():
 
 
 @pytest.mark.tier2
-def test_positive_delete_manifest_as_another_user(function_org, default_sat):
+def test_positive_delete_manifest_as_another_user(function_org, target_sat):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
 
@@ -200,7 +200,7 @@ def test_positive_delete_manifest_as_another_user(function_org, default_sat):
     :CaseImportance: Medium
     """
     user1_password = gen_string('alphanumeric')
-    user1 = default_sat.api.User(
+    user1 = target_sat.api.User(
         admin=True,
         password=user1_password,
         organization=[function_org],
@@ -208,11 +208,11 @@ def test_positive_delete_manifest_as_another_user(function_org, default_sat):
     ).create()
     sc1 = ServerConfig(
         auth=(user1.login, user1_password),
-        url=default_sat.url,
+        url=target_sat.url,
         verify=False,
     )
     user2_password = gen_string('alphanumeric')
-    user2 = default_sat.api.User(
+    user2 = target_sat.api.User(
         admin=True,
         password=user2_password,
         organization=[function_org],
@@ -220,7 +220,7 @@ def test_positive_delete_manifest_as_another_user(function_org, default_sat):
     ).create()
     sc2 = ServerConfig(
         auth=(user2.login, user2_password),
-        url=default_sat.url,
+        url=target_sat.url,
         verify=False,
     )
     # use the first admin to upload a manifest
@@ -236,9 +236,7 @@ def test_positive_delete_manifest_as_another_user(function_org, default_sat):
 
 
 @pytest.mark.tier2
-def test_positive_subscription_status_disabled(
-    module_ak, rhel_contenthost, module_org, default_sat
-):
+def test_positive_subscription_status_disabled(module_ak, rhel_contenthost, module_org, target_sat):
     """Verify that Content host Subscription status is set to 'Disabled'
      for a golden ticket manifest
 
@@ -252,7 +250,7 @@ def test_positive_subscription_status_disabled(
 
     :CaseImportance: Medium
     """
-    rhel_contenthost.install_katello_ca(default_sat)
+    rhel_contenthost.install_katello_ca(target_sat)
     rhel_contenthost.register_contenthost(module_org.label, module_ak.name)
     assert rhel_contenthost.subscribed
     host_content = entities.Host(id=rhel_contenthost.nailgun_host.id).read_raw().content
@@ -262,9 +260,7 @@ def test_positive_subscription_status_disabled(
 @pytest.mark.tier2
 @pytest.mark.pit_client
 @pytest.mark.pit_server
-def test_sca_end_to_end(
-    module_ak, rhel7_contenthost, module_org, rh_repo, custom_repo, default_sat
-):
+def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custom_repo, target_sat):
     """Perform end to end testing for Simple Content Access Mode
 
     :id: c6c4b68c-a506-46c9-bd1d-22e4c1926ef8
@@ -276,7 +272,7 @@ def test_sca_end_to_end(
 
     :CaseImportance: Critical
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(module_org.label, module_ak.name)
     assert rhel7_contenthost.subscribed
     # Check to see if Organization is in SCA Mode
@@ -313,7 +309,7 @@ def test_sca_end_to_end(
 
 
 @pytest.mark.tier2
-def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, function_org, default_sat):
+def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, function_org, target_sat):
     """Verify that Candlepin events are being read and processed by
         attaching subscriptions, validating host subscriptions status,
         and viewing processed and failed Candlepin events
@@ -348,7 +344,7 @@ def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, functio
         environment=entities.LifecycleEnvironment(id=function_org.library.id),
         auto_attach=True,
     ).create()
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(function_org.name, ak.name)
     host = entities.Host().search(query={'search': f'name={rhel7_contenthost.hostname}'})
     host_id = host[0].id
@@ -369,7 +365,7 @@ def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, functio
     assert '0 Failed' in response['message']
 
 
-def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, default_sat):
+def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, target_sat):
     """Verify that a content host with an expired SCA cert can
         re-register successfully
 
@@ -405,7 +401,7 @@ def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, defau
     ).create()
     # registering the content host with no content enabled/synced in the org
     # should create a client SCA cert with no content
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org=module_org.label, activation_key=ak.name)
     assert rhel7_contenthost.subscribed
     rhel7_contenthost.unregister()

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -589,7 +589,7 @@ class TestSshKeyInUser:
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    def test_positive_ssh_key_in_host_enc(self, default_sat):
+    def test_positive_ssh_key_in_host_enc(self, target_sat):
         """SSH key appears in host ENC output
 
         :id: 4b70a950-e777-4b2d-a83d-29279715fe6d
@@ -611,7 +611,7 @@ class TestSshKeyInUser:
         ssh_key = gen_ssh_keypairs()[1]
         entities.SSHKey(user=user, name=gen_string('alpha'), key=ssh_key).create()
         host = entities.Host(owner=user, owner_type='User', organization=org, location=loc).create()
-        sshkey_updated_for_host = f'{ssh_key} {user.login}@{default_sat.hostname}'
+        sshkey_updated_for_host = f'{ssh_key} {user.login}@{target_sat.hostname}'
         host_enc_key = host.enc()['data']['parameters']['ssh_authorized_keys']
         assert sshkey_updated_for_host == host_enc_key[0]
 
@@ -621,18 +621,18 @@ class TestActiveDirectoryUser:
     """Implements the LDAP auth User Tests with Active Directory"""
 
     @pytest.fixture(scope='module')
-    def create_ldap(self, ad_data, default_sat):
+    def create_ldap(self, ad_data, module_target_sat):
         """Fetch necessary properties from settings and Create ldap auth source"""
-        org = default_sat.api.Organization().create()
-        loc = default_sat.api.Location(organization=[org]).create()
+        org = module_target_sat.api.Organization().create()
+        loc = module_target_sat.api.Location(organization=[org]).create()
         ad_data = ad_data()
         yield dict(
             org=org,
             loc=loc,
-            sat_url=default_sat.url,
+            sat_url=module_target_sat.url,
             ldap_user_name=ad_data['ldap_user_name'],
             ldap_user_passwd=ad_data['ldap_user_passwd'],
-            authsource=default_sat.api.AuthSourceLDAP(
+            authsource=module_target_sat.api.AuthSourceLDAP(
                 onthefly_register=True,
                 account=ad_data['ldap_user_name'],
                 account_password=ad_data['ldap_user_passwd'],
@@ -651,7 +651,7 @@ class TestActiveDirectoryUser:
                 organization=[org],
             ).create(),
         )
-        for user in default_sat.api.User().search(
+        for user in module_target_sat.api.User().search(
             query={'search': f'login={ad_data["ldap_user_name"]}'}
         ):
             user.delete()
@@ -763,10 +763,10 @@ class TestFreeIPAUser:
     """Implements the LDAP auth User Tests with FreeIPA"""
 
     @pytest.fixture(scope='class')
-    def create_ldap(self, default_sat):
+    def create_ldap(self, class_target_sat):
         """Fetch necessary properties from settings and Create ldap auth source"""
-        org = default_sat.api.Organization().create()
-        loc = default_sat.api.Location(organization=[org]).create()
+        org = class_target_sat.api.Organization().create()
+        loc = class_target_sat.api.Location(organization=[org]).create()
         ldap_user_name = settings.ipa.username
         ldap_user_passwd = settings.ipa.password
         username = settings.ipa.user
@@ -775,9 +775,9 @@ class TestFreeIPAUser:
             loc=loc,
             ldap_user_name=ldap_user_name,
             ldap_user_passwd=ldap_user_passwd,
-            sat_url=default_sat.url,
+            sat_url=class_target_sat.url,
             username=username,
-            authsource=default_sat.api.AuthSourceLDAP(
+            authsource=class_target_sat.api.AuthSourceLDAP(
                 onthefly_register=True,
                 account=ldap_user_name,
                 account_password=ldap_user_passwd,
@@ -796,7 +796,7 @@ class TestFreeIPAUser:
                 organization=[org],
             ).create(),
         )
-        for user in default_sat.api.User().search(query={'search': f'login={username}'}):
+        for user in class_target_sat.api.User().search(query={'search': f'login={username}'}):
             user.delete()
 
     @pytest.mark.tier3

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -587,7 +587,7 @@ def test_negative_update_usage_limit(module_org):
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_usage_limit(module_org, default_sat):
+def test_positive_usage_limit(module_org, target_sat):
     """Test that Usage limit actually limits usage
 
     :id: 00ded856-e939-4140-ac84-91b6a8643623
@@ -622,10 +622,10 @@ def test_positive_usage_limit(module_org, default_sat):
     )
     with VMBroker(nick=DISTRO_RHEL7, host_classes={'host': ContentHost}, _count=2) as clients:
         vm1, vm2 = clients
-        vm1.install_katello_ca(default_sat)
+        vm1.install_katello_ca(target_sat)
         vm1.register_contenthost(module_org.label, new_ak['name'])
         assert vm1.subscribed
-        vm2.install_katello_ca(default_sat)
+        vm2.install_katello_ca(target_sat)
         result = vm2.register_contenthost(module_org.label, new_ak['name'])
         assert not vm2.subscribed
         assert result.status == 70
@@ -873,7 +873,7 @@ def test_positive_delete_subscription(module_manifest_org):
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, default_sat):
+def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, target_sat):
     """Check if multiple Activation keys can be attached to a
     Content host
 
@@ -899,7 +899,7 @@ def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, default_sat
         )
         for _ in range(2)
     ]
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     for i in range(2):
         rhel7_contenthost.register_contenthost(module_org.label, new_aks[i]['name'])
         assert rhel7_contenthost.subscribed
@@ -1203,7 +1203,7 @@ def test_update_ak_with_syspurpose_values(module_org, module_manifest_org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_positive_add_subscription_by_id(module_org, default_sat):
+def test_positive_add_subscription_by_id(module_org, target_sat):
     """Test that subscription can be added to activation key
 
     :id: b884be1c-b35d-440a-9a9d-c854c83e10a7
@@ -1223,7 +1223,7 @@ def test_positive_add_subscription_by_id(module_org, default_sat):
     :BZ: 1463685
     """
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     org_id = make_org()['id']
     ackey_id = make_activation_key({'organization-id': org_id})['id']
     Subscription.upload({'file': manifest.filename, 'organization-id': org_id})
@@ -1576,8 +1576,7 @@ def test_positive_view_subscriptions_by_non_admin_user(module_manifest_org):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-@pytest.mark.skip_if_not_set('repos_hosting_url')
-def test_positive_subscription_quantity_attached(module_org, rhel7_contenthost, default_sat):
+def test_positive_subscription_quantity_attached(module_org, rhel7_contenthost, target_sat):
     """Check the Quantity and Attached fields of 'hammer activation-key subscriptions'
 
     see https://bugzilla.redhat.com/show_bug.cgi?id=1633094
@@ -1617,7 +1616,7 @@ def test_positive_subscription_quantity_attached(module_org, rhel7_contenthost, 
     )
     subs = Subscription.list({'organization-id': org['id']}, per_page=False)
     subs_lookup = {s['id']: s for s in subs}
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org['label'], activation_key=ak['name'])
     assert rhel7_contenthost.subscribed
 

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -71,7 +71,7 @@ def non_admin_user():
 
 
 @pytest.mark.tier1
-def test_positive_create_session(admin_user, default_sat):
+def test_positive_create_session(admin_user, target_sat):
     """Check if user stays authenticated with session enabled
 
     :id: fcee7f5f-1040-41a9-bf17-6d0c24a93e22
@@ -90,7 +90,7 @@ def test_positive_create_session(admin_user, default_sat):
     try:
         idle_timeout = Settings.list({'search': 'name=idle_timeout'})[0]['value']
         Settings.set({'name': 'idle_timeout', 'value': 1})
-        result = configure_sessions(default_sat)
+        result = configure_sessions(target_sat)
         assert result == 0, 'Failed to configure hammer sessions'
         AuthLogin.basic({'username': admin_user['login'], 'password': password})
         result = Auth.with_user().status()
@@ -110,7 +110,7 @@ def test_positive_create_session(admin_user, default_sat):
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_disable_session(admin_user, default_sat):
+def test_positive_disable_session(admin_user, target_sat):
     """Check if user logs out when session is disabled
 
     :id: 38ee0d85-c2fe-4cac-a992-c5dbcec11031
@@ -125,7 +125,7 @@ def test_positive_disable_session(admin_user, default_sat):
     :expectedresults: The session is terminated
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -133,7 +133,7 @@ def test_positive_disable_session(admin_user, default_sat):
     # list organizations without supplying credentials
     assert Org.with_user().list()
     # disabling sessions
-    result = configure_sessions(satellite=default_sat, enable=False)
+    result = configure_sessions(satellite=target_sat, enable=False)
     assert result == 0, 'Failed to configure hammer sessions'
     result = Auth.with_user().status()
     assert NOTCONF_MSG.format(admin_user['login']) in result[0]['message']
@@ -142,7 +142,7 @@ def test_positive_disable_session(admin_user, default_sat):
 
 
 @pytest.mark.tier1
-def test_positive_log_out_from_session(admin_user, default_sat):
+def test_positive_log_out_from_session(admin_user, target_sat):
     """Check if session is terminated when user logs out
 
     :id: 0ba05f2d-7b83-4b0c-a04c-80e62b7c4cf2
@@ -157,7 +157,7 @@ def test_positive_log_out_from_session(admin_user, default_sat):
     :expectedresults: The session is terminated
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -172,7 +172,7 @@ def test_positive_log_out_from_session(admin_user, default_sat):
 
 
 @pytest.mark.tier1
-def test_positive_change_session(admin_user, non_admin_user, default_sat):
+def test_positive_change_session(admin_user, non_admin_user, target_sat):
     """Change from existing session to a different session
 
     :id: b6ea6f3c-fcbd-4e7b-97bd-f3e0e6b9da8f
@@ -189,7 +189,7 @@ def test_positive_change_session(admin_user, non_admin_user, default_sat):
     :expectedresults: The session is altered
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -203,7 +203,7 @@ def test_positive_change_session(admin_user, non_admin_user, default_sat):
 
 
 @pytest.mark.tier1
-def test_positive_session_survives_unauthenticated_call(admin_user, default_sat):
+def test_positive_session_survives_unauthenticated_call(admin_user, target_sat):
     """Check if session stays up after unauthenticated call
 
     :id: 8bc304a0-70ea-489c-9c3f-ea8343c5284c
@@ -220,14 +220,14 @@ def test_positive_session_survives_unauthenticated_call(admin_user, default_sat)
     :expectedresults: The session is unchanged
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
     assert LOGEDIN_MSG.format(admin_user['login']) in result[0]['message']
     # list organizations without supplying credentials
     Org.with_user().list()
-    result = default_sat.execute('hammer ping')
+    result = target_sat.execute('hammer ping')
     assert result.status == 0, 'Failed to run hammer ping'
     result = Auth.with_user().status()
     assert LOGEDIN_MSG.format(admin_user['login']) in result[0]['message']
@@ -235,7 +235,7 @@ def test_positive_session_survives_unauthenticated_call(admin_user, default_sat)
 
 
 @pytest.mark.tier1
-def test_positive_session_survives_failed_login(admin_user, non_admin_user, default_sat):
+def test_positive_session_survives_failed_login(admin_user, non_admin_user, target_sat):
     """Check if session stays up after failed login attempt
 
     :id: 6c4d5c4c-eff0-411b-829f-0c2f2ec26132
@@ -252,7 +252,7 @@ def test_positive_session_survives_failed_login(admin_user, non_admin_user, defa
     :expectedresults: The session is unchanged
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -268,7 +268,7 @@ def test_positive_session_survives_failed_login(admin_user, non_admin_user, defa
 
 
 @pytest.mark.tier1
-def test_positive_session_preceeds_saved_credentials(admin_user, default_sat):
+def test_positive_session_preceeds_saved_credentials(admin_user, target_sat):
     """Check if enabled session is mutually exclusive with
     saved credentials in hammer config
 
@@ -293,7 +293,7 @@ def test_positive_session_preceeds_saved_credentials(admin_user, default_sat):
     try:
         idle_timeout = Settings.list({'search': 'name=idle_timeout'})[0]['value']
         Settings.set({'name': 'idle_timeout', 'value': 1})
-        result = configure_sessions(satellite=default_sat, add_default_creds=True)
+        result = configure_sessions(satellite=target_sat, add_default_creds=True)
         assert result == 0, 'Failed to configure hammer sessions'
         AuthLogin.basic({'username': admin_user['login'], 'password': password})
         result = Auth.with_user().status()
@@ -311,7 +311,7 @@ def test_positive_session_preceeds_saved_credentials(admin_user, default_sat):
 
 
 @pytest.mark.tier1
-def test_negative_no_credentials(default_sat):
+def test_negative_no_credentials(target_sat):
     """Attempt to execute command without authentication
 
     :id: 8a3b5c68-1027-450f-997c-c5630218f49f
@@ -320,7 +320,7 @@ def test_negative_no_credentials(default_sat):
 
     :CaseImportance: High
     """
-    result = configure_sessions(satellite=default_sat, enable=False)
+    result = configure_sessions(satellite=target_sat, enable=False)
     assert result == 0, 'Failed to configure hammer sessions'
     result = Auth.with_user().status()
     assert NOTCONF_MSG in result[0]['message']
@@ -329,7 +329,7 @@ def test_negative_no_credentials(default_sat):
 
 
 @pytest.mark.tier1
-def test_negative_no_permissions(admin_user, non_admin_user, default_sat):
+def test_negative_no_permissions(admin_user, non_admin_user, target_sat):
     """Attempt to execute command out of user's permissions
 
     :id: 756f666f-270a-4b02-b587-a2ab09b7d46c
@@ -339,7 +339,7 @@ def test_negative_no_permissions(admin_user, non_admin_user, default_sat):
     :CaseImportance: High
 
     """
-    result = configure_sessions(default_sat)
+    result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
     AuthLogin.basic({'username': non_admin_user['login'], 'password': password})
     result = Auth.with_user().status()
@@ -351,7 +351,7 @@ def test_negative_no_permissions(admin_user, non_admin_user, default_sat):
 
 @pytest.mark.destructive
 @pytest.mark.tier1
-def test_positive_password_reset(destructive_sat):
+def test_positive_password_reset(target_sat):
     """Reset admin password using foreman rake and update the hammer config.
     verify the reset password is working.
 
@@ -362,17 +362,17 @@ def test_positive_password_reset(destructive_sat):
     :CaseImportance: High
 
     """
-    result = destructive_sat.execute('foreman-rake permissions:reset')
+    result = target_sat.execute('foreman-rake permissions:reset')
     assert result.status == 0
     reset_password = result.stdout.strip().split('password: ')[1]
-    result = destructive_sat.execute(
+    result = target_sat.execute(
         f'''sed -i -e '/username/d;/password/d;/use_sessions/d' {HAMMER_CONFIG};\
         echo '  :use_sessions: true' >> {HAMMER_CONFIG}'''
     )
     assert result.status == 0
-    destructive_sat.cli.AuthLogin.basic(
+    target_sat.cli.AuthLogin.basic(
         {'username': settings.server.admin_username, 'password': reset_password}
     )
-    result = destructive_sat.cli.Auth.with_user().status()
+    result = target_sat.cli.Auth.with_user().status()
     assert LOGEDIN_MSG.format(settings.server.admin_username) in result[0]['message']
-    assert destructive_sat.cli.Org.with_user().list()
+    assert target_sat.cli.Org.with_user().list()

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -24,7 +24,7 @@ from robottelo.hosts import ContentHost
 
 @pytest.mark.tier1
 def test_positive_register(
-    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv, default_sat
+    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv, target_sat
 ):
     """System is registered
 
@@ -44,17 +44,17 @@ def test_positive_register(
 
     :CaseImportance: Critical
     """
-    hg = default_sat.api.HostGroup(location=[module_location], organization=[module_org]).create()
+    hg = target_sat.api.HostGroup(location=[module_location], organization=[module_org]).create()
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
         # assure system is not registered
         result = vm.execute('subscription-manager identity')
         # result will be 1 if not registered
         assert result.status == 1
         assert vm.execute(
-            f'curl -o /root/bootstrap.py "http://{default_sat.hostname}/pub/bootstrap.py" '
+            f'curl -o /root/bootstrap.py "http://{target_sat.hostname}/pub/bootstrap.py" '
         )
         assert vm.execute(
-            f'python /root/bootstrap.py -s {default_sat.hostname} -o {module_org.name}'
+            f'python /root/bootstrap.py -s {target_sat.hostname} -o {module_org.name}'
             f' -L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             ' --skip puppet --skip foreman'
         )
@@ -64,7 +64,7 @@ def test_positive_register(
         assert result.status == 0
         # register system once again
         assert vm.execute(
-            f'python /root/bootstrap.py -s "{default_sat.hostname}" -o {module_org.name} '
+            f'python /root/bootstrap.py -s "{target_sat.hostname}" -o {module_org.name} '
             f'-L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
             '--skip puppet --skip foreman '
         )

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -32,9 +32,9 @@ from robottelo.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def module_puppet(default_sat, module_org, module_location):
+def module_puppet(module_target_sat, module_org, module_location):
     puppet_class = 'cli_test_classparameters'
-    env_name = default_sat.create_custom_environment(repo=puppet_class)
+    env_name = module_target_sat.create_custom_environment(repo=puppet_class)
     Environment.update(
         {
             'name': env_name,

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -322,7 +322,7 @@ class TestAzureRMFinishTemplateProvisioning:
     @pytest.fixture(scope='class')
     def class_host_ft(
         self,
-        default_sat,
+        class_target_sat,
         azurermclient,
         module_azurerm_finishimg,
         module_azurerm_cr,
@@ -338,8 +338,8 @@ class TestAzureRMFinishTemplateProvisioning:
         Provisions the host on AzureRM using Finish template
         Later in tests this host will be used to perform assertions
         """
-        with default_sat.hammer_api_timeout():
-            with default_sat.skip_yum_update_during_provisioning(
+        with class_target_sat.hammer_api_timeout():
+            with class_target_sat.skip_yum_update_during_provisioning(
                 template='Kickstart default finish'
             ):
                 host = Host.create(
@@ -444,7 +444,7 @@ class TestAzureRMUserDataProvisioning:
     @pytest.fixture(scope='class')
     def class_host_ud(
         self,
-        default_sat,
+        class_target_sat,
         azurermclient,
         module_azurerm_cloudimg,
         module_azurerm_cr,
@@ -461,8 +461,8 @@ class TestAzureRMUserDataProvisioning:
         Provisions the host on AzureRM using UserData template
         Later in tests this host will be used to perform assertions
         """
-        with default_sat.hammer_api_timeout():
-            with default_sat.skip_yum_update_during_provisioning(
+        with class_target_sat.hammer_api_timeout():
+            with class_target_sat.skip_yum_update_during_provisioning(
                 template='Kickstart default user data'
             ):
                 host = Host.create(
@@ -561,7 +561,7 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
     @pytest.fixture(scope='class')
     def class_byos_ft_host(
         self,
-        default_sat,
+        class_target_sat,
         azurermclient,
         module_azurerm_byos_finishimg,
         module_azurerm_cr,
@@ -577,8 +577,8 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
         Provisions the host on AzureRM with BYOS Image
         Later in tests this host will be used to perform assertions
         """
-        with default_sat.hammer_api_timeout():
-            with default_sat.skip_yum_update_during_provisioning(
+        with class_target_sat.hammer_api_timeout():
+            with class_target_sat.skip_yum_update_during_provisioning(
                 template='Kickstart default finish'
             ):
                 host = Host.create(

--- a/tests/foreman/cli/test_content_credentials.py
+++ b/tests/foreman/cli/test_content_credentials.py
@@ -271,7 +271,7 @@ def test_positive_update_name(new_name, module_org):
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 @pytest.mark.tier1
-def test_positive_update_key(name, module_org, default_sat):
+def test_positive_update_key(name, module_org, target_sat):
     """Create gpg key with valid name and valid gpg key via file
     import then update its gpg key file
 
@@ -289,7 +289,7 @@ def test_positive_update_key(name, module_org, default_sat):
     local_key = create_gpg_key_file(content)
     assert gpg_key, 'GPG Key file must be created'
     key = f'/tmp/{gen_alphanumeric()}'
-    default_sat.put(local_key, key)
+    target_sat.put(local_key, key)
     ContentCredential.update(
         {'path': key, 'name': gpg_key['name'], 'organization-id': module_org.id}
     )

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -75,14 +75,14 @@ def vm(
     module_gt_manifest_org,
     module_ak,
     rhel7_contenthost_module,
-    default_sat,
+    module_target_sat,
 ):
     # python-psutil obsoleted by python2-psutil, install older python2-psutil for errata test.
     rhel7_contenthost_module.run(
         'rpm -Uvh https://download.fedoraproject.org/pub/epel/7/x86_64/Packages/p/'
         'python2-psutil-5.6.7-1.el7.x86_64.rpm'
     )
-    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.install_katello_ca(module_target_sat)
     rhel7_contenthost_module.register_contenthost(module_gt_manifest_org.label, module_ak.name)
     host = entities.Host().search(query={'search': f'name={rhel7_contenthost_module.hostname}'})
     host_id = host[0].id
@@ -166,7 +166,7 @@ def test_positive_erratum_installable(vm):
 
 
 @pytest.mark.tier2
-def test_negative_rct_not_shows_golden_ticket_enabled(default_sat):
+def test_negative_rct_not_shows_golden_ticket_enabled(target_sat):
     """Assert restricted manifest has no Golden Ticket enabled .
 
     :id: 754c1be7-468e-4795-bcf9-258a38f3418b
@@ -186,14 +186,14 @@ def test_negative_rct_not_shows_golden_ticket_enabled(default_sat):
     # upload organization manifest with org environment access disabled
     manifest = manifests.clone()
     manifests.upload_manifest_locked(org.id, manifest, interface=manifests.INTERFACE_CLI)
-    result = default_sat.execute(f'rct cat-manifest {manifest.filename}')
+    result = target_sat.execute(f'rct cat-manifest {manifest.filename}')
     assert result.status == 0
     assert 'Content Access Mode: Simple Content Access' not in result.stdout
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_rct_shows_golden_ticket_enabled(module_gt_manifest_org, default_sat):
+def test_positive_rct_shows_golden_ticket_enabled(module_gt_manifest_org, target_sat):
     """Assert unrestricted manifest has Golden Ticket enabled .
 
     :id: 0c6e2f88-1a86-4417-9248-d7bd20584197
@@ -207,7 +207,7 @@ def test_positive_rct_shows_golden_ticket_enabled(module_gt_manifest_org, defaul
 
     :CaseImportance: Medium
     """
-    result = default_sat.execute(f'rct cat-manifest {module_gt_manifest_org.manifest_filename}')
+    result = target_sat.execute(f'rct cat-manifest {module_gt_manifest_org.manifest_filename}')
     assert result.status == 0
     assert 'Content Access Mode: Simple Content Access' in result.stdout
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2221,7 +2221,7 @@ class TestContentView:
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
     def test_positive_sub_host_with_restricted_user_perm_at_custom_loc(
-        self, module_org, rhel7_contenthost, default_sat
+        self, module_org, rhel7_contenthost, target_sat
     ):
         """Attempt to subscribe a host with restricted user permissions and
         custom location.
@@ -2365,7 +2365,7 @@ class TestContentView:
         # assert that this is the same content view
         assert content_view['name'] == user_content_view['name']
         # create a client host and register it with the created user
-        rhel7_contenthost.install_katello_ca(default_sat)
+        rhel7_contenthost.install_katello_ca(target_sat)
         rhel7_contenthost.register_contenthost(
             org['label'],
             lce=f'{env["name"]}/{content_view["name"]}',
@@ -2380,7 +2380,7 @@ class TestContentView:
 
     @pytest.mark.tier3
     def test_positive_sub_host_with_restricted_user_perm_at_default_loc(
-        self, module_org, rhel7_contenthost, default_sat
+        self, module_org, rhel7_contenthost, target_sat
     ):
         """Attempt to subscribe a host with restricted user permissions and
         default location.
@@ -2520,7 +2520,7 @@ class TestContentView:
         # assert that this is the same content view
         assert content_view['name'] == user_content_view['name']
         # create a client host and register it with the created user
-        rhel7_contenthost.install_katello_ca(default_sat)
+        rhel7_contenthost.install_katello_ca(target_sat)
         rhel7_contenthost.register_contenthost(
             org['label'],
             lce='/'.join([env['name'], content_view['name']]),
@@ -4125,7 +4125,7 @@ class TestContentViewFileRepo:
 
     @pytest.mark.skip_if_open('BZ:1610309')
     @pytest.mark.tier3
-    def test_positive_arbitrary_file_repo_addition(self, module_org, module_product, default_sat):
+    def test_positive_arbitrary_file_repo_addition(self, module_org, module_product, target_sat):
         """Check a File Repository with Arbitrary File can be added to a
         Content View
 
@@ -4150,7 +4150,7 @@ class TestContentViewFileRepo:
         :BZ: 1610309, 1908465
         """
         repo = self.make_file_repository_upload_contents(
-            module_org, module_product, satellite=default_sat
+            module_org, module_product, satellite=target_sat
         )
         cv = cli_factory.make_content_view({'organization-id': module_org.id})
         # Associate repo to CV with names.
@@ -4167,7 +4167,7 @@ class TestContentViewFileRepo:
 
     @pytest.mark.skip_if_open('BZ:1908465')
     @pytest.mark.tier3
-    def test_positive_arbitrary_file_repo_removal(self, module_org, module_product, default_sat):
+    def test_positive_arbitrary_file_repo_removal(self, module_org, module_product, target_sat):
         """Check a File Repository with Arbitrary File can be removed from a
         Content View
 
@@ -4192,7 +4192,7 @@ class TestContentViewFileRepo:
         """
         cv = cli_factory.make_content_view({'organization-id': module_org.id})
         repo = self.make_file_repository_upload_contents(
-            module_org, module_product, satellite=default_sat
+            module_org, module_product, satellite=target_sat
         )
         ContentView.add_repository(
             {'id': cv['id'], 'repository-id': repo['id'], 'organization-id': module_org.id}
@@ -4228,7 +4228,7 @@ class TestContentViewFileRepo:
         """
 
     @pytest.mark.tier3
-    def test_positive_arbitrary_file_repo_promotion(self, module_org, module_product, default_sat):
+    def test_positive_arbitrary_file_repo_promotion(self, module_org, module_product, target_sat):
         """Check arbitrary files availability for Content view version after
         content-view promotion.
 
@@ -4256,7 +4256,7 @@ class TestContentViewFileRepo:
 
         cv = cli_factory.make_content_view({'organization-id': module_org.id})
         repo = self.make_file_repository_upload_contents(
-            module_product, module_product, satellite=default_sat
+            module_product, module_product, satellite=target_sat
         )
         ContentView.add_repository(
             {'id': cv['id'], 'repository-id': repo['id'], 'organization-id': module_org.id}
@@ -4279,7 +4279,7 @@ class TestContentViewFileRepo:
         assert repo['name'] in expected_repo
 
     @pytest.mark.tier3
-    def test_positive_katello_repo_rpms_max_int(self, default_sat):
+    def test_positive_katello_repo_rpms_max_int(self, target_sat):
         """Checking that datatype for katello_repository_rpms table is a
         bigint for id for a closed loop bz.
 
@@ -4293,7 +4293,7 @@ class TestContentViewFileRepo:
 
         :BZ: 1793701
         """
-        result = default_sat.execute(
+        result = target_sat.execute(
             'sudo -u postgres psql -d foreman -c "\\d katello_repository_rpms"'
         )
         assert 'id|bigint' in result.stdout.splitlines()[3].replace(' ', '')

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -50,7 +50,7 @@ def _assertdiscoveredhost(hostname):
 
 @pytest.mark.skip_if_not_set('vlan_networking')
 @pytest.fixture(scope='class')
-def foreman_discovery(default_sat):
+def foreman_discovery(target_sat):
     """Steps to Configure foreman discovery
 
     1. Build PXE default template
@@ -63,10 +63,10 @@ def foreman_discovery(default_sat):
     # Build PXE default template to get default PXE file
     Template.build_pxe_default()
     # let's just modify the timeouts to speed things up
-    default_sat.execute(
+    target_sat.execute(
         "sed -ie 's/TIMEOUT [[:digit:]]\\+/TIMEOUT 1/g' /var/lib/tftpboot/pxelinux.cfg/default"
     )
-    default_sat.execute(
+    target_sat.execute(
         "sed -ie '/APPEND initrd/s/$/ fdi.countdown=1/' /var/lib/tftpboot/pxelinux.cfg/default"
     )
 

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1198,7 +1198,7 @@ class TestDockerClient:
     """
 
     @pytest.mark.tier3
-    def test_positive_pull_image(self, module_org, container_contenthost, default_sat):
+    def test_positive_pull_image(self, module_org, container_contenthost, target_sat):
         """A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
 
@@ -1218,7 +1218,7 @@ class TestDockerClient:
         try:
             result = container_contenthost.execute(
                 f'docker login -u {settings.server.admin_username}'
-                f' -p {settings.server.admin_password} {default_sat.hostname}'
+                f' -p {settings.server.admin_password} {target_sat.hostname}'
             )
             assert result.status == 0
 
@@ -1249,7 +1249,7 @@ class TestDockerClient:
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     def test_positive_container_admin_end_to_end_search(
-        self, module_org, container_contenthost, default_sat
+        self, module_org, container_contenthost, target_sat
     ):
         """Verify that docker command line can be used against
         Satellite server to search for container images stored
@@ -1301,12 +1301,12 @@ class TestDockerClient:
             }
         )
         docker_repo_uri = (
-            f' {default_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f' {target_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
             f'{CONTAINER_UPSTREAM_NAME} '
         ).lower()
 
         # 3. Try to search for docker images on Satellite
-        remote_search_command = f'docker search {default_sat.hostname}/{CONTAINER_UPSTREAM_NAME}'
+        remote_search_command = f'docker search {target_sat.hostname}/{CONTAINER_UPSTREAM_NAME}'
         result = container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri not in result.stdout
@@ -1314,7 +1314,7 @@ class TestDockerClient:
         # 4. Use Docker client to login to Satellite docker hub
         result = container_contenthost.execute(
             f'docker login -u {settings.server.admin_username}'
-            f' -p {settings.server.admin_password} {default_sat.hostname}'
+            f' -p {settings.server.admin_password} {target_sat.hostname}'
         )
         assert result.status == 0
 
@@ -1324,7 +1324,7 @@ class TestDockerClient:
         assert docker_repo_uri in result.stdout
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = container_contenthost.execute(f'docker logout {default_sat.hostname}')
+        result = container_contenthost.execute(f'docker logout {target_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to search for docker images
@@ -1349,7 +1349,7 @@ class TestDockerClient:
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     def test_positive_container_admin_end_to_end_pull(
-        self, module_org, container_contenthost, default_sat
+        self, module_org, container_contenthost, target_sat
     ):
         """Verify that docker command line can be used against
         Satellite server to pull in container images stored
@@ -1402,7 +1402,7 @@ class TestDockerClient:
             }
         )
         docker_repo_uri = (
-            f'{default_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f'{target_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
             f'{docker_upstream_name}'
         ).lower()
 
@@ -1414,7 +1414,7 @@ class TestDockerClient:
         # 4. Use Docker client to login to Satellite docker hub
         result = container_contenthost.execute(
             f'docker login -u {settings.server.admin_username}'
-            f' -p {settings.server.admin_password} {default_sat.hostname}'
+            f' -p {settings.server.admin_password} {target_sat.hostname}'
         )
         assert result.status == 0
 
@@ -1430,7 +1430,7 @@ class TestDockerClient:
         assert result.status == 0
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = container_contenthost.execute(f'docker logout {default_sat.hostname}')
+        result = container_contenthost.execute(f'docker logout {target_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to pull in docker image
@@ -1453,7 +1453,7 @@ class TestDockerClient:
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_upload_image(self, module_org, default_sat, container_contenthost):
+    def test_positive_upload_image(self, module_org, target_sat, container_contenthost):
         """A Docker-enabled client can create a new ``Dockerfile``
         pointing to an existing Docker image from a Satellite 6 and modify it.
         Then, using ``docker build`` generate a new image which can then be
@@ -1509,7 +1509,7 @@ class TestDockerClient:
 
             tar_file = f'{repo_name}.tar'
             container_contenthost.get(remote_path=tar_file)
-            default_sat.put(
+            target_sat.put(
                 local_path=tar_file,
                 remote_path=f'/tmp/{tar_file}',
             )
@@ -1521,10 +1521,10 @@ class TestDockerClient:
 
             # Verify repository was uploaded successfully
             repo = Repository.info({'id': repo['id']})
-            assert default_sat.hostname == repo['published-at']
+            assert target_sat.hostname == repo['published-at']
 
             repo_name = '-'.join((module_org.label, product['label'], repo['label'])).lower()
             assert repo_name in repo['published-at']
         finally:
             # Remove the archive
-            default_sat.execute(f'rm -f /tmp/{tar_file}')
+            target_sat.execute(f'rm -f /tmp/{tar_file}')

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -32,8 +32,8 @@ from robottelo.datafactory import parametrized
 
 
 @pytest.fixture(scope='module')
-def module_locations(default_sat):
-    return (default_sat.api.Location().create(), default_sat.api.Location().create())
+def module_locations(module_target_sat):
+    return (module_target_sat.api.Location().create(), module_target_sat.api.Location().create())
 
 
 @pytest.mark.tier2
@@ -84,7 +84,7 @@ def test_negative_create_with_name(name):
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_CRUD_with_attributes(default_sat, module_org, module_locations):
+def test_positive_CRUD_with_attributes(target_sat, module_org, module_locations):
     """Check if Environment with attributes can be created, updated and removed
 
     :id: d2187971-86b2-40c9-a93c-66f37691ae2b
@@ -128,7 +128,7 @@ def test_positive_CRUD_with_attributes(default_sat, module_org, module_locations
     assert env_name in [res['name'] for res in results]
 
     # Update org and loc
-    new_org = default_sat.api.Organization().create()
+    new_org = target_sat.api.Organization().create()
     Environment.update(
         {
             'location-ids': module_locations[1].id,

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -202,10 +202,10 @@ def hosts(request):
 
 
 @pytest.fixture(scope='module')
-def register_hosts(hosts, module_org, module_ak_cv_lce, rh_repo, custom_repo, default_sat):
+def register_hosts(hosts, module_org, module_ak_cv_lce, rh_repo, custom_repo, module_target_sat):
     """Register hosts to Satellite and install katello-agent rpm."""
     for host in hosts:
-        host.install_katello_ca(default_sat)
+        host.install_katello_ca(module_target_sat)
         host.register_contenthost(module_org.name, module_ak_cv_lce.name)
         host.enable_repo(REPOS['rhst7']['id'])
         host.install_katello_agent()
@@ -382,7 +382,7 @@ def cv_filter_cleanup(filter_id, cv, org, lce):
     'filter_by_org', ('id', 'name', 'title'), ids=('org_id', 'org_name', 'org_title')
 )
 def test_positive_install_by_host_collection_and_org(
-    module_org, host_collection, errata_hosts, filter_by_hc, filter_by_org, default_sat
+    module_org, host_collection, errata_hosts, filter_by_hc, filter_by_org, target_sat
 ):
     """Use host collection id or name and org id, name, or label to install an update on the host
     collection.
@@ -409,7 +409,7 @@ def test_positive_install_by_host_collection_and_org(
     errata_id = REPO_WITH_ERRATA['errata'][0]['id']
 
     for host in errata_hosts:
-        host.add_rex_key(satellite=default_sat)
+        host.add_rex_key(satellite=target_sat)
 
     if filter_by_hc == 'id':
         host_collection_query = f'host_collection_id = {host_collection["id"]}'
@@ -593,7 +593,7 @@ def test_positive_list_affected_chosts(module_org, errata_hosts):
 
 
 @pytest.mark.tier3
-def test_install_errata_to_one_host(module_org, errata_hosts, host_collection, default_sat):
+def test_install_errata_to_one_host(module_org, errata_hosts, host_collection, target_sat):
     """Install an erratum to one of the hosts in a host collection.
 
     :id: bfcee2de-3448-497e-a696-fcd30cea9d33
@@ -626,7 +626,7 @@ def test_install_errata_to_one_host(module_org, errata_hosts, host_collection, d
     assert result.status == 0, f'Failed to erase the rpm: {result.stdout}'
     # Add ssh keys
     for host in errata_hosts:
-        host.add_rex_key(satellite=default_sat)
+        host.add_rex_key(satellite=target_sat)
     # Apply errata to the host collection using job invocation
     JobInvocation.create(
         {
@@ -1338,21 +1338,22 @@ def new_module_ak(module_manifest_org, rh_repo_module_manifest, default_lce):
 
 
 @pytest.fixture
-def errata_host(module_manifest_org, rhel7_contenthost_module, new_module_ak, default_sat):
+def errata_host(module_manifest_org, rhel7_contenthost_module, new_module_ak, target_sat):
     """A RHEL77 Content Host that has applicable errata and registered to Library"""
     # python-psutil is obsoleted by python2-psutil, so get older python2-psutil for errata test
     rhel7_contenthost_module.run(f'rpm -Uvh {settings.repos.epel_repo.url}/{PSUTIL_RPM}')
-    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.install_katello_ca(target_sat)
     rhel7_contenthost_module.register_contenthost(module_manifest_org.label, new_module_ak.name)
     assert rhel7_contenthost_module.nailgun_host.read_json()['subscription_status'] == 0
     rhel7_contenthost_module.install_katello_host_tools()
+    rhel7_contenthost_module.add_rex_key(satellite=target_sat)
     return rhel7_contenthost_module
 
 
 @pytest.fixture
-def chost(module_manifest_org, rhel7_contenthost_module, new_module_ak, default_sat):
+def chost(module_manifest_org, rhel7_contenthost_module, new_module_ak, target_sat):
     """A RHEL77 Content Host registered to Library that does not have applicable errata"""
-    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.install_katello_ca(target_sat)
     rhel7_contenthost_module.register_contenthost(module_manifest_org.label, new_module_ak.name)
     assert rhel7_contenthost_module.nailgun_host.read_json()['subscription_status'] == 0
     rhel7_contenthost_module.install_katello_host_tools()
@@ -1360,7 +1361,7 @@ def chost(module_manifest_org, rhel7_contenthost_module, new_module_ak, default_
 
 
 @pytest.mark.tier2
-def test_apply_errata_using_default_content_view(errata_host):
+def test_apply_errata_using_default_content_view(errata_host, target_sat):
     """Updating an applicable errata on a host attached to the default content view
      causes the errata to not be applicable.
 

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -83,7 +83,7 @@ def format_commands_diff(commands_diff):
 
 
 @pytest.mark.upgrade
-def test_positive_all_options(default_sat):
+def test_positive_all_options(target_sat):
     """check all provided options for every hammer command
 
     :id: 1203ab9f-896d-4039-a166-9e2d36925b5b
@@ -93,7 +93,7 @@ def test_positive_all_options(default_sat):
     :CaseImportance: Critical
     """
     differences = {}
-    raw_output = default_sat.execute('hammer full-help').stdout
+    raw_output = target_sat.execute('hammer full-help').stdout
     commands = re.split(r'.*\n(?=hammer.*\n^[-]+)', raw_output, flags=re.M)
     commands.pop(0)  # remove "Hammer CLI help" line
     for raw_command in commands:
@@ -132,7 +132,7 @@ def test_positive_all_options(default_sat):
 
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
-def test_positive_disable_hammer_defaults(default_sat):
+def test_positive_disable_hammer_defaults(target_sat):
     """Verify hammer disable defaults command.
 
     :id: d0b65f36-b91f-4f2f-aaf8-8afda3e23708
@@ -154,26 +154,26 @@ def test_positive_disable_hammer_defaults(default_sat):
     try:
         Defaults.add({'param-name': 'organization_id', 'param-value': default_org['id']})
         # list templates for BZ#1368173
-        result = default_sat.execute('hammer job-template list')
+        result = target_sat.execute('hammer job-template list')
         assert result.status == 0
         # Verify --organization-id is not required to pass if defaults are set
-        result = default_sat.execute('hammer product list')
+        result = target_sat.execute('hammer product list')
         assert result.status == 0
         # Verify product list fail without using defaults
-        result = default_sat.execute('hammer --no-use-defaults product list')
+        result = target_sat.execute('hammer --no-use-defaults product list')
         assert result.status != 0
         assert default_product_name not in result.stdout
         # Verify --organization-id is not required to pass if defaults are set
-        result = default_sat.execute('hammer --use-defaults product list')
+        result = target_sat.execute('hammer --use-defaults product list')
         assert result.status == 0
         assert default_product_name in result.stdout
     finally:
         Defaults.delete({'param-name': 'organization_id'})
-        result = default_sat.execute('hammer defaults list')
+        result = target_sat.execute('hammer defaults list')
         assert default_org['id'] not in result.stdout
 
 
-def test_positive_check_debug_log_levels(default_sat):
+def test_positive_check_debug_log_levels(target_sat):
     """Enabling debug log level in candlepin via hammer logging
 
     :id: 029c80f1-2bc5-494e-a04a-7d6beb0f769a
@@ -188,12 +188,12 @@ def test_positive_check_debug_log_levels(default_sat):
     """
     Admin.logging({'all': True, 'level-debug': True})
     # Verify value of `log4j.logger.org.candlepin` as `DEBUG`
-    result = default_sat.execute('grep DEBUG /etc/candlepin/candlepin.conf')
+    result = target_sat.execute('grep DEBUG /etc/candlepin/candlepin.conf')
     assert result.status == 0
     assert 'log4j.logger.org.candlepin = DEBUG' in result.stdout
 
     Admin.logging({"all": True, "level-production": True})
     # Verify value of `log4j.logger.org.candlepin` as `WARN`
-    result = default_sat.execute('grep WARN /etc/candlepin/candlepin.conf')
+    result = target_sat.execute('grep WARN /etc/candlepin/candlepin.conf')
     assert result.status == 0
     assert 'log4j.logger.org.candlepin = WARN' in result.stdout

--- a/tests/foreman/cli/test_host_collection.py
+++ b/tests/foreman/cli/test_host_collection.py
@@ -275,7 +275,7 @@ def test_positive_copy_by_id(module_org):
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_register_host_ak_with_host_collection(module_org, module_ak_with_cv, default_sat):
+def test_positive_register_host_ak_with_host_collection(module_org, module_ak_with_cv, target_sat):
     """Attempt to register a host using activation key with host collection
 
     :id: 62459e8a-0cfa-44ff-b70c-7f55b4757d66
@@ -302,7 +302,7 @@ def test_positive_register_host_ak_with_host_collection(module_org, module_ak_wi
     )
 
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}) as client:
-        client.install_katello_ca(default_sat)
+        client.install_katello_ca(target_sat)
         # register the client host with the current activation key
         client.register_contenthost(module_org.name, activation_key=module_ak_with_cv.name)
         assert client.subscribed

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -55,11 +55,11 @@ pc_name = 'generic_1'
 
 
 @pytest.fixture(scope='module')
-def env(module_org, module_location, default_sat):
+def env(module_org, module_location, module_target_sat):
     """Return the puppet environment."""
 
-    env_name = default_sat.create_custom_environment(repo=pc_name)
-    env = default_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
+    env_name = module_target_sat.create_custom_environment(repo=pc_name)
+    env = module_target_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
     env.location = [module_location]
     env.organization = [module_org]
     env.update(['location', 'organization'])
@@ -73,9 +73,9 @@ def puppet_classes(env):
 
 
 @pytest.fixture(scope='module')
-def content_source(default_sat):
+def content_source(module_target_sat):
     """Return the proxy."""
-    return Proxy.list({'search': f'url = {default_sat.url}:9090'})[0]
+    return Proxy.list({'search': f'url = {module_target_sat.url}:9090'})[0]
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_katello_agent.py
+++ b/tests/foreman/cli/test_katello_agent.py
@@ -33,20 +33,20 @@ pytestmark = [
 
 
 @pytest.fixture(scope='module')
-def sat_with_katello_agent(module_destructive_sat):
-    """Enable katello-agent on destructive_sat"""
-    module_destructive_sat.register_to_dogfood()
+def sat_with_katello_agent(module_target_sat):
+    """Enable katello-agent on target_sat"""
+    module_target_sat.register_to_dogfood()
     # Enable katello-agent from satellite-installer
-    result = module_destructive_sat.install(
+    result = module_target_sat.install(
         InstallerCommand('foreman-proxy-content-enable-katello-agent true')
     )
     assert result.status == 0
     # Verify katello-agent is enabled
-    result = module_destructive_sat.install(
+    result = module_target_sat.install(
         InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
     )
     assert 'true' in result.stdout
-    yield module_destructive_sat
+    yield module_target_sat
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -451,7 +451,7 @@ class TestRHSSOAuthSource:
         run_command(f"echo '  :use_sessions: {'true' if enable else 'false'}' >> {HAMMER_CONFIG}")
 
     @pytest.fixture()
-    def rh_sso_hammer_auth_setup(self, destructive_sat, request):
+    def rh_sso_hammer_auth_setup(self, target_sat, request):
         """rh_sso hammer setup before running the auth login tests"""
         self.configure_hammer_session()
         client_config = {'publicClient': 'true'}
@@ -469,7 +469,7 @@ class TestRHSSOAuthSource:
     @pytest.mark.destructive
     def test_rhsso_login_using_hammer(
         self,
-        destructive_sat,
+        target_sat,
         enable_external_auth_rhsso,
         rhsso_setting_setup,
         rh_sso_hammer_auth_setup,
@@ -482,7 +482,7 @@ class TestRHSSOAuthSource:
 
         :CaseImportance: High
         """
-        result = destructive_sat.cli.AuthLogin.oauth(
+        result = target_sat.cli.AuthLogin.oauth(
             {
                 'oidc-token-endpoint': get_oidc_token_endpoint(),
                 'oidc-client-id': get_oidc_client_id(),
@@ -491,19 +491,19 @@ class TestRHSSOAuthSource:
             }
         )
         assert f"Successfully logged in as '{settings.rhsso.rhsso_user}'." == result[0]['message']
-        result = destructive_sat.cli.Auth.with_user(
+        result = target_sat.cli.Auth.with_user(
             username=settings.rhsso.rhsso_user, password=settings.rhsso.rhsso_password
         ).status()
         assert (
             f"Session exists, currently logged in as '{settings.rhsso.rhsso_user}'."
             == result[0]['message']
         )
-        task_list = destructive_sat.cli.Task.with_user(
+        task_list = target_sat.cli.Task.with_user(
             username=settings.rhsso.rhsso_user, password=settings.rhsso.rhsso_password
         ).list()
         assert len(task_list) >= 0
         with pytest.raises(CLIReturnCodeError) as error:
-            destructive_sat.cli.Role.with_user(
+            target_sat.cli.Role.with_user(
                 username=settings.rhsso.rhsso_user, password=settings.rhsso.rhsso_password
             ).list()
         assert 'Missing one of the required permissions' in error.value.message

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -37,7 +37,7 @@ from robottelo.logging import logger
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_foreman_core(default_sat):
+def test_positive_logging_from_foreman_core(target_sat):
     """Check that GET command to Hosts API is logged and has request ID.
 
     :id: 0785260d-cb81-4351-a7cb-d7841335e2de
@@ -51,16 +51,16 @@ def test_positive_logging_from_foreman_core(default_sat):
     source_log = '/var/log/foreman/production.log'
     test_logfile = '/var/tmp/logfile_from_foreman_core'
     # get the number of lines in the source log before the test
-    line_count_start = line_count(source_log, default_sat)
+    line_count_start = line_count(source_log, target_sat)
     # hammer command for this test
-    result = default_sat.execute('hammer host list')
+    result = target_sat.execute('hammer host list')
     assert result.status == 0, f'Non-zero status for host list: {result.stderr}'
     # get the number of lines in the source log after the test
-    line_count_end = line_count(source_log, default_sat)
+    line_count_end = line_count(source_log, target_sat)
     # get the log lines of interest, put them in test_logfile
-    cut_lines(line_count_start, line_count_end, source_log, test_logfile, default_sat)
+    cut_lines(line_count_start, line_count_end, source_log, test_logfile, target_sat)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile)
+    target_sat.get(remote_path=test_logfile)
     # search the log file extract for the line with GET to host API
     with open(test_logfile) as logfile:
         for line in logfile:
@@ -76,7 +76,7 @@ def test_positive_logging_from_foreman_core(default_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_foreman_proxy(default_sat):
+def test_positive_logging_from_foreman_proxy(target_sat):
     """Check PUT to Smart Proxy API to refresh the features is logged and has request ID.
 
     :id: 0ecd8406-6cf1-4520-b8b6-8a164a1e60c2
@@ -93,22 +93,22 @@ def test_positive_logging_from_foreman_proxy(default_sat):
     source_log_2 = '/var/log/foreman-proxy/proxy.log'
     test_logfile_2 = '/var/tmp/logfile_2_from_proxy'
     # get the number of lines in the source logs before the test
-    line_count_start_1 = line_count(source_log_1, default_sat)
-    line_count_start_2 = line_count(source_log_2, default_sat)
+    line_count_start_1 = line_count(source_log_1, target_sat)
+    line_count_start_2 = line_count(source_log_2, target_sat)
     # hammer command for this test
-    result = default_sat.execute('hammer proxy refresh-features --id 1')
+    result = target_sat.execute('hammer proxy refresh-features --id 1')
     assert result.status == 0, f'Non-zero status for host list: {result.stderr}'
     # get the number of lines in the source logs after the test
-    line_count_end_1 = line_count(source_log_1, default_sat)
-    line_count_end_2 = line_count(source_log_2, default_sat)
+    line_count_end_1 = line_count(source_log_1, target_sat)
+    line_count_end_2 = line_count(source_log_2, target_sat)
     # get the log lines of interest, put them in test_logfile_1
-    cut_lines(line_count_start_1, line_count_end_1, source_log_1, test_logfile_1, default_sat)
+    cut_lines(line_count_start_1, line_count_end_1, source_log_1, test_logfile_1, target_sat)
     # get the log lines of interest, put them in test_logfile_2
-    cut_lines(line_count_start_2, line_count_end_2, source_log_2, test_logfile_2, default_sat)
+    cut_lines(line_count_start_2, line_count_end_2, source_log_2, test_logfile_2, target_sat)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile_1)
+    target_sat.get(remote_path=test_logfile_1)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile_2)
+    target_sat.get(remote_path=test_logfile_2)
     # search the log file extract for the line with PUT to host API
     with open(test_logfile_1) as logfile:
         for line in logfile:
@@ -135,7 +135,7 @@ def test_positive_logging_from_foreman_proxy(default_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_candlepin(module_org, default_sat):
+def test_positive_logging_from_candlepin(module_org, target_sat):
     """Check logging after manifest upload.
 
     :id: 8c06e501-52d7-4baf-903e-7de9caffb066
@@ -151,20 +151,20 @@ def test_positive_logging_from_candlepin(module_org, default_sat):
     # regex for a version 4 UUID (8-4-4-12 format)
     regex = r"\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b"
     # get the number of lines in the source log before the test
-    line_count_start = line_count(source_log, default_sat)
+    line_count_start = line_count(source_log, target_sat)
     # command for this test
     with manifests.clone() as manifest:
         with NamedTemporaryFile(dir=robottelo_tmp_dir) as content_file:
             content_file.write(manifest.content.read())
             content_file.seek(0)
-            default_sat.put(local_path=content_file.name, remote_path=manifest.filename)
+            target_sat.put(local_path=content_file.name, remote_path=manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': module_org.id})
     # get the number of lines in the source log after the test
-    line_count_end = line_count(source_log, default_sat)
+    line_count_end = line_count(source_log, target_sat)
     # get the log lines of interest, put them in test_logfile
-    cut_lines(line_count_start, line_count_end, source_log, test_logfile, default_sat)
+    cut_lines(line_count_start, line_count_end, source_log, test_logfile, target_sat)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile)
+    target_sat.get(remote_path=test_logfile)
     # search the log file extract for the line with POST to candlepin API
     with open(test_logfile) as logfile:
         for line in logfile:
@@ -180,7 +180,7 @@ def test_positive_logging_from_candlepin(module_org, default_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_dynflow(module_org, default_sat):
+def test_positive_logging_from_dynflow(module_org, target_sat):
     """Check POST to repositories API is logged while enabling a repo \
         and it has the request ID.
 
@@ -197,16 +197,16 @@ def test_positive_logging_from_dynflow(module_org, default_sat):
     product = entities.Product(organization=module_org).create()
     repo_name = gen_string('alpha')
     # get the number of lines in the source log before the test
-    line_count_start = line_count(source_log, default_sat)
+    line_count_start = line_count(source_log, target_sat)
     # command for this test
     new_repo = entities.Repository(name=repo_name, product=product).create()
     logger.info(f'Created Repo {new_repo.name} for dynflow log test')
     # get the number of lines in the source log after the test
-    line_count_end = line_count(source_log, default_sat)
+    line_count_end = line_count(source_log, target_sat)
     # get the log lines of interest, put them in test_logfile
-    cut_lines(line_count_start, line_count_end, source_log, test_logfile, default_sat)
+    cut_lines(line_count_start, line_count_end, source_log, test_logfile, target_sat)
     # use same location on remote and local for log file extract
-    default_sat.get(remote_path=test_logfile)
+    target_sat.get(remote_path=test_logfile)
     # search the log file extract for the line with POST to to repositories API
     with open(test_logfile) as logfile:
         for line in logfile:
@@ -221,7 +221,7 @@ def test_positive_logging_from_dynflow(module_org, default_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_pulp3(module_org, default_sat):
+def test_positive_logging_from_pulp3(module_org, target_sat):
     """
     Verify Pulp3 logs are getting captured using pulp3 correlation ID
 
@@ -253,12 +253,12 @@ def test_positive_logging_from_pulp3(module_org, default_sat):
     Product.synchronize({'id': product['id'], 'organization-id': module_org.id})
     Repository.synchronize({'id': repo['id']})
     # Get the id of repository sync from task
-    task_out = default_sat.execute(
+    task_out = target_sat.execute(
         "hammer task list | grep -F \'Synchronize repository {\"text\"=>\"repository\'"
     ).stdout.splitlines()[0][:8]
-    prod_log_out = default_sat.execute(f'grep  {task_out} {source_log}').stdout.splitlines()[0]
+    prod_log_out = target_sat.execute(f'grep  {task_out} {source_log}').stdout.splitlines()[0]
     # Get correlation id of pulp from production logs
     pulp_correlation_id = re.search(r'\[I\|bac\|\w{8}\]', prod_log_out).group()[7:15]
     # verify pulp correlation id in message
-    message_log = default_sat.execute(f'cat {test_logfile} | grep {pulp_correlation_id}')
+    message_log = target_sat.execute(f'cat {test_logfile} | grep {pulp_correlation_id}')
     assert message_log.status == 0

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -119,7 +119,7 @@ class TestTailoringFiles:
         assert name in [tailoringfile['name'] for tailoringfile in result]
 
     @pytest.mark.tier1
-    def test_negative_create_with_invalid_file(self, default_sat):
+    def test_negative_create_with_invalid_file(self, target_sat):
         """Create Tailoring files with invalid file
 
         :id: 86f5ce13-856c-4e58-997f-fa21093edd04
@@ -132,7 +132,7 @@ class TestTailoringFiles:
 
         :CaseImportance: Medium
         """
-        default_sat.put(get_data_file(SNIPPET_DATA_FILE), f'/tmp/{SNIPPET_DATA_FILE}')
+        target_sat.put(get_data_file(SNIPPET_DATA_FILE), f'/tmp/{SNIPPET_DATA_FILE}')
         name = gen_string('alphanumeric')
         with pytest.raises(CLIFactoryError):
             make_tailoringfile({'name': name, 'scap-file': f'/tmp/{SNIPPET_DATA_FILE}'})
@@ -179,7 +179,7 @@ class TestTailoringFiles:
 
     @pytest.mark.skip_if_open("BZ:1857572")
     @pytest.mark.tier2
-    def test_positive_download_tailoring_file(self, tailoring_file_path, default_sat):
+    def test_positive_download_tailoring_file(self, tailoring_file_path, target_sat):
 
         """Download the tailoring file from satellite
 
@@ -204,7 +204,7 @@ class TestTailoringFiles:
         assert tailoring_file['name'] == name
         result = TailoringFiles.download_tailoring_file({'name': name, 'path': '/var/tmp/'})
         assert file_path in result
-        result = default_sat.execute(f'find {file_path} 2> /dev/null')
+        result = target_sat.execute(f'find {file_path} 2> /dev/null')
         assert result.status == 0
         assert file_path == result.stdout.strip()
 

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -21,7 +21,7 @@ import pytest
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_ping(default_sat):
+def test_positive_ping(target_sat):
     """hammer ping return code
 
     :id: dfa3ab4f-a64f-4a96-8c7f-d940df22b8bf
@@ -33,7 +33,7 @@ def test_positive_ping(default_sat):
 
     :expectedresults: hammer ping returns a right return code
     """
-    result = default_sat.execute('hammer ping')
+    result = target_sat.execute('hammer ping')
     assert result.stderr[1].decode() == ''
 
     status_count = 0
@@ -57,7 +57,7 @@ def test_positive_ping(default_sat):
 
 
 @pytest.mark.destructive
-def test_negative_ping_fail_status_code(default_sat):
+def test_negative_ping_fail_status_code(target_sat):
     """Negative test to verify non-zero status code of ping fail
 
     :id: 8f8675aa-df52-11eb-9353-b0a460e02491
@@ -71,9 +71,9 @@ def test_negative_ping_fail_status_code(default_sat):
     :expectedresults: Hammer ping fails and returns non-zero(1) status code.
 
     """
-    command_out = default_sat.execute('satellite-maintain service stop --only tomcat.service')
+    command_out = target_sat.execute('satellite-maintain service stop --only tomcat.service')
     assert command_out.status == 0
-    result = default_sat.execute("hammer ping")
+    result = target_sat.execute("hammer ping")
     assert result.status == 1
-    command_out = default_sat.execute('satellite-maintain service start --only tomcat.service')
+    command_out = target_sat.execute('satellite-maintain service start --only tomcat.service')
     assert command_out.status == 0

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -174,7 +174,7 @@ def test_negative_create_with_label(label, module_org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_product_list_with_default_settings(module_org, default_sat):
+def test_product_list_with_default_settings(module_org, target_sat):
     """Listing product of an organization apart from default organization using hammer
      does not return output if a defaults settings are applied on org.
 
@@ -205,14 +205,14 @@ def test_product_list_with_default_settings(module_org, default_sat):
         )
 
     Defaults.add({'param-name': 'organization_id', 'param-value': org_id})
-    result = default_sat.cli.Defaults.list(per_page=False)
+    result = target_sat.cli.Defaults.list(per_page=False)
     assert any([res['value'] == org_id for res in result if res['parameter'] == 'organization_id'])
 
     try:
         # Verify --organization-id is not required to pass if defaults are set
-        result = default_sat.cli.Product.list()
+        result = target_sat.cli.Product.list()
         assert any([res['name'] == default_product_name for res in result])
-        result = default_sat.cli.Repository.list()
+        result = target_sat.cli.Repository.list()
         assert any([res['product'] == default_product_name for res in result])
 
         # verify that defaults setting should not affect other entities
@@ -223,7 +223,7 @@ def test_product_list_with_default_settings(module_org, default_sat):
 
     finally:
         Defaults.delete({'param-name': 'organization_id'})
-        result = default_sat.cli.Defaults.list(per_page=False)
+        result = target_sat.cli.Defaults.list(per_page=False)
         assert not [res for res in result if res['parameter'] == 'organization_id']
 
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -45,7 +45,7 @@ from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture()
-def fixture_vmsetup(request, module_org, default_sat):
+def fixture_vmsetup(request, module_org, target_sat):
     """Create VM and register content host"""
     if '_count' in request.param.keys():
         with VMBroker(
@@ -54,16 +54,16 @@ def fixture_vmsetup(request, module_org, default_sat):
             _count=request.param['_count'],
         ) as clients:
             for client in clients:
-                client.configure_rex(satellite=default_sat, org=module_org)
+                client.configure_rex(satellite=target_sat, org=module_org)
             yield clients
     else:
         with VMBroker(nick=request.param['nick'], host_classes={'host': ContentHost}) as client:
-            client.configure_rex(satellite=default_sat, org=module_org)
+            client.configure_rex(satellite=target_sat, org=module_org)
             yield client
 
 
 @pytest.fixture()
-def fixture_sca_vmsetup(request, module_gt_manifest_org, default_sat):
+def fixture_sca_vmsetup(request, module_gt_manifest_org, target_sat):
     """Create VM and register content host to Simple Content Access organization"""
     if '_count' in request.param.keys():
         with VMBroker(
@@ -72,11 +72,11 @@ def fixture_sca_vmsetup(request, module_gt_manifest_org, default_sat):
             _count=request.param['_count'],
         ) as clients:
             for client in clients:
-                client.configure_rex(satellite=default_sat, org=module_gt_manifest_org)
+                client.configure_rex(satellite=target_sat, org=module_gt_manifest_org)
             yield clients
     else:
         with VMBroker(nick=request.param['nick'], host_classes={'host': ContentHost}) as client:
-            client.configure_rex(satellite=default_sat, org=module_gt_manifest_org)
+            client.configure_rex(satellite=target_sat, org=module_gt_manifest_org)
             yield client
 
 
@@ -196,13 +196,8 @@ class TestRemoteExecution:
         nick_params.append({'nick': 'rhel8_fips'})
 
     @pytest.mark.tier3
-    @pytest.mark.parametrize(
-        'fixture_vmsetup',
-        nick_params,
-        ids=[n['nick'] for n in nick_params],
-        indirect=True,
-    )
-    def test_positive_run_custom_job_template_by_ip(self, fixture_vmsetup, module_org, default_sat):
+    @pytest.mark.rhel_ver_list([7, '7_fips', 8, '8_fips', 9, '9_fips'])
+    def test_positive_run_custom_job_template_by_ip(self, rex_contenthost, module_org, target_sat):
         """Run custom template on host connected by ip
 
         :id: 9740eb1d-59f5-42b2-b3ab-659ca0202c74
@@ -216,15 +211,14 @@ class TestRemoteExecution:
         :parametrized: yes
         """
         self.org = module_org
-        client = fixture_vmsetup
         template_file = 'template_file.txt'
-        default_sat.execute(f'echo "echo Enforcing" > {template_file}')
+        target_sat.execute(f'echo "echo Enforcing" > {template_file}')
         template_name = gen_string('alpha', 7)
         make_job_template(
             {'organizations': self.org.name, 'name': template_name, 'file': template_file}
         )
         invocation_command = make_job_invocation(
-            {'job-template': template_name, 'search-query': f"name ~ {client.hostname}"}
+            {'job-template': template_name, 'search-query': f"name ~ {rex_contenthost.hostname}"}
         )
         result = JobInvocation.info({'id': invocation_command['id']})
         try:
@@ -233,20 +227,15 @@ class TestRemoteExecution:
             result = 'host output: {}'.format(
                 ' '.join(
                     JobInvocation.get_output(
-                        {'id': invocation_command['id'], 'host': client.hostname}
+                        {'id': invocation_command['id'], 'host': rex_contenthost.hostname}
                     )
                 )
             )
             raise AssertionError(result)
 
     @pytest.mark.destructive
-    @pytest.mark.parametrize(
-        'fixture_vmsetup',
-        [{'nick': 'rhel7'}],
-        ids=['rhel7'],
-        indirect=True,
-    )
-    def test_positive_use_alternate_directory(self, fixture_vmsetup, module_org, default_sat):
+    @pytest.mark.rhel_ver_list([7])
+    def test_positive_use_alternate_directory(self, rex_contenthost, module_org, target_sat):
         """Use alternate working directory on client to execute rex jobs
 
         :id: a0181f18-d3dc-4bd9-a2a6-430c2a49809e
@@ -257,18 +246,18 @@ class TestRemoteExecution:
 
         :parametrized: yes
         """
-        client = fixture_vmsetup
+        client = rex_contenthost
         testdir = gen_string('alpha')
         result = client.run(f'mkdir /{testdir}')
         assert result.status == 0
         result = client.run(f'chcon --reference=/var /{testdir}')
         assert result.status == 0
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"sed -i r's/^:remote_working_dir:.*/:remote_working_dir: \\/{testdir}/' \
             /etc/foreman-proxy/settings.d/remote_execution_ssh.yml",
         )
         assert result.status == 0
-        result = default_sat.execute('systemctl restart foreman-proxy')
+        result = target_sat.execute('systemctl restart foreman-proxy')
         assert result.status == 0
 
         command = f'echo {gen_string("alpha")}'
@@ -436,8 +425,8 @@ class TestRemoteExecution:
         assert rec_logic['iteration'] == '2'
 
     @pytest.mark.tier3
-    @pytest.mark.parametrize('fixture_vmsetup', [{'nick': 'rhel7'}], ids=['rhel7'], indirect=True)
-    def test_positive_run_scheduled_job_template_by_ip(self, fixture_vmsetup, default_sat):
+    @pytest.mark.rhel_ver_list([7])
+    def test_positive_run_scheduled_job_template_by_ip(self, rex_contenthost, target_sat):
         """Schedule a job to be ran against a host
 
         :id: 0407e3de-ef59-4706-ae0d-b81172b81e5c
@@ -447,8 +436,8 @@ class TestRemoteExecution:
 
         :parametrized: yes
         """
-        client = fixture_vmsetup
-        system_current_time = default_sat.execute('date --utc +"%b %d %Y %I:%M%p"').stdout
+        client = rex_contenthost
+        system_current_time = target_sat.execute('date --utc +"%b %d %Y %I:%M%p"').stdout
         current_time_object = datetime.strptime(system_current_time.strip('\n'), '%b %d %Y %I:%M%p')
         plan_time = (current_time_object + timedelta(seconds=30)).strftime("%Y-%m-%d %H:%M")
         Host.set_parameter(
@@ -488,7 +477,7 @@ class TestRemoteExecution:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
-    def test_positive_run_receptor_installer(self, default_sat):
+    def test_positive_run_receptor_installer(self, target_sat, subscribe_satellite):
         """Run Receptor installer ("Configure Cloud Connector")
 
         :CaseComponent: RHCloud-CloudConnector
@@ -501,13 +490,20 @@ class TestRemoteExecution:
 
         :BZ: 1818076
         """
+        result = target_sat.execute('stat /etc/receptor/*/receptor.conf')
+        if result.status == 0:
+            pytest.skip(
+                'Cloud Connector has already been configured on this system. '
+                'It is possible to reconfigure it but then the test would not really '
+                'check if everything is correctly configured from scratch. Skipping.'
+            )
         # Copy foreman-proxy user's key to root@localhost user's authorized_keys
-        default_sat.add_rex_key(satellite=default_sat)
+        target_sat.add_rex_key(satellite=target_sat)
 
         # Set Host parameter source_display_name to something random.
         # To avoid 'name has already been taken' error when run multiple times
         # on a machine with the same hostname.
-        host_id = Host.info({'name': default_sat.hostname})['id']
+        host_id = Host.info({'name': target_sat.hostname})['id']
         Host.set_parameter(
             {'host-id': host_id, 'name': 'source_display_name', 'value': gen_string('alpha')}
         )
@@ -519,7 +515,7 @@ class TestRemoteExecution:
                 'job-template': template_name,
                 'inputs': f'satellite_user="{settings.server.admin_username}",\
                         satellite_password="{settings.server.admin_password}"',
-                'search-query': f'name ~ {default_sat.hostname}',
+                'search-query': f'name ~ {target_sat.hostname}',
             }
         )
         invocation_id = invocation['id']
@@ -529,22 +525,22 @@ class TestRemoteExecution:
             timeout="1500s",
         )
 
-        result = JobInvocation.get_output({'id': invocation_id, 'host': default_sat.hostname})
-        logger.debug(f"Invocation output>>\n{result}\n<<End of invocation output")
+        result = JobInvocation.get_output({'id': invocation_id, 'host': target_sat.hostname})
+        logger.debug(f'Invocation output>>\n{result}\n<<End of invocation output')
         # if installation fails, it's often due to missing rhscl repo -> print enabled repos
-        repolist = default_sat.execute('yum repolist')
-        logger.debug(f"Repolist>>\n{repolist}\n<<End of repolist")
+        repolist = target_sat.execute('yum repolist')
+        logger.debug(f'Repolist>>\n{repolist}\n<<End of repolist')
 
         assert entities.JobInvocation(id=invocation_id).read().status == 0
         assert 'project-receptor.satellite_receptor_installer' in result
         assert 'Exit status: 0' in result
         # check that there is one receptor conf file and it's only readable
         # by the receptor user and root
-        result = default_sat.execute('stat /etc/receptor/*/receptor.conf --format "%a:%U"')
+        result = target_sat.execute('stat /etc/receptor/*/receptor.conf --format "%a:%U"')
         assert all(
             filestats == '400:foreman-proxy' for filestats in result.stdout.strip().split('\n')
         )
-        result = default_sat.execute('ls -l /etc/receptor/*/receptor.conf | wc -l')
+        result = target_sat.execute('ls -l /etc/receptor/*/receptor.conf | wc -l')
         assert int(result.stdout.strip()) >= 1
 
 

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -25,12 +25,12 @@ from robottelo.cli.report import Report
 
 
 @pytest.fixture(scope='module', autouse=True)
-def run_puppet_agent(default_sat):
+def run_puppet_agent(module_target_sat):
     """Retrieves the client configuration from the puppet master and
     applies it to the local host. This is required to make sure
     that we have reports available.
     """
-    default_sat.execute('puppet agent -t')
+    module_target_sat.execute('puppet agent -t')
 
 
 @pytest.mark.tier1

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -67,11 +67,11 @@ from robottelo.hosts import ContentHost
 
 
 @pytest.fixture(scope='module')
-def local_org(default_sat):
+def local_org(module_target_sat):
     """Create org with CLI factory and upload cloned manifest"""
     org = make_org()
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        module_target_sat.put(manifest, manifest.filename)
     return org
 
 
@@ -752,7 +752,7 @@ def test_positive_generate_ansible_template():
 
 @pytest.mark.tier3
 def test_positive_generate_entitlements_report_multiple_formats(
-    local_org, local_ak, local_subscription, rhel7_contenthost, default_sat
+    local_org, local_ak, local_subscription, rhel7_contenthost, target_sat
 ):
     """Generate an report using the Subscription - Entitlement Report template
     in html, yaml, and csv format.
@@ -773,7 +773,7 @@ def test_positive_generate_entitlements_report_multiple_formats(
     :customerscenario: true
     """
     client = rhel7_contenthost
-    client.install_katello_ca(default_sat)
+    client.install_katello_ca(target_sat)
     client.register_contenthost(local_org['label'], local_ak['name'])
     assert client.subscribed
     result_html = ReportTemplate.generate(
@@ -815,7 +815,7 @@ def test_positive_generate_entitlements_report_multiple_formats(
 
 @pytest.mark.tier3
 def test_positive_schedule_entitlements_report(
-    local_org, local_ak, local_subscription, rhel7_contenthost, default_sat
+    local_org, local_ak, local_subscription, rhel7_contenthost, target_sat
 ):
     """Schedule an report using the Subscription - Entitlement Report template in csv format.
 
@@ -833,7 +833,7 @@ def test_positive_schedule_entitlements_report(
                       regarding entitlements.
     """
     client = rhel7_contenthost
-    client.install_katello_ca(default_sat)
+    client.install_katello_ca(target_sat)
     client.register_contenthost(local_org['label'], local_ak['name'])
     assert client.subscribed
     scheduled_csv = ReportTemplate.schedule(
@@ -856,7 +856,7 @@ def test_positive_schedule_entitlements_report(
 
 @pytest.mark.tier3
 def test_positive_generate_hostpkgcompare(
-    local_org, local_ak, local_content_view, local_environment, default_sat
+    local_org, local_ak, local_content_view, local_environment, target_sat
 ):
     """Generate 'Host - compare content hosts packages' report
 
@@ -902,7 +902,7 @@ def test_positive_generate_hostpkgcompare(
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}, _count=2) as hosts:
         for client in hosts:
             # Create RHEL hosts via broker and register content host
-            client.install_katello_ca(default_sat)
+            client.install_katello_ca(target_sat)
             # Register content host, install katello-agent
             client.register_contenthost(local_org['label'], local_ak['name'])
             assert client.subscribed

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -570,7 +570,7 @@ class TestRepository:
             assert repo.get(key) == repo_options[key]
 
     @pytest.mark.tier1
-    def test_positive_create_repo_with_new_organization_and_location(self, default_sat):
+    def test_positive_create_repo_with_new_organization_and_location(self, target_sat):
         """Check if error is thrown when creating a Repo with a new Organization and Location.
 
         :id: 9ea4f2a9-f339-4215-b301-cd39c6b5c474
@@ -598,7 +598,7 @@ class TestRepository:
             }
         )
 
-        result = default_sat.execute(
+        result = target_sat.execute(
             "cat /var/log/foreman/production.log | "
             "grep \"undefined method `id' for nil:NilClass (NoMethodError)\""
         )
@@ -1165,8 +1165,8 @@ class TestRepository:
         ),
         indirect=True,
     )
-    def test_positive_synchronize_rpm_repo_ignore_content(
-        self, module_org, module_product, repo, default_sat
+    def test_positive_synchronize_rpm_repo_ignore_SRPM(
+        self, module_org, module_product, repo, target_sat
     ):
         """Synchronize yum repository with ignore content setting
 
@@ -1190,7 +1190,7 @@ class TestRepository:
         assert repo['content-counts']['errata'] == '0', 'content not ignored correctly'
         assert repo['content-counts']['source-rpms'] == '0', 'content not ignored correctly'
         # drpm check requires a different method
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
             f"/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
@@ -1220,7 +1220,7 @@ class TestRepository:
             assert repo['content-counts']['source-rpms'] == '3', 'content not synced correctly'
 
         if not is_open('BZ:1682951'):
-            result = default_sat.execute(
+            result = target_sat.execute(
                 f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
                 f"/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
             )
@@ -1541,7 +1541,7 @@ class TestRepository:
         assert repo['content-counts']['packages'] == '0'
 
     @pytest.mark.tier1
-    def test_positive_upload_content(self, repo, default_sat):
+    def test_positive_upload_content(self, repo, target_sat):
         """Create repository and upload content
 
         :id: eb0ec599-2bf1-483a-8215-66652f948d67
@@ -1556,9 +1556,7 @@ class TestRepository:
 
         :CaseImportance: Critical
         """
-        default_sat.put(
-            local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}"
-        )
+        target_sat.put(local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}")
         result = Repository.upload_content(
             {
                 'name': repo['name'],
@@ -1576,7 +1574,7 @@ class TestRepository:
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
         indirect=True,
     )
-    def test_positive_upload_content_to_file_repo(self, repo, default_sat):
+    def test_positive_upload_content_to_file_repo(self, repo, target_sat):
         """Create file repository and upload content to it
 
         :id: 5e24b416-2928-4533-96cf-6bffbea97a95
@@ -1595,7 +1593,7 @@ class TestRepository:
         # Verify it has finished
         new_repo = Repository.info({'id': repo['id']})
         assert int(new_repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT
-        default_sat.put(
+        target_sat.put(
             local_path=get_data_file(OS_TEMPLATE_DATA_FILE),
             remote_path=f"/tmp/{OS_TEMPLATE_DATA_FILE}",
         )
@@ -1772,7 +1770,7 @@ class TestRepository:
         assert len(repos) == 0
 
     @pytest.mark.tier2
-    def test_positive_upload_remove_srpm_content(self, repo, default_sat):
+    def test_positive_upload_remove_srpm_content(self, repo, target_sat):
         """Create repository, upload and remove an SRPM content
 
         :id: 706dc3e2-dacb-4fdd-8eef-5715ce498888
@@ -1787,7 +1785,7 @@ class TestRepository:
 
         :BZ: 1378442
         """
-        default_sat.put(
+        target_sat.put(
             local_path=get_data_file(SRPM_TO_UPLOAD), remote_path=f"/tmp/{SRPM_TO_UPLOAD}"
         )
         # Upload SRPM
@@ -1815,7 +1813,7 @@ class TestRepository:
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
-    def test_positive_srpm_list_end_to_end(self, repo, default_sat):
+    def test_positive_srpm_list_end_to_end(self, repo, target_sat):
         """Create repository,  upload, list and remove an SRPM content
 
         :id: 98ad4228-f2e5-438a-9210-5ce6561769f2
@@ -1831,7 +1829,7 @@ class TestRepository:
 
         :CaseImportance: High
         """
-        default_sat.put(
+        target_sat.put(
             local_path=get_data_file(SRPM_TO_UPLOAD), remote_path=f"/tmp/{SRPM_TO_UPLOAD}"
         )
         # Upload SRPM
@@ -2282,7 +2280,7 @@ class TestSRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
     )
-    def test_positive_sync(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with SRPMs
 
         :id: eb69f840-122d-4180-b869-1bd37518480c
@@ -2292,7 +2290,7 @@ class TestSRPMRepository:
         :expectedresults: srpms can be listed in repository
         """
         Repository.synchronize({'id': repo['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
             f"/custom/{module_product.label}/{repo['label']}/Packages/t/ | grep .src.rpm"
         )
@@ -2304,7 +2302,7 @@ class TestSRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_cv(self, module_org, module_product, repo, default_sat):
+    def test_positive_sync_publish_cv(self, module_org, module_product, repo, target_sat):
         """Synchronize repository with SRPMs, add repository to content view
         and publish content view
 
@@ -2318,7 +2316,7 @@ class TestSRPMRepository:
         cv = make_content_view({'organization-id': module_org.id})
         ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': cv['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/content_views/"
             f"{cv['label']}/1.0/custom/{module_product.label}/{repo['label']}/Packages/t/"
             " | grep .src.rpm"
@@ -2332,7 +2330,7 @@ class TestSRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_SRPM_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with SRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
@@ -2351,7 +2349,7 @@ class TestSRPMRepository:
         content_view = ContentView.info({'id': cv['id']})
         cvv = content_view['versions'][0]
         ContentView.version_promote({'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/{lce['label']}/"
             f"{cv['label']}/custom/{module_product.label}/{repo['label']}/Packages/t"
             " | grep .src.rpm"
@@ -2421,9 +2419,7 @@ class TestAnsibleCollectionRepository:
         ids=['ansible_galaxy'],
         indirect=True,
     )
-    def test_positive_export_ansible_collection(
-        self, repo, module_org, module_product, default_sat
-    ):
+    def test_positive_export_ansible_collection(self, repo, module_org, module_product, target_sat):
         """Export ansible collection between organizations
 
         :id: 4858227e-1669-476d-8da3-4e6bfb6b7e2a
@@ -2441,10 +2437,8 @@ class TestAnsibleCollectionRepository:
         assert repo['sync']['status'] == 'Success'
         # export
         result = ContentExport.completeLibrary({'organization-id': module_org.id})
-        default_sat.execute(
-            f'cp -r /var/lib/pulp/exports/{module_org.name} /var/lib/pulp/imports/.'
-        )
-        default_sat.execute('chown -R pulp:pulp /var/lib/pulp/imports')
+        target_sat.execute(f'cp -r /var/lib/pulp/exports/{module_org.name} /var/lib/pulp/imports/.')
+        target_sat.execute('chown -R pulp:pulp /var/lib/pulp/imports')
         export_metadata = result['message'].split()[1]
         # import
         import_path = export_metadata.replace('/metadata.json', '').replace('exports', 'imports')
@@ -2458,7 +2452,7 @@ class TestAnsibleCollectionRepository:
         ]
         assert len(ac_content) > 0
         repo = Repository.info({'name': ac_content[0]['repo-name'], 'product-id': prod['id']})
-        result = default_sat.execute(f'curl {repo["published-at"]}')
+        result = target_sat.execute(f'curl {repo["published-at"]}')
         assert "available_versions" in result.stdout
 
     @pytest.mark.tier2
@@ -2478,7 +2472,7 @@ class TestAnsibleCollectionRepository:
         indirect=True,
     )
     def test_positive_sync_ansible_collection_from_satellite(
-        self, repo, module_org, module_product, default_sat
+        self, repo, module_org, module_product, target_sat
     ):
         """Sync ansible collection from another organization
 
@@ -2523,7 +2517,7 @@ class TestMD5Repository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_MD5_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, target_sat):
         """Synchronize MD5 signed repository with add repository to content view,
         publish and promote content view to lifecycle environment
 
@@ -2559,7 +2553,7 @@ class TestDRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
     )
-    def test_positive_sync(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with DRPMs
 
         :id: a645966c-750b-40ef-a264-dc3bb632b9fd
@@ -2569,7 +2563,7 @@ class TestDRPMRepository:
         :expectedresults: drpms can be listed in repository
         """
         Repository.synchronize({'id': repo['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/Library"
             f"/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
@@ -2581,7 +2575,7 @@ class TestDRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_cv(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync_publish_cv(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with DRPMs, add repository to content view
         and publish content view
 
@@ -2595,7 +2589,7 @@ class TestDRPMRepository:
         cv = make_content_view({'organization-id': module_org.id})
         ContentView.add_repository({'id': cv['id'], 'repository-id': repo['id']})
         ContentView.publish({'id': cv['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/content_views/"
             f"{cv['label']}/1.0/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
@@ -2608,7 +2602,7 @@ class TestDRPMRepository:
     @pytest.mark.parametrize(
         'repo_options', **parametrized([{'url': FAKE_YUM_DRPM_REPO}]), indirect=True
     )
-    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, default_sat):
+    def test_positive_sync_publish_promote_cv(self, repo, module_org, module_product, target_sat):
         """Synchronize repository with DRPMs, add repository to content view,
         publish and promote content view to lifecycle environment
 
@@ -2627,7 +2621,7 @@ class TestDRPMRepository:
         content_view = ContentView.info({'id': cv['id']})
         cvv = content_view['versions'][0]
         ContentView.version_promote({'id': cvv['id'], 'to-lifecycle-environment-id': lce['id']})
-        result = default_sat.execute(
+        result = target_sat.execute(
             f"ls /var/lib/pulp/published/yum/https/repos/{module_org.label}/{lce['label']}"
             f"/{cv['label']}/custom/{module_product.label}/{repo['label']}/drpms/ | grep .drpm"
         )
@@ -2833,7 +2827,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
         indirect=True,
     )
-    def test_positive_upload_file_to_file_repo(self, repo_options, repo, default_sat):
+    def test_positive_upload_file_to_file_repo(self, repo_options, repo, target_sat):
         """Check arbitrary file can be uploaded to File Repository
 
         :id: 134d668d-bd63-4475-bf7b-b899bb9fb7bb
@@ -2850,9 +2844,7 @@ class TestFileRepository:
 
         :CaseImportance: Critical
         """
-        default_sat.put(
-            local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}"
-        )
+        target_sat.put(local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}")
         result = Repository.upload_content(
             {
                 'name': repo['name'],
@@ -2896,7 +2888,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
         indirect=True,
     )
-    def test_positive_remove_file(self, repo, default_sat):
+    def test_positive_remove_file(self, repo, target_sat):
         """Check arbitrary file can be removed from File Repository
 
         :id: 07ca9c8d-e764-404e-866d-30d8cd2ca2b6
@@ -2914,9 +2906,7 @@ class TestFileRepository:
 
         :CaseImportance: Critical
         """
-        default_sat.put(
-            local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}"
-        )
+        target_sat.put(local_path=get_data_file(RPM_TO_UPLOAD), remote_path=f"/tmp/{RPM_TO_UPLOAD}")
         result = Repository.upload_content(
             {
                 'name': repo['name'],
@@ -2979,7 +2969,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': f'file://{CUSTOM_LOCAL_FOLDER}'}]),
         indirect=True,
     )
-    def test_positive_file_repo_local_directory_sync(self, repo, default_sat):
+    def test_positive_file_repo_local_directory_sync(self, repo, target_sat):
         """Check an entire local directory can be synced to File Repository
 
         :id: ee91ecd2-2f07-4678-b782-95a7e7e57159
@@ -3001,8 +2991,8 @@ class TestFileRepository:
         :CaseImportance: Critical
         """
         # Making Setup For Creating Local Directory using Pulp Manifest
-        default_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
-        default_sat.execute(
+        target_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
+        target_sat.execute(
             f'wget -P {CUSTOM_LOCAL_FOLDER} -r -np -nH --cut-dirs=5 -R "index.html*" '
             f'{CUSTOM_FILE_REPO}'
         )
@@ -3016,7 +3006,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': f'file://{CUSTOM_LOCAL_FOLDER}'}]),
         indirect=True,
     )
-    def test_positive_symlinks_sync(self, repo, default_sat):
+    def test_positive_symlinks_sync(self, repo, target_sat):
         """Check symlinks can be synced to File Repository
 
         :id: b0b0a725-b754-450b-bc0d-572d0294307a
@@ -3039,12 +3029,12 @@ class TestFileRepository:
         :CaseAutomation: Automated
         """
         # Downloading the pulp repository into Satellite Host
-        default_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
-        default_sat.execute(
+        target_sat.execute(f'mkdir -p {CUSTOM_LOCAL_FOLDER}')
+        target_sat.execute(
             f'wget -P {CUSTOM_LOCAL_FOLDER} -r -np -nH --cut-dirs=5 -R "index.html*" '
             f'{CUSTOM_FILE_REPO}'
         )
-        default_sat.execute(f'ln -s {CUSTOM_LOCAL_FOLDER} /{gen_string("alpha")}')
+        target_sat.execute(f'ln -s {CUSTOM_LOCAL_FOLDER} /{gen_string("alpha")}')
 
         Repository.synchronize({'id': repo['id']})
         repo = Repository.info({'id': repo['id']})
@@ -3056,7 +3046,7 @@ class TestFileRepository:
         **parametrized([{'content-type': 'file', 'url': CUSTOM_FILE_REPO}]),
         indirect=True,
     )
-    def test_file_repo_contains_only_newer_file(self, repo_options, repo, default_sat):
+    def test_file_repo_contains_only_newer_file(self, repo_options, repo, target_sat):
         """
             Check that a file-type repo contains only the newer of
             two versions of a file with the same name.
@@ -3079,7 +3069,7 @@ class TestFileRepository:
         :parametrized: yes
         """
         text_file_name = f'test-{gen_string("alpha", 5)}.txt'.lower()
-        default_sat.execute(f'echo "First File" > /tmp/{text_file_name}')
+        target_sat.execute(f'echo "First File" > /tmp/{text_file_name}')
         result = Repository.upload_content(
             {
                 'name': repo['name'],
@@ -3097,7 +3087,7 @@ class TestFileRepository:
         )
         assert text_file_name == filesearch[0].name
         # Create new version of the file by changing the text
-        default_sat.execute(f'echo "Second File" > /tmp/{text_file_name}')
+        target_sat.execute(f'echo "Second File" > /tmp/{text_file_name}')
         result = Repository.upload_content(
             {
                 'name': repo['name'],

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -118,10 +118,10 @@ def org():
 
 
 @pytest.fixture
-def manifest_org(org, default_sat):
+def manifest_org(org, target_sat):
     """Upload a manifest to the organization."""
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     Subscription.upload({'file': manifest.filename, 'organization-id': org['id']})
     return org
 

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -65,22 +65,22 @@ def config_export_import_settings():
     Settings.set({'name': 'content_disconnected', 'value': disconnected_mode_value})
 
 
-@pytest.fixture(scope='function')
-def export_import_cleanup_function(default_sat, function_org):
+@pytest.fixture
+def export_import_cleanup_function(target_sat, function_org):
     """Deletes export/import dirs of function org"""
     yield
     # Deletes directories created for export/import test
-    assert default_sat.execute(f'rm -rf {EXPORT_DIR}/{function_org.name}').stdout == ''
-    assert default_sat.execute(f'rm -rf {IMPORT_DIR}/{function_org.name}').stdout == ''
+    assert target_sat.execute(f'rm -rf {EXPORT_DIR}/{function_org.name}').stdout == ''
+    assert target_sat.execute(f'rm -rf {IMPORT_DIR}/{function_org.name}').stdout == ''
 
 
-@pytest.fixture(scope='function')  # perform the cleanup after each testcase of a module
-def export_import_cleanup_module(default_sat, module_org):
+@pytest.fixture  # perform the cleanup after each testcase of a module
+def export_import_cleanup_module(target_sat, module_org):
     """Deletes export/import dirs of module_org"""
     yield
     # Deletes directories created for export/import test
-    assert default_sat.execute(f'rm -rf {EXPORT_DIR}/{module_org.name}').stdout == ''
-    assert default_sat.execute(f'rm -rf {IMPORT_DIR}/{module_org.name}').stdout == ''
+    assert target_sat.execute(f'rm -rf {EXPORT_DIR}/{module_org.name}').stdout == ''
+    assert target_sat.execute(f'rm -rf {IMPORT_DIR}/{module_org.name}').stdout == ''
 
 
 def validate_filepath(sat_obj, org):
@@ -113,7 +113,7 @@ class TestRepositoryExport:
 
     @pytest.mark.tier3
     def test_positive_export_complete_version_custom_repo(
-        self, default_sat, export_import_cleanup_module, module_org
+        self, target_sat, export_import_cleanup_module, module_org
     ):
         """Export a custom repository via complete version
 
@@ -149,15 +149,15 @@ class TestRepositoryExport:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export content view
         ContentExport.completeVersion({'id': cvv['id'], 'organization-id': module_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat, module_org) != ''
+        assert validate_filepath(target_sat, module_org) != ''
 
     @pytest.mark.tier3
     def test_positive_export_incremental_version_custom_repo(
-        self, default_sat, export_import_cleanup_module, module_org
+        self, target_sat, export_import_cleanup_module, module_org
     ):
         """Export custom repo via incremental export
 
@@ -193,16 +193,16 @@ class TestRepositoryExport:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export complete first, then incremental
         ContentExport.completeVersion({'id': cvv['id'], 'organization-id': module_org.id})
         ContentExport.incrementalVersion({'id': cvv['id'], 'organization-id': module_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat, module_org) != ''
+        assert validate_filepath(target_sat, module_org) != ''
 
     @pytest.mark.tier3
     def test_positive_export_complete_library_custom_repo(
-        self, function_org, export_import_cleanup_function, default_sat
+        self, function_org, export_import_cleanup_function, target_sat
     ):
         """Export custom repo via complete library export
 
@@ -233,15 +233,15 @@ class TestRepositoryExport:
         )
         ContentView.publish({'id': cv['id']})
         # Verify export directory is empty
-        assert validate_filepath(default_sat, function_org) == ''
+        assert validate_filepath(target_sat, function_org) == ''
         # Export content view
         ContentExport.completeLibrary({'organization-id': function_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat, function_org) != ''
+        assert validate_filepath(target_sat, function_org) != ''
 
     @pytest.mark.tier3
     def test_positive_export_incremental_library_custom_repo(
-        self, export_import_cleanup_function, function_org, default_sat
+        self, export_import_cleanup_function, function_org, target_sat
     ):
         """Export custom repo via incremental library export
 
@@ -273,18 +273,18 @@ class TestRepositoryExport:
         )
         ContentView.publish({'id': cv['id']})
         # Verify export directory is empty
-        assert validate_filepath(default_sat, function_org) == ''
+        assert validate_filepath(target_sat, function_org) == ''
         # Export complete library, then export incremental
         ContentExport.completeLibrary({'organization-id': function_org.id})
         ContentExport.incrementalLibrary({'organization-id': function_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat, function_org) != ''
+        assert validate_filepath(target_sat, function_org) != ''
 
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_export_complete_version_rh_repo(
-        self, default_sat, export_import_cleanup_module, module_org
+        self, target_sat, export_import_cleanup_module, module_org
     ):
         """Export RedHat repo via complete version
 
@@ -298,7 +298,7 @@ class TestRepositoryExport:
         # Enable RH repository
         cv_name = gen_string('alpha')
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': module_org.id})
         RepositorySet.enable(
             {
@@ -333,17 +333,17 @@ class TestRepositoryExport:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export content view
         ContentExport.completeVersion({'id': cvv['id'], 'organization-id': module_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat, module_org) != ''
+        assert validate_filepath(target_sat, module_org) != ''
 
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_complete_library_rh_repo(
-        self, export_import_cleanup_function, function_org, default_sat
+        self, export_import_cleanup_function, function_org, target_sat
     ):
         """Export RedHat repo via complete library
 
@@ -357,7 +357,7 @@ class TestRepositoryExport:
         # Enable RH repository
         cv_name = gen_string('alpha')
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': function_org.id})
         RepositorySet.enable(
             {
@@ -389,11 +389,11 @@ class TestRepositoryExport:
         )
         ContentView.publish({'id': cv['id']})
         # Verify export directory is empty
-        assert validate_filepath(default_sat, function_org) == ''
+        assert validate_filepath(target_sat, function_org) == ''
         # Export content view
         ContentExport.completeLibrary({'organization-id': function_org.id})
         # Verify export directory is not empty
-        assert validate_filepath(default_sat, function_org) != ''
+        assert validate_filepath(target_sat, function_org) != ''
 
 
 @pytest.fixture(scope='class')
@@ -541,7 +541,8 @@ class TestContentViewSync:
         class_export_entities,
         config_export_import_settings,
         export_import_cleanup_module,
-        default_sat,
+        export_import_cleanup_function,
+        target_sat,
         module_org,
     ):
         """Export the CV and import it.  Ensure that all content is same from
@@ -581,19 +582,26 @@ class TestContentViewSync:
         exported_packages = Package.list({'content-view-version-id': export_cvv_id})
         assert len(exported_packages)
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export cv
-        export = ContentExport.completeVersion(
+        path = ContentExport.completeVersion(
             {'id': export_cvv_id, 'organization-id': module_org.id}
         )
-        import_path = move_pulp_archive(default_sat, module_org, export['message'])
-
+        import_path = move_pulp_archive(target_sat, module_org, path['message'])
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
+        # Move export files to import location and set permission
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import files and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -628,7 +636,7 @@ class TestContentViewSync:
         export_import_cleanup_function,
         function_org,
         config_export_import_settings,
-        default_sat,
+        target_sat,
     ):
         """Export Default Organization View version contents in directory and Import them.
 
@@ -696,11 +704,16 @@ class TestContentViewSync:
         cv_packages = Package.list({'content-view-version-id': default_cvv_id})
         assert len(cv_packages)
         # Verify export directory is empty
-        assert validate_filepath(default_sat, function_org) == ''
+        assert validate_filepath(target_sat, function_org) == ''
         # Export complete library
-        export = ContentExport.completeLibrary({'organization-id': function_org.id})
+        path = ContentExport.completeLibrary({'organization-id': function_org.id})
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert result.stdout != ''
         # Verify 'export-library' is created and packages are there
-        import_path = move_pulp_archive(default_sat, function_org, export['message'])
+        import_path = move_pulp_archive(target_sat, function_org, path['message'])
         export_lib_cv = ContentView.info(
             {
                 'name': export_library,
@@ -711,12 +724,18 @@ class TestContentViewSync:
         exported_lib_packages = Package.list({'content-view-version-id': export_lib_cvv_id})
         assert len(cv_packages)
         assert exported_lib_packages == cv_packages
+        # Verify export directory is not empty
+        assert validate_filepath(target_sat, function_org) != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on and set download policy to immediate
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
+        # Move export files to import location and set permission
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import and verify content of library
         ContentImport.library({'organization-id': importing_org['id'], 'path': import_path})
@@ -734,7 +753,7 @@ class TestContentViewSync:
         class_export_entities,
         export_import_cleanup_module,
         config_export_import_settings,
-        default_sat,
+        target_sat,
         module_org,
     ):
         """CV Version with filtered contents is the only one that gets exported and imported
@@ -797,19 +816,26 @@ class TestContentViewSync:
         export_packages = Package.list({'content-view-version-id': exporting_cvv_id})
         assert len(export_packages) == 1
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export cv
-        export = ContentExport.completeVersion(
+        path = ContentExport.completeVersion(
             {'id': exporting_cvv_id, 'organization-id': module_org.id}
         )
-        import_path = move_pulp_archive(default_sat, module_org, export['message'])
-
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert result.stdout != ''
         # Import section
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
+        # Move export files to import location and set permission
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import file and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -828,7 +854,7 @@ class TestContentViewSync:
         class_export_entities,
         export_import_cleanup_module,
         config_export_import_settings,
-        default_sat,
+        target_sat,
         module_org,
     ):
         """Export promoted CV version contents in directory and Import them.
@@ -867,19 +893,27 @@ class TestContentViewSync:
         exported_packages = Package.list({'content-view-version-id': promoted_cvv_id})
         assert len(exported_packages)
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export cv
-        export = ContentExport.completeVersion(
+        path = ContentExport.completeVersion(
             {'id': export_cvv_id, 'organization-id': module_org.id}
         )
-        import_path = move_pulp_archive(default_sat, module_org, export['message'])
-
+        # Grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
         # Move export files to import location and set permission
-
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
+        # check that files are present in import_path
+        result = target_sat.execute(f'ls {import_path}')
+        assert result.stdout != ''
         # Import and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
         importing_cv_id = ContentView.info(
@@ -903,7 +937,7 @@ class TestContentViewSync:
         export_import_cleanup_function,
         config_export_import_settings,
         function_org,
-        default_sat,
+        target_sat,
     ):
         """Export CV version redhat contents in directory and Import them
 
@@ -937,7 +971,7 @@ class TestContentViewSync:
         # Setup rhel repo
         cv_name = gen_string('alpha')
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': function_org.id})
         RepositorySet.enable(
             {
@@ -972,19 +1006,24 @@ class TestContentViewSync:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat, function_org) == ''
+        assert validate_filepath(target_sat, function_org) == ''
         # Export cv
-        export = ContentExport.completeVersion(
-            {'id': cvv['id'], 'organization-id': function_org.id}
-        )
-        import_path = move_pulp_archive(default_sat, function_org, export['message'])
+        path = ContentExport.completeVersion({'id': cvv['id'], 'organization-id': function_org.id})
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert len(result.stdout) > 1
         exported_packages = Package.list({'content-view-version-id': cvv['id']})
         assert len(exported_packages)
 
         # importing portion
         importing_org = make_org()
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'/{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         manifests.upload_manifest_locked(
             importing_org['id'], interface=manifests.INTERFACE_CLI, timeout=7200000
@@ -1022,7 +1061,7 @@ class TestContentViewSync:
         self,
         export_import_cleanup_function,
         config_export_import_settings,
-        default_sat,
+        target_sat,
         function_org,
     ):
         """Export CV version redhat contents in directory and Import them
@@ -1057,7 +1096,7 @@ class TestContentViewSync:
         cv_name = gen_string('alpha')
 
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': function_org.id})
         RepositorySet.enable(
             {
@@ -1092,16 +1131,23 @@ class TestContentViewSync:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Export cv
-        export = ContentExport.completeVersion(
+        path = ContentExport.completeVersion(
             {'id': cvv['id'], 'organization-id': function_org.id}, timeout=7200000
         )
-        import_path = move_pulp_archive(default_sat, function_org, export['message'])
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert len(result.stdout) > 1
         exported_packages = Package.list({'content-view-version-id': cvv['id']})
         assert len(exported_packages)
         # importing portion
         importing_org = make_org()
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import and verify content
         manifests.upload_manifest_locked(
@@ -1142,7 +1188,7 @@ class TestContentViewSync:
         class_export_entities,
         export_import_cleanup_function,
         config_export_import_settings,
-        default_sat,
+        target_sat,
         module_org,
     ):
         """Import the same cv twice
@@ -1166,19 +1212,25 @@ class TestContentViewSync:
         export_cvv_id = class_export_entities['exporting_cvv_id']
         export_cv_name = class_export_entities['exporting_cv_name']
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export cv
-        export = ContentExport.completeVersion(
+        path = ContentExport.completeVersion(
             {'id': export_cvv_id, 'organization-id': module_org.id}
         )
-        import_path = move_pulp_archive(default_sat, module_org, export['message'])
-
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import section
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -1296,7 +1348,7 @@ class TestContentViewSync:
 
     @pytest.mark.tier3
     def test_postive_export_cv_with_mixed_content_repos(
-        self, class_export_entities, export_import_cleanup_module, default_sat, module_org
+        self, class_export_entities, export_import_cleanup_module, target_sat, module_org
     ):
         """Exporting CV version having yum and non-yum(docker) is successful
 
@@ -1367,17 +1419,19 @@ class TestContentViewSync:
         exported_packages = Package.list({'content-view-version-id': exporting_cvv_id['id']})
         assert len(exported_packages)
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export cv
-        ContentExport.completeVersion(
+        path = ContentExport.completeVersion(
             {'id': exporting_cvv_id['id'], 'organization-id': module_org.id}
         )
-        # Verify export directory is not empty
-        assert validate_filepath(default_sat, module_org) != ''
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        result = target_sat.execute(f'ls {export_dir}')
+        assert result.stdout != ''
 
     @pytest.mark.tier3
     def test_postive_import_export_cv_with_file_content(
-        self, default_sat, config_export_import_settings, export_import_cleanup_module, module_org
+        self, target_sat, config_export_import_settings, export_import_cleanup_module, module_org
     ):
         """Exporting and Importing cv with file content
 
@@ -1423,19 +1477,26 @@ class TestContentViewSync:
         exported_files = File.list({'content-view-version-id': exporting_cvv_id})
         assert len(exported_files)
         # Verify export directory is empty
-        assert validate_filepath(default_sat, module_org) == ''
+        assert validate_filepath(target_sat, module_org) == ''
         # Export cv
-        export = ContentExport.completeVersion(
+        path = ContentExport.completeVersion(
             {'id': exporting_cvv_id, 'organization-id': module_org.id}
         )
-        import_path = move_pulp_archive(default_sat, module_org, export['message'])
-
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
+        # Move export files to import location and set permission
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import files and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
@@ -1449,11 +1510,7 @@ class TestContentViewSync:
 
     @pytest.mark.tier3
     def test_postive_import_export_ansible_collection_repo(
-        self,
-        default_sat,
-        config_export_import_settings,
-        export_import_cleanup_function,
-        function_org,
+        self, target_sat, config_export_import_settings, export_import_cleanup_module, function_org
     ):
         """Exporting and Importing library with ansible collection
 
@@ -1484,16 +1541,22 @@ class TestContentViewSync:
         )
         Repository.synchronize({'id': ansible_repo['id']})
         # Export library
-        export = ContentExport.completeLibrary({'organization-id': function_org.id})
-        import_path = move_pulp_archive(default_sat, function_org, export['message'])
-
+        path = ContentExport.completeLibrary({'organization-id': function_org.id})
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert result.stdout != ''
         # importing portion
         importing_org = make_org()
         # set disconnected mode on
         Settings.set({'name': 'content_disconnected', 'value': "Yes"})
-
+        # Move export files to import location and set permission
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
         # Import files and verify content
         ContentImport.library({'organization-id': importing_org['id'], 'path': import_path})
@@ -1511,11 +1574,7 @@ class TestContentViewSync:
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.mark.tier3
     def test_negative_import_redhat_cv_without_manifest(
-        self,
-        export_import_cleanup_function,
-        config_export_import_settings,
-        function_org,
-        default_sat,
+        self, export_import_cleanup_module, config_export_import_settings, function_org, target_sat
     ):
         """Redhat content can't be imported into satellite/organization without manifest
 
@@ -1539,7 +1598,7 @@ class TestContentViewSync:
         # Setup rhel repo
         cv_name = gen_string('alpha')
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': function_org.id})
         RepositorySet.enable(
             {
@@ -1574,14 +1633,21 @@ class TestContentViewSync:
         assert len(cv['versions']) == 1
         cvv = cv['versions'][0]
         # Verify export directory is empty
-        assert validate_filepath(default_sat, function_org) == ''
+        assert validate_filepath(target_sat, function_org) == ''
         # Export cv
-        export = ContentExport.completeVersion(
-            {'id': cvv['id'], 'organization-id': function_org.id}
-        )
-        import_path = move_pulp_archive(default_sat, function_org, export['message'])
+        path = ContentExport.completeVersion({'id': cvv['id'], 'organization-id': function_org.id})
+        # grab export dir and check all exported files are there
+        export_dir = os.path.dirname(path['message'])
+        export_folder = os.path.split(export_dir)
+        result = target_sat.execute(f'ls {export_dir}')
+        assert len(result.stdout) > 1
+        # importing portion
+        importing_org = make_org()
+        target_sat.execute(f'mv {export_dir} {IMPORT_DIR}')
+        import_path = f'/{IMPORT_DIR}{export_folder[1]}'
+        target_sat.execute(f'chown -R pulp:pulp {import_path}')
         # check that files are present in import_path
-        result = default_sat.execute(f'ls {import_path}')
+        result = target_sat.execute(f'ls {import_path}')
         assert result.stdout != ''
 
         # importing portion

--- a/tests/foreman/cli/test_setting.py
+++ b/tests/foreman/cli/test_setting.py
@@ -425,7 +425,7 @@ def test_negative_update_send_welcome_email(value):
 @pytest.mark.tier3
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['failed_login_attempts_limit'], indirect=True)
-def test_positive_failed_login_attempts_limit(setting_update, default_sat):
+def test_positive_failed_login_attempts_limit(setting_update, target_sat):
     """automate brute force protection limit configurable function
 
     :id: f95407ed-451b-4387-ac9b-2959ae2f51ae
@@ -454,14 +454,12 @@ def test_positive_failed_login_attempts_limit(setting_update, default_sat):
 
     username = settings.server.admin_username
     password = settings.server.admin_password
-    result = default_sat.execute(f'hammer -u {username} -p {password} user list')
-    assert result.status == 0
+    assert target_sat.execute(f'hammer -u {username} -p {password} user list').status == 0
     Settings.set({'name': 'failed_login_attempts_limit', 'value': '5'})
-    for i in range(5):
-        output = default_sat.execute(f'hammer -u {username} -p BAD_PASS user list')
-        assert output.status == 129
-    result = default_sat.execute(f'hammer -u {username} -p {password} user list')
-    assert result.status == 129
+    for _ in range(5):
+        assert target_sat.execute(f'hammer -u {username} -p BAD_PASS user list').status == 129
+    assert target_sat.execute(f'hammer -u {username} -p {password} user list').status == 129
     sleep(301)
-    result = default_sat.execute(f'hammer -u {username} -p {password} user list')
-    assert result.status == 0
+    assert target_sat.execute(f'hammer -u {username} -p {password} user list').status == 0
+    Settings.set({'name': 'failed_login_attempts_limit', 'value': '0'})
+    assert Settings.info({'name': 'failed_login_attempts_limit'})['value'] == '0'

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -179,7 +179,7 @@ def test_positive_subscription_list(function_org, manifest_clone_upload):
 
 
 @pytest.mark.tier2
-def test_positive_delete_manifest_as_another_user(default_sat):
+def test_positive_delete_manifest_as_another_user(target_sat):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
 
@@ -204,7 +204,7 @@ def test_positive_delete_manifest_as_another_user(default_sat):
     ).create()
     # use the first admin to upload a manifest
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     Subscription.with_user(username=user1.login, password=user1_password).upload(
         {'file': manifest.filename, 'organization-id': org.id}
     )
@@ -261,7 +261,7 @@ def test_positive_candlepin_events_processed_by_STOMP():
 
 @pytest.mark.tier2
 def test_positive_auto_attach_disabled_golden_ticket(
-    module_org, golden_ticket_host_setup, rhel7_contenthost_class, default_sat
+    module_org, golden_ticket_host_setup, rhel7_contenthost_class, target_sat
 ):
     """Verify that Auto-Attach is disabled or "Not Applicable"
     when a host organization is in Simple Content Access mode (Golden Ticket)
@@ -277,7 +277,7 @@ def test_positive_auto_attach_disabled_golden_ticket(
 
     :CaseImportance: Medium
     """
-    rhel7_contenthost_class.install_katello_ca(default_sat)
+    rhel7_contenthost_class.install_katello_ca(target_sat)
     rhel7_contenthost_class.register_contenthost(module_org.label, golden_ticket_host_setup['name'])
     assert rhel7_contenthost_class.subscribed
     host = Host.list({'search': rhel7_contenthost_class.hostname})

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -565,7 +565,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_rh_product_past_sync_date(default_sat):
+def test_positive_synchronize_rh_product_past_sync_date(target_sat):
     """Create a sync plan with past datetime as a sync date, add a
     RH product and verify the product gets synchronized on the next sync
     occurrence
@@ -582,7 +582,7 @@ def test_positive_synchronize_rh_product_past_sync_date(default_sat):
     delay = 2 * 60
     org = make_org()
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     Subscription.upload({'file': manifest.filename, 'organization-id': org['id']})
     RepositorySet.enable(
         {
@@ -633,7 +633,7 @@ def test_positive_synchronize_rh_product_past_sync_date(default_sat):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_rh_product_future_sync_date(default_sat):
+def test_positive_synchronize_rh_product_future_sync_date(target_sat):
     """Create a sync plan with sync date in a future and sync one RH
     product with it automatically.
 
@@ -650,7 +650,7 @@ def test_positive_synchronize_rh_product_future_sync_date(default_sat):
     guardtime = 180  # do not start test less than 2 mins before the next sync event
     org = make_org()
     with manifests.clone() as manifest:
-        default_sat.put(manifest, manifest.filename)
+        target_sat.put(manifest, manifest.filename)
     Subscription.upload({'file': manifest.filename, 'organization-id': org['id']})
     RepositorySet.enable(
         {

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -359,7 +359,7 @@ class TestSshKeyInUser:
         assert ssh_name not in [i['name'] for i in result]
 
     @pytest.mark.tier1
-    def test_positive_create_ssh_key_super_admin_from_file(self, default_sat):
+    def test_positive_create_ssh_key_super_admin_from_file(self, target_sat):
         """SSH Key can be added to Super Admin user from file
 
         :id: b865d0ae-6317-475c-a6da-600615b71eeb
@@ -370,7 +370,7 @@ class TestSshKeyInUser:
         :CaseImportance: Critical
         """
         ssh_name = gen_string('alpha')
-        result = default_sat.execute(f"echo '{self.ssh_key}' > test_key.pub")
+        result = target_sat.execute(f"echo '{self.ssh_key}' > test_key.pub")
         assert result.status == 0, 'key file not created'
         User.ssh_keys_add({'user': 'admin', 'key-file': 'test_key.pub', 'name': ssh_name})
         result = User.ssh_keys_list({'user': 'admin'})
@@ -383,7 +383,7 @@ class TestPersonalAccessToken:
     """Implement personal access token for the users"""
 
     @pytest.mark.tier2
-    def test_personal_access_token_admin_user(self, default_sat):
+    def test_personal_access_token_admin_user(self, target_sat):
         """Personal access token for admin user
 
         :id: f2d3813f-e477-4b6b-8507-246b08fcb3b4
@@ -407,16 +407,16 @@ class TestPersonalAccessToken:
             action="create", options={'name': token_name, 'user-id': user['id']}
         )
         token_value = result[0]['message'].split(':')[-1]
-        curl_command = f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
-        command_output = default_sat.execute(curl_command)
+        curl_command = f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
+        command_output = target_sat.execute(curl_command)
         assert user['login'] in command_output.stdout
         assert user['email'] in command_output.stdout
         User.access_token(action="revoke", options={'name': token_name, 'user-id': user['id']})
-        command_output = default_sat.execute(curl_command)
+        command_output = target_sat.execute(curl_command)
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout
 
     @pytest.mark.tier2
-    def test_positive_personal_access_token_user_with_role(self, default_sat):
+    def test_positive_personal_access_token_user_with_role(self, target_sat):
         """Personal access token for user with a role
 
         :id: b9fe7ddd-d1e4-4d76-9966-d223b02768ec
@@ -444,18 +444,18 @@ class TestPersonalAccessToken:
             action="create", options={'name': token_name, 'user-id': user['id']}
         )
         token_value = result[0]['message'].split(':')[-1]
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
         )
         assert user['login'] in command_output.stdout
         assert user['email'] in command_output.stdout
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/dashboard'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/dashboard'
         )
         assert 'Access denied' in command_output.stdout
 
     @pytest.mark.tier2
-    def test_expired_personal_access_token(self, default_sat):
+    def test_expired_personal_access_token(self, target_sat):
         """Personal access token expired for the user.
 
         :id: cb07b096-aba4-4a95-9a15-5413f32b597b
@@ -482,19 +482,19 @@ class TestPersonalAccessToken:
             options={'name': token_name, 'user-id': user['id'], 'expires-at': datetime_expire},
         )
         token_value = result[0]['message'].split(':')[-1]
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
         )
         assert user['login'] in command_output.stdout
         assert user['email'] in command_output.stdout
         sleep(20)
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/hosts'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/hosts'
         )
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout
 
     @pytest.mark.tier2
-    def test_custom_personal_access_token_role(self, default_sat):
+    def test_custom_personal_access_token_role(self, target_sat):
         """Personal access token for non admin user with custom role
 
         :id: dcbd22df-2641-4d3e-a1ad-76f36642e31b
@@ -530,13 +530,13 @@ class TestPersonalAccessToken:
             action="create", options={'name': token_name, 'user-id': user['id']}
         )
         token_value = result[0]['message'].split(':')[-1]
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
         )
         assert user['login'] in command_output.stdout
         assert user['email'] in command_output.stdout
         User.access_token(action="revoke", options={'name': token_name, 'user-id': user['id']})
-        command_output = default_sat.execute(
-            f'curl -k -u {user["login"]}:{token_value} {default_sat.url}/api/v2/users'
+        command_output = target_sat.execute(
+            f'curl -k -u {user["login"]}:{token_value} {target_sat.url}/api/v2/users'
         )
         assert f'Unable to authenticate user {user["login"]}' in command_output.stdout

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -48,7 +48,7 @@ def lce(org):
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize('cdn', [True, False], ids=['cdn', 'no_cdn'])
 @pytest.mark.parametrize('distro', DISTROS_SUPPORTED)
-def test_vm_install_package(org, lce, distro, cdn, default_sat):
+def test_vm_install_package(org, lce, distro, cdn, target_sat):
     """Install a package with all supported distros and cdn / non-cdn variants
 
     :id: b2a6065a-69f6-4805-a28b-eaaa812e0f4b
@@ -72,7 +72,7 @@ def test_vm_install_package(org, lce, distro, cdn, default_sat):
     with VMBroker(nick=distro, host_classes={'host': ContentHost}) as host:
         # install katello-agent
         repos_collection.setup_virtual_machine(
-            host, default_sat, enable_custom_repos=True, install_katello_agent=False
+            host, target_sat, enable_custom_repos=True, install_katello_agent=False
         )
         # install a package from custom repo
         result = host.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1085,7 +1085,7 @@ class TestEndToEnd:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    def test_positive_end_to_end(self, fake_manifest_is_set, default_sat, rhel7_contenthost):
+    def test_positive_end_to_end(self, fake_manifest_is_set, target_sat, rhel7_contenthost):
         """Perform end to end smoke tests using RH and custom repos.
 
         1. Create a new user with admin permissions
@@ -1233,7 +1233,7 @@ class TestEndToEnd:
         # step 2.18: Provision a client
         # TODO this isn't provisioning through satellite as intended
         # Note it wasn't well before the change that added this todo
-        rhel7_contenthost.install_katello_ca(default_sat)
+        rhel7_contenthost.install_katello_ca(target_sat)
         # Register client with foreman server using act keys
         rhel7_contenthost.register_contenthost(org.label, activation_key_name)
         assert rhel7_contenthost.subscribed

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -92,7 +92,7 @@ def test_positive_cli_find_admin_user():
 @pytest.mark.tier4
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_cli_end_to_end(fake_manifest_is_set, default_sat, rhel7_contenthost):
+def test_positive_cli_end_to_end(fake_manifest_is_set, target_sat, rhel7_contenthost):
     """Perform end to end smoke tests using RH and custom repos.
 
     1. Create a new user with admin permissions
@@ -132,7 +132,7 @@ def test_positive_cli_end_to_end(fake_manifest_is_set, default_sat, rhel7_conten
     # step 2.2: Clone and upload manifest
     if fake_manifest_is_set:
         with manifests.clone() as manifest:
-            default_sat.put(manifest, manifest.filename)
+            target_sat.put(manifest, manifest.filename)
         Subscription.upload({'file': manifest.filename, 'organization-id': org['id']})
 
     # step 2.3: Create a new lifecycle environment
@@ -327,7 +327,7 @@ def test_positive_cli_end_to_end(fake_manifest_is_set, default_sat, rhel7_conten
     # step 2.18: Provision a client
     # TODO this isn't provisioning through satellite as intended
     # Note it wasn't well before the change that added this todo
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     # Register client with foreman server using act keys
     rhel7_contenthost.register_contenthost(org['label'], activation_key['name'])
     assert rhel7_contenthost.subscribed

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -64,7 +64,7 @@ def register_satellite(sat):
     params,
     ids=['isc_dhcp', 'infoblox_dhcp', 'infoblox_dns'],
 )
-def test_plugin_installation(destructive_sat, command_args, command_opts, rpm_command):
+def test_plugin_installation(target_sat, command_args, command_opts, rpm_command):
     """Check that external DNS and DHCP plugins install correctly
 
     :id: c75aa5f3-870a-4f4a-9d7a-0a871b47fd6f
@@ -79,11 +79,11 @@ def test_plugin_installation(destructive_sat, command_args, command_opts, rpm_co
 
     :BZ: 1994490, 2000237
     """
-    register_satellite(destructive_sat)
+    register_satellite(target_sat)
     installer_obj = InstallerCommand(command_args, **command_opts)
-    command_output = destructive_sat.execute(installer_obj.get_command())
+    command_output = target_sat.execute(installer_obj.get_command())
     assert 'Success!' in command_output.stdout
-    rpm_result = destructive_sat.execute(rpm_command)
+    rpm_result = target_sat.execute(rpm_command)
     assert rpm_result.status == 0
 
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1296,7 +1296,7 @@ def extract_help(filter='params'):
 
 @pytest.mark.upgrade
 @pytest.mark.tier1
-def test_positive_foreman_module(default_sat):
+def test_positive_foreman_module(target_sat):
     """Check if SELinux foreman module has the right version
 
     :id: a0736b3a-3d42-4a09-a11a-28c1d58214a5
@@ -1309,10 +1309,10 @@ def test_positive_foreman_module(default_sat):
 
     :expectedresults: Foreman RPM and SELinux module versions match
     """
-    rpm_result = default_sat.execute('rpm -q foreman-selinux')
+    rpm_result = target_sat.execute('rpm -q foreman-selinux')
     assert rpm_result.status == 0
 
-    semodule_result = default_sat.execute('semodule -l | grep foreman')
+    semodule_result = target_sat.execute('semodule -l | grep foreman')
     assert semodule_result.status == 0
 
     # Sample rpm output: foreman-selinux-1.7.2.8-1.el7sat.noarch
@@ -1327,7 +1327,7 @@ def test_positive_foreman_module(default_sat):
 @pytest.mark.skip_if_open('BZ:1964394')
 @pytest.mark.upgrade
 @pytest.mark.tier1
-def test_positive_check_installer_services(default_sat):
+def test_positive_check_installer_services(target_sat):
     """Check if services start correctly
 
     :id: 85fd4388-6d94-42f5-bed2-24be38e9f104
@@ -1344,7 +1344,7 @@ def test_positive_check_installer_services(default_sat):
 
     :CaseLevel: System
     """
-    if default_sat.os_version.major >= RHEL_7_MAJOR_VERSION:
+    if target_sat.os_version.major >= RHEL_7_MAJOR_VERSION:
         service_name = 'tomcat'
         status_format = "systemctl status {0}"
     else:
@@ -1353,14 +1353,14 @@ def test_positive_check_installer_services(default_sat):
     SATELLITE_SERVICES.add(service_name)
 
     for service in SATELLITE_SERVICES:
-        result = default_sat.execute(status_format.format(service))
+        result = target_sat.execute(status_format.format(service))
         assert result.status == 0
         assert len(result.stderr) == 0
 
     # check status reported by hammer ping command
     username = settings.server.admin_username
     password = settings.server.admin_password
-    result = default_sat.execute(f'hammer -u {username} -p {password} ping')
+    result = target_sat.execute(f'hammer -u {username} -p {password} ping')
 
     result_output = [
         service.strip() for service in result.stdout if not re.search(r'message:', service)
@@ -1669,7 +1669,7 @@ def test_positive_capsule_installer_logfile_check():
 
 
 @pytest.mark.destructive
-def test_installer_sat_pub_directory_accessibility(destructive_sat):
+def test_installer_sat_pub_directory_accessibility(target_sat):
     """Verify the public directory accessibility from satellite url after disabling it from
     the custom-hiera
 
@@ -1698,26 +1698,26 @@ def test_installer_sat_pub_directory_accessibility(destructive_sat):
     custom_hiera_settings = (
         'foreman_proxy_content::pub_dir::pub_dir_options: "+FollowSymLinks -Indexes"'
     )
-    http_curl_command = f'curl -i {destructive_sat.url.replace("https", "http")}/pub/ -k'
-    https_curl_command = f'curl -i {destructive_sat.url}/pub/ -k'
+    http_curl_command = f'curl -i {target_sat.url.replace("https", "http")}/pub/ -k'
+    https_curl_command = f'curl -i {target_sat.url}/pub/ -k'
     for command in [http_curl_command, https_curl_command]:
-        accessibility_check = destructive_sat.execute(command)
+        accessibility_check = target_sat.execute(command)
         assert 'HTTP/1.1 200 OK' in accessibility_check.stdout.split('\r\n')
-    destructive_sat.get(
+    target_sat.get(
         local_path='custom-hiera-satellite.yaml',
         remote_path=f'{custom_hiera_location}',
     )
-    _ = destructive_sat.execute(f'echo {custom_hiera_settings} >> {custom_hiera_location}')
-    command_output = destructive_sat.execute('satellite-installer')
+    _ = target_sat.execute(f'echo {custom_hiera_settings} >> {custom_hiera_location}')
+    command_output = target_sat.execute('satellite-installer')
     assert 'Success!' in command_output.stdout
     for command in [http_curl_command, https_curl_command]:
-        accessibility_check = destructive_sat.execute(command)
+        accessibility_check = target_sat.execute(command)
         assert 'HTTP/1.1 200 OK' not in accessibility_check.stdout.split('\r\n')
-    destructive_sat.put(
+    target_sat.put(
         local_path='custom-hiera-satellite.yaml',
         remote_path=f'{custom_hiera_location}',
     )
-    command_output = destructive_sat.execute('satellite-installer')
+    command_output = target_sat.execute('satellite-installer')
     assert 'Success!' in command_output.stdout
 
 
@@ -1776,7 +1776,7 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
 
 
 @pytest.mark.destructive
-def test_installer_inventory_plugin_update(destructive_sat):
+def test_installer_inventory_plugin_update(target_sat):
     """DB consistency should not break after enabling the inventory plugin flags
 
     :id: a2b66d38-e819-428f-9529-23bed398c916
@@ -1796,27 +1796,27 @@ def test_installer_inventory_plugin_update(destructive_sat):
     :customerscenario: true
 
     """
-    destructive_sat.create_custom_repos(rhel7=settings.repos.rhel7_os)
+    target_sat.create_custom_repos(rhel7=settings.repos.rhel7_os)
     installer_obj = InstallerCommand(
         'enable-foreman-plugin-rh-cloud',
         foreman_proxy_plugin_remote_execution_ssh_install_key=['true'],
     )
-    command_output = destructive_sat.execute(installer_obj.get_command())
+    command_output = target_sat.execute(installer_obj.get_command())
     assert 'Success!' in command_output.stdout
     installer_obj = InstallerCommand(
         help='|grep "\'foreman_plugin_rh_cloud\' puppet module (default: true)"'
     )
-    updated_cloud_flags = destructive_sat.execute(installer_obj.get_command())
+    updated_cloud_flags = target_sat.execute(installer_obj.get_command())
     assert 'true' in updated_cloud_flags.stdout
     installer_obj = InstallerCommand(
         help='|grep -A1 "foreman-proxy-plugin-remote-execution-ssh-install-key"'
     )
-    update_proxy_plugin_output = destructive_sat.execute(installer_obj.get_command())
+    update_proxy_plugin_output = target_sat.execute(installer_obj.get_command())
     assert 'true' in update_proxy_plugin_output.stdout
 
 
 @pytest.mark.destructive
-def test_installer_puppet_overload(destructive_sat):
+def test_installer_puppet_overload(target_sat):
     """Check the puppet server tuning parameter update
 
     :id: 70458b3a-1215-49ad-9c94-a115888c8dbd
@@ -1839,9 +1839,9 @@ def test_installer_puppet_overload(destructive_sat):
     puppet_server_jvm_param_1 = '-Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger'
     puppet_server_jvm_param_2 = '-XX:ReservedCodeCacheSize=1024m'
     installer_obj = InstallerCommand(puppet_server_jvm_extra_args=f'{puppet_server_jvm_param_1}')
-    command_output = destructive_sat.execute(installer_obj.get_command())
+    command_output = target_sat.execute(installer_obj.get_command())
     assert 'Success!' in command_output.stdout
-    puppet_service_output = destructive_sat.execute('systemctl status puppetserver')
+    puppet_service_output = target_sat.execute('systemctl status puppetserver')
     assert puppet_server_jvm_param_1 in puppet_service_output.stdout
     installer_obj = InstallerCommand(
         puppet_server_jvm_extra_args=[
@@ -1849,8 +1849,8 @@ def test_installer_puppet_overload(destructive_sat):
             f'{puppet_server_jvm_param_2}',
         ]
     )
-    command_output = destructive_sat.execute(installer_obj.get_command())
+    command_output = target_sat.execute(installer_obj.get_command())
     assert 'Success!' in command_output.stdout
-    puppet_service_output = destructive_sat.execute('systemctl status puppetserver')
+    puppet_service_output = target_sat.execute('systemctl status puppetserver')
     assert puppet_server_jvm_param_1 in puppet_service_output.stdout
     assert puppet_server_jvm_param_2 in puppet_service_output.stdout

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -135,10 +135,10 @@ def host(
     custom_repo,
     module_ak,
     module_cv,
-    default_sat,
+    module_target_sat,
 ):
     # Create client machine and register it to satellite with rhel_7_partial_ak
-    rhel7_contenthost_module.install_katello_ca(default_sat)
+    rhel7_contenthost_module.install_katello_ca(module_target_sat)
     # Register, enable tools repo and install katello-host-tools.
     rhel7_contenthost_module.register_contenthost(module_manifest_org.label, module_ak.name)
     rhel7_contenthost_module.enable_repo(REPOS['rhst7']['id'])

--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -20,7 +20,7 @@ import pytest
 
 
 @pytest.mark.tier2
-def test_positive_setup_dynflow(default_sat):
+def test_positive_setup_dynflow(target_sat):
     """Set dynflow parameters, restart it and check it adheres to them
 
     :id: a5aaab5e-bc18-453e-a284-64aef752ec88
@@ -37,5 +37,5 @@ def test_positive_setup_dynflow(default_sat):
     ]
     # if thread count is not respected or the process is not running, this should timeout
     # how is this a test? Nothing is asserted.
-    default_sat.execute(' && '.join(commands))
-    default_sat.execute("systemctl stop 'dynflow-sidekiq@test'; rm /etc/foreman/dynflow/test.yml")
+    target_sat.execute(' && '.join(commands))
+    target_sat.execute("systemctl stop 'dynflow-sidekiq@test'; rm /etc/foreman/dynflow/test.yml")

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -24,7 +24,7 @@ from robottelo.constants import FOREMAN_ANSIBLE_MODULES
 
 @pytest.mark.destructive
 @pytest.mark.run_in_one_thread
-def test_positive_ansible_modules_installation(default_sat):
+def test_positive_ansible_modules_installation(target_sat):
     """Foreman ansible modules installation test
 
     :id: 553a927e-2665-4227-8542-0258d7b1ccc4
@@ -33,18 +33,18 @@ def test_positive_ansible_modules_installation(default_sat):
         available and supported modules are contained
 
     """
-    result = default_sat.execute(
+    result = target_sat.execute(
         'yum install -y ansible-collection-redhat-satellite --disableplugin=foreman-protector'
     )
     assert result.status == 0
     # list installed modules
-    result = default_sat.execute(f'ls {FAM_MODULE_PATH} | grep .py$ | sed "s/.[^.]*$//"')
+    result = target_sat.execute(f'ls {FAM_MODULE_PATH} | grep .py$ | sed "s/.[^.]*$//"')
     assert result.status == 0
     installed_modules = result.stdout.split('\n')
     installed_modules.remove('')
     # see help for installed modules
     for module_name in installed_modules:
-        result = default_sat.execute(f'ansible-doc redhat.satellite.{module_name} -s')
+        result = target_sat.execute(f'ansible-doc redhat.satellite.{module_name} -s')
         assert result.status == 0
         doc_name = result.stdout.split('\n')[1].lstrip()[:-1]
         assert doc_name == module_name

--- a/tests/foreman/sys/test_foreman_rake.py
+++ b/tests/foreman/sys/test_foreman_rake.py
@@ -18,7 +18,7 @@ import pytest
 @pytest.mark.destructive
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_katello_reimport(destructive_sat):
+def test_positive_katello_reimport(target_sat):
     """Close loop bug for running katello:reimport.  Making sure
     that katello:reimport works and doesn't throw an error.
 
@@ -37,6 +37,6 @@ def test_positive_katello_reimport(destructive_sat):
     :customerscenario: true
     """
 
-    result = destructive_sat.execute('foreman-rake katello:reimport')
+    result = target_sat.execute('foreman-rake katello:reimport')
     assert 'NoMethodError:' not in result.stdout
     assert 'rake aborted!' not in result.stdout

--- a/tests/foreman/sys/test_hooks.py
+++ b/tests/foreman/sys/test_hooks.py
@@ -33,21 +33,21 @@ pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.destructive]
 
 
 @pytest.fixture(scope='function')
-def logger_hook(default_org, default_sat):
+def logger_hook(default_org, target_sat):
     """Create logger script to be executed via hooks"""
-    default_sat.execute(
+    target_sat.execute(
         '''printf '#!/bin/sh\necho "$(date): Executed $1 hook'''
         + f''' on object $2" > {LOGS_DIR}' > {SCRIPT_PATH}'''
     )
-    default_sat.execute(f'chmod 774 {SCRIPT_PATH}')
-    default_sat.execute(f'chown foreman:foreman {SCRIPT_PATH}')
-    default_sat.execute(f'restorecon -RvF {HOOKS_DIR}')
+    target_sat.execute(f'chmod 774 {SCRIPT_PATH}')
+    target_sat.execute(f'chown foreman:foreman {SCRIPT_PATH}')
+    target_sat.execute(f'restorecon -RvF {HOOKS_DIR}')
     yield
 
-    default_sat.execute(f'rm -rf {HOOKS_DIR}/*')
+    target_sat.execute(f'rm -rf {HOOKS_DIR}/*')
 
 
-def test_positive_host_hooks(logger_hook, default_sat):
+def test_positive_host_hooks(logger_hook, target_sat):
     """Create hooks to be executed on host create, update and destroy
 
     :id: 4fe35fda-1524-44f7-9221-96d1aeafc75c
@@ -69,15 +69,15 @@ def test_positive_host_hooks(logger_hook, default_sat):
     destroy_event = 'destroy'
     for event in [create_event, destroy_event, update_event]:
         hook_dir = f'{HOOKS_DIR}/host/managed/{event}'
-        default_sat.execute(f'mkdir -p {hook_dir}')
-        default_sat.execute(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
-    result = default_sat.execute('systemctl restart httpd')
+        target_sat.execute(f'mkdir -p {hook_dir}')
+        target_sat.execute(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
+    result = target_sat.execute('systemctl restart httpd')
     assert result.status == 0
 
     # delete host, check logs for hook activity
     host = entities.Host(name=host_name).create()
     assert host.name == f'{host_name}.{host.domain.read().name}'
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(create_event, host_name) in result.stdout
 
@@ -86,7 +86,7 @@ def test_positive_host_hooks(logger_hook, default_sat):
     host.ip = new_ip
     host = host.update(['ip'])
     assert host.ip == new_ip
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(update_event, host_name) in result.stdout
 
@@ -94,12 +94,12 @@ def test_positive_host_hooks(logger_hook, default_sat):
     host.delete()
     with pytest.raises(HTTPError):
         host.read()
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(destroy_event, host_name) in result.stdout
 
 
-def test_positive_hostgroup_hooks(logger_hook, default_org, default_sat):
+def test_positive_hostgroup_hooks(logger_hook, default_org, target_sat):
     """Create hooks to be executed on hostgroup create, udpdate and destroy
 
     :id: 7e935dec-e4fe-47d8-be02-8c687a99ae7a
@@ -122,15 +122,15 @@ def test_positive_hostgroup_hooks(logger_hook, default_org, default_sat):
     destroy_event = 'before_destroy'
     for event in [create_event, update_event, destroy_event]:
         hook_dir = f'{HOOKS_DIR}/hostgroup/{event}'
-        default_sat.execute(f'mkdir -p {hook_dir}')
-        default_sat.execute(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
-    result = default_sat.execute('systemctl restart httpd')
+        target_sat.execute(f'mkdir -p {hook_dir}')
+        target_sat.execute(f'ln -sf {SCRIPT_PATH} {hook_dir}/')
+    result = target_sat.execute('systemctl restart httpd')
     assert result.status == 0
 
     # create hg, check logs for hook activity
     hg = entities.HostGroup(name=hg_name, organization=[default_org.id]).create()
     assert hg.name == hg_name
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(create_event, hg_name) in result.stdout
 
@@ -139,7 +139,7 @@ def test_positive_hostgroup_hooks(logger_hook, default_org, default_sat):
     hg.architecture = new_arch
     hg = hg.update(['architecture'])
     assert hg.architecture.read().name == new_arch.name
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(update_event, hg_name) in result.stdout
 
@@ -147,6 +147,6 @@ def test_positive_hostgroup_hooks(logger_hook, default_org, default_sat):
     hg.delete()
     with pytest.raises(HTTPError):
         hg.read()
-    result = default_sat.execute(f'cat {LOGS_DIR}')
+    result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(destroy_event, hg_name) in result.stdout

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -92,22 +92,26 @@ class TestKatelloCertsCheck:
             yield cert_data, host
 
     @pytest.fixture
-    def cert_setup_destructive_teardown(self, destructive_sat, cert_data):
+    def cert_setup_destructive_teardown(self, target_sat, cert_data):
         """Get host name, scripts, and create working directory."""
-        cert_data['key_file_name'] = f'{destructive_sat.hostname}/{destructive_sat.hostname}.key'
-        cert_data['cert_file_name'] = f'{destructive_sat.hostname}/{destructive_sat.hostname}.crt'
-        destructive_sat.custom_cert_generate(cert_data['capsule_hostname'])
-        yield cert_data, destructive_sat
-        destructive_sat.custom_certs_cleanup()
+        cert_data['key_file_name'] = f'{target_sat.hostname}/{target_sat.hostname}.key'
+        cert_data['cert_file_name'] = f'{target_sat.hostname}/{target_sat.hostname}.crt'
+        target_sat.custom_cert_generate(cert_data['capsule_hostname'])
+        yield cert_data, target_sat
+        target_sat.custom_certs_cleanup()
 
     @pytest.fixture(scope='module')
-    def cert_setup_teardown(self, default_sat, cert_data):
+    def cert_setup_teardown(self, module_target_sat, cert_data):
         """Get host name, scripts, and create working directory."""
-        cert_data['key_file_name'] = f'{default_sat.hostname}/{default_sat.hostname}.key'
-        cert_data['cert_file_name'] = f'{default_sat.hostname}/{default_sat.hostname}.crt'
-        default_sat.custom_cert_generate(cert_data['capsule_hostname'])
-        yield cert_data, default_sat
-        default_sat.custom_certs_cleanup()
+        cert_data[
+            'key_file_name'
+        ] = f'{module_target_sat.hostname}/{module_target_sat.hostname}.key'
+        cert_data[
+            'cert_file_name'
+        ] = f'{module_target_sat.hostname}/{module_target_sat.hostname}.crt'
+        module_target_sat.custom_cert_generate(cert_data['capsule_hostname'])
+        yield cert_data, module_target_sat
+        module_target_sat.custom_certs_cleanup()
 
     def validate_output(self, result, cert_data):
         """Validate katello-certs-check output against a set.
@@ -147,7 +151,7 @@ class TestKatelloCertsCheck:
         assert set(options) == expected_result
 
     @pytest.mark.tier1
-    def test_positive_validate_katello_certs_check_output(self, cert_setup_teardown, default_sat):
+    def test_positive_validate_katello_certs_check_output(self, cert_setup_teardown, target_sat):
         """Validate that katello-certs-check generates correct output.
 
         :id: 4c9e4c6e-8d8e-4953-87a1-09cb55df3adf
@@ -163,13 +167,13 @@ class TestKatelloCertsCheck:
         :expectedresults: Katello-certs-check should generate correct commands
          with options.
         """
-        cert_data, default_sat = cert_setup_teardown
-        hostname = default_sat.hostname
+        cert_data, target_sat = cert_setup_teardown
+        hostname = target_sat.hostname
         command = (
             f'katello-certs-check -c {hostname}/{hostname}.crt '
             f'-k {hostname}/{hostname}.key -b cacert.crt'
         )
-        result = default_sat.execute(command)
+        result = target_sat.execute(command)
         self.validate_output(result, cert_data)
 
     @pytest.mark.tier1
@@ -189,9 +193,9 @@ class TestKatelloCertsCheck:
         :expectedresults: katello-certs-check should generate correct commands
          with options.
         """
-        cert_data, default_sat = cert_setup_teardown
+        cert_data, target_sat = cert_setup_teardown
         command = 'katello-certs-check -c certs/wildcard.crt -k certs/wildcard.key -b certs/ca.crt'
-        result = default_sat.execute(command)
+        result = target_sat.execute(command)
         self.validate_output(result, cert_data)
 
     @pytest.mark.parametrize('error, cert_file, key_file, ca_file', invalid_inputs)
@@ -222,9 +226,9 @@ class TestKatelloCertsCheck:
         :expectedresults: Katello-certs-check should raise error when it receives the invalid
          inputs.
         """
-        cert_data, default_sat = cert_setup_teardown
+        cert_data, target_sat = cert_setup_teardown
         command = f'katello-certs-check -c {cert_file} -k {key_file} -b {ca_file}'
-        certs_check_result = default_sat.execute(command)
+        certs_check_result = target_sat.execute(command)
         for result in certs_check_result.stdout.split('\n\n'):
             if error['check'] in result:
                 assert '[FAIL]' in result
@@ -452,14 +456,14 @@ class TestKatelloCertsCheck:
 
         :CaseAutomation: NotAutomated
         """
-        cert_data, default_sat = cert_setup_teardown
-        hostname = default_sat.hostname
-        default_sat.execute("date -s 'next year'")
+        cert_data, target_sat = cert_setup_teardown
+        hostname = target_sat.hostname
+        target_sat.execute("date -s 'next year'")
         command = (
             f'katello-certs-check -c {hostname}/{hostname}.key '
             f'-k {hostname}/{hostname}.crt -b cacert.crt'
         )
-        result = default_sat.execute(command)
+        result = target_sat.execute(command)
         messages = [
             'Checking expiration of certificate: \n[FAIL]',
             'Checking CA bundle against the certificate file: \n[FAIL]',
@@ -472,7 +476,7 @@ class TestKatelloCertsCheck:
                     break
             else:
                 assert False, f'Failed, Unable to find message "{message}" in result'
-        default_sat.execute("date -s 'last year'")
+        target_sat.execute("date -s 'last year'")
 
     @pytest.mark.stubbed
     @pytest.mark.tier1
@@ -518,22 +522,22 @@ class TestCapsuleCertsCheckTestCase:
     """
 
     @pytest.fixture
-    def capsule_certs_teardown(self, default_sat):
+    def capsule_certs_teardown(self, target_sat):
         """Create working directory and file."""
         capsule = Box({'hostname': 'capsule.example.com'})
         tmp_dir = '/var/tmp/{}'.format(gen_string('alpha', 6))
         caps_cert_file = f'{tmp_dir}/ssl-build/capsule.example.com/cert-data'
         # Use same path locally as on remote for storing files
         Path(f'{tmp_dir}/ssl-build/capsule.example.com/').mkdir(parents=True, exist_ok=True)
-        result = default_sat.execute(f'mkdir {tmp_dir}')
+        result = target_sat.execute(f'mkdir {tmp_dir}')
         assert result.status == 0, 'Create working directory failed.'
         # Generate a Capsule cert for capsule.example.com
-        default_sat.capsule_certs_generate(capsule, f'{tmp_dir}/capsule_certs.tar')
+        target_sat.capsule_certs_generate(capsule, f'{tmp_dir}/capsule_certs.tar')
         return {
             'tmp_dir': tmp_dir,
             'caps_cert_file': caps_cert_file,
             'capsule_hostname': capsule.hostname,
-        }, default_sat
+        }, target_sat
 
     @pytest.mark.destructive
     @pytest.mark.tier1
@@ -556,16 +560,16 @@ class TestCapsuleCertsCheckTestCase:
 
         :CaseAutomation: Automated
         """
-        file_setup, default_sat = capsule_certs_teardown
+        file_setup, target_sat = capsule_certs_teardown
         DNS_Check = False
         # extract the cert from the tar file
-        result = default_sat.execute(
+        result = target_sat.execute(
             f'tar -xf {file_setup["tmp_dir"]}/capsule_certs.tar '
             f'--directory {file_setup["tmp_dir"]}/ '
         )
         assert result.status == 0, 'Extraction to working directory failed.'
         # Extract raw data from RPM to a file
-        default_sat.execute(
+        target_sat.execute(
             'rpm2cpio {0}/ssl-build/{1}/'
             '{1}-qpid-router-server*.rpm'
             '>> {0}/ssl-build/{1}/cert-raw-data'.format(
@@ -573,14 +577,14 @@ class TestCapsuleCertsCheckTestCase:
             )
         )
         # Extract the cert data from file cert-raw-data and write to cert-data
-        default_sat.execute(
+        target_sat.execute(
             'openssl x509 -noout -text -in {0}/ssl-build/{1}/cert-raw-data'
             '>> {0}/ssl-build/{1}/cert-data'.format(
                 file_setup['tmp_dir'], file_setup['capsule_hostname']
             )
         )
         # use same location on remote and local for cert_file
-        default_sat.get(file_setup['caps_cert_file'])
+        target_sat.get(file_setup['caps_cert_file'])
         # search the file for the line with DNS
         with open(file_setup['caps_cert_file']) as file:
             for line in file:

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -21,7 +21,7 @@ import pytest
 
 
 @pytest.mark.upgrade
-def test_selinux_status(default_sat):
+def test_selinux_status(target_sat):
     """Test SELinux status.
 
     :id: 43218070-ac5e-4679-b74a-3e2bcb497a0a
@@ -30,10 +30,10 @@ def test_selinux_status(default_sat):
 
     """
     # check SELinux is enabled
-    result = default_sat.execute('getenforce')
+    result = target_sat.execute('getenforce')
     assert 'Enforcing' in result.stdout
     # check there are no SELinux denials
-    result = default_sat.execute('ausearch --input-logs -m avc -ts today --raw')
+    result = target_sat.execute('ausearch --input-logs -m avc -ts today --raw')
     assert result.status == 1
 
 
@@ -47,7 +47,7 @@ def test_selinux_status(default_sat):
         '/var/lib/pulp/tmp',
     ],
 )
-def test_pulp_directory_exists(default_sat, directory):
+def test_pulp_directory_exists(target_sat, directory):
     """Check Pulp3 directories are present.
 
     :id: 96a64932-9e89-4063-9d5b-55c811375361
@@ -58,11 +58,11 @@ def test_pulp_directory_exists(default_sat, directory):
 
     """
     # check pulp3 directories present
-    assert default_sat.execute(f'test -d {directory}').status == 0, f'{directory} must exist.'
+    assert target_sat.execute(f'test -d {directory}').status == 0, f'{directory} must exist.'
 
 
 @pytest.mark.upgrade
-def test_pulp_service_definitions(default_sat):
+def test_pulp_service_definitions(target_sat):
     """Test systemd settings for Pulp3 file system layout.
 
     :id: e584faea-dede-4895-8d7f-411cb074f6c0
@@ -71,15 +71,15 @@ def test_pulp_service_definitions(default_sat):
 
     """
     # check pulpcore settings
-    result = default_sat.execute('systemctl cat pulpcore-content.socket')
+    result = target_sat.execute('systemctl cat pulpcore-content.socket')
     assert result.status == 0
     assert 'ListenStream=/run/pulpcore-content.sock' in result.stdout
-    result = default_sat.execute('systemctl cat pulpcore-content.service')
+    result = target_sat.execute('systemctl cat pulpcore-content.service')
     assert result.status == 0
     assert 'Requires=pulpcore-content.socket' in result.stdout
-    result = default_sat.execute('systemctl cat pulpcore-api.service')
+    result = target_sat.execute('systemctl cat pulpcore-api.service')
     assert result.status == 0
     assert 'Requires=pulpcore-api.socket' in result.stdout
     # check pulp3 configuration file present
-    result = default_sat.execute('test -f /etc/pulp/settings.py')
+    result = target_sat.execute('test -f /etc/pulp/settings.py')
     assert result.status == 0

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -81,7 +81,7 @@ def test_positive_end_to_end_crud(session, module_org):
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_end_to_end_register(session, rhel7_contenthost, default_sat):
+def test_positive_end_to_end_register(session, rhel7_contenthost, target_sat):
     """Create activation key and use it during content host registering
 
     :id: dfaecf6a-ba61-47e1-87c5-f8966a319b41
@@ -101,7 +101,7 @@ def test_positive_end_to_end_register(session, rhel7_contenthost, default_sat):
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
     ak_name = repos_collection.setup_content_data['activation_key']['name']
 
-    repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
     with session:
         session.organization.select(org.name)
         chost = session.contenthost.read(rhel7_contenthost.hostname, widget_names='details')
@@ -855,7 +855,7 @@ def test_positive_add_docker_repo_ccv(session, module_org):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_positive_add_host(session, module_org, rhel6_contenthost, default_sat):
+def test_positive_add_host(session, module_org, rhel6_contenthost, target_sat):
     """Test that hosts can be associated to Activation Keys
 
     :id: 886e9ea5-d917-40e0-a3b1-41254c4bf5bf
@@ -876,7 +876,7 @@ def test_positive_add_host(session, module_org, rhel6_contenthost, default_sat):
         organization=module_org,
     ).create()
 
-    rhel6_contenthost.install_katello_ca(default_sat)
+    rhel6_contenthost.install_katello_ca(target_sat)
     rhel6_contenthost.register_contenthost(module_org.label, ak.name)
     assert rhel6_contenthost.subscribed
     with session:
@@ -888,7 +888,7 @@ def test_positive_add_host(session, module_org, rhel6_contenthost, default_sat):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_positive_delete_with_system(session, rhel6_contenthost, default_sat):
+def test_positive_delete_with_system(session, rhel6_contenthost, target_sat):
     """Delete an Activation key which has registered systems
 
     :id: 86cd070e-cf46-4bb1-b555-e7cb42e4dc9f
@@ -917,7 +917,7 @@ def test_positive_delete_with_system(session, rhel6_contenthost, default_sat):
         )
         assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.add_subscription(name, product_name)
-        rhel6_contenthost.install_katello_ca(default_sat)
+        rhel6_contenthost.install_katello_ca(target_sat)
         rhel6_contenthost.register_contenthost(org.label, name)
         assert rhel6_contenthost.subscribed
         session.activationkey.delete(name)
@@ -926,7 +926,7 @@ def test_positive_delete_with_system(session, rhel6_contenthost, default_sat):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_negative_usage_limit(session, module_org, rhel6_contenthost, default_sat):
+def test_negative_usage_limit(session, module_org, target_sat):
     """Test that Usage limit actually limits usage
 
     :id: 9fe2d661-66f8-46a4-ae3f-0a9329494bdd
@@ -952,10 +952,10 @@ def test_negative_usage_limit(session, module_org, rhel6_contenthost, default_sa
         assert ak['details']['hosts_limit'] == hosts_limit
     with VMBroker(nick='rhel6', host_classes={'host': ContentHost}, _count=2) as hosts:
         vm1, vm2 = hosts
-        vm1.install_katello_ca(default_sat)
+        vm1.install_katello_ca(target_sat)
         vm1.register_contenthost(module_org.label, name)
         assert vm1.subscribed
-        vm2.install_katello_ca(default_sat)
+        vm2.install_katello_ca(target_sat)
         result = vm2.register_contenthost(module_org.label, name)
         assert not vm2.subscribed
         assert len(result.stderr)
@@ -966,7 +966,7 @@ def test_negative_usage_limit(session, module_org, rhel6_contenthost, default_sa
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
-def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenthost, default_sat):
+def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenthost, target_sat):
     """Check if multiple Activation keys can be attached to a system
 
     :id: 4d6b6b69-9d63-4180-af2e-a5d908f8adb7
@@ -1007,8 +1007,8 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenth
             ]
             assert product_name in subscriptions
         # Create VM
-        rhel6_contenthost.install_katello_ca(default_sat)
-        rhel6_contenthost.register_contenthost(module_org.label, ','.join(key_1_name, key_2_name))
+        rhel6_contenthost.install_katello_ca(target_sat)
+        rhel6_contenthost.register_contenthost(module_org.label, ','.join([key_1_name, key_2_name]))
         assert rhel6_contenthost.subscribed
         # Assert the content-host association with activation keys
         for key_name in [key_1_name, key_2_name]:
@@ -1021,7 +1021,7 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenth
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_host_associations(session, default_sat):
+def test_positive_host_associations(session, target_sat):
     """Register few hosts with different activation keys and ensure proper
     data is reflected under Associations > Content Hosts tab
 
@@ -1048,10 +1048,10 @@ def test_positive_host_associations(session, default_sat):
     ).create()
     with VMBroker(nick='rhel7', host_classes={'host': ContentHost}, _count=2) as hosts:
         vm1, vm2 = hosts
-        vm1.install_katello_ca(default_sat)
+        vm1.install_katello_ca(target_sat)
         vm1.register_contenthost(org.label, ak1.name)
         assert vm1.subscribed
-        vm2.install_katello_ca(default_sat)
+        vm2.install_katello_ca(target_sat)
         vm2.register_contenthost(org.label, ak2.name)
         assert vm2.subscribed
         with session:
@@ -1068,7 +1068,7 @@ def test_positive_host_associations(session, default_sat):
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_service_level_subscription_with_custom_product(
-    session, rhel7_contenthost, default_sat
+    session, rhel7_contenthost, target_sat
 ):
     """Subscribe a host to activation key with Premium service level and with
     custom product
@@ -1118,7 +1118,7 @@ def test_positive_service_level_subscription_with_custom_product(
     activation_key.service_level = 'Premium'
     activation_key = activation_key.update(['service_level'])
 
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org.label, activation_key=activation_key.name)
     assert rhel7_contenthost.subscribed
     result = rhel7_contenthost.run('subscription-manager list --consumed')

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -91,7 +91,7 @@ def module_azure_hg(
 @pytest.mark.tier4
 def test_positive_end_to_end_azurerm_ft_host_provision(
     session,
-    default_sat,
+    target_sat,
     azurermclient,
     module_azurerm_finishimg,
     module_azurerm_cr,
@@ -124,7 +124,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
 
         # Provision Host
         try:
-            with default_sat.skip_yum_update_during_provisioning(
+            with target_sat.skip_yum_update_during_provisioning(
                 template='Kickstart default finish'
             ):
                 session.host.create(
@@ -173,7 +173,7 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
 @pytest.mark.upgrade
 def test_positive_azurerm_host_provision_ud(
     session,
-    default_sat,
+    target_sat,
     azurermclient,
     module_azurerm_cloudimg,
     module_azurerm_cr,
@@ -207,7 +207,7 @@ def test_positive_azurerm_host_provision_ud(
 
         # Provision Host
         try:
-            with default_sat.skip_yum_update_during_provisioning(
+            with target_sat.skip_yum_update_during_provisioning(
                 template='Kickstart default user data'
             ):
                 session.host.create(

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -103,20 +103,20 @@ def repos_collection_for_module_streams(module_org):
 
 
 @pytest.fixture
-def vm(repos_collection, rhel7_contenthost, default_sat):
+def vm(repos_collection, rhel7_contenthost, target_sat):
     """Virtual machine registered in satellite"""
-    repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
-    rhel7_contenthost.add_rex_key(default_sat)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
+    rhel7_contenthost.add_rex_key(target_sat)
     yield rhel7_contenthost
 
 
 @pytest.fixture
-def vm_module_streams(repos_collection_for_module_streams, rhel8_contenthost, default_sat):
+def vm_module_streams(repos_collection_for_module_streams, rhel8_contenthost, target_sat):
     """Virtual machine registered in satellite without katello-agent installed"""
     repos_collection_for_module_streams.setup_virtual_machine(
-        rhel8_contenthost, default_sat, install_katello_agent=False
+        rhel8_contenthost, target_sat, install_katello_agent=False
     )
-    rhel8_contenthost.add_rex_key(satellite=default_sat)
+    rhel8_contenthost.add_rex_key(satellite=target_sat)
     yield rhel8_contenthost
 
 
@@ -664,7 +664,7 @@ def test_positive_check_ignore_facts_os_setting(session, default_location, vm, m
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_virt_who_hypervisor_subscription_status(
-    session, default_location, rhel7_contenthost, default_sat
+    session, default_location, rhel7_contenthost, target_sat
 ):
     """Check that virt-who hypervisor shows the right subscription status
     without and with attached subscription.
@@ -702,7 +702,7 @@ def test_positive_virt_who_hypervisor_subscription_status(
     # configure virtual machine and setup virt-who service
     # do not supply subscription to attach to virt_who hypervisor
     virt_who_data = rhel7_contenthost.virt_who_hypervisor_config(
-        default_sat,
+        target_sat,
         virt_who_config['general-information']['id'],
         org_id=org.id,
         lce_id=lce.id,
@@ -1406,7 +1406,7 @@ def test_search_for_virt_who_hypervisors(session, default_location):
 @pytest.mark.run_in_one_thread
 @pytest.mark.upgrade
 def test_content_access_after_stopped_foreman(
-    foreman_service_teardown, rhel7_contenthost, default_sat
+    foreman_service_teardown, rhel7_contenthost, target_sat
 ):
     """Install a package even after foreman service is stopped
 
@@ -1443,11 +1443,11 @@ def test_content_access_after_stopped_foreman(
             ],
         )
         repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
-        repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+        repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
     result = rhel7_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
-    assert default_sat.execute('systemctl stop foreman').status == 0
-    result = default_sat.execute('foreman-maintain service status --only=foreman')
+    assert target_sat.execute('systemctl stop foreman').status == 0
+    result = target_sat.execute('satellite-maintain service status --only=foreman')
     assert result.status == 1
     result = rhel7_contenthost.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
     assert result.status == 0

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2588,7 +2588,7 @@ def test_positive_publish_with_repo_with_disabled_http(session, module_org):
 
 @pytest.mark.upgrade
 @pytest.mark.tier2
-def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthost, default_sat):
+def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthost, target_sat):
     """Attempt to subscribe a host to content view with custom repository
 
     :id: 715db997-707b-4868-b7cc-b6977fd6ac04
@@ -2608,7 +2608,7 @@ def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthos
         repositories=[SatelliteToolsRepository(), YumRepository(url=settings.repos.yum_0.url)],
     )
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
-    repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
     assert rhel7_contenthost.subscribed
     with session:
         session.organization.select(org.name)
@@ -2621,7 +2621,7 @@ def test_positive_subscribe_system_with_custom_content(session, rhel7_contenthos
 
 
 @pytest.mark.tier3
-def test_positive_delete_with_kickstart_repo_and_host_group(session, default_sat):
+def test_positive_delete_with_kickstart_repo_and_host_group(session):
     """Check that Content View associated with kickstart repository and
     which is used by a host group can be removed from the system
 
@@ -2935,7 +2935,7 @@ def test_positive_rh_mixed_content_end_to_end(session, module_prod, module_org):
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_errata_inc_update_list_package(session, default_sat):
+def test_positive_errata_inc_update_list_package(session):
     """Publish incremental update with a new errata for a custom repo
 
     :BZ: 1489778
@@ -2996,7 +2996,7 @@ def test_positive_errata_inc_update_list_package(session, default_sat):
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_composite_child_inc_update(session, rhel7_contenthost, default_sat):
+def test_positive_composite_child_inc_update(session, rhel7_contenthost, target_sat):
     """Incremental update with a new errata on a child content view should
     trigger incremental update of parent composite content view
 
@@ -3072,7 +3072,7 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, default
         f'hammer activation-key add-subscription --id {ak_id} '
         f'--subscription {product.name} --organization-id {org.id}'
     )
-    result = default_sat.execute(command)
+    result = target_sat.execute(command)
     assert result.status == 0
     # Create composite cv
     composite_cv = entities.ContentView(composite=True, organization=org).create()
@@ -3089,7 +3089,7 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, default
     entities.ActivationKey(
         id=content_data['activation_key']['id'], content_view=composite_cv
     ).update(['content_view'])
-    repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
     result = rhel7_contenthost.run(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
     with session:
@@ -3734,7 +3734,7 @@ def test_positive_depsolve_with_module_errata(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_filter_by_pkg_group_name(session, module_org, default_sat):
+def test_positive_filter_by_pkg_group_name(session, module_org, target_sat):
     """Publish a filtered version of a Content View, filtering on the package group's name.
 
     :id: c7021f46-0168-44f7-a863-4aa34533efdb
@@ -3750,10 +3750,10 @@ def test_positive_filter_by_pkg_group_name(session, module_org, default_sat):
     package_group = 'birds'
     expected_packages = [('cockateel'), ('duck'), ('penguin'), ('stork')]
     create_sync_custom_repo(module_org.id, repo_name=repo_name)
-    repo = default_sat.api.Repository(name=repo_name).search(
+    repo = target_sat.api.Repository(name=repo_name).search(
         query={'organization_id': module_org.id}
     )[0]
-    cv = default_sat.api.ContentView(organization=module_org, repository=[repo]).create()
+    cv = target_sat.api.ContentView(organization=module_org, repository=[repo]).create()
     with session:
         session.contentviewfilter.create(
             cv.name,

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -194,7 +194,7 @@ def test_positive_task_status(session):
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_user_access_with_host_filter(
-    test_name, module_location, rhel7_contenthost, default_sat
+    test_name, module_location, rhel7_contenthost, target_sat
 ):
     """Check if user with necessary host permissions can access dashboard
     and required widgets are rendered with proper values
@@ -247,7 +247,9 @@ def test_positive_user_access_with_host_filter(
             repositories=[SatelliteToolsRepository(), YumRepository(url=settings.repos.yum_6.url)],
         )
         repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
-        repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
+        repos_collection.setup_virtual_machine(
+            rhel7_contenthost, target_sat, location_title=module_location.name
+        )
         result = rhel7_contenthost.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
         assert result.status == 0
         hostname = rhel7_contenthost.hostname

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -172,12 +172,12 @@ def module_erratatype_repos_col(module_org, module_lce):
 
 
 @pytest.fixture
-def erratatype_vm(module_erratatype_repos_col, default_sat):
+def erratatype_vm(module_erratatype_repos_col, target_sat):
     """Virtual machine client using module_erratatype_repos_col for subscription"""
     with VMBroker(
         nick=module_erratatype_repos_col.distro, host_classes={'host': ContentHost}
     ) as client:
-        module_erratatype_repos_col.setup_virtual_machine(client, default_sat)
+        module_erratatype_repos_col.setup_virtual_machine(client, target_sat)
         yield client
 
 
@@ -209,15 +209,15 @@ def repos_collection(module_org):
 
 
 @pytest.fixture(scope='function')
-def vm(repos_collection, rhel7_contenthost, default_sat):
+def vm(repos_collection, rhel7_contenthost, target_sat):
     """Virtual machine registered in satellite"""
-    repos_collection.setup_virtual_machine(rhel7_contenthost, default_sat)
-    rhel7_contenthost.add_rex_key(satellite=default_sat)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, target_sat)
+    rhel7_contenthost.add_rex_key(satellite=target_sat)
     yield rhel7_contenthost
 
 
 @pytest.mark.tier3
-def test_end_to_end(session, module_org, module_repos_col, vm, default_sat):
+def test_end_to_end(session, module_org, module_repos_col, vm):
     """Create all entities required for errata, set up applicable host,
     read errata details and apply it to host
 
@@ -288,7 +288,7 @@ def test_end_to_end(session, module_org, module_repos_col, vm, default_sat):
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_content_host_errata_page_pagination(session, org, lce, default_sat):
+def test_content_host_errata_page_pagination(session, org, lce, target_sat):
     """
     # Test per-page pagination for BZ#1662254
     # Test apply by REX using Select All for BZ#1846670
@@ -330,9 +330,9 @@ def test_content_host_errata_page_pagination(session, org, lce, default_sat):
     )
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
     with VMBroker(nick=repos_collection.distro, host_classes={'host': ContentHost}) as client:
-        client.add_rex_key(satellite=default_sat)
+        client.add_rex_key(satellite=target_sat)
         # Add repo and install packages that need errata
-        repos_collection.setup_virtual_machine(client, default_sat)
+        repos_collection.setup_virtual_machine(client, target_sat)
         assert _install_client_package(client, pkgs)
         with session:
             # Go to content host's Errata tab and read the page's pagination widgets
@@ -451,7 +451,7 @@ def test_positive_list_permission(test_name, module_org, module_repos_col, modul
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_apply_for_all_hosts(session, module_org, module_repos_col, default_sat):
+def test_positive_apply_for_all_hosts(session, module_org, module_repos_col, target_sat):
     """Apply an erratum for all content hosts
 
     :id: d70a1bee-67f4-4883-a0b9-2ccc08a91738
@@ -474,12 +474,13 @@ def test_positive_apply_for_all_hosts(session, module_org, module_repos_col, def
         nick=module_repos_col.distro, host_classes={'host': ContentHost}, _count=2
     ) as clients:
         for client in clients:
-            module_repos_col.setup_virtual_machine(client, default_sat)
+            module_repos_col.setup_virtual_machine(client, target_sat, install_katello_agent=False)
+            client.add_rex_key(satellite=target_sat)
             assert _install_client_package(client, FAKE_1_CUSTOM_PACKAGE)
         with session:
             session.location.select(loc_name=DEFAULT_LOC)
             for client in clients:
-                client.add_rex_key(satellite=default_sat)
+                client.add_rex_key(satellite=target_sat)
                 status = session.contenthost.install_errata(
                     client.hostname, CUSTOM_REPO_ERRATA_ID, install_via='rex'
                 )
@@ -521,7 +522,7 @@ def test_positive_view_cve(session, module_repos_col, module_rhva_repos_col):
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_filter_by_environment(session, module_org, module_repos_col, default_sat):
+def test_positive_filter_by_environment(session, module_org, module_repos_col, target_sat):
     """Filter Content hosts by environment
 
     :id: 578c3a92-c4d8-4933-b122-7ff511c276ec
@@ -543,7 +544,7 @@ def test_positive_filter_by_environment(session, module_org, module_repos_col, d
         nick=module_repos_col.distro, host_classes={'host': ContentHost}, _count=2
     ) as clients:
         for client in clients:
-            module_repos_col.setup_virtual_machine(client, default_sat)
+            module_repos_col.setup_virtual_machine(client, target_sat, install_katello_agent=False)
             assert _install_client_package(client, FAKE_1_CUSTOM_PACKAGE, errata_applicability=True)
         # Promote the latest content view version to a new lifecycle environment
         content_view = entities.ContentView(
@@ -845,7 +846,7 @@ def test_positive_show_count_on_content_host_details_page(session, module_org, e
 @pytest.mark.skip_if_open('BZ:2013093')
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_filtered_errata_status_installable_param(
-    session, errata_status_installable, default_sat
+    session, errata_status_installable, target_sat
 ):
     """Filter errata for specific content view and verify that host that
     was registered using that content view has different states in
@@ -887,7 +888,7 @@ def test_positive_filtered_errata_status_installable_param(
     )
     repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
     with VMBroker(nick=repos_collection.distro, host_classes={'host': ContentHost}) as client:
-        repos_collection.setup_virtual_machine(client, default_sat)
+        repos_collection.setup_virtual_machine(client, target_sat)
         assert _install_client_package(client, FAKE_1_CUSTOM_PACKAGE, errata_applicability=True)
         # Adding content view filter and content view filter rule to exclude errata for the
         # installed package.
@@ -941,7 +942,7 @@ def test_positive_filtered_errata_status_installable_param(
 
 
 @pytest.mark.tier3
-def test_content_host_errata_search_commands(session, module_org, module_repos_col, default_sat):
+def test_content_host_errata_search_commands(session, module_org, module_repos_col, target_sat):
     """View a list of affected content hosts for security (RHSA) and bugfix (RHBA) errata,
     filtered with errata status and applicable flags. Applicability is calculated using the
     Library, but Installability is calculated using the attached CV, and is subject to the
@@ -971,7 +972,7 @@ def test_content_host_errata_search_commands(session, module_org, module_repos_c
         nick=module_repos_col.distro, host_classes={'host': ContentHost}, _count=2
     ) as clients:
         for client in clients:
-            module_repos_col.setup_virtual_machine(client, default_sat)
+            module_repos_col.setup_virtual_machine(client, target_sat)
         # Install pkg walrus-0.71-1.noarch to create need for RHSA on client 1
         assert _install_client_package(
             clients[0], FAKE_1_CUSTOM_PACKAGE, errata_applicability=False

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -165,9 +165,13 @@ def os_path(module_os):
 
 
 @pytest.fixture(scope='module')
-def module_proxy(module_org, smart_proxy_location, default_sat):
+def module_proxy(module_org, smart_proxy_location, module_target_sat):
     # Search for SmartProxy, and associate organization/location
-    proxy = entities.SmartProxy().search(query={'search': f'name={default_sat.hostname}'})[0].read()
+    proxy = (
+        entities.SmartProxy()
+        .search(query={'search': f'name={module_target_sat.hostname}'})[0]
+        .read()
+    )
     return proxy
 
 
@@ -201,10 +205,10 @@ def module_libvirt_resource(module_org, smart_proxy_location):
 
 
 @pytest.fixture(scope='module')
-def module_libvirt_domain(module_org, smart_proxy_location, module_proxy, default_sat):
+def module_libvirt_domain(module_org, smart_proxy_location, module_proxy, module_target_sat):
     # Search for existing domain or create new otherwise. Associate org,
     # location and dns to it
-    _, _, domain = default_sat.hostname.partition('.')
+    _, _, domain = module_target_sat.hostname.partition('.')
     domain = entities.Domain().search(query={'search': f'name="{domain}"'})
     if len(domain) > 0:
         domain = domain[0].read()
@@ -579,7 +583,7 @@ def test_positive_inherit_puppet_env_from_host_group_when_action(session):
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_create_with_puppet_class(
-    session, module_host_template, module_org, smart_proxy_location, default_sat
+    session, module_host_template, module_org, smart_proxy_location, target_sat
 ):
     """Create new Host with puppet class assigned to it
 
@@ -590,8 +594,8 @@ def test_positive_create_with_puppet_class(
     :CaseLevel: System
     """
     pc_name = 'generic_1'
-    env_name = default_sat.create_custom_environment(repo=pc_name)
-    env = default_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
+    env_name = target_sat.create_custom_environment(repo=pc_name)
+    env = target_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
     env = entities.Environment(
         id=env.id,
         location=[smart_proxy_location],
@@ -1268,7 +1272,7 @@ def test_positive_search_by_org(session, smart_proxy_location):
 
 
 @pytest.mark.tier2
-def test_positive_validate_inherited_cv_lce(session, module_host_template, default_sat):
+def test_positive_validate_inherited_cv_lce(session, module_host_template, target_sat):
     """Create a host with hostgroup specified via CLI. Make sure host
     inherited hostgroup's lifecycle environment, content view and both
     fields are properly reflected via WebUI.
@@ -1300,7 +1304,7 @@ def test_positive_validate_inherited_cv_lce(session, module_host_template, defau
             'organization-ids': module_host_template.organization.id,
         }
     )
-    puppet_proxy = Proxy.list({'search': f'name = {default_sat.hostname}'})[0]
+    puppet_proxy = Proxy.list({'search': f'name = {target_sat.hostname}'})[0]
     host = make_host(
         {
             'architecture-id': module_host_template.architecture.id,
@@ -1323,7 +1327,7 @@ def test_positive_validate_inherited_cv_lce(session, module_host_template, defau
 
 @pytest.mark.tier2
 def test_positive_global_registration_form(
-    session, module_activation_key, module_org, smart_proxy_location, module_os, default_sat
+    session, module_activation_key, module_org, smart_proxy_location, module_os, target_sat
 ):
     """Host registration form produces a correct curl command for various inputs
 
@@ -1366,7 +1370,7 @@ def test_positive_global_registration_form(
         f'remote_execution_interface={iface}',
         f'setup_insights={"true" if insights_value else "false"}',
         f'setup_remote_execution={"true" if rex_value else "false"}',
-        f'{default_sat.hostname}',
+        f'{target_sat.hostname}',
         'insecure',
     ]
     for pair in expected_pairs:
@@ -1712,7 +1716,7 @@ def test_global_re_registration_host_with_force_ignore_error_options(
 
 @pytest.mark.tier2
 def test_global_registration_token_restriction(
-    session, module_activation_key, rhel7_contenthost, module_os, module_proxy, default_sat
+    session, module_activation_key, rhel7_contenthost, module_os, module_proxy, target_sat
 ):
     """Global registration token should be only used for registration call, it
     should be restricted for any other api calls.
@@ -1744,8 +1748,8 @@ def test_global_registration_token_restriction(
     auth_header = re.search(pattern, cmd).group()
 
     # build curl
-    curl_users = f'curl -X GET -k -H {auth_header} -i {default_sat.url}/api/users/'
-    curl_hosts = f'curl -X GET -k -H {auth_header} -i {default_sat.url}/api/hosts/'
+    curl_users = f'curl -X GET -k -H {auth_header} -i {target_sat.url}/api/users/'
+    curl_hosts = f'curl -X GET -k -H {auth_header} -i {target_sat.url}/api/hosts/'
     for curl_cmd in (curl_users, curl_hosts):
         result = client.execute(curl_cmd)
         assert result.status == 0
@@ -2138,7 +2142,7 @@ def gce_hostgroup(
 @pytest.mark.skip_if_not_set('gce')
 def test_positive_gce_provision_end_to_end(
     session,
-    default_sat,
+    target_sat,
     module_org,
     smart_proxy_location,
     module_os,
@@ -2165,7 +2169,7 @@ def test_positive_gce_provision_end_to_end(
         session.location.select(loc_name=smart_proxy_location.name)
         # Provision GCE Host
         try:
-            with default_sat.skip_yum_update_during_provisioning(
+            with target_sat.skip_yum_update_during_provisioning(
                 template='Kickstart default finish'
             ):
                 session.host.create(
@@ -2231,7 +2235,7 @@ def test_positive_gce_provision_end_to_end(
 @pytest.mark.skip_if_not_set('gce')
 def test_positive_gce_cloudinit_provision_end_to_end(
     session,
-    default_sat,
+    target_sat,
     module_org,
     smart_proxy_location,
     module_os,
@@ -2258,7 +2262,7 @@ def test_positive_gce_cloudinit_provision_end_to_end(
         session.location.select(loc_name=smart_proxy_location.name)
         # Provision GCE Host
         try:
-            with default_sat.skip_yum_update_during_provisioning(
+            with target_sat.skip_yum_update_during_provisioning(
                 template='Kickstart default user data'
             ):
                 session.host.create(

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -131,7 +131,7 @@ def test_create_with_config_group(session, module_org, module_location):
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_create_with_puppet_class(session, module_org, module_location, default_sat):
+def test_create_with_puppet_class(session, module_org, module_location, target_sat):
     """Create new host group with assigned puppet class to it
 
     :id: 166ca6a6-c0f7-4fa0-a3f2-b0d6980cf50d
@@ -142,8 +142,8 @@ def test_create_with_puppet_class(session, module_org, module_location, default_
     """
     name = gen_string('alpha')
     pc_name = 'generic_1'
-    env_name = default_sat.create_custom_environment(repo=pc_name)
-    env = default_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
+    env_name = target_sat.create_custom_environment(repo=pc_name)
+    env = target_sat.api.Environment().search(query={'search': f'name={env_name}'})[0].read()
     env = entities.Environment(
         id=env.id,
         location=[module_location],
@@ -187,7 +187,7 @@ def test_positive_create_new_host():
 
 
 def test_positive_nested_host_groups(
-    session, module_org, module_lce, module_published_cv, module_ak_cv_lce, default_sat
+    session, module_org, module_lce, module_published_cv, module_ak_cv_lce, target_sat
 ):
     """Verify create, update and delete operation for nested host-groups
 
@@ -209,8 +209,8 @@ def test_positive_nested_host_groups(
     parent_hg_name = gen_string('alpha')
     child_hg_name = gen_string('alpha')
     description = gen_string('alpha')
-    architecture = default_sat.api.Architecture().create()
-    os = default_sat.api.OperatingSystem(architecture=[architecture]).create()
+    architecture = target_sat.api.Architecture().create()
+    os = target_sat.api.OperatingSystem(architecture=[architecture]).create()
     os_name = f'{os.name} {os.major}'
     with session:
         # Create parent host-group with default lce and content view
@@ -224,7 +224,7 @@ def test_positive_nested_host_groups(
                 'operating_system.operating_system': os_name,
             }
         )
-        assert default_sat.api.HostGroup().search(query={'search': f'name={parent_hg_name}'})
+        assert target_sat.api.HostGroup().search(query={'search': f'name={parent_hg_name}'})
 
         # Create nested host group
         session.hostgroup.create(
@@ -233,7 +233,7 @@ def test_positive_nested_host_groups(
                 'host_group.name': child_hg_name,
             }
         )
-        assert default_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})
+        assert target_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})
         child_hostgroup_values = session.hostgroup.read(f'{parent_hg_name}/{child_hg_name}')
         assert parent_hg_name in child_hostgroup_values['host_group']['parent_name']
         assert ENVIRONMENT in child_hostgroup_values['host_group']['lce']
@@ -255,4 +255,4 @@ def test_positive_nested_host_groups(
 
         # Delete nested host group
         session.hostgroup.delete(f'{parent_hg_name}/{child_hg_name}')
-        assert not default_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})
+        assert not target_sat.api.HostGroup().search(query={'search': f'name={child_hg_name}'})

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -24,9 +24,9 @@ from robottelo.datafactory import gen_string
 
 
 @pytest.fixture
-def module_rhel_client_by_ip(module_org, smart_proxy_location, rhel7_contenthost, default_sat):
+def module_rhel_client_by_ip(module_org, smart_proxy_location, rhel7_contenthost, target_sat):
     """Setup a broker rhel client to be used in remote execution by ip"""
-    rhel7_contenthost.configure_rex(satellite=default_sat, org=module_org)
+    rhel7_contenthost.configure_rex(satellite=target_sat, org=module_org)
     update_vm_host_location(rhel7_contenthost, location_id=smart_proxy_location.id)
     yield rhel7_contenthost
 

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -21,7 +21,7 @@ from fauxfactory import gen_string
 
 
 @pytest.mark.tier2
-def test_positive_end_to_end(session, module_org, module_location, default_sat):
+def test_positive_end_to_end(session, module_org, module_location, target_sat):
     """Perform end to end testing for Job Template component.
 
     :id: 2e0e31c5-e557-4151-83f9-21820c9cb1be
@@ -207,7 +207,7 @@ def test_positive_end_to_end(session, module_org, module_location, default_sat):
             editor_view_option='Preview',
             widget_names='template.template_editor.editor',
         )
-        assert default_sat.hostname in template_values['template']['template_editor']['editor']
+        assert target_sat.hostname in template_values['template']['template_editor']['editor']
         session.jobtemplate.clone(template_new_name, {'template.name': template_clone_name})
         assert session.jobtemplate.search(template_clone_name)[0]['Name'] == template_clone_name
         for name in (template_new_name, template_clone_name):

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -27,17 +27,17 @@ from robottelo.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def oscap_content_path(default_sat):
+def oscap_content_path(module_target_sat):
     _, file_name = os.path.split(settings.oscap.content_path)
 
     local_file = robottelo_tmp_dir.joinpath(file_name)
-    default_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
+    module_target_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
     return local_file
 
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, oscap_content_path, default_sat):
+def test_positive_end_to_end(session, oscap_content_path, target_sat):
     """Perform end to end testing for openscap content component
 
     :id: 9870555d-0b60-41ab-a481-81d4d3f78fec
@@ -55,8 +55,8 @@ def test_positive_end_to_end(session, oscap_content_path, default_sat):
     """
     title = gen_string('alpha')
     new_title = gen_string('alpha')
-    org = default_sat.api.Organization().create()
-    loc = default_sat.api.Location().create()
+    org = target_sat.api.Organization().create()
+    loc = target_sat.api.Location().create()
     with session:
         session.oscapcontent.create(
             {

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -61,7 +61,7 @@ def test_positive_end_to_end(session, module_org, module_location):
 
 @pytest.mark.tier2
 def test_positive_availability_for_host_and_hostgroup_in_multiple_orgs(
-    session, default_sat, module_location
+    session, target_sat, module_location
 ):
     """An environment that is present in different organizations should be
     visible for any created host and hostgroup in those organizations
@@ -80,7 +80,7 @@ def test_positive_availability_for_host_and_hostgroup_in_multiple_orgs(
     :CaseImportance: High
     """
     env_name = gen_string('alpha')
-    orgs = [default_sat.api.Organization().create() for _ in range(2)]
+    orgs = [target_sat.api.Organization().create() for _ in range(2)]
     with session:
         session.puppetenvironment.create(
             {
@@ -92,7 +92,7 @@ def test_positive_availability_for_host_and_hostgroup_in_multiple_orgs(
         for org in orgs:
             session.organization.select(org_name=org.name)
             assert session.puppetenvironment.search(env_name)[0]['Name'] == env_name
-            host = default_sat.api.Host(location=module_location, organization=org)
+            host = target_sat.api.Host(location=module_location, organization=org)
             host.create_missing()
             os_name = f'{host.operatingsystem.name} {host.operatingsystem.major}'
             session.host.create(

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -29,9 +29,9 @@ from robottelo.hosts import ContentHost
 
 
 @pytest.fixture
-def module_vm_client_by_ip(rhel7_contenthost, module_org, smart_proxy_location, default_sat):
+def module_vm_client_by_ip(rhel7_contenthost, module_org, smart_proxy_location, target_sat):
     """Setup a VM client to be used in remote execution by ip"""
-    rhel7_contenthost.configure_rex(satellite=default_sat, org=module_org)
+    rhel7_contenthost.configure_rex(satellite=target_sat, org=module_org)
     update_vm_host_location(rhel7_contenthost, location_id=smart_proxy_location.id)
     yield rhel7_contenthost
 
@@ -130,7 +130,7 @@ def test_positive_run_custom_job_template_by_ip(
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_positive_run_job_template_multiple_hosts_by_ip(
-    session, module_org, smart_proxy_location, default_sat
+    session, module_org, smart_proxy_location, target_sat
 ):
     """Run a job template against multiple hosts by ip
 
@@ -154,7 +154,7 @@ def test_positive_run_job_template_multiple_hosts_by_ip(
         host_names = []
         for host in hosts:
             host_names.append(host.hostname)
-            host.configure_rex(satellite=default_sat, org=module_org)
+            host.configure_rex(satellite=target_sat, org=module_org)
             update_vm_host_location(host, location_id=smart_proxy_location.id)
         with session:
             session.location.select(smart_proxy_location.name)

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -386,7 +386,7 @@ def test_positive_autocomplete(session):
 
 @pytest.mark.tier2
 def test_positive_schedule_generation_and_get_mail(
-    session, module_manifest_org, module_location, default_sat
+    session, module_manifest_org, module_location, target_sat
 ):
     """Schedule generating a report. Request the result be sent via e-mail.
 
@@ -435,14 +435,11 @@ def test_positive_schedule_generation_and_get_mail(
         f'send "q\\r"\n'
     )
 
-    result = default_sat.execute(f"expect -c '{expect_script}'")
-    assert result.status == 0
-    default_sat.get(remote_path=str(gzip_path), local_path=str(local_gzip_file))
-    result = os.system(f'gunzip {local_gzip_file}')
-    assert result == 0
-    text = local_file.read_text()
-    data = json.loads(text)
-    subscription_search = default_sat.api.Subscription(organization=module_manifest_org).search()
+    assert target_sat.execute(f"expect -c '{expect_script}'").status == 0
+    target_sat.get(remote_path=str(gzip_path), local_path=str(local_gzip_file))
+    assert os.system(f'gunzip {local_gzip_file}') == 0
+    data = json.loads(local_file.read_text())
+    subscription_search = target_sat.api.Subscription(organization=module_manifest_org).search()
     assert len(data) >= len(subscription_search) > 0
     keys_expected = [
         'Account number',
@@ -499,7 +496,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
 
 @pytest.mark.tier3
 def test_positive_gen_entitlements_reports_multiple_formats(
-    session, setup_content, rhel7_contenthost, default_sat
+    session, setup_content, rhel7_contenthost, target_sat
 ):
     """Generate reports using the Entitlements template in html, yaml, json, and csv format.
 
@@ -521,7 +518,7 @@ def test_positive_gen_entitlements_reports_multiple_formats(
     :CaseImportance: High
     """
     client = rhel7_contenthost
-    client.install_katello_ca(default_sat)
+    client.install_katello_ca(target_sat)
     module_org, ak = setup_content
     client.register_contenthost(module_org.label, ak.name)
     assert client.subscribed

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -503,7 +503,7 @@ def test_failed_inventory_upload():
 
 
 @pytest.mark.tier2
-def test_rhcloud_inventory_without_manifest(session, module_org, default_sat):
+def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
     """Verify that proper error message is given when no manifest is imported in an organization.
 
     :id: 1d90bb24-2380-4653-8ed6-a084fce66d1e
@@ -527,7 +527,7 @@ def test_rhcloud_inventory_without_manifest(session, module_org, default_sat):
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(module_org.name)
         wait_for(
-            lambda: default_sat.api.ForemanTask()
+            lambda: target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -353,7 +353,7 @@ def test_negative_update_email_delivery_method_smtp():
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_update_email_delivery_method_sendmail(session, default_sat):
+def test_positive_update_email_delivery_method_sendmail(session, target_sat):
     """Updating Sendmail params on Email tab
 
     :id: c774e713-9640-402d-8987-c3509e918eb6
@@ -392,7 +392,7 @@ def test_positive_update_email_delivery_method_sendmail(session, default_sat):
     }
     mail_config_new_params = {
         "delivery_method": "Sendmail",
-        "email_reply_address": f"root@{default_sat.hostname}",
+        "email_reply_address": f"root@{target_sat.hostname}",
         "email_subject_prefix": [gen_string('alpha')],
         "sendmail_location": "/usr/sbin/sendmail",
         "send_welcome_email": "Yes",
@@ -405,7 +405,7 @@ def test_positive_update_email_delivery_method_sendmail(session, default_sat):
                 session.settings.update(mail_content, mail_content_value)
             test_mail_response = session.settings.send_test_mail(property_name)[0]
             assert test_mail_response == "Email was sent successfully"
-            assert default_sat.execute(command).status == 0
+            assert target_sat.execute(command).status == 0
         finally:
             for key, value in mail_config_default_param.items():
                 setting_cleanup(setting_name=key, setting_value=value.value)

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -23,15 +23,17 @@ from robottelo.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def module_dom(default_sat, module_org, module_location):
-    d = default_sat.api.Domain(organization=[module_org.id], location=[module_location.id]).create()
+def module_dom(module_target_sat, module_org, module_location):
+    d = module_target_sat.api.Domain(
+        organization=[module_org.id], location=[module_location.id]
+    ).create()
     yield d.read()
     d.delete()
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, default_sat, module_dom):
+def test_positive_end_to_end(session, module_target_sat, module_dom):
     """Perform end to end testing for subnet component in ipv6 network
 
     :id: f77031c9-2ca8-44db-8afa-d0212aeda540
@@ -59,7 +61,7 @@ def test_positive_end_to_end(session, default_sat, module_dom):
                 'domains.resources.assigned': [module_dom.name],
             }
         )
-        sn = default_sat.api.Subnet().search(query={'search': f'name={name}'})
+        sn = module_target_sat.api.Subnet().search(query={'search': f'name={name}'})
         assert sn, f'Subnet {sn} expected to exist, but it is not listed'
         sn = sn[0]
         subnet_values = session.subnet.read(name, widget_names=['subnet', 'domains'])
@@ -78,6 +80,6 @@ def test_positive_end_to_end(session, default_sat, module_dom):
         sn.domain = []
         sn.update(['domain'])
         session.subnet.delete(new_name)
-        assert not default_sat.api.Subnet().search(
+        assert not module_target_sat.api.Subnet().search(
             query={'search': f'name={new_name}'}
         ), 'The subnet was supposed to be deleted'

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -244,7 +244,7 @@ def test_positive_access_manifest_as_another_admin_user(test_name):
 
 
 @pytest.mark.tier3
-def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, default_sat):
+def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, target_sat):
     """Ensure that Virtual Datacenters subscription provided products is
     not empty and that a consumed product exist in content products.
 
@@ -285,7 +285,7 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, def
         org.id, lce.id, upload_manifest=True, rh_subscriptions=[DEFAULT_SUBSCRIPTION_NAME]
     )
     rhel7_contenthost.contenthost_setup(
-        default_sat,
+        target_sat,
         org.label,
         activation_key=repos_collection.setup_content_data['activation_key']['name'],
         install_katello_agent=False,
@@ -305,7 +305,7 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, def
 
 @pytest.mark.skip_if_not_set('libvirt')
 @pytest.mark.tier3
-def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthost, default_sat):
+def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthost, target_sat):
     """Ensure that Virtual Data Centers guest subscription Provided
     Products and Content Products are not empty.
 
@@ -349,7 +349,7 @@ def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthos
     )
     # configure virtual machine and setup virt-who service
     virt_who_data = rhel7_contenthost.virt_who_hypervisor_config(
-        default_sat,
+        target_sat,
         virt_who_config['general-information']['id'],
         org_id=org.id,
         lce_id=lce.id,
@@ -439,7 +439,7 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(session):
 
 @pytest.mark.tier3
 def test_positive_subscription_status_disabled_golden_ticket(
-    session, golden_ticket_host_setup, rhel7_contenthost, default_sat
+    session, golden_ticket_host_setup, rhel7_contenthost, target_sat
 ):
     """Verify that Content host Subscription status is set to 'Disabled'
      for a golden ticket manifest
@@ -454,7 +454,7 @@ def test_positive_subscription_status_disabled_golden_ticket(
 
     :CaseImportance: Medium
     """
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     org, ak = golden_ticket_host_setup
     rhel7_contenthost.register_contenthost(org.label, ak.name)
     assert rhel7_contenthost.subscribed
@@ -467,7 +467,7 @@ def test_positive_subscription_status_disabled_golden_ticket(
 
 
 @pytest.mark.tier2
-def test_positive_candlepin_events_processed_by_STOMP(session, rhel7_contenthost, default_sat):
+def test_positive_candlepin_events_processed_by_STOMP(session, rhel7_contenthost, target_sat):
     """Verify that Candlepin events are being read and processed by
        attaching subscriptions, validating host subscriptions status,
        and viewing processed and failed Candlepin events
@@ -499,7 +499,7 @@ def test_positive_candlepin_events_processed_by_STOMP(session, rhel7_contenthost
         organization=org,
         environment=entities.LifecycleEnvironment(id=org.library.id),
     ).create()
-    rhel7_contenthost.install_katello_ca(default_sat)
+    rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org.name, ak.name)
     with session:
         session.organization.select(org_name=org.name)

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -96,7 +96,7 @@ def test_positive_import_templates(session, templates_org, templates_loc):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_export_templates(session, create_import_export_local_dir, default_sat):
+def test_positive_export_templates(session, create_import_export_local_dir, target_sat):
     """Export the satellite templates to local directory
 
     :id: 1c24cf51-7198-48aa-a70a-8c0441333374
@@ -135,10 +135,10 @@ def test_positive_export_templates(session, create_import_export_local_dir, defa
         )
         assert export_title == f'Export to {FOREMAN_TEMPLATE_ROOT_DIR} as user {session._user}'
     exported_file = f'{dir_path}/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb'
-    result = default_sat.execute(f'find {exported_file} -type f')
+    result = target_sat.execute(f'find {exported_file} -type f')
     assert result.status == 0
     search_string = f'name: {export_template}'
-    result = default_sat.execute(f"grep -F '{search_string}' {exported_file}")
+    result = target_sat.execute(f"grep -F '{search_string}' {exported_file}")
     assert result.status == 0
 
 

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -32,7 +32,7 @@ from robottelo.constants import ROLES
 @pytest.mark.tier2
 @pytest.mark.pit_server
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, default_sat, test_name, module_org, module_location):
+def test_positive_end_to_end(session, target_sat, test_name, module_org, module_location):
     """Perform end to end testing for user component
 
     :id: 2794fdd0-cfe3-4f1a-aa5f-25b2d211ae12
@@ -53,7 +53,7 @@ def test_positive_end_to_end(session, default_sat, test_name, module_org, module
     description = gen_string('alphanumeric')
     language = 'English (United States)'
     timezone = '(GMT+00:00) UTC'
-    role = default_sat.api.Role().create().name
+    role = target_sat.api.Role().create().name
     with session:
         # Create new user and validate its values
         session.user.create(
@@ -107,7 +107,7 @@ def test_positive_end_to_end(session, default_sat, test_name, module_org, module
 
 
 @pytest.mark.tier2
-def test_positive_create_with_multiple_roles(session, default_sat):
+def test_positive_create_with_multiple_roles(session, target_sat):
     """Create User with multiple roles
 
     :id: d3cc4434-25ca-4465-8878-42495390c17b
@@ -122,7 +122,7 @@ def test_positive_create_with_multiple_roles(session, default_sat):
     role2 = gen_string('alpha')
     password = gen_string('alpha')
     for role in [role1, role2]:
-        default_sat.api.Role(name=role).create()
+        target_sat.api.Role(name=role).create()
     with session:
         session.user.create(
             {
@@ -166,7 +166,7 @@ def test_positive_create_with_all_roles(session):
 
 
 @pytest.mark.tier2
-def test_positive_create_with_multiple_orgs(session, default_sat):
+def test_positive_create_with_multiple_orgs(session, target_sat):
     """Create User associated to multiple Orgs
 
     :id: d74c0284-3995-4a4a-8746-00858282bf5d
@@ -180,7 +180,7 @@ def test_positive_create_with_multiple_orgs(session, default_sat):
     org_name2 = gen_string('alpha')
     password = gen_string('alpha')
     for org_name in [org_name1, org_name2]:
-        default_sat.api.Organization(name=org_name).create()
+        target_sat.api.Organization(name=org_name).create()
     with session:
         session.organization.select(org_name=DEFAULT_ORG)
         session.user.create(
@@ -202,7 +202,7 @@ def test_positive_create_with_multiple_orgs(session, default_sat):
 
 
 @pytest.mark.tier2
-def test_positive_update_with_multiple_roles(session, default_sat):
+def test_positive_update_with_multiple_roles(session, target_sat):
     """Update User with multiple roles
 
     :id: 127fb368-09fd-4f10-8319-566a1bcb5cd2
@@ -212,7 +212,7 @@ def test_positive_update_with_multiple_roles(session, default_sat):
     :CaseLevel: Integration
     """
     name = gen_string('alpha')
-    role_names = [default_sat.api.Role().create().name for _ in range(3)]
+    role_names = [target_sat.api.Role().create().name for _ in range(3)]
     password = gen_string('alpha')
     with session:
         session.user.create(
@@ -257,7 +257,7 @@ def test_positive_update_with_all_roles(session):
 
 
 @pytest.mark.tier2
-def test_positive_update_orgs(session, default_sat):
+def test_positive_update_orgs(session, target_sat):
     """Assign a User to multiple Orgs
 
     :id: a207188d-1ad1-4ff1-9906-bae1d91104fd
@@ -268,7 +268,7 @@ def test_positive_update_orgs(session, default_sat):
     """
     name = gen_string('alpha')
     password = gen_string('alpha')
-    org_names = [default_sat.api.Organization().create().name for _ in range(3)]
+    org_names = [target_sat.api.Organization().create().name for _ in range(3)]
     with session:
         session.organization.select(org_name=random.choice(org_names))
         session.user.create(
@@ -287,7 +287,7 @@ def test_positive_update_orgs(session, default_sat):
 
 @pytest.mark.tier2
 def test_positive_create_product_with_limited_user_permission(
-    session, default_sat, test_name, module_org, module_location
+    session, target_sat, test_name, module_org, module_location
 ):
     """A user with all permissions in Product and Repositories should be able to
     create a new product
@@ -309,10 +309,10 @@ def test_positive_create_product_with_limited_user_permission(
     product_name = gen_string('alpha')
     product_label = gen_string('alpha')
     product_description = gen_string('alpha')
-    role = default_sat.api.Role().create()
+    role = target_sat.api.Role().create()
     # Calling Products and Repositoy to get all the permissions in it
     create_role_permissions(role, {'Katello::Product': PERMISSIONS['Katello::Product']})
-    default_sat.api.User(
+    target_sat.api.User(
         default_organization=module_org,
         organization=[module_org],
         firstname='sample',

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -33,7 +33,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -43,7 +43,7 @@ def form_data(default_org, default_sat):
         'hypervisor_server': settings.virtwho.esx.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'hypervisor_username': settings.virtwho.esx.hypervisor_username,
         'hypervisor_password': settings.virtwho.esx.hypervisor_password,
     }

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_org, default_sat):
         'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
         'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
     }

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -40,7 +40,7 @@ def form_data(default_org, default_sat):
         'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_org, default_sat):
+def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_org, default_sat):
         'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
         'organization_id': default_org.id,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -40,7 +40,7 @@ from robottelo.virtwho_utils import virtwho_package_locked
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -50,7 +50,7 @@ def form_data(default_sat, default_org):
         'hypervisor-server': settings.virtwho.esx.hypervisor_server,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'hypervisor-username': settings.virtwho.esx.hypervisor_username,
         'hypervisor-password': settings.virtwho.esx.hypervisor_password,
     }
@@ -323,7 +323,7 @@ class TestVirtWhoConfigforEsx:
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_rhsm_option(self, default_org, form_data, virtwho_config, default_sat):
+    def test_positive_rhsm_option(self, default_org, form_data, virtwho_config, target_sat):
         """Verify rhsm options in the configure file"
 
         :id: b5b93d4d-e780-41c0-9eaa-2407cc1dcc9b
@@ -341,13 +341,13 @@ class TestVirtWhoConfigforEsx:
         deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
         rhsm_username = get_configure_option('rhsm_username', config_file)
         assert not User.exists(search=('login', rhsm_username))
-        assert get_configure_option('rhsm_hostname', config_file) == default_sat.hostname
+        assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
         assert get_configure_option('rhsm_prefix', config_file) == '/rhsm'
         VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_post_hypervisors(self, function_org, default_sat):
+    def test_positive_post_hypervisors(self, function_org, target_sat):
         """Post large json file to /rhsm/hypervisors"
 
         :id: e344c9d2-3538-4432-9a74-b025e9ef852d
@@ -364,7 +364,7 @@ class TestVirtWhoConfigforEsx:
         :BZ: 1637042, 1769680
         """
         data = hypervisor_json_create(hypervisors=100, guests=10)
-        url = f"{default_sat.url}/rhsm/hypervisors/{function_org.label}"
+        url = f"{target_sat.url}/rhsm/hypervisors/{function_org.label}"
         auth = (settings.server.admin_username, settings.server.admin_password)
         result = requests.post(url, auth=auth, verify=False, json=data)
         if result.status_code != 200:

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_sat, default_org):
         'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
         'hypervisor-password': settings.virtwho.hyperv.hypervisor_password,
     }

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -40,7 +40,7 @@ def form_data(default_sat, default_org):
         'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_sat, default_org):
         'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -7,7 +7,7 @@ from robottelo.logging import logger
 
 
 @pytest.fixture(scope='module')
-def module_user(request, default_sat, default_org, default_location):
+def module_user(request, module_target_sat, default_org, default_location):
     """Creates admin user with default org set to module org and shares that
     user for all tests in the same test module. User's login contains test
     module name as a prefix.
@@ -19,7 +19,7 @@ def module_user(request, default_sat, default_org, default_location):
     login = f'{test_module_name}_{gen_string("alphanumeric")}'
     password = gen_string('alphanumeric')
     logger.debug('Creating session user %r', login)
-    user = default_sat.api.User(
+    user = module_target_sat.api.User(
         admin=True,
         default_organization=default_org,
         default_location=default_location,

--- a/tests/upgrades/scenario_workers.py
+++ b/tests/upgrades/scenario_workers.py
@@ -14,13 +14,13 @@ _json_file = 'upgrade_workers.json'
 json_file = Path(_json_file)
 
 
-def save_worker_hostname(test_name, default_sat):
+def save_worker_hostname(test_name, target_sat):
     data = {}
     if json_file.exists():
         data = json.loads(json_file.read_text())
     # Removing the parameter name from test name before save
     test_name = test_name.split('[')[0] if '[' in test_name else test_name
-    data.update({test_name: default_sat.hostname})
+    data.update({test_name: target_sat.hostname})
     json_file.write_text(json.dumps(data))
 
 
@@ -35,10 +35,10 @@ def get_worker_hostname_from_testname(test_name, shared_workers):
 
 
 @pytest.fixture(autouse=True)
-def save_pre_upgrade_worker_hostname(request, default_sat):
+def save_pre_upgrade_worker_hostname(request, target_sat):
     """Saves the worker id of pre_upgrade test in json"""
     if request.node.get_closest_marker('pre_upgrade'):
-        save_worker_hostname(request.node.name, default_sat)
+        save_worker_hostname(request.node.name, target_sat)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -52,7 +52,7 @@ class TestCapsuleSync:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_user_scenario_capsule_sync(self, request, default_sat, default_org):
+    def test_pre_user_scenario_capsule_sync(self, request, target_sat, default_org):
         """Pre-upgrade scenario that creates and sync repository with
         rpm in satellite which will be synced in post upgrade scenario.
 
@@ -76,17 +76,17 @@ class TestCapsuleSync:
         )
         prod_name = f"{pre_test_name}_prod"
         cv_name = f"{pre_test_name}_cv"
-        repo_url = f'http://{default_sat.hostname}/pub/{repo_name}'
-        ak = default_sat.api.ActivationKey(organization=default_org.id).search(
+        repo_url = f'http://{target_sat.hostname}/pub/{repo_name}'
+        ak = target_sat.api.ActivationKey(organization=default_org.id).search(
             query={'search': f'name={activation_key}'}
         )[0]
         ak_env = ak.environment.read()
 
-        product = default_sat.api.Product(name=prod_name, organization=default_org.id).create()
+        product = target_sat.api.Product(name=prod_name, organization=default_org.id).create()
         create_repo(rpm1, repo_path)
-        repo = default_sat.api.Repository(product=product.id, name=repo_name, url=repo_url).create()
+        repo = target_sat.api.Repository(product=product.id, name=repo_name, url=repo_url).create()
         repo.sync()
-        content_view = default_sat.api.ContentView(
+        content_view = target_sat.api.ContentView(
             name=cv_name, organization=default_org.id
         ).create()
         content_view.repository = [repo]
@@ -98,7 +98,7 @@ class TestCapsuleSync:
 
     @pytest.mark.post_upgrade(depend_on=test_pre_user_scenario_capsule_sync)
     def test_post_user_scenario_capsule_sync(
-        self, request, dependent_scenario_name, default_sat, default_org
+        self, request, dependent_scenario_name, target_sat, default_org
     ):
         """Post-upgrade scenario that sync capsule from satellite and then
         verifies if the repo/rpm of pre-upgrade scenario is synced to capsule
@@ -123,24 +123,24 @@ class TestCapsuleSync:
             settings.upgrade.capsule_ak[settings.upgrade.os]
             or settings.upgrade.custom_capsule_ak[settings.upgrade.os]
         )
-        ak = default_sat.api.ActivationKey(organization=default_org.id).search(
+        ak = target_sat.api.ActivationKey(organization=default_org.id).search(
             query={'search': f'name={activation_key}'}
         )[0]
-        repo = default_sat.api.Repository(organization=default_org.id).search(
+        repo = target_sat.api.Repository(organization=default_org.id).search(
             query={'search': f'name={pre_test_name}_repo'}
         )[0]
-        product = default_sat.api.Product(organization=default_org.id).search(
+        product = target_sat.api.Product(organization=default_org.id).search(
             query={'search': f'name={pre_test_name}_prod'}
         )[0]
         env_name = ak.environment.read()
         org_name = env_name.organization.read_json()['label']
 
-        content_view = default_sat.api.ContentView(organization=f'{default_org.id}').search(
+        content_view = target_sat.api.ContentView(organization=f'{default_org.id}').search(
             query={'search': f'name={pre_test_name}_cv'}
         )[0]
-        capsule = default_sat.api.SmartProxy().search(query={'search': f'name={cap_host}'})[0]
+        capsule = target_sat.api.SmartProxy().search(query={'search': f'name={cap_host}'})[0]
         call_entity_method_with_timeout(
-            default_sat.api.Capsule(id=capsule.id).content_sync, timeout=3600
+            target_sat.api.Capsule(id=capsule.id).content_sync, timeout=3600
         )
         result = execute(
             lambda: run(
@@ -160,7 +160,7 @@ class TestCapsuleSyncNewRepo:
     """
 
     @pytest.mark.post_upgrade
-    def test_post_user_scenario_capsule_sync_yum_repo(self, request, default_sat, default_org):
+    def test_post_user_scenario_capsule_sync_yum_repo(self, request, target_sat, default_org):
         """Post-upgrade scenario that creates and sync repository with
         rpm, sync capsule with satellite and verifies if the repo/rpm in
         satellite is synced to capsule.
@@ -186,20 +186,20 @@ class TestCapsuleSyncNewRepo:
             or settings.upgrade.custom_capsule_ak[settings.upgrade.os]
         )
         cap_host = settings.upgrade.capsule_hostname
-        ak = default_sat.api.ActivationKey(organization=default_org.id).search(
+        ak = target_sat.api.ActivationKey(organization=default_org.id).search(
             query={'search': f'name={activation_key}'}
         )[0]
         ak_env = ak.environment.read()
-        repo_url = f'http://{default_sat.hostname}/pub/{repo_name}/'
-        product = default_sat.api.Product(organization=default_org.id).create()
+        repo_url = f'http://{target_sat.hostname}/pub/{repo_name}/'
+        product = target_sat.api.Product(organization=default_org.id).create()
         repo_path = f'/var/www/html/pub/{repo_name}/'
         create_repo(rpm2, repo_path)
 
-        repo = default_sat.api.Repository(
+        repo = target_sat.api.Repository(
             product=product.id, name=f'{repo_name}', url=repo_url
         ).create()
         repo.sync()
-        content_view = default_sat.api.ContentView(organization=default_org.id).create()
+        content_view = target_sat.api.ContentView(organization=default_org.id).create()
         content_view.repository = [repo]
         content_view = content_view.update(['repository'])
         content_view.publish()

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -23,8 +23,6 @@ from nailgun import entities
 from upgrade_tests.helpers.scenarios import create_dict
 from upgrade_tests.helpers.scenarios import get_entity_data
 
-from robottelo.api.utils import delete_puppet_class
-
 
 def _valid_sc_parameters_data():
     """Returns a list of valid smart class parameter types and values"""
@@ -56,7 +54,7 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
     """
 
     @pytest.fixture(scope="class")
-    def _setup_scenario(self, default_sat):
+    def _setup_scenario(self, class_target_sat):
         """Import some parametrized puppet classes. This is required to make
         sure that we have smart class variable available.
         Read all available smart class parameters for imported puppet class to
@@ -64,7 +62,7 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
         """
         self.org = entities.Organization().create()
         repo = 'api_test_classparameters'
-        env_name = default_sat.create_custom_environment(repo=repo)
+        env_name = class_target_sat.create_custom_environment(repo=repo)
         self.puppet_class = entities.PuppetClass().search(
             query={'search': f'name = "{repo}" and environment = "{env_name}"'}
         )[0]
@@ -75,11 +73,11 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
         create_dict(scenario_ents)
 
     @pytest.fixture(scope="class")
-    def _clean_scenario(self, request):
+    def _clean_scenario(self, request, class_target_sat):
         @request.addfinalizer
         def _cleanup():
             puppet_class = get_entity_data(self.__class__.__name__)['puppet_class']
-            delete_puppet_class(puppet_class)
+            class_target_sat.delete_puppet_class(puppet_class)
 
     def _validate_value(self, data, sc_param):
         """The helper function to validate the parameter actual and expected

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -30,7 +30,7 @@ class TestContentView:
     """
 
     @pytest.mark.pre_upgrade
-    def test_cv_preupgrade_scenario(self, request, default_sat):
+    def test_cv_preupgrade_scenario(self, request, target_sat):
         """Pre-upgrade scenario that creates content-view with various repositories.
 
         :id: preupgrade-a4ebbfa1-106a-4962-9c7c-082833879ae8
@@ -56,7 +56,7 @@ class TestContentView:
 
         remote_file_path = f"/tmp/{RPM_TO_UPLOAD}"
 
-        default_sat.put(get_data_file(RPM_TO_UPLOAD), remote_file_path)
+        target_sat.put(get_data_file(RPM_TO_UPLOAD), remote_file_path)
         with open(f'{get_data_file(RPM_TO_UPLOAD)}', "rb") as content:
             file_repository.upload_content(files={'content': content})
         assert RPM_TO_UPLOAD in file_repository.files()["results"][0]['name']

--- a/tests/upgrades/test_foreman_maintain.py
+++ b/tests/upgrades/test_foreman_maintain.py
@@ -97,7 +97,7 @@ class TestForemanMaintain:
         return zstream_version, next_version
 
     @pytest.mark.pre_upgrade
-    def test_pre_foreman_maintain_upgrade_list_versions(self, default_sat):
+    def test_pre_satellite_maintain_upgrade_list_versions(self, target_sat):
         """Pre-upgrade sceanrio that tests list of satellite version
         which satellite can be upgraded.
 
@@ -114,7 +114,7 @@ class TestForemanMaintain:
             upgradable_version,
             major_version_change,
             y_version,
-        ) = self.satellite_upgradable_version_list(default_sat)
+        ) = self.satellite_upgradable_version_list(target_sat)
         if satellite_version:
             # In future If foreman-maintain packages update add before
             # pre-upgrade test case execution then next version kind of
@@ -127,7 +127,7 @@ class TestForemanMaintain:
         assert zstream_version in upgradable_version
 
     @pytest.mark.post_upgrade
-    def test_post_foreman_maintain_upgrade_list_versions(self, default_sat):
+    def test_post_satellite_maintain_upgrade_list_versions(self, target_sat):
         """Post-upgrade sceanrio that tests list of satellite version
         which satellite can be upgraded.
 
@@ -144,7 +144,7 @@ class TestForemanMaintain:
             upgradable_version,
             major_version_change,
             y_version,
-        ) = self.satellite_upgradable_version_list(default_sat)
+        ) = self.satellite_upgradable_version_list(target_sat)
         if satellite_version:
             zstream_version, next_version = self.version_details(
                 satellite_version[0], major_version_change, y_version, upgrade_stage="post-upgrade"

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -50,13 +50,13 @@ class TestScenarioPositiveGCEHostComputeResource:
     """
 
     @pytest.fixture(scope='class')
-    def arch_os_domain(self, default_sat):
-        arch = default_sat.api.Architecture().search(query={'search': 'name=x86_64'})[0]
-        os = default_sat.api.OperatingSystem().search(
+    def arch_os_domain(self, class_target_sat):
+        arch = class_target_sat.api.Architecture().search(query={'search': 'name=x86_64'})[0]
+        os = class_target_sat.api.OperatingSystem().search(
             query={'search': 'family=Redhat and major=7'}
         )[0]
 
-        domain_name = default_sat.hostname.split('.', 1)[1]
+        domain_name = class_target_sat.hostname.split('.', 1)[1]
         return namedtuple('ArchOsDomain', ['arch', 'os', 'domain'])(arch, os, domain_name)
 
     @pytest.fixture(scope='class')
@@ -115,7 +115,7 @@ class TestScenarioPositiveGCEHostComputeResource:
         assert gce_img.name == 'autoupgrade_gce_img'
 
     @pytest.mark.post_upgrade(depend_on=test_pre_create_gce_cr_and_host)
-    def test_post_create_gce_cr_and_host(self, default_sat, arch_os_domain, delete_host):
+    def test_post_create_gce_cr_and_host(self, target_sat, arch_os_domain, delete_host):
         """Host provisioned using preupgrade GCE CR
 
         :id: postupgrade-ef82143d-efef-49b2-9702-93d67ef6804c
@@ -147,7 +147,7 @@ class TestScenarioPositiveGCEHostComputeResource:
             'image_id': LATEST_RHEL7_GCE_IMG_UUID,
         }
         # Host Provisioning Tests
-        with default_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
+        with target_sat.skip_yum_update_during_provisioning(template='Kickstart default finish'):
             gce_hst = entities.Host(
                 name=hostname,
                 organization=org,

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -48,7 +48,7 @@ class TestScenarioPerformanceTuning:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_performance_tuning_apply(self, default_sat):
+    def test_pre_performance_tuning_apply(self, target_sat):
         """In preupgrade scenario we apply the medium tuning size.
 
         :id: preupgrade-83404326-20b7-11ea-a370-48f17f1fc2e1
@@ -63,27 +63,27 @@ class TestScenarioPerformanceTuning:
 
         """
         try:
-            default_sat.get(
+            target_sat.get(
                 local_path="custom-hiera-before-upgrade.yaml",
                 remote_path="/etc/foreman-installer/custom-hiera.yaml",
             )
             installer_obj = InstallerCommand(tuning='medium')
-            command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
+            command_output = target_sat.execute(installer_obj.get_command(), timeout='30m')
             assert 'Success!' in command_output.stdout
             installer_obj = InstallerCommand(help='tuning')
-            command_output = default_sat.execute(installer_obj.get_command())
+            command_output = target_sat.execute(installer_obj.get_command())
             assert 'default: "medium"' in command_output.stdout
 
         except Exception as exp:
             logger.critical(exp)
             installer_obj = InstallerCommand(tuning='default')
-            command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
+            command_output = target_sat.execute(installer_obj.get_command(), timeout='30m')
             assert 'Success!' in command_output.stdout
             assert 'default: "default"' in command_output.stdout
             raise
 
     @pytest.mark.post_upgrade(depend_on=test_pre_performance_tuning_apply)
-    def test_post_performance_tuning_apply(self, default_sat):
+    def test_post_performance_tuning_apply(self, target_sat):
         """In postupgrade scenario, we verify the set tuning parameters and custom-hiera.yaml
         file's content.
 
@@ -101,16 +101,16 @@ class TestScenarioPerformanceTuning:
 
         """
         installer_obj = InstallerCommand(help='tuning')
-        command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
+        command_output = target_sat.execute(installer_obj.get_command(), timeout='30m')
         assert 'default: "medium"' in command_output.stdout
-        default_sat.get(
+        target_sat.get(
             local_path="custom-hiera-after-upgrade.yaml",
             remote_path="/etc/foreman-installer/custom-hiera.yaml",
         )
         assert filecmp.cmp('custom-hiera-before-upgrade.yaml', 'custom-hiera-after-upgrade.yaml')
         installer_obj = InstallerCommand(tuning='default')
-        command_output = default_sat.execute(installer_obj.get_command(), timeout='30m')
+        command_output = target_sat.execute(installer_obj.get_command(), timeout='30m')
         assert 'Success!' in command_output.stdout
         installer_obj = InstallerCommand(help='tuning')
-        command_output = default_sat.execute(installer_obj.get_command())
+        command_output = target_sat.execute(installer_obj.get_command())
         assert 'default: "default"' in command_output.stdout

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -164,7 +164,7 @@ class TestScenarioREXSatellite:
 
     @pytest.mark.pre_upgrade
     def test_pre_scenario_remoteexecution_satellite(
-        self, request, compute_resource_setup, default_location, rhel7_contenthost, default_sat
+        self, request, compute_resource_setup, default_location, rhel7_contenthost, target_sat
     ):
         """Run REX job on client registered with Satellite
 
@@ -191,7 +191,7 @@ class TestScenarioREXSatellite:
             organization=[self.org.id],
             remote_execution_proxy=[entities.SmartProxy(id=1)],
         ).create()
-        rhel7_contenthost.configure_rex(satellite=default_sat, org=self.org, by_ip=False)
+        rhel7_contenthost.configure_rex(satellite=target_sat, org=self.org, by_ip=False)
         host = rhel7_contenthost.nailgun_host
         host[0].subnet = sn
         host[0].update(['subnet'])

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -58,7 +58,7 @@ class TestScenarioRepositoryUpstreamAuthorizationCheck:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_repository_scenario_upstream_authorization(self, default_sat):
+    def test_pre_repository_scenario_upstream_authorization(self, target_sat):
         """Create a custom repository and set the upstream username on it.
 
         :id: preupgrade-11c5ceee-bfe0-4ce9-8f7b-67a835baf522
@@ -73,7 +73,7 @@ class TestScenarioRepositoryUpstreamAuthorizationCheck:
         :BZ: 1641785
         """
 
-        org = default_sat.api.Organization().create()
+        org = target_sat.api.Organization().create()
         custom_repo = create_sync_custom_repo(org_id=org.id)
         rake_repo = f'repo = Katello::Repository.find_by_id({custom_repo})'
         rake_username = f'; repo.root.upstream_username = "{UPSTREAM_USERNAME}"'
@@ -128,7 +128,7 @@ class TestScenarioCustomRepoCheck:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_scenario_custom_repo_check(self, default_sat):
+    def test_pre_scenario_custom_repo_check(self, target_sat):
         """This is pre-upgrade scenario test to verify if we can create a
          custom repository and consume it via content host.
 
@@ -147,21 +147,21 @@ class TestScenarioCustomRepoCheck:
             2. Package is installed on Content host.
 
         """
-        org = default_sat.api.Organization().create()
-        loc = default_sat.api.Location(organization=[org]).create()
-        lce = default_sat.api.LifecycleEnvironment(organization=org).create()
+        org = target_sat.api.Organization().create()
+        loc = target_sat.api.Location(organization=[org]).create()
+        lce = target_sat.api.LifecycleEnvironment(organization=org).create()
 
-        product = default_sat.api.Product(organization=org).create()
+        product = target_sat.api.Product(organization=org).create()
         create_repo(rpm1, FILE_PATH)
-        repo = default_sat.api.Repository(
-            product=product.id, url=f'{default_sat.url}/pub/custom_repo'
+        repo = target_sat.api.Repository(
+            product=product.id, url=f'{target_sat.url}/pub/custom_repo'
         ).create()
         repo.sync()
 
         content_view = publish_content_view(org=org, repolist=repo)
         promote(content_view.version[0], lce.id)
 
-        result = default_sat.execute(
+        result = target_sat.execute(
             f'ls /var/lib/pulp/published/yum/https/repos/{org.label}/{lce.name}/'
             f'{content_view.label}/custom/{product.label}/{repo.label}/Packages/b/'
             f'|grep {RPM1_NAME}'
@@ -170,10 +170,10 @@ class TestScenarioCustomRepoCheck:
         assert result.status == 0
         assert len(result.stdout) >= 1
 
-        subscription = default_sat.api.Subscription(organization=org).search(
+        subscription = target_sat.api.Subscription(organization=org).search(
             query={'search': f'name={product.name}'}
         )[0]
-        ak = default_sat.api.ActivationKey(
+        ak = target_sat.api.ActivationKey(
             content_view=content_view, organization=org.id, environment=lce
         ).create()
         ak.add_subscriptions(data={'subscription_id': subscription.id})
@@ -208,7 +208,7 @@ class TestScenarioCustomRepoCheck:
         create_dict(scenario_dict)
 
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_custom_repo_check)
-    def test_post_scenario_custom_repo_check(self, default_sat):
+    def test_post_scenario_custom_repo_check(self, target_sat):
         """This is post-upgrade scenario test to verify if we can alter the
         created custom repository and satellite will be able to sync back
         the repo.
@@ -235,16 +235,16 @@ class TestScenarioCustomRepoCheck:
         repo_name = entity_data.get('repo_name')
 
         create_repo(rpm2, FILE_PATH, post_upgrade=True, other_rpm=rpm1)
-        repo = default_sat.api.Repository(name=repo_name).search()[0]
+        repo = target_sat.api.Repository(name=repo_name).search()[0]
         repo.sync()
 
-        content_view = default_sat.api.ContentView(name=content_view_name).search()[0]
+        content_view = target_sat.api.ContentView(name=content_view_name).search()[0]
         content_view.publish()
 
-        content_view = default_sat.api.ContentView(name=content_view_name).search()[0]
+        content_view = target_sat.api.ContentView(name=content_view_name).search()[0]
         promote(content_view.version[-1], lce_id)
 
-        result = default_sat.execute(
+        result = target_sat.execute(
             'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'
             'Packages/c/| grep {}'.format(
                 org_label, lce_name, content_view.label, prod_label, repo.label, RPM2_NAME

--- a/tests/upgrades/test_satellitesync.py
+++ b/tests/upgrades/test_satellitesync.py
@@ -74,7 +74,7 @@ class TestSatelliteSync:
         indirect=True,
     )
     def test_post_version_cv_export_import(
-        self, request, set_importing_org, dependent_scenario_name, default_sat
+        self, request, set_importing_org, dependent_scenario_name, target_sat
     ):
         """After upgrade, content view version import and export works on the existing content
          view(that we created before the upgrade).
@@ -111,7 +111,7 @@ class TestSatelliteSync:
         ContentView.version_export({'export-dir': f'{export_base}', 'id': exporting_cvv_id})
         exported_tar = f'{export_base}/export-{exporting_cv.name}-{exporting_cvv_version}.tar'
 
-        result = default_sat.execute(f'[ -f {exported_tar} ]')
+        result = target_sat.execute(f'[ -f {exported_tar} ]')
         assert result.status == 0
 
         exported_packages = Package.list({'content-view-version-id': exporting_cvv_id})
@@ -125,7 +125,7 @@ class TestSatelliteSync:
         imported_packages = Package.list({'content-view-version-id': importing_cvv[0].id})
         assert len(imported_packages) > 0
         assert len(exported_packages) == len(imported_packages)
-        default_sat.execute(f'rm -rf {export_base}/*')
+        target_sat.execute(f'rm -rf {export_base}/*')
         exporting_cv_json = exporting_cv.read_json()
         importing_cv_json = importing_cv.read_json()
         exporting_cv_env_id = exporting_cv_json['environments'][0]['id']

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -92,7 +92,7 @@ class TestSubscriptionAutoAttach:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_subscription_scenario_autoattach(self, request, default_sat):
+    def test_pre_subscription_scenario_autoattach(self, request, target_sat):
         """Create content host and register with Satellite
 
         :id: preupgrade-940fc78c-ffa6-4d9a-9c4b-efa1b9480a22
@@ -148,7 +148,7 @@ class TestSubscriptionAutoAttach:
 
     @pytest.mark.post_upgrade(depend_on=test_pre_subscription_scenario_autoattach)
     def test_post_subscription_scenario_autoattach(
-        self, request, dependent_scenario_name, default_sat
+        self, request, dependent_scenario_name, target_sat
     ):
         """Run subscription auto-attach on pre-upgrade content host registered
         with Satellite.

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -32,7 +32,7 @@ class TestUserGroupMembership:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_create_usergroup_with_ldap_user(self, request, default_sat):
+    def test_pre_create_usergroup_with_ldap_user(self, request, target_sat):
         """Create Usergroup in preupgrade version.
 
         :id: preupgrade-4b11d883-f523-4f38-b65a-650ecd90335c
@@ -44,7 +44,7 @@ class TestUserGroupMembership:
 
         :expectedresults: The usergroup, with ldap user as member, should be created successfully.
         """
-        authsource = default_sat.api.AuthSourceLDAP(
+        authsource = target_sat.api.AuthSourceLDAP(
             onthefly_register=True,
             account=settings.ldap.username,
             account_password=settings.ldap.password,
@@ -63,14 +63,14 @@ class TestUserGroupMembership:
         assert authsource.name == request.node.name + "_server"
         sc = ServerConfig(
             auth=(settings.ldap.username, settings.ldap.password),
-            url=default_sat.url,
+            url=target_sat.url,
             verify=False,
         )
 
         with pytest.raises(HTTPError):
             entities.User(sc).search()
-        user_group = default_sat.api.UserGroup(name=request.node.name + "_user_group").create()
-        user = default_sat.api.User().search(query={'search': f'login={settings.ldap.username}'})[0]
+        user_group = target_sat.api.UserGroup(name=request.node.name + "_user_group").create()
+        user = target_sat.api.User().search(query={'search': f'login={settings.ldap.username}'})[0]
         user_group.user = [user]
         user_group = user_group.update(['user'])
         assert user.login == user_group.user[0].read().login

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -37,7 +37,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture
-def form_data(default_sat):
+def form_data(target_sat):
     esx = settings.virtwho.esx
     return {
         'debug': 1,
@@ -46,7 +46,7 @@ def form_data(default_sat):
         'hypervisor_type': esx.hypervisor_type,
         'hypervisor_server': esx.hypervisor_server,
         'filtering_mode': 'none',
-        'satellite_url': default_sat.hostname,
+        'satellite_url': target_sat.hostname,
         'hypervisor_username': esx.hypervisor_username,
         'hypervisor_password': esx.hypervisor_password,
         'name': 'preupgrade_virt_who',


### PR DESCRIPTION
In this change, I replace all current usage of the default_sat fixture
with a new target_sat fixture. This new fixture can provide the original
default_sat object as well as dynamically provision new Satellite
instances when needed. This is initially used to replace all uses of the
destructive_sat fixture to also use the new target_sat. It achieves this
by looking for the destructive marker; when attached to a downstream
test, all fixtures in the chain will then use the destructive target_sat
instance.
Other satellite types (like fips) could be similarly controlled in this
way.