### PR TITLE
Expand Search tests to more components.

### DIFF
--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -99,7 +99,7 @@ def test_positive_end_to_end(session, ui_entity):
 
 
 @pytest.mark.tier2
-def test_positive_create_bookmark_public(session, random_entity, default_viewer_role, test_name):
+def test_positive_create_bookmark_public(session, ui_entity, default_viewer_role, test_name):
     """Create and check visibility of the (non)public bookmarks
 
     :id: 93139529-7690-429b-83fe-3dcbac4f91dc
@@ -127,7 +127,7 @@ def test_positive_create_bookmark_public(session, random_entity, default_viewer_
     public_name = gen_string('alphanumeric')
     nonpublic_name = gen_string('alphanumeric')
     with session:
-        ui_lib = getattr(session, random_entity['name'].lower())
+        ui_lib = getattr(session, ui_entity['name'].lower())
         for name in (public_name, nonpublic_name):
             ui_lib.create_bookmark(
                 {'name': name, 'query': gen_string('alphanumeric'), 'public': name == public_name}
@@ -140,7 +140,7 @@ def test_positive_create_bookmark_public(session, random_entity, default_viewer_
 
 @pytest.mark.tier2
 def test_positive_update_bookmark_public(
-    session, random_entity, default_viewer_role, ui_user, test_name
+    session, ui_entity, default_viewer_role, ui_user, test_name
 ):
     """Update and save a bookmark public state
 
@@ -186,7 +186,7 @@ def test_positive_update_bookmark_public(
     cfg.auth = (ui_user.login, ui_user.password)
     for name in (public_name, nonpublic_name):
         entities.Bookmark(
-            cfg, name=name, controller=random_entity['controller'], public=name == public_name
+            cfg, name=name, controller=ui_entity['controller'], public=name == public_name
         ).create()
     with Session(
         test_name, default_viewer_role.login, default_viewer_role.password
@@ -206,7 +206,7 @@ def test_positive_update_bookmark_public(
 
 
 @pytest.mark.tier2
-def test_negative_delete_bookmark(random_entity, default_viewer_role, test_name):
+def test_negative_delete_bookmark(ui_entity, default_viewer_role, test_name):
     """Simple removal of a bookmark query without permissions
 
     :id: 1a94bf2b-bcc6-4663-b70d-e13244a0783b
@@ -227,7 +227,7 @@ def test_negative_delete_bookmark(random_entity, default_viewer_role, test_name)
 
     :CaseLevel: Integration
     """
-    bookmark = entities.Bookmark(controller=random_entity['controller'], public=True).create()
+    bookmark = entities.Bookmark(controller=ui_entity['controller'], public=True).create()
     with Session(
         test_name, default_viewer_role.login, default_viewer_role.password
     ) as non_admin_session:
@@ -238,7 +238,7 @@ def test_negative_delete_bookmark(random_entity, default_viewer_role, test_name)
 
 
 @pytest.mark.tier2
-def test_negative_create_with_duplicate_name(session, random_entity):
+def test_negative_create_with_duplicate_name(session, ui_entity):
     """Create bookmark with duplicate name
 
     :id: 18168c9c-bdd1-4839-a506-cf9b06c4ab44
@@ -258,10 +258,10 @@ def test_negative_create_with_duplicate_name(session, random_entity):
     :CaseLevel: Integration
     """
     query = gen_string('alphanumeric')
-    bookmark = entities.Bookmark(controller=random_entity['controller'], public=True).create()
+    bookmark = entities.Bookmark(controller=ui_entity['controller'], public=True).create()
     with session:
         assert session.bookmark.search(bookmark.name)[0]['Name'] == bookmark.name
-        ui_lib = getattr(session, random_entity['name'].lower())
+        ui_lib = getattr(session, ui_entity['name'].lower())
         with pytest.raises(DisabledWidgetError) as error:
             ui_lib.create_bookmark({'name': bookmark.name, 'query': query, 'public': True})
             assert error == 'name already exists'


### PR DESCRIPTION
This is gonna make tests less flaky (random behavior) because it makes the test going trough all the defined components rather than just randomly pick one.

This increases running time quite significantly