### PR TITLE
Replace instances of dogfood registration with repofile downloads

### DIFF
--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -53,7 +53,7 @@ def puppet_proxy_port_range(session_puppet_enabled_sat):
 
 @pytest.fixture(scope='class')
 def install_cockpit_plugin(class_target_sat):
-    class_target_sat.register_to_dogfood()
+    class_target_sat.download_repofile()
     class_target_sat.install_cockpit()
     # TODO remove this change when we start using new host detail view
     setting_object = class_target_sat.api.Setting().search(

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -16,7 +16,6 @@
 """
 import pytest
 
-from robottelo.config import settings
 from robottelo.helpers import InstallerCommand
 
 pytestmark = pytest.mark.destructive
@@ -46,18 +45,6 @@ params = [
 ]
 
 
-def register_satellite(sat):
-    sat.execute(
-        'yum -y localinstall '
-        f'{settings.repos.dogfood_repo_host}/pub/katello-ca-consumer-latest.noarch.rpm'
-    )
-    sat.execute(
-        f'subscription-manager register --org {settings.subscription.dogfood_org} '
-        f'--activationkey {settings.subscription.dogfood_activationkey}'
-    )
-    return sat
-
-
 @pytest.mark.tier4
 @pytest.mark.parametrize(
     'command_args,command_opts,rpm_command',
@@ -79,7 +66,7 @@ def test_plugin_installation(target_sat, command_args, command_opts, rpm_command
 
     :BZ: 1994490, 2000237
     """
-    register_satellite(target_sat)
+    target_sat.download_repofile()
     installer_obj = InstallerCommand(command_args, **command_opts)
     command_output = target_sat.execute(installer_obj.get_command())
     assert 'Success!' in command_output.stdout

--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -117,6 +117,7 @@ def test_positive_install_sat_with_katello_certs(certs_vm_setup):
     result = rhel_vm.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[0]
     for repo in getattr(constants, f"OHSNAP_RHEL{version}_REPOS"):
         rhel_vm.enable_repo(repo, force=True)
+    # What is the purpose of this?
     rhel_vm.execute(
         f'yum -y localinstall {settings.repos.dogfood_repo_host}'
         f'/pub/katello-ca-consumer-latest.noarch.rpm'

--- a/tests/foreman/destructive/test_puppetplugin.py
+++ b/tests/foreman/destructive/test_puppetplugin.py
@@ -94,7 +94,7 @@ def test_positive_enable_disable_logic(target_sat, capsule_configured):
     assert 'failed to load one or more features (Puppet)' in result.stdout
 
     # Enable puppet on Satellite and check it succeeded.
-    target_sat.register_to_dogfood()
+    target_sat.download_repofile()
     result = target_sat.execute(enable_satellite_cmd.get_command(), timeout='20m')
     assert result.status == 0
     assert 'Success!' in result.stdout


### PR DESCRIPTION
New dogfood no longer supports the previous registration process. Instead, we will be directly using repofiles for dogfood content.