### PR TITLE
Automation for bz-1832858

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -433,7 +433,10 @@ def _create_cv(cv_name, repo, module_org, publish=True):
     :param publish: Publishes the CV if True else doesnt
     :return: The directory of CV and Content View ID
     """
-    content_view = make_content_view({'name': cv_name, 'organization-id': module_org.id})
+    description = gen_string('alpha')
+    content_view = make_content_view(
+        {'name': cv_name, 'description': description, 'organization-id': module_org.id}
+    )
     ContentView.add_repository(
         {
             'id': content_view['id'],
@@ -569,10 +572,15 @@ class TestContentViewSync:
         :CaseImportance: High
 
         :CaseLevel: System
+
+        :BZ: 1832858
+
+        :customerscenario: true
         """
         export_prod_name = import_prod_name = class_export_entities['exporting_prod_name']
         export_repo_name = import_repo_name = class_export_entities['exporting_repo_name']
         export_cvv_id = class_export_entities['exporting_cvv_id']
+        export_cv_description = class_export_entities['exporting_cv']['description']
         import_cv_name = class_export_entities['exporting_cv_name']
         # check packages
         exported_packages = Package.list({'content-view-version-id': export_cvv_id})
@@ -594,9 +602,11 @@ class TestContentViewSync:
         assert result.stdout != ''
         # Import files and verify content
         ContentImport.version({'organization-id': importing_org['id'], 'path': import_path})
-        importing_cvv = ContentView.info(
+        importing_cv = ContentView.info(
             {'name': import_cv_name, 'organization-id': importing_org['id']}
-        )['versions']
+        )
+        importing_cvv = importing_cv['versions']
+        assert importing_cv['description'] == export_cv_description
         assert len(importing_cvv) >= 1
         imported_packages = Package.list({'content-view-version-id': importing_cvv[0]['id']})
         assert len(imported_packages)


### PR DESCRIPTION
Adding description verification to ISS for [bz-1832858](https://bugzilla.redhat.com/show_bug.cgi?id=1832858)

test result:
```
pytest tests/foreman/cli/test_satellitesync.py -k test_positive_export_import_cv_end_to_end
================== 1 passed, 36 deselected, 2 warnings in 134.01s (0:02:14) ============
```