### PR TITLE
Fix katello-agent tests to use client repo and register to cdn

### DIFF
--- a/pytest_fixtures/component/subscription.py
+++ b/pytest_fixtures/component/subscription.py
@@ -4,18 +4,6 @@ from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 
 
 @pytest.fixture(scope='module')
-def module_clean_rhsm(module_target_sat):
-    """removes pre-existing candlepin certs and resets RHSM."""
-    module_target_sat.remove_katello_ca()
-
-
-@pytest.fixture
-def func_clean_rhsm(target_sat):
-    """removes pre-existing candlepin certs and resets RHSM."""
-    target_sat.remove_katello_ca()
-
-
-@pytest.fixture(scope='module')
 def default_subscription(module_target_sat, module_org_with_manifest):
     subscription = module_target_sat.api.Subscription(
         organization=module_org_with_manifest.id
@@ -24,39 +12,25 @@ def default_subscription(module_target_sat, module_org_with_manifest):
     return subscription[0]
 
 
-def subscribe_satellite(sat):
-    from robottelo.config import settings
-
-    if sat.os_version.major < 8:
-        release_version = f'{sat.os_version.major}Server'
-    else:
-        release_version = f'{sat.os_version.major}'
-    sat.register_contenthost(
-        org=None,
-        lce=None,
-        username=settings.subscription.rhn_username,
-        password=settings.subscription.rhn_password,
-        releasever=release_version,
-    )
-    result = sat.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[0]
-    if 'Successfully attached a subscription' in result.stdout:
-        # extras is not in RHEL8: https://access.redhat.com/solutions/5331391
-        if sat.os_version.major < 8:
-            sat.enable_repo(f'rhel-{sat.os_version.major}-server-extras-rpms', force=True)
-        yield
-    else:
-        pytest.fail('Failed to attach system to pool. Aborting Test!.')
-    sat.unregister()
-    sat.remove_katello_ca()
-
-
 @pytest.fixture(scope='module')
-def module_subscribe_satellite(module_clean_rhsm, module_target_sat):
-    """subscribe satellite to cdn"""
-    subscribe_satellite(module_target_sat)
+def module_subscribe_satellite(module_target_sat):
+    """Subscribe Satellite to CDN"""
+    module_target_sat.register_to_cdn()
+    # Enable extras repo if os_version is RHEL7
+    if module_target_sat.os_version.major < 8:
+        module_target_sat.enable_repo(
+            f'rhel-{module_target_sat.os_version.major}-server-extras-rpms', force=True
+        )
+    yield
+    module_target_sat.unregister()
 
 
 @pytest.fixture
-def func_subscribe_satellite(func_clean_rhsm, target_sat):
-    """subscribe satellite to cdn"""
-    subscribe_satellite(target_sat)
+def subscribe_satellite(target_sat):
+    """Subscribe Satellite to CDN"""
+    target_sat.register_to_cdn()
+    # Enable extras repo if os_version is RHEL7
+    if target_sat.os_version.major < 8:
+        target_sat.enable_repo(f'rhel-{target_sat.os_version.major}-server-extras-rpms', force=True)
+    yield
+    target_sat.unregister()

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -9,7 +9,6 @@ from broker import Broker
 from fauxfactory import gen_string
 
 from robottelo import constants
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
@@ -159,7 +158,7 @@ def register_host_custom_repo(target_sat, module_org, rhel_contenthost, repo_url
         task = repo.sync(synchronous=False)
         tasks.append(task)
     for task in tasks:
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             search_query=(f'id = {task["id"]}'),
             poll_timeout=1500,
         )

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -10,6 +10,7 @@ def pytest_configure(config):
         "tier2: Tier 2 tests",  # Association tests
         "tier3: Tier 3 tests",  # Systems integration tests
         "tier4: Tier 4 tests",  # Long running tests
+        "tier5: Tier 5 tests",  # Deprecated component tests
         "destructive: Destructive tests",
         "upgrade: Upgrade tests",
         "pit_server: PIT server scenario tests",

--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -1,5 +1,6 @@
 import contextlib
 import random
+import time
 
 from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.logging import logger
@@ -93,3 +94,31 @@ class CapsuleInfo:
             finally:
                 logger.debug(f'Killing ncat pid: {ncat_pid}')
                 self.execute(f'kill {ncat_pid.pop()}')
+
+    def wait_for_tasks(
+        self, search_query, search_rate=1, max_tries=10, poll_rate=None, poll_timeout=None
+    ):
+        """Search for tasks by specified search query and poll them to ensure that
+        task has finished.
+
+        :param search_query: Search query that will be passed to API call.
+        :param search_rate: Delay between searches.
+        :param max_tries: How many times search should be executed.
+        :param poll_rate: Delay between the end of one task check-up and
+            the start of the next check-up. Parameter for ``sat.api.ForemanTask.poll()`` method.
+        :param poll_timeout: Maximum number of seconds to wait until timing out.
+            Parameter for ``sat.api.ForemanTask.poll()`` method.
+        :return: List of ``sat.api.ForemanTasks`` entities.
+        :raises: ``AssertionError``. If not tasks were found until timeout.
+        """
+        for _ in range(max_tries):
+            tasks = self.api.ForemanTask().search(query={'search': search_query})
+            if tasks:
+                for task in tasks:
+                    task.poll(poll_rate=poll_rate, timeout=poll_timeout)
+                break
+            else:
+                time.sleep(search_rate)
+        else:
+            raise AssertionError(f"No task was found using query '{search_query}'")
+        return tasks

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -384,7 +384,7 @@ class ContentHost(Host, ContentHostMixins):
         if result.status != 0:
             raise ContentHostError(f'Failed to install katello-agent: {result.stdout}')
         try:
-            wait_for(lambda: self.execute('systemctl status goferd').status == 0)
+            wait_for(lambda: self.execute('service goferd status').status == 0)
         except TimedOutError:
             raise ContentHostError('katello-agent is not running')
 
@@ -1118,6 +1118,24 @@ class ContentHost(Host, ContentHostMixins):
             raise ContentHostError('There was an error installing katello-host-tools-tracer')
         self.execute('katello-tracer-upload')
 
+    def register_to_cdn(self):
+        """Subscribe satellite to CDN"""
+        self.remove_katello_ca()
+        major_version = self.os_version.major
+        release_version = f'{major_version}Server' if major_version < 8 else f'{major_version}'
+        cmd_result = self.register_contenthost(
+            org=None,
+            lce=None,
+            username=settings.subscription.rhn_username,
+            password=settings.subscription.rhn_password,
+            releasever=release_version,
+        )
+        if cmd_result.status != 0:
+            raise ContentHostError(
+                f'Error during registration, command output: {cmd_result.stdout}'
+            )
+        self.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[0]
+
 
 class Capsule(ContentHost, CapsuleMixins):
     rex_key_path = '~foreman-proxy/.ssh/id_rsa_foreman_proxy.pub'
@@ -1524,3 +1542,31 @@ class Satellite(Capsule, SatelliteMixins):
                 f'Error during cockpit installation, installation output: {cmd_result.stdout}'
             )
         self.add_rex_key(self)
+
+    def wait_for_tasks(
+        self, search_query, search_rate=1, max_tries=10, poll_rate=None, poll_timeout=None
+    ):
+        """Search for tasks by specified search query and poll them to ensure that
+        task has finished.
+
+        :param search_query: Search query that will be passed to API call.
+        :param search_rate: Delay between searches.
+        :param max_tries: How many times search should be executed.
+        :param poll_rate: Delay between the end of one task check-up and
+            the start of the next check-up. Parameter for ``sat.api.ForemanTask.poll()`` method.
+        :param poll_timeout: Maximum number of seconds to wait until timing out.
+            Parameter for ``sat.api.ForemanTask.poll()`` method.
+        :return: List of ``sat.api.ForemanTasks`` entities.
+        :raises: ``AssertionError``. If not tasks were found until timeout.
+        """
+        for _ in range(max_tries):
+            tasks = self.api.ForemanTask().search(query={'search': search_query})
+            if len(tasks) > 0:
+                for task in tasks:
+                    task.poll(poll_rate=poll_rate, timeout=poll_timeout)
+                break
+            else:
+                time.sleep(search_rate)
+        else:
+            raise AssertionError(f"No task was found using query '{search_query}'")
+        return tasks

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -62,7 +62,7 @@ def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
 
 @pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_apply_errata(katello_agent_client):
-    """Apply errata to a host
+    """Apply errata on a host
 
     :id: 8d0e5c93-f9fd-4ec0-9a61-aa93082a30c5
 
@@ -85,17 +85,16 @@ def test_positive_apply_errata(katello_agent_client):
     sat.cli.Host.errata_apply(
         {'errata-ids': settings.repos.yum_0.errata[1], 'host-id': host_info['id']}
     )
-    result = client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}')
-    assert result.status == 0
+    assert client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}').status == 0
 
 
 @pytest.mark.rhel_ver_list([6, 7, 8, 9])
-def test_positive_install_package(katello_agent_client):
-    """Install a package to a host remotely
+def test_positive_install_and_remove_package(katello_agent_client):
+    """Install and remove a package on a host remotely
 
     :id: b1009bba-0c7e-4b00-8ac4-256e5cfe4a78
 
-    :expectedresults: Package was successfully installed
+    :expectedresults: Package successfully installed and removed
 
     :parametrized: yes
 
@@ -107,40 +106,20 @@ def test_positive_install_package(katello_agent_client):
     sat.cli.Host.package_install(
         {'host-id': host_info['id'], 'packages': constants.FAKE_0_CUSTOM_PACKAGE_NAME}
     )
-    result = client.run(f'rpm -q {constants.FAKE_0_CUSTOM_PACKAGE_NAME}')
-    assert result.status == 0
-
-
-@pytest.mark.rhel_ver_list([6, 7, 8, 9])
-def test_positive_remove_package(katello_agent_client):
-    """Remove a package from a host remotely
-
-    :id: 573dec11-8f14-411f-9e41-84426b0f23b5
-
-    :expectedresults: Package was successfully removed
-
-    :parametrized: yes
-
-    :CaseLevel: System
-    """
-    sat = katello_agent_client['sat']
-    client = katello_agent_client['client']
-    host_info = katello_agent_client['host_info']
-    client.run(f'yum install -y {constants.FAKE_1_CUSTOM_PACKAGE}')
+    assert client.run(f'rpm -q {constants.FAKE_0_CUSTOM_PACKAGE_NAME}').status == 0
     sat.cli.Host.package_remove(
-        {'host-id': host_info['id'], 'packages': constants.FAKE_1_CUSTOM_PACKAGE_NAME}
+        {'host-id': host_info['id'], 'packages': constants.FAKE_0_CUSTOM_PACKAGE_NAME}
     )
-    result = client.run(f'rpm -q {constants.FAKE_1_CUSTOM_PACKAGE_NAME}')
-    assert result.status != 0
+    assert client.run(f'rpm -q {constants.FAKE_0_CUSTOM_PACKAGE_NAME}').status != 0
 
 
 @pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_upgrade_package(katello_agent_client):
-    """Upgrade a host package remotely
+    """Upgrade a package on a host remotely
 
     :id: ad751c63-7175-40ae-8bc4-800462cd9c29
 
-    :expectedresults: Package was successfully upgraded
+    :expectedresults: Package successfully upgraded
 
     :parametrized: yes
 
@@ -153,18 +132,16 @@ def test_positive_upgrade_package(katello_agent_client):
     sat.cli.Host.package_upgrade(
         {'host-id': host_info['id'], 'packages': constants.FAKE_1_CUSTOM_PACKAGE_NAME}
     )
-    result = client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}')
-    assert result.status == 0
+    assert client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}').status == 0
 
 
 @pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_upgrade_packages_all(katello_agent_client):
-    """Upgrade all the host packages remotely
+    """Upgrade all packages on a host remotely
 
     :id: 003101c7-bb95-4e51-a598-57977b2858a9
 
-    :expectedresults: Packages (at least 1 with newer version available)
-        were successfully upgraded
+    :expectedresults: Packages successfully upgraded (at least 1 with newer version available)
 
     :parametrized: yes
 
@@ -175,18 +152,16 @@ def test_positive_upgrade_packages_all(katello_agent_client):
     host_info = katello_agent_client['host_info']
     client.run(f'yum install -y {constants.FAKE_1_CUSTOM_PACKAGE}')
     sat.cli.Host.package_upgrade_all({'host-id': host_info['id']})
-    result = client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}')
-    assert result.status == 0
+    assert client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}').status == 0
 
 
 @pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_install_and_remove_package_group(katello_agent_client):
-    """Install and remove a package group to a host remotely
+    """Install and remove a package group on a host remotely
 
     :id: ded20a89-cfd9-48d5-8829-739b1a4d4042
 
-    :expectedresults: Package group was successfully installed
-        and removed
+    :expectedresults: Package group successfully installed and removed
 
     :parametrized: yes
 
@@ -198,9 +173,7 @@ def test_positive_install_and_remove_package_group(katello_agent_client):
     hammer_args = {'groups': constants.FAKE_0_CUSTOM_PACKAGE_GROUP_NAME, 'host-id': host_info['id']}
     sat.cli.Host.package_group_install(hammer_args)
     for package in constants.FAKE_0_CUSTOM_PACKAGE_GROUP:
-        result = client.run(f'rpm -q {package}')
-        assert result.status == 0
+        assert client.run(f'rpm -q {package}').status == 0
     sat.cli.Host.package_group_remove(hammer_args)
     for package in constants.FAKE_0_CUSTOM_PACKAGE_GROUP:
-        result = client.run(f'rpm -q {package}')
-        assert result.status != 0
+        assert client.run(f'rpm -q {package}').status != 0

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -60,6 +60,7 @@ def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
     yield {'client': rhel_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent}
 
 
+@pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_apply_errata(katello_agent_client):
     """Apply errata to a host
 
@@ -88,6 +89,7 @@ def test_positive_apply_errata(katello_agent_client):
     assert result.status == 0
 
 
+@pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_install_package(katello_agent_client):
     """Install a package to a host remotely
 
@@ -109,6 +111,7 @@ def test_positive_install_package(katello_agent_client):
     assert result.status == 0
 
 
+@pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_remove_package(katello_agent_client):
     """Remove a package from a host remotely
 
@@ -131,6 +134,7 @@ def test_positive_remove_package(katello_agent_client):
     assert result.status != 0
 
 
+@pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_upgrade_package(katello_agent_client):
     """Upgrade a host package remotely
 
@@ -153,6 +157,7 @@ def test_positive_upgrade_package(katello_agent_client):
     assert result.status == 0
 
 
+@pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_upgrade_packages_all(katello_agent_client):
     """Upgrade all the host packages remotely
 
@@ -174,6 +179,7 @@ def test_positive_upgrade_packages_all(katello_agent_client):
     assert result.status == 0
 
 
+@pytest.mark.rhel_ver_list([6, 7, 8, 9])
 def test_positive_install_and_remove_package_group(katello_agent_client):
     """Install and remove a package group to a host remotely
 

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -60,7 +60,7 @@ def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
     yield {'client': rhel_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent}
 
 
-@pytest.mark.rhel_ver_list([6, 7, 8, 9])
+@pytest.mark.rhel_ver_match(r'[\d]+')
 def test_positive_apply_errata(katello_agent_client):
     """Apply errata on a host
 
@@ -88,7 +88,7 @@ def test_positive_apply_errata(katello_agent_client):
     assert client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}').status == 0
 
 
-@pytest.mark.rhel_ver_list([6, 7, 8, 9])
+@pytest.mark.rhel_ver_match(r'[\d]+')
 def test_positive_install_and_remove_package(katello_agent_client):
     """Install and remove a package on a host remotely
 
@@ -113,7 +113,7 @@ def test_positive_install_and_remove_package(katello_agent_client):
     assert client.run(f'rpm -q {constants.FAKE_0_CUSTOM_PACKAGE_NAME}').status != 0
 
 
-@pytest.mark.rhel_ver_list([6, 7, 8, 9])
+@pytest.mark.rhel_ver_match(r'[\d]+')
 def test_positive_upgrade_package(katello_agent_client):
     """Upgrade a package on a host remotely
 
@@ -135,7 +135,7 @@ def test_positive_upgrade_package(katello_agent_client):
     assert client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}').status == 0
 
 
-@pytest.mark.rhel_ver_list([6, 7, 8, 9])
+@pytest.mark.rhel_ver_match(r'[\d]+')
 def test_positive_upgrade_packages_all(katello_agent_client):
     """Upgrade all packages on a host remotely
 
@@ -155,7 +155,7 @@ def test_positive_upgrade_packages_all(katello_agent_client):
     assert client.run(f'rpm -q {constants.FAKE_2_CUSTOM_PACKAGE}').status == 0
 
 
-@pytest.mark.rhel_ver_list([6, 7, 8, 9])
+@pytest.mark.rhel_ver_match(r'[\d]+')
 def test_positive_install_and_remove_package_group(katello_agent_client):
     """Install and remove a package group on a host remotely
 

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -18,7 +18,6 @@
 """
 import pytest
 
-from pytest_fixtures.core.contenthosts import register_host_custom_repo
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.helpers import InstallerCommand
@@ -52,9 +51,9 @@ def sat_with_katello_agent(module_target_sat):
 def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
     """Register content host to Satellite and install katello-agent on the host."""
     org = sat_with_katello_agent.api.Organization().create()
-    repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
-    register_host_custom_repo(
-        sat_with_katello_agent, org, rhel_contenthost, [repo, settings.repos.yum_1.url]
+    client_repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
+    sat_with_katello_agent.register_host_custom_repo(
+        org, rhel_contenthost, [client_repo, settings.repos.yum_1.url]
     )
     rhel_contenthost.install_katello_agent()
     host_info = sat_with_katello_agent.cli.Host.info({'name': rhel_contenthost.hostname})

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -200,7 +200,7 @@ def test_positive_create_with_https(
 
 
 def test_single_sign_on_ldap_ipa_server(
-    func_subscribe_satellite, func_enroll_idm_and_configure_external_auth, target_sat
+    subscribe_satellite, func_enroll_idm_and_configure_external_auth, target_sat
 ):
     """Verify the single sign-on functionality with external authentication
 
@@ -244,7 +244,7 @@ def test_single_sign_on_ldap_ipa_server(
     'enroll_ad_and_configure_external_auth', ['AD_2016', 'AD_2019'], indirect=True
 )
 def test_single_sign_on_ldap_ad_server(
-    func_subscribe_satellite, enroll_ad_and_configure_external_auth, target_sat
+    subscribe_satellite, enroll_ad_and_configure_external_auth, target_sat
 ):
     """Verify the single sign-on functionality with external authentication
 


### PR DESCRIPTION
**Description:**
1. Using DF's client repo for katello-agent package install on the client instead of old tools repo from CDN.
2. register_to_cdn instead of register_to_dogfood.
3. Parametrizing tests to run on rhel6/7/8/9 and rhel7/8-fips content hosts.
4. Moving tests to new tier5 for deprecated components.

**Dependant MR**: satlab-tower-MR#562 (merged)

Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>