### PR TITLE
Fix issue with creating cli object

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -105,7 +105,6 @@ def create_object(cli_object, options, values):
                 "Option(s) {} not supported by CLI factory. Please check for "
                 "a typo or update default options".format(diff)
             )
-    if options:
         for key in set(options.keys()).intersection(set(values.keys())):
             options[key] = values[key]
 


### PR DESCRIPTION
This was caused by #9782 while replacing the old method options and values were mixed, originally the condition was based on values, not on options.
original call: https://github.com/SatelliteQE/robottelo/pull/9782/files#diff-bc6a63837cec643c2195ebaca5c9f833e9c4f20af2555e57cc77789431730ebbL109
old method: https://github.com/SatelliteQE/robottelo/pull/9782/files#diff-825c5b0e0eb8cd7eeda6528dcbe21f2de66967c2ca7e60ab281cc56d46e9aa45L166-L183