### PR TITLE
katello-ca installation from rhel7 sat to rhel8 fips client

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -389,13 +389,18 @@ class ContentHost(Host, ContentHostMixins):
             f'curl --insecure --output katello-ca-consumer-latest.noarch.rpm \
                     {satellite.url_katello_ca_rpm}'
         )
-        self.execute('rpm -Uvh katello-ca-consumer-latest.noarch.rpm')
+        # check if the host is fips-enabled
+        result = self.execute('sysctl crypto.fips_enabled')
+        if 'crypto.fips_enabled = 1' in result.stdout:
+            self.execute('rpm -Uvh --nodigest --nofiledigest katello-ca-consumer-latest.noarch.rpm')
+        else:
+            self.execute('rpm -Uvh katello-ca-consumer-latest.noarch.rpm')
         # Not checking the status here, as rpm could be installed before
         # and installation may fail
-        result = self.execute(f'rpm -q katello-ca-consumer-{satellite.hostname}')
+        result = self.execute('rpm -q katello-ca-consumer*')
         # Checking the status here to verify katello-ca rpm is actually
         # present in the system
-        if result.status != 0:
+        if satellite.hostname not in result.stdout:
             raise ContentHostError('Failed to download and install the katello-ca rpm')
 
     def remove_katello_ca(self):


### PR DESCRIPTION
Turns out https://github.com/SatelliteQE/robottelo/pull/9571 only helps when pulling from Satellite on rhel8, I suppose it has to do with rpm version shipped with rhel7. A cleaner solution would be to stop relying on the katello-ca rpm altogether and use global registration api (works well on all fips hosts), but that would be a bigger effort. Anyway, this PR should work until we get there.