### PR TITLE
add wait_for to get the complete mapping info in rhsm.log 

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -8,6 +8,7 @@ from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from fauxfactory import gen_url
 from nailgun import entities
+from wait_for import wait_for
 
 from robottelo import ssh
 from robottelo.cli.base import Base
@@ -204,7 +205,15 @@ def get_configure_option(option, filename):
         raise VirtWhoError(f"option {option} is not exist or not be enabled in {filename}")
 
 
-def _get_hypervisor_mapping(logs, hypervisor_type):
+def get_rhsm_log():
+    """
+    Return the content of log file /var/log/rhsm/rhsm.log
+    """
+    _, logs = runcmd('cat /var/log/rhsm/rhsm.log')
+    return logs
+
+
+def _get_hypervisor_mapping(hypervisor_type):
     """Analysing rhsm.log and get to know: what is the hypervisor_name
     for the specific guest.
     :param str logs: the output of rhsm.log.
@@ -212,6 +221,12 @@ def _get_hypervisor_mapping(logs, hypervisor_type):
     :raises: VirtWhoError: If hypervisor_name is None.
     :return: hypervisor_name and guest_name
     """
+    wait_for(
+        lambda: 'Host-to-guest mapping being sent to' in get_rhsm_log(),
+        timeout=10,
+        delay=2,
+    )
+    logs = get_rhsm_log()
     mapping = list()
     entry = None
     guest_name, guest_uuid = get_guest_info(hypervisor_type)
@@ -250,7 +265,7 @@ def deploy_validation(hypervisor_type):
     if status != 'running':
         raise VirtWhoError("Failed to start virt-who service")
     _, logs = runcmd('cat /var/log/rhsm/rhsm.log')
-    hypervisor_name, guest_name = _get_hypervisor_mapping(logs, hypervisor_type)
+    hypervisor_name, guest_name = _get_hypervisor_mapping(hypervisor_type)
     for host in Host.list({'search': hypervisor_name}):
         Host.delete({'id': host['id']})
     restart_virtwho_service()
@@ -400,7 +415,7 @@ def get_hypervisor_info(hypervisor_type):
     Get the hypervisor_name and guest_name from rhsm.log.
     """
     _, logs = runcmd('cat /var/log/rhsm/rhsm.log')
-    hypervisor_name, guest_name = _get_hypervisor_mapping(logs, hypervisor_type)
+    hypervisor_name, guest_name = _get_hypervisor_mapping(hypervisor_type)
     return hypervisor_name, guest_name
 
 


### PR DESCRIPTION
Hey,
This changes has been merged in Satellite6.11
https://github.com/SatelliteQE/robottelo/pull/9556/

Cases PASS on Esx, hyperv, libvirt and kubevirt.