### PR TITLE
Fixed docker tags whitelist tests and updated helper function

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -563,7 +563,7 @@ def make_repository_with_credentials(options=None, credentials=None):
     args = {
         'checksum-type': None,
         'content-type': 'yum',
-        'docker-tags-whitelist': None,
+        'include-tags': None,
         'docker-upstream-name': None,
         'download-policy': None,
         'gpg-key': None,

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -990,7 +990,7 @@ class TestRepository:
     )
     def test_positive_synchronize_docker_repo_set_tags_later_content_only(self, repo):
         """Verify that adding tags whitelist and re-syncing after
-        synchronizing full repository doesn't remove content that was
+        synchronizing full repository does remove content that was
         already pulled in when mirroring policy is set to content only
 
         :id: 539dc138-8566-40ad-b0de-1d9ec80aa56f

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -960,8 +960,7 @@ class TestRepository:
 
         :parametrized: yes
 
-        :expectedresults: Non-whitelisted tags are not removed when
-        mirroring policy is set to additive
+        :expectedresults: Non-whitelisted tags are not removed
         """
         tags = 'latest'
         Repository.synchronize({'id': repo['id']})
@@ -999,8 +998,7 @@ class TestRepository:
 
         :parametrized: yes
 
-        :expectedresults: Non-whitelisted tags are removed when mirroring policy
-        is set to content only
+        :expectedresults: Non-whitelisted tags are removed
         """
         tags = 'latest'
         Repository.synchronize({'id': repo['id']})


### PR DESCRIPTION
Fixed failing tests in the CLI due to 'docker-tags-whitelist' being replaced with 'include-tags'. Also added new tests based on the repository mirroring policy. 

if it's additive, tags won't be removed
if it's mirroring, then the tags should be removed