### PR TITLE
Update hypervisor attach to Automatic mode for virtwho plugin cases

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -100,7 +100,7 @@ class TestVirtWhoConfigforEsx:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
@@ -161,7 +161,7 @@ class TestVirtWhoConfigforEsx:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -98,7 +98,7 @@ class TestVirtWhoConfigforHyperv:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
@@ -159,7 +159,7 @@ class TestVirtWhoConfigforHyperv:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -96,7 +96,7 @@ class TestVirtWhoConfigforKubevirt:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
@@ -157,7 +157,7 @@ class TestVirtWhoConfigforKubevirt:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -97,7 +97,7 @@ class TestVirtWhoConfigforLibvirt:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
@@ -158,7 +158,7 @@ class TestVirtWhoConfigforLibvirt:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -99,7 +99,7 @@ class TestVirtWhoConfigforNutanix:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
@@ -160,7 +160,7 @@ class TestVirtWhoConfigforNutanix:
                         vdc_id = item['id']
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'


### PR DESCRIPTION
Cases failed for "Partially entitled" because of the number of hypervisor sockets is not full occupied

Update it to Automatic attach

Hypervisors ESX, libvirt, hyperv,nutanix,kubevirt all PASS

These have been updated in Satellite6.12
https://github.com/SatelliteQE/robottelo/pull/9984

ESX Test Results:
```
(robottelo_vv_6.11.z) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx.py -k test_positive_deploy_configure_by_id  --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 15 deselected, 14 warnings in 90.20s (0:01:30)
(robottelo_vv_6.11.z) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx.py -k test_positive_deploy_configure_by_script  --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 15 deselected, 15 warnings in 93.23s (0:01:33)

```