### PR TITLE
Update bootstrap test support rhel8

### DIFF
--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -17,14 +17,18 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
-
-from robottelo.hosts import ContentHost
 
 
+@pytest.mark.rhel_ver_list([7, 8])
 @pytest.mark.tier1
 def test_positive_register(
-    module_org, module_location, module_lce, module_ak_cv_lce, module_published_cv, target_sat
+    module_org,
+    module_location,
+    module_lce,
+    module_ak_cv_lce,
+    module_published_cv,
+    target_sat,
+    rhel_contenthost,
 ):
     """System is registered
 
@@ -43,32 +47,41 @@ def test_positive_register(
     :CaseAutomation: Automated
 
     :CaseImportance: Critical
+
+    :customerscenario: true
+
+    :BZ: 2001476
     """
+    if rhel_contenthost.os_version.major == 7:
+        python_cmd = 'python'
+    elif rhel_contenthost.os_version.major == 8:
+        python_cmd = '/usr/libexec/platform-python'
+    else:
+        python_cmd = 'python3'
     hg = target_sat.api.HostGroup(location=[module_location], organization=[module_org]).create()
-    with Broker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
-        # assure system is not registered
-        result = vm.execute('subscription-manager identity')
-        # result will be 1 if not registered
-        assert result.status == 1
-        assert vm.execute(
-            f'curl -o /root/bootstrap.py "http://{target_sat.hostname}/pub/bootstrap.py" '
-        )
-        assert vm.execute(
-            f'python /root/bootstrap.py -s {target_sat.hostname} -o {module_org.name}'
-            f' -L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
-            ' --skip puppet --skip foreman'
-        )
-        # assure system is registered
-        result = vm.execute('subscription-manager identity')
-        # result will be 0 if registered
-        assert result.status == 0
-        # register system once again
-        assert vm.execute(
-            f'python /root/bootstrap.py -s "{target_sat.hostname}" -o {module_org.name} '
-            f'-L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
-            '--skip puppet --skip foreman '
-        )
-        # assure system is registered
-        result = vm.execute('subscription-manager identity')
-        # result will be 0 if registered
-        assert result.status == 0
+    # assure system is not registered
+    result = rhel_contenthost.execute('subscription-manager identity')
+    # result will be 1 if not registered
+    assert result.status == 1
+    assert rhel_contenthost.execute(
+        f'curl -o /root/bootstrap.py "http://{target_sat.hostname}/pub/bootstrap.py" '
+    )
+    assert rhel_contenthost.execute(
+        f'{python_cmd} /root/bootstrap.py -s {target_sat.hostname} -o {module_org.name}'
+        f' -L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
+        ' --skip puppet --skip foreman'
+    )
+    # assure system is registered
+    result = rhel_contenthost.execute('subscription-manager identity')
+    # result will be 0 if registered
+    assert result.status == 0
+    # register system once again
+    assert rhel_contenthost.execute(
+        f'{python_cmd} /root/bootstrap.py -s "{target_sat.hostname}" -o {module_org.name} '
+        f'-L {module_location.name} -a {module_ak_cv_lce.name} --hostgroup={hg.name}'
+        '--skip puppet --skip foreman '
+    )
+    # assure system is registered
+    result = rhel_contenthost.execute('subscription-manager identity')
+    # result will be 0 if registered
+    assert result.status == 0


### PR DESCRIPTION
  Closed loop: BZ#2001476

Hello

Add RHEL8 support to existing bootstrap test.

Because "Closing the loop" for:

[Bug 2001476](https://bugzilla.redhat.com/show_bug.cgi?id=2001476) - 'str' object has no attribute 'decode' When register RHEL-8.5.0-20210902.5 against Satellite6.8/Satellite6.9/Satellite6.10 by bootstrap.py
