### PR TITLE
fix in rex alternate dir test

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -255,7 +255,7 @@ class TestRemoteExecution:
 
     @pytest.mark.destructive
     @pytest.mark.rhel_ver_list([7])
-    def test_positive_use_alternate_directory(self, rex_contenthost, module_org, target_sat):
+    def test_positive_use_alternate_directory(self, rex_contenthost, target_sat):
         """Use alternate working directory on client to execute rex jobs
 
         :id: a0181f18-d3dc-4bd9-a2a6-430c2a49809e


### PR DESCRIPTION
Removed module_org fixture that was not used in the test and also caused failure (probably due to the combination of target_sat and destructive mark described in #9690)

test result:
```============================= test session starts ==============================
platform linux -- Python 3.10.4, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, configfile: pyproject.toml
plugins: forked-1.4.0, xdist-2.5.0, services-2.2.1, reportportal-5.1.1, mock-3.7.0, ibutsu-2.0.2, cov-3.0.0
collected 1 item

tests/foreman/cli/test_remoteexecution.py .                              [100%]

================== 1 passed, 16 warnings in 634.66s (0:10:34) =================
```

