### PR TITLE
Update module streams fixture to use satutils repo for 6.11+

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -96,7 +96,7 @@ def repos_collection_for_module_streams(module_org):
         repositories=[
             YumRepository(url=settings.repos.rhel8_os.baseos),
             YumRepository(url=settings.repos.rhel8_os.appstream),
-            YumRepository(url=settings.repos.sattools_repo[DISTRO_RHEL8]),
+            YumRepository(url=settings.repos.satutils_repo),
             YumRepository(url=settings.repos.module_stream_1.url),
         ],
     )


### PR DESCRIPTION
Hi, quite a few tests were [failing in 6.11](https://satqe-jenkins-csb-satellite-qe.apps.ocp-c1.prod.psi.redhat.com/view/6.11%20Rhel8%20Components/job/sat-6.11-rhel8-Hosts-Content/6/testReport/) for module stream tests because the `sattools_repo` was changed to `satutils_repo` in 6.11+. This PR adresses this, I have tested most of the affected cases locally with success.