### PR TITLE
[Nutanix_UI_Support]: add new cases

### DIFF
--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -1,0 +1,152 @@
+"""Test class for Virtwho Configure UI
+
+:Requirement: Virt-whoConfigurePlugin
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Virt-whoConfigurePlugin
+
+:Assignee: yanpliu
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+from fauxfactory import gen_string
+
+from robottelo.config import settings
+from robottelo.virtwho_utils import deploy_configure_by_command
+from robottelo.virtwho_utils import deploy_configure_by_script
+from robottelo.virtwho_utils import get_configure_command
+from robottelo.virtwho_utils import get_configure_file
+from robottelo.virtwho_utils import get_configure_id
+from robottelo.virtwho_utils import get_configure_option
+
+
+@pytest.fixture()
+def form_data():
+    form = {
+        'debug': True,
+        'interval': 'Every hour',
+        'hypervisor_id': 'hostname',
+        'hypervisor_type': settings.virtwho.ahv.hypervisor_type,
+        'hypervisor_content.server': settings.virtwho.ahv.hypervisor_server,
+        'hypervisor_content.username': settings.virtwho.ahv.hypervisor_username,
+        'hypervisor_content.password': settings.virtwho.ahv.hypervisor_password,
+        'hypervisor_content.prism_flavor': "Prism Element",
+    }
+    return form
+
+
+class TestVirtwhoConfigforNutanix:
+    @pytest.mark.tier2
+    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
+        """Verify configure created and deployed with id.
+
+        :id: becea4d0-db4e-4a85-93d2-d40e86da0e2f
+
+        :expectedresults:
+            1. Config can be created and deployed by command
+            2. No error msg in /var/log/rhsm/rhsm.log
+            3. Report is sent to satellite
+            4. Virtual sku can be generated and attached
+            5. Config can be deleted
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+        """
+        name = gen_string('alpha')
+        form_data['name'] = name
+        with session:
+            session.virtwho_configure.create(form_data)
+            values = session.virtwho_configure.read(name)
+            command = values['deploy']['command']
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
+            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+            session.contenthost.add_subscription(guest_name, vdc_virtual)
+            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
+            session.virtwho_configure.delete(name)
+            assert not session.virtwho_configure.search(name)
+
+    @pytest.mark.tier2
+    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
+        """Verify configure created and deployed with script.
+
+        :id: 1c1b19c9-988c-4b86-a2b2-658fded10ccb
+
+        :expectedresults:
+            1. Config can be created and deployed by script
+            2. No error msg in /var/log/rhsm/rhsm.log
+            3. Report is sent to satellite
+            4. Virtual sku can be generated and attached
+            5. Config can be deleted
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+        """
+        name = gen_string('alpha')
+        form_data['name'] = name
+        with session:
+            session.virtwho_configure.create(form_data)
+            values = session.virtwho_configure.read(name)
+            script = values['deploy']['script']
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
+            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+            session.contenthost.add_subscription(guest_name, vdc_virtual)
+            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
+            session.virtwho_configure.delete(name)
+            assert not session.virtwho_configure.search(name)
+
+    @pytest.mark.tier2
+    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
+        """Verify Hypervisor ID dropdown options.
+
+        :id: e076a305-88f4-42fb-8ef2-cb55e38eb912
+
+        :expectedresults:
+            hypervisor_id can be changed in virt-who-config-{}.conf if the
+            dropdown option is selected to uuid/hwuuid/hostname.
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+        """
+        name = gen_string('alpha')
+        form_data['name'] = name
+        with session:
+            session.virtwho_configure.create(form_data)
+            config_id = get_configure_id(name)
+            config_command = get_configure_command(config_id, default_org.name)
+            config_file = get_configure_file(config_id)
+            values = ['uuid', 'hostname']
+            for value in values:
+                session.virtwho_configure.edit(name, {'hypervisor_id': value})
+                results = session.virtwho_configure.read(name)
+                assert results['overview']['hypervisor_id'] == value
+                deploy_configure_by_command(
+                    config_command, form_data['hypervisor_type'], org=default_org.label
+                )
+                assert get_configure_option('hypervisor_id', config_file) == value
+            session.virtwho_configure.delete(name)
+            assert not session.virtwho_configure.search(name)


### PR DESCRIPTION
Add Nutanix UI new cases:
test_positive_deploy_configure_by_id
test_positive_deploy_configure_by_script
test_positive_hypervisor_id_option

Nutanix cases: PASS

```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/ui/test_nutanix.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.0.12
collected 3 items / 3 deselected / 0 selected                                                                                                                                                                     

tests/foreman/virtwho/ui/test_nutanix.py ...                                                                                                                                                                [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-03.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_script
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_hypervisor_id_option
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_id
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_script
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_script
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_script
tests/foreman/virtwho/ui/test_nutanix.py::TestVirtwhoConfigforNutanix::test_positive_deploy_configure_by_script
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/widgetastic/browser.py:260: DeprecationWarning: desired_capabilities is deprecated. Please call capabilities.
    version = self.selenium.desired_capabilities.get("browserVersion")

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 3 passed, 3 deselected, 17 warnings in 1712.91s (0:28:32) 
```
This PR is depended on the nutanix airgun support PR
https://github.com/SatelliteQE/airgun/pull/700

