### PR TITLE
Add Http proxy test scenario related to auto-attaching subscription to content host.

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -505,6 +505,7 @@ REPOS = {
         'product': PRDS['rhel8'],
         'distro': 'rhel8',
         'key': 'rhel8_bos',
+        'basearch': 'x86_64',
     },
     'rhel8_aps': {
         'id': 'rhel-8-for-x86_64-appstream-rpms',

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -17,18 +17,12 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
 
 from robottelo import constants
 from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import promote
 from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-from robottelo.hosts import ContentHost
 from robottelo.hosts import ContentHostError
 
 
@@ -144,15 +138,20 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
     indirect=True,
     ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
 )
-@pytest.mark.cli_host_subscription
 @pytest.mark.tier3
-def test_positive_auto_attach(setup_http_proxy, module_target_sat, function_org):
+def test_positive_auto_attach(setup_http_proxy, module_target_sat, function_org, rhel7_contenthost):
     """Attempt to auto attach a subscription to content host
 
     :id: cce888b5-e023-4ee2-bffe-efa9260224ee
 
+    :customerscenario: true
+
     :expectedresults: host successfully subscribed, subscription
         repository enabled, and repository package installed
+
+    :Assignee: jpathan
+
+    :BZ: 2046337
 
     :parametrized: yes
 
@@ -162,26 +161,23 @@ def test_positive_auto_attach(setup_http_proxy, module_target_sat, function_org)
         upload_manifest(function_org.id, manifest.content)
     lce = module_target_sat.api.LifecycleEnvironment(organization=function_org).create()
     content_view = module_target_sat.api.ContentView(organization=function_org).create()
-    content_view.publish()
-    content_view = content_view.read()
-    module_target_sat.api.LifecycleEnvironment(organization=function_org).create()
-    promote(content_view.version[0], environment_id=lce.id)
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch=constants.DEFAULT_ARCHITECTURE,
         org_id=function_org.id,
-        product=PRDS['rhel'],
-        repo=REPOS['rhst7']['name'],
-        reposet=REPOSET['rhst7'],
+        product=constants.PRDS['rhel'],
+        repo=constants.REPOS['rhst7']['name'],
+        reposet=constants.REPOSET['rhst7'],
         releasever=None,
     )
     rh_repo = module_target_sat.api.Repository(id=rh_repo_id).read()
     rh_repo.sync()
+    assert rh_repo.read().content_counts['rpm'] >= 1
     cv = module_target_sat.api.ContentView(id=content_view.id, repository=[rh_repo]).update(
         ["repository"]
     )
     cv.publish()
     cv = cv.read()
-    promote(cv.version[-1], environment_id=lce.id)
+    cv.version[-1].promote(data={'environment_ids': lce.id})
     subscription = module_target_sat.api.Subscription(organization=function_org.id).search(
         query={'search': f'name="{constants.DEFAULT_SUBSCRIPTION_NAME}"'}
     )
@@ -193,23 +189,28 @@ def test_positive_auto_attach(setup_http_proxy, module_target_sat, function_org)
         auto_attach=False,
     ).create()
     activation_key.add_subscriptions(data={'subscription_id': subscription[0].id})
-
-    with Broker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
-        # Test auto-attach
-        module_target_sat.cli.Host.subscription_register(
-            {
-                'organization-id': function_org.id,
-                'content-view-id': content_view.id,
-                'lifecycle-environment-id': lce.id,
-                'name': vm.hostname,
-            }
-        )
-        host = module_target_sat.cli.Host.info({'name': vm.hostname})
-        vm.register_contenthost(org=function_org.name, activation_key=activation_key.name)
-        module_target_sat.cli.Host.subscription_auto_attach({'host-id': host['id']})
-        vm.enable_repo(REPOS['rhst7']['id'])
-        # ensure that katello agent can be installed
-        try:
-            vm.install_katello_agent()
-        except ContentHostError:
-            pytest.fail('ContentHostError raised unexpectedly!')
+    rhel7_contenthost.install_katello_ca(module_target_sat)
+    rhel7_contenthost.register_contenthost(
+        org=function_org.name, activation_key=activation_key.name
+    )
+    assert rhel7_contenthost.subscribed
+    # To Do: Use api
+    module_target_sat.cli.Host.subscription_register(
+        {
+            'organization-id': function_org.id,
+            'content-view-id': content_view.id,
+            'lifecycle-environment-id': lce.id,
+            'name': rhel7_contenthost.hostname,
+        }
+    )
+    host = module_target_sat.api.Host().search(
+        query={'search': f'name={rhel7_contenthost.hostname}'}
+    )[0]
+    # To Do: Use api
+    module_target_sat.cli.Host.subscription_auto_attach({'host-id': host.id})
+    rhel7_contenthost.enable_repo(constants.REPOS['rhst7']['id'])
+    # ensure that katello agent can be installed
+    try:
+        rhel7_contenthost.install_katello_agent()
+    except ContentHostError:
+        pytest.fail('ContentHostError raised unexpectedly!')

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -17,10 +17,19 @@
 :Upstream: No
 """
 import pytest
+from broker import Broker
 
 from robottelo import constants
+from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
+from robottelo.api.utils import promote
+from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
+from robottelo.constants import PRDS
+from robottelo.constants import REPOS
+from robottelo.constants import REPOSET
+from robottelo.hosts import ContentHost
+from robottelo.hosts import ContentHostError
 
 
 @pytest.mark.tier2
@@ -125,3 +134,82 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
     )
     assert len(yum_repo['output']) >= 1
     assert 'quay/busybox' in yum_repo['output']
+
+
+@pytest.mark.upgrade
+@pytest.mark.run_in_one_thread
+@pytest.mark.parametrize(
+    'setup_http_proxy',
+    [None, True, False],
+    indirect=True,
+    ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
+)
+@pytest.mark.cli_host_subscription
+@pytest.mark.tier3
+def test_positive_auto_attach(setup_http_proxy, module_target_sat, function_org):
+    """Attempt to auto attach a subscription to content host
+
+    :id: cce888b5-e023-4ee2-bffe-efa9260224ee
+
+    :expectedresults: host successfully subscribed, subscription
+        repository enabled, and repository package installed
+
+    :parametrized: yes
+
+    :CaseLevel: System
+    """
+    with manifests.clone() as manifest:
+        upload_manifest(function_org.id, manifest.content)
+    lce = module_target_sat.api.LifecycleEnvironment(organization=function_org).create()
+    content_view = module_target_sat.api.ContentView(organization=function_org).create()
+    content_view.publish()
+    content_view = content_view.read()
+    module_target_sat.api.LifecycleEnvironment(organization=function_org).create()
+    promote(content_view.version[0], environment_id=lce.id)
+    rh_repo_id = enable_rhrepo_and_fetchid(
+        basearch=constants.DEFAULT_ARCHITECTURE,
+        org_id=function_org.id,
+        product=PRDS['rhel'],
+        repo=REPOS['rhst7']['name'],
+        reposet=REPOSET['rhst7'],
+        releasever=None,
+    )
+    rh_repo = module_target_sat.api.Repository(id=rh_repo_id).read()
+    rh_repo.sync()
+    cv = module_target_sat.api.ContentView(id=content_view.id, repository=[rh_repo]).update(
+        ["repository"]
+    )
+    cv.publish()
+    cv = cv.read()
+    promote(cv.version[-1], environment_id=lce.id)
+    subscription = module_target_sat.api.Subscription(organization=function_org.id).search(
+        query={'search': f'name="{constants.DEFAULT_SUBSCRIPTION_NAME}"'}
+    )
+    assert len(subscription)
+    activation_key = module_target_sat.api.ActivationKey(
+        content_view=cv,
+        organization=function_org,
+        environment=lce,
+        auto_attach=False,
+    ).create()
+    activation_key.add_subscriptions(data={'subscription_id': subscription[0].id})
+
+    with Broker(nick='rhel7', host_classes={'host': ContentHost}) as vm:
+        # Test auto-attach
+        module_target_sat.cli.Host.subscription_register(
+            {
+                'organization-id': function_org.id,
+                'content-view-id': content_view.id,
+                'lifecycle-environment-id': lce.id,
+                'name': vm.hostname,
+            }
+        )
+        host = module_target_sat.cli.Host.info({'name': vm.hostname})
+        vm.register_contenthost(org=function_org.name, activation_key=activation_key.name)
+        module_target_sat.cli.Host.subscription_auto_attach({'host-id': host['id']})
+        vm.enable_repo(REPOS['rhst7']['id'])
+        # ensure that katello agent can be installed
+        try:
+            vm.install_katello_agent()
+        except ContentHostError:
+            pytest.fail('ContentHostError raised unexpectedly!')


### PR DESCRIPTION
This PR Adds Http proxy test scenario related to auto-attaching subscriptions to the content host.

Note: Manifest import, RH repo enable, and sync are also part of the test itself and that's why they are not part of the test setup.