### PR TITLE
Add coverage for hammer negotiate auth (IDM)

### DIFF
--- a/robottelo/cli/auth.py
+++ b/robottelo/cli/auth.py
@@ -54,3 +54,9 @@ class AuthLogin(Base):
         """Supports for both with/without 2fa"""
         cls.command_sub = 'oauth'
         return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def negotiate(cls, options=None):
+        """Kerberos ticket based auth"""
+        cls.command_sub = 'negotiate'
+        return cls.execute(cls._construct_command(options), output_format='csv')

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1633,6 +1633,7 @@ VMWARE_CONSTANTS = {
 }
 
 HAMMER_CONFIG = "~/.hammer/cli.modules.d/foreman.yml"
+HAMMER_SESSIONS = "~/.hammer/sessions"
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
 FOREMAN_TEMPLATE_IMPORT_API_URL = 'http://api.github.com/repos/SatelliteQE/foreman_templates'


### PR DESCRIPTION
Introduced changes:
- added test cases for hammer negotiate auth
- added fixture to run the added cases against IDM and AD servers
- moved the IDM enrollment into fixture, added disenroll on IDM teardown to clean up the server side
