### PR TITLE
add Katello::Repository to search string

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -79,7 +79,8 @@ def validate_task_status(repo_id, org_id, max_tries=6):
     wait_for_tasks(
         search_query='Actions::Katello::Repository::Sync'
         f' and organization_id = {org_id}'
-        f' and resource_id = {repo_id}',
+        f' and resource_id = {repo_id}'
+        ' and resource_type = Katello::Repository',
         max_tries=max_tries,
         search_rate=10,
     )

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -110,7 +110,8 @@ def validate_task_status(repo_id, org_id, max_tries=10):
     wait_for_tasks(
         search_query='Actions::Katello::Repository::Sync'
         f' and organization_id = {org_id}'
-        f' and resource_id = {repo_id}',
+        f' and resource_id = {repo_id}'
+        ' and resource_type = Katello::Repository',
         max_tries=max_tries,
         search_rate=10,
     )

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -41,7 +41,8 @@ def validate_task_status(repo_id, org_id, max_tries=10):
     wait_for_tasks(
         search_query='Actions::Katello::Repository::Sync'
         f' and organization_id = {org_id}'
-        f' and resource_id = {repo_id}',
+        f' and resource_id = {repo_id}'
+        ' and resource_type = Katello::Repository',
         max_tries=max_tries,
         search_rate=10,
     )


### PR DESCRIPTION
Hi

while checking flakey sync plan tests I noticed this issue and raised a bug:

[Bug 2106350](https://bugzilla.redhat.com/show_bug.cgi?id=2106350) - Search query for Actions::Katello::Repository::Sync using resource_id is inconsistent

So just adding Katello::Repository to the search string for now to see if that improves these tests intermittent failures.

