### PR TITLE
Install capsule using CDN repos for RHSCL and AE

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -133,6 +133,7 @@ def capsule_host(capsule_factory):
     """A fixture that provides a Capsule based on config settings"""
     new_cap = capsule_factory()
     yield new_cap
+    new_cap.unregister()
     Broker(hosts=[new_cap]).checkin()
 
 
@@ -141,6 +142,7 @@ def module_capsule_host(capsule_factory):
     """A fixture that provides a Capsule based on config settings"""
     new_cap = capsule_factory()
     yield new_cap
+    new_cap.unregister()
     Broker(hosts=[new_cap]).checkin()
 
 


### PR DESCRIPTION
In snap 24 the capsule installer fails at RHEL7 with a dependency error because SatLab template provides postgres in version 12.11, while packages available in DF are 12.9.

```
    #x1B[34m2022-06-10 04:59:20#x1B[0m [#x1B[31mERROR #x1B[0m] [#x1B[36mroot#x1B[0m] Failed to ensure rh-postgresql12-postgresql-server, rh-redis5-redis, pulpcore-selinux are installed
    #x1B[34m2022-06-10 04:59:20#x1B[0m [#x1B[31mERROR #x1B[0m] [#x1B[36mroot#x1B[0m] #x1B[1;31mError: Execution of '/bin/yum -d 0 -e 0 -y install rh-postgresql12-postgresql-server' returned 1: Error: Package: rh-postgresql12-postgresql-server-12.9-1.el7.x86_64 (rhel-server-rhscl-7-rpms)
               Requires: rh-postgresql12-postgresql-libs(x86-64) = 12.9-1.el7
               Installed: rh-postgresql12-postgresql-libs-12.11-1.el7.x86_64 (@rhel-server-rhscl-7-rpms)
                   rh-postgresql12-postgresql-libs(x86-64) = 12.11-1.el7
```

So in this PR I register to CDN instead of DF to get latest content from `rhel`, `rhscl` and `ansible_engine` repos, while Satellite/Capsule repos remain the ones defined in `/etc/yum.repos.d./satellite.repo`
