### PR TITLE
Fix content tests with content upload

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -215,7 +215,8 @@ class TestSatelliteContentManagement:
         packages = entities.Package(repository=repo).search(query={'per_page': '1000'})
         repo.remove_content(data={'ids': [package.id for package in packages]})
 
-        repo.upload_content(files={'content': DataFile.RPM_TO_UPLOAD.read_bytes()})
+        with open(DataFile.RPM_TO_UPLOAD, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
 
         repo = repo.read()
         assert repo.content_counts['rpm'] == 1
@@ -359,7 +360,8 @@ class TestCapsuleContentManagement:
         cv = entities.ContentView(organization=function_org, repository=[repo]).create()
 
         # Upload custom content into the repo
-        repo.upload_content(files={'content': DataFile.RPM_TO_UPLOAD.read_bytes()})
+        with open(DataFile.RPM_TO_UPLOAD, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
 
         assert repo.read().content_counts['rpm'] == 1
 
@@ -524,7 +526,8 @@ class TestCapsuleContentManagement:
         assert function_lce.id in [capsule_lce['id'] for capsule_lce in result['results']]
 
         # Upload custom content into the repo
-        repo.upload_content(files={'content': DataFile.RPM_TO_UPLOAD.read_bytes()})
+        with open(DataFile.RPM_TO_UPLOAD, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
 
         assert repo.read().content_counts['rpm'] == 1
 
@@ -542,7 +545,8 @@ class TestCapsuleContentManagement:
         self.wait_for_sync(module_capsule_configured)
 
         # Upload more content to the repository
-        repo.upload_content(files={'content': DataFile.SRPM_TO_UPLOAD.read_bytes()})
+        with open(DataFile.SRPM_TO_UPLOAD, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
 
         assert repo.read().content_counts['rpm'] == 2
 
@@ -694,7 +698,8 @@ class TestCapsuleContentManagement:
         assert lce_revision_capsule == new_lce_revision_capsule
 
         # Update a repository with 1 new rpm
-        repo.upload_content(files={'content': DataFile.RPM_TO_UPLOAD.read_bytes()})
+        with open(DataFile.RPM_TO_UPLOAD, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
 
         # Publish and promote the repository
         repo = repo.read()
@@ -1313,7 +1318,8 @@ class TestCapsuleContentManagement:
         repo.sync()
 
         # Upload one more iso file
-        repo.upload_content(files={'content': DataFile.FAKE_FILE_NEW_NAME.read_bytes()})
+        with open(DataFile.FAKE_FILE_NEW_NAME, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
 
         # Associate LCE with the capsule
         module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(


### PR DESCRIPTION
The change introduced in #9782 (using `read_bytes()`) creates packages named `content` instead of the real file name (see the `published_at` link of the repository, you will find the package in `.../Packages/c/content` instead of `.../Packages/w/which-2.19-6.el6.x86_64.rpm` for example), which breaks capsule syncs and other tests which check for the actual repository content.

Here I just bring back context manager for opening the file which seems to work well - tested with 6.11.2 SAT and CAPS:
```
$ pytest tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_capsule_sync \
tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_uploaded_content_library_sync \
tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_sync_updated_repo \
tests/foreman/api/test_contentmanagement.py::TestCapsuleContentManagement::test_positive_sync_file_repo \
tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_mirroring_policy
...
collected 5 items                                                                                                                                                                                                                                                  

tests/foreman/api/test_contentmanagement.py .....         [100%]

========= 5 passed, 260 warnings in 363.32s (0:06:03) ==========
```