### PR TITLE
[6.10.z Checks fixes] bulk fixes to calm down CI checks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,7 +13,6 @@ pytest_plugins = [
     'pytest_plugins.metadata_markers',
     'pytest_plugins.settings_skip',
     'pytest_plugins.rerun_rp.rerun_rp',
-    'pytest_plugins.fspath_plugins',
     'pytest_plugins.fixture_collection',
     # Fixtures
     'pytest_fixtures.core.broker',

--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -87,7 +87,7 @@ def pytest_collection_modifyitems(session, items, config):
     deselected = []
     logger.info('Processing test items to add testimony token markers')
     for item in items:
-        if item.nodeid.startswith('tests/robottelo/') and 'test_junit' not in item.nodeid:
+        if item.nodeid.startswith('tests/robottelo/'):
             # Unit test, no testimony markers
             continue
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pexpect==4.8.0
 productmd==1.33
 pyotp==2.6.0
 python-box==5.4.1
-pytest==6.2.5
+pytest==7.1.2
 pytest-services==2.2.1
 pytest-mock==3.6.1
 pytest-reportportal==5.0.11

--- a/robottelo/constants/repos.py
+++ b/robottelo/constants/repos.py
@@ -4,6 +4,7 @@
 CUSTOM_FILE_REPO = 'https://fixtures.pulpproject.org/file/'
 CUSTOM_KICKSTART_REPO = 'http://ftp.cvut.cz/centos/8/BaseOS/x86_64/kickstart/'
 CUSTOM_RPM_REPO = 'https://fixtures.pulpproject.org/rpm-signed/'
+CUSTOM_RPM_SHA = 'https://fixtures.pulpproject.org/rpm-with-sha/'
 CUSTOM_RPM_SHA_512 = 'https://fixtures.pulpproject.org/rpm-with-sha-512/'
 FAKE_5_YUM_REPO = 'https://rplevka.fedorapeople.org/fakerepo01/'
 FAKE_YUM_DRPM_REPO = 'https://fixtures.pulpproject.org/drpm-signed/'

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -146,6 +146,12 @@ Requirement:
     required: true
 Setup: {}
 Steps: {}
+SubComponent:
+    casesensitive: true
+    choices:
+    - Candlepin
+    - Pulp
+    type: choice
 Subtype1: {}
 Teardown: {}
 TestType:

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -16,7 +16,9 @@
 
 :Upstream: No
 """
+import re
 import tempfile
+import time
 from string import punctuation
 from urllib.parse import urljoin
 from urllib.parse import urlparse

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -46,13 +46,13 @@ def module_proxy_attrs(module_target_sat):
     return set(smart_proxy.update_json([]).keys())
 
 
-def _create_smart_proxy(request, **kwargs):
+def _create_smart_proxy(request, target_sat, **kwargs):
     """Create a Smart Proxy and add the finalizer"""
-    proxy = entities.SmartProxy(**kwargs).create()
+    proxy = target_sat.api.SmartProxy(**kwargs).create()
 
     @request.addfinalizer
     def _cleanup():
-        capsule_cleanup(proxy.id)
+        target_sat.api.SmartProxy(id=proxy.id).delete()
 
     return proxy
 
@@ -78,7 +78,7 @@ def test_negative_create_with_url():
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(request, name):
+def test_positive_create_with_name(request, target_sat, name):
     """Proxy creation with valid name
 
     :id: 0ffe0dc5-675e-45f4-b7e1-a14d3dd81f6e
@@ -92,7 +92,7 @@ def test_positive_create_with_name(request, name):
     """
     new_port = get_available_capsule_port()
     with default_url_on_new_port(9090, new_port) as url:
-        proxy = _create_smart_proxy(request, name=name, url=url)
+        proxy = _create_smart_proxy(request, target_sat, name=name, url=url)
         assert proxy.name == name
 
 
@@ -120,7 +120,7 @@ def test_positive_delete():
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier1
-def test_positive_update_name(request):
+def test_positive_update_name(request, target_sat):
     """Proxy name update
 
     :id: f279640e-d7e9-48a3-aed8-7bf406e9d6f2
@@ -132,7 +132,7 @@ def test_positive_update_name(request):
     """
     new_port = get_available_capsule_port()
     with default_url_on_new_port(9090, new_port) as url:
-        proxy = _create_smart_proxy(request, url=url)
+        proxy = _create_smart_proxy(request, target_sat, url=url)
         for new_name in valid_data_list():
             proxy.name = new_name
             proxy = proxy.update(['name'])
@@ -141,7 +141,7 @@ def test_positive_update_name(request):
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier1
-def test_positive_update_url(request):
+def test_positive_update_url(request, target_sat):
     """Proxy url update
 
     :id: 0305fd54-4e0c-4dd9-a537-d342c3dc867e
@@ -154,7 +154,7 @@ def test_positive_update_url(request):
     # Create fake capsule
     port = get_available_capsule_port()
     with default_url_on_new_port(9090, port) as url:
-        proxy = _create_smart_proxy(request, url=url)
+        proxy = _create_smart_proxy(request, target_sat, url=url)
     # Open another tunnel to update url
     new_port = get_available_capsule_port()
     with default_url_on_new_port(9090, new_port) as url:
@@ -165,7 +165,7 @@ def test_positive_update_url(request):
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier1
-def test_positive_update_organization(request):
+def test_positive_update_organization(request, target_sat):
     """Proxy name update with the home proxy
 
     :id: 62631275-7a92-4d34-a949-c56e0c4063f1
@@ -178,7 +178,7 @@ def test_positive_update_organization(request):
     organizations = [entities.Organization().create() for _ in range(2)]
     newport = get_available_capsule_port()
     with default_url_on_new_port(9090, newport) as url:
-        proxy = _create_smart_proxy(request, url=url)
+        proxy = _create_smart_proxy(request, target_sat, url=url)
         proxy.organization = organizations
         proxy = proxy.update(['organization'])
         assert {org.id for org in proxy.organization} == {org.id for org in organizations}
@@ -186,7 +186,7 @@ def test_positive_update_organization(request):
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier1
-def test_positive_update_location(request):
+def test_positive_update_location(request, target_sat):
     """Proxy name update with the home proxy
 
     :id: e08eaaa9-7c11-4cda-bbe7-6d1f7c732569
@@ -199,7 +199,7 @@ def test_positive_update_location(request):
     locations = [entities.Location().create() for _ in range(2)]
     new_port = get_available_capsule_port()
     with default_url_on_new_port(9090, new_port) as url:
-        proxy = _create_smart_proxy(request, url=url)
+        proxy = _create_smart_proxy(request, target_sat, url=url)
         proxy.location = locations
         proxy = proxy.update(['location'])
         assert {loc.id for loc in proxy.location} == {loc.id for loc in locations}
@@ -208,7 +208,7 @@ def test_positive_update_location(request):
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_refresh_features(request):
+def test_positive_refresh_features(request, target_sat):
     """Refresh smart proxy features, search for proxy by id
 
     :id: d0237546-702e-4d1a-9212-8391295174da
@@ -225,13 +225,13 @@ def test_positive_refresh_features(request):
     # get an available port for our fake capsule
     new_port = get_available_capsule_port()
     with default_url_on_new_port(9090, new_port) as url:
-        proxy = _create_smart_proxy(request, url=url)
+        proxy = _create_smart_proxy(request, target_sat, url=url)
         proxy.refresh()
 
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier2
-def test_positive_import_puppet_classes(request):
+def test_positive_import_puppet_classes(request, target_sat):
     """Import puppet classes from proxy
 
     :id: 385efd1b-6146-47bf-babf-0127ce5955ed
@@ -244,7 +244,7 @@ def test_positive_import_puppet_classes(request):
     """
     new_port = get_available_capsule_port()
     with default_url_on_new_port(9090, new_port) as url:
-        proxy = _create_smart_proxy(request, url=url)
+        proxy = _create_smart_proxy(request, target_sat, url=url)
         result = proxy.import_puppetclasses()
         assert (
             "Successfully updated environment and puppetclasses from "


### PR DESCRIPTION
Fixes 6.10 PRs checks failing for:
- pytest dependency conflicts from broker vs local
- flake8 failures from recently merged auto cherrypicked PRs where the checks were not running and hence merged without checks !
- Pytest collection issues fixed including metadata_markers plugin skipping for test_junit test.
- fspath plugin unintentionally cherrypicked to 6.10 in plugins listing in conftest without plugin, removed !
- testimony subcomponent added to testimony.yaml