### PR TITLE
Add ansible roles and vars tests

### DIFF
--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -44,6 +44,9 @@ def test_positive_import_all_roles(default_sat):
         assert available_roles_count == imported_roles_count
         ansible_variables_count = int(session.ansiblevariables.read_total_variables())
         assert ansible_variables_count > 0
+        delete_role = 'theforeman.foreman_scap_client'
+        session.ansibleroles.delete(delete_role)
+        assert not session.ansibleroles.search(delete_role)
 
 
 def test_positive_create_and_delete_variable(default_sat):

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Ansible
 
-:Assignee: dsynk
+:Assignee: sbible
 
 :TestType: Functional
 
@@ -16,7 +16,7 @@
 
 :Upstream: No
 """
-from robottelo.datafactory import gen_string
+from fauxfactory import gen_string
 
 
 def test_positive_import_all_roles(target_sat):

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -16,8 +16,6 @@
 
 :Upstream: No
 """
-from airgun.session import Session
-
 from robottelo.datafactory import gen_string
 
 
@@ -38,7 +36,7 @@ def test_positive_import_all_roles(target_sat):
 
     :expectedresults: All roles are imported successfully.
     """
-    with Session(hostname=target_sat.hostname) as session:
+    with target_sat.ui_session as session:
         available_roles_count = session.ansibleroles.import_all_roles()
         imported_roles_count = session.ansibleroles.imported_roles_count
         assert available_roles_count == imported_roles_count
@@ -66,7 +64,7 @@ def test_positive_create_and_delete_variable(target_sat):
     """
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
-    with Session(hostname=target_sat.hostname) as session:
+    with target_sat.ui_session as session:
         preimport_check = session.ansibleroles.preimport_check()
         if preimport_check is False:
             session.ansibleroles.import_all_roles()
@@ -96,7 +94,7 @@ def test_positive_create_variable_with_overrides(target_sat):
     """
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
-    with Session(hostname=target_sat.hostname) as session:
+    with target_sat.ui_session as session:
         preimport_check = session.ansibleroles.preimport_check()
         if preimport_check is False:
             session.ansibleroles.import_all_roles()

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -21,7 +21,7 @@ from airgun.session import Session
 from robottelo.datafactory import gen_string
 
 
-def test_positive_import_all_roles(default_sat):
+def test_positive_import_all_roles(target_sat):
     """Import all Ansible roles available by default.
 
     :id: 53fe3857-a08f-493d-93c7-3fed331ed391
@@ -38,7 +38,7 @@ def test_positive_import_all_roles(default_sat):
 
     :expectedresults: All roles are imported successfully.
     """
-    with Session(hostname=default_sat.hostname) as session:
+    with Session(hostname=target_sat.hostname) as session:
         available_roles_count = session.ansibleroles.import_all_roles()
         imported_roles_count = session.ansibleroles.imported_roles_count
         assert available_roles_count == imported_roles_count
@@ -49,7 +49,7 @@ def test_positive_import_all_roles(default_sat):
         assert not session.ansibleroles.search(delete_role)
 
 
-def test_positive_create_and_delete_variable(default_sat):
+def test_positive_create_and_delete_variable(target_sat):
     """Create an Ansible variable with the minimum required values, then delete the variable.
 
     :id: 7006d7c7-788a-4447-a564-d6b03ec06aaf
@@ -66,7 +66,7 @@ def test_positive_create_and_delete_variable(default_sat):
     """
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
-    with Session(hostname=default_sat.hostname) as session:
+    with Session(hostname=target_sat.hostname) as session:
         preimport_check = session.ansibleroles.preimport_check()
         if preimport_check is False:
             session.ansibleroles.import_all_roles()
@@ -81,7 +81,7 @@ def test_positive_create_and_delete_variable(default_sat):
         assert not session.ansiblevariables.search(key)
 
 
-def test_positive_create_variable_with_overrides(default_sat):
+def test_positive_create_variable_with_overrides(target_sat):
     """Create an Ansible variable with all values populated.
 
     :id: 90acea37-4c2f-42e5-92a6-0c88148f4fb6
@@ -96,7 +96,7 @@ def test_positive_create_variable_with_overrides(default_sat):
     """
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
-    with Session(hostname=default_sat.hostname) as session:
+    with Session(hostname=target_sat.hostname) as session:
         preimport_check = session.ansibleroles.preimport_check()
         if preimport_check is False:
             session.ansibleroles.import_all_roles()

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -94,8 +94,7 @@ def test_positive_create_variable_with_overrides(target_sat):
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
     with target_sat.ui_session as session:
-        preimport_check = session.ansibleroles.preimport_check()
-        if preimport_check is False:
+        if session.ansibleroles.preimport_check() is False:
             session.ansibleroles.import_all_roles()
         session.ansiblevariables.create_with_overrides(
             {

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -38,7 +38,7 @@ def test_positive_import_all_roles(target_sat):
 
     :expectedresults: All roles are imported successfully. One role is deleted successfully.
     """
-    with target_sat.ui_session as session:
+    with target_sat.ui_session() as session:
         assert session.ansibleroles.import_all_roles() == session.ansibleroles.imported_roles_count
         assert int(session.ansiblevariables.read_total_variables()) > 0
         # The choice of role to be deleted is arbitrary; any of the roles present on Satellite
@@ -64,7 +64,7 @@ def test_positive_create_and_delete_variable(target_sat):
     """
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
-    with target_sat.ui_session as session:
+    with target_sat.ui_session() as session:
         if not session.ansibleroles.imported_roles_count:
             session.ansibleroles.import_all_roles()
         session.ansiblevariables.create(
@@ -93,7 +93,7 @@ def test_positive_create_variable_with_overrides(target_sat):
     """
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
-    with target_sat.ui_session as session:
+    with target_sat.ui_session() as session:
         if not session.ansibleroles.imported_roles_count:
             session.ansibleroles.import_all_roles()
         session.ansiblevariables.create_with_overrides(

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -23,11 +23,11 @@ from airgun.session import Session
 
 from robottelo.datafactory import gen_string
 
-# from fauxfactory import gen_string
-# from fauxfactory.factories.strings import gen_alpha
-
 # from broker import VMBroker
 # from nailgun import entities
+
+# from fauxfactory import gen_string
+# from fauxfactory.factories.strings import gen_alpha
 # from wait_for import wait_for
 # from robottelo.hosts import ContentHost
 

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -65,7 +65,7 @@ def test_positive_create_and_delete_variable(target_sat):
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
     with target_sat.ui_session as session:
-        if session.ansibleroles.preimport_check() is False:
+        if not session.ansibleroles.imported_roles_count:
             session.ansibleroles.import_all_roles()
         session.ansiblevariables.create(
             {
@@ -94,7 +94,7 @@ def test_positive_create_variable_with_overrides(target_sat):
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
     with target_sat.ui_session as session:
-        if session.ansibleroles.preimport_check() is False:
+        if not session.ansibleroles.imported_roles_count:
             session.ansibleroles.import_all_roles()
         session.ansiblevariables.create_with_overrides(
             {

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -44,12 +44,23 @@ def test_positive_import_all_roles(default_sat):
         assert available_roles_count == imported_roles_count
         ansible_variables_count = int(session.ansiblevariables.read_total_variables())
         assert ansible_variables_count > 0
-        # delete_role = 'theforeman.foreman_scap_client'
-        # session.ansibleroles.delete(delete_role)
-        # assert not session.ansibleroles.search(delete_role)
 
 
 def test_positive_create_and_delete_variable(default_sat):
+    """Create an Ansible variable with the minimum required values, then delete the variable.
+
+    :id: 7006d7c7-788a-4447-a564-d6b03ec06aaf
+
+    :Steps:
+
+        1. Import Ansible roles if none have been imported yet.
+        2. Create an Ansible variable with only a name and an assigned Ansible role.
+        3. Verify that the Ansible variable has been created.
+        4. Delete the Ansible variable.
+        5. Verify that the Ansible Variable has been deleted.
+
+    :expectedresults: The variable is successfully created and deleted.
+    """
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
     with Session(hostname=default_sat.hostname) as session:
@@ -68,6 +79,18 @@ def test_positive_create_and_delete_variable(default_sat):
 
 
 def test_positive_create_variable_with_overrides(default_sat):
+    """Create an Ansible variable with all values populated.
+
+    :id: 90acea37-4c2f-42e5-92a6-0c88148f4fb6
+
+    :Steps:
+
+        1. Import Ansible roles if none have been imported yet.
+        2. Create an Anible variable, populating all fields on the creation form.
+        3. Verify that the Ansible variable was created successfully.
+
+    :expectedresults: The variable is successfully created.
+    """
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
     with Session(hostname=default_sat.hostname) as session:

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -78,7 +78,7 @@ def test_positive_create_and_delete_variable(default_sat):
 def test_positive_create_with_overrides(default_sat):
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
-    param = {'Attribute type': 'fqdn', 'Value': 'example.com', 'Actions': 'test value'}
+    param = {'attribute_type': 'fqdn', 'attribute_value': 'example.com', 'value': 'test value'}
     with Session(hostname=default_sat.hostname) as session:
         session.ansiblevariables.create(
             {

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -78,8 +78,9 @@ def test_positive_create_and_delete_variable(default_sat):
 def test_positive_create_with_overrides(default_sat):
     key = gen_string('alpha')
     role = 'redhat.satellite.activation_keys'
+    param = {'Attribute type': 'fqdn', 'Value': 'example.com', 'Actions': 'test value'}
     with Session(hostname=default_sat.hostname) as session:
-        session.ansiblevariables.create_with_overrides(
+        session.ansiblevariables.create(
             {
                 'key': key,
                 'description': 'this is a description',
@@ -88,10 +89,8 @@ def test_positive_create_with_overrides(default_sat):
                 'default_value': '11',
                 'validator_type': 'list',
                 'validator_rule': 'not sure what this means',
-                # 'attribute_order': ['domain', 'fqdn', 'hostgroup', 'os'],
-                'attribute_type': 'fqdn',
-                'attribute_value': 'example.com',
-                'matcher_value': 'test',
+                # 'attribute_order': 'domain \n fqdn \n hostgroup \n os',
+                'matcher_section.params': [param],
             }
         )
         session.ansiblevariables.donk()

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -1,0 +1,97 @@
+"""Test class for Ansible Roles and Variables pages
+
+:Requirement: Ansible
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Ansible
+
+:Assignee: dsynk
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+# import datetime
+# import time
+# import pytest
+from airgun.session import Session
+
+from robottelo.datafactory import gen_string
+
+# from fauxfactory import gen_string
+# from fauxfactory.factories.strings import gen_alpha
+
+# from broker import VMBroker
+# from nailgun import entities
+# from wait_for import wait_for
+# from robottelo.hosts import ContentHost
+
+
+def test_positive_import_all_roles(default_sat):
+    """Import all Ansible roles available by default.
+
+    :id: 53fe3857-a08f-493d-93c7-3fed331ed391
+
+    :Steps:
+
+        1. Navigate to the Configure > Roles page.
+        2. Click the `Import from [hostname]` button.
+        3. Get totally number of importable roles from pagination?
+        4. Fill the `Select All` checkbox.
+        5. Click the `Submit` button.
+        6. Verify that number of imported roles == number of importable roles from step 3.
+        7. Verify that Ansible variables have been imported along with roles.
+
+    :expectedresults: All roles are imported successfully.
+    """
+    with Session(hostname=default_sat.hostname) as session:
+        available_roles_count = session.ansibleroles.import_all_roles()
+        imported_roles_count = session.ansibleroles.imported_roles_count
+        assert available_roles_count == imported_roles_count
+        ansible_variables_count = int(session.ansiblevariables.read_total_variables())
+        assert ansible_variables_count > 0
+        # delete_role = 'theforeman.foreman_scap_client'
+        # session.ansibleroles.delete(delete_role)
+        # assert not session.ansibleroles.search(delete_role)
+
+
+def test_positive_create_and_delete_variable(default_sat):
+    key = gen_string('alpha')
+    role = 'redhat.satellite.activation_keys'
+    with Session(hostname=default_sat.hostname) as session:
+        session.ansiblevariables.create(
+            {
+                'key': key,
+                'ansible_role': role,
+            }
+        )
+        assert session.ansiblevariables.search(key)[0]['Name'] == key
+        session.ansiblevariables.delete(key)
+        assert not session.ansiblevariables.search(key)
+
+
+def test_positive_create_with_overrides(default_sat):
+    key = gen_string('alpha')
+    role = 'redhat.satellite.activation_keys'
+    with Session(hostname=default_sat.hostname) as session:
+        session.ansiblevariables.create_with_overrides(
+            {
+                'key': key,
+                'description': 'this is a description',
+                'ansible_role': role,
+                'parameter_type': 'integer',
+                'default_value': '11',
+                'validator_type': 'list',
+                'validator_rule': 'not sure what this means',
+                # 'attribute_order': ['domain', 'fqdn', 'hostgroup', 'os'],
+                'attribute_type': 'fqdn',
+                'attribute_value': 'example.com',
+                'matcher_value': 'test',
+            }
+        )
+        session.ansiblevariables.donk()


### PR DESCRIPTION
This PR adds initial tests for the Satellite UI Ansible Roles and Ansible Variables pages.

These tests depend on https://github.com/SatelliteQE/airgun/pull/642/, which should be merged in the next day or so.