### PR TITLE
ssh with non default port support

### DIFF
--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -20,6 +20,7 @@ def get_client(
         hostname=hostname or settings.server.hostname,
         username=username or settings.server.ssh_username,
         password=password or settings.server.ssh_password,
+        port=port or settings.server.port,
     )
     return client
 


### PR DESCRIPTION
Hey,
ssh host with non-default port 22 support.

Now cases with default 22 ssh and non-default port all pass.