### PR TITLE
Avoid adding capsule to the http proxy except list

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1353,14 +1353,6 @@ class Capsule(ContentHost, CapsuleMixins):
         if result.status:
             raise CapsuleHostError(f'The satellite-capsule package was not found\n{result.stdout}')
 
-        # Update Satellite's http proxy except list
-        result = self.satellite.cli.Settings.list({'search': 'http_proxy_except_list'})[0]
-        if result['value'] == '[]':
-            except_list = f'[{self.hostname}]'
-        else:
-            except_list = result['value'][:-1] + f', {self.hostname}]'
-        self.satellite.cli.Settings.set({'name': 'http_proxy_except_list', 'value': except_list})
-
         # Generate certificate, copy it to Capsule, run installer, check it succeeds
         installer = self.satellite.capsule_certs_generate(self, **installer_kwargs)
         self.satellite.session.remote_copy(installer.opts['certs-tar-file'], self)

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -974,6 +974,7 @@ class TestCapsuleContentManagement:
         caps_files = get_repo_files_by_url(caps_repo_url)
         assert len(caps_files) == packages_count
 
+    @pytest.mark.skip_if_open("BZ:2122780")
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_capsule_pub_url_accessible(self, module_capsule_configured):
@@ -985,7 +986,7 @@ class TestCapsuleContentManagement:
 
         :expectedresults: capsule pub url is accessible
 
-        :BZ: 1463810
+        :BZ: 1463810, 2122780
 
         :CaseLevel: System
         """


### PR DESCRIPTION
This was used earlier to bypass the proxying of sat-to-caps communication which was not working properly.
Currently BZ#1984400 solves the issue so the workaround is not needed anymore (even if we kept using of http proxy in our
current automation).

Plus pushed a test skipping until a BZ is resolved.