### PR TITLE
Test fixes for rhcloud inventory/insights

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -76,7 +76,13 @@ def test_positive_inventory_generate_upload_cli(
     remote_report_path = (
         f'/var/lib/foreman/red_hat_inventory/uploads/done/report_for_{org.id}.tar.xz'
     )
-    rhcloud_sat_host.get(remote_path=remote_report_path, local_path=local_report_path)
+    wait_for(
+        lambda: rhcloud_sat_host.get(remote_path=remote_report_path, local_path=local_report_path),
+        timeout=60,
+        delay=15,
+        silent_failure=True,
+        handle_exception=True,
+    )
     local_file_data = get_local_file_data(local_report_path)
     assert local_file_data['checksum'] == get_remote_report_checksum(rhcloud_sat_host, org.id)
     assert local_file_data['size'] > 0

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -74,6 +74,7 @@ def test_rhcloud_insights_e2e(
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+        session.cloudinsights.sync_hits()
         wait_for(
             lambda: rhcloud_sat_host.api.ForemanTask()
             .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]


### PR DESCRIPTION
```
Tests -
1. test_positive_inventory_generate_upload_cli
2. test_rhcloud_insights_e2e

Test result - [1]
pytest tests/foreman/cli/test_rhcloud_inventory.py -k test_positive_inventory_generate_upload_cli
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.8.6, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.7.0, forked-1.3.0, cov-3.0.0, xdist-2.5.0, ibutsu-2.2.1, reportportal-5.1.2
collected 6 items / 5 deselected / 1 selected                                                                                                                                                                                                                                            

tests/foreman/cli/test_rhcloud_inventory.py .                                                                                                                                                                                                                                      [100%]
================================================================================================================ 1 passed, 5 deselected, 2 warnings in 1237.51s (0:20:37) ===============================================================================================================

[2] -
pytest tests/foreman/ui/test_rhcloud_insights.py -k test_rhcloud_insights_e2e
================================================================================================================================== test session starts ===================================================================================================================================
platform linux -- Python 3.8.6, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.7.0, forked-1.3.0, cov-3.0.0, xdist-2.5.0, ibutsu-2.2.1, reportportal-5.1.2
collected 10 items / 8 deselected / 2 selected                                                                                                                                                                                                                                           

tests/foreman/ui/test_rhcloud_insights.py .E 
=========================================================================================================== 1 passed, 8 deselected, 3 warnings, 1 error in 1721.06s (0:28:41) ============================================================================================================

**The scenario with the error is for rhel9 host** 
```


