### PR TITLE
Add manifester logging configuration to robottelo

### DIFF
--- a/logging.yaml
+++ b/logging.yaml
@@ -26,5 +26,8 @@ robozilla:
 broker:
     level: WARNING
     fileLevel: DEBUG
+manifester:
+    level: INFO
+    fileLevel: DEBUG
 other:
     fileLevel: INFO

--- a/robottelo/logging.py
+++ b/robottelo/logging.py
@@ -6,6 +6,7 @@ import logzero
 import yaml
 from box import Box
 from broker.logger import setup_logzero as broker_log_setup
+from manifester.logger import setup_logzero as manifester_log_setup
 
 
 robottelo_root_dir = Path(os.environ.get('ROBOTTELO_DIR', Path(__file__).resolve().parent.parent))
@@ -42,6 +43,7 @@ def configure_third_party_logging():
         'awxkit',
         'broker',
         'easyprocess',
+        'manifester',
         'nailgun',
         'requests.packages.urllib3.connectionpool',
         'robozilla',
@@ -57,6 +59,7 @@ def configure_third_party_logging():
 
 configure_third_party_logging()
 broker_log_setup(logging_yaml.robottelo.fileLevel, str(robottelo_log_file))
+manifester_log_setup(logging_yaml.robottelo.fileLevel, str(robottelo_log_file))
 
 
 collection_logger = logzero.setup_logger(


### PR DESCRIPTION
This PR adds Manifester to the list of third-party loggers in Robottelo and enables setting debug-level Manifester logging.