### PR TITLE
Nutanix Prism Central API cases automation support for virt-who plugin

### DIFF
--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -197,3 +197,160 @@ class TestVirtWhoConfigforNutanix:
         assert not target_sat.api.VirtWhoConfig().search(
             query={'search': f"name={form_data['name']}"}
         )
+
+    @pytest.mark.tier2
+    def test_positive_prism_central_deploy_configure_by_id(
+        self, default_org, form_data, target_sat
+    ):
+        """Verify "POST /foreman_virt_who_configure/api/v2/configs" on nutanix prism central mode
+
+        :id: e7652f64-eaf8-45a5-ac01-eb40d53b6603
+
+        :expectedresults:
+            Config can be created and deployed
+            The prism_central has been set in /etc/virt-who.d/vir-who.conf file
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+        """
+        form_data['prism_flavor'] = "central"
+        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+        assert virtwho_config.status == 'unknown'
+        command = get_configure_command(virtwho_config.id, default_org.name)
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        # Check the option "prism_central=true" should be set in etc/virt-who.d/virt-who.conf
+        config_file = get_configure_file(virtwho_config.id)
+        assert get_configure_option("prism_central", config_file) == 'true'
+        virt_who_instance = (
+            target_sat.api.VirtWhoConfig()
+            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .status
+        )
+        assert virt_who_instance == 'ok'
+        hosts = [
+            (
+                hypervisor_name,
+                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
+            ),
+            (
+                guest_name,
+                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
+            ),
+        ]
+        for hostname, sku in hosts:
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
+            vdc_id = subscriptions[0]['id']
+            if 'type=STACK_DERIVED' in sku:
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
+            )
+            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
+            assert result['subscription_status_label'] == 'Fully entitled'
+        virtwho_config.delete()
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )
+
+    @pytest.mark.tier2
+    def test_positive_prism_central_deploy_configure_by_script(
+        self, default_org, form_data, target_sat
+    ):
+        """Verify "GET /foreman_virt_who_configure/api/ on nutanix prism central mode
+
+        v2/configs/:id/deploy_script"
+
+        :id: d139d70b-7c4a-4325-a892-4829c83755cd
+
+        :expectedresults:
+            Config can be created and deployed on nutanix prism central mode
+            The prism_central has been set in /etc/virt-who.d/vir-who.conf file
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+        """
+        form_data['prism_flavor'] = "central"
+        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+        assert virtwho_config.status == 'unknown'
+        script = virtwho_config.deploy_script()
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script['virt_who_config_script'],
+            form_data['hypervisor_type'],
+            debug=True,
+            org=default_org.label,
+        )
+        # Check the option "prism_central=true" should be set in etc/virt-who.d/virt-who.conf
+        config_file = get_configure_file(virtwho_config.id)
+        assert get_configure_option("prism_central", config_file) == 'true'
+        virt_who_instance = (
+            target_sat.api.VirtWhoConfig()
+            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .status
+        )
+        assert virt_who_instance == 'ok'
+        hosts = [
+            (
+                hypervisor_name,
+                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
+            ),
+            (
+                guest_name,
+                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
+            ),
+        ]
+        for hostname, sku in hosts:
+            host = target_sat.cli.Host.list({'search': hostname})[0]
+            subscriptions = target_sat.cli.Subscription.list(
+                {'organization': default_org.name, 'search': sku}
+            )
+            vdc_id = subscriptions[0]['id']
+            if 'type=STACK_DERIVED' in sku:
+                for item in subscriptions:
+                    if hypervisor_name.lower() in item['type']:
+                        vdc_id = item['id']
+                        break
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
+            )
+            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
+            assert result['subscription_status_label'] == 'Fully entitled'
+        virtwho_config.delete()
+        target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+
+    @pytest.mark.tier2
+    def test_positive_prism_central_prism_central_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
+        """Verify prism_flavor option by "PUT
+
+        /foreman_virt_who_configure/api/v2/configs/:id"
+
+        :id: 7f3b18c7-178c-4547-86ed-0e34772f755f
+
+        :expectedresults: prism_flavor option can be updated.
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+        """
+        value = 'central'
+        virtwho_config.prism_flavor = value
+        virtwho_config.update(['prism_flavor'])
+        config_file = get_configure_file(virtwho_config.id)
+        command = get_configure_command(virtwho_config.id, default_org.name)
+        deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
+        assert get_configure_option("prism_central", config_file) == 'true'
+        virtwho_config.delete()
+        assert not target_sat.api.VirtWhoConfig().search(
+            query={'search': f"name={form_data['name']}"}
+        )

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -83,23 +83,27 @@ class TestVirtWhoConfigforNutanix:
         hosts = [
             (
                 hypervisor_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
+                settings.virtwho.sku.vdc_physical,
+                'NORMAL',
             ),
             (
                 guest_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
+                settings.virtwho.sku.vdc_virtual,
+                'STACK_DERIVED',
             ),
         ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
-            )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
+        for hostname, sku, type in hosts:
+            host = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
+            subscriptions = target_sat.api.Organization(id=default_org.id).subscriptions()[
+                'results'
+            ]
+            for item in subscriptions:
+                if item['type'] == type and item['product_id'] == sku:
+                    vdc_id = item['id']
+                    if (
+                        'hypervisor' in item
+                        and hypervisor_name.lower() in item['hypervisor']['name']
+                    ):
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
@@ -140,23 +144,27 @@ class TestVirtWhoConfigforNutanix:
         hosts = [
             (
                 hypervisor_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
+                settings.virtwho.sku.vdc_physical,
+                'NORMAL',
             ),
             (
                 guest_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
+                settings.virtwho.sku.vdc_virtual,
+                'STACK_DERIVED',
             ),
         ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
-            )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
+        for hostname, sku, type in hosts:
+            host = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
+            subscriptions = target_sat.api.Organization(id=default_org.id).subscriptions()[
+                'results'
+            ]
+            for item in subscriptions:
+                if item['type'] == type and item['product_id'] == sku:
+                    vdc_id = item['id']
+                    if (
+                        'hypervisor' in item
+                        and hypervisor_name.lower() in item['hypervisor']['name']
+                    ):
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
@@ -236,23 +244,27 @@ class TestVirtWhoConfigforNutanix:
         hosts = [
             (
                 hypervisor_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
+                settings.virtwho.sku.vdc_physical,
+                'NORMAL',
             ),
             (
                 guest_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
+                settings.virtwho.sku.vdc_virtual,
+                'STACK_DERIVED',
             ),
         ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
-            )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
+        for hostname, sku, type in hosts:
+            host = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
+            subscriptions = target_sat.api.Organization(id=default_org.id).subscriptions()[
+                'results'
+            ]
+            for item in subscriptions:
+                if item['type'] == type and item['product_id'] == sku:
+                    vdc_id = item['id']
+                    if (
+                        'hypervisor' in item
+                        and hypervisor_name.lower() in item['hypervisor']['name']
+                    ):
                         break
             target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
                 data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -48,7 +48,10 @@ def form_data(default_org, target_sat):
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    return target_sat.api.VirtWhoConfig(**form_data).create()
+    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+    yield virtwho_config
+    virtwho_config.delete()
+    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
 
 class TestVirtWhoConfigforNutanix:
@@ -103,10 +106,6 @@ class TestVirtWhoConfigforNutanix:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(
@@ -164,8 +163,6 @@ class TestVirtWhoConfigforNutanix:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
@@ -193,10 +190,6 @@ class TestVirtWhoConfigforNutanix:
                 command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
@@ -266,10 +259,6 @@ class TestVirtWhoConfigforNutanix:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_prism_central_prism_central_option(
@@ -294,7 +283,3 @@ class TestVirtWhoConfigforNutanix:
         command = get_configure_command(virtwho_config.id, default_org.name)
         deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
         assert get_configure_option("prism_central", config_file) == 'true'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )


### PR DESCRIPTION
Hey,
Realize Nutanix Prism Central API cases automation support for virt-who plugin.

Nutanix API Cases:PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix.py -k test_positive_prism_central_prism_central_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 11 deselected, 9 warnings in 65.93s (0:01:05)
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix.py -k test_positive_prism_central_deploy_configure_by_id --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 11 deselected, 15 warnings in 103.63s (0:01:43)
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix.py -k test_positive_prism_central_deploy_configure_by_script --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 11 deselected, 16 warnings in 119.11s (0:01:59)

```