### PR TITLE
Add test name to be part of screenshot name

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1369,7 +1369,7 @@ class Satellite(Capsule, SatelliteMixins):
                     return frame.function
 
         return Session(
-            session_name=get_caller(),
+            session_name=testname or get_caller(),
             user=user or settings.server.admin_username,
             password=password or settings.server.admin_password,
             url=url,


### PR DESCRIPTION
After moving destructive tests to a separate folder there was a change in naming screenshots. Screenshots were named after the caller, in this case, most of the time it was a fixture for creating users. Adding back names based on test names but keeping fallback to the caller. 