### PR TITLE
update all the entities to target_sat for virt-who plugin cases

### DIFF
--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -18,10 +18,7 @@
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 
-from robottelo.cli.host import Host
-from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -49,13 +46,15 @@ def form_data(default_org, target_sat):
 
 
 @pytest.fixture()
-def virtwho_config(form_data):
-    return entities.VirtWhoConfig(**form_data).create()
+def virtwho_config(form_data, target_sat):
+    return target_sat.api.VirtWhoConfig(**form_data).create()
 
 
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
         :id: f5228e01-bb8d-4c8e-877e-cd8bc494f00e
@@ -72,7 +71,7 @@ class TestVirtWhoConfigforHyperv:
             command, form_data['hypervisor_type'], debug=True, org=default_org.label
         )
         virt_who_instance = (
-            entities.VirtWhoConfig()
+            target_sat.api.VirtWhoConfig()
             .search(query={'search': f'name={virtwho_config.name}'})[0]
             .status
         )
@@ -88,24 +87,30 @@ class TestVirtWhoConfigforHyperv:
             ),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            entities.HostSubscription(host=host['id']).add_subscriptions(
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
-            result = entities.Host().search(query={'search': hostname})[0].read_json()
+            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify "GET /foreman_virt_who_configure/api/
 
         v2/configs/:id/deploy_script"
@@ -127,7 +132,7 @@ class TestVirtWhoConfigforHyperv:
             org=default_org.label,
         )
         virt_who_instance = (
-            entities.VirtWhoConfig()
+            target_sat.api.VirtWhoConfig()
             .search(query={'search': f'name={virtwho_config.name}'})[0]
             .status
         )
@@ -143,24 +148,30 @@ class TestVirtWhoConfigforHyperv:
             ),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            entities.HostSubscription(host=host['id']).add_subscriptions(
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
-            result = entities.Host().search(query={'search': hostname})[0].read_json()
+            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify hypervisor_id option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -184,4 +195,6 @@ class TestVirtWhoConfigforHyperv:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -48,7 +48,6 @@ def virtwho_config(form_data, target_sat):
     return target_sat.api.VirtWhoConfig(**form_data).create()
 
 
-# @pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -18,10 +18,7 @@
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 
-from robottelo.cli.host import Host
-from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -47,14 +44,16 @@ def form_data(default_org, target_sat):
 
 
 @pytest.fixture()
-def virtwho_config(form_data):
-    return entities.VirtWhoConfig(**form_data).create()
+def virtwho_config(form_data, target_sat):
+    return target_sat.api.VirtWhoConfig(**form_data).create()
 
 
-@pytest.mark.skip_if_open('BZ:1735540')
+# @pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
         :id: 97f776af-cbd0-4885-9a74-603a3bc01157
@@ -71,7 +70,7 @@ class TestVirtWhoConfigforKubevirt:
             command, form_data['hypervisor_type'], debug=True, org=default_org.label
         )
         virt_who_instance = (
-            entities.VirtWhoConfig()
+            target_sat.api.VirtWhoConfig()
             .search(query={'search': f'name={virtwho_config.name}'})[0]
             .status
         )
@@ -87,24 +86,30 @@ class TestVirtWhoConfigforKubevirt:
             ),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            entities.HostSubscription(host=host['id']).add_subscriptions(
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
-            result = entities.Host().search(query={'search': hostname})[0].read_json()
+            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify "GET /foreman_virt_who_configure/api/
 
         v2/configs/:id/deploy_script"
@@ -126,7 +131,7 @@ class TestVirtWhoConfigforKubevirt:
             org=default_org.label,
         )
         virt_who_instance = (
-            entities.VirtWhoConfig()
+            target_sat.api.VirtWhoConfig()
             .search(query={'search': f'name={virtwho_config.name}'})[0]
             .status
         )
@@ -142,24 +147,30 @@ class TestVirtWhoConfigforKubevirt:
             ),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            entities.HostSubscription(host=host['id']).add_subscriptions(
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
-            result = entities.Host().search(query={'search': hostname})[0].read_json()
+            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify hypervisor_id option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -183,4 +194,6 @@ class TestVirtWhoConfigforKubevirt:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -18,10 +18,7 @@
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 
-from robottelo.cli.host import Host
-from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -48,13 +45,15 @@ def form_data(default_org, target_sat):
 
 
 @pytest.fixture()
-def virtwho_config(form_data):
-    return entities.VirtWhoConfig(**form_data).create()
+def virtwho_config(form_data, target_sat):
+    return target_sat.api.VirtWhoConfig(**form_data).create()
 
 
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
         :id: 2598cfa8-3bec-4f41-9911-979ae92c89c0
@@ -71,7 +70,7 @@ class TestVirtWhoConfigforLibvirt:
             command, form_data['hypervisor_type'], debug=True, org=default_org.label
         )
         virt_who_instance = (
-            entities.VirtWhoConfig()
+            target_sat.api.VirtWhoConfig()
             .search(query={'search': f'name={virtwho_config.name}'})[0]
             .status
         )
@@ -87,24 +86,30 @@ class TestVirtWhoConfigforLibvirt:
             ),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            entities.HostSubscription(host=host['id']).add_subscriptions(
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
-            result = entities.Host().search(query={'search': hostname})[0].read_json()
+            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify "GET /foreman_virt_who_configure/api/
 
         v2/configs/:id/deploy_script"
@@ -126,7 +131,7 @@ class TestVirtWhoConfigforLibvirt:
             org=default_org.label,
         )
         virt_who_instance = (
-            entities.VirtWhoConfig()
+            target_sat.api.VirtWhoConfig()
             .search(query={'search': f'name={virtwho_config.name}'})[0]
             .status
         )
@@ -142,24 +147,30 @@ class TestVirtWhoConfigforLibvirt:
             ),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            entities.HostSubscription(host=host['id']).add_subscriptions(
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
             )
-            result = entities.Host().search(query={'search': hostname})[0].read_json()
+            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify hypervisor_id option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -183,4 +194,6 @@ class TestVirtWhoConfigforLibvirt:
             )
             assert get_configure_option('hypervisor_id', config_file) == value
         virtwho_config.delete()
-        assert not entities.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -19,9 +19,6 @@
 import pytest
 from fauxfactory import gen_string
 
-from robottelo.cli.host import Host
-from robottelo.cli.subscription import Subscription
-from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -49,13 +46,15 @@ def form_data(target_sat, default_org):
 
 
 @pytest.fixture()
-def virtwho_config(form_data):
-    return VirtWhoConfig.create(form_data)['general-information']
+def virtwho_config(form_data, target_sat):
+    return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
 
 
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify " hammer virt-who-config deploy"
 
         :id: 7cc0ad4f-e185-4d63-a2f5-1cb0245faa6c
@@ -71,30 +70,36 @@ class TestVirtWhoConfigforHyperv:
         hypervisor_name, guest_name = deploy_configure_by_command(
             command, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
-        virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
-            'status'
-        ]
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+            'general-information'
+        ]['status']
         assert virt_who_instance == 'OK'
         hosts = [
             (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
             (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
+            result = target_sat.cli.Host.subscription_attach(
+                {'host-id': host['id'], 'subscription-id': vdc_id}
+            )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify " hammer virt-who-config fetch"
 
         :id: 22dc8068-c843-4ca0-acbe-0b2aef8ece31
@@ -106,34 +111,42 @@ class TestVirtWhoConfigforHyperv:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
+        script = target_sat.cli.VirtWhoConfig.fetch(
+            {'id': virtwho_config['id']}, output_format='base'
+        )
         hypervisor_name, guest_name = deploy_configure_by_script(
             script, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
-        virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
-            'status'
-        ]
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+            'general-information'
+        ]['status']
         assert virt_who_instance == 'OK'
         hosts = [
             (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
             (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
+            result = target_sat.cli.Host.subscription_attach(
+                {'host-id': host['id'], 'subscription-id': vdc_id}
+            )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 8e234492-33cb-4523-abb3-582626ad704c
@@ -146,8 +159,10 @@ class TestVirtWhoConfigforHyperv:
         """
         values = ['uuid', 'hostname']
         for value in values:
-            VirtWhoConfig.update({'id': virtwho_config['id'], 'hypervisor-id': value})
-            result = VirtWhoConfig.info({'id': virtwho_config['id']})
+            target_sat.cli.VirtWhoConfig.update(
+                {'id': virtwho_config['id'], 'hypervisor-id': value}
+            )
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
             command = get_configure_command(virtwho_config['id'], default_org.name)
@@ -155,5 +170,5 @@ class TestVirtWhoConfigforHyperv:
                 command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -19,9 +19,6 @@
 import pytest
 from fauxfactory import gen_string
 
-from robottelo.cli.host import Host
-from robottelo.cli.subscription import Subscription
-from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -47,14 +44,16 @@ def form_data(target_sat, default_org):
 
 
 @pytest.fixture()
-def virtwho_config(form_data):
-    return VirtWhoConfig.create(form_data)['general-information']
+def virtwho_config(form_data, target_sat):
+    return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
 
 
 @pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify " hammer virt-who-config deploy"
 
         :id: d0b109f5-2699-43e4-a6cd-d682204d97a7
@@ -70,30 +69,36 @@ class TestVirtWhoConfigforKubevirt:
         hypervisor_name, guest_name = deploy_configure_by_command(
             command, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
-        virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
-            'status'
-        ]
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+            'general-information'
+        ]['status']
         assert virt_who_instance == 'OK'
         hosts = [
             (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
             (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
+            result = target_sat.cli.Host.subscription_attach(
+                {'host-id': host['id'], 'subscription-id': vdc_id}
+            )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify " hammer virt-who-config fetch"
 
         :id: 273df8e0-5ef5-47d9-9567-543157be7dd8
@@ -105,34 +110,42 @@ class TestVirtWhoConfigforKubevirt:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
+        script = target_sat.cli.VirtWhoConfig.fetch(
+            {'id': virtwho_config['id']}, output_format='base'
+        )
         hypervisor_name, guest_name = deploy_configure_by_script(
             script, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
-        virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
-            'status'
-        ]
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+            'general-information'
+        ]['status']
         assert virt_who_instance == 'OK'
         hosts = [
             (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
             (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
+            result = target_sat.cli.Host.subscription_attach(
+                {'host-id': host['id'], 'subscription-id': vdc_id}
+            )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 57b89c7e-538e-4ab8-98b5-af4b9f587792
@@ -145,8 +158,10 @@ class TestVirtWhoConfigforKubevirt:
         """
         values = ['uuid', 'hostname']
         for value in values:
-            VirtWhoConfig.update({'id': virtwho_config['id'], 'hypervisor-id': value})
-            result = VirtWhoConfig.info({'id': virtwho_config['id']})
+            target_sat.cli.VirtWhoConfig.update(
+                {'id': virtwho_config['id'], 'hypervisor-id': value}
+            )
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
             command = get_configure_command(virtwho_config['id'], default_org.name)
@@ -154,5 +169,5 @@ class TestVirtWhoConfigforKubevirt:
                 command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -19,9 +19,6 @@
 import pytest
 from fauxfactory import gen_string
 
-from robottelo.cli.host import Host
-from robottelo.cli.subscription import Subscription
-from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.virtwho_utils import deploy_configure_by_command
 from robottelo.virtwho_utils import deploy_configure_by_script
@@ -50,13 +47,15 @@ def form_data(target_sat, default_org):
 
 
 @pytest.fixture()
-def virtwho_config(form_data):
-    return VirtWhoConfig.create(form_data)['general-information']
+def virtwho_config(form_data, target_sat):
+    return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
 
 
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_id(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify "hammer virt-who-config deploy"
 
         :id: 129d8e57-b4fc-4d95-ad33-5aa6ec6fb146
@@ -72,30 +71,36 @@ class TestVirtWhoConfigforNutanix:
         hypervisor_name, guest_name = deploy_configure_by_command(
             command, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
-        virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
-            'status'
-        ]
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+            'general-information'
+        ]['status']
         assert virt_who_instance == 'OK'
         hosts = [
             (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
             (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
+            result = target_sat.cli.Host.subscription_attach(
+                {'host-id': host['id'], 'subscription-id': vdc_id}
+            )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, form_data, virtwho_config):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify "hammer virt-who-config fetch"
 
         :id: d707fac0-f2b1-4493-b083-cf1edc231691
@@ -107,34 +112,42 @@ class TestVirtWhoConfigforNutanix:
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        script = VirtWhoConfig.fetch({'id': virtwho_config['id']}, output_format='base')
+        script = target_sat.cli.VirtWhoConfig.fetch(
+            {'id': virtwho_config['id']}, output_format='base'
+        )
         hypervisor_name, guest_name = deploy_configure_by_script(
             script, form_data['hypervisor-type'], debug=True, org=default_org.label
         )
-        virt_who_instance = VirtWhoConfig.info({'id': virtwho_config['id']})['general-information'][
-            'status'
-        ]
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+            'general-information'
+        ]['status']
         assert virt_who_instance == 'OK'
         hosts = [
             (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
             (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
         ]
         for hostname, sku in hosts:
-            host = Host.list({'search': hostname})[0]
-            subscriptions = Subscription.list({'organization': default_org.name, 'search': sku})
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
             vdc_id = subscriptions[0]['id']
             if 'type=STACK_DERIVED' in sku:
                 for item in subscriptions:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            result = Host.subscription_attach({'host-id': host['id'], 'subscription-id': vdc_id})
+            result = target_sat.cli.Host.subscription_attach(
+                {'host-id': host['id'], 'subscription-id': vdc_id}
+            )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, form_data, virtwho_config):
+    def test_positive_hypervisor_id_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
         :id: 565228cd-2124-41ed-89b7-84ec6ff77213
@@ -147,8 +160,10 @@ class TestVirtWhoConfigforNutanix:
         """
         values = ['uuid', 'hostname']
         for value in values:
-            VirtWhoConfig.update({'id': virtwho_config['id'], 'hypervisor-id': value})
-            result = VirtWhoConfig.info({'id': virtwho_config['id']})
+            target_sat.cli.VirtWhoConfig.update(
+                {'id': virtwho_config['id'], 'hypervisor-id': value}
+            )
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
             assert result['connection']['hypervisor-id'] == value
             config_file = get_configure_file(virtwho_config['id'])
             command = get_configure_command(virtwho_config['id'], default_org.name)
@@ -156,5 +171,5 @@ class TestVirtWhoConfigforNutanix:
                 command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))


### PR DESCRIPTION
Hey,
Update all the entities to target_sat for virt-who plugin cases.

Hypervisor Hyperv, Kubevirt, Nutanix, libvirt cases for API and CLI : PASS

Test Results:
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_libvirt.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.1.0, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.1.1
collected 3 items / 3 deselected / 0 selected                                                                                                                                                                     

tests/foreman/virtwho/cli/test_libvirt.py ...                                                                                                                                                               [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/cli/test_libvirt.py::TestVirtWhoConfigforLibvirt::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 3 passed, 3 deselected, 4 warnings in 569.93s (0:09:29) =============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_hyperv.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.1.0, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.1.1
collected 3 items / 3 deselected / 0 selected                                                                                                                                                                     

tests/foreman/virtwho/cli/test_hyperv.py ...                                                                                                                                                                [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/cli/test_hyperv.py::TestVirtWhoConfigforHyperv::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 3 passed, 3 deselected, 4 warnings in 305.74s (0:05:05) =============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.1.0, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.1.1
collected 3 items / 3 deselected / 0 selected                                                                                                                                                                     

tests/foreman/virtwho/cli/test_nutanix.py ...                                                                                                                                                               [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/cli/test_nutanix.py::TestVirtWhoConfigforNutanix::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 3 passed, 3 deselected

(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_kubevirt.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.1.0, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.1.1
collected 3 items / 3 deselected / 0 selected                                                                                                                                                                     

tests/foreman/virtwho/cli/test_kubevirt.py ...                                                                                                                                                              [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/cli/test_kubevirt.py::TestVirtWhoConfigforKubevirt::test_positive_deploy_configure_by_id
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 3 passed, 3 deselected, 4 warnings in 504.12s (0:08:24) =============================================================================
(

(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_hyperv.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.1.0, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.1.1
collected 3 items / 3 deselected / 0 selected                                                                                                                                                                     

tests/foreman/virtwho/api/test_hyperv.py ...                                                                                                                                                                [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/api/test_hyperv.py: 27 warnings
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 3 passed, 3 deselected, 30 warnings in 261.29s (0:04:21) =============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_libvirt.py 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.1.0, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.1.1
collected 3 items / 3 deselected / 0 selected                                                                                                                                                                     

tests/foreman/virtwho/api/test_libvirt.py ...                                                                                                                                                               [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/api/test_libvirt.py: 27 warnings
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html

============================================================================ 3 passed, 3 deselected, 30 warnings in 547.45s (0:09:07) =============================================================================



```