### PR TITLE
Add check subscription startdate displayed

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -177,10 +177,10 @@ def test_positive_end_to_end(session, default_location, module_repos_collection_
         # Check start date for BZ#1920860 (but handle BZ#2112320 offset-by-one bug)
         custom_product_name = module_repos_collection_with_manifest.custom_product['name']
         custom_sub = next(
-                item
-                for item in chost['subscriptions']['resources']['assigned']
-                if item["Repository Name"] == custom_product_name
-            )
+            item
+            for item in chost['subscriptions']['resources']['assigned']
+            if item["Repository Name"] == custom_product_name
+        )
         if is_open('BZ:2112320'):
             assert startdate in custom_sub['Expires']
         else:

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -176,19 +176,14 @@ def test_positive_end_to_end(session, default_location, module_repos_collection_
         assert actual_repos == expected_repos
         # Check start date for BZ#1920860 (but handle BZ#2112320 offset-by-one bug)
         custom_product_name = module_repos_collection_with_manifest.custom_product['name']
-        if is_open('BZ:2112320'):
-            custom_sub = next(
+        custom_sub = next(
                 item
                 for item in chost['subscriptions']['resources']['assigned']
                 if item["Repository Name"] == custom_product_name
             )
+        if is_open('BZ:2112320'):
             assert startdate in custom_sub['Expires']
         else:
-            custom_sub = next(
-                item
-                for item in chost['subscriptions']['resources']['assigned']
-                if item["Repository Name"] == custom_product_name
-            )
             assert startdate in custom_sub['Starts']
         # Update description
         new_description = gen_string('alpha')


### PR DESCRIPTION
Hello

A simple check but a lot of setup so I have added it to the end_to_end test.

This is closed loop for:
[Bug 1920860 – The Start Date field is blank for Subscriptions within Content Hosts page in Satellite WebUI](https://bugzilla.redhat.com/show_bug.cgi?id=1920860)

but with workaround for bug:
[Bug 2112320](https://bugzilla.redhat.com/show_bug.cgi?id=2112320) - Hidden column between Quantity and Attached in the table of subscriptions