### PR TITLE
replace virtwho config cases default_sat fixture with target_sat and module_target_sat fixture

### DIFF
--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -31,7 +31,7 @@ from robottelo.virtwho_utils import get_configure_option
 
 
 @pytest.fixture()
-def form_data(default_sat, default_org):
+def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
@@ -41,7 +41,7 @@ def form_data(default_sat, default_org):
         'hypervisor-server': settings.virtwho.ahv.hypervisor_server,
         'organization-id': default_org.id,
         'filtering-mode': 'none',
-        'satellite-url': default_sat.hostname,
+        'satellite-url': target_sat.hostname,
         'hypervisor-username': settings.virtwho.ahv.hypervisor_username,
         'hypervisor-password': settings.virtwho.ahv.hypervisor_password,
         'prism-flavor': settings.virtwho.ahv.prism_flavor,

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -2,12 +2,13 @@ import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 from requests.exceptions import HTTPError
+import nailgun.entities
 
 from robottelo.logging import logger
 
 
 @pytest.fixture(scope='module')
-def module_user(request, target_sat, default_org, default_location):
+def module_user(request, module_target_sat, default_org, default_location):
     """Creates admin user with default org set to module org and shares that
     user for all tests in the same test module. User's login contains test
     module name as a prefix.
@@ -19,7 +20,7 @@ def module_user(request, target_sat, default_org, default_location):
     login = f'{test_module_name}_{gen_string("alphanumeric")}'
     password = gen_string('alphanumeric')
     logger.debug('Creating session user %r', login)
-    user = target_sat.api.User(
+    user = module_target_sat.api.User(
         admin=True,
         default_organization=default_org,
         default_location=default_location,
@@ -36,7 +37,7 @@ def module_user(request, target_sat, default_org, default_location):
         logger.warning('Unable to delete session user: %s', str(err))
 
 
-@pytest.fixture
+@pytest.fixture()
 def session(test_name, module_user):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -2,7 +2,6 @@ import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 from requests.exceptions import HTTPError
-import nailgun.entities
 
 from robottelo.logging import logger
 


### PR DESCRIPTION
Hey,
1. replace /tests/foreman/virtwho/cli/test_nutanix.py default_sat to target_sat
2. replace /tests/foreman/virtwho/conftest.py to module_target_sat fixture to fix  "ScopeMismatch: You tried to access the function scoped fixture target_sat with a module scoped request object, involved factories:" issue.

virtwho config UI cases: PASS
CLI nutanix cases: PASS