### PR TITLE
Skip OS create/update tests if BZ open

### DIFF
--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -324,6 +324,7 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             entities.OperatingSystem(description=gen_string('alphanumeric', 256)).create()
 
+    @pytest.mark.skip_if_open('BZ:2101435')
     @pytest.mark.tier1
     @pytest.mark.parametrize('major_version', **parametrized((gen_string('numeric', 6), '', '-6')))
     def test_negative_create_with_invalid_major_version(self, major_version):
@@ -336,6 +337,8 @@ class TestOperatingSystem:
         :parametrized: yes
 
         :expectedresults: Operating system entity is not created
+
+        :BZ: 2101435
 
         :CaseImportance: Critical
         """
@@ -607,6 +610,7 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             os = entities.OperatingSystem(id=os.id, name=new_name).update(['name'])
 
+    @pytest.mark.skip_if_open('BZ:2101435')
     @pytest.mark.tier1
     def test_negative_update_major_version(self):
         """Create operating entity providing the initial major version,
@@ -615,6 +619,8 @@ class TestOperatingSystem:
         :id: de07c2f7-0896-493d-976c-e9f3a8a57025
 
         :expectedresults: Operating system entity is not updated
+
+        :BZ: 2101435
 
         :CaseImportance: Critical
         """


### PR DESCRIPTION
I tried to fixed these two tests but it turned out there is bug which allows provide user with negative OS version (see https://bugzilla.redhat.com/show_bug.cgi?id=2101435)

So for now I just add `skip_if_open`.