### PR TITLE
Removed `skip tests for bug 1850934` and UI test teardown fix

### DIFF
--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -278,7 +278,6 @@ class TestAzureRMHostProvisioningTestCase:
 
         return azurermclient.get_vm(name=class_host_ft.name.split('.')[0])
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_azurerm_host_provisioned(self, class_host_ft, azureclient_host):
@@ -312,7 +311,6 @@ class TestAzureRMHostProvisioningTestCase:
         assert self.hostname.lower() == azureclient_host.name
         assert self.vm_size == azureclient_host.type
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.tier3
     def test_positive_azurerm_host_power_on_off(self, class_host_ft, azureclient_host):
         """Host can be powered on and off
@@ -437,7 +435,6 @@ class TestAzureRMUserDataProvisioning:
 
         return azurermclient.get_vm(name=class_host_ud.name.split('.')[0])
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_azurerm_ud_host_provisioned(self, class_host_ud, azureclient_host):
@@ -473,7 +470,6 @@ class TestAzureRMUserDataProvisioning:
         assert self.hostname.lower() == azureclient_host.name
         assert self.vm_size == azureclient_host.type
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_host_disassociate_associate(self, class_host_ud, module_azurerm_cr_puppet):
@@ -594,7 +590,6 @@ class TestAzureRMSharedGalleryFinishTemplateProvisioning:
 
         return azurermclient.get_vm(name=class_host_gallery_ft.name.split('.')[0])
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_azurerm_shared_gallery_host_provisioned(
@@ -722,7 +717,6 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
 
         return azurermclient.get_vm(name=class_host_custom_ft.name.split('.')[0])
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_azurerm_custom_image_host_provisioned(

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -215,7 +215,6 @@ class TestAzureRMComputeResourceTestCase:
         assert result['message'] == 'Image deleted.'
         assert result['name'] == new_img_name
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.tier2
     def test_positive_check_available_networks(self, azurermclient, module_azurerm_cr):
         """Check networks from AzureRm CR are available to select during host provision.
@@ -373,7 +372,6 @@ class TestAzureRMFinishTemplateProvisioning:
         """Returns the AzureRM Client Host object to perform the assertions"""
         return azurermclient.get_vm(name=class_host_ft['name'].split('.')[0])
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_azurerm_host_provisioned(
@@ -499,7 +497,6 @@ class TestAzureRMUserDataProvisioning:
         """Returns the AzureRM Client Host object to perform the assertions"""
         return azurermclient.get_vm(name=class_host_ud['name'].split('.')[0])
 
-    @pytest.mark.skip_if_open("BZ:1850934")
     @pytest.mark.upgrade
     @pytest.mark.tier3
     def test_positive_azurerm_host_provisioned(

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -85,7 +85,6 @@ def module_azure_hg(
     ).create()
 
 
-@pytest.mark.skip_if_open("BZ:1850934")
 @pytest.mark.tier4
 def test_positive_end_to_end_azurerm_ft_host_provision(
     session,
@@ -163,12 +162,12 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
             )
             if azure_vm:
                 azure_vm[0].delete(synchronous=False)
+            azurecloud_vm = azurermclient.get_vm(name=hostname.lower())
             if azurecloud_vm.exists:
                 azurecloud_vm.delete()
             raise error
 
 
-@pytest.mark.skip_if_open("BZ:1850934")
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_azurerm_host_provision_ud(


### PR DESCRIPTION
- Removed `skip_if_open("BZ:1850934")` on tests since the bug is closed.
- Fixing the issue in UI teardown saying `azurecloud_vm referenced before assignment`