### PR TITLE
Fixing DiscoveryPlugin tests

### DIFF
--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -74,7 +74,7 @@ class TestDiscoveryRule:
                 'model = KVM',
                 'Organization = Default_Organization',
                 'last_report = Today',
-                'subnet =  192.168.100.0',
+                'subnet = 192.168.100.0',
                 'facts.architecture != x86_64',
             ]
 
@@ -202,22 +202,6 @@ class TestDiscoveryRule:
         hosts_limit = '5'
         rule = discoveryrule_factory(options={'hosts-limit': hosts_limit})
         assert rule['hosts-limit'] == hosts_limit
-
-    @pytest.mark.tier1
-    def test_positive_create_with_max_count(self, discoveryrule_factory):
-        """Create Discovery Rule providing any number from range 1..100 for
-        max count option
-
-        :id: 590ca353-d3d7-4700-be34-13de00f46276
-
-        :expectedresults: Rule should be successfully created and has max_count
-            set as per given value
-
-        :CaseLevel: Component
-        """
-        max_count = '10'
-        rule = discoveryrule_factory(options={'max-count': max_count})
-        assert rule['hosts-limit'] == max_count
 
     @pytest.mark.tier1
     def test_positive_create_with_priority(self, discoveryrule_factory):

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -29,27 +29,25 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
-def discovery_org():
-    org = entities.Organization().create()
+def discovery_org(module_org):
     # Update default discovered host organization
     discovery_org = entities.Setting().search(query={'search': 'name="discovery_organization"'})[0]
     default_discovery_org = discovery_org.value
-    discovery_org.value = org.name
+    discovery_org.value = module_org.name
     discovery_org.update(['value'])
-    yield org
+    yield module_org
     discovery_org.value = default_discovery_org
     discovery_org.update(['value'])
 
 
 @pytest.fixture(scope='module')
-def discovery_location(discovery_org):
-    loc = entities.Location(name=gen_string('alpha'), organization=[discovery_org]).create()
+def discovery_location(module_location):
     # Update default discovered host location
     discovery_loc = entities.Setting().search(query={'search': 'name="discovery_location"'})[0]
     default_discovery_loc = discovery_loc.value
-    discovery_loc.value = loc.name
+    discovery_loc.value = module_location.name
     discovery_loc.update(['value'])
-    yield loc
+    yield module_location
     discovery_loc.value = default_discovery_loc
     discovery_loc.update(['value'])
 
@@ -283,7 +281,7 @@ def test_positive_auto_provision_host_with_rule(
 
 
 @pytest.mark.tier3
-def test_positive_delete(session, discovered_host):
+def test_positive_delete(session, discovery_org, discovery_location, discovered_host):
     """Delete the selected discovered host
 
     :id: 25a2a3ea-9659-4bdb-8631-c4dd19766014


### PR DESCRIPTION
Fixing some DiscoveryPlugin failures I was seeing. All of the Discovery Host UI tests were failing, because the discovery fixtures were using their own orgs and locations instead of module org and module location. I also removed the `max_count` test, as it was replaced by `hosts_limit` and we already have a test for that.

Need to back port these changes to 6.10 as those are also failing (except for the max_count test).

Related Airgun PR: https://github.com/SatelliteQE/airgun/pull/712