### PR TITLE
marking rex infra tests for fips pipeline inclusion

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -972,6 +972,7 @@ class TestRexUsers:
         yield (rexinfra, password)
 
     @pytest.mark.tier3
+    @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'infra_host',
         ['target_sat', 'capsule_configured'],


### PR DESCRIPTION
Marking the test to be included into fips pipeline, mainly because it uses a capsule. This in connection with satelliteqe-jenkins pr 629 should help verify rhel8 fips capsule installation (jira SAT-5894)