### PR TITLE
Updated GHA AutoCherryPick to 1.0.2

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
         if: matrix.to_branch != github.base_ref
       - name: Cherry pick into ${{ matrix.to_branch }}
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.1
+        uses: carloscastrojumo/github-cherry-pick-action@v1.0.2
         with:
           branch: ${{ matrix.to_branch }}
           labels: |


### PR DESCRIPTION
We have seen AutoCherrypicks failing due to the branch name calculation was missing the target branch name in it and its been fixed in v1.0.2 https://github.com/carloscastrojumo/github-cherry-pick-action/releases/tag/v1.0.2 