### PR TITLE
Remove RHEL9 from supportability matrix

### DIFF
--- a/conf/supportability.yaml
+++ b/conf/supportability.yaml
@@ -1,4 +1,4 @@
 supportability:
   content_hosts:
     rhel:
-      versions: [6, 7,'7_fips', 8, '8_fips', 9]
+      versions: [6, 7,'7_fips', 8, '8_fips']


### PR DESCRIPTION
We currently are not able to deploy rhel9 hosts. Due to this, we're
going to temporarily disable the entry.