### PR TITLE
Fix puppetclass UI test

### DIFF
--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -18,12 +18,11 @@
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, module_org, module_location):
+def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_org, module_puppet_loc):
     """Perform end to end testing for puppet class component
 
     :id: f837eec0-101c-4aff-a270-652005bdee51
@@ -35,9 +34,12 @@ def test_positive_end_to_end(session, module_org, module_location):
     :CaseImportance: High
     """
     name = gen_string('alpha')
-    hostgroup = entities.HostGroup(organization=[module_org], location=[module_location]).create()
-    puppet_class = entities.PuppetClass(name=name).create()
-    with session:
+    hostgroup = session_puppet_enabled_sat.api.HostGroup(
+        organization=[module_puppet_org], location=[module_puppet_loc]
+    ).create()
+    puppet_class = session_puppet_enabled_sat.api.PuppetClass(name=name).create()
+    with session_puppet_enabled_sat.ui_session as session:
+        session.organization.select(org_name=module_puppet_org.name)
         # Check that created puppet class can be found in UI
         assert session.puppetclass.search(name)[0]['Class name'] == name
         # Read puppet class values and check that they are expected


### PR DESCRIPTION
Thanks to @omkarkhatavkar's fix of PF4 notifications https://github.com/SatelliteQE/airgun/pull/705 I was able to fix this UI test.

Passes locally, without setup `=== 1 passed, 1 warning in 256.56s (0:04:16) ===`
