### PR TITLE
Remove environment from list of params

### DIFF
--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -68,7 +68,6 @@ def test_positive_create_event(session, module_org, module_location):
         assert summary.get('Architecture') == host.architecture.read().name
         os = host.operatingsystem.read()
         assert summary.get('Operatingsystem') == f'{os.name} {os.major}'
-        assert summary.get('Environment') == host.environment.read().name
         assert summary.get('Ptable') == host.ptable.read().name
         assert summary.get('Medium') == host.medium.read().name
         assert summary.get('Build') == 'false'


### PR DESCRIPTION
Same thing with the other Audit Log test, removing parameters that aren't present anymore.
The definition of low hanging fruit, but hey - might as well pick it if it's free yeah? :smile: 