### PR TITLE
Make CR tests run even without VLAN_NETWORKING specified where possible

### DIFF
--- a/conf/rhev.yaml.template
+++ b/conf/rhev.yaml.template
@@ -26,6 +26,8 @@ RHEV:
   IMAGE_NAME:
   # Image UUID
   IMAGE_UUID:
+  # Interface used for some tests; not required to work with provisioning, not required to be in VLAN
+  INTERFACE:
   # RHV CA cert for adding RHV as compute resource
   CA_CERT: |
     ---BEGIN CERT---

--- a/conf/vmware.yaml.template
+++ b/conf/vmware.yaml.template
@@ -22,3 +22,5 @@ VMWARE:
   IMAGE_PASSWORD:
   # Image name on the external provider
   IMAGE_NAME:
+  # Interface used for some tests; not required to work with provisioning, not required to be in VLAN
+  INTERFACE:

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -36,7 +36,6 @@ from robottelo.utils.issue_handlers import is_open
 
 @pytest.fixture(scope='module')
 def rhev():
-    bridge = settings.vlan_networking.bridge
     rhev = settings.rhev.copy()
     rhev.rhv_api = RHEVMSystem(
         hostname=rhev.hostname.split('/')[2],
@@ -47,10 +46,6 @@ def rhev():
     )
     rhev.cluster_id = rhev.rhv_api.get_cluster(rhev.datacenter).id
     rhev.storage_id = rhev.rhv_api.get_storage_domain(rhev.storage_domain).id
-    if bridge:
-        rhev.network_id = (
-            rhev.rhv_api.api.system_service().networks_service().list(search=f'name={bridge}')[0].id
-        )
     if is_open('BZ:1685949'):
         dc = rhev.rhv_api._data_centers_service.list(search=f'name={rhev.datacenter}')[0]
         dc = rhev.rhv_api._data_centers_service.data_center_service(dc.id)

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -20,7 +20,6 @@ from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.org import Org
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import VMWARE_CONSTANTS
 
 
 @pytest.fixture(scope='module')
@@ -39,9 +38,6 @@ def vmware(module_org, module_location):
     vmware.vmware_img_user = settings.vmware.image_username
     vmware.vmware_img_pass = settings.vmware.image_password
     vmware.vmware_vm_name = settings.vmware.vm_name
-    vmware.current_interface = (
-        VMWARE_CONSTANTS.get('network_interfaces') % settings.vlan_networking.bridge
-    )
     return vmware
 
 

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -37,7 +37,7 @@ if not setting_is_set('rhev'):
 
 @pytest.fixture(scope='module')
 def rhev_data():
-    return {
+    ret = {
         'rhev_url': settings.rhev.hostname,
         'username': settings.rhev.username,
         'password': settings.rhev.password,
@@ -51,6 +51,9 @@ def rhev_data():
         'storage_domain': settings.rhev.storage_domain,
         'cert': settings.rhev.ca_cert,
     }
+    if 'INTERFACE' in settings.rhev:
+        ret['interface'] = settings.rhev.interface
+    return ret
 
 
 @pytest.mark.tier2
@@ -435,7 +438,6 @@ def test_positive_image_end_to_end(session, rhev_data, module_location):
         )
 
 
-@pytest.mark.skip_if_not_set('vlan_networking')
 @pytest.mark.tier2
 def test_positive_associate_with_custom_profile(session, rhev_data):
     """ "Associate custom default (3-Large) compute profile to RHV compute resource.
@@ -467,10 +469,12 @@ def test_positive_associate_with_custom_profile(session, rhev_data):
         cores='2',
         sockets='2',
         memory='1 GB',
-        network_interfaces=[
-            dict(name='nic1', network=settings.vlan_networking.bridge),
-            dict(name='nic2', network=settings.vlan_networking.bridge),
-            dict(name='nic3', network=settings.vlan_networking.bridge),
+        network_interfaces=[]
+        if 'interface' not in rhev_data
+        else [
+            dict(name='nic1', network=rhev_data['interface']),
+            dict(name='nic1', network=rhev_data['interface']),
+            dict(name='nic1', network=rhev_data['interface']),
         ],
         storage=[
             dict(size='10', bootable=False, preallocate_disk=True),

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -39,7 +39,7 @@ def module_libvirt_url():
 def test_positive_end_to_end(session, module_org, module_location, module_libvirt_url):
     """Perform end to end testing for compute resource Libvirt component.
 
-    :id: 4f4650c8-32f3-4dab-b3bf-9c54d0cda3b2
+    :id: 7ef925ac-5aec-4e9d-b786-328a9b219c01
 
     :expectedresults: All expected CRUD actions finished successfully.
 

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -90,7 +90,7 @@ def module_org():
 
 @pytest.fixture(scope='module')
 def module_vmware_settings():
-    return dict(
+    ret = dict(
         vcenter=settings.vmware.vcenter,
         user=settings.vmware.username,
         password=settings.vmware.password,
@@ -101,8 +101,10 @@ def module_vmware_settings():
         image_username=settings.vmware.image_username,
         image_password=settings.vmware.image_password,
         vm_name=settings.vmware.vm_name,
-        current_interface=VMWARE_CONSTANTS['network_interfaces'] % settings.vlan_networking.bridge,
     )
+    if 'INTERFACE' in settings.vmware:
+        ret['interface'] = VMWARE_CONSTANTS['network_interfaces'] % settings.vmware.interface
+    return ret
 
 
 @pytest.mark.tier1
@@ -404,14 +406,16 @@ def test_positive_access_vmware_with_custom_profile(session, module_vmware_setti
         cpu_hot_add=True,
         cdrom_drive=True,
         annotation_notes=gen_string('alpha'),
-        network_interfaces=[
+        network_interfaces=[]
+        if 'interface' not in module_vmware_settings
+        else [
             dict(
                 nic_type=VMWARE_CONSTANTS.get('network_interface_name'),
-                network=module_vmware_settings['current_interface'],
+                network=module_vmware_settings['interface'],
             ),
             dict(
                 nic_type=VMWARE_CONSTANTS.get('network_interface_name'),
-                network=module_vmware_settings['current_interface'],
+                network=module_vmware_settings['interface'],
             ),
         ],
         storage=[


### PR DESCRIPTION
This should resolve issue with some tests failing due to missing `vlan_networking` even though they don't really use it (e.g. `tests/foreman/cli/test_computeresource_rhev.py::test_positive_delete_by_id`). The tests that do use it do not work anyway since `vlan_networking` is not specified in automation and will be replaced as part of the provisioning-in-satlab effort.

```
$ pytest tests/foreman/cli/test_computeresource_rhev.py tests/foreman/cli/test_computeresource_vmware.py tests/foreman/ui/test_computeresource.py tests/foreman/ui/test_computeresource_vmware.py 
==================================================================== test session starts ====================================================================
platform linux -- Python 3.8.5, pytest-7.1.2, pluggy-0.13.1 -- /home/lhellebr/broker/venv/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo, configfile: pytest.ini
plugins: mock-3.7.0, ibutsu-2.1.0, cov-3.0.0, services-2.2.1, xdist-2.5.0, forked-1.3.0, reportportal-5.1.1
collected 33 items / 3 deselected / 30 selected                                                                                                             

tests/foreman/cli/test_computeresource_rhev.py::test_positive_create_rhev_with_valid_name PASSED                                                      [  3%]
tests/foreman/cli/test_computeresource_rhev.py::test_positive_rhev_info PASSED                                                                        [  6%]
tests/foreman/cli/test_computeresource_rhev.py::test_positive_delete_by_name PASSED                                                                   [ 10%]
tests/foreman/cli/test_computeresource_rhev.py::test_positive_delete_by_id PASSED                                                                     [ 13%]
tests/foreman/cli/test_computeresource_rhev.py::test_negative_create_rhev_with_url PASSED                                                             [ 16%]
tests/foreman/cli/test_computeresource_rhev.py::test_negative_create_with_same_name PASSED                                                            [ 20%]
tests/foreman/cli/test_computeresource_rhev.py::test_positive_update_name PASSED                                                                      [ 23%]
[...]
```
Some tests fail due to unrelated reasons.