### PR TITLE
`test_rhel_pxe_provisioning` requires the fixture to provide OS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ tmp/
 
 # Virtual Environments
 ven*/
+
+# pytest-fixture-tools artifacts
+artifacts/

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -118,9 +118,7 @@ def module_provisioning_rhel_content(
         ],
     ).create()
 
-    return Box(
-        hostgroup=hostgroup,
-    )
+    return Box(hostgroup=hostgroup, os=os)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
`module_provisioning_rhel_content` fixture should also provide OS entity to the test.

I also propose to add the `artifacts` directory to `.gitignore`. I sometimes use pytest-fixture-tools which store generated diagrams in this directory.