### PR TITLE
cli_factory pickling

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -272,7 +272,7 @@ class CLIFactory:
             fields = self._evaluate_functions(fields)
             return partial(create_object, entity_cls, fields)
         else:
-            raise CLIFactoryError(f'unknown factory method name: {name.replace("make_", "")}')
+            raise AttributeError(f'unknown factory method name: {name}')
 
     def _evaluate_function(self, function):
         """Some functions may require an instance reference"""


### PR DESCRIPTION
**Problem statement:**
It seems that raising `CLIFactoryError` added in #9564 causes issues when broker checks in the Satellite and tries to pickle it:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.8/multiprocessing/queues.py", line 239, in _feed
    obj = _ForkingPickler.dumps(obj)
  File "/usr/lib64/python3.8/multiprocessing/reduction.py", line 51, in dumps
    cls(buf, protocol).dump(obj)
  File "/opt/app-root/lib64/python3.8/site-packages/broker/hosts.py", line 43, in __getstate__
    self._purify()
  File "/opt/app-root/lib64/python3.8/site-packages/broker/hosts.py", line 50, in _purify
    pickle.dumps(obj)
  File "/opt/app-root/src/robottelo/robottelo/host_helpers/cli_factory.py", line 275, in __getattr__
    raise CLIFactoryError(f'unknown factory method name: {name.replace("make_", "")}')
robottelo.host_helpers.cli_factory.CLIFactoryError: unknown factory method name: __getstate__
```

According to https://docs.python.org/3.8/reference/datamodel.html#customizing-attribute-access the `__getattr__` method
should either return the (computed) attribute value or raise an `AttributeError` exception, which should be handled similar to when the attribute was not found. So I guess this way we say there is no `__getstate__` attribute in the class and the pickler should go on.

I'm unable to reproduce the issue locally for some reason, but the PRT seems to pass. 