### PR TITLE
Update kubeconfig-path option for Nutanix CLI cases

### DIFF
--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -41,7 +41,7 @@ def form_data(target_sat, default_org):
         'organization-id': default_org.id,
         'filtering-mode': 'none',
         'satellite-url': target_sat.hostname,
-        'kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
+        'kubeconfig-path': settings.virtwho.kubevirt.hypervisor_config_file,
     }
     return form
 


### PR DESCRIPTION
Hey,
It is a simple update for hammer virt-who-config  create "kubeconfig-path" option
Reference:
```
[root@dell-per740-68-vm-03 ~]# hammer virt-who-config  create --help | grep "kubeconfig"
 --kubeconfig-path VALUE                 Configuration file containing details about how to connect to the cluster and
```

Kubevirt CLI cases: PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest  ./tests/foreman/virtwho/cli/test_kubevirt.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.1.1
collected 3 items / 3 deselected / 0 selected                                                                                                                                                                     

tests/foreman/virtwho/cli/test_kubevirt.py ...                                                                                                                                                              [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/cli/test_kubevirt.py::TestVirtWhoConfigforKubevirt::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-03.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 3 passed, 3 deselected, 4 warnings in 525.60s (0:08:45) =============================================================================
```

