### PR TITLE
Add test scenario for repo discovery with http proxy

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -33,6 +33,7 @@ pytest_plugins = [
     'pytest_fixtures.component.domain',
     'pytest_fixtures.component.host',
     'pytest_fixtures.component.hostgroup',
+    'pytest_fixtures.component.http_proxy',
     'pytest_fixtures.component.katello_certs_check',
     'pytest_fixtures.component.lce',
     'pytest_fixtures.component.maintain',

--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -1,0 +1,49 @@
+import pytest
+from fauxfactory import gen_string
+
+from robottelo.config import settings
+
+
+def create_http_proxy(sat, org, proxy_type):
+    """
+    Creates HTTP proxy.
+
+    :param str sat: Satellite to use.
+    :param str org: Organization
+    :param str proxy_type: 'auth_http_proxy' or 'unauth_http_proxy' http proxy.
+    """
+    if proxy_type == 'unauth_http_proxy':
+        return sat.api.HTTPProxy(
+            name=gen_string('alpha', 15),
+            url=settings.http_proxy.un_auth_proxy_url,
+            organization=[org.id],
+        ).create()
+    if proxy_type == 'auth_http_proxy':
+        return sat.api.HTTPProxy(
+            name=gen_string('alpha', 15),
+            url=settings.http_proxy.auth_proxy_url,
+            username=settings.http_proxy.username,
+            password=settings.http_proxy.password,
+            organization=[org.id],
+        ).create()
+
+
+@pytest.fixture(scope='function')
+def function_http_proxy(request, module_manifest_org, target_sat):
+    """Create a new HTTP proxy and set related settings based on proxy"""
+    http_proxy = create_http_proxy(target_sat, module_manifest_org, request.param)
+    general_proxy = http_proxy.url if request.param == "unauth_http_proxy" else ''
+    if request.param == "auth_http_proxy":
+        general_proxy = (
+            f'http://{settings.http_proxy.username}:'
+            f'{settings.http_proxy.password}@{http_proxy.url[7:]}'
+        )
+    content_proxy_value = target_sat.update_setting(
+        'content_default_http_proxy', http_proxy.name if request.param != "no_http_proxy" else ''
+    )
+    general_proxy_value = target_sat.update_setting(
+        'http_proxy', general_proxy if request.param != "no_http_proxy" else ''
+    )
+    yield http_proxy, request.param
+    target_sat.update_setting('content_default_http_proxy', content_proxy_value)
+    target_sat.update_setting('http_proxy', general_proxy_value)

--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -1,36 +1,12 @@
 import pytest
-from fauxfactory import gen_string
 
 from robottelo.config import settings
 
 
-def create_http_proxy(sat, org, http_proxy_type):
-    """
-    Creates HTTP proxy.
-    :param str sat: Satellite to use.
-    :param str org: Organization
-    :param str http_proxy_type: None, False, True
-    """
-    if http_proxy_type is False:
-        return sat.api.HTTPProxy(
-            name=gen_string('alpha', 15),
-            url=settings.http_proxy.un_auth_proxy_url,
-            organization=[org.id],
-        ).create()
-    if http_proxy_type:
-        return sat.api.HTTPProxy(
-            name=gen_string('alpha', 15),
-            url=settings.http_proxy.auth_proxy_url,
-            username=settings.http_proxy.username,
-            password=settings.http_proxy.password,
-            organization=[org.id],
-        ).create()
-
-
 @pytest.fixture(scope='function')
-def function_http_proxy(request, module_manifest_org, target_sat):
+def setup_http_proxy(request, module_manifest_org, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
-    http_proxy = create_http_proxy(target_sat, module_manifest_org, request.param)
+    http_proxy = target_sat.api_factory.make_http_proxy(module_manifest_org, request.param)
     general_proxy = http_proxy.url if request.param is False else ''
     if request.param:
         general_proxy = (

--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -4,21 +4,20 @@ from fauxfactory import gen_string
 from robottelo.config import settings
 
 
-def create_http_proxy(sat, org, proxy_type):
+def create_http_proxy(sat, org, http_proxy_type):
     """
     Creates HTTP proxy.
-
     :param str sat: Satellite to use.
     :param str org: Organization
-    :param str proxy_type: 'auth_http_proxy' or 'unauth_http_proxy' http proxy.
+    :param str http_proxy_type: None, False, True
     """
-    if proxy_type == 'unauth_http_proxy':
+    if http_proxy_type is False:
         return sat.api.HTTPProxy(
             name=gen_string('alpha', 15),
             url=settings.http_proxy.un_auth_proxy_url,
             organization=[org.id],
         ).create()
-    if proxy_type == 'auth_http_proxy':
+    if http_proxy_type:
         return sat.api.HTTPProxy(
             name=gen_string('alpha', 15),
             url=settings.http_proxy.auth_proxy_url,
@@ -32,17 +31,17 @@ def create_http_proxy(sat, org, proxy_type):
 def function_http_proxy(request, module_manifest_org, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
     http_proxy = create_http_proxy(target_sat, module_manifest_org, request.param)
-    general_proxy = http_proxy.url if request.param == "unauth_http_proxy" else ''
-    if request.param == "auth_http_proxy":
+    general_proxy = http_proxy.url if request.param is False else ''
+    if request.param:
         general_proxy = (
             f'http://{settings.http_proxy.username}:'
             f'{settings.http_proxy.password}@{http_proxy.url[7:]}'
         )
     content_proxy_value = target_sat.update_setting(
-        'content_default_http_proxy', http_proxy.name if request.param != "no_http_proxy" else ''
+        'content_default_http_proxy', http_proxy.name if request.param is not None else ''
     )
     general_proxy_value = target_sat.update_setting(
-        'http_proxy', general_proxy if request.param != "no_http_proxy" else ''
+        'http_proxy', general_proxy if request.param is not None else ''
     )
     yield http_proxy, request.param
     target_sat.update_setting('content_default_http_proxy', content_proxy_value)

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -2,6 +2,9 @@
 It is not meant to be used directly, but as part of a robottelo.hosts.Satellite instance
 example: my_satellite.api_factory.api_method()
 """
+from fauxfactory import gen_string
+
+from robottelo.config import settings
 
 
 class APIFactory:
@@ -9,3 +12,24 @@ class APIFactory:
 
     def __init__(self, satellite):
         self._satellite = satellite
+
+    def make_http_proxy(self, org, http_proxy_type):
+        """
+        Creates HTTP proxy.
+        :param str org: Organization
+        :param str http_proxy_type: None, False, True
+        """
+        if http_proxy_type is False:
+            return self._satellite.api.HTTPProxy(
+                name=gen_string('alpha', 15),
+                url=settings.http_proxy.un_auth_proxy_url,
+                organization=[org.id],
+            ).create()
+        if http_proxy_type:
+            return self._satellite.api.HTTPProxy(
+                name=gen_string('alpha', 15),
+                url=settings.http_proxy.auth_proxy_url,
+                username=settings.http_proxy.username,
+                password=settings.http_proxy.password,
+                organization=[org.id],
+            ).create()

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -17,56 +17,10 @@
 :Upstream: No
 """
 import pytest
-from fauxfactory import gen_string
 
 from robottelo import constants
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
-
-
-def create_http_proxy(sat, org, http_proxy_type):
-    """
-    Creates HTTP proxy.
-
-    :param str sat: Satellite to use.
-    :param str org: Organization
-    :param str http_proxy_type: None, False, True
-    """
-    if http_proxy_type is False:
-        return sat.api.HTTPProxy(
-            name=gen_string('alpha', 15),
-            url=settings.http_proxy.un_auth_proxy_url,
-            organization=[org.id],
-        ).create()
-    if http_proxy_type:
-        return sat.api.HTTPProxy(
-            name=gen_string('alpha', 15),
-            url=settings.http_proxy.auth_proxy_url,
-            username=settings.http_proxy.username,
-            password=settings.http_proxy.password,
-            organization=[org.id],
-        ).create()
-
-
-@pytest.fixture(scope='function')
-def function_http_proxy(request, module_manifest_org, target_sat):
-    """Create a new HTTP proxy and set related settings based on proxy"""
-    http_proxy = create_http_proxy(target_sat, module_manifest_org, request.param)
-    general_proxy = http_proxy.url if request.param is False else ''
-    if request.param:
-        general_proxy = (
-            f'http://{settings.http_proxy.username}:'
-            f'{settings.http_proxy.password}@{http_proxy.url[7:]}'
-        )
-    content_proxy_value = target_sat.update_setting(
-        'content_default_http_proxy', http_proxy.name if request.param is not None else ''
-    )
-    general_proxy_value = target_sat.update_setting(
-        'http_proxy', general_proxy if request.param is not None else ''
-    )
-    yield http_proxy, request.param
-    target_sat.update_setting('content_default_http_proxy', content_proxy_value)
-    target_sat.update_setting('http_proxy', general_proxy_value)
 
 
 @pytest.mark.tier2

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -104,7 +104,7 @@ def test_positive_end_to_end(function_http_proxy, module_target_sat, module_mani
 
     # test scenario for yum type repo discovery.
     repo_name = 'fakerepo01'
-    yum_repo = target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
+    yum_repo = module_target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
         data={
             "id": module_manifest_org.id,
             "url": settings.repos.repo_discovery.url,
@@ -115,7 +115,7 @@ def test_positive_end_to_end(function_http_proxy, module_target_sat, module_mani
     assert yum_repo['output'][0] == f'{settings.repos.repo_discovery.url}/{repo_name}/'
 
     # test scenario for docker type repo discovery.
-    yum_repo = target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
+    yum_repo = module_target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
         data={
             "id": module_manifest_org.id,
             "url": 'quay.io',

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -32,7 +32,7 @@ from robottelo.config import settings
     indirect=True,
     ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
 )
-def test_positive_end_to_end(function_http_proxy, target_sat, module_manifest_org):
+def test_positive_end_to_end(function_http_proxy, module_target_sat, module_manifest_org):
     """End-to-end test for HTTP Proxy related scenarios.
 
     :id: 38df5479-9127-49f3-a30e-26b33655971a
@@ -68,7 +68,7 @@ def test_positive_end_to_end(function_http_proxy, target_sat, module_manifest_or
         reposet=constants.REPOSET['rhae2'],
         releasever=None,
     )
-    rh_repo = target_sat.api.Repository(
+    rh_repo = module_target_sat.api.Repository(
         id=rh_repo_id,
         http_proxy_policy=http_proxy_policy,
         http_proxy_id=http_proxy_id,
@@ -85,7 +85,7 @@ def test_positive_end_to_end(function_http_proxy, target_sat, module_manifest_or
         'http_proxy_policy': http_proxy_policy,
         'http_proxy_id': http_proxy_id,
     }
-    repo = target_sat.api.Repository(**repo_options).create()
+    repo = module_target_sat.api.Repository(**repo_options).create()
 
     assert repo.http_proxy_policy == http_proxy_policy
     assert repo.http_proxy_id == http_proxy_id
@@ -94,7 +94,7 @@ def test_positive_end_to_end(function_http_proxy, target_sat, module_manifest_or
 
     # Use global_default_http_proxy
     repo_options['http_proxy_policy'] = 'global_default_http_proxy'
-    repo_2 = target_sat.api.Repository(**repo_options).create()
+    repo_2 = module_target_sat.api.Repository(**repo_options).create()
     assert repo_2.http_proxy_policy == 'global_default_http_proxy'
 
     # Update to selected_http_proxy

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -27,12 +27,12 @@ from robottelo.config import settings
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize(
-    'function_http_proxy',
+    'setup_http_proxy',
     [None, True, False],
     indirect=True,
     ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
 )
-def test_positive_end_to_end(function_http_proxy, module_target_sat, module_manifest_org):
+def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifest_org):
     """End-to-end test for HTTP Proxy related scenarios.
 
     :id: 38df5479-9127-49f3-a30e-26b33655971a
@@ -56,7 +56,7 @@ def test_positive_end_to_end(function_http_proxy, module_target_sat, module_mani
 
     :CaseImportance: Critical
     """
-    http_proxy, http_proxy_type = function_http_proxy
+    http_proxy, http_proxy_type = setup_http_proxy
     http_proxy_id = http_proxy.id if http_proxy_type is not None else None
     http_proxy_policy = 'use_selected_http_proxy' if http_proxy_type is not None else 'none'
     # Assign http_proxy to Redhat repository and perform repository sync.

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -337,12 +337,12 @@ def test_http_proxy_containing_special_characters():
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.usefixtures('allow_repo_discovery')
 @pytest.mark.parametrize(
-    'function_http_proxy',
+    'setup_http_proxy',
     [None, True, False],
     indirect=True,
     ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
 )
-def test_positive_repo_discovery(function_http_proxy, module_target_sat, module_org):
+def test_positive_repo_discovery(setup_http_proxy, module_target_sat, module_org):
     """Create repository via repo discovery under new product
 
     :id: fd385552-8cbb-49f7-8557-cc4e6ac7e79a


### PR DESCRIPTION
This PR 
- Adds a parameterized ui test for discovering yum and docker type repo with Http proxy set in Satellite settings. It also creates and syncs discovered repo.
- reactors few tests to use `target_sat`.
- Moves HTTP proxy fixture to `pytest_fixtures/component/http_proxy.py`.

Test result:

```
pytest tests/foreman/ui/test_http_proxy.py -k test_positive_repo_discovery 
============================= test session starts ==============================
collected 8 items / 5 deselected / 3 selected

tests/foreman/ui/test_http_proxy.py ...                                  [100%]
========== 3 passed, 5 deselected, 25 warnings in 1633.43s (0:27:13) ===========
```


Note:
- Depends on https://github.com/SatelliteQE/airgun/pull/745 

