### PR TITLE
Speed up capsule-content tests

### DIFF
--- a/pytest_fixtures/component/lce.py
+++ b/pytest_fixtures/component/lce.py
@@ -15,11 +15,26 @@ def module_lce(module_org):
     return entities.LifecycleEnvironment(organization=module_org).create()
 
 
+@pytest.fixture(scope='function')
+def function_lce(function_org):
+    return entities.LifecycleEnvironment(organization=function_org).create()
+
+
 @pytest.fixture(scope='module')
 def module_lce_library(module_org):
     """Returns the Library lifecycle environment from chosen organization"""
     return (
         entities.LifecycleEnvironment()
         .search(query={'search': f'name={ENVIRONMENT} and organization_id={module_org.id}'})[0]
+        .read()
+    )
+
+
+@pytest.fixture(scope='function')
+def function_lce_library(function_org):
+    """Returns the Library lifecycle environment from chosen organization"""
+    return (
+        entities.LifecycleEnvironment()
+        .search(query={'search': f'name={ENVIRONMENT} and organization_id={function_org.id}'})[0]
         .read()
     )

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -136,8 +136,23 @@ def capsule_host(capsule_factory):
     VMBroker(hosts=[new_cap]).checkin()
 
 
+@pytest.fixture(scope='module')
+def module_capsule_host(capsule_factory):
+    """A fixture that provides a Capsule based on config settings"""
+    new_cap = capsule_factory()
+    yield new_cap
+    VMBroker(hosts=[new_cap]).checkin()
+
+
 @pytest.fixture
 def capsule_configured(capsule_host, target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     capsule_host.capsule_setup(sat_host=target_sat)
     yield capsule_host
+
+
+@pytest.fixture(scope='module')
+def module_capsule_configured(module_capsule_host, module_target_sat):
+    """Configure the capsule instance with the satellite from settings.server.hostname"""
+    module_capsule_host.capsule_setup(sat_host=module_target_sat)
+    yield module_capsule_host


### PR DESCRIPTION
Introduced changes:
1) Used module-scoped capsule for all test cases, isolation on the org level.
2) Removed on-disk artifact checks, content is checked properly another way.
3) Wider use of fixtures rather than in-test entities creation.
4) Repetitive code moved to function (wait_for_sync).

Test results:
1) Run time decreased from ~6 hrs to ~1:15
```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement
================================================== test session starts ==================================================
platform linux -- Python 3.9.9, pytest-7.1.2, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, mock-3.7.0, lazy-fixture-0.6.3, ibutsu-2.0.2, reportportal-5.1.1, xdist-2.5.0
collected 13 items                                                                                                                                                                                                                        

tests/foreman/api/test_contentmanagement.py .....F.......                                                        [100%]

================================================ short test summary info ================================================
FAILED tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_iso_library_sync
 - requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://shiny-metal-satellite.redhat.com:443/ka...
================================ 1 failed, 12 passed, 475 warnings in 4336.29s (1:12:16) ================================
```
The only failure of `test_positive_iso_library_sync` seems unrelated. It is failing due to some intermittent issue with subscriptions. With another manifest or manifest refresh it passes ok.

