### PR TITLE
Adding coverage for BZ 2112093

### DIFF
--- a/tests/foreman/ui/test_webhook.py
+++ b/tests/foreman/ui/test_webhook.py
@@ -30,6 +30,12 @@ def test_positive_end_to_end(session):
     :expectedresults: All expected CRUD actions finished successfully
 
     :CaseImportance: Critical
+
+    :BZ: 2112093
+
+    :customerscenario: true
+
+    :CaseAutomation: Automated
     """
     hook_name = gen_string('alpha')
     subscribe_to = 'Host Created'
@@ -50,6 +56,8 @@ def test_positive_end_to_end(session):
                 'general.template': template,
                 'general.http_method': http_method,
                 'general.enabled': False,
+                'credentials.capsule_auth': True,
+                'credentials.verify_ssl': False,
             }
         )
         values = session.webhook.read(hook_name)
@@ -59,6 +67,8 @@ def test_positive_end_to_end(session):
         assert values['general']['template'] == template
         assert values['general']['http_method'] == http_method
         assert values['general']['enabled'] is False
+        assert values['credentials']['capsule_auth'] is True
+        assert values['credentials']['verify_ssl'] is False
         session.webhook.update(
             hook_name,
             {


### PR DESCRIPTION
Simply adding a check that capsule_auth is staying checked in the UI.

```
============================= test session starts ==============================
platform linux -- Python 3.9.13, pytest-7.1.2, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, cov-2.12.1, xdist-2.5.0, reportportal-5.1.2, ibutsu-2.2.2, mock-3.8.2
collected 1 item

tests/foreman/ui/test_webhook.py .                                       [100%]

================== 1 passed, 5 warnings in 340.10s (0:05:40) ===================
```