### PR TITLE
Fix 6.11 InterSatelliteSync tests

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -532,7 +532,6 @@ class TestContentViewSync:
 
     :CaseComponent: ContentViews
 
-    :Assignee: rmynar
     """
 
     @pytest.mark.tier3
@@ -566,8 +565,6 @@ class TestContentViewSync:
         :CaseAutomation: Automated
 
         :CaseComponent: ContentViews
-
-        :Assignee: rmynar
 
         :CaseImportance: High
 
@@ -655,8 +652,6 @@ class TestContentViewSync:
         :CaseAutomation: Automated
 
         :CaseComponent: ContentViews
-
-        :Assignee: rmynar
 
         :CaseImportance: High
 
@@ -928,8 +923,6 @@ class TestContentViewSync:
 
         :CaseComponent: ContentViews
 
-        :Assignee: rmynar
-
         :CaseImportance: High
 
         :CaseLevel: System
@@ -1047,8 +1040,6 @@ class TestContentViewSync:
         :CaseAutomation: Automated
 
         :CaseComponent: ContentViews
-
-        :Assignee: rmynar
 
         :CaseImportance: Critical
 

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -70,8 +70,8 @@ def export_import_cleanup_function(target_sat, function_org):
     """Deletes export/import dirs of function org"""
     yield
     # Deletes directories created for export/import test
-    assert target_sat.execute(f'rm -rf {EXPORT_DIR}/{function_org.name}').stdout == ''
-    assert target_sat.execute(f'rm -rf {IMPORT_DIR}/{function_org.name}').stdout == ''
+    target_sat.execute(f'rm -rf {EXPORT_DIR}/{function_org.name}')
+    target_sat.execute(f'rm -rf {IMPORT_DIR}/{function_org.name}')
 
 
 @pytest.fixture(scope='function')  # perform the cleanup after each testcase of a module
@@ -79,8 +79,8 @@ def export_import_cleanup_module(target_sat, module_org):
     """Deletes export/import dirs of module_org"""
     yield
     # Deletes directories created for export/import test
-    assert target_sat.execute(f'rm -rf {EXPORT_DIR}/{module_org.name}').stdout == ''
-    assert target_sat.execute(f'rm -rf {IMPORT_DIR}/{module_org.name}').stdout == ''
+    target_sat.execute(f'rm -rf {EXPORT_DIR}/{module_org.name}')
+    target_sat.execute(f'rm -rf {IMPORT_DIR}/{module_org.name}')
 
 
 def validate_filepath(sat_obj, org):


### PR DESCRIPTION
This pull request fixes failing test of InterSatelliteSync. It's basically a merge of changes that were already included in 6.10 (https://github.com/SatelliteQE/robottelo/pull/9483). There are just few more changes
- setting `content_disconnected` was removed and replaced by `subscription_connection_enabled`
- owner changed from ltran to rmynar

More changes to InterSatelliteSync are comming and they will also include the changes i promised in 6.10 PR

Test results:
```
$ pytest --disable-warnings tests/foreman/cli/test_satellitesync.py
========================================= test session starts ==========================================
platform linux -- Python 3.10.4, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rmynar/rmynar/robottelo, configfile: pyproject.toml
plugins: cov-3.0.0, services-2.2.1, forked-1.4.0, xdist-2.5.0, reportportal-5.0.11, ibutsu-2.0.2, mock-3.6.1
collected 36 items / 16 deselected / 20 selected                                                       

tests/foreman/cli/test_satellitesync.py ..............s.....                                     [100%]

=============== 19 passed, 1 skipped, 16 deselected, 22 warnings in 10949.04s (3:02:29) ================
```