### PR TITLE
Replace Pyup-bot with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+# This is the configuration file for Dependabot. You can find configuration information below.
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# Note: Dependabot has a configurable max open PR limit of 5
+
+version: 2
+updates:
+  # Maintain dependencies for Robottelo itself
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "CherryPick"
+      - "dependencies"
+
+  # Maintain dependencies for our GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "CherryPick"
+      - "dependencies"

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,9 +1,0 @@
-pin: False
-
-requirements:
-  - requirements.txt
-  - requirements-optional.txt
-
-label_prs: dependencies
-
-close_prs: True


### PR DESCRIPTION
Pyup-bot has moved to a paid model. Due to this, we're taking this opportunity to switch to dependabot.
Dependabot looks to also have a bonus with managing our GitHub actions and providing other features.
fixes #7371 