### PR TITLE
Automation coverage for new api feature for ansible_playbooks

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -1,0 +1,61 @@
+"""Test class for Ansible Roles and Variables pages
+
+:Requirement: Ansible
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Ansible
+
+:Assignee: sbible
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+
+
+def test_fetch_and_sync_ansible_playbooks(target_sat):
+    """
+    Test Ansible Playbooks api for fetching and syncing playbooks
+
+    :id: 17b4e767-1494-4960-bc60-f31a0495c09f
+
+    :customerscenario: true
+
+    :Steps:
+
+        1. Install ansible collection with playbooks.
+        2. Try to fetch the playbooks via api.
+        3. Sync the playbooks.
+        4. Assert the count of playbooks fetched and synced are equal.
+
+    :expectedresults:
+        1. Playbooks should be fetched and synced successfully.
+
+    :BZ: 2115686
+
+    :CaseAutomation: Automated
+    """
+    target_sat.execute(
+        "ansible-galaxy collection install -p /usr/share/ansible/collections "
+        "xprazak2.forklift_collection"
+    )
+    id = target_sat.api.SmartProxy(name=target_sat.hostname).search()[0].id
+    playbook_fetch = target_sat.api.AnsiblePlaybooks().fetch(data={'proxy_id': id})
+    playbooks_count = len(playbook_fetch['results']['playbooks_names'])
+    playbook_sync = target_sat.api.AnsiblePlaybooks().sync(data={'proxy_id': id})
+    assert playbook_sync['action'] == "Sync playbooks"
+
+    target_sat.wait_for_tasks(
+        search_query=(f'id = {playbook_sync["id"]}'),
+        poll_timeout=100,
+    )
+    task_details = target_sat.api.ForemanTask().search(
+        query={'search': f'id = {playbook_sync["id"]}'}
+    )
+    assert task_details[0].result == 'success'
+    assert len(task_details[0].output['result']['created']) == playbooks_count


### PR DESCRIPTION
Run with https://github.com/SatelliteQE/nailgun/pull/840/files for better results


```
Test results

pytest tests/foreman/api/test_ansible.py -k test_fetch_and_sync_ansible_playbooks
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.8.6, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.7.0, forked-1.3.0, cov-3.0.0, xdist-2.5.0, ibutsu-2.2.2, reportportal-5.1.2
collected 1 item                                                                                                                                                                                                  

tests/foreman/api/test_ansible.py .                                                                                                                                                                         [100%]
==================================================================================== 1 passed, in 63.41s (0:01:03) ====================================================================================
```



