### PR TITLE
Automate bug1870816 bug1959136 API/ UI cases for virt-who plugin

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -22,6 +22,7 @@ from fauxfactory import gen_string
 from robottelo.config import settings
 from robottelo.virtwho_utils import create_http_proxy
 from robottelo.virtwho_utils import deploy_configure_by_command
+from robottelo.virtwho_utils import deploy_configure_by_command_check
 from robottelo.virtwho_utils import deploy_configure_by_script
 from robottelo.virtwho_utils import ETC_VIRTWHO_CONFIG
 from robottelo.virtwho_utils import get_configure_command
@@ -380,6 +381,59 @@ class TestVirtWhoConfigforEsx:
         deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
         search_result = virtwho_config.get_organization_configs(data={'per_page': '1000'})
         assert [item for item in search_result['results'] if item['name'] == form_data['name']]
+        virtwho_config.delete()
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
+
+    @pytest.mark.tier2
+    def test_positive_deploy_configure_hypervisor_password_with_special_characters(
+        self, default_org, form_data, target_sat
+    ):
+        """Verify " hammer virt-who-config deploy hypervisor with special characters"
+
+        :id: 3a79d65a-e206-4693-a5ba-59f6c44c984e
+
+        :expectedresults: Config can be created and deployed without any error
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+
+        :BZ: 1870816,1959136
+
+        :customerscenario: true
+        """
+        # check the hypervisor password contains single quotes
+        form_data['hypervisor_password'] = "Tes't"
+        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+        assert virtwho_config.status == 'unknown'
+        command = get_configure_command(virtwho_config.id, default_org.name)
+        deploy_status = deploy_configure_by_command_check(command)
+        assert deploy_status == 'Finished successfully'
+        config_file = get_configure_file(virtwho_config.id)
+        assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
+        assert (
+            get_configure_option('username', config_file)
+            == settings.virtwho.esx.hypervisor_username
+        )
+        virtwho_config.delete()
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
+        # check the hypervisor password contains backtick
+        form_data['hypervisor_password'] = "my`password"
+        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+        assert virtwho_config.status == 'unknown'
+        command = get_configure_command(virtwho_config.id, default_org.name)
+        deploy_status = deploy_configure_by_command_check(command)
+        assert deploy_status == 'Finished successfully'
+        config_file = get_configure_file(virtwho_config.id)
+        assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
+        assert (
+            get_configure_option('username', config_file)
+            == settings.virtwho.esx.hypervisor_username
+        )
         virtwho_config.delete()
         assert not target_sat.api.VirtWhoConfig().search(
             query={'search': f"name={form_data['name']}"}

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -428,7 +428,7 @@ class TestVirtWhoConfigforEsx:
     ):
         """Verify " hammer virt-who-config deploy hypervisor with special characters"
 
-        :id: 9892a94e-ff4b-44dd-87eb-1289d4a965be
+        :id: 654f869e-182b-4951-bc4e-8761d666a449
 
         :expectedresults: Config can be created and deployed without any error
 
@@ -444,7 +444,6 @@ class TestVirtWhoConfigforEsx:
         form_data['hypervisor-password'] = "Tes't"
         virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
         assert virtwho_config['status'] == 'No Report Yet'
-        virtwho_config['id']
         command = get_configure_command(virtwho_config['id'], default_org.name)
         deploy_status = deploy_configure_by_command_check(command)
         assert deploy_status == 'Finished successfully'
@@ -461,7 +460,6 @@ class TestVirtWhoConfigforEsx:
         form_data['hypervisor-password'] = r"my\`password"
         virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
         assert virtwho_config['status'] == 'No Report Yet'
-        virtwho_config['id']
         command = get_configure_command(virtwho_config['id'], default_org.name)
         deploy_status = deploy_configure_by_command_check(command)
         assert deploy_status == 'Finished successfully'

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -428,7 +428,7 @@ class TestVirtWhoConfigforEsx:
     ):
         """Verify " hammer virt-who-config deploy hypervisor with special characters"
 
-        :id: 654f869e-182b-4951-bc4e-8761d666a449
+        :id: 9892a94e-ff4b-44dd-87eb-1289d4a965be
 
         :expectedresults: Config can be created and deployed without any error
 

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -739,7 +739,7 @@ class TestVirtwhoConfigforEsx:
     ):
         """Verify " hammer virt-who-config deploy hypervisor with special characters"
 
-        :id: 9892a94e-ff4b-44dd-87eb-1289d4a965be
+        :id: 654f869e-182b-4951-bc4e-8761d666a449
 
         :expectedresults: Config can be created and deployed without any error
 


### PR DESCRIPTION
Hey,
Automate Bug1870816 and Bug1959136 for virt-who plugin API/UI, and remove unused sentence for CLI cases.

CLI case PR; merged
https://github.com/SatelliteQE/robottelo/pull/9992

Test Cases： PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx.py  -k test_positive_deploy_configure_hypervisor_password_with_special_c(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx.py  -k test_positive_deploy_configure_hypervisor_password_with_special_characters --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 17 deselected, 11 warnings in 51.91s
(robottelo_vv) [yanpliu@yanpliu robottelo]$ 

(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py  -k test_positive_deploy_configure_hypervisor_password_with_special_characters  --disable-pytest-warnings -q

.                                                                                                                                                                                                           [100%]
1 passed, 31 deselected, 9 warnings in 1214.53s (0:20:14)

(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx.py  -k test_positive_deploy_configure_hypervisor_password_with_special_characters --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 21 deselected, 5 warnings in 64.68s (0:01:04)
(robottelo_vv) [yanpliu@yanpliu robottelo]$ 
```