### PR TITLE
Add test upgrade without init template

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -8,6 +8,7 @@ on:
 
 env:
     PYCURL_SSL_LIBRARY: openssl
+    ROBOTTELO_BUGZILLA__API_KEY: ${{ secrets.BUGZILLA_KEY }}
 
 jobs:
   codechecks:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,6 +7,7 @@ on:
 
 env:
     PYCURL_SSL_LIBRARY: openssl
+    ROBOTTELO_BUGZILLA__API_KEY: ${{ secrets.BUGZILLA_KEY }}
 
 jobs:
   codechecks:

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -186,3 +186,31 @@ class TestScenarioPositiveGCEHostComputeResource:
         gce_cr = entities.GCEComputeResource(id=gce_cr.id).read()
         assert gce_cr.name == newgce_name
         assert gce_cr.zone == newgce_zone
+
+
+class TestScenarioUpgradeWithoutTemplate:
+    """
+    Test that Sat6.9 can be upgraded to Sat6.10.5 or later without a default init template.
+
+    Test Steps::
+
+        1. Before Satellite upgrade, set the `default_host_init_config_template` setting to
+        `not-existing-host-init-config-template` value.
+        2. Upgrade the Satellite.
+
+           :expectedresults:
+
+        1. The Pulp3 migration and Satellite upgrade succeeds.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_pre_senario_no_default_init_template(self, default_sat):
+        init_template = entities.Setting().search(
+            query={'search': 'name="default_host_init_config_template"'}
+        )[0]
+        init_template.value = ''
+        init_template.update({'value'})
+        init_template = entities.Setting().search(
+            query={'search': 'name="default_host_init_config_template"'}
+        )[0]
+        assert init_template.value == ''


### PR DESCRIPTION
  Closed loop: BZ#2063190

Hi, not sure where to put this code, it really needs to run just before the upgrade.
Will need some testing still to make sure other tests do not change the default init template setting.



[Bug 2063190](https://bugzilla.redhat.com/show_bug.cgi?id=2063190) - Upgrading from Satellite 6.9 to Satellite 6.10.3 fails with error "undefined method operatingsystems' for nil:NilClass" during the db:migrate step