### PR TITLE
Fix partition table end to end test

### DIFF
--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -24,7 +24,7 @@ from robottelo.constants import DataFile
 
 @pytest.fixture(scope='module')
 def template_data():
-    return DataFile.PARTITION_SCRIPT_DATA_FILE.read_bytes()
+    return DataFile.PARTITION_SCRIPT_DATA_FILE.read_text()
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
This was changed in helpers refactor https://github.com/SatelliteQE/robottelo/pull/9782
Tests were failing with using bytes instead of text.
![image](https://user-images.githubusercontent.com/43444182/188464831-c97bd8fa-ea19-4ae1-9879-3e810bb3f169.png)
