### PR TITLE
Change Host Collections assignee to spusater

### DIFF
--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: HostCollections
 
-:Assignee: swadeley
+:Assignee: spusater
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: HostCollections
 
-:Assignee: swadeley
+:Assignee: spusater
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: HostCollections
 
-:Assignee: swadeley
+:Assignee: spusater
 
 :TestType: Functional
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -11,7 +11,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :CaseComponent: Hosts-Content
 
-:Assignee: swadeley
+:Assignee: spusater
 
 :TestType: Functional
 


### PR DESCRIPTION
Change Host Collections assignee to spusater (myself) along with a Hosts-Content upgrade test I must have missed in my initial Hosts-Content assignee change PR. 

Sry for delay @swadeley, thought I had done this before I went PTO a few weeks ago :sweat_smile: 