### PR TITLE
Automation coverage for bz-1920511

### DIFF
--- a/robottelo/constants/repos.py
+++ b/robottelo/constants/repos.py
@@ -1,6 +1,7 @@
 """Only External Repos url specific constants module"""
 
 
+CUSTOM_3RD_PARTY_REPO = 'http://repo.calcforge.org/fedora/21/x86_64/'
 CUSTOM_FILE_REPO = 'https://fixtures.pulpproject.org/file/'
 CUSTOM_KICKSTART_REPO = 'http://ftp.cvut.cz/centos/8/BaseOS/x86_64/kickstart/'
 CUSTOM_RPM_REPO = 'https://fixtures.pulpproject.org/rpm-signed/'

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -69,6 +69,7 @@ from robottelo.constants import REPO_TYPE
 from robottelo.constants import RPM_TO_UPLOAD
 from robottelo.constants import SRPM_TO_UPLOAD
 from robottelo.constants.repos import ANSIBLE_GALAXY
+from robottelo.constants.repos import CUSTOM_3RD_PARTY_REPO
 from robottelo.constants.repos import CUSTOM_FILE_REPO
 from robottelo.constants.repos import CUSTOM_RPM_SHA
 from robottelo.constants.repos import FAKE_5_YUM_REPO
@@ -2137,6 +2138,31 @@ class TestRepository:
         Repository.synchronize({'id': sha_repo['id']})
         sha_repo = Repository.info({'id': sha_repo['id']})
         assert sha_repo['sync']['status'] == 'Success'
+
+    @pytest.mark.tier2
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized([{'content_type': 'yum', 'url': CUSTOM_3RD_PARTY_REPO}]),
+        indirect=True,
+    )
+    def test_positive_sync_third_party_repo(self, repo_options):
+        """Sync third party repo successfully
+
+        :id: 45936ab8-46b7-4f07-8b71-d7c8a4a2d984
+
+        :parametrized: yes
+
+        :customerscenario: true
+
+        :BZ: 1920511
+
+        :SubComponent: Pulp
+        """
+        repo = make_repository(repo_options)
+        repo = Repository.info({'id': repo['id']})
+        Repository.synchronize({'id': repo['id']})
+        repo = Repository.info({'id': repo['id']})
+        assert repo['sync']['status'] == 'Success'
 
 
 # TODO: un-comment when OSTREE functionality is restored in Satellite 6.11

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -37,6 +37,7 @@ from robottelo.constants import INVALID_URL
 from robottelo.constants import REPO_TYPE
 from robottelo.constants import REPOSET
 from robottelo.constants.repos import ANSIBLE_GALAXY
+from robottelo.constants.repos import CUSTOM_3RD_PARTY_REPO
 from robottelo.constants.repos import CUSTOM_RPM_SHA
 from robottelo.datafactory import gen_string
 from robottelo.hosts import get_sat_version
@@ -1249,6 +1250,33 @@ def test_positive_sync_sha_repo(session, module_org):
                 'name': repo_name,
                 'repo_type': REPO_TYPE['yum'],
                 'repo_content.upstream_url': CUSTOM_RPM_SHA,
+            },
+        )
+        result = session.repository.synchronize(product.name, repo_name)
+        assert result['result'] == 'success'
+
+
+@pytest.mark.tier2
+def test_positive_sync_third_party_repo(session, module_org):
+    """Sync third part repo successfully
+
+    :id: 655161e0-aa90-4c7c-9a0d-cb5b9f56eac3
+
+    :customerscenario: true
+
+    :BZ: 1920511
+
+    :SubComponent: Pulp
+    """
+    repo_name = gen_string('alpha')
+    product = entities.Product(organization=module_org).create()
+    with session:
+        session.repository.create(
+            product.name,
+            {
+                'name': repo_name,
+                'repo_type': REPO_TYPE['yum'],
+                'repo_content.upstream_url': CUSTOM_3RD_PARTY_REPO,
             },
         )
         result = session.repository.synchronize(product.name, repo_name)


### PR DESCRIPTION
Automation coverage for https://bugzilla.redhat.com/show_bug.cgi?id=1920511

test results:
```
pytest tests/foreman/cli/test_repository.py -k test_positive_sync_third_party_repo
================= 1 passed, 163 deselected, 2 warnings in 42.63s =======================


pytest tests/foreman/ui/test_repository.py -k test_positive_sync_third_party_repo
================ 1 passed, 31 deselected, 5 warnings in 166.81s (0:02:46) ===========
```
