### PR TITLE
Create upgrade test for db seed mismatch failure

### DIFF
--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -106,4 +106,5 @@ class TestScenarioDBseedHostMismatch:
         assert org_id == chost[0].organization.id
         assert loc_id == chost[0].location.id
 
-        VMBroker().from_inventory(f'hostname<{chostname}').checkin()
+        match = VMBroker().from_inventory(f'hostname<{chostname}')
+        VMBroker(hosts=match).checkin()

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -17,6 +17,7 @@
 :Upstream: No
 """
 import pytest
+from fabric.api import run
 from nailgun import entities
 
 
@@ -50,11 +51,12 @@ class TestScenarioDBseedHostMismatch:
         loc2 = default_sat.api.Location(organization=[org2]).create()
 
         # chost = default_sat.api.
+
         # assert chost in loc1, not in loc2
         # assert chost in org1, not in loc2
 
     @pytest.mark.post_upgrade()
-    def test_db_seed_host_mismatch(self):
+    def test_db_seed_host_mismatch(self, default_sat):
         """
 
         :id:
@@ -71,3 +73,13 @@ class TestScenarioDBseedHostMismatch:
 
         :customerscenario: true
         """
+
+        # HOST_ID =
+        # LOCATION_ID =
+
+        rake_host = f'host = ::Host.find(${HOST_ID})'
+        rake_location = f'; host.location_id=${LOCATION_ID}'
+        rake_host_save = '; host.save!'
+        result = run(f"echo '{rake_host}{rake_location}{rake_host_save}' | foreman-rake console")
+
+        assert 'true' in result

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -1,4 +1,4 @@
-"""Test db:seed related Upgrade Scenario's
+"""Test Hosts Content related Upgrade Scenario's
 
 :Requirement: UpgradedSatellite
 
@@ -55,8 +55,8 @@ class TestScenarioDBseedHostMismatch:
         # assert chost in loc1, not in loc2
         # assert chost in org1, not in loc2
 
-    @pytest.mark.post_upgrade()
-    def test_db_seed_host_mismatch(self, default_sat):
+    @pytest.mark.pre_upgrade
+    def test_pre_db_seed_host_mismatch(self, default_sat):
         """
 
         :id:
@@ -83,3 +83,7 @@ class TestScenarioDBseedHostMismatch:
         result = run(f"echo '{rake_host}{rake_location}{rake_host_save}' | foreman-rake console")
 
         assert 'true' in result
+
+    @pytest.mark.post_upgrade(depend_on=test_pre_db_seed_host_mismatch)
+    def test_post_db_seed_host_mismatch(self, default_sat):
+        """"""

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -93,8 +93,18 @@ class TestScenarioDBseedHostMismatch:
 
     @pytest.mark.post_upgrade(depend_on=test_pre_db_seed_host_mismatch)
     def test_post_db_seed_host_mismatch(self, target_sat):
-        """Check whether the upgrade succeeds, and ensure Content Host
-        exists on the Satellite and has not had any attributes changed
+        """
+        :id: postupgrade-28861b9f-8abd-4efc-bfd5-40b7e825a941
+
+        :steps:
+            1. After the upgrade finishes ensure the content host data is unchanged
+
+        :expectedresults:
+            1. The upgrade succeeds and content host exists
+
+        :BZ: 2043705, 2028786, 2019467
+
+        :customerscenario: true
         """
         data = get_entity_data(self.__class__.__name__)
         chostname = data['client_name']

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -1,0 +1,73 @@
+"""Test db:seed related Upgrade Scenario's
+
+:Requirement: UpgradedSatellite
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Host-Content
+
+:Assignee: spusater
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+from nailgun import entities
+
+
+class TestScenarioDBseedHostMismatch:
+    """This test scenenario veryfies the
+
+    Test Steps:
+
+        1. Before Satellite upgrade
+        2. Create a New Organization and Location
+        3. Create another Organization in another Location
+        4. Create a content host in the first Location
+        5. Ensure the host's org is not in the first location
+        6. Edit the host information using rake console
+        7. Ensure the host is not in the same Location as its Org
+        8. Upgrade Satellite
+        9. Ensure upgrade succeeds
+
+    BZ: 2043705
+    """
+
+    @pytest.fixture(scope='function')
+    def setup_host_mismatch(self, default_sat):
+        """Create the organizaitons and locations needed for the contest hosts"""
+
+        org = default_sat.api.Organization().create()
+        loc = default_sat.api.Location(organization=[org]).create()
+        lce = default_sat.api.LifecycleEnvironment(organization=org).create()
+
+        org2 = default_sat.api.Organization().create()
+        loc2 = default_sat.api.Location(organization=[org2]).create()
+
+        # chost = default_sat.api.
+        # assert chost in loc1, not in loc2
+        # assert chost in org1, not in loc2
+
+    @pytest.mark.post_upgrade()
+    def test_db_seed_host_mismatch(self):
+        """
+
+        :id:
+
+        :steps:
+            1. Create an Organizaiton1 and Location1
+            2. Create another Organization2 in another Location2
+            3. Create a content host on Organization1 but not in Location2
+
+        :expectedresults:
+            1. The Content Host exists on Organization but not Location
+
+        :BZ: 2043705
+
+        :customerscenario: true
+        """

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -45,7 +45,7 @@ class TestScenarioDBseedHostMismatch:
     @pytest.mark.pre_upgrade
     def test_pre_db_seed_host_mismatch(self, target_sat):
         """
-        :id:
+        :id: 28861b9f-8abd-4efc-bfd5-40b7e825a941
 
         :steps:
             1. Create a Location

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -33,11 +33,11 @@ class TestScenarioDBseedHostMismatch:
         1. Before Satellite upgrade
         2. Create a New Organization and Location
         3. Create a Content Host in the Organization
-        4. Ensure the Org is not in the Location
-        4. Assign the Content Host to the Location using the rake console
-        7. Ensure the Host is in both but the Org is not in Location, creating a mismatch
-        8. Upgrade Satellite
-        9. Ensure upgrade succeeds
+        4. Ensure the Location is not in the Org
+        5. Assign the Content Host to the Location using the rake console
+        6. Ensure the Host is in both but the Location is not in Org, creating a mismatch
+        7. Upgrade Satellite
+        8. Ensure upgrade succeeds
 
     BZ: 2043705, 2028786, 2019467
     """
@@ -45,18 +45,18 @@ class TestScenarioDBseedHostMismatch:
     @pytest.mark.pre_upgrade
     def test_pre_db_seed_host_mismatch(self, target_sat):
         """
-        :id: 28861b9f-8abd-4efc-bfd5-40b7e825a941
+        :id: preupgrade-28861b9f-8abd-4efc-bfd5-40b7e825a941
 
         :steps:
             1. Create a Location
-            2. Create an Org and ensure the Org is not in the Location
+            2. Create an Org and ensure the Location is not in the Org
             3. Create a Content Host on Org
             4. Use rake console to assign the Content Host to the Location
-            5. Ensure the mismatch is created for Content Host when Org is not in the Location
+            5. Ensure the mismatch is created for Content Host when Location is not in the Org
             6. Do the upgrade
 
         :expectedresults:
-            1. The Content Host is assigned to both Location and Org, but Org is not in Location
+            1. The Content Host is assigned to both Location and Org, but Location is not in Org
 
         :BZ: 2043705, 2028786, 2019467
 

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -1,4 +1,4 @@
-"""Test Hosts Content related Upgrade Scenarios
+"""Test Hosts-Content related Upgrade Scenarios
 
 :Requirement: UpgradedSatellite
 
@@ -25,7 +25,7 @@ from robottelo.hosts import ContentHost
 
 
 class TestScenarioDBseedHostMismatch:
-    """This test scenenario veryfies that the upgrade succeeds even when inconsistencies exist
+    """This test scenario verifies that the upgrade succeeds even when inconsistencies exist
     in the database between Organization, Location and Content Host.
 
     Test Steps:
@@ -70,12 +70,10 @@ class TestScenarioDBseedHostMismatch:
         chost_vm.install_katello_ca(target_sat)
         chost_vm.register_contenthost(org=org.label, lce='Library')
 
-        chost = target_sat.api.Host().search(query={'search': chost_vm.hostname})
-
-        assert chost[0].organization.id == org.id
+        assert chost_vm.nailgun_host.organization.id == org.id
 
         # Now we need to break the taxonomy between chost, org and location
-        rake_host = f"host = ::Host.find({chost[0].id})"
+        rake_host = f"host = ::Host.find({chost_vm.nailgun_host.id})"
         rake_organization = f"; host.location_id={loc.id}"
         rake_host_save = "; host.save!"
         result = target_sat.run(
@@ -83,8 +81,7 @@ class TestScenarioDBseedHostMismatch:
         )
 
         assert 'true' in result.stdout
-        chost = target_sat.api.Host().search(query={'search': chost_vm.hostname})
-        assert chost[0].location.id == loc.id
+        assert chost_vm.nailgun_host.location.id == loc.id
 
         global_dict = {
             self.__class__.__name__: {
@@ -109,4 +106,4 @@ class TestScenarioDBseedHostMismatch:
         assert org_id == chost[0].organization.id
         assert loc_id == chost[0].location.id
 
-        VMBroker(host=chost).checkin()
+        VMBroker().from_inventory(f'hostname<{chostname}').checkin()


### PR DESCRIPTION
This PR is created to add an upgrade scenario for this BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2043705

As of the creation of this PR, the pre upgrade scenario is passing but the post upgrade scenario fails with a `TypeError`:

`>       assert org_id == chost[0].organization.id`
`E       TypeError: 'Host' object is not subscriptable`

However, I wanted to open this as a draft so I could start getting feedback on the rest of it