### PR TITLE
Automation for bz-2040870

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -917,7 +917,7 @@ class TestContentViewSync:
             1. CV version redhat contents has been exported to directory
             2. All The exported redhat contents has been imported in org/satellite
 
-        :BZ: 1655239
+        :BZ: 1655239, 2040870
 
         :CaseAutomation: Automated
 
@@ -935,15 +935,15 @@ class TestContentViewSync:
         RepositorySet.enable(
             {
                 'basearch': 'x86_64',
-                'name': REPOSET['rhva6'],
+                'name': REPOSET['kickstart']['rhel7'],
                 'organization-id': function_org.id,
                 'product': PRDS['rhel'],
-                'releasever': '6Server',
+                'releasever': '7.9',
             }
         )
         repo = Repository.info(
             {
-                'name': REPOS['rhva6']['name'],
+                'name': REPOS['kickstart']['rhel7']['name'],
                 'organization-id': function_org.id,
                 'product': PRDS['rhel'],
             }


### PR DESCRIPTION
We already have an existing test case that has all the necessary steps for [bz-2040870](https://bugzilla.redhat.com/show_bug.cgi?id=2040870) except it uses rh vitualization repo because the syncing is faster.  I'm changing this to fit the bz need with few changes involved.