### PR TITLE
Update pytest-ibutsu integration

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -113,6 +113,7 @@ def pytest_collection_modifyitems(session, items, config):
                 item.add_marker(pytest.mark.assignee(doc_assignee[0]))
 
         # add markers as user_properties so they are recorded in XML properties of the report
+        # pytest-ibutsu will include user_properties dict in testresult metadata
         for marker in item.iter_markers():
             item.user_properties.append((marker.name, next(iter(marker.args), None)))
         item.user_properties.append(("BaseOS", rhel_version))
@@ -121,16 +122,6 @@ def pytest_collection_modifyitems(session, items, config):
         item.user_properties.append(
             ("start_time", datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME))
         )
-
-        # add custom ibutsu metadata fields for test case grouping and heatmaps
-        if hasattr(item, "_ibutsu"):
-            item._ibutsu["data"]["metadata"].update(
-                {
-                    # TODO Work with ibutsu team, better mechanism for defining 'special' data
-                    # TODO Add sat version to this item data at test execution time
-                    "component": item.get_closest_marker('component').args[0]
-                }
-            )
 
         # exit early if no filters were passed
         if importance or component or assignee:

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ pytest-services==2.2.1
 pytest-mock==3.7.0
 pytest-reportportal==5.1.1
 pytest-xdist==2.5.0
-pytest-ibutsu==2.0.2
+pytest-ibutsu==2.1.0
 PyYAML==6.0
 requests==2.27.1
 tenacity==8.0.1


### PR DESCRIPTION
A pending release of pytest-ibutsu will make it unnecessary for us to
manually inject metadata for tests.  user_properties is now
automatically accounted for.

I've tested this integration with a locally running ibutsu server and
the current master branch of pytest-ibutsu