### PR TITLE
Add setup for iqe remediation tests.

### DIFF
--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -1,4 +1,4 @@
 RH_CLOUD:
   INSTALL_RHC: false
-  Organization: org_name
-  Activation_key: ak_name
+  ORGANIZATION: org_name
+  ACTIVATION_KEY: ak_name

--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -1,3 +1,4 @@
 RH_CLOUD:
-  Token: rh_cloud_token_value
   INSTALL_RHC: false
+  Organization: org_name
+  Activation_key: ak_name

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 """Global Configurations for py.test runner"""
+import pytest
 
 pytest_plugins = [
     # Plugins
@@ -55,3 +56,15 @@ pytest_plugins = [
     'pytest_fixtures.component.templatesync',
     'pytest_fixtures.component.user_role',
 ]
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    # execute all other hooks to obtain the report object
+    outcome = yield
+    rep = outcome.get_result()
+
+    # set a report attribute for each phase of a call, which can
+    # be "setup", "call", "teardown"
+
+    setattr(item, "rep_" + rep.when, rep)

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -23,11 +23,9 @@ import pytest
 from broker import Broker
 from wait_for import wait_for
 
-from robottelo import constants
 from robottelo.api.utils import update_vm_host_location
 from robottelo.datafactory import gen_string
 from robottelo.hosts import ContentHost
-from robottelo.logging import logger
 
 
 @pytest.fixture
@@ -36,17 +34,6 @@ def module_vm_client_by_ip(rhel7_contenthost, module_org, smart_proxy_location, 
     rhel7_contenthost.configure_rex(satellite=target_sat, org=module_org)
     update_vm_host_location(rhel7_contenthost, location_id=smart_proxy_location.id)
     yield rhel7_contenthost
-
-
-@pytest.fixture()
-def fixture_enable_rhc_repos(request, target_sat):
-    """Enable repos required for configuring RHC."""
-    if target_sat.os_version.major == 8:
-        target_sat.enable_repo(constants.REPOS['rhel8_bos']['id'])
-        target_sat.enable_repo(constants.REPOS['rhel8_aps']['id'])
-    else:
-        target_sat.enable_repo(constants.REPOS['rhscl7']['id'])
-        target_sat.enable_repo(constants.REPOS['rhel7']['id'])
 
 
 @pytest.mark.tier3
@@ -578,82 +565,3 @@ def test_positive_matcher_field_highlight(session):
 
     :assignee: sbible
     """
-
-
-@pytest.mark.tier3
-def test_positive_configure_cloud_connector(
-    session, target_sat, subscribe_satellite, fixture_enable_rhc_repos
-):
-    """Install Cloud Connector through WebUI button
-
-    :id: 67e45cfe-31bb-51a8-b88f-27918c68f32e
-
-    :Steps:
-
-        1. Navigate to Configure > Inventory Upload
-        2. Click Configure Cloud Connector
-        3. Open the started job and wait until it is finished
-
-    :expectedresults: The Cloud Connector has been installed and the service is running
-
-    :CaseLevel: Integration
-
-    :CaseComponent: RHCloud-CloudConnector
-
-    :CaseImportance: Medium
-
-    :assignee: lhellebr
-
-    :BZ: 1818076
-    """
-    # Copy foreman-proxy user's key to root@localhost user's authorized_keys
-    target_sat.add_rex_key(satellite=target_sat)
-
-    # Set Host parameter source_display_name to something random.
-    # To avoid 'name has already been taken' error when run multiple times
-    # on a machine with the same hostname.
-    host_id = target_sat.cli.Host.info({'name': target_sat.hostname})['id']
-    target_sat.cli.Host.set_parameter(
-        {'host-id': host_id, 'name': 'source_display_name', 'value': gen_string('alpha')}
-    )
-
-    with session:
-        if session.cloudinventory.is_cloud_connector_configured():
-            pytest.skip(
-                'Cloud Connector has already been configured on this system. '
-                'It is possible to reconfigure it but then the test would not really '
-                'check if everything is correctly configured from scratch. Skipping.'
-            )
-        session.cloudinventory.configure_cloud_connector()
-
-    template_name = 'Configure Cloud Connector'
-    invocation_id = (
-        target_sat.api.JobInvocation()
-        .search(query={'search': f'description="{template_name}"'})[0]
-        .id
-    )
-    wait_for(
-        lambda: target_sat.api.JobInvocation(id=invocation_id).read().status_label
-        in ["succeeded", "failed"],
-        timeout="1500s",
-    )
-
-    result = target_sat.cli.JobInvocation.get_output(
-        {'id': invocation_id, 'host': target_sat.hostname}
-    )
-    logger.debug(f"Invocation output>>\n{result}\n<<End of invocation output")
-    # if installation fails, it's often due to missing rhscl repo -> print enabled repos
-    repolist = target_sat.execute('yum repolist')
-    logger.debug(f"Repolist>>\n{repolist}\n<<End of repolist")
-    assert target_sat.api.JobInvocation(id=invocation_id).read().status == 0
-    assert "Install yggdrasil-worker-forwarder and rhc" in result
-    assert "Restart rhcd" in result
-    assert 'Exit status: 0' in result
-
-    result = target_sat.execute('rhc status')
-    assert result.status == 0
-    assert "Connected to Red Hat Subscription Management" in result.stdout
-    assert "The Red Hat connector daemon is active" in result.stdout
-
-    result = target_sat.execute('journalctl --unit=rhcd')
-    assert "error" not in result.stdout

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -17,20 +17,14 @@
 :Upstream: No
 """
 import pytest
+from fauxfactory import gen_string
 from wait_for import wait_for
 
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.datafactory import gen_string
 from robottelo.helpers import file_downloader
 from robottelo.logging import logger
-
-
-@pytest.fixture(scope='module')
-def subscribe_rhc_satellite(clean_rhsm, module_target_sat):
-    """subscribe rhc satellite to cdn"""
-    module_target_sat.register_to_cdn()
 
 
 @pytest.fixture(scope='module')
@@ -50,9 +44,7 @@ def fixture_enable_rhc_repos(module_target_sat):
 def module_rhc_org(module_target_sat):
     """Module level fixture for creating organization"""
     org = module_target_sat.api.Organization(
-        name=gen_string('alpha')
-        if not settings.rh_cloud.organization
-        else settings.rh_cloud.organization
+        name=settings.rh_cloud.organization or gen_string('alpha')
     ).create()
     # adding remote_execution_connect_by_ip=Yes at org level
     module_target_sat.api.Parameter(
@@ -63,7 +55,7 @@ def module_rhc_org(module_target_sat):
     return org
 
 
-@pytest.fixture()
+@pytest.fixture(scope='module')
 def fixture_setup_rhc_satellite(request, module_target_sat, module_rhc_org):
     """Create Organization and activation key after successful test execution"""
     yield
@@ -76,18 +68,15 @@ def fixture_setup_rhc_satellite(request, module_target_sat, module_rhc_org):
         )
         # Create Activation key
         ak = module_target_sat.api.ActivationKey(
-            name=gen_string('alpha')
-            if not settings.rh_cloud.activation_key
-            else settings.rh_cloud.activation_key,
+            name=settings.rh_cloud.activation_key or gen_string('alpha'),
             content_view=module_rhc_org.default_content_view,
             organization=module_rhc_org,
             environment=module_target_sat.api.LifecycleEnvironment(id=module_rhc_org.library.id),
             auto_attach=True,
         ).create()
-        subscription = module_target_sat.api.Subscription(organization=module_rhc_org)
-        default_subscription = subscription.search(
-            query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
-        )[0]
+        default_subscription = module_target_sat.api.Subscription(
+            organization=module_rhc_org
+        ).search(query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'})[0]
         ak.add_subscriptions(data={'quantity': 10, 'subscription_id': default_subscription.id})
         logger.debug(f"Activation key: {ak} \n Organization: {module_rhc_org}")
 
@@ -151,24 +140,27 @@ def test_positive_configure_cloud_connector(
         timeout="1500s",
     )
 
-    result = module_target_sat.cli.JobInvocation.get_output(
+    job_output = module_target_sat.cli.JobInvocation.get_output(
         {'id': invocation_id, 'host': module_target_sat.hostname}
     )
-    logger.debug(f"Invocation output>>\n{result}\n<<End of invocation output")
+    logger.debug(f"Invocation output>>\n{job_output}\n<<End of invocation output")
     # if installation fails, it's often due to missing rhscl repo -> print enabled repos
     repolist = module_target_sat.execute('yum repolist')
     logger.debug(f"Repolist>>\n{repolist}\n<<End of repolist")
+    # print rhc status
+    rhc_status = module_target_sat.execute('rhc status')
+    logger.debug(f"rhc status>>\n{rhc_status}\n<<End of rhc status")
+    # print rhcd log
+    rhcd_log = module_target_sat.execute('journalctl --unit=rhcd')
+    logger.debug(f"journalctl log>>\n{rhcd_log}\n<<End of log")
+
     assert module_target_sat.api.JobInvocation(id=invocation_id).read().status == 0
-    assert "Install yggdrasil-worker-forwarder and rhc" in result
-    assert "Restart rhcd" in result
-    assert 'Exit status: 0' in result
+    assert "Install yggdrasil-worker-forwarder and rhc" in job_output
+    assert "Restart rhcd" in job_output
+    assert 'Exit status: 0' in job_output
 
-    result = module_target_sat.execute('rhc status')
-    logger.debug(f"rhc status>>\n{result}\n<<End of rhc status")
-    assert result.status == 0
-    assert "Connected to Red Hat Subscription Management" in result.stdout
-    assert "The Red Hat connector daemon is active" in result.stdout
+    assert rhc_status.status == 0
+    assert "Connected to Red Hat Subscription Management" in rhc_status.stdout
+    assert "The Red Hat connector daemon is active" in rhc_status.stdout
 
-    result = module_target_sat.execute('journalctl --unit=rhcd')
-    logger.debug(f"journalctl log>>\n{result}\n<<End of log")
-    assert "error" not in result.stdout
+    assert "error" not in rhcd_log.stdout

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -20,7 +20,6 @@ import pytest
 from wait_for import wait_for
 
 from robottelo import constants
-from robottelo.api.utils import enable_sync_redhat_repo
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.datafactory import gen_string
@@ -28,27 +27,53 @@ from robottelo.helpers import file_downloader
 from robottelo.logging import logger
 
 
-@pytest.fixture()
-def fixture_enable_rhc_repos(target_sat):
-    """Enable repos required for configuring RHC."""
-    if target_sat.os_version.major == 8:
-        target_sat.enable_repo(constants.REPOS['rhel8_bos']['id'])
-        target_sat.enable_repo(constants.REPOS['rhel8_aps']['id'])
+@pytest.fixture(scope='module')
+def subscribe_rhc_satellite(clean_rhsm, module_target_sat):
+    """subscribe rhc satellite to cdn"""
+    if module_target_sat.os_version.major < 8:
+        release_version = f'{module_target_sat.os_version.major}Server'
     else:
-        target_sat.enable_repo(constants.REPOS['rhscl7']['id'])
-        target_sat.enable_repo(constants.REPOS['rhel7']['id'])
+        release_version = f'{module_target_sat.os_version.major}'
+    module_target_sat.register_contenthost(
+        org=None,
+        lce=None,
+        username=settings.subscription.rhn_username,
+        password=settings.subscription.rhn_password,
+        releasever=release_version,
+    )
+    result = module_target_sat.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[0]
+    if 'Successfully attached a subscription' in result.stdout:
+        # extras is not in RHEL8: https://access.redhat.com/solutions/5331391
+        if module_target_sat.os_version.major < 8:
+            module_target_sat.enable_repo(
+                f'rhel-{module_target_sat.os_version.major}-server-extras-rpms', force=True
+            )
+        yield
+    else:
+        pytest.fail('Failed to attach system to pool. Aborting Test!.')
+
+
+@pytest.fixture()
+def fixture_enable_rhc_repos(module_target_sat):
+    """Enable repos required for configuring RHC."""
+    if module_target_sat.os_version.major == 8:
+        module_target_sat.enable_repo(constants.REPOS['rhel8_bos']['id'])
+        module_target_sat.enable_repo(constants.REPOS['rhel8_aps']['id'])
+    else:
+        module_target_sat.enable_repo(constants.REPOS['rhscl7']['id'])
+        module_target_sat.enable_repo(constants.REPOS['rhel7']['id'])
 
 
 @pytest.fixture(scope='module')
-def module_rhc_org(target_sat):
+def module_rhc_org(module_target_sat):
     """Module level fixture for creating organization"""
-    org = target_sat.api.Organization(
+    org = module_target_sat.api.Organization(
         name=gen_string('alpha')
         if not settings.rh_cloud.organization
         else settings.rh_cloud.organization
     ).create()
     # adding remote_execution_connect_by_ip=Yes at org level
-    target_sat.api.Parameter(
+    module_target_sat.api.Parameter(
         name='remote_execution_connect_by_ip',
         value='Yes',
         organization=org.id,
@@ -57,27 +82,27 @@ def module_rhc_org(target_sat):
 
 
 @pytest.fixture()
-def fixture_setup_rhc_satellite(request, target_sat, module_rhc_org):
+def fixture_setup_rhc_satellite(request, module_target_sat, module_rhc_org):
     """Create Organization and activation key after successful test execution"""
     yield
     if request.node.rep_call.passed:
         manifests_path = file_downloader(
-            file_url=settings.fake_manifest.url['default'], hostname=target_sat.hostname
+            file_url=settings.fake_manifest.url['default'], hostname=module_target_sat.hostname
         )[0]
-        target_sat.cli.Subscription.upload(
+        module_target_sat.cli.Subscription.upload(
             {'file': manifests_path, 'organization-id': module_rhc_org.id}
         )
         # Create Activation key
-        ak = target_sat.api.ActivationKey(
+        ak = module_target_sat.api.ActivationKey(
             name=gen_string('alpha')
             if not settings.rh_cloud.activation_key
             else settings.rh_cloud.activation_key,
             content_view=module_rhc_org.default_content_view,
             organization=module_rhc_org,
-            environment=target_sat.api.LifecycleEnvironment(id=module_rhc_org.library.id),
+            environment=module_target_sat.api.LifecycleEnvironment(id=module_rhc_org.library.id),
             auto_attach=True,
         ).create()
-        subscription = target_sat.api.Subscription(organization=module_rhc_org)
+        subscription = module_target_sat.api.Subscription(organization=module_rhc_org)
         default_subscription = subscription.search(
             query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
         )[0]
@@ -88,8 +113,8 @@ def fixture_setup_rhc_satellite(request, target_sat, module_rhc_org):
 @pytest.mark.tier3
 def test_positive_configure_cloud_connector(
     session,
-    target_sat,
-    subscribe_satellite,
+    module_target_sat,
+    subscribe_rhc_satellite,
     fixture_enable_rhc_repos,
     module_rhc_org,
     fixture_setup_rhc_satellite,
@@ -113,13 +138,13 @@ def test_positive_configure_cloud_connector(
     :BZ: 1818076
     """
     # Copy foreman-proxy user's key to root@localhost user's authorized_keys
-    target_sat.add_rex_key(satellite=target_sat)
+    module_target_sat.add_rex_key(satellite=module_target_sat)
 
     # Set Host parameter source_display_name to something random.
     # To avoid 'name has already been taken' error when run multiple times
     # on a machine with the same hostname.
-    host_id = target_sat.cli.Host.info({'name': target_sat.hostname})['id']
-    target_sat.cli.Host.set_parameter(
+    host_id = module_target_sat.cli.Host.info({'name': module_target_sat.hostname})['id']
+    module_target_sat.cli.Host.set_parameter(
         {'host-id': host_id, 'name': 'source_display_name', 'value': gen_string('alpha')}
     )
 
@@ -135,34 +160,34 @@ def test_positive_configure_cloud_connector(
 
     template_name = 'Configure Cloud Connector'
     invocation_id = (
-        target_sat.api.JobInvocation()
+        module_target_sat.api.JobInvocation()
         .search(query={'search': f'description="{template_name}"'})[0]
         .id
     )
     wait_for(
-        lambda: target_sat.api.JobInvocation(id=invocation_id).read().status_label
+        lambda: module_target_sat.api.JobInvocation(id=invocation_id).read().status_label
         in ["succeeded", "failed"],
         timeout="1500s",
     )
 
-    result = target_sat.cli.JobInvocation.get_output(
-        {'id': invocation_id, 'host': target_sat.hostname}
+    result = module_target_sat.cli.JobInvocation.get_output(
+        {'id': invocation_id, 'host': module_target_sat.hostname}
     )
     logger.debug(f"Invocation output>>\n{result}\n<<End of invocation output")
     # if installation fails, it's often due to missing rhscl repo -> print enabled repos
-    repolist = target_sat.execute('yum repolist')
+    repolist = module_target_sat.execute('yum repolist')
     logger.debug(f"Repolist>>\n{repolist}\n<<End of repolist")
-    assert target_sat.api.JobInvocation(id=invocation_id).read().status == 0
+    assert module_target_sat.api.JobInvocation(id=invocation_id).read().status == 0
     assert "Install yggdrasil-worker-forwarder and rhc" in result
     assert "Restart rhcd" in result
     assert 'Exit status: 0' in result
 
-    result = target_sat.execute('rhc status')
+    result = module_target_sat.execute('rhc status')
     logger.debug(f"rhc status>>\n{result}\n<<End of rhc status")
     assert result.status == 0
     assert "Connected to Red Hat Subscription Management" in result.stdout
     assert "The Red Hat connector daemon is active" in result.stdout
 
-    result = target_sat.execute('journalctl --unit=rhcd')
+    result = module_target_sat.execute('journalctl --unit=rhcd')
     logger.debug(f"journalctl log>>\n{result}\n<<End of log")
     assert "error" not in result.stdout

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -22,6 +22,7 @@ from wait_for import wait_for
 from robottelo import constants
 from robottelo.api.utils import enable_sync_redhat_repo
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.datafactory import gen_string
 from robottelo.helpers import file_downloader
 from robottelo.logging import logger
@@ -89,6 +90,11 @@ def fixture_setup_rhc_satellite(request, target_sat, module_org):
         cv.publish()
         # Create Activation key
         ak = target_sat.api.ActivationKey(content_view=cv, organization=module_org).create()
+        subscription = target_sat.api.Subscription(organization=module_org)
+        default_subscription = subscription.search(
+            query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
+        )[0]
+        ak.add_subscriptions(data={'quantity': 10, 'subscription_id': default_subscription.id})
         logger.debug(f"Activation key: {ak} \n Content view: {cv} \n Organization: {module_org}")
 
 

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -65,13 +65,6 @@ def fixture_setup_rhc_satellite(request, target_sat, module_org):
             'releasever': '8',
         }
         rh_repo3 = {
-            'name': constants.REPOS['rhscl7']['name'],
-            'product': constants.PRDS['rhscl'],
-            'reposet': constants.REPOSET['rhscl7'],
-            'basearch': constants.DEFAULT_ARCHITECTURE,
-            'releasever': '7Server',
-        }
-        rh_repo4 = {
             'name': constants.REPOS['rhel7']['name'],
             'product': constants.PRDS['rhel'],
             'reposet': constants.REPOSET['rhel7'],
@@ -82,14 +75,17 @@ def fixture_setup_rhc_satellite(request, target_sat, module_org):
         repo1_id = enable_sync_redhat_repo(rh_repo1, module_org.id)
         repo2_id = enable_sync_redhat_repo(rh_repo2, module_org.id)
         repo3_id = enable_sync_redhat_repo(rh_repo3, module_org.id)
-        repo4_id = enable_sync_redhat_repo(rh_repo4, module_org.id)
         # Add repos to Content view
         cv = target_sat.api.ContentView(
-            organization=module_org, repository=[repo1_id, repo2_id, repo3_id, repo4_id]
+            organization=module_org, repository=[repo1_id, repo2_id, repo3_id]
         ).create()
         cv.publish()
         # Create Activation key
-        ak = target_sat.api.ActivationKey(content_view=cv, organization=module_org).create()
+        ak = target_sat.api.ActivationKey(
+            content_view=cv,
+            organization=module_org,
+            environment=target_sat.api.LifecycleEnvironment(id=module_org.library.id),
+        ).create()
         subscription = target_sat.api.Subscription(organization=module_org)
         default_subscription = subscription.search(
             query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -1,0 +1,175 @@
+"""Test class for RH Cloud connector - rhc
+
+:Requirement: Remoteexecution
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: RHCloud-CloudConnector
+
+:Assignee: jpathan
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+from wait_for import wait_for
+
+from robottelo import constants
+from robottelo.api.utils import enable_sync_redhat_repo
+from robottelo.config import settings
+from robottelo.datafactory import gen_string
+from robottelo.helpers import file_downloader
+from robottelo.logging import logger
+
+
+@pytest.fixture()
+def fixture_enable_rhc_repos(target_sat):
+    """Enable repos required for configuring RHC."""
+    if target_sat.os_version.major == 8:
+        target_sat.enable_repo(constants.REPOS['rhel8_bos']['id'])
+        target_sat.enable_repo(constants.REPOS['rhel8_aps']['id'])
+    else:
+        target_sat.enable_repo(constants.REPOS['rhscl7']['id'])
+        target_sat.enable_repo(constants.REPOS['rhel7']['id'])
+
+
+@pytest.fixture()
+def fixture_setup_rhc_satellite(request, target_sat, module_org):
+    """Populate Satellite with repo, cv and ak after successful test execution"""
+    yield
+    if request.node.rep_call.passed:
+        manifests_path = file_downloader(
+            file_url=settings.fake_manifest.url['default'], hostname=target_sat.hostname
+        )[0]
+        target_sat.cli.Subscription.upload(
+            {'file': manifests_path, 'organization-id': module_org.id}
+        )
+        rh_repo1 = {
+            'name': constants.REPOS['rhel8_bos']['name'],
+            'product': constants.PRDS['rhel8'],
+            'reposet': constants.REPOSET['rhel8_bos'],
+            'basearch': constants.DEFAULT_ARCHITECTURE,
+            'releasever': '8',
+        }
+        rh_repo2 = {
+            'name': constants.REPOS['rhel8_aps']['name'],
+            'product': constants.PRDS['rhel8'],
+            'reposet': constants.REPOSET['rhel8_aps'],
+            'basearch': constants.DEFAULT_ARCHITECTURE,
+            'releasever': '8',
+        }
+        rh_repo3 = {
+            'name': constants.REPOS['rhscl7']['name'],
+            'product': constants.PRDS['rhscl'],
+            'reposet': constants.REPOSET['rhscl7'],
+            'basearch': constants.DEFAULT_ARCHITECTURE,
+            'releasever': '7Server',
+        }
+        rh_repo4 = {
+            'name': constants.REPOS['rhel7']['name'],
+            'product': constants.PRDS['rhel'],
+            'reposet': constants.REPOSET['rhel7'],
+            'basearch': constants.DEFAULT_ARCHITECTURE,
+            'releasever': '7Server',
+        }
+        # Enable and sync required repos
+        repo1_id = enable_sync_redhat_repo(rh_repo1, module_org.id)
+        repo2_id = enable_sync_redhat_repo(rh_repo2, module_org.id)
+        repo3_id = enable_sync_redhat_repo(rh_repo3, module_org.id)
+        repo4_id = enable_sync_redhat_repo(rh_repo4, module_org.id)
+        # Add repos to Content view
+        cv = target_sat.api.ContentView(
+            organization=module_org, repository=[repo1_id, repo2_id, repo3_id, repo4_id]
+        ).create()
+        cv.publish()
+        # Create Activation key
+        ak = target_sat.api.ActivationKey(content_view=cv, organization=module_org).create()
+        logger.debug(f"Activation key: {ak} \n Content view: {cv} \n Organization: {module_org}")
+
+
+@pytest.mark.tier3
+def test_positive_configure_cloud_connector(
+    session,
+    target_sat,
+    subscribe_satellite,
+    fixture_enable_rhc_repos,
+    module_org,
+    fixture_setup_rhc_satellite,
+):
+    """Install Cloud Connector through WebUI button
+
+    :id: 67e45cfe-31bb-51a8-b88f-27918c68f32e
+
+    :Steps:
+
+        1. Navigate to Configure > Inventory Upload
+        2. Click Configure Cloud Connector
+        3. Open the started job and wait until it is finished
+
+    :expectedresults: The Cloud Connector has been installed and the service is running
+
+    :CaseLevel: Integration
+
+    :CaseImportance: Critical
+
+    :BZ: 1818076
+    """
+    # Copy foreman-proxy user's key to root@localhost user's authorized_keys
+    target_sat.add_rex_key(satellite=target_sat)
+
+    # Set Host parameter source_display_name to something random.
+    # To avoid 'name has already been taken' error when run multiple times
+    # on a machine with the same hostname.
+    host_id = target_sat.cli.Host.info({'name': target_sat.hostname})['id']
+    target_sat.cli.Host.set_parameter(
+        {'host-id': host_id, 'name': 'source_display_name', 'value': gen_string('alpha')}
+    )
+
+    with session:
+        session.organization.select(org_name=module_org.name)
+        if session.cloudinventory.is_cloud_connector_configured():
+            pytest.skip(
+                'Cloud Connector has already been configured on this system. '
+                'It is possible to reconfigure it but then the test would not really '
+                'check if everything is correctly configured from scratch. Skipping.'
+            )
+        session.cloudinventory.configure_cloud_connector()
+
+    template_name = 'Configure Cloud Connector'
+    invocation_id = (
+        target_sat.api.JobInvocation()
+        .search(query={'search': f'description="{template_name}"'})[0]
+        .id
+    )
+    wait_for(
+        lambda: target_sat.api.JobInvocation(id=invocation_id).read().status_label
+        in ["succeeded", "failed"],
+        timeout="1500s",
+    )
+
+    result = target_sat.cli.JobInvocation.get_output(
+        {'id': invocation_id, 'host': target_sat.hostname}
+    )
+    logger.debug(f"Invocation output>>\n{result}\n<<End of invocation output")
+    # if installation fails, it's often due to missing rhscl repo -> print enabled repos
+    repolist = target_sat.execute('yum repolist')
+    logger.debug(f"Repolist>>\n{repolist}\n<<End of repolist")
+    assert target_sat.api.JobInvocation(id=invocation_id).read().status == 0
+    assert "Install yggdrasil-worker-forwarder and rhc" in result
+    assert "Restart rhcd" in result
+    assert 'Exit status: 0' in result
+
+    result = target_sat.execute('rhc status')
+    logger.debug(f"rhc status>>\n{result}\n<<End of rhc status")
+    assert result.status == 0
+    assert "Connected to Red Hat Subscription Management" in result.stdout
+    assert "The Red Hat connector daemon is active" in result.stdout
+
+    result = target_sat.execute('journalctl --unit=rhcd')
+    logger.debug(f"journalctl log>>\n{result}\n<<End of log")
+    assert "error" not in result.stdout

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -55,7 +55,7 @@ def module_rhc_org(module_target_sat):
     return org
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture()
 def fixture_setup_rhc_satellite(request, module_target_sat, module_rhc_org):
     """Create Organization and activation key after successful test execution"""
     yield
@@ -113,10 +113,10 @@ def test_positive_configure_cloud_connector(
     # Set Host parameter source_display_name to something random.
     # To avoid 'name has already been taken' error when run multiple times
     # on a machine with the same hostname.
-    host_id = module_target_sat.cli.Host.info({'name': module_target_sat.hostname})['id']
-    module_target_sat.cli.Host.set_parameter(
-        {'host-id': host_id, 'name': 'source_display_name', 'value': gen_string('alpha')}
-    )
+    host = module_target_sat.api.Host().search(query={'search': module_target_sat.hostname})[0]
+    parameters = [{'name': 'source_display_name', 'value': gen_string('alpha')}]
+    host.host_parameters_attributes = parameters
+    host.update(['host_parameters_attributes'])
 
     with session:
         session.organization.select(org_name=module_rhc_org.name)


### PR DESCRIPTION
This PR:

- Adds `fixture_setup_rhc_satellite` which creates organization and activation key after successful execution `test_positive_configure_cloud_connector` test.
- Moves `test_positive_configure_cloud_connector` test to `tests/foreman/ui/test_rhc.py`.
- Adds `pytest_runtest_makereport`, which is used for determining the status of the executed test.

For more information see SAT-9327(stage 2) jira card.