### PR TITLE
Fixing srpm duplicate assertion for 6.10.z

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2017,7 +2017,7 @@ class TestSRPMRepositoryIgnoreContent:
         """
         repo.sync()
         repo = repo.read()
-        assert repo.content_counts['srpm'] == 4
+        assert repo.content_counts['srpm'] == 2
 
     @pytest.mark.tier2
     @pytest.mark.skip('Uses deprecated SRPM repository')


### PR DESCRIPTION
This test case has flip flopped between having 2 and 4 as it's content counts.  I'm reverting it what it originally was (2) and will continue to monitor if the repo has been updated again.  The last update was in December 2021.  We might need something more reliable to use.

result:
```
pytest tests/foreman/api/test_repository.py -k test_positive_sync_srpm_duplicate
============= 1 passed, 158 deselected in 55.47s =====================
```