### PR TITLE
Remove Satellite object from the fuction call

### DIFF
--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -254,7 +254,7 @@ def test_positive_user_access_with_host_filter(
         assert len(session.dashboard.read('LatestErrata')['erratas']) == 0
         repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
         repos_collection.setup_virtual_machine(
-            rhel7_contenthost, target_sat, location_title=module_location.name
+            rhel7_contenthost, location_title=module_location.name
         )
         result = rhel7_contenthost.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
         assert result.status == 0


### PR DESCRIPTION
#9497 left `setup_virtual_machine` as it was. Satellite is now a property of the `RepositoryCollection` now, no need to specify it explicitly.