### PR TITLE
remove hypervisorId from hypervisor json file

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -389,7 +389,7 @@ def hypervisor_json_create(hypervisors, guests):
                     "attributes": {"active": 1, "virtWhoType": "esx"},
                 }
             )
-        hypervisor = {"hypervisorId": str(uuid.uuid4()), "guestIds": guest_list}
+        hypervisor = {"guestIds": guest_list}
         hypervisors_list.append(hypervisor)
     mapping = {"hypervisors": hypervisors_list}
     return mapping


### PR DESCRIPTION
Hey,
Remove  hypervisorId from hypervisor json file to confirm the correct format.
The changes is from the BZ https://bugzilla.redhat.com/show_bug.cgi?id=2083444.
And I have submit the PR in https://github.com/SatelliteQE/robottelo/pull/9669 before.
There are still  hypervisorId need to removed from the json file.

The correct json file generated:
 data = hypervisor_json_create(hypervisors=2, guests=10)
```
{'hypervisors': [{'guestIds': [{'guestId': '5399aa47-3245-4ed1-8b60-1f9b92a9067d', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '9d505457-c1c5-4055-a422-1e72a8c6a48e', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '5990ee43-6b9b-403a-a757-b1a322c4d2da', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '48a12b6c-c4da-4bc7-836c-2aede4b9c706', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': 'd1c75701-4a27-4fd4-a177-e3769626e27d', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': 'bb82178e-3fbb-4b3a-94ef-9b5581a118eb', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '7a8f7162-6cb6-4662-a3ba-c5919bd000b3', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '580960f1-6240-43be-839a-2c79459dc4ad', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '3456c7f3-22c2-4d18-a33c-1c1f1214a4ff', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '91770190-b2bf-499c-a15a-9302cd84537c', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}]}, {'guestIds': [{'guestId': '21960cb8-2be3-43e0-9128-e65b8202f75a', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '3ed0bf3d-4aa7-48cb-966f-6dbe0e7bde52', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '1adb2281-9a95-4a21-a131-9ca5dad37352', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '234b0b94-caac-4395-9803-b00a9e79325d', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': 'a9862c47-dff8-47ce-8ed1-49f17cf4a6f1', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '8e9945b5-2a23-4c58-8593-86658eb26045', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '9727a782-d677-406b-a867-c1d32c46f763', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '2385259b-010e-4548-88b0-6359c8daff1b', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '7fe57ff1-a91a-45ea-be7d-417f24be0e66', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}, {'guestId': '732fb6b7-8402-4d2d-999b-bd1e70e48fc8', 'state': 1, 'attributes': {'active': 1, 'virtWhoType': 'esx'}}]}]}

```

Test Case: PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest tests/foreman/virtwho/cli/test_esx.py -k test_positive_post_hypervisors -s
2022-07-26 10:34:38 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    server.version.release is required in env main
2022-07-26 10:34:38 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    server.version.release is required in env main
/home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/pytest_ibutsu/modeling.py:119: DeprecationWarning: _ibutsu["metadata"] will be deprecated in 3.0. Please use a corresponding TestRun field.
  warnings.warn(
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.2.1, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.7.0, reportportal-5.1.2
collecting ... 2022-07-26 10:34:40 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 10 items / 19 deselected / -9 selected                                                                                                                                                                  

tests/foreman/virtwho/cli/test_esx.py [D 220726 10:34:40 broker:91] Broker instantiated with kwargs={}
[D 220726 10:34:40 hosts:101] dell-per740-68-vm-04.lab.eng.pek2.redhat.com executing command: semanage port -l | grep 9091-14999
[D 220726 10:34:41 hosts:103] dell-per740-68-vm-04.lab.eng.pek2.redhat.com command result:
    websm_port_t                   tcp      19090, 9091-14999, 9090
    
[D 220726 10:34:41 hosts:101] dell-per740-68-vm-04.lab.eng.pek2.redhat.com executing command: b'LANG=en_US.UTF-8  hammer -v -u admin -p admin  settings set --name="failed_login_attempts_limit" --value="0" '
[D 220726 10:34:44 hosts:103] dell-per740-68-vm-04.lab.eng.pek2.redhat.com command result:
    Setting [failed_login_attempts_limit] updated to [0].
    
.

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/trio/_core/_multierror.py:511
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/trio/_core/_multierror.py:511: RuntimeWarning: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.
    warnings.warn(

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/cli/test_esx.py::TestVirtWhoConfigforEsx::test_positive_post_hypervisors
tests/foreman/virtwho/cli/test_esx.py::TestVirtWhoConfigforEsx::test_positive_post_hypervisors
tests/foreman/virtwho/cli/test_esx.py::TestVirtWhoConfigforEsx::test_positive_post_hypervisors
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-04.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 1 passed, 19 deselected, 7 warnings in 11.17s ==================================================================================

```