### PR TITLE
General improvements to Vault Login script

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1,5 +1,16 @@
 """Defines various constants"""
+from box import Box
 from nailgun import entities
+
+
+# String Color codes
+class Colored(Box):
+    YELLOW = '\033[1;33m'
+    REDLIGHT = '\033[3;31m'
+    REDDARK = '\033[1;31m'
+    GREEN = '\033[1;32m'
+    WHITELIGHT = '\033[1;30m'
+
 
 # This should be updated after each version branch
 SATELLITE_VERSION = "6.11"

--- a/robottelo/utils/__init__.py
+++ b/robottelo/utils/__init__.py
@@ -1,0 +1,24 @@
+# General utility functions which does not fit into other util modules
+import os
+import re
+from pathlib import Path
+
+from robottelo.constants import Colored
+from robottelo.errors import InvalidVaultURLForOIDC
+
+
+def export_vault_env_vars(filename=None, envdata=None):
+    if not envdata:
+        envdata = Path(filename or '.env').read_text()
+    vaulturl = re.findall('VAULT_URL_FOR_DYNACONF=(.*)', envdata)[0]
+
+    # Vault CLI Env Var
+    os.environ['VAULT_ADDR'] = vaulturl
+
+    # Dynaconf Vault Env Vars
+    if re.findall('VAULT_ENABLED_FOR_DYNACONF=(.*)', envdata)[0] == 'true':
+        if 'localhost:8200' in vaulturl:
+            raise InvalidVaultURLForOIDC(
+                f"{Colored.REDDARK}{vaulturl} doesnt supports OIDC login,"
+                "please change url to corp vault in env file!"
+            )

--- a/scripts/vault_login.py
+++ b/scripts/vault_login.py
@@ -6,8 +6,11 @@ import re
 import subprocess
 import sys
 import time
+from pathlib import Path
 
-from robottelo.errors import InvalidVaultURLForOIDC
+from robottelo.constants import Colored
+from robottelo.utils import export_vault_env_vars
+
 
 HELP_TEXT = (
     "Vault CLI in not installed in your system, "
@@ -15,79 +18,54 @@ HELP_TEXT = (
     "install vault CLI as per your system spec!"
 )
 
-# Color Codes
-YELLOW = '\033[1;33m'
-REDL = '\033[3;31m'
-REDD = '\033[1;31m'
-GREEN = '\033[1;32m'
-WHITEL = '\033[1;30m'
-
-
-def _load_env():
-    print("\nFetching vault data from .env file and Exporting vault URL .....\n")
-    ROOT_PATH = os.path.realpath(
-        os.path.join(os.path.dirname(os.path.abspath(__file__)), os.path.pardir)
-    )
-    with open(ROOT_PATH + '/.env') as envfile:
-        envdata = envfile.read()
-    return ROOT_PATH, envdata
-
-
-def _export_vault_url(envdata):
-    vaulturl = re.findall('VAULT_URL_FOR_DYNACONF=(.*)', envdata)[0]
-    if 'localhost:8200' in vaulturl:
-        raise InvalidVaultURLForOIDC(
-            f"{REDL}{vaulturl} doesnt supports OIDC login,"
-            "please change url to corp vault in env file!"
-        )
-    os.environ['VAULT_ADDR'] = vaulturl
-
 
 def _vault_command(command: str):
     vcommand = subprocess.run(command, capture_output=True, shell=True)
     if vcommand.returncode != 0:
         verror = str(vcommand.stderr)
         if 'vault: command not found' in verror:
-            print(f"{REDD}Error! {HELP_TEXT}")
+            print(f"{Colored.REDDARK}Error! {HELP_TEXT}")
             sys.exit(1)
         elif 'Error revoking token' in verror:
-            print(f"{GREEN}Token is alredy revoked!")
+            print(f"{Colored.GREEN}Token is alredy revoked!")
             sys.exit(0)
         elif 'Error looking up token' in verror:
-            print(f"{YELLOW}Warning! Vault not logged in, please run 'make vault-login'!")
+            print(f"{Colored.YELLOW}Warning! Vault not logged in, please run 'make vault-login'!")
             sys.exit(2)
         else:
-            print(f"{REDD}Error! {verror}")
+            print(f"{Colored.REDDARK}Error! {verror}")
             sys.exit(1)
     return vcommand
 
 
 def _vault_login(root_path, envdata):
     print(
-        f"{WHITEL}Warning! The browser is about to open for vault OIDC login, "
-        "close the tab once the sign in is done!"
+        f"{Colored.WHITELIGHT}Warning! The browser is about to open for vault OIDC login, "
+        "close the tab once the sign-in is done!"
     )
     time.sleep(5)
     if _vault_command(command="vault login -method=oidc").returncode == 0:
         _vault_command(command="vault token renew -i 10h")
-        print(f"{GREEN}Success! Vault OIDC Logged-In and extended for 10 hours!")
+        print(f"{Colored.GREEN}Success! Vault OIDC Logged-In and extended for 10 hours!")
     # Fetching token
     token = _vault_command("vault token lookup --format json").stdout
     token = json.loads(str(token.decode('UTF-8')))['data']['id']
     # Setting new token in env file
     envdata = re.sub('.*VAULT_TOKEN_FOR_DYNACONF=.*', f"VAULT_TOKEN_FOR_DYNACONF={token}", envdata)
-    with open(root_path + '/.env', 'w') as envfile:
+    with open(root_path, 'w') as envfile:
         envfile.write(envdata)
-    print(f"{GREEN}Success! New OIDC token is added to .env file to access secrets from vault!")
+    print(
+        f"{Colored.GREEN}Success! New OIDC token added to .env file to access secrets from vault!"
+    )
 
 
 def _vault_logout(root_path, envdata):
     # Teardown - Setting dymmy token in env file
     envdata = re.sub('.*VAULT_TOKEN_FOR_DYNACONF=.*', "# VAULT_TOKEN_FOR_DYNACONF=myroot", envdata)
-    with open(root_path + '/.env', 'w') as envfile:
+    with open(root_path, 'w') as envfile:
         envfile.write(envdata)
     _vault_command('vault token revoke -self')
-    print(f"{GREEN}Success! OIDC token removed from Env file successfully!")
+    print(f"{Colored.GREEN}Success! OIDC token removed from Env file successfully!")
 
 
 def _vault_status():
@@ -97,8 +75,9 @@ def _vault_status():
 
 
 if __name__ == '__main__':
-    root_path, envdata = _load_env()
-    _export_vault_url(envdata)
+    root_path = Path('.env')
+    envdata = root_path.read_text()
+    export_vault_env_vars(envdata=envdata)
     if sys.argv[-1] == '--login':
         _vault_login(root_path, envdata)
     elif sys.argv[-1] == '--status':


### PR DESCRIPTION
~~The vault was complaining locally and in the CI for PRT for the unavailability of VAULT URL. The issue is raised in dynaconf https://github.com/rochacbruno/dynaconf/issues/751~~

~~But until if fixed in dynaconf this PR would help to get it addressed in robottelo!~~

New:

- **New Modules**: `robottelo/utils/io.py` for io-related helpers.
- Color code constant to display the log lines colour coded.

Successful Custom Pipeline execution using Broker 0.2.2, Gitlab MR 663 to remove explicit export of env vars of VAULT as w/o and this PR: https://satqe-stage-jenkins-url/job/jyejare-6.11-rhel7-MR663-PR9651-broker022/5/console 