### PR TITLE
Fix master cherrypick target branch

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - id: set-branch
-        run: echo "::set-output name=previous_branch::$(if [ $GITHUB_BASE_REF  == 'master' ]; then echo $(git branch -rl --sort=-authordate 'origin/6.*.z' --format='%(refname:lstrip=-1)' | head -n1 | jq -cnR '[inputs | select(length>0)]'); else echo ['"6.'$(($(echo $GITHUB_BASE_REF | cut -d. -f2) - 1))'.z"']; fi)"
+        run: echo "::set-output name=previous_branch::$(if [ $GITHUB_BASE_REF  == 'master' ]; then echo $(git branch -rl 'origin/6.*.z' --format='%(refname:lstrip=-1)' | sort --version-sort | tail -n1 | jq -cnR '[inputs | select(length>0)]'); else echo ['"6.'$(($(echo $GITHUB_BASE_REF | cut -d. -f2) - 1))'.z"']; fi)"
 
   auto-cherry-pick:
     name: Auto Cherry Pick to previous branch


### PR DESCRIPTION
Branches were sorted by authordate which caused cherry-picking from master directly to 6.10.z as it was branch with the newest commit. This should sort branches based on version sort and pick the newest version.

Worth to note:
If some day we decide to create new version that is ahead of master that could cause some issues, but usually we are waiting with branching and master is still the newest version.