### PR TITLE
fixed the auth tests for RHSSO

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -9,6 +9,7 @@ from robottelo.api.utils import update_rhsso_settings_in_satellite
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
 from robottelo.constants import AUDIENCE_MAPPER
+from robottelo.constants import CERT_PATH
 from robottelo.constants import GROUP_MEMBERSHIP_MAPPER
 from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
@@ -269,6 +270,20 @@ def enroll_configure_rhsso_external_auth(module_target_sat):
         'yum -y --disableplugin=foreman-protector install '
         'mod_auth_openidc keycloak-httpd-client-install'
     )
+    if module_target_sat.os_version.major == '8':
+        # if target directory not given it is installing in /usr/local/lib64
+        module_target_sat.execute(
+            'python3 -m pip install lxml -t /usr/lib64/python3.6/site-packages'
+        )
+    module_target_sat.execute(
+        f'openssl s_client -connect {settings.rhsso.host_name} -showcerts </dev/null 2>/dev/null| '
+        f'sed "/BEGIN CERTIFICATE/,/END CERTIFICATE/!d" > {CERT_PATH}/rh-sso.crt'
+    )
+    module_target_sat.execute(
+        f'sshpass -p "{settings.rhsso.rhsso_password}" scp -o "StrictHostKeyChecking no" '
+        f'root@{settings.rhsso.host_name}:/root/ca_certs/*.crt {CERT_PATH}'
+    )
+    module_target_sat.execute('update-ca-trust')
     module_target_sat.execute(
         f'echo {settings.rhsso.rhsso_password} | keycloak-httpd-client-install --app-name foreman-openidc \
                 --keycloak-server-url {settings.rhsso.host_url} \
@@ -277,6 +292,7 @@ def enroll_configure_rhsso_external_auth(module_target_sat):
                 --keycloak-admin-realm master \
                 --keycloak-auth-role root-admin -t openidc -l /users/extlogin --force'
     )
+
     module_target_sat.execute(
         f'satellite-installer --foreman-keycloak true '
         f"--foreman-keycloak-app-name 'foreman-openidc' "
@@ -294,9 +310,9 @@ def enable_external_auth_rhsso(enroll_configure_rhsso_external_auth, module_targ
     audience_mapper = copy.deepcopy(AUDIENCE_MAPPER)
     audience_mapper['config']['included.client.audience'] = audience_mapper['config'][
         'included.client.audience'
-    ].format(rhsso_host=module_target_sat)
+    ].format(rhsso_host=module_target_sat.hostname)
     create_mapper(audience_mapper, client_id)
-    set_the_redirect_uri()
+    set_the_redirect_uri(module_target_sat)
 
 
 def enroll_idm_and_configure_external_auth(sat):
@@ -359,7 +375,7 @@ def configure_realm(session_target_sat):
 
 
 @pytest.fixture(scope="module")
-def rhsso_setting_setup(module_target_sat, request):
+def rhsso_setting_setup(module_target_sat):
     """Update the RHSSO setting and revert it in cleanup"""
     update_rhsso_settings_in_satellite(sat=module_target_sat)
     yield
@@ -367,7 +383,7 @@ def rhsso_setting_setup(module_target_sat, request):
 
 
 @pytest.fixture(scope="module")
-def rhsso_setting_setup_with_timeout(module_target_sat, rhsso_setting_setup, request):
+def rhsso_setting_setup_with_timeout(module_target_sat, rhsso_setting_setup):
     """Update the RHSSO setting with timeout setting and revert it in cleanup"""
     setting_entity = module_target_sat.api.Setting().search(query={'search': 'name=idle_timeout'})[
         0

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -877,9 +877,9 @@ def update_rhsso_settings_in_satellite(revert=False, sat=None):
     rhhso_settings = {
         'authorize_login_delegation': True,
         'authorize_login_delegation_auth_source_user_autocreate': 'External',
-        'login_delegation_logout_url': f'https://{settings.server.hostname}/users/extlogout',
+        'login_delegation_logout_url': f'https://{sat.hostname}/users/extlogout',
         'oidc_algorithm': 'RS256',
-        'oidc_audience': [f'{settings.server.hostname}-foreman-openidc'],
+        'oidc_audience': [f'{sat.hostname}-foreman-openidc'],
         'oidc_issuer': f'{settings.rhsso.host_url}/auth/realms/{settings.rhsso.realm}',
         'oidc_jwks_url': f'{settings.rhsso.host_url}/auth/realms'
         f'/{settings.rhsso.realm}/protocol/openid-connect/certs',

--- a/robottelo/rhsso_utils.py
+++ b/robottelo/rhsso_utils.py
@@ -71,7 +71,7 @@ def get_rhsso_user_details(username):
         cmd=f"{KEY_CLOAK_CLI} get users -r {settings.rhsso.realm} -q username={username}",
         hostname=settings.rhsso.host_name,
     )
-    result_json = json.loads(f'[{{{result}')
+    result_json = json.loads(result)
     return result_json[0]
 
 
@@ -81,7 +81,7 @@ def get_rhsso_groups_details(group_name):
         cmd=f"{KEY_CLOAK_CLI} get groups -r {settings.rhsso.realm} -q group_name={group_name}",
         hostname=settings.rhsso.host_name,
     )
-    result_json = json.loads(f'[{{{result}')
+    result_json = json.loads(result)
     return result_json[0]
 
 
@@ -172,9 +172,9 @@ def delete_rhsso_group(group_name):
     )
 
 
-def update_client_configuration(json_content):
+def update_client_configuration(sat, json_content):
     """Update the client configuration"""
-    client_id = get_rhsso_client_id()
+    client_id = get_rhsso_client_id(sat)
     upload_rhsso_entity(json_content, "update_client_info")
     update_cmd = (
         f"{KEY_CLOAK_CLI} update clients/{client_id} -f update_client_info -s enabled=true --merge"
@@ -190,9 +190,9 @@ def get_oidc_token_endpoint():
     )
 
 
-def get_oidc_client_id():
+def get_oidc_client_id(sat):
     """getter for the oidc client_id"""
-    return f"{settings.server.hostname}-foreman-openidc"
+    return f"{sat.hostname}-foreman-openidc"
 
 
 def get_oidc_authorization_endpoint():
@@ -203,12 +203,12 @@ def get_oidc_authorization_endpoint():
     )
 
 
-def get_two_factor_token_rh_sso_url():
+def get_two_factor_token_rh_sso_url(sat):
     """getter for the two factor token rh_sso url"""
     return (
         f"https://{settings.rhsso.host_name}/auth/realms/"
         f"{settings.rhsso.realm}/protocol/openid-connect/"
-        f"auth?response_type=code&client_id={settings.server.hostname}-foreman-openidc&"
+        f"auth?response_type=code&client_id={sat.hostname}-foreman-openidc&"
         f"redirect_uri=urn:ietf:wg:oauth:2.0:oob&scope=openid"
     )
 
@@ -226,12 +226,12 @@ def open_pxssh_session(
     ssh_session.logout()
 
 
-def set_the_redirect_uri():
+def set_the_redirect_uri(sat):
     client_config = {
         "redirectUris": [
             "urn:ietf:wg:oauth:2.0:oob",
-            f"https://{settings.server.hostname}/users/extlogin/redirect_uri",
-            f"https://{settings.server.hostname}/users/extlogin",
+            f"https://{sat.hostname}/users/extlogin/redirect_uri",
+            f"https://{sat.hostname}/users/extlogin",
         ]
     }
-    update_client_configuration(client_config)
+    update_client_configuration(sat, client_config)

--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -82,10 +82,9 @@ def test_positive_update_katello_certs(cert_setup_destructive_teardown):
 @pytest.mark.parametrize(
     'certs_vm_setup',
     [
-        {'nick': 'rhel7', 'target_memory': '20GiB', 'target_cores': 4},
         {'nick': 'rhel8', 'target_memory': '20GiB', 'target_cores': 4},
     ],
-    ids=['rhel7', 'rhel8'],
+    ids=['rhel8'],
     indirect=True,
 )
 def test_positive_install_sat_with_katello_certs(certs_vm_setup):

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -383,7 +383,7 @@ def test_external_new_user_login_and_check_count_rhsso(
     :expectedresults: New User created in RHSSO server should able to get log-in
         and correct count shown for external users
     """
-    client_id = get_rhsso_client_id()
+    client_id = get_rhsso_client_id(module_target_sat)
     user_details = create_new_rhsso_user(client_id)
     login_details = {
         'username': user_details['username'],
@@ -431,7 +431,7 @@ def test_login_failure_rhsso_user_if_internal_user_exist(
 
     :expectedresults: external rhsso user should not able to login with same username as internal
     """
-    client_id = get_rhsso_client_id()
+    client_id = get_rhsso_client_id(module_target_sat)
     username = gen_string('alpha')
     module_target_sat.api.User(
         admin=True,
@@ -477,6 +477,7 @@ def test_user_permissions_rhsso_user_after_group_delete(
         group deletion.
 
     """
+    get_rhsso_client_id(module_target_sat)
     username = settings.rhsso.rhsso_user
     location_name = gen_string('alpha')
     login_details = {
@@ -543,6 +544,7 @@ def test_user_permissions_rhsso_user_multiple_group(
     :expectedresults: external rhsso user have highest level of permissions from among the
         multiple groups.
     """
+    get_rhsso_client_id(module_target_sat)
     username = settings.rhsso.rhsso_user
     location_name = gen_string('alpha')
     login_details = {
@@ -554,7 +556,7 @@ def test_user_permissions_rhsso_user_multiple_group(
     create_role_permissions(katello_role, user_permissions)
 
     group_names = ['sat_users', 'sat_admins']
-    arguments = [{'role': katello_role}, {'admin': 1}]
+    arguments = [{'roles': katello_role.name}, {'admin': 1}]
     external_auth_source = module_target_sat.cli.ExternalAuthSource.info({'name': "External"})
     for group_name, argument in zip(group_names, arguments):
         # adding/creating rhsso groups


### PR DESCRIPTION
This PR fixes many tests are failed because of the recent changes happened in the framework. These are also modified based on the RHEL version. 

```
Launching pytest with arguments -k test_single_sign_on_using_rhsso /Users/okhatavk/satellite/robottelo/tests/foreman/destructive --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

/Users/okhatavk/satellite/robottelo/env/lib/python3.9/site-packages/pytest_ibutsu/modeling.py:119: DeprecationWarning: _ibutsu["metadata"] will be deprecated in 3.0. Please use a corresponding TestRun field.
  warnings.warn(
============================= test session starts ==============================
collecting ... collected 84 items / 83 deselected / 1 selected

tests/foreman/destructive/test_ldap_authentication.py::test_single_sign_on_using_rhsso 

========== 1 passed, 83 deselected, 20 warnings in 1073.22s (0:17:53) ==========
```