### PR TITLE
Create setup_method for clean env before test method run 

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -267,8 +267,6 @@ def deploy_configure_by_command(command, hypervisor_type, debug=False, org='Defa
     :param str org: Organization Label
     """
     virtwho_cleanup()
-    guest_name, guest_uuid = get_guest_info(hypervisor_type)
-    Host.delete({'name': guest_name})
     register_system(get_system(hypervisor_type), org=org)
     ret, stdout = runcmd(command)
     if ret != 0 or 'Finished successfully' not in stdout:

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -22,6 +22,7 @@ import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 
+from robottelo.cli.host import Host
 from robottelo.config import settings
 from robottelo.datafactory import valid_emails_list
 from robottelo.virtwho_utils import add_configure_option
@@ -34,9 +35,11 @@ from robottelo.virtwho_utils import get_configure_command
 from robottelo.virtwho_utils import get_configure_file
 from robottelo.virtwho_utils import get_configure_id
 from robottelo.virtwho_utils import get_configure_option
+from robottelo.virtwho_utils import get_guest_info
 from robottelo.virtwho_utils import get_virtwho_status
 from robottelo.virtwho_utils import restart_virtwho_service
 from robottelo.virtwho_utils import update_configure_option
+from robottelo.virtwho_utils import virtwho_cleanup
 
 
 @pytest.fixture()
@@ -54,6 +57,14 @@ def form_data():
 
 
 class TestVirtwhoConfigforEsx:
+    @pytest.mark.tier2
+    def setup_method(self):
+        """Set up a clean env for tests."""
+        virtwho_cleanup()
+        guest_name, guest_uuid = get_guest_info(settings.virtwho.esx.hypervisor_type)
+        if Host.list({'search': guest_name}):
+            Host.delete({'name': guest_name})
+
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
         """Verify configure created and deployed with id.
@@ -420,7 +431,6 @@ class TestVirtwhoConfigforEsx:
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
             session.organization.select("Default Organization")
-            session.organization.delete(org_name)
 
     @pytest.mark.tier2
     def test_positive_delete_configure(self, default_org, session, form_data):


### PR DESCRIPTION
Hey,
Changes:
1. Create setup_method for clean env before test method run 
2. Remove "session.organization.delete(org_name)" from test_positive_virtwho_configs_widget, because  there are hosts in org , so it will not delete. so remove this step, consider there is only one case wil create new org for testing, it will not effect the other case , so remove this step

ESX UI cases :pass
```
(robottelo_vv_6.10) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, reportportal-5.0.11, mock-3.6.1, ibutsu-2.0.2, forked-1.4.0, xdist-2.5.0, cov-3.0.0
collected 15 items / 15 deselected                                                                                                                                                                                

tests/foreman/virtwho/ui/test_esx.py ...............                                                                                                                                                        [100%]

================================================================================================ warnings summary =================================================================================================
tests/foreman/virtwho/ui/test_esx.py: 10 warnings
  /home/yanpliu/data/virtualenv_38/robottelo_vv_6.10/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-01.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

tests/foreman/virtwho/ui/test_esx.py: 18 warnings
  /home/yanpliu/data/virtualenv_38/robottelo_vv_6.10/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: desired_capabilities has been deprecated, please pass in an Options object with options kwarg
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=========================================================================== 15 passed, 15 deselected, 28 warnings in 7170.54s (1:59:30) ===========================================================================
```