### PR TITLE
Automate Bug1870816 and Bug1959136 for virt-who plugin CLI

### DIFF
--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -287,6 +287,8 @@ def deploy_configure_by_command(command, hypervisor_type, debug=False, org='Defa
         Host.delete({'name': guest_name})
     register_system(get_system(hypervisor_type), org=org)
     ret, stdout = runcmd(command)
+    print(ret)
+    print(stdout)
     if ret != 0 or 'Finished successfully' not in stdout:
         raise VirtWhoError(f"Failed to deploy configure by {command}")
     if debug:
@@ -314,6 +316,26 @@ def deploy_configure_by_script(
         raise VirtWhoError(f"Failed to deploy configure by {script_filename}")
     if debug:
         return deploy_validation(hypervisor_type)
+
+
+def deploy_configure_by_command_check(command):
+    """Deploy and run virt-who servcie by the hammer command to check deploy log.
+
+    :param str command: get the command by UI/CLI/API, it should be like:
+        `hammer virt-who-config deploy --id 1 --organization-id 1`
+    :param str hypervisor_type: esx, libvirt, rhevm, xen, libvirt, kubevirt, ahv
+    :param str org: Organization Label
+    """
+    virtwho_cleanup()
+    try:
+        ret, stdout = runcmd(command)
+    except Exception:
+        raise VirtWhoError(f"Failed to deploy configure by {command}")
+    else:
+        if ret != 0 or 'Finished successfully' not in stdout:
+            raise VirtWhoError(f"Failed to deploy configure by {command}")
+        else:
+            return 'Finished successfully'
 
 
 def restart_virtwho_service():

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -287,8 +287,6 @@ def deploy_configure_by_command(command, hypervisor_type, debug=False, org='Defa
         Host.delete({'name': guest_name})
     register_system(get_system(hypervisor_type), org=org)
     ret, stdout = runcmd(command)
-    print(ret)
-    print(stdout)
     if ret != 0 or 'Finished successfully' not in stdout:
         raise VirtWhoError(f"Failed to deploy configure by {command}")
     if debug:

--- a/robottelo/virtwho_utils.py
+++ b/robottelo/virtwho_utils.py
@@ -317,7 +317,7 @@ def deploy_configure_by_script(
 
 
 def deploy_configure_by_command_check(command):
-    """Deploy and run virt-who servcie by the hammer command to check deploy log.
+    """Deploy and run virt-who service by the hammer command to check deploy log.
 
     :param str command: get the command by UI/CLI/API, it should be like:
         `hammer virt-who-config deploy --id 1 --organization-id 1`

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -27,6 +27,7 @@ from robottelo.cli.user import User
 from robottelo.config import settings
 from robottelo.virtwho_utils import create_http_proxy
 from robottelo.virtwho_utils import deploy_configure_by_command
+from robottelo.virtwho_utils import deploy_configure_by_command_check
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import ETC_VIRTWHO_CONFIG
 from robottelo.virtwho_utils import get_configure_command
@@ -418,5 +419,55 @@ class TestVirtWhoConfigforEsx:
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+
+    @pytest.mark.tier2
+    def test_positive_deploy_configure_hypervisor_password_with_special_characters(
+        self, default_org, form_data, target_sat
+    ):
+        """Verify " hammer virt-who-config deploy hypervisor with special characters"
+
+        :id: 9892a94e-ff4b-44dd-87eb-1289d4a965be
+
+        :expectedresults: Config can be created and deployed with any error
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+
+        :BZ: 1870816,1959136
+        """
+        # check the hypervisor password contains single quotes
+        form_data['hypervisor-password'] = "Tes't"
+        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+        assert virtwho_config['status'] == 'No Report Yet'
+        virtwho_config['id']
+        command = get_configure_command(virtwho_config['id'], default_org.name)
+        deploy_status = deploy_configure_by_command_check(command)
+        assert deploy_status == 'Finished successfully'
+        config_file = get_configure_file(virtwho_config['id'])
+        assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
+        assert (
+            get_configure_option('username', config_file)
+            == settings.virtwho.esx.hypervisor_username
+        )
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+
+        # check the hypervisor password contains backtick
+        form_data['hypervisor-password'] = r"my\`password"
+        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+        assert virtwho_config['status'] == 'No Report Yet'
+        virtwho_config['id']
+        command = get_configure_command(virtwho_config['id'], default_org.name)
+        deploy_status = deploy_configure_by_command_check(command)
+        assert deploy_status == 'Finished successfully'
+        config_file = get_configure_file(virtwho_config['id'])
+        assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
+        assert (
+            get_configure_option('username', config_file)
+            == settings.virtwho.esx.hypervisor_username
+        )
         target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
         assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -437,6 +437,8 @@ class TestVirtWhoConfigforEsx:
         :CaseImportance: High
 
         :BZ: 1870816,1959136
+
+        :customerscenario: true
         """
         # check the hypervisor password contains single quotes
         form_data['hypervisor-password'] = "Tes't"

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -430,7 +430,7 @@ class TestVirtWhoConfigforEsx:
 
         :id: 9892a94e-ff4b-44dd-87eb-1289d4a965be
 
-        :expectedresults: Config can be created and deployed with any error
+        :expectedresults: Config can be created and deployed without any error
 
         :CaseLevel: Integration
 


### PR DESCRIPTION
Hey,
Automate [Bug1870816](https://bugzilla.redhat.com/show_bug.cgi?id=1870816) and [Bug1959136](https://bugzilla.redhat.com/show_bug.cgi?id=1959136) for virt-who plugin.
As real change the hypervisor password may be affect the following testing, so use the fake hypervisor password to check these features.
Case PASS on ESX env:
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx.py -k test_positive_deploy_configure_hypervisor_password_with_special_characters
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.2.4, forked-1.4.0, xdist-2.5.0, cov-3.0.0, metadata-1.11.0, html-3.1.1, mock-3.8.2, reportportal-5.1.2
collected 11 items / 21 deselected / -10 selected                                                                                                                                                                 

tests/foreman/virtwho/cli/test_esx.py .                                                                                                                                                                     [100%]

================================================================================================ warnings summary =================================================================================================
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/trio/_core/_multierror.py:511
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/trio/_core/_multierror.py:511: RuntimeWarning: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.
    warnings.warn(

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/swiftclient/client.py:84: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    if StrictVersion(requests.__version__) < StrictVersion('2.0.0') \

../../data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/_pytest/config/__init__.py:1252: PytestConfigWarning: Unknown config option: rp_ignore_errors
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

tests/foreman/virtwho/cli/test_esx.py:454
  /home/yanpliu/gitrepo/robottelo/tests/foreman/virtwho/cli/test_esx.py:454: DeprecationWarning: invalid escape sequence \`
    form_data['hypervisor-password'] = "my\`password"

tests/foreman/virtwho/cli/test_esx.py::TestVirtWhoConfigforEsx::test_positive_deploy_configure_hypervisor_password_with_special_characters
  /home/yanpliu/data/virtualenv_38/robottelo_vv/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-03.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 21 deselected, 6 warnings in 76.12s (0:01:16) =============================================================================

```