### PR TITLE
rex pull-provider tests

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -168,3 +168,16 @@ def module_capsule_configured(module_capsule_host, module_target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     module_capsule_host.capsule_setup(sat_host=module_target_sat)
     yield module_capsule_host
+
+
+@pytest.fixture(scope='module')
+def module_capsule_configured_mqtt(module_capsule_configured):
+    """Configure the capsule instance with the satellite from settings.server.hostname,
+    enable MQTT broker"""
+    module_capsule_configured.enable_mqtt()
+    result = module_capsule_configured.execute('systemctl status mosquitto')
+    assert result.status == 0, 'MQTT broker is not running'
+    result = module_capsule_configured.execute('firewall-cmd --permanent --add-port="1883/tcp"')
+    assert result.status == 0, 'Failed to open mqtt port on capsule'
+    module_capsule_configured.execute('firewall-cmd --reload')
+    yield module_capsule_configured

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from pathlib import Path
 from pathlib import PurePath
 from tempfile import NamedTemporaryFile
+from urllib.parse import urlencode
 from urllib.parse import urljoin
 from urllib.parse import urlunsplit
 
@@ -481,10 +482,10 @@ class ContentHost(Host, ContentHostMixins):
 
     def register(
         self,
-        target=settings.server.hostname,
-        org='Default_Organization',
-        loc='Default_Location',
-        activation_keys=None,
+        target,
+        org,
+        loc,
+        activation_keys,
         setup_insights=False,
         setup_remote_execution=True,
         setup_remote_execution_pull=False,
@@ -505,8 +506,8 @@ class ContentHost(Host, ContentHostMixins):
         using a global registration template.
 
         :param target: Satellite or Capusle hostname to register to, required.
-        :param org: Organization name to register content host for, required.
-        :param loc: Location name to register content host for, required.
+        :param org: Organization to register content host for, required.
+        :param loc: Location to register content host for, required.
         :param activation_keys: Activation key name to register content host
             with, required.
         :param setup_insights: Install and register Insights client, requires OS repo.
@@ -522,73 +523,68 @@ class ContentHost(Host, ContentHostMixins):
         :param ignore_subman_errors: Ignore subscription manager errors.
         :param force: Register the content host even if it's already registered.
         :param insecure: Don't verify server authenticity.
-        :param username: A user name to register the content host with.
-        :param password: The user password.
+        :param username: Satellite admin username
+        :param password: Satellite admin password
         :return: SSHCommandResult instance filled with the result of the
             registration.
         """
-        cmd = 'curl -sS '
-        if username and password:
-            cmd += f'-u {username}:{password} '
-        if insecure:
-            cmd += '--insecure '
-        if target:
-            cmd += f"'https://{target}:9090/register?"
-        else:
-            raise ContentHostError('Target Satellite/Capsule not specified')
-        if activation_keys:
-            cmd += f'activation_keys={activation_keys}'
-        else:
-            raise ContentHostError('Activation key not specified')
-        if org:
-            selected_org = entities.Organization().search(query={'search': f'name="{org}"'})[0]
-            cmd += f'&organization_id={selected_org.id}'
-        else:
-            raise ContentHostError('Organization not specified')
-        if loc:
-            selected_loc = entities.Location().search(query={'search': f'name="{loc}"'})[0]
-            cmd += f'&location_id={selected_loc.id}'
-        else:
-            raise ContentHostError('Location not specified')
-        if setup_insights:
+        insights = (
             # requires OS repo enabled for host
-            cmd += '&setup_insights=true'
-        else:
-            cmd += '&setup_insights=false'
-        if setup_remote_execution:
-            cmd += '&setup_remote_execution=true'
-        else:
-            cmd += '&setup_remote_execution=false'
-        if update_packages:
-            cmd += '&update_packages=true'
-        else:
-            cmd += '&update_packages=false'
-        if lifecycle_environment:
-            selected_lce = entities.LifecycleEnvironment().search(
-                query={'search': f'name="{lifecycle_environment}"'}
-            )[0]
-            cmd += f'&lifecycle_environment_id={selected_lce.id}'
-        if operating_system:
-            selected_os = entities.OperatingSystem().search(
-                query={'search': f'name="{operating_system}"'}
-            )[0]
-            cmd += f'&operating_system_id={selected_os.id}'
-        if setup_remote_execution_pull:
+            f'&setup_insights={str(setup_insights).lower()}'
+            if setup_insights is not None
+            else ''
+        )
+        rex = (
+            f'&setup_remote_execution={str(setup_remote_execution).lower()}'
+            if setup_remote_execution is not None
+            else ''
+        )
+        rex_pull = (
             # requires Satellite Client repo enabled for host
-            cmd += '&setup_remote_execution_pull=true'
-        if packages:
-            cmd += f'&packages={"+".join(packages)}'
-        if repo_gpg_key_url:
-            cmd += f'&repo_gpg_key_url={repo_gpg_key_url.replace("/", "%2F").replace(":", "%3A")}'
-        if repo:
-            cmd += f'&repo={repo.replace("/", "%2F").replace(":", "%3A")}'
-        if remote_execution_interface:
-            cmd += f'&remote_execution_interface={remote_execution_interface}'
-        if ignore_subman_errors:
-            cmd += '&ignore_subman_errors=true'
-        if force:
-            cmd += '&force=true'
-        cmd += "' | bash"
+            f'&setup_remote_execution_pull={str(setup_remote_execution_pull).lower()}'
+            if setup_remote_execution_pull is not None
+            else ''
+        )
+        lce = (
+            f'&lifecycle_environment_id={lifecycle_environment.id}'
+            if lifecycle_environment is not None
+            else ''
+        )
+        os = f'&operating_system_id={operating_system.id}' if operating_system is not None else ''
+        pkgs = f'&packages={"+".join(packages)}' if packages is not None else ''
+        rex_iface = (
+            f'&remote_execution_interface={remote_execution_interface}'
+            if remote_execution_interface is not None
+            else ''
+        )
+        rp = f'&{urlencode({"repo": repo })}' if repo is not None else ''
+        gpg = (
+            f'&{urlencode({"repo_gpg_key_url": repo_gpg_key_url })}'
+            if repo_gpg_key_url is not None
+            else ''
+        )
+        cmd = (
+            'curl -sS '
+            f'-u {username}:{password} '
+            f'{"--insecure " if insecure else ""}'
+            f"'https://{target.hostname}:9090/register?"
+            f'activation_keys={activation_keys}'
+            f'&organization_id={org.id}'
+            f'&location_id={loc.id}'
+            f'{insights}'
+            f'{rex}'
+            f'&update_packages={"true" if update_packages else "false"}'
+            f'{rex_pull}'
+            f'{rex_iface}'
+            f'{lce}'
+            f'{os}'
+            f'{pkgs}'
+            f'{"&ignore_subman_errors=true" if ignore_subman_errors else ""}'
+            f'{"&force=true" if force else ""}'
+            f'{rp}'
+            f'{gpg}'
+            "' | bash"
+        )
         return self.execute(cmd)
 
     def register_contenthost(
@@ -1386,11 +1382,16 @@ class Capsule(ContentHost, CapsuleMixins):
             )
 
     def enable_mqtt(self):
+        installer_opts = {
+            'foreman-proxy-templates': 'true',
+            'foreman-proxy-registration': 'true',
+            'foreman-proxy-plugin-remote-execution-script-mode': 'pull-mqtt',
+        }
+        enable_mqtt_command = InstallerCommand(
+            installer_opts=installer_opts,
+        )
         result = self.execute(
-            'satellite-installer \
-                    --foreman-proxy-templates=true \
-                    --foreman-proxy-registration=true \
-                    --foreman-proxy-plugin-remote-execution-script-mode=pull-mqtt',
+            enable_mqtt_command.get_command(),
             timeout='20m',
         )
         if result.status != 0:

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1053,7 +1053,7 @@ class TestPullProviderRex:
         )
         assert result.status == 0, 'Failed to download certificate'
         client_repo = (
-            f'{settings.repos["DOGFOOD_REPO_HOST"]}/pulp/content/'
+            f'{settings.repos["DOGFOOD_REPO_HOST"].replace("http", "https")}/pulp/content/'
             'Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/'
             f'Satellite_Client_RHEL{rhel_contenthost.os_version.major}_x86_64/'
         )
@@ -1063,9 +1063,9 @@ class TestPullProviderRex:
 
         # register host with rex, enable client repo, install katello-agent
         result = rhel_contenthost.register(
-            module_capsule_configured_mqtt.hostname,
-            module_org.name,
-            smart_proxy_location.name,
+            module_capsule_configured_mqtt,
+            module_org,
+            smart_proxy_location,
             module_ak_with_cv.name,
             packages=['katello-agent'],
             repo=client_repo,
@@ -1180,7 +1180,7 @@ class TestPullProviderRex:
         )
         assert result.status == 0, 'Failed to download certificate'
         client_repo = (
-            f'{settings.repos["DOGFOOD_REPO_HOST"]}/pulp/content/'
+            f'{settings.repos["DOGFOOD_REPO_HOST"].replace("http", "https")}/pulp/content/'
             'Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/'
             f'Satellite_Client_RHEL{rhel_contenthost.os_version.major}_x86_64/'
         )
@@ -1190,15 +1190,14 @@ class TestPullProviderRex:
 
         # register host with pull provider rex (SAT-1677)
         result = rhel_contenthost.register(
-            module_capsule_configured_mqtt.hostname,
-            module_org.name,
-            smart_proxy_location.name,
+            module_capsule_configured_mqtt,
+            module_org,
+            smart_proxy_location,
             module_ak_with_cv.name,
             setup_remote_execution_pull=True,
             repo=client_repo,
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
-
         # check mqtt client is running
         result = rhel_contenthost.execute('yggdrasil status')
         assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -255,6 +255,7 @@ class TestRemoteExecution:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
+    @pytest.mark.rhel_ver_list([8])
     def test_positive_run_default_job_template_multiple_hosts_by_ip(
         self, registered_hosts, module_org
     ):
@@ -1019,3 +1020,205 @@ class TestRexUsers:
         )
         result = JobInvocation.info({'id': invocation_command['id']})
         assert result['success'] == '1'
+
+
+class TestPullProviderRex:
+    """Tests related to remote execution via pull provider (mqtt)"""
+
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
+    @pytest.mark.rhel_ver_match('[^6].*')
+    def test_positive_run_job_on_host_converted_to_pull_provider(
+        self,
+        module_org,
+        smart_proxy_location,
+        module_ak_with_cv,
+        module_capsule_configured_mqtt,
+        rhel_contenthost,
+    ):
+        """Run custom template on host converted to mqtt
+
+        :id: 9ad68172-de7b-4578-a3ae-49b6ff461691
+
+        :expectedresults: Verify the job was successfully ran against the host converted to mqtt
+
+        :CaseImportance: Critical
+
+        :parametrized: yes
+        """
+        result = rhel_contenthost.execute(
+            f'curl -o /etc/pki/ca-trust/source/anchors/satellite-sat-engineering-ca.crt \
+                    {settings.repos["DOGFOOD_REPO_HOST"]}/pub/katello-server-ca.crt; \
+                    update-ca-trust'
+        )
+        assert result.status == 0, 'Failed to download certificate'
+        client_repo = (
+            'https://satellite.sat.engineering.redhat.com/pulp/content/'
+            'Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/'
+            f'Satellite_Client_RHEL{rhel_contenthost.os_version.major}_x86_64/'
+        )
+        # TODO client_repo should be changed to
+        # settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
+        # when/if the new dogfood url pattern settles
+
+        # register host with rex, enable client repo, install katello-agent
+        result = rhel_contenthost.register(
+            module_capsule_configured_mqtt.hostname,
+            module_org.name,
+            smart_proxy_location.name,
+            module_ak_with_cv.name,
+            packages=['katello-agent'],
+            repo=client_repo,
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+        # result = rhel_contenthost.execute('subsription-manager identity/status')
+
+        # install conversion script (SAT-1670)
+        result = rhel_contenthost.execute('yum install -y katello-pull-transport-migrate')
+        assert result.status == 0, 'Failed to install katello-pull-transport-migrate'
+        # check mqtt client is running
+        result = rhel_contenthost.execute('yggdrasil status')
+        assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+        result = rhel_contenthost.execute('systemctl status yggdrasild')
+        assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+        # run script provider rex command
+        invocation_command = make_job_invocation(
+            {
+                'job-template': 'Run Command - Script Default',
+                'inputs': 'command=ls',
+                'search-query': f"name ~ {rhel_contenthost.hostname}",
+            }
+        )
+        result = JobInvocation.info({'id': invocation_command['id']})
+        try:
+            assert result['success'] == '1'
+        except AssertionError:
+            result = 'host output: {}'.format(
+                ' '.join(
+                    JobInvocation.get_output(
+                        {'id': invocation_command['id'], 'host': rhel_contenthost.hostname}
+                    )
+                )
+            )
+            raise AssertionError(result)
+
+        # check katello-agent runs along ygdrassil (SAT-1671)
+        result = rhel_contenthost.execute('systemctl status goferd')
+        assert result.status == 0, 'Failed to start goferd on client'
+
+        # run Ansible rex command to prove ssh provider works, remove katello-agent
+        invocation_command = make_job_invocation(
+            {
+                'job-template': 'Package Action - Ansible Default',
+                'inputs': 'state=absent, name=katello-agent',
+                'search-query': f"name ~ {rhel_contenthost.hostname}",
+            }
+        )
+        result = JobInvocation.info({'id': invocation_command['id']})
+        try:
+            assert result['success'] == '1'
+        except AssertionError:
+            result = 'host output: {}'.format(
+                ' '.join(
+                    JobInvocation.get_output(
+                        {'id': invocation_command['id'], 'host': rhel_contenthost.hostname}
+                    )
+                )
+            )
+            raise AssertionError(result)
+
+        # check katello-agent removal did not influence ygdrassil (SAT-1672)
+        result = rhel_contenthost.execute('yggdrasil status')
+        assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+        result = rhel_contenthost.execute('systemctl status yggdrasild')
+        assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+        invocation_command = make_job_invocation(
+            {
+                'job-template': 'Run Command - Script Default',
+                'inputs': 'command=ls',
+                'search-query': f"name ~ {rhel_contenthost.hostname}",
+            }
+        )
+        result = JobInvocation.info({'id': invocation_command['id']})
+        try:
+            assert result['success'] == '1'
+        except AssertionError:
+            result = 'host output: {}'.format(
+                ' '.join(
+                    JobInvocation.get_output(
+                        {'id': invocation_command['id'], 'host': rhel_contenthost.hostname}
+                    )
+                )
+            )
+            raise AssertionError(result)
+
+    @pytest.mark.tier3
+    @pytest.mark.upgrade
+    @pytest.mark.rhel_ver_match('[^6].*')
+    def test_positive_run_job_on_host_registered_to_pull_provider(
+        self,
+        module_org,
+        smart_proxy_location,
+        module_ak_with_cv,
+        module_capsule_configured_mqtt,
+        rhel_contenthost,
+    ):
+        """Run custom template on host registered to mqtt
+
+        :id: 759ad51d-eea7-4d7b-b6ee-60af2b814464
+
+        :expectedresults: Verify the job was successfully ran against the host registered to mqtt
+
+        :CaseImportance: Critical
+
+        :parametrized: yes
+        """
+        result = rhel_contenthost.execute(
+            f'curl -o /etc/pki/ca-trust/source/anchors/satellite-sat-engineering-ca.crt \
+                    {settings.repos["DOGFOOD_REPO_HOST"]}/pub/katello-server-ca.crt; \
+                    update-ca-trust'
+        )
+        assert result.status == 0, 'Failed to download certificate'
+        client_repo = (
+            'https://satellite.sat.engineering.redhat.com/pulp/content/'
+            'Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/'
+            f'Satellite_Client_RHEL{rhel_contenthost.os_version.major}_x86_64/'
+        )
+        # TODO client_repo should be changed to
+        # settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
+        # when/if the new dogfood url pattern settles
+
+        # register host with pull provider rex (SAT-1677)
+        result = rhel_contenthost.register(
+            module_capsule_configured_mqtt.hostname,
+            module_org.name,
+            smart_proxy_location.name,
+            module_ak_with_cv.name,
+            setup_remote_execution_pull=True,
+            repo=client_repo,
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+        # check mqtt client is running
+        result = rhel_contenthost.execute('yggdrasil status')
+        assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+        # run script provider rex command
+        invocation_command = make_job_invocation(
+            {
+                'job-template': 'Service Action - Script Default',
+                'inputs': 'action=status, service=yggdrasild',
+                'search-query': f"name ~ {rhel_contenthost.hostname}",
+            }
+        )
+        result = JobInvocation.info({'id': invocation_command['id']})
+        try:
+            assert result['success'] == '1'
+        except AssertionError:
+            result = 'host output: {}'.format(
+                ' '.join(
+                    JobInvocation.get_output(
+                        {'id': invocation_command['id'], 'host': rhel_contenthost.hostname}
+                    )
+                )
+            )
+            raise AssertionError(result)

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1048,8 +1048,8 @@ class TestPullProviderRex:
         """
         result = rhel_contenthost.execute(
             f'curl -o /etc/pki/ca-trust/source/anchors/satellite-sat-engineering-ca.crt \
-                    {settings.repos["DOGFOOD_REPO_HOST"]}/pub/katello-server-ca.crt; \
-                    update-ca-trust'
+                    {settings.repos["DOGFOOD_REPO_HOST"]}/pub/katello-server-ca.crt \
+                    && update-ca-trust'
         )
         assert result.status == 0, 'Failed to download certificate'
         client_repo = (
@@ -1071,7 +1071,6 @@ class TestPullProviderRex:
             repo=client_repo,
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
-        # result = rhel_contenthost.execute('subsription-manager identity/status')
 
         # install conversion script (SAT-1670)
         result = rhel_contenthost.execute('yum install -y katello-pull-transport-migrate')
@@ -1175,8 +1174,8 @@ class TestPullProviderRex:
         """
         result = rhel_contenthost.execute(
             f'curl -o /etc/pki/ca-trust/source/anchors/satellite-sat-engineering-ca.crt \
-                    {settings.repos["DOGFOOD_REPO_HOST"]}/pub/katello-server-ca.crt; \
-                    update-ca-trust'
+                    {settings.repos["DOGFOOD_REPO_HOST"]}/pub/katello-server-ca.crt \
+                    && update-ca-trust'
         )
         assert result.status == 0, 'Failed to download certificate'
         client_repo = (

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1053,7 +1053,7 @@ class TestPullProviderRex:
         )
         assert result.status == 0, 'Failed to download certificate'
         client_repo = (
-            'https://satellite.sat.engineering.redhat.com/pulp/content/'
+            f'{settings.repos["DOGFOOD_REPO_HOST"]}/pulp/content/'
             'Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/'
             f'Satellite_Client_RHEL{rhel_contenthost.os_version.major}_x86_64/'
         )

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1180,7 +1180,7 @@ class TestPullProviderRex:
         )
         assert result.status == 0, 'Failed to download certificate'
         client_repo = (
-            'https://satellite.sat.engineering.redhat.com/pulp/content/'
+            f'{settings.repos["DOGFOOD_REPO_HOST"]}/pulp/content/'
             'Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/'
             f'Satellite_Client_RHEL{rhel_contenthost.os_version.major}_x86_64/'
         )


### PR DESCRIPTION
Initial tests for pull provider remote execution. This PR:

- adds a capsule fixture, as the pull-provider feature is enabled via installer per capsule
- adds a helper to register host via global registration, needed to enable pp on client. It's actually the recommended way to register hosts and can be used without additional helpers for many other tasks (e.g. for key transfer or insights installation)
- adds two rex tests for enabling pp client either via conversion script and straight trough global registration. The latter expects changes that are yet to come in sn5, but passed locally on patched sn4

Still, the tests might get flaky due to ocassional job hanging, bz#2115229 is open to keep track on that