### PR TITLE
[cherrypick] [6.9z] backport new contenthost config

### DIFF
--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -1,9 +1,7 @@
 content_host:
-    deploy_workflow:
-        default:
-        rhel9: # example of workflow override for version
     default_rhel_version: 7
-    hardware:
+    default_deploy_workflow: deploy-base-rhel
+    deploy_kwargs:
         RHEL6:
             RELEASE: 6.10
             MEMORY: 1GiB

--- a/pytest_fixtures/content_hosts.py
+++ b/pytest_fixtures/content_hosts.py
@@ -16,18 +16,22 @@ def host_conf(request):
     conf = params = {}
     if hasattr(request, 'param'):
         params = request.param
-    _rhelver = f"rhel{params.get('rhel_version', settings.content_host.default_rhel_version)}"
-    rhel_compose_id = settings.get(f"content_host.hardware.{_rhelver}.compose")
+    distro = params.get('distro', 'rhel')
+    _rhelver = f"{distro}{params.get('rhel_version', settings.content_host.default_rhel_version)}"
+    rhel_compose_id = settings.get(f"content_host.deploy_kwargs.{_rhelver}.compose")
     if rhel_compose_id:
         conf['deploy_rhel_compose_id'] = rhel_compose_id
-    default_workflow = (
-        settings.content_host.deploy_workflow.get(_rhelver)
-        or settings.content_host.deploy_workflow.default
-    )
-    conf['workflow'] = params.get('workflow', default_workflow)
-    conf['deploy_rhel_version'] = settings.content_host.hardware.get(_rhelver).release
-    conf['memory'] = params.get('memory', settings.content_host.hardware.get(_rhelver).memory)
-    conf['cores'] = params.get('cores', settings.content_host.hardware.get(_rhelver).cores)
+    scenario = settings.get(f"content_host.deploy_kwargs.{_rhelver}.scenario")
+    if scenario:
+        conf['deploy_scenario'] = scenario
+    if hasattr(settings.content_host.deploy_kwargs.get(_rhelver), 'deploy_workflow'):
+        workflow = settings.content_host.deploy_kwargs.get(_rhelver).deploy_workflow
+    else:
+        workflow = settings.content_host.default_deploy_workflow
+    conf['workflow'] = params.get('workflow', workflow)
+    conf['deploy_rhel_version'] = settings.content_host.deploy_kwargs.get(_rhelver).release
+    conf['memory'] = params.get('memory', settings.content_host.deploy_kwargs.get(_rhelver).memory)
+    conf['cores'] = params.get('cores', settings.content_host.deploy_kwargs.get(_rhelver).cores)
     return conf
 
 


### PR DESCRIPTION
Backport of changes to `content_host.yam` that was introduced as part of PR for convert2rhel feature https://github.com/SatelliteQE/robottelo/pull/9510

Test result:
![image](https://user-images.githubusercontent.com/43444182/170725754-9b0f4130-e4ef-45cb-b0c2-0c48d4abfaa5.png)
