### PR TITLE
downgrade ibutsu plugin version to resolve dependency issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pytest-services==2.2.1
 pytest-mock==3.6.1
 pytest-reportportal==5.0.11
 pytest-xdist==2.5.0
-pytest-ibutsu==2.2.4
+pytest-ibutsu==2.0.2
 PyYAML==6.0
 requests==2.28.1
 tenacity==8.0.1


### PR DESCRIPTION
Due to the pytest version breaking changes (affecting robottelo code):
https://docs.pytest.org/en/7.1.x/deprecations.html#fspath-argument-for-node-constructors-replaced-with-pathlib-path

and time constraints, I decided to downgrade the ibutsu plugin version for now.