### PR TITLE
Adding subcomponent docstring for Candlepin in test cases where appropriate

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -90,6 +90,8 @@ def test_positive_create():
     :expectedresults: Manifest is uploaded successfully
 
     :CaseImportance: Critical
+
+    :subcomponent: Candlepin
     """
     org = entities.Organization().create()
     with manifests.clone() as manifest:
@@ -107,6 +109,8 @@ def test_positive_refresh(request):
     :expectedresults: Manifest is refreshed successfully
 
     :CaseImportance: Critical
+
+    :subcomponent: Candlepin
     """
     org = entities.Organization().create()
     sub = entities.Subscription(organization=org)
@@ -133,6 +137,8 @@ def test_positive_create_after_refresh(function_org):
     :BZ: 1393442
 
     :CaseImportance: Critical
+
+    :subcomponent: Candlepin
     """
     org_sub = entities.Subscription(organization=function_org)
     new_org = entities.Organization().create()
@@ -157,6 +163,8 @@ def test_positive_delete(function_org):
     :expectedresults: Manifest is Deleted successfully
 
     :CaseImportance: Critical
+
+    :subcomponent: Candlepin
     """
     sub = entities.Subscription(organization=function_org)
     with manifests.clone() as manifest:
@@ -336,6 +344,8 @@ def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, functio
     :parametrized: yes
 
     :CaseImportance: High
+
+    :subcomponent: Candlepin
     """
     repo = entities.Repository(
         product=entities.Product(organization=function_org).create()

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1949,6 +1949,8 @@ def test_positive_attach(
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     # create an activation key without subscriptions
     # register the client host
@@ -2004,6 +2006,8 @@ def test_positive_attach_with_lce(
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     host_subscription_client.register_contenthost(
         module_org.name,
@@ -2143,6 +2147,8 @@ def test_positive_remove(
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     Host.subscription_register(
         {
@@ -2217,6 +2223,8 @@ def test_positive_auto_attach(
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     Host.subscription_register(
         {
@@ -2253,6 +2261,8 @@ def test_positive_unregister_host_subscription(
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     # register the host client
     host_subscription_client.register_contenthost(

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -72,6 +72,8 @@ def test_positive_manifest_upload(function_org, manifest_clone_upload):
     :expectedresults: Manifest are uploaded properly
 
     :CaseImportance: Critical
+
+    :subcomponent: Candlepin
     """
 
     Subscription.list({'organization-id': function_org.id}, per_page=False)
@@ -87,6 +89,8 @@ def test_positive_manifest_delete(function_org, manifest_clone_upload):
     :expectedresults: Manifest are deleted properly
 
     :CaseImportance: Critical
+
+    :subcomponent: Candlepin
     """
     Subscription.list({'organization-id': function_org.id}, per_page=False)
     Subscription.delete_manifest({'organization-id': function_org.id})
@@ -152,6 +156,8 @@ def test_positive_manifest_refresh(function_org):
     :expectedresults: Manifests can be refreshed
 
     :CaseImportance: Critical
+
+    :subcomponent: Candlepin
     """
     upload_manifest(function_org.id, manifests.original_manifest().content)
     Subscription.list({'organization-id': function_org.id}, per_page=False)

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -328,6 +328,8 @@ def test_positive_search_by_subscription_status(session, default_location, vm):
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     with session:
         session.location.select(default_location.name)
@@ -381,6 +383,8 @@ def test_positive_toggle_subscription_status(session, default_location, vm):
     :parametrized: yes
 
     :CaseImportance: Medium
+
+    :subcomponent: Candlepin
     """
     with session:
         session.location.select(default_location.name)
@@ -688,6 +692,8 @@ def test_positive_ensure_errata_applicability_with_host_reregistered(session, de
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     vm.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     result = vm.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
@@ -887,6 +893,8 @@ def test_positive_virt_who_hypervisor_subscription_status(
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -1614,6 +1622,8 @@ def test_syspurpose_matched(session, default_location, vm_module_streams):
     :parametrized: yes
 
     :CaseImportance: High
+
+    :subcomponent: Candlepin
     """
     run_remote_command_on_content_host('syspurpose set-sla Premium', vm_module_streams)
     run_remote_command_on_content_host('subscription-manager attach --auto', vm_module_streams)
@@ -1703,6 +1713,8 @@ def test_syspurpose_mismatched(session, default_location, vm_module_streams):
     :parametrized: yes
 
     :CaseImportance: High
+
+    :subcomponent: Candlepin
     """
     run_remote_command_on_content_host('syspurpose set-sla Premium', vm_module_streams)
     run_remote_command_on_content_host('subscription-manager attach --auto', vm_module_streams)

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -95,6 +95,8 @@ def test_positive_end_to_end(session, target_sat):
     :customerscenario: true
 
     :CaseImportance: Critical
+
+    :subcomponent: Candlepin
     """
     expected_message_lines = [
         'Are you sure you want to delete the manifest?',
@@ -308,6 +310,8 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, tar
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -369,6 +373,8 @@ def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthos
     :parametrized: yes
 
     :CaseLevel: System
+
+    :subcomponent: Candlepin
     """
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -534,6 +540,8 @@ def test_positive_candlepin_events_processed_by_STOMP(session, rhel7_contenthost
     :parametrized: yes
 
     :CaseImportance: High
+
+    :subcomponent: Candlepin
     """
     org = entities.Organization().create()
     repo = entities.Repository(product=entities.Product(organization=org).create()).create()


### PR DESCRIPTION
This is a continuation of last month from an email I sent out about adding `subcomponent` for components that are shared with a katello component, but not necessary covered in automation.  I'm now implementing this for a few test cases that I think `Candlepin` shares with another component.  I'm putting this in draft for now because I still want to go through it more thoroughly, but still wanted some feedback from the original component owner in the files and others.

1. What do you guys think of this simple change?
2. @mshriver How long would it take to inject this new field into ibutsu/ReportPortal?
3. Other feedback?