### PR TITLE
Helpers refactor2

### DIFF
--- a/pytest_fixtures/component/contentview.py
+++ b/pytest_fixtures/component/contentview.py
@@ -1,9 +1,8 @@
 # Content View Fixtures
 import pytest
 from nailgun import entities
+from nailgun.entity_mixins import call_entity_method_with_timeout
 
-from robottelo.api.utils import call_entity_method_with_timeout
-from robottelo.api.utils import promote
 from robottelo.constants import DEFAULT_CV
 
 
@@ -22,7 +21,8 @@ def module_published_cv(module_org):
 @pytest.fixture(scope="module")
 def module_promoted_cv(module_lce, module_published_cv):
     """Promote published content view"""
-    promote(module_published_cv.version[0], environment_id=module_lce.id)
+    content_view_version = module_published_cv.version[0]
+    content_view_version.promote(data={'environment_ids': module_lce.id})
     return module_published_cv
 
 
@@ -34,7 +34,8 @@ def module_default_org_view(module_org):
 @pytest.fixture(scope='module')
 def module_ak_cv_lce(module_org, module_lce, module_published_cv):
     """Module Activation key with CV promoted to LCE"""
-    promote(module_published_cv.version[0], module_lce.id)
+    content_view_version = module_published_cv.version[0]
+    content_view_version.promote(data={'environment_ids': module_lce.id})
     module_published_cv = module_published_cv.read()
     module_ak_with_cv_lce = entities.ActivationKey(
         content_view=module_published_cv,
@@ -52,7 +53,7 @@ def module_cv_repo(module_org, module_repository, module_lce, module_target_sat)
     content_view = content_view.update(['repository'])
     call_entity_method_with_timeout(content_view.publish, timeout=3600)
     content_view = content_view.read()
-    promote(content_view.version[0], module_lce.id)
+    content_view.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
     return content_view
 
 

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -2,10 +2,9 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+from nailgun.entity_mixins import call_entity_method_with_timeout
 
-from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -59,7 +58,7 @@ def module_rhst_repo(module_target_sat, module_org_with_manifest, module_promote
     )
     cv.publish()
     cv = cv.read()
-    promote(cv.version[-1], environment_id=module_lce.id)
+    cv.version[-1].promote(data={'environment_ids': module_lce.id})
     return REPOS['rhst7']['id']
 
 

--- a/robottelo/upgrade_utility.py
+++ b/robottelo/upgrade_utility.py
@@ -2,10 +2,10 @@
 from fabric.api import execute
 from fabric.api import run
 from nailgun import entities
+from nailgun.entity_mixins import call_entity_method_with_timeout
 from upgrade.helpers.docker import docker_execute_command
 from wait_for import wait_for
 
-from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.config import settings
 
 

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -23,11 +23,10 @@ from datetime import datetime
 import pytest
 from nailgun import client
 from nailgun import entities
+from nailgun.entity_mixins import call_entity_method_with_timeout
 
 from robottelo import constants
-from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import DataFile
 from robottelo.constants.repos import ANSIBLE_GALAXY
@@ -434,7 +433,7 @@ class TestCapsuleContentManagement:
         assert len(cv.version) == 1
 
         cvv = cv.version[-1].read()
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -468,7 +467,7 @@ class TestCapsuleContentManagement:
 
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -538,7 +537,7 @@ class TestCapsuleContentManagement:
         assert len(cv.version) == 1
 
         cvv = cv.version[-1].read()
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
         assert len(cvv.environment) == 2
 
@@ -556,7 +555,7 @@ class TestCapsuleContentManagement:
         assert len(cv.version) == 2
 
         cvv = cv.version[-1].read()
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
         assert len(cvv.environment) == 2
 
@@ -636,7 +635,7 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -685,7 +684,7 @@ class TestCapsuleContentManagement:
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         # Promote new content view version to lifecycle environment
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -707,7 +706,7 @@ class TestCapsuleContentManagement:
         cv = cv.read()
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -847,7 +846,7 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -927,7 +926,7 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -955,7 +954,7 @@ class TestCapsuleContentManagement:
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -1058,7 +1057,7 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        promote(cvv, lce.id)
+        cvv.promote(data={'environment_ids': lce.id})
         cvv = cvv.read()
 
         assert len(cvv.environment) == 2
@@ -1149,7 +1148,7 @@ class TestCapsuleContentManagement:
 
         # Promote the latest CV version into capsule's LCE
         cvv = cv.version[-1].read()
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
         assert len(cvv.environment) == 2
 
@@ -1341,7 +1340,7 @@ class TestCapsuleContentManagement:
 
         # Promote the latest CV version into capsule's LCE
         cvv = cv.version[-1].read()
-        promote(cvv, function_lce.id)
+        cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()
         assert len(cvv.environment) == 2
 

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -30,7 +30,6 @@ from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.api.utils import promote
 from robottelo.config import get_credentials
 from robottelo.config import settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
@@ -753,7 +752,7 @@ class TestContentViewFilterRule:
 
         # Promote Content View
         lce = entities.LifecycleEnvironment(organization=module_org).create()
-        promote(content_view.version[0], lce.id)
+        content_view.version[0].promote(data={'environment_ids': lce.id, 'force': False})
         content_view = content_view.read()
         content_view_version_info = content_view.version[0].read()
 

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -21,7 +21,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
 from robottelo.constants import DataFile
@@ -114,7 +113,7 @@ def test_positive_promote_valid_environment(module_lce_cv, module_org):
     # environments (i.e. 'Library')
     assert len(version.environment) == 1
     # Promote it to the next 'in sequence' lifecycle environment
-    promote(version, module_lce_cv[0].id)
+    version.promote(data={'environment_ids': module_lce_cv[0].id, 'force': False})
     # Assert that content view version is found in 2 lifecycle
     # environments.
     version = version.read()
@@ -142,7 +141,7 @@ def test_positive_promote_out_of_sequence_environment(module_org, module_lce_cv)
     assert len(cv.version) == 1
     version = cv.version[0].read()
     # The immediate lifecycle is lce1, not lce2
-    promote(version, module_lce_cv[1].id, force=True)
+    version.promote(data={'environment_ids': module_lce_cv[1].id, 'force': True})
     # Assert that content view version is found in 2 lifecycle
     # environments.
     version = version.read()
@@ -163,7 +162,7 @@ def test_negative_promote_valid_environment(module_lce_cv):
     """
     lce1, _, default_cvv = module_lce_cv
     with pytest.raises(HTTPError):
-        promote(default_cvv, lce1.id)
+        default_cvv.promote(data={'environment_ids': lce1.id, 'force': False})
 
 
 @pytest.mark.tier2
@@ -188,7 +187,7 @@ def test_negative_promote_out_of_sequence_environment(module_lce_cv, module_org)
     version = cv.version[0].read()
     # The immediate lifecycle is lce1, not lce2
     with pytest.raises(HTTPError):
-        promote(version, module_lce_cv[1].id)
+        version.promote(data={'environment_ids': module_lce_cv[1].id, 'force': False})
 
 
 # Tests for content view version promotion.
@@ -262,7 +261,7 @@ def test_positive_delete_non_default(module_org):
     assert len(content_view.version) == 1
     assert len(content_view.version[0].read().environment) == 1
     lce = entities.LifecycleEnvironment(organization=module_org).create()
-    promote(content_view.version[0], lce.id)
+    content_view.version[0].promote(data={'environment_ids': lce.id, 'force': False})
     cvv = content_view.version[0].read()
     assert len(cvv.environment) == 2
     # Delete the content-view version from selected environments
@@ -435,7 +434,7 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(module_org):
     assert lce_library.name == ENVIRONMENT
     # promote content view version to DEV and QE lifecycle environments
     for lce in [lce_dev, lce_qe]:
-        promote(content_view_version, lce.id)
+        content_view_version.promote(data={'environment_ids': lce.id, 'force': False})
     assert {lce_library.id, lce_dev.id, lce_qe.id} == {
         lce.id for lce in content_view_version.read().environment
     }
@@ -494,7 +493,7 @@ def test_positive_remove_prod_promoted_cv_version_from_default_env(module_org):
     assert lce_library.name == ENVIRONMENT
     # promote content view version to DEV QE PROD lifecycle environments
     for lce in [lce_dev, lce_qe, lce_prod]:
-        promote(content_view_version, lce.id)
+        content_view_version.promote(data={'environment_ids': lce.id, 'force': False})
     assert {lce_library.id, lce_dev.id, lce_qe.id, lce_prod.id} == {
         lce.id for lce in content_view_version.read().environment
     }
@@ -561,7 +560,7 @@ def test_positive_remove_cv_version_from_env(module_org):
     # promote content view version to DEV QE STAGE PROD lifecycle
     # environments
     for lce in [lce_dev, lce_qe, lce_stage, lce_prod]:
-        promote(content_view_version, lce.id)
+        content_view_version.promote(data={'environment_ids': lce.id, 'force': False})
     assert {lce_library.id, lce_dev.id, lce_qe.id, lce_stage.id, lce_prod.id} == {
         lce.id for lce in content_view_version.read().environment
     }
@@ -573,7 +572,7 @@ def test_positive_remove_cv_version_from_env(module_org):
         lce.id for lce in content_view_version.read().environment
     }
     # promote content view version to PROD environment again
-    promote(content_view_version, lce_prod.id)
+    content_view_version.promote(data={'environment_ids': lce_prod.id, 'force': False})
     assert {lce_library.id, lce_dev.id, lce_qe.id, lce_stage.id, lce_prod.id} == {
         lce.id for lce in content_view_version.read().environment
     }
@@ -630,7 +629,7 @@ def test_positive_remove_cv_version_from_multi_env(module_org):
     # promote content view version to DEV QE STAGE PROD lifecycle
     # environments
     for lce in [lce_dev, lce_qe, lce_stage, lce_prod]:
-        promote(content_view_version, lce.id)
+        content_view_version.promote(data={'environment_ids': lce.id, 'force': False})
     assert {lce_library.id, lce_dev.id, lce_qe.id, lce_stage.id, lce_prod.id} == {
         lce.id for lce in content_view_version.read().environment
     }
@@ -698,7 +697,7 @@ def test_positive_delete_cv_promoted_to_multi_env(module_org):
     # promote content view version to DEV QE STAGE PROD lifecycle
     # environments
     for lce in [lce_dev, lce_qe, lce_stage, lce_prod]:
-        promote(content_view_version, lce.id)
+        content_view_version.promote(data={'environment_ids': lce.id, 'force': False})
     content_view_version = content_view_version.read()
     assert {lce_library.id, lce_dev.id, lce_qe.id, lce_stage.id, lce_prod.id} == {
         lce.id for lce in content_view_version.environment

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -18,7 +18,6 @@ import pytest
 import requests
 
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE
@@ -60,7 +59,7 @@ def update_cv(sat, cv, lce, repos):
     cv = sat.api.ContentView(id=cv.id, repository=repos).update(["repository"])
     cv.publish()
     cv = cv.read()
-    promote(cv.version[-1], environment_id=lce.id)
+    cv.version[-1].promote(data={'environment_ids': lce.id, 'force': False})
     return cv
 
 

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -22,7 +22,6 @@ from fauxfactory import gen_url
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.api.utils import promote
 from robottelo.constants import CONTAINER_REGISTRY_HUB
 from robottelo.constants import CONTAINER_UPSTREAM_NAME
 from robottelo.datafactory import generate_strings_list
@@ -89,7 +88,7 @@ def content_view_publish_promote(content_view_with_repo, module_lce):
     cv.publish()
 
     cvv = cv.read().version[0].read()
-    promote(cvv, module_lce.id)
+    cvv.promote(data={'environment_ids': module_lce.id, 'force': False})
 
     return cv.read()
 
@@ -612,7 +611,7 @@ class TestDockerContentView:
         cvv = content_view.version[0].read()
         assert len(cvv.environment) == 1
 
-        promote(cvv, lce.id)
+        cvv.promote(data={'environment_ids': lce.id, 'force': False})
         assert len(cvv.read().environment) == 2
 
     @pytest.mark.tier2
@@ -638,7 +637,7 @@ class TestDockerContentView:
 
         for i in range(1, randint(3, 6)):
             lce = entities.LifecycleEnvironment(organization=module_org).create()
-            promote(cvv, lce.id)
+            cvv.promote(data={'environment_ids': lce.id, 'force': False})
             assert len(cvv.read().environment) == i + 1
 
     @pytest.mark.tier2
@@ -671,7 +670,7 @@ class TestDockerContentView:
         comp_cvv = comp_content_view.read().version[0]
         assert len(comp_cvv.read().environment) == 1
 
-        promote(comp_cvv, lce.id)
+        comp_cvv.promote(data={'environment_ids': lce.id, 'force': False})
         assert len(comp_cvv.read().environment) == 2
 
     @pytest.mark.upgrade
@@ -706,7 +705,7 @@ class TestDockerContentView:
 
         for i in range(1, randint(3, 6)):
             lce = entities.LifecycleEnvironment(organization=module_org).create()
-            promote(comp_cvv, lce.id)
+            comp_cvv.promote(data={'environment_ids': lce.id, 'force': False})
             assert len(comp_cvv.read().environment) == i + 1
 
     @pytest.mark.tier2
@@ -737,7 +736,7 @@ class TestDockerContentView:
         content_view.publish()
         cvv = content_view.read().version[0]
         lce = entities.LifecycleEnvironment(organization=module_org).create()
-        promote(cvv, lce.id)
+        cvv.promote(data={'environment_ids': lce.id, 'force': False})
         lce.registry_name_pattern = new_pattern
         lce = lce.update(['registry_name_pattern'])
         repos = entities.Repository(organization=module_org).search(
@@ -775,7 +774,7 @@ class TestDockerContentView:
         lce = entities.LifecycleEnvironment(organization=module_org).create()
         lce.registry_name_pattern = new_pattern
         lce = lce.update(['registry_name_pattern'])
-        promote(cvv, lce.id)
+        cvv.promote(data={'environment_ids': lce.id, 'force': False})
         prod.name = new_prod_name
         prod.update(['name'])
         repos = entities.Repository(organization=module_org).search(
@@ -787,7 +786,7 @@ class TestDockerContentView:
 
         content_view.publish()
         cvv = content_view.read().version[-1]
-        promote(cvv, lce.id)
+        cvv.promote(data={'environment_ids': lce.id, 'force': False})
         repos = entities.Repository(organization=module_org).search(
             query={'environment_id': lce.id}
         )
@@ -825,7 +824,7 @@ class TestDockerContentView:
         lce = entities.LifecycleEnvironment(organization=module_org).create()
         lce.registry_name_pattern = new_pattern
         lce = lce.update(['registry_name_pattern'])
-        promote(cvv, lce.id)
+        cvv.promote(data={'environment_ids': lce.id, 'force': False})
         repo.name = new_repo_name
         repo.update(['name'])
         repos = entities.Repository(organization=module_org).search(
@@ -837,7 +836,7 @@ class TestDockerContentView:
 
         content_view.publish()
         cvv = content_view.read().version[-1]
-        promote(cvv, lce.id)
+        cvv.promote(data={'environment_ids': lce.id, 'force': False})
         repos = entities.Repository(organization=module_org).search(
             query={'environment_id': lce.id}
         )
@@ -873,7 +872,7 @@ class TestDockerContentView:
         content_view.publish()
         cvv = content_view.read().version[0]
         with pytest.raises(HTTPError):
-            promote(cvv, lce.id)
+            cvv.promote(data={'environment_ids': lce.id, 'force': False})
 
     @pytest.mark.tier2
     def test_negative_promote_and_set_non_unique_name_pattern(self, module_org):
@@ -901,7 +900,7 @@ class TestDockerContentView:
         content_view.publish()
         cvv = content_view.read().version[0]
         lce = entities.LifecycleEnvironment(organization=module_org).create()
-        promote(cvv, lce.id)
+        cvv.promote(data={'environment_ids': lce.id, 'force': False})
         with pytest.raises(HTTPError):
             lce.registry_name_pattern = new_pattern
             lce.update(['registry_name_pattern'])
@@ -979,7 +978,7 @@ class TestDockerActivationKey:
 
         comp_content_view.publish()
         comp_cvv = comp_content_view.read().version[0].read()
-        promote(comp_cvv, module_lce.id)
+        comp_cvv.promote(data={'environment_ids': module_lce.id, 'force': False})
 
         ak = entities.ActivationKey(
             content_view=comp_content_view, environment=module_lce, organization=module_org
@@ -1007,7 +1006,7 @@ class TestDockerActivationKey:
 
         comp_content_view.publish()
         comp_cvv = comp_content_view.read().version[0].read()
-        promote(comp_cvv, module_lce.id)
+        comp_cvv.promote(data={'environment_ids': module_lce.id, 'force': False})
 
         ak = entities.ActivationKey(
             content_view=comp_content_view, environment=module_lce, organization=module_org

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -25,7 +25,6 @@ from nailgun import entities
 from robottelo import constants
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.factory import setup_org_for_a_custom_repo
@@ -459,7 +458,7 @@ def setup_content_rhel6():
     ).create()
     cv.publish()
     cvv = cv.read().version[0].read()
-    promote(cvv, lce.id)
+    cvv.promote(data={'environment_ids': lce.id, 'force': False})
 
     ak = entities.ActivationKey(content_view=cv, organization=org, environment=lce).create()
 
@@ -596,7 +595,7 @@ def test_positive_get_diff_for_cv_envs():
         )
     new_env = entities.LifecycleEnvironment(organization=org, prior=env).create()
     cvvs = content_view.read().version[-2:]
-    promote(cvvs[-1], new_env.id)
+    cvvs[-1].promote(data={'environment_ids': new_env.id, 'force': False})
     result = entities.Errata().compare(
         data={'content_view_version_ids': [cvv.id for cvv in cvvs], 'per_page': '9999'}
     )
@@ -687,7 +686,7 @@ def test_positive_incremental_update_required(
     module_cv = module_cv.read()
     CV1V = module_cv.version[-1].read()
     # Must promote a CV version into a new Environment before we can add errata
-    promote(CV1V, module_lce.id)
+    CV1V.promote(data={'environment_ids': module_lce.id, 'force': False})
     module_cv = module_cv.read()
     # Call nailgun to make the API POST to ensure an incremental update is required
     response = entities.Host().bulk_available_incremental_updates(

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -33,7 +33,6 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo import datafactory
-from robottelo.api.utils import promote
 from robottelo.config import get_credentials
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_CV
@@ -249,7 +248,7 @@ def test_positive_create_and_update_with_hostgroup(
 
     :CaseLevel: Integration
     """
-    promote(module_published_cv.version[0], environment_id=module_lce.id)
+    module_published_cv.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
     hostgroup = entities.HostGroup(location=[module_location], organization=[module_org]).create()
     host = entities.Host(
         hostgroup=hostgroup,
@@ -992,7 +991,7 @@ def test_positive_read_content_source_id(
     :CaseLevel: System
     """
     proxy = entities.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0].read()
-    promote(module_published_cv.version[0], environment_id=module_lce.id)
+    module_published_cv.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
     host = entities.Host(
         organization=module_org,
         location=module_location,
@@ -1028,7 +1027,7 @@ def test_positive_update_content_source_id(
     :CaseLevel: System
     """
     proxy = target_sat.api.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0]
-    promote(module_published_cv.version[0], environment_id=module_lce.id)
+    module_published_cv.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
     host = target_sat.api.Host(
         organization=module_org,
         location=module_location,

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -26,7 +26,6 @@ from nailgun import entity_fields
 from requests.exceptions import HTTPError
 
 from robottelo.api.utils import one_to_one_names
-from robottelo.api.utils import promote
 from robottelo.config import get_credentials
 from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
@@ -82,7 +81,7 @@ class TestHostGroup:
         lc_env = session_puppet_enabled_sat.api.LifecycleEnvironment(
             name=gen_string('alpha'), organization=org
         ).create()
-        promote(content_view.version[0], lc_env.id)
+        content_view.version[0].promote(data={'environment_ids': lc_env.id, 'force': False})
         content_view = content_view.read()
         assert len(content_view.version) == 1
 
@@ -175,7 +174,7 @@ class TestHostGroup:
         content_view = entities.ContentView(organization=module_org).create()
         content_view.publish()
         content_view = content_view.read()
-        promote(content_view.version[0], environment_id=lce.id)
+        content_view.version[0].promote(data={'environment_ids': lce.id, 'force': False})
         entities.Host(
             hostgroup=hostgroup,
             location=module_location,
@@ -283,7 +282,7 @@ class TestHostGroup:
         lce = session_puppet_enabled_sat.api.LifecycleEnvironment(
             organization=module_puppet_org
         ).create()
-        promote(content_view.version[0], lce.id)
+        content_view.version[0].promote(data={'environment_ids': lce.id, 'force': False})
         hostgroup = session_puppet_enabled_sat.api.HostGroup(
             architecture=arch,
             content_source=proxy,
@@ -342,7 +341,7 @@ class TestHostGroup:
         new_media = session_puppet_enabled_sat.api.Media(
             operatingsystem=[os], location=[new_loc], organization=[new_org]
         ).create()
-        promote(new_cv.version[0], new_lce.id)
+        new_cv.version[0].promote(data={'environment_ids': new_lce.id, 'force': False})
 
         # update itself
         hostgroup.organization = [new_org]

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -25,7 +25,6 @@ from wait_for import wait_for
 
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
@@ -63,7 +62,7 @@ def setup_content():
     ).create()
     cv.publish()
     cvv = cv.read().version[0].read()
-    promote(cvv, lce.id)
+    cvv.promote(data={'environment_ids': lce.id, 'force': False})
     ak = entities.ActivationKey(
         content_view=cv, max_hosts=100, organization=org, environment=lce, auto_attach=True
     ).create()

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -28,15 +28,14 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun import entities
+from nailgun.entity_mixins import call_entity_method_with_timeout
 from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 
 from robottelo import constants
 from robottelo import datafactory
 from robottelo import manifests
-from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
 from robottelo.constants import DataFile
@@ -2059,7 +2058,7 @@ class TestSRPMRepository:
             len(entities.Srpms().search(query={'content_view_version_id': cv.version[0].id})) >= 3
         )
 
-        promote(cv.version[0], env.id)
+        cv.version[0].promote(data={'environment_ids': env.id, 'force': False})
         assert len(entities.Srpms().search(query={'environment_id': env.id})) == 3
 
 

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -20,7 +20,6 @@ import pytest
 from nailgun import entities
 
 from robottelo import manifests
-from robottelo.api.utils import promote
 from robottelo.cli.host import Host
 from robottelo.cli.package import Package
 from robottelo.config import settings
@@ -51,7 +50,7 @@ def rh_repo_cv(module_gt_manifest_org, rh_repo_gt_manifest, module_lce):
     rh_repo_cv.publish()
     rh_repo_cv = rh_repo_cv.read()
     # promote the last version published into the module lce
-    promote(rh_repo_cv.version[-1], environment_id=module_lce.id)
+    rh_repo_cv.version[-1].promote(data={'environment_ids': module_lce.id, 'force': False})
     return rh_repo_cv
 
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -29,7 +29,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 from wait_for import wait_for
 
-from robottelo.api.utils import promote
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import add_role_permissions
@@ -818,7 +817,7 @@ def test_positive_create_inherit_nested_hostgroup():
     lce = entities.LifecycleEnvironment(organization=options.organization).create()
     content_view = entities.ContentView(organization=options.organization).create()
     content_view.publish()
-    promote(content_view.read().version[0], environment_id=lce.id)
+    content_view.read().version[0].promote(data={'environment_ids': lce.id, 'force': False})
     host_name = gen_string('alpha').lower()
     nested_hg_name = gen_string('alpha')
     parent_hostgroups = []
@@ -880,7 +879,7 @@ def test_positive_list_with_nested_hostgroup():
     lce = entities.LifecycleEnvironment(organization=options.organization).create()
     content_view = entities.ContentView(organization=options.organization).create()
     content_view.publish()
-    promote(content_view.read().version[0], environment_id=lce.id)
+    content_view.read().version[0].promote(data={'environment_ids': lce.id, 'force': False})
     parent_hg = entities.HostGroup(
         name=parent_hg_name, organization=[options.organization]
     ).create()
@@ -2103,7 +2102,7 @@ def test_negative_without_attach_with_lce(
     host_lce = target_sat.api.LifecycleEnvironment(organization=function_org).create()
     # refresh content view data
     content_view.publish()
-    promote(content_view.read().version[-1], environment_id=host_lce.id)
+    content_view.read().version[-1].promote(data={'environment_ids': host_lce.id, 'force': False})
 
     # register client
     host_subscription_client.register_contenthost(

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -30,7 +30,6 @@ from nailgun import entities
 from robottelo import constants
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.config import get_credentials
 from robottelo.config import get_url
@@ -1125,7 +1124,7 @@ class TestEndToEnd:
         assert len(content_view.version) == 1
         cv_version = content_view.version[0].read()
         assert len(cv_version.environment) == 1
-        promote(cv_version, le1.id)
+        cv_version.promote(data={'environment_ids': le1.id})
         # check that content view exists in lifecycle
         content_view = content_view.read()
         assert len(content_view.version) == 1

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -23,7 +23,6 @@ import pytest
 from nailgun import entities
 
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE
@@ -198,7 +197,7 @@ def test_positive_noapply_api(module_manifest_org, module_cv, custom_repo, host,
     # Promote CV to new LCE
     versions = sorted(module_cv.read().version, key=lambda ver: ver.id)
     cvv = versions[-1].read()
-    promote(cvv, dev_lce.id)
+    cvv.promote(data={'environment_ids': dev_lce.id})
     # Read CV to pick up LCE ID and next_version
     module_cv = module_cv.read()
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -31,7 +31,6 @@ from robottelo.api.utils import create_sync_custom_repo
 from robottelo.api.utils import cv_publish_promote
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import enable_sync_redhat_repo
-from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.config import settings
@@ -694,7 +693,10 @@ def test_positive_access_non_admin_user(session, test_name):
     env_name = random.choice(envs_list)
     cv = entities.ContentView(organization=org).create()
     cv.publish()
-    promote(cv.read().version[0], entities.LifecycleEnvironment(name=env_name).search()[0].id)
+    content_view_version = cv.read().version[0]
+    content_view_version.promote(
+        data={'environment_ids': [entities.LifecycleEnvironment(name=env_name).search()[0].id]}
+    )
     # Create new role
     role = entities.Role().create()
     # Create filter with predefined activation keys search criteria
@@ -802,7 +804,7 @@ def test_positive_add_docker_repo_cv(session, module_org):
     ).create()
     content_view.publish()
     cvv = content_view.read().version[0].read()
-    promote(cvv, lce.id)
+    cvv.promote(data={'environment_ids': lce.id, 'force': False})
     ak_name = gen_string('alphanumeric')
     with session:
         session.activationkey.create(
@@ -838,13 +840,13 @@ def test_positive_add_docker_repo_ccv(session, module_org):
     ).create()
     content_view.publish()
     cvv = content_view.read().version[0].read()
-    promote(cvv, lce.id)
+    cvv.promote(data={'environment_ids': lce.id, 'force': False})
     composite_cv = entities.ContentView(
         component=[cvv], composite=True, organization=module_org
     ).create()
     composite_cv.publish()
     ccvv = composite_cv.read().version[0].read()
-    promote(ccvv, lce.id)
+    ccvv.promote(data={'environment_ids': lce.id, 'force': False})
     ak_name = gen_string('alphanumeric')
     with session:
         session.activationkey.create(

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -27,16 +27,15 @@ from airgun.exceptions import InvalidElementStateException
 from airgun.exceptions import NoSuchElementException
 from airgun.session import Session
 from nailgun import entities
+from nailgun.entity_mixins import call_entity_method_with_timeout
 from navmazing import NavigationTriesExceeded
 from productmd.common import parse_nvra
 
 from robottelo import constants
 from robottelo import manifests
-from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.api.utils import create_role_permissions
 from robottelo.api.utils import create_sync_custom_repo
 from robottelo.api.utils import enable_sync_redhat_repo
-from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.cli.contentview import ContentView
 from robottelo.config import settings
@@ -1497,7 +1496,7 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(session, module
     repo_name = repo.repos_info[0]['name']
     cv, lce = repo.setup_content_view(module_org.id, dev_lce.id)
     cvv = entities.ContentView(id=cv['id']).read().version[0]
-    promote(cvv, qe_lce.id)
+    cvv.promote(data={'environment_ids': qe_lce.id})
     with session:
         cv_values = session.contentview.read(cv['name'])
         assert cv_values['docker_repositories']['resources']['assigned'][0]['Name'] == repo_name
@@ -1566,7 +1565,7 @@ def test_positive_remove_cv_version_from_env(session, module_org, repos_collecti
     ][0]
     cv, lce = repos_collection.setup_content_view(module_org.id, dev_lce.id)
     cvv = entities.ContentView(id=cv['id']).read().version[0]
-    promote(cvv, qe_lce.id)
+    cvv.promote(data={'environment_ids': qe_lce.id})
     with session:
         cvv = session.contentview.read_version(cv['name'], VERSION)
         assert cvv['yum_repositories']['table'][0]['Name']
@@ -1725,7 +1724,7 @@ def test_positive_delete_version_with_ak(session):
     cv.publish()
     cvv = cv.read().version[0].read()
     lc_env = entities.LifecycleEnvironment(organization=org).create()
-    promote(cvv, lc_env.id)
+    cvv.promote(data={'environment_ids': lc_env.id})
     ak = entities.ActivationKey(
         name=gen_string('alphanumeric'), environment=lc_env.id, organization=org, content_view=cv
     ).create()
@@ -2689,7 +2688,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(
     content_view = content_view.update(['repository'])
     content_view.publish()
     content_view = content_view.read()
-    promote(content_view.version[0], lc_env.id)
+    content_view.version[0].promote(data={'environment_ids': lc_env.id})
     cv_name = content_view.name
     # Get the Partition table ID
     ptable = entities.PartitionTable().search(query={'search': f'name="{DEFAULT_PTABLE}"'})[0]
@@ -2915,7 +2914,7 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, target_
     ).create()
     cv.publish()
     cvv = entities.ContentView(id=cv.id).read().version[0]
-    promote(cvv, lce.id)
+    cvv.promote(data={'environment_ids': lce.id})
     # Setup tools repo and add it to ak
     repos_collection = target_sat.cli_factory.RepositoryCollection(
         distro='rhel7',
@@ -2940,7 +2939,7 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, target_
     composite_cv = composite_cv.update(['component'])
     # Publish and promote
     composite_cv.publish()
-    promote(composite_cv.read().version[0], lce.id)
+    composite_cv.read().version[0].promote(data={'environment_ids': lce.id})
     # Update AK to use composite cv
     entities.ActivationKey(
         id=content_data['activation_key']['id'], content_view=composite_cv

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -22,7 +22,6 @@ from broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import FAKE_10_YUM_BUGFIX_ERRATUM
@@ -567,7 +566,7 @@ def test_positive_filter_by_environment(
         content_view_version = content_view.version[-1].read()
         lce = content_view_version.environment[-1].read()
         new_lce = entities.LifecycleEnvironment(organization=module_org, prior=lce).create()
-        promote(content_view_version, new_lce.id)
+        content_view_version.promote(data={'environment_ids': new_lce.id})
         host = entities.Host().search(query={'search': f'name={clients[0].hostname}'})[0].read()
         host.content_facet_attributes = {
             'content_view_id': content_view.id,
@@ -639,7 +638,7 @@ def test_positive_content_host_previous_env(
     content_view_version = content_view.version[-1].read()
     lce = content_view_version.environment[-1].read()
     new_lce = entities.LifecycleEnvironment(organization=module_org, prior=lce).create()
-    promote(content_view_version, new_lce.id)
+    content_view_version.promote(data={'environment_ids': new_lce.id})
     host = entities.Host().search(query={'search': f'name={hostname}'})[0].read()
     host.content_facet_attributes = {
         'content_view_id': content_view.id,
@@ -940,7 +939,7 @@ def test_positive_filtered_errata_status_installable_param(
         content_view.publish()
         content_view = content_view.read()
         content_view_version = content_view.version[-1]
-        promote(content_view_version, lce.id)
+        content_view_version.promote(data={'environment_ids': lce.id})
         with session:
             session.organization.select(org_name=org.name)
             session.location.select(loc_name=DEFAULT_LOC)

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -33,7 +33,6 @@ from wait_for import wait_for
 from robottelo import constants
 from robottelo.api.utils import create_role_permissions
 from robottelo.api.utils import cv_publish_promote
-from robottelo.api.utils import promote
 from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT
@@ -797,7 +796,7 @@ def test_positive_check_permissions_affect_create_procedure(
     for content_view in [cv, filter_cv]:
         content_view.publish()
         content_view = content_view.read()
-        promote(content_view.version[0], filter_lc_env.id)
+        content_view.version[0].promote(data={'environment_ids': filter_lc_env.id})
     # Create two host groups
     hg = target_sat.api.HostGroup(organization=[function_org]).create()
     filter_hg = target_sat.api.HostGroup(organization=[function_org]).create()

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -23,7 +23,6 @@ from broker import Broker
 from nailgun import entities
 
 from robottelo import constants
-from robottelo.api.utils import promote
 from robottelo.api.utils import update_vm_host_location
 from robottelo.config import settings
 from robottelo.datafactory import gen_string
@@ -330,7 +329,7 @@ def test_positive_add_host(session):
     cv = entities.ContentView(organization=org).create()
     lce = entities.LifecycleEnvironment(organization=org).create()
     cv.publish()
-    promote(cv.read().version[0], lce.id)
+    cv.read().version[0].promote(data={'environment_ids': lce.id})
     host = entities.Host(
         organization=org,
         location=loc,
@@ -653,7 +652,7 @@ def test_negative_hosts_limit(session, module_org, smart_proxy_location):
     cv = entities.ContentView(organization=org).create()
     lce = entities.LifecycleEnvironment(organization=org).create()
     cv.publish()
-    promote(cv.read().version[0], lce.id)
+    cv.read().version[0].promote(data={'environment_ids': lce.id})
     hosts = []
     for _ in range(2):
         hosts.append(

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -19,7 +19,6 @@
 import pytest
 from nailgun import entities
 
-from robottelo.api.utils import promote
 from robottelo.constants import OSCAP_PROFILE
 from robottelo.datafactory import gen_string
 
@@ -66,7 +65,7 @@ def test_positive_check_dashboard(
     content_view = entities.ContentView(organization=default_org).create()
     content_view.publish()
     content_view = content_view.read()
-    promote(content_view.version[0], environment_id=lce.id)
+    content_view.version[0].promote(data={'environment_ids': lce.id})
     entities.Host(
         hostgroup=module_host_group,
         location=default_location,

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -29,7 +29,6 @@ from nailgun import entities
 
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.config import robottelo_tmp_dir
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
@@ -66,7 +65,7 @@ def setup_content(module_org):
     ).create()
     cv.publish()
     cvv = cv.read().version[0].read()
-    promote(cvv, lce.id)
+    cvv.promote(data={'environment_ids': lce.id})
     ak = entities.ActivationKey(
         content_view=cv, organization=module_org, environment=lce, auto_attach=True
     ).create()

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -19,12 +19,11 @@
 import pytest
 from fabric.api import execute
 from fabric.api import run
+from nailgun.entity_mixins import call_entity_method_with_timeout
 from upgrade.helpers.tasks import wait_untill_capsule_sync
 from upgrade_tests.helpers.scenarios import rpm1
 from upgrade_tests.helpers.scenarios import rpm2
 
-from robottelo.api.utils import call_entity_method_with_timeout
-from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.datafactory import gen_string
 from robottelo.upgrade_utility import create_repo
@@ -92,7 +91,7 @@ class TestCapsuleSync:
         content_view.repository = [repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-        promote(content_view.read().version[0], ak_env.id)
+        content_view.read().version[0].promote(data={'environment_ids': ak_env.id})
         content_view_env_id = [env.id for env in content_view.read().environment]
         assert ak_env.id in content_view_env_id
 
@@ -203,7 +202,7 @@ class TestCapsuleSyncNewRepo:
         content_view.repository = [repo]
         content_view = content_view.update(['repository'])
         content_view.publish()
-        promote(content_view.read().version[0], ak_env.id)
+        content_view.read().version[0].promote(data={'environment_ids': ak_env.id})
         content_view_env = [env.id for env in content_view.read().environment]
         assert ak_env.id in content_view_env
 

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -19,13 +19,13 @@
 import pytest
 from fabric.api import execute
 from nailgun import entities
+from nailgun.entity_mixins import call_entity_method_with_timeout
 from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests.helpers.scenarios import create_dict
 from upgrade_tests.helpers.scenarios import dockerize
 from upgrade_tests.helpers.scenarios import get_entity_data
 from wait_for import wait_for
 
-from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import FAKE_9_YUM_OUTDATED_PACKAGES

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -29,7 +29,6 @@ from upgrade_tests.helpers.scenarios import rpm1
 from upgrade_tests.helpers.scenarios import rpm2
 
 from robottelo.api.utils import create_sync_custom_repo
-from robottelo.api.utils import promote
 from robottelo.config import settings
 from robottelo.logging import logger
 from robottelo.upgrade_utility import create_repo
@@ -163,7 +162,7 @@ class TestScenarioCustomRepoCheck:
         repo.sync()
 
         content_view = publish_content_view(org=org, repolist=repo)
-        promote(content_view.version[0], lce.id)
+        content_view.version[0].promote(data={'environment_ids': lce.id})
 
         result = target_sat.execute(
             f'ls /var/lib/pulp/published/yum/https/repos/{org.label}/{lce.name}/'
@@ -246,7 +245,7 @@ class TestScenarioCustomRepoCheck:
         content_view.publish()
 
         content_view = target_sat.api.ContentView(name=content_view_name).search()[0]
-        promote(content_view.version[-1], lce_id)
+        content_view.version[-1].promote(data={'environment_ids': lce_id})
 
         result = target_sat.execute(
             'ls /var/lib/pulp/published/yum/https/repos/{}/{}/{}/custom/{}/{}/'

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -19,6 +19,7 @@
 import pytest
 from fabric.api import execute
 from nailgun import entities
+from nailgun.entity_mixins import call_entity_method_with_timeout
 from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests.helpers.scenarios import create_dict
 from upgrade_tests.helpers.scenarios import dockerize
@@ -26,7 +27,6 @@ from upgrade_tests.helpers.scenarios import get_entity_data
 from wait_for import wait_for
 
 from robottelo.api.utils import attach_custom_product_subscription
-from robottelo.api.utils import call_entity_method_with_timeout
 from robottelo.config import settings
 from robottelo.constants import REPOS
 from robottelo.logging import logger


### PR DESCRIPTION
API utils refactor:
robottelo.api.utils.call_entity_method_with_timeout --> nailgun.entity_mixins.call_entity_method_with_timeout
robottelo.api.utils.promote --> removed and replaced this function call with direct api calls in test functions


