### PR TITLE
[6.10] adding name parameter to register_contenthost

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -182,6 +182,8 @@ class ContentHost(Host):
         self.execute('subscription-manager clean')
 
     def teardown(self):
+        if self.nailgun_host:
+            self.nailgun_host.delete()
         self.unregister()
 
     def power_control(self, state=VmState.RUNNING, ensure=True):
@@ -444,6 +446,7 @@ class ContentHost(Host):
         :param org: Organization name to register content host for.
         :param force: Register the content host even if it's already registered
         :param releasever: Set a release version
+        :param name: name of the system to register, defaults to the hostname
         :param username: a user name to register the content host with
         :param password: the user password
         :param auto_attach: automatically attach compatible subscriptions to


### PR DESCRIPTION
Some rex tests fail in 6.10 runs with `failed on setup with "TypeError: register_contenthost() got an unexpected keyword argument 'name'"`, likely due to some flawed cherry-pick coordination. This pr adds the missing argument to register_contenthost

testing with test_positive_run_custom_job_template[rhel7]

```
============================= test session starts ==============================
platform linux -- Python 3.10.5, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, reportportal-5.0.11, mock-3.6.1, ibutsu-2.0.2, forked-1.4.0, cov-3.0.0, xdist-2.5.0
collected 1 item

tests/foreman/cli/test_remoteexecution.py .                              [100%]

================== 1 passed, 14 warnings in 514.81s (0:08:34) ==================
```