### PR TITLE
Remove usage of docker_tags_whitelist

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1808,7 +1808,7 @@ class TestDockerRepository:
             {
                 constants.CONTAINER_UPSTREAM_NAME: {
                     'content_type': 'docker',
-                    'docker_tags_whitelist': ['latest'],
+                    'include_tags': ['latest'],
                     'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
                     'name': gen_string('alphanumeric', 10),
                     'url': constants.CONTAINER_REGISTRY_HUB,
@@ -1817,20 +1817,23 @@ class TestDockerRepository:
         ),
         indirect=True,
     )
-    def test_positive_synchronize_docker_repo_with_tags_whitelist(self, repo_options, repo):
-        """Check if only whitelisted tags are synchronized
+    def test_positive_synchronize_docker_repo_with_included_tags(self, repo_options, repo):
+        """Check if only included tags are synchronized
 
-        :id: abd584ef-f616-49d8-ab30-ae32e4e8a685
+        :id: 3d0f9aad-d564-4d2e-acc5-d71c35f52703
 
         :parametrized: yes
 
-        :expectedresults: Only whitelisted tag is synchronized
+        :expectedresults: Only included tag is synchronized
         """
         repo.sync()
         repo = repo.read()
-        assert repo.docker_tags_whitelist == repo_options['docker_tags_whitelist']
+        assert repo.include_tags == repo_options['include_tags']
         assert repo.content_counts['docker_tag'] == 1
 
+    @pytest.mark.skip(
+        reason="Tests behavior that is no longer present in the same way, needs refactor"
+    )
     @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
@@ -1879,7 +1882,7 @@ class TestDockerRepository:
             {
                 constants.CONTAINER_UPSTREAM_NAME: {
                     'content_type': 'docker',
-                    'docker_tags_whitelist': ['latest', gen_string('alpha')],
+                    'include_tags': ['latest', gen_string('alpha')],
                     'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
                     'name': gen_string('alphanumeric', 10),
                     'url': constants.CONTAINER_REGISTRY_HUB,
@@ -1889,18 +1892,18 @@ class TestDockerRepository:
         indirect=True,
     )
     def test_negative_synchronize_docker_repo_with_mix_valid_invalid_tags(self, repo_options, repo):
-        """Set tags whitelist to contain both valid and invalid (non-existing)
-        tags. Check if only whitelisted tags are synchronized
+        """Set included tags to contain both valid and invalid (non-existing)
+        tags. Check if only valid tags are synchronized
 
         :id: 7b66171f-5bf1-443b-9ca3-9614d66a0c6b
 
         :parametrized: yes
 
-        :expectedresults: Only whitelisted tag is synchronized
+        :expectedresults: Only valid tag is synchronized
         """
         repo.sync()
         repo = repo.read()
-        assert repo.docker_tags_whitelist == repo_options['docker_tags_whitelist']
+        assert repo.include_tags == repo_options['include_tags']
         assert repo.content_counts['docker_tag'] == 1
 
     @pytest.mark.tier2
@@ -1910,7 +1913,7 @@ class TestDockerRepository:
             {
                 constants.CONTAINER_UPSTREAM_NAME: {
                     'content_type': 'docker',
-                    'docker_tags_whitelist': [gen_string('alpha') for _ in range(3)],
+                    'include_tags': [gen_string('alpha') for _ in range(3)],
                     'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
                     'name': gen_string('alphanumeric', 10),
                     'url': constants.CONTAINER_REGISTRY_HUB,
@@ -1920,7 +1923,7 @@ class TestDockerRepository:
         indirect=True,
     )
     def test_negative_synchronize_docker_repo_with_invalid_tags(self, repo_options, repo):
-        """Set tags whitelist to contain only invalid (non-existing)
+        """Set included tags to contain only invalid (non-existing)
         tags. Check that no data is synchronized.
 
         :id: c419da6a-1530-4f66-8f8e-d4ec69633356
@@ -1931,7 +1934,7 @@ class TestDockerRepository:
         """
         repo.sync()
         repo = repo.read()
-        assert repo.docker_tags_whitelist == repo_options['docker_tags_whitelist']
+        assert repo.include_tags == repo_options['include_tags']
         assert repo.content_counts['docker_tag'] == 0
 
 


### PR DESCRIPTION
A bit tardy to the party on swapping out docker_tags_whitelist for include_tags, but this should fix a few more test errors. The disabled test was exercising some behavior of docker_tags_whitelist that is not replicated by include_tags, since it doesn't 1 to 1 match the behavior. 

At some point it would be good to refactor/add tests to check the behavior that's now split into include_tags and exclude_tags, but that can be a separate PR