### PR TITLE
Fixed UI tests in test_subscription.py

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -201,7 +201,6 @@ def test_positive_access_with_non_admin_user_with_manifest(test_name):
     org = entities.Organization().create()
     manifests.upload_manifest_locked(org.id)
     role = entities.Role(organization=[org]).create()
-    # create_role_permissions(role, {'Katello::Subscription': ['view_subscriptions']})
     create_role_permissions(
         role,
         {'Katello::Subscription': ['view_subscriptions'], 'Organization': ['view_organizations']},


### PR DESCRIPTION
A few tests in ui/test_subscription.py were failing due to:
1. New error message( No longer just a 404 pop-up)
2. non-admin users require more permissions to interact with the manifest modal