### PR TITLE
Fix typo in pytest mark

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -734,7 +734,7 @@ def test_positive_list_infrastructure_hosts(
 @pytest.mark.skip_if_not_set('libvirt')
 @pytest.mark.cli_host_create
 @pytest.mark.libvirt_discovery
-@pytest.mark.onprem_provisioning
+@pytest.mark.on_premises_provisioning
 @pytest.mark.tier1
 def test_positive_create_using_libvirt_without_mac(module_location, module_org):
     """Create a libvirt host and not specify a MAC address.


### PR DESCRIPTION
Fixing the typo will resolve below warning:
```22:55:22  tests/foreman/cli/test_host.py:737
22:55:22    /opt/app-root/src/robottelo/tests/foreman/cli/test_host.py:737: PytestUnknownMarkWarning: Unknown pytest.mark.onprem_provisioning - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
22:55:22      @pytest.mark.onprem_provisioning```