### PR TITLE
Rewrite Host subscription tests without helper class

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -52,7 +52,7 @@ def module_rhst_repo(module_target_sat, module_org_with_manifest, module_promote
         reposet=REPOSET['rhst7'],
         releasever=None,
     )
-    rh_repo = entities.Repository(id=rh_repo_id).read()
+    rh_repo = module_target_sat.api.Repository(id=rh_repo_id).read()
     rh_repo.sync()
     cv = module_target_sat.api.ContentView(id=module_promoted_cv.id, repository=[rh_repo]).update(
         ["repository"]

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -5,6 +5,7 @@ from nailgun import entities
 
 from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.api.utils import enable_rhrepo_and_fetchid
+from robottelo.api.utils import promote
 from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -37,6 +38,29 @@ def rh_repo_gt_manifest(module_gt_manifest_org):
     rh_repo = entities.Repository(id=rh_repo_id).read()
     rh_repo.sync()
     return rh_repo
+
+
+@pytest.fixture(scope='module')
+def module_rhst_repo(module_target_sat, module_org_with_manifest, module_promoted_cv, module_lce):
+    """Use module org with manifest, creates RH tools repo, syncs and returns RH repo id."""
+    # enable rhel repo and return its ID
+    rh_repo_id = enable_rhrepo_and_fetchid(
+        basearch=DEFAULT_ARCHITECTURE,
+        org_id=module_org_with_manifest.id,
+        product=PRDS['rhel'],
+        repo=REPOS['rhst7']['name'],
+        reposet=REPOSET['rhst7'],
+        releasever=None,
+    )
+    rh_repo = entities.Repository(id=rh_repo_id).read()
+    rh_repo.sync()
+    cv = module_target_sat.api.ContentView(id=module_promoted_cv.id, repository=[rh_repo]).update(
+        ["repository"]
+    )
+    cv.publish()
+    cv = cv.read()
+    promote(cv.version[-1], environment_id=module_lce.id)
+    return REPOS['rhst7']['id']
 
 
 @pytest.fixture(scope="function")

--- a/pytest_fixtures/component/subscription.py
+++ b/pytest_fixtures/component/subscription.py
@@ -1,10 +1,22 @@
 import pytest
 
+from robottelo.cli.subscription import Subscription
+from robottelo.constants import SATELLITE_SUBSCRIPTION_NAME
+
 
 @pytest.fixture(scope='session')
 def clean_rhsm(session_target_sat):
     """removes pre-existing candlepin certs and resets RHSM."""
     session_target_sat.remove_katello_ca()
+
+
+@pytest.fixture(scope='module')
+def default_subscription(module_org_with_manifest):
+    subscription = Subscription.exists(
+        {'organization-id': module_org_with_manifest.id}, ('name', SATELLITE_SUBSCRIPTION_NAME)
+    )
+    assert len(subscription)
+    return subscription
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/subscription.py
+++ b/pytest_fixtures/component/subscription.py
@@ -1,7 +1,6 @@
 import pytest
 
-from robottelo.cli.subscription import Subscription
-from robottelo.constants import SATELLITE_SUBSCRIPTION_NAME
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 
 
 @pytest.fixture(scope='session')
@@ -11,12 +10,12 @@ def clean_rhsm(session_target_sat):
 
 
 @pytest.fixture(scope='module')
-def default_subscription(module_org_with_manifest):
-    subscription = Subscription.exists(
-        {'organization-id': module_org_with_manifest.id}, ('name', SATELLITE_SUBSCRIPTION_NAME)
-    )
+def default_subscription(module_target_sat, module_org_with_manifest):
+    subscription = module_target_sat.api.Subscription(
+        organization=module_org_with_manifest.id
+    ).search(query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'})
     assert len(subscription)
-    return subscription
+    return subscription[0]
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -67,6 +67,14 @@ def module_manifest_org(module_target_sat):
 
 
 @pytest.fixture(scope='module')
+def module_org_with_manifest(module_org):
+    """Upload manifest to organization."""
+    with manifests.clone() as manifest:
+        upload_manifest(module_org.id, manifest.content)
+    return module_org
+
+
+@pytest.fixture(scope='module')
 def module_gt_manifest_org(module_target_sat):
     """Creates a new org and loads GT manifest in the new org"""
     org = module_target_sat.api.Organization().create()

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -17,10 +17,8 @@
 import pytest
 import requests
 
-from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import promote
-from robottelo.api.utils import upload_manifest
 from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE
@@ -90,12 +88,6 @@ def ssl_cert(module_target_sat, module_org):
     ).create()
 
 
-@pytest.fixture(scope='module')
-def manifest(module_org):
-    with manifests.clone() as manifest:
-        upload_manifest(module_org.id, manifest.content)
-
-
 @pytest.fixture
 def activation_key_rhel(target_sat, module_org, module_lce, module_promoted_cv, version):
     """Create activation key that will be used after conversion for registration"""
@@ -107,7 +99,7 @@ def activation_key_rhel(target_sat, module_org, module_lce, module_promoted_cv, 
 
 
 @pytest.fixture(scope='module')
-def enable_rhel_subscriptions(module_target_sat, module_org, manifest, version):
+def enable_rhel_subscriptions(module_target_sat, module_org_with_manifest, version):
     """Enable and sync RHEL rpms repos"""
     major = version.split('.')[0]
     minor = ""
@@ -122,7 +114,7 @@ def enable_rhel_subscriptions(module_target_sat, module_org, manifest, version):
     for name in repo_names:
         rh_repo_id = enable_rhrepo_and_fetchid(
             basearch=DEFAULT_ARCHITECTURE,
-            org_id=module_org.id,
+            org_id=module_org_with_manifest.id,
             product=REPOS[name]['product'],
             repo=REPOS[name]['name'] + minor,
             reposet=REPOS[name]['reposet'],

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -42,7 +42,6 @@ from robottelo.cli.host import HostInterface
 from robottelo.cli.host import HostTraces
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.package import Package
-from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
@@ -1856,15 +1855,6 @@ def test_positive_install_package_via_rex(
 def host_subscription_client(rhel7_contenthost, target_sat):
     rhel7_contenthost.install_katello_ca(target_sat)
     yield rhel7_contenthost
-
-
-@pytest.fixture(scope='module')
-def default_subscription(module_org_with_manifest):
-    subscription = Subscription.exists(
-        {'organization-id': module_org_with_manifest.id}, ('name', SATELLITE_SUBSCRIPTION_NAME)
-    )
-    assert len(subscription) > 0
-    return subscription
 
 
 @pytest.fixture


### PR DESCRIPTION
This class began really messy and as it was shared there were some tests that had incorrect setup. The main goal was to reduce the complexity of those tests using our shared fixtures