### PR TITLE
Do not enable extras in RHEL8

### DIFF
--- a/pytest_fixtures/component/subscription.py
+++ b/pytest_fixtures/component/subscription.py
@@ -27,9 +27,11 @@ def subscribe_satellite(clean_rhsm, module_target_sat):
         0
     ]
     if 'Successfully attached a subscription' in result.stdout:
-        module_target_sat.enable_repo(
-            f'rhel-{module_target_sat.os_version.major}-server-extras-rpms', force=True
-        )
+        # extras is not in RHEL8: https://access.redhat.com/solutions/5331391
+        if module_target_sat.os_version.major < 8:
+            module_target_sat.enable_repo(
+                f'rhel-{module_target_sat.os_version.major}-server-extras-rpms', force=True
+            )
         yield
     else:
         pytest.fail('Failed to attach system to pool. Aborting Test!.')


### PR DESCRIPTION
Addressing https://github.com/SatelliteQE/robottelo/pull/9405#discussion_r817995955
I wasn't able to track why the extras repository is being enabled here in the first place. However, as per https://access.redhat.com/solutions/5331391 , extras is no more in RHEL8 and its contents should be in Appstream and BaseOS. I don't think I should enable those here so I just skipped this step in RHEL8 entirely.
If someone has more insights and wants to suggest what else to do here, I'm open to that.