### PR TITLE
Update expected API endpoints for 6.12

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -56,6 +56,18 @@ API_PATHS = {
         '/katello/api/activation_keys/:id/releases',
         '/katello/api/activation_keys/:id/remove_subscriptions',
     ),
+    'alternate_content_sources': (
+        '/katello/api/alternate_content_sources',
+        '/katello/api/alternate_content_sources/:id',
+        '/katello/api/alternate_content_sources',
+        '/katello/api/alternate_content_sources/:id',
+        '/katello/api/alternate_content_sources/:id',
+        '/katello/api/alternate_content_sources/:id/refresh',
+    ),
+    'alternate_content_sources_bulk_actions': (
+        '/katello/api/alternate_content_sources/bulk/destroy',
+        '/katello/api/alternate_content_sources/bulk/refresh',
+    ),
     'ansible_collections': (
         '/katello/api/ansible_collections',
         '/katello/api/ansible_collections/compare',
@@ -69,6 +81,10 @@ API_PATHS = {
     'ansible_override_values': (
         '/ansible/api/ansible_override_values',
         '/ansible/api/ansible_override_values/:id',
+    ),
+    'ansible_playbooks': (
+        '/ansible/api/ansible_playbooks/fetch',
+        '/ansible/api/ansible_playbooks/sync',
     ),
     'ansible_roles': (
         '/ansible/api/ansible_roles',
@@ -268,6 +284,7 @@ API_PATHS = {
         '/katello/api/content_views/:id',
         '/katello/api/content_views/:id',
         '/katello/api/content_views/:id',
+        '/katello/api/content_views/:id/bulk_delete_versions',
         '/katello/api/content_views/:id/copy',
         '/katello/api/content_views/:id/environments/:environment_id',
         '/katello/api/content_views/:id/publish',
@@ -450,6 +467,7 @@ API_PATHS = {
         '/api/hosts/bulk/installable_errata',
         '/api/hosts/bulk/available_incremental_updates',
         '/api/hosts/bulk/content_overrides',
+        '/api/hosts/bulk/change_content_source',
         '/api/hosts/bulk/destroy',
         '/api/hosts/bulk/environment_content_view',
         '/api/hosts/bulk/install_content',
@@ -714,6 +732,7 @@ API_PATHS = {
         '/katello/api/organizations/:organization_id/simple_content_access/eligible',
         '/katello/api/organizations/:organization_id/simple_content_access/enable',
         '/katello/api/organizations/:organization_id/simple_content_access/disable',
+        '/katello/api/organizations/:organization_id/simple_content_access/status',
     ),
     'registration': ('/api/register', '/api/register'),
     'registration_commands': ('/api/registration_commands',),
@@ -783,6 +802,7 @@ API_PATHS = {
         '/api/smart_proxies/:id',
         '/api/smart_proxies/:id',
         '/api/smart_proxies/:id',
+        '/api/smart_proxies/:id/import_subnets',
         '/api/smart_proxies/:id/refresh',
     ),
     'smart_proxy_hosts': (


### PR DESCRIPTION
**Additions:**
alternate_content_sources https://github.com/Katello/katello/pull/9906
alternate_content_sources_bulk_actions https://github.com/Katello/katello/pull/10083
ansible_playbooks https://github.com/theforeman/foreman_ansible/pull/457
bulk_delete_versions https://github.com/Katello/katello/pull/9884
change_content_source https://github.com/Katello/katello/pull/9873
simple_content_access/status https://github.com/Katello/katello/pull/10174
import_subnets https://github.com/theforeman/foreman/pull/9029

**Test Results:**
```
(.robottelo) ➜  robottelo git:(fix-endpoints-612) ✗ pytest -q --disable-pytest-warnings tests/foreman/endtoend/test_api_endtoend.py::TestAvailableURLs::test_positive_get_links
.                                                                                                                                                                          [100%]
1 passed, 4 warnings in 12.63s
```
Signed-off-by: Gaurav Talreja <gtalreja@redhat.com>