### PR TITLE
Nutanix Prism Central CLI cases automation support for virt-who plugin

### DIFF
--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -245,7 +245,10 @@ class TestVirtWhoConfigforNutanix:
         :CaseImportance: Medium
         """
         value = 'central'
-        target_sat.cli.VirtWhoConfig.update({'id': virtwho_config['id'], 'prism-flavor': value})
+        result = target_sat.cli.VirtWhoConfig.update(
+            {'id': virtwho_config['id'], 'prism-flavor': value}
+        )
+        assert result[0]['message'] == f"Virt Who configuration [{virtwho_config['name']}] updated"
         result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
         assert result['general-information']['ahv-prism-flavor'] == value
         config_file = get_configure_file(virtwho_config['id'])


### PR DESCRIPTION
Hey,
Realize Nutanix Prism Central CLI cases automation support for virt-who plugin.

Nutanix CLI Cases:PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py -k test_positive_prism_central_deploy_configure_by_id --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 11 deselected, 5 warnings in 117.19s (0:01:57)

============================================================================ 1 passed, 11 deselected, 5 warnings in 114.81s (0:01:54) =============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py -k test_positive_prism_central_deploy_configure_by_script --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 11 deselected, 5 warnings in 104.94s (0:01:44)
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py -k test_positive_prism_central_prism_central_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 11 deselected, 5 warnings in 70.43s (0:01:10)

```