### PR TITLE
automation coverage for bz-2066899 and 2076684

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -147,6 +147,12 @@ Requirement:
     required: true
 Setup: {}
 Steps: {}
+SubComponent:
+    casesensitive: true
+    choices:
+    - Candlepin
+    - Pulp
+    type: choice
 Subtype1: {}
 Teardown: {}
 TestType:


### PR DESCRIPTION
Writing automation coverage for these candlepin BZs: https://bugzilla.redhat.com/show_bug.cgi?id=2066899, https://bugzilla.redhat.com/show_bug.cgi?id=2076684

Seems that the functionality for manifest refresh is broken?

Also thinking of grepping for the candlepin log for errors as another means of verification.  I'm putting these as tasks.

Tasks
- Address manifest refresh or get info on it
- Check candlepin.log for errors