### PR TITLE
Remove unused module_proxy param

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1580,7 +1580,7 @@ def test_global_registration_with_gpg_repo_and_default_package(
 @pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6].*')
 def test_global_registration_upgrade_subscription_manager(
-    session, module_activation_key, module_os, module_proxy, rhel_contenthost
+    session, module_activation_key, module_os, rhel_contenthost
 ):
     """Host registration form produces a correct registration command and
     subscription-manager can be updated from a custom repository before


### PR DESCRIPTION
This parameter was never used, but after removing the `module_proxy` fixture in #9553 test started to fail. This was probably forgotten in the PR rebase.