### PR TITLE
refactor1: replaced the entities with target.sat

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -754,7 +754,7 @@ class TestContentViewPublishPromote:
 
         :CaseAutomation: Automated
         """
-        org = entities.Organization().create()
+        org = target_sat.api.Organization().create()
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
         rhel7_extra = enable_rhrepo_and_fetchid(
@@ -781,12 +781,12 @@ class TestContentViewPublishPromote:
             reposet=constants.REPOSET['rhel7_sup'],
             releasever=constants.REPOS['rhel7_sup']['releasever'],
         )
-        rhel7_extra = entities.Repository(id=rhel7_extra).read()
-        rhel7_optional = entities.Repository(id=rhel7_optional).read()
-        rhel7_sup = entities.Repository(id=rhel7_sup).read()
+        rhel7_extra = target_sat.api.Repository(id=rhel7_extra).read()
+        rhel7_optional = target_sat.api.Repository(id=rhel7_optional).read()
+        rhel7_sup = target_sat.api.Repository(id=rhel7_sup).read()
         for repo in [rhel7_extra, rhel7_optional, rhel7_sup]:
             repo.sync(timeout=1200)
-        cv = entities.ContentView(
+        cv = target_sat.api.ContentView(
             organization=org,
             solve_dependencies=True,
             repository=[rhel7_extra, rhel7_sup, rhel7_optional],
@@ -800,13 +800,13 @@ class TestContentViewPublishPromote:
                 max_tries=60,
             )
         except TaskFailedError:
-            entities.ForemanTask().bulk_resume(data={"task_ids": [publish_task['id']]})
+            target_sat.api.ForemanTask().bulk_resume(data={"task_ids": [publish_task['id']]})
             wait_for_tasks(
                 search_query=(f'id = {publish_task["id"]}'),
                 search_rate=30,
                 max_tries=60,
             )
-        task_status = entities.ForemanTask(id=publish_task['id']).poll()
+        task_status = target_sat.api.ForemanTask(id=publish_task['id']).poll()
         assert task_status['result'] == 'success'
 
 

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -679,7 +679,7 @@ class TestLibvirtHostDiscovery:
 
         :CaseImportance: Critical
         """
-        subnet = entities.Subnet(id=provisioning_env['subnet']['id']).read()
+        subnet = target_sat.api.Subnet(id=provisioning_env['subnet']['id']).read()
         # Updating satellite subnet component and dhcp conf ranges
         # Storing now for restoring later
         old_sub_from = subnet.from_
@@ -709,13 +709,13 @@ class TestLibvirtHostDiscovery:
                         new_dhcp_conf_to.split('.')[-1]
                     )
                     # Provision just discovered host
-                    discovered_host.hostgroup = entities.HostGroup(
+                    discovered_host.hostgroup = target_sat.api.HostGroup(
                         id=provisioning_env['hostgroup']['id']
                     ).read()
                     discovered_host.root_pass = gen_string('alphanumeric')
                     discovered_host.update(['hostgroup', 'root_pass'])
                     # Assertions
-                    provisioned_host = entities.Host().search(
+                    provisioned_host = target_sat.api.Host().search(
                         query={
                             'search': 'name={}.{}'.format(
                                 discovered_host.name, provisioning_env['domain']['name']
@@ -726,7 +726,7 @@ class TestLibvirtHostDiscovery:
                         new_subnet_from.split('.')[-1]
                     )
                     assert int(provisioned_host.ip.split('.')[-1]) <= int(old_sub_to_4o)
-                    assert not entities.DiscoveredHost().search(
+                    assert not target_sat.api.DiscoveredHost().search(
                         query={'search': f'name={discovered_host.name}'}
                     )
             finally:

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1443,7 +1443,7 @@ class TestRepositorySync:
 
         :CaseAutomation: Automated
         """
-        org = entities.Organization().create()
+        org = target_sat.api.Organization().create()
         with manifests.clone() as manifest:
             upload_manifest(org.id, manifest.content)
         rhel7_extra = enable_rhrepo_and_fetchid(
@@ -1454,7 +1454,7 @@ class TestRepositorySync:
             reposet=constants.REPOSET['rhel7_extra'],
             releasever=None,
         )
-        rhel7_extra = entities.Repository(id=rhel7_extra).read()
+        rhel7_extra = target_sat.api.Repository(id=rhel7_extra).read()
         sync_task = rhel7_extra.sync(synchronous=False)
         target_sat.power_control(state='reboot', ensure=True)
         try:
@@ -1470,7 +1470,7 @@ class TestRepositorySync:
                 search_rate=15,
                 max_tries=10,
             )
-        task_status = entities.ForemanTask(id=sync_task['id']).poll()
+        task_status = target_sat.api.ForemanTask(id=sync_task['id']).poll()
         assert task_status['result'] == 'success'
 
 

--- a/tests/foreman/sys/test_hooks.py
+++ b/tests/foreman/sys/test_hooks.py
@@ -18,7 +18,6 @@
 """
 import pytest
 from fauxfactory import gen_ipaddr
-from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.datafactory import valid_hostgroups_list
@@ -75,7 +74,7 @@ def test_positive_host_hooks(logger_hook, target_sat):
     assert result.status == 0
 
     # delete host, check logs for hook activity
-    host = entities.Host(name=host_name).create()
+    host = target_sat.api.Host(name=host_name).create()
     assert host.name == f'{host_name}.{host.domain.read().name}'
     result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
@@ -128,14 +127,14 @@ def test_positive_hostgroup_hooks(logger_hook, default_org, target_sat):
     assert result.status == 0
 
     # create hg, check logs for hook activity
-    hg = entities.HostGroup(name=hg_name, organization=[default_org.id]).create()
+    hg = target_sat.api.HostGroup(name=hg_name, organization=[default_org.id]).create()
     assert hg.name == hg_name
     result = target_sat.execute(f'cat {LOGS_DIR}')
     assert result.status == 0
     assert expected_msg.format(create_event, hg_name) in result.stdout
 
     # update hg, check logs for hook activity
-    new_arch = entities.Architecture().create()
+    new_arch = target_sat.api.Architecture().create()
     hg.architecture = new_arch
     hg = hg.update(['architecture'])
     assert hg.architecture.read().name == new_arch.name

--- a/tests/foreman/sys/test_rename.py
+++ b/tests/foreman/sys/test_rename.py
@@ -19,7 +19,6 @@
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 
 from robottelo.cli import hammer
 from robottelo.config import settings
@@ -76,8 +75,8 @@ class TestRenameHost:
         new_hostname = f'new-{old_hostname}'
         # create installation medium with hostname in path
         medium_path = f'http://{old_hostname}/testpath-{gen_string("alpha")}/os/'
-        medium = entities.Media(organization=[module_org], path_=medium_path).create()
-        repo = entities.Repository(product=module_product, name='testrepo').create()
+        medium = target_sat.api.Media(organization=[module_org], path_=medium_path).create()
+        repo = target_sat.api.Repository(product=module_product, name='testrepo').create()
         result = target_sat.execute(
             f'satellite-change-hostname {new_hostname} -y -u {username} -p {password}',
             timeout=1200000,
@@ -128,7 +127,7 @@ class TestRenameHost:
         assert result.status == 1, 'there are remaining instances of the old hostname'
 
         repo.sync()
-        cv = entities.ContentView(organization=module_org).create()
+        cv = target_sat.api.ContentView(organization=module_org).create()
         cv.repository = [repo]
         cv.update(['repository'])
         cv.publish()

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -305,8 +305,8 @@ def test_positive_create_with_https(
             server_type='AD', target_sat=target_sat, hostname=ldap_data['ldap_hostname']
         )
         username = settings.ldap.username
-    org = entities.Organization().create()
-    loc = entities.Location().create()
+    org = target_sat.api.Organization().create()
+    loc = target_sat.api.Location().create()
     ldap_auth_name = gen_string('alphanumeric')
 
     with session:
@@ -339,7 +339,7 @@ def test_positive_create_with_https(
     with Session(test_name, username, ldap_data['ldap_user_passwd']) as ldapsession:
         with pytest.raises(NavigationTriesExceeded):
             ldapsession.user.search('')
-    users = entities.User().search(
+    users = target_sat.api.User().search(
         query={'search': 'login="{}"'.format(ldap_data['ldap_user_name'])}
     )
     assert users[0].login == ldap_data['ldap_user_name']


### PR DESCRIPTION
At the test level, `entities` should be replaced with `target_sat.api `. This PR only covers at test level, further PR will update the common functions where the entities are used in destructive tests.  