### PR TITLE
[GHA] Auto CherryPick Pull Requests using branch-matrices

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -1,0 +1,42 @@
+# CI stages to execute against all branches on PR merge
+name: auto_cherry_pick_commits
+
+on:
+  push
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  branch-matrix:
+    name: Generate a branch matrix to apply cherrypicks
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.set-matrix.outputs.branches }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - id: set-matrix
+        run: echo "::set-output name=branches::$(git branch -rl --sort=-authordate 'origin/6.*.z' --format='%(refname:lstrip=-1)' | head -n2 | jq -cnR '[inputs | select(length>0)]')"
+
+  auto_cherry_picking:
+    name: Auto Cherry picking to branches
+    needs: branch-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        to_branch: ${{ fromJson(needs.branch-matrix.outputs.branches) }}
+    # skipping PRs remote target_branch from cherrypicking again in self with the if condition
+    if: ${{ matrix.to_branch }} != github.base_ref && contains(github.event.pull_request.labels.*.name, 'CherryPick')
+    steps:
+      - name: Checkout Robottelo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Cherry pick into ${{ matrix.to_branch }}
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        with:
+          branch: ${{ matrix.to_branch }}
+          labels: |
+            Auto_Cherry_Picked


### PR DESCRIPTION
New GitHub Action **Auto Cherry Pick commits to released branches** :

- [x] Opens up cherry-pick PRs for merged PR in previous branches.
- [x] For master it opens in the last two branches and for `n-1` it opens in `n-2`. That means we will cherrypick up to the last 
2 released versions doesn't matter what branch we opened the PR and merged.

What should you do for cherrypicking:
- Make sure you add `CherryPick` label to your PR so that this GHA triggers on that PRs merge to remote branch.
- Keep monitoring the GHA of AutoCherryPick from  https://github.com/SatelliteQE/robottelo/actions if its successful or failing with any conflict.
  - If GHA fails with conflicts, the cherrypick should be manually performed and GHA cant do anything more. 
  - Else, Make sure the cherry pick PRs are opened by the GHA in  https://github.com/SatelliteQE/robottelo/pulls 
- Once the PRs are opened from GHA, make sure if the cherrypick of PR is feasible or not.
  - If feasible, Update the PRs summary by prepending text `<Branach> CherryPick` and add assigned labels(not CherryPick), assign reviewers etc.
  - Else, Feel free to close the PR with appropriate description.

**Testing** :

Tested locally using https://github.com/nektos/act and it successfully takes me upto the `push` event with `cherrypicked` commit on target/calculated-matrices branches.

**nektos/act results**:

$ act -l
```
Stage  Job ID               Job name                                       Workflow name             Workflow file         Events
0      branch-matrix        Generate a branch matrix to apply cherrypicks  auto_cherry_pick_commits  auto_cherry_pick.yml  push  
0      codechecks           Code Quality                                   update_robottelo_image    merge_to_master.yml   push  
1      auto_cherry_picking  Auto Cherry picking to branches                auto_cherry_pick_commits  auto_cherry_pick.yml  push  
1      robottelo_container  Update Robottelo container image on Quay.      update_robottelo_image    merge_to_master.yml   push  
```

$ act -j auto_cherry_picking
```
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks] 🚀  Start image=catthehacker/ubuntu:act-latest
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=false
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   🐳  docker exec cmd=[chown -R 0:0 /Users/jitendrayejare/JWorkspace/GitRepos/robottelo] user=0 workdir=
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks] ⭐ Run Main actions/checkout@v3
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   🐳  docker cp src=/Users/jitendrayejare/JWorkspace/GitRepos/robottelo/. dst=/Users/jitendrayejare/JWorkspace/GitRepos/robottelo
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks] close /var/folders/zt/__lk2x1j2692_48pb_bz5bnw0000gn/T/act166194929: file already closed
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   🐳  docker exec cmd=[chown -R 0:0 /Users/jitendrayejare/JWorkspace/GitRepos/robottelo] user=0 workdir=
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   ✅  Success - Main actions/checkout@v3
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks] ⭐ Run Main echo "::set-output name=branches::$(git branch -rl --sort=-authordate 'origin/6.*.z' --format='%(refname:lstrip=-1)' | head -n2 | jq -cnR '[inputs | select(length>0)]')"
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/set-matrix] user= workdir=
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   ⚙  ::set-output:: branches=["6.9.z","6.10.z"]
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks]   ✅  Success - Main echo "::set-output name=branches::$(git branch -rl --sort=-authordate 'origin/6.*.z' --format='%(refname:lstrip=-1)' | head -n2 | jq -cnR '[inputs | select(length>0)]')"
[auto_cherry_pick_commits/Generate a branch matrix to apply cherrypicks] 🏁  Job succeeded
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ] 🚀  Start image=catthehacker/ubuntu:act-latest
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ] 🚀  Start image=catthehacker/ubuntu:act-latest
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=false
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=false
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker exec cmd=[chown -R 0:0 /Users/jitendrayejare/JWorkspace/GitRepos/robottelo] user=0 workdir=
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker exec cmd=[chown -R 0:0 /Users/jitendrayejare/JWorkspace/GitRepos/robottelo] user=0 workdir=
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ☁  git clone 'https://github.com/carloscastrojumo/github-cherry-pick-action' # ref=v1.0.1
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ☁  git clone 'https://github.com/carloscastrojumo/github-cherry-pick-action' # ref=v1.0.1
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ] 🧪  Matrix: map[to_branch:6.10.z]
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ] ⭐ Run Main Checkout Robottelo
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker cp src=/Users/jitendrayejare/JWorkspace/GitRepos/robottelo/. dst=/Users/jitendrayejare/JWorkspace/GitRepos/robottelo
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ] 🧪  Matrix: map[to_branch:6.9.z]
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ] ⭐ Run Main Checkout Robottelo
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker cp src=/Users/jitendrayejare/JWorkspace/GitRepos/robottelo/. dst=/Users/jitendrayejare/JWorkspace/GitRepos/robottelo
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ] close /var/folders/zt/__lk2x1j2692_48pb_bz5bnw0000gn/T/act3668222411: file already closed
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker exec cmd=[chown -R 0:0 /Users/jitendrayejare/JWorkspace/GitRepos/robottelo] user=0 workdir=
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ✅  Success - Main Checkout Robottelo
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ] ⭐ Run Main Cherry pick into ${{ matrix.to_branch }}
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker cp src=/Users/jitendrayejare/.cache/act/carloscastrojumo-github-cherry-pick-action@v1.0.1/ dst=/var/run/act/actions/carloscastrojumo-github-cherry-pick-action@v1.0.1/
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ] close /var/folders/zt/__lk2x1j2692_48pb_bz5bnw0000gn/T/act3663712642: file already closed
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker exec cmd=[chown -R 0:0 /var/run/act/actions/carloscastrojumo-github-cherry-pick-action@v1.0.1/] user=0 workdir=
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ] close /var/folders/zt/__lk2x1j2692_48pb_bz5bnw0000gn/T/act3772632495: file already closed
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker exec cmd=[chown -R 0:0 /Users/jitendrayejare/JWorkspace/GitRepos/robottelo] user=0 workdir=
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   🐳  docker exec cmd=[node /var/run/act/actions/carloscastrojumo-github-cherry-pick-action@v1.0.1/dist/index.js] user= workdir=
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ✅  Success - Main Checkout Robottelo
| Cherry pick into branch 6.10.z!
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::group::Configuring the committer and author
| Configured git committer as 'GitHub <noreply@github.com>'
| [command]/usr/bin/git config --global user.name nektos/act
| 
| [command]/usr/bin/git config --global user.email noreply@github.com
| 
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::endgroup::
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::group::Fetch all branchs
| [command]/usr/bin/git remote update
| Fetching origin
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ] ⭐ Run Main Cherry pick into ${{ matrix.to_branch }}
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker cp src=/Users/jitendrayejare/.cache/act/carloscastrojumo-github-cherry-pick-action@v1.0.1/ dst=/var/run/act/actions/carloscastrojumo-github-cherry-pick-action@v1.0.1/
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ] close /var/folders/zt/__lk2x1j2692_48pb_bz5bnw0000gn/T/act287834943: file already closed
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker exec cmd=[chown -R 0:0 /var/run/act/actions/carloscastrojumo-github-cherry-pick-action@v1.0.1/] user=0 workdir=
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   🐳  docker exec cmd=[node /var/run/act/actions/carloscastrojumo-github-cherry-pick-action@v1.0.1/dist/index.js] user= workdir=
| Cherry pick into branch 6.9.z!
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::group::Configuring the committer and author
| Configured git committer as 'GitHub <noreply@github.com>'
| [command]/usr/bin/git config --global user.name nektos/act
| 
| [command]/usr/bin/git config --global user.email noreply@github.com
| 
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::endgroup::
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::group::Fetch all branchs
| [command]/usr/bin/git remote update
| Fetching origin
| Fetching upstream
| Fetching upstream
| Fetching origin
| Fetching upstream
| [command]/usr/bin/git fetch --all
| Fetching origin
| Fetching origin
| Fetching upstream
| [command]/usr/bin/git fetch --all
| Fetching origin
| Fetching upstream
| Fetching upstream
| Fetching origin
| Fetching upstream
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::endgroup::
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::group::Create new branch from 6.10.z
| [command]/usr/bin/git checkout -b cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9 origin/6.10.z
| Switched to a new branch 'cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9'
| Branch 'cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9' set up to track remote branch '6.10.z' from 'origin'.
| Branch 'cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9' set up to track remote branch '6.10.z' from 'origin'.
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::endgroup::
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::group::Cherry picking
| [command]/usr/bin/git cherry-pick -m 1 --strategy=recursive --strategy-option=theirs 817ac09dcde0f11e15a620cc58cea41916e637e9
| [cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9 2a8ff1022] Auto CherryPick Pull Requests using branch-matrix job
|  Author: jyejare <jyejare@redhat.com>
|  Date: Thu Jun 30 20:38:05 2022 +0530
|  1 file changed, 42 insertions(+)
|  create mode 100644 .github/workflows/auto_cherry_pick.yml
| [cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9 2a8ff1022] Auto CherryPick Pull Requests using branch-matrix job
|  Author: jyejare <jyejare@redhat.com>
|  Date: Thu Jun 30 20:38:05 2022 +0530
|  1 file changed, 42 insertions(+)
|  create mode 100644 .github/workflows/auto_cherry_pick.yml
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::endgroup::
[auto_cherry_pick_commits/Auto Cherry picking to branches-2            ]   ❓  ::group::Push new branch to remote
| [command]/usr/bin/git push -u origin cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9
| Fetching origin
| Fetching upstream
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::endgroup::
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::group::Create new branch from 6.9.z
| [command]/usr/bin/git checkout -b cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9 origin/6.9.z
| Switched to a new branch 'cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9'
| Branch 'cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9' set up to track remote branch '6.9.z' from 'origin'.
| Branch 'cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9' set up to track remote branch '6.9.z' from 'origin'.
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::endgroup::
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::group::Cherry picking
| [command]/usr/bin/git cherry-pick -m 1 --strategy=recursive --strategy-option=theirs 817ac09dcde0f11e15a620cc58cea41916e637e9
| [cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9 e71ab3558] Auto CherryPick Pull Requests using branch-matrix job
|  Author: jyejare <jyejare@redhat.com>
|  Date: Thu Jun 30 20:38:05 2022 +0530
|  1 file changed, 42 insertions(+)
|  create mode 100644 .github/workflows/auto_cherry_pick.yml
| [cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9 e71ab3558] Auto CherryPick Pull Requests using branch-matrix job
|  Author: jyejare <jyejare@redhat.com>
|  Date: Thu Jun 30 20:38:05 2022 +0530
|  1 file changed, 42 insertions(+)
|  create mode 100644 .github/workflows/auto_cherry_pick.yml
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::endgroup::
[auto_cherry_pick_commits/Auto Cherry picking to branches-1            ]   ❓  ::group::Push new branch to remote
| [command]/usr/bin/git push -u origin cherry-pick-817ac09dcde0f11e15a620cc58cea41916e637e9
```