### PR TITLE
rhel9_fips returning

### DIFF
--- a/conf/supportability.yaml
+++ b/conf/supportability.yaml
@@ -1,4 +1,4 @@
 supportability:
   content_hosts:
     rhel:
-      versions: [6, 7,'7_fips', 8, '8_fips', 9]
+      versions: [6, 7,'7_fips', 8, '8_fips', 9, '9_fips']


### PR DESCRIPTION
With rhel9 hosts being available we can start testing the fips version again as well, confirmed manually that the AT workflow returns fips rhel9 host as expected