### PR TITLE
Remove BZ check

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -62,7 +62,6 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import valid_data_list
 from robottelo.datafactory import valid_hosts_list
 from robottelo.hosts import ContentHostError
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope="module")
@@ -720,20 +719,14 @@ def test_positive_list_infrastructure_hosts(
     Host.update({'name': target_sat.hostname, 'new-organization-id': module_org.id})
     # list satellite hosts
     hosts = Host.list({'search': 'infrastructure_facet.foreman=true'})
-    if is_open('BZ:1994685'):
-        assert len(hosts) == 2
-    else:
-        assert len(hosts) == 1
+    assert len(hosts) == 1
     hostnames = [host['name'] for host in hosts]
     assert rhel7_contenthost.hostname not in hostnames
     assert target_sat.hostname in hostnames
     # list capsule hosts
     hosts = Host.list({'search': 'infrastructure_facet.smart_proxy_id=1'})
     hostnames = [host['name'] for host in hosts]
-    if is_open('BZ:1994685'):
-        assert len(hosts) == 2
-    else:
-        assert len(hosts) == 1
+    assert len(hosts) == 1
     assert rhel7_contenthost.hostname not in hostnames
     assert target_sat.hostname in hostnames
 


### PR DESCRIPTION
This BZ is actually not closed, but the target version is 6.10 and it appears in test results that it got fixed in 6.11 in snap 24. The test is failing because there is only one host listed, as expected without BZ, checked with the hammer and only one host was listed.