### PR TITLE
Smoothing Teardown in Azure Host provisioning

### DIFF
--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -365,7 +365,8 @@ class TestAzureRMFinishTemplateProvisioning:
                 )
                 yield host
                 with satellite_setting('destroy_vm_on_host_delete=True'):
-                    Host.delete({'name': self.fullhostname}, timeout=1800000)
+                    if Host.exists(search=('name', host['name'])):
+                        Host.delete({'name': self.fullhostname}, timeout=1800000)
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_ft):
@@ -490,7 +491,8 @@ class TestAzureRMUserDataProvisioning:
                 )
                 yield host
                 with satellite_setting('destroy_vm_on_host_delete=True'):
-                    Host.delete({'name': self.fullhostname}, timeout=1800000)
+                    if Host.exists(search=('name', host['name'])):
+                        Host.delete({'name': self.fullhostname}, timeout=1800000)
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_host_ud):
@@ -614,7 +616,8 @@ class TestAzureRMBYOSFinishTemplateProvisioning:
                 )
                 yield host
                 with satellite_setting('destroy_vm_on_host_delete=True'):
-                    Host.delete({'name': self.fullhostname}, timeout=1800000)
+                    if Host.exists(search=('name', host['name'])):
+                        Host.delete({'name': self.fullhostname}, timeout=1800000)
 
     @pytest.fixture(scope='class')
     def azureclient_host(self, azurermclient, class_byos_ft_host):


### PR DESCRIPTION
The azure test cases were failing in teardown due to VM being deleted in yielding VM creation fixture.

Now at the test level, we verify the VMs existence( in case teardown in yielding fixture doesnt work) before we delete it.