### PR TITLE
Resolve ACP PRs checks waiting, using Personal Access Token

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Cherry pick into ${{ matrix.to_branch }}
         uses: jyejare/github-cherry-pick-action@main
         with:
+          token: ${{ secrets.CHERRYPICK_PAT }}
           branch: ${{ matrix.to_branch }}
           labels: |
             Auto_Cherry_Picked


### PR DESCRIPTION
After some research on why checks stay in a waiting state for the PRs created by Github Action bot, the article https://stackoverflow.com/questions/52200096/github-pull-request-waiting-for-status-to-be-reported (Answer number 2) helped me to understand the same.


So as part of the solution for the same issue for AutoCherryPick GHA PRs checks stays in `waiting` state,

<img width="854" alt="Screenshot 2022-09-09 at 12 01 32 PM" src="https://user-images.githubusercontent.com/11752425/189296999-d109b081-6681-4434-8eea-a37d28fe5ccb.png">


I have:
- Created a Personal Access Token at Robottelo repo level
- Using that Personal Access Token in ACP GHA instead of GITHUB_TOKEN.
