### PR TITLE
[Best for PRT] Select tests based on fixtures they are using

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,7 @@ pytest_plugins = [
     'pytest_plugins.settings_skip',
     'pytest_plugins.rerun_rp.rerun_rp',
     'pytest_plugins.fspath_plugins',
+    'pytest_plugins.fixture_collection',
     # Fixtures
     'pytest_fixtures.core.broker',
     'pytest_fixtures.core.contenthosts',

--- a/pytest_plugins/fixture_collection.py
+++ b/pytest_plugins/fixture_collection.py
@@ -1,0 +1,38 @@
+# Pytest Plugin to modify collection of test cases based on fixtures used by tests.
+from robottelo.logging import collection_logger as logger
+
+
+def pytest_addoption(parser):
+    """Add options for pytest to collect tests based on fixtures its using"""
+    help_text = '''
+        Collects tests based on fixtures used by tests
+
+        Usage: --uses-fixtures [options]
+
+        Options: [ specific_fixture_name | list_of fixture names ]
+
+        example: pytest tests/foreman --uses-fixtures target_sat module_target_sat
+    '''
+    parser.addoption("--uses-fixtures", nargs='+', help=help_text)
+
+
+def pytest_collection_modifyitems(items, config):
+
+    if not config.getoption('uses_fixtures', False):
+        return
+
+    filter_fixtures = config.getvalue('uses_fixtures')
+    selected = []
+    deselected = []
+
+    for item in items:
+        if set(item.fixturenames).intersection(set(filter_fixtures)):
+            selected.append(item)
+        else:
+            deselected.append(item)
+    logger.debug(
+        f'Selected {len(selected)} and deselected {len(deselected)} '
+        f'tests based on given fixtures {filter_fixtures} used by tests'
+    )
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected


### PR DESCRIPTION
## What it is ?

- The pytest plugin that selects/deselects test based on the fixtures the tests are using
- The new option to pytest `--test-fixtures [options]` should help to filter the tests that using given fixtures
- This is best for PRT at least to check if your changes to tests using particular or more fixtures are working or not especially with changes in any specific fixture or around. There could be multiple purposes of it depends on you, how you use it !!
- E.g `pytest --test-fixtures target_sat module_taget_sat` or u might think about simple fixtures use case as well !

## Examples:

1. The test collection was filtered based on a fixture:
```
✗ pytest --collect-only tests/foreman/api --uses-fixtures module_host --disable-warnings 
=========== test session starts ============
collected 2791 items / 2787 deselected / 4 selected                                                                                                                                                        

<Package api>
  <Module test_host.py>
    <Function test_negative_update_name>
    <Function test_negative_update_mac>
    <Class TestHostInterface>
      <Function test_positive_create_end_to_end>
      <Function test_negative_end_to_end>

============= 4/2791 tests collected (2787 deselected) in 9.24s ==========

```

2. The test collection was filtered based on multiple fixtures :
```
✗ pytest --collect-only tests/foreman/api --uses-fixtures module_host module_os default_org --disable-warnings
================ test session starts ==============

<Package api>
  <Module test_host.py>
    <Function test_positive_create_and_update_os>
    <Function test_negative_update_name>
    <Function test_negative_update_mac>
    <Class TestHostInterface>
      <Function test_positive_create_end_to_end>
      <Function test_negative_end_to_end>
  <Module test_oscap_tailoringfiles.py>
    <Class TestTailoringFile>
      <Function test_positive_crud_tailoringfile>
  <Module test_oscappolicy.py>
    <Class TestOscapPolicy>
      <Function test_positive_crud_scap_policy>
  <Module test_templatesync.py>
    <Class TestTemplateSyncTestCase>
      <Function test_positive_import_and_associate>

============ 8/2791 tests collected (2783 deselected) in 8.76s ===============
```
