### PR TITLE
Test fix related to sc parameter ui test

### DIFF
--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -462,7 +462,7 @@ def test_positive_create_with_21_filters(session):
 
 
 @pytest.mark.tier2
-def test_positive_create_with_sc_parameter_permission(session):
+def test_positive_create_with_sc_parameter_permission(session_puppet_enabled_sat):
     """Create role filter with few permissions for smart class parameters.
 
     :id: c9e466e5-d6ce-4596-bd32-c2a7817da34a
@@ -478,13 +478,13 @@ def test_positive_create_with_sc_parameter_permission(session):
     role_name = gen_string('alpha')
     resource_type = 'Smart class parameter'
     permissions = ['view_external_parameters', 'edit_external_parameters']
-    with session:
+    with session_puppet_enabled_sat.ui_session as session:
         session.role.create({'name': role_name})
         assert session.role.search(role_name)[0]['Name'] == role_name
         session.filter.create(
             role_name, {'resource_type': resource_type, 'permission.assigned': permissions}
         )
-        values = session.filter.search(role_name, 'PuppetclassLookupKey')
+        values = session.filter.search(role_name, 'ForemanPuppet::PuppetclassLookupKey')
         assert values
         assert values[0]['Resource'] == resource_type
         assigned_permissions = values[0]['Permissions'].split(', ')


### PR DESCRIPTION
**`Test Result:`**
```
$ pytest -k test_positive_create_with_sc_parameter_permission tests/foreman/ui/test_role.py -sv
============================================= test session starts ====================================================
platform linux -- Python 3.8.6, pytest-7.1.2, pluggy-0.13.1 -- /home/sganar/satellite/satenv/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sganar/satellite/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, forked-1.3.0, ibutsu-2.0.2, reportportal-5.1.1, cov-3.0.0, xdist-2.5.0, mock-3.7.0, fixture-tools-1.1.0
collecting ... 2022-06-23 12:50:54 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 10 items / 9 deselected / 1 selected  
=================================== 1 passed, 9 deselected in 2642.29s (0:44:02) ===================================================== 
```                                                                                                                                                                                     
