### PR TITLE
Fixing inheriting labels and cherrypicking commit history using my fork

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
         if: matrix.to_branch != github.base_ref
       - name: Cherry pick into ${{ matrix.to_branch }}
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.2
+        uses: jyejare/github-cherry-pick-action@main
         with:
           branch: ${{ matrix.to_branch }}
           labels: |


### PR DESCRIPTION
Fixes from https://github.com/jyejare/github-cherry-pick-action/pull/1 

and Robottelo is switching to using my fork since there is a delay in response from the author in existing repo. 
