### PR TITLE
change target_sat to module_target_sat

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -519,6 +519,7 @@ def test_positive_install_errata(
         assert _is_package_installed(vm_content_hosts, constants.FAKE_2_CUSTOM_PACKAGE)
 
 
+@pytest.mark.skip_if_open("BZ:2094815")
 @pytest.mark.tier3
 def test_positive_change_assigned_content(
     session,


### PR DESCRIPTION
Hello

After helper refactor commit I got the following error after running `pytest tests/foreman/ui/test_hostcollection.py::test_positive_install_package_group`:

`ScopeMismatch: You tried to access the function scoped fixture target_sat with a module scoped request object, involved factories:
tests/foreman/ui/test_hostcollection.py:51:  def module_repos_collection(module_org, module_lce, target_sat)`

I am changing the UI module to use `module_target_sat` throughout.