### PR TITLE
updated packages for rhel8/9 fips install

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -356,12 +356,12 @@ class TestRemoteExecution:
         """
         self.org = module_org
         client = rex_contenthost
-        packages = ['cow', 'dog', 'lion']
+        packages = ['monkey', 'panda', 'seal']
         # Create a custom repo
         repo = entities.Repository(
             content_type='yum',
             product=entities.Product(organization=self.org).create(),
-            url=settings.repos.yum_0.url,
+            url=settings.repos.yum_3.url,
         ).create()
         repo.sync()
         prod = repo.product.read()
@@ -786,12 +786,12 @@ class TestAnsibleREX:
         """
         self.org = module_org
         client = rex_contenthost
-        packages = ['cow']
+        packages = ['tapir']
         # Create a custom repo
         repo = entities.Repository(
             content_type='yum',
             product=entities.Product(organization=self.org).create(),
-            url=settings.repos.yum_0.url,
+            url=settings.repos.yum_3.url,
         ).create()
         repo.sync()
         prod = repo.product.read()


### PR DESCRIPTION
rhel8/9 fips hosts won't install packages created by older versions of rpm, installation would fail with `package tiger-1.0-4.noarch does not verify: no digest`

This is the case for our fake yum_0 repo. This PR updates the rex package install tests to use fake_yum_3 that passes on these systems. The output of `rpm --checksig` for a rhel8/9 fips acceptable pkg should look something like:

```
rpm --checksig -v tapir-8.4.4-1.noarch.rpm 
tapir-8.4.4-1.noarch.rpm:
    Header SHA256 digest: OK
    Header SHA1 digest: OK
    Payload SHA256 digest: OK
    MD5 digest: OK
```

