### PR TITLE
Remove closed skip Bug 1735540 - Virt-who-config for kubevirt does not support in API and hammer CLI

### DIFF
--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -48,7 +48,6 @@ def virtwho_config(form_data, target_sat):
     return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
 
 
-@pytest.mark.skip_if_open('BZ:1735540')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(


### PR DESCRIPTION
Hey, 
Bug 1735540 - Virt-who-config for kubevirt does not support in API and hammer CLI is closed on Satellite6.11. so remove the skip  case step
