### PR TITLE
Fixing the lce creation that requires "prior" as a param and adding more skip markers

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -222,6 +222,7 @@ ENTITY_FIELDS = {
     },
     'lifecycle_environment': {
         '_entity_cls': 'LifecycleEnvironment',
+        'prior': 'Library',
         'name': gen_alphanumeric,
     },
     'tailoringfile': {

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -1417,6 +1417,7 @@ def test_positive_remove_cv_version_from_default_env(session, module_org):
         assert ENVIRONMENT not in cvv['Environments']
 
 
+@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_remove_promoted_cv_version_from_default_env(session, module_org, target_sat):
@@ -1591,6 +1592,7 @@ def test_positive_remove_cv_version_from_env(session, module_org, repos_collecti
         assert all(item in cvv['Environments'] for item in [ENVIRONMENT, dev_lce.name, qe_lce.name])
 
 
+@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.upgrade
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
@@ -1987,6 +1989,7 @@ def test_positive_add_package_exclusion_filter_and_publish(session, module_org):
         assert not packages[0]['Name']
 
 
+@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_remove_package_from_exclusion_filter(session, module_org, target_sat):


### PR DESCRIPTION
There's a few test cases that failed when calling `repo.setup_content_view(module_org.id)` because `self.satellite.cli_factory.make_lifecycle_environment({'organization-id': org_id})` requires `prior` parameter.  That has been fixed now.

I've also included the skip markers for a few test cases that I passed over because of this issue.

Lastly, it seems only `ui/test_contentview.py` uses `setup_content_view()` being used so this is pretty isolated.