### PR TITLE
Use async repo synchronization

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2191,7 +2191,7 @@ class TestHostCockpit:
             hostname_inside_cockpit = session.host.get_webconsole_content(
                 entity_name=cockpit_host.hostname, rhel_version=cockpit_host.os_version.major
             )
-            assert hostname_inside_cockpit == cockpit_host.hostname, (
+            assert cockpit_host.hostname in hostname_inside_cockpit, (
                 f'cockpit page shows hostname {hostname_inside_cockpit} '
                 f'instead of {cockpit_host.hostname}'
             )


### PR DESCRIPTION
This should be faster in case there are multiple repos, such as rhel7 cockpit tests. I also had to slightly extend the timeout as tests were failing due to a timeout error in the last snap.