### PR TITLE
API Factory for satellites API based helpers

### DIFF
--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -1,0 +1,11 @@
+"""
+It is not meant to be used directly, but as part of a robottelo.hosts.Satellite instance
+example: my_satellite.api_factory.api_method()
+"""
+
+
+class APIFactory:
+    """This class is part of a mixin and not to be used directly. See robottelo.hosts.Satellite"""
+
+    def __init__(self, satellite):
+        self._satellite = satellite

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -3,6 +3,7 @@ import re
 import requests
 
 from robottelo.cli.base import CLIReturnCodeError
+from robottelo.host_helpers.api_factory import APIFactory
 from robottelo.host_helpers.cli_factory import CLIFactory
 
 
@@ -92,3 +93,9 @@ class Factories:
         if not getattr(self, '_cli_factory', None):
             self._cli_factory = CLIFactory(self)
         return self._cli_factory
+
+    @property
+    def api_factory(self):
+        if not getattr(self, '_api_factory', None):
+            self._api_factory = APIFactory(self)
+        return self._api_factory


### PR DESCRIPTION
- The new api_factory child object to be used with sat parent object as `sat.api_factory` for API based helpers.
- The new `robottelo/host_helpers/api_factory.py` module to add API helpers directly or import from helperMixin modules.