### PR TITLE
Adding missing customerscenario docstring to test case

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -931,6 +931,8 @@ class TestContentViewSync:
 
         :CaseAutomation: Automated
 
+        :customerscenario: true
+
         :CaseComponent: ContentViews
 
         :CaseImportance: High


### PR DESCRIPTION
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py::TestContentViewSync::test_positive_export_import_redhat_cv