### PR TITLE
Abandon DF registration for puppet_enabled_sat

### DIFF
--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -42,7 +42,6 @@ enable_capsule_cmd = InstallerCommand(
 @pytest.fixture(scope='session')
 def session_puppet_enabled_sat(session_satellite_host):
     """Satellite with enabled puppet plugin"""
-    session_satellite_host.register_to_dogfood()
     result = session_satellite_host.execute(enable_satellite_cmd.get_command(), timeout='20m')
     assert result.status == 0
     session_satellite_host.execute('hammer -r')  # workaround for BZ#2039696


### PR DESCRIPTION
Sat repofiles should be sufficient to enable puppet.