### PR TITLE
Change foreman service teardown

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -10,7 +10,7 @@ from robottelo.hosts import SatelliteHostError
 def foreman_service_teardown(target_sat):
     """stop and restart of foreman service"""
     yield target_sat
-    target_sat.execute('satellite-maintain service start --only=foreman')
+    target_sat.execute('satellite-maintain service start')
 
 
 @pytest.fixture


### PR DESCRIPTION
Hello

1] I think we should remove the `--only=foreman` because I think the aim of this fixture is to return Satellite to its original state, and due to bug [1] we should not assume only foreman needs starting.

2] Is this fixture aptly named?  In stead of `foreman_service_teardown` would `foreman_service_restore` be more accurate?


[1] [Bug 2104134](https://bugzilla.redhat.com/show_bug.cgi?id=2104134) - Stopping foreman also stops dynflow-sidekiq