### PR TITLE
API utils helpers refactor:Part2

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -10,8 +10,6 @@ from fauxfactory import gen_string
 from packaging.version import Version
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
@@ -47,7 +45,7 @@ def module_provisioning_rhel_content(
     tasks = []
     content_view = sat.api.ContentView(organization=module_sca_manifest_org).create()
     for name in repo_names:
-        rh_kickstart_repo_id = enable_rhrepo_and_fetchid(
+        rh_kickstart_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=constants.DEFAULT_ARCHITECTURE,
             org_id=module_sca_manifest_org.id,
             product=constants.REPOS['kickstart'][name]['product'],
@@ -56,7 +54,7 @@ def module_provisioning_rhel_content(
             releasever=constants.REPOS['kickstart'][name]['version'],
         )
 
-        rh_repo_id = enable_rhrepo_and_fetchid(
+        rh_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=constants.DEFAULT_ARCHITECTURE,
             org_id=module_sca_manifest_org.id,
             product=constants.REPOS[name]['product'],
@@ -74,7 +72,7 @@ def module_provisioning_rhel_content(
             content_view.repository.append(rh_repo)
             content_view.update(['repository'])
     for task in tasks:
-        wait_for_tasks(
+        sat.wait_for_tasks(
             search_query=(f'id = {task["id"]}'),
             poll_timeout=2500,
         )
@@ -93,7 +91,7 @@ def module_provisioning_rhel_content(
     # return only the first kickstart repo - RHEL X KS or RHEL X BaseOS KS
     ksrepo = rh_repos[0]
     publish = content_view.publish()
-    task_status = wait_for_tasks(
+    task_status = sat.wait_for_tasks(
         search_query=(f'Actions::Katello::ContentView::Publish and id = {publish["id"]}'),
         search_rate=15,
         max_tries=10,

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -4,7 +4,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -37,12 +36,12 @@ def module_product(module_org, module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def rh_repo_gt_manifest(module_sca_manifest_org):
+def rh_repo_gt_manifest(module_gt_manifest_org, module_target_sat):
     """Use GT manifest org, creates RH tools repo, syncs and returns RH repo."""
     # enable rhel repo and return its ID
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=DEFAULT_ARCHITECTURE,
-        org_id=module_sca_manifest_org.id,
+        org_id=module_gt_manifest_org.id,
         product=PRDS['rhel'],
         repo=REPOS['rhst7']['name'],
         reposet=REPOSET['rhst7'],
@@ -58,7 +57,7 @@ def rh_repo_gt_manifest(module_sca_manifest_org):
 def module_rhst_repo(module_target_sat, module_org_with_manifest, module_promoted_cv, module_lce):
     """Use module org with manifest, creates RH tools repo, syncs and returns RH repo id."""
     # enable rhel repo and return its ID
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=DEFAULT_ARCHITECTURE,
         org_id=module_org_with_manifest.id,
         product=PRDS['rhel'],

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -4,9 +4,20 @@ example: my_satellite.api_factory.api_method()
 """
 from contextlib import contextmanager
 
+from fauxfactory import gen_ipaddr
+from fauxfactory import gen_mac
 from fauxfactory import gen_string
+from nailgun import entity_mixins
+from nailgun.entity_mixins import call_entity_method_with_timeout
+from requests import HTTPError
 
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_ARCHITECTURE
+from robottelo.constants import DEFAULT_PTABLE
+from robottelo.constants import DEFAULT_PXE_TEMPLATE
+from robottelo.constants import DEFAULT_TEMPLATE
+from robottelo.constants import REPO_TYPE
+from robottelo.exceptions import ImproperlyConfigured
 
 
 class APIFactory:
@@ -36,6 +47,518 @@ class APIFactory:
                 organization=[org.id],
             ).create()
 
+    def cv_publish_promote(self, name=None, env_name=None, repo_id=None, org_id=None):
+        """Create, publish and promote CV to selected environment"""
+        if org_id is None:
+            org_id = self._satellite.api.Organization().create().id
+        # Create Life-Cycle content environment
+        kwargs = {'name': env_name} if env_name is not None else {}
+        lce = self._satellite.api.LifecycleEnvironment(organization=org_id, **kwargs).create()
+        # Create content view(CV)
+        kwargs = {'name': name} if name is not None else {}
+        content_view = self._satellite.api.ContentView(organization=org_id, **kwargs).create()
+        # Associate YUM repo to created CV
+        if repo_id is not None:
+            content_view.repository = [self._satellite.api.Repository(id=repo_id)]
+            content_view = content_view.update(['repository'])
+        # Publish content view
+        content_view.publish()
+        # Promote the content view version.
+        content_view_version = content_view.read().version[0]
+        content_view_version.promote(data={'environment_ids': lce.id})
+        return content_view.read()
+
+    def enable_rhrepo_and_fetchid(
+        self, basearch, org_id, product, repo, reposet, releasever=None, strict=False
+    ):
+        """Enable a RedHat Repository and fetches it's Id.
+
+        :param str org_id: The organization Id.
+        :param str product: The product name in which repository exists.
+        :param str reposet: The reposet name in which repository exists.
+        :param str repo: The repository name who's Id is to be fetched.
+        :param str basearch: The architecture of the repository.
+        :param str optional releasever: The releasever of the repository.
+        :param bool optional strict: Raise exception if the reposet was already enabled.
+        :return: Returns the repository Id.
+        :rtype: str
+
+        """
+        product = self._satellite.api.Product(name=product, organization=org_id).search()[0]
+        r_set = self._satellite.api.RepositorySet(name=reposet, product=product).search()[0]
+        payload = {}
+        if basearch is not None:
+            payload['basearch'] = basearch
+        if releasever is not None:
+            payload['releasever'] = releasever
+        payload['product_id'] = product.id
+        try:
+            r_set.enable(data=payload)
+        except HTTPError as e:
+            if (
+                not strict
+                and e.response.status_code == 409
+                and 'repository is already enabled' in e.response.json()['displayMessage']
+            ):
+                pass
+            else:
+                raise
+        result = self._satellite.api.Repository(name=repo).search(query={'organization_id': org_id})
+        return result[0].id
+
+    def create_sync_custom_repo(
+        self,
+        org_id=None,
+        product_name=None,
+        repo_name=None,
+        repo_url=None,
+        repo_type=None,
+        repo_unprotected=True,
+        docker_upstream_name=None,
+    ):
+        """Create product/repo, sync it and returns repo_id"""
+        if org_id is None:
+            org_id = self._satellite.api.Organization().create().id
+        product_name = product_name or gen_string('alpha')
+        repo_name = repo_name or gen_string('alpha')
+        # Creates new product and repository via API's
+        product = self._satellite.api.Product(name=product_name, organization=org_id).create()
+        repo = self._satellite.api.Repository(
+            name=repo_name,
+            url=repo_url or settings.repos.yum_1.url,
+            content_type=repo_type or REPO_TYPE['yum'],
+            product=product,
+            unprotected=repo_unprotected,
+            docker_upstream_name=docker_upstream_name,
+        ).create()
+        # Sync repository
+        self._satellite.api.Repository(id=repo.id).sync()
+        return repo.id
+
+    def enable_sync_redhat_repo(self, rh_repo, org_id, timeout=1500):
+        """Enable the RedHat repo, sync it and returns repo_id"""
+        # Enable RH repo and fetch repository_id
+        repo_id = self.enable_rhrepo_and_fetchid(
+            basearch=rh_repo['basearch'],
+            org_id=org_id,
+            product=rh_repo['product'],
+            repo=rh_repo['name'],
+            reposet=rh_repo['reposet'],
+            releasever=rh_repo['releasever'],
+        )
+        # Sync repository
+        call_entity_method_with_timeout(
+            self._satellite.api.Repository(id=repo_id).sync, timeout=timeout
+        )
+        return repo_id
+
+    def one_to_one_names(name):
+        """Generate the names Satellite might use for a one to one field.
+
+        Example of usage::
+
+            >>> one_to_one_names('person') == {'person_name', 'person_id'}
+            True
+
+        :param name: A field name.
+        :returns: A set including both ``name`` and variations on ``name``.
+
+        """
+        return {name + '_name', name + '_id'}
+
+    def configure_provisioning(self, org=None, loc=None, compute=False, os=None):
+        """Create and configure org, loc, product, repo, cv, env. Update proxy,
+        domain, subnet, compute resource, provision templates and medium with
+        previously created entities and create a hostgroup using all mentioned
+        entities.
+
+        :param str org: Default Organization that should be used in both host
+            discovering and host provisioning procedures
+        :param str loc: Default Location that should be used in both host
+            discovering and host provisioning procedures
+        :param bool compute: If False creates a default Libvirt compute resource
+        :param str os: Specify the os to be used while provisioning and to
+            associate related entities to the specified os.
+        :return: List of created entities that can be re-used further in
+            provisioning or validation procedure (e.g. hostgroup or domain)
+        """
+        # Create new organization and location in case they were not passed
+        if org is None:
+            org = self._satellite.api.Organization().create()
+        if loc is None:
+            loc = self._satellite.api.Location(organization=[org]).create()
+        if settings.repos.rhel7_os is None:
+            raise ImproperlyConfigured('settings file is not configured for rhel os')
+        # Create a new Life-Cycle environment
+        lc_env = self._satellite.api.LifecycleEnvironment(organization=org).create()
+        # Create a Product, Repository for custom RHEL7 contents
+        product = self._satellite.api.Product(organization=org).create()
+        repo = self._satellite.api.Repository(
+            product=product, url=settings.repos.rhel7_os, download_policy='immediate'
+        ).create()
+
+        # Increased timeout value for repo sync and CV publishing and promotion
+        try:
+            old_task_timeout = entity_mixins.TASK_TIMEOUT
+            entity_mixins.TASK_TIMEOUT = 3600
+            repo.sync()
+            # Create, Publish and promote CV
+            content_view = self._satellite.api.ContentView(organization=org).create()
+            content_view.repository = [repo]
+            content_view = content_view.update(['repository'])
+            content_view.publish()
+            content_view = content_view.read()
+            content_view.read().version[0].promote(data={'environment_ids': lc_env.id})
+        finally:
+            entity_mixins.TASK_TIMEOUT = old_task_timeout
+        # Search for existing organization puppet environment, otherwise create a
+        # new one, associate organization and location where it is appropriate.
+        environments = self._satellite.api.Environment().search(
+            query=dict(search=f'organization_id={org.id}')
+        )
+        if len(environments) > 0:
+            environment = environments[0].read()
+            environment.location.append(loc)
+            environment = environment.update(['location'])
+        else:
+            environment = self._satellite.api.Environment(
+                organization=[org], location=[loc]
+            ).create()
+
+        # Search for SmartProxy, and associate location
+        proxy = self._satellite.api.SmartProxy().search(
+            query={'search': f'name={settings.server.hostname}'}
+        )
+        proxy = proxy[0].read()
+        if loc.id not in [location.id for location in proxy.location]:
+            proxy.location.append(loc)
+        if org.id not in [organization.id for organization in proxy.organization]:
+            proxy.organization.append(org)
+        proxy = proxy.update(['location', 'organization'])
+
+        # Search for existing domain or create new otherwise. Associate org,
+        # location and dns to it
+        _, _, domain = settings.server.hostname.partition('.')
+        domain = self._satellite.api.Domain().search(query={'search': f'name="{domain}"'})
+        if len(domain) == 1:
+            domain = domain[0].read()
+            domain.location.append(loc)
+            domain.organization.append(org)
+            domain.dns = proxy
+            domain = domain.update(['dns', 'location', 'organization'])
+        else:
+            domain = self._satellite.api.Domain(
+                dns=proxy, location=[loc], organization=[org]
+            ).create()
+
+        # Search if subnet is defined with given network.
+        # If so, just update its relevant fields otherwise,
+        # Create new subnet
+        network = settings.vlan_networking.subnet
+        subnet = self._satellite.api.Subnet().search(query={'search': f'network={network}'})
+        if len(subnet) == 1:
+            subnet = subnet[0].read()
+            subnet.domain = [domain]
+            subnet.location.append(loc)
+            subnet.organization.append(org)
+            subnet.dns = proxy
+            subnet.dhcp = proxy
+            subnet.tftp = proxy
+            subnet.discovery = proxy
+            subnet.ipam = 'DHCP'
+            subnet = subnet.update(
+                ['domain', 'discovery', 'dhcp', 'dns', 'location', 'organization', 'tftp', 'ipam']
+            )
+        else:
+            # Create new subnet
+            subnet = self._satellite.api.Subnet(
+                network=network,
+                mask=settings.vlan_networking.netmask,
+                domain=[domain],
+                location=[loc],
+                organization=[org],
+                dns=proxy,
+                dhcp=proxy,
+                tftp=proxy,
+                discovery=proxy,
+                ipam='DHCP',
+            ).create()
+
+        # Search if Libvirt compute-resource already exists
+        # If so, just update its relevant fields otherwise,
+        # Create new compute-resource with 'libvirt' provider.
+        # compute boolean is added to not block existing test's that depend on
+        # Libvirt resource and use this same functionality to all CR's.
+        if compute is False:
+            resource_url = f'qemu+ssh://root@{settings.libvirt.libvirt_hostname}/system'
+            comp_res = [
+                res
+                for res in self._satellite.api.LibvirtComputeResource().search()
+                if res.provider == 'Libvirt' and res.url == resource_url
+            ]
+            if len(comp_res) > 0:
+                computeresource = self._satellite.api.LibvirtComputeResource(
+                    id=comp_res[0].id
+                ).read()
+                computeresource.location.append(loc)
+                computeresource.organization.append(org)
+                computeresource.update(['location', 'organization'])
+            else:
+                # Create Libvirt compute-resource
+                self._satellite.api.LibvirtComputeResource(
+                    provider='libvirt',
+                    url=resource_url,
+                    set_console_password=False,
+                    display_type='VNC',
+                    location=[loc.id],
+                    organization=[org.id],
+                ).create()
+
+        # Get the Partition table ID
+        ptable = (
+            self._satellite.api.PartitionTable()
+            .search(query={'search': f'name="{DEFAULT_PTABLE}"'})[0]
+            .read()
+        )
+        if loc.id not in [location.id for location in ptable.location]:
+            ptable.location.append(loc)
+        if org.id not in [organization.id for organization in ptable.organization]:
+            ptable.organization.append(org)
+        ptable = ptable.update(['location', 'organization'])
+
+        # Get the OS ID
+        if os is None:
+            os = (
+                self._satellite.api.OperatingSystem()
+                .search(query={'search': 'name="RedHat" AND (major="6" OR major="7")'})[0]
+                .read()
+            )
+        else:
+            os_ver = os.split(' ')[1].split('.')
+            os = (
+                self._satellite.api.OperatingSystem()
+                .search(
+                    query={
+                        'search': f'family="Redhat" AND major="{os_ver[0]}" '
+                        f'AND minor="{os_ver[1]}")'
+                    }
+                )[0]
+                .read()
+            )
+
+        # Get the Provisioning template_ID and update with OS, Org, Location
+        provisioning_template = self._satellite.api.ProvisioningTemplate().search(
+            query={'search': f'name="{DEFAULT_TEMPLATE}"'}
+        )
+        provisioning_template = provisioning_template[0].read()
+        provisioning_template.operatingsystem.append(os)
+        if org.id not in [organization.id for organization in provisioning_template.organization]:
+            provisioning_template.organization.append(org)
+        if loc.id not in [location.id for location in provisioning_template.location]:
+            provisioning_template.location.append(loc)
+        provisioning_template = provisioning_template.update(
+            ['location', 'operatingsystem', 'organization']
+        )
+
+        # Get the PXE template ID and update with OS, Org, location
+        pxe_template = self._satellite.api.ProvisioningTemplate().search(
+            query={'search': f'name="{DEFAULT_PXE_TEMPLATE}"'}
+        )
+        pxe_template = pxe_template[0].read()
+        pxe_template.operatingsystem.append(os)
+        if org.id not in [organization.id for organization in pxe_template.organization]:
+            pxe_template.organization.append(org)
+        if loc.id not in [location.id for location in pxe_template.location]:
+            pxe_template.location.append(loc)
+        pxe_template = pxe_template.update(['location', 'operatingsystem', 'organization'])
+
+        # Get the arch ID
+        arch = (
+            self._satellite.api.Architecture()
+            .search(query={'search': f'name="{DEFAULT_ARCHITECTURE}"'})[0]
+            .read()
+        )
+
+        # Update the OS to associate arch, ptable, templates
+        os.architecture.append(arch)
+        os.ptable.append(ptable)
+        os.provisioning_template.append(provisioning_template)
+        os.provisioning_template.append(pxe_template)
+        os = os.update(['architecture', 'provisioning_template', 'ptable'])
+        # kickstart_repository is the content view and lce bind repo
+        kickstart_repository = self._satellite.api.Repository().search(
+            query=dict(content_view_id=content_view.id, environment_id=lc_env.id, name=repo.name)
+        )[0]
+        # Create Hostgroup
+        host_group = self._satellite.api.HostGroup(
+            architecture=arch,
+            domain=domain.id,
+            subnet=subnet.id,
+            lifecycle_environment=lc_env.id,
+            content_view=content_view.id,
+            location=[loc.id],
+            environment=environment.id,
+            puppet_proxy=proxy,
+            puppet_ca_proxy=proxy,
+            content_source=proxy,
+            kickstart_repository=kickstart_repository,
+            root_pass=gen_string('alphanumeric'),
+            operatingsystem=os.id,
+            organization=[org.id],
+            ptable=ptable.id,
+        ).create()
+
+        return {
+            'host_group': host_group.name,
+            'domain': domain.name,
+            'environment': environment.name,
+            'ptable': ptable.name,
+            'subnet': subnet.name,
+            'os': os.title,
+        }
+
+    def create_role_permissions(
+        self, role, permissions_types_names, search=None
+    ):  # pragma: no cover
+        """Create role permissions found in dict permissions_types_names.
+
+        :param role: nailgun.entities.Role
+        :param permissions_types_names: a dict containing resource types
+            and permission names to add to the role.
+        :param search: string that contains search criteria that should be applied
+            to the filter
+
+              example usage::
+
+               permissions_types_names = {
+                   None: ['access_dashboard'],
+                   'Organization': ['view_organizations'],
+                   'Location': ['view_locations'],
+                   'Katello::KTEnvironment': [
+                       'view_lifecycle_environments',
+                       'edit_lifecycle_environments',
+                       'promote_or_remove_content_views_to_environments'
+                   ]
+               }
+               role = entities.Role(name='example_role_name').create()
+               create_role_permissions(
+                   role,
+                   permissions_types_names,
+                   'name = {0}'.format(lce.name)
+               )
+        """
+        for resource_type, permissions_name in permissions_types_names.items():
+            if resource_type is None:
+                permissions_entities = []
+                for name in permissions_name:
+                    result = self._satellite.api.Permission().search(
+                        query={'search': f'name="{name}"'}
+                    )
+                    if not result:
+                        raise self._satellite.api.APIResponseError(f'permission "{name}" not found')
+                    if len(result) > 1:
+                        raise self._satellite.api.APIResponseError(
+                            f'found more than one entity for permission "{name}"'
+                        )
+                    entity_permission = result[0]
+                    if entity_permission.name != name:
+                        raise self._satellite.api.APIResponseError(
+                            'the returned permission is different from the'
+                            ' requested one "{} != {}"'.format(entity_permission.name, name)
+                        )
+                    permissions_entities.append(entity_permission)
+            else:
+                if not permissions_name:
+                    raise ValueError(
+                        'resource type "{}" empty. You must select at'
+                        ' least one permission'.format(resource_type)
+                    )
+
+                resource_type_permissions_entities = self._satellite.api.Permission().search(
+                    query={'per_page': '350', 'search': f'resource_type="{resource_type}"'}
+                )
+                if not resource_type_permissions_entities:
+                    raise self._satellite.api.APIResponseError(
+                        f'resource type "{resource_type}" permissions not found'
+                    )
+
+                permissions_entities = [
+                    entity
+                    for entity in resource_type_permissions_entities
+                    if entity.name in permissions_name
+                ]
+                # ensure that all the requested permissions entities where
+                # retrieved
+                permissions_entities_names = {entity.name for entity in permissions_entities}
+                not_found_names = set(permissions_name).difference(permissions_entities_names)
+                if not_found_names:
+                    raise self._satellite.api.APIResponseError(
+                        f'permissions names entities not found "{not_found_names}"'
+                    )
+            self._satellite.api.Filter(
+                permission=permissions_entities, role=role, search=search
+            ).create()
+
+    def create_discovered_host(self, name=None, ip_address=None, mac_address=None, options=None):
+        """Creates a discovered host.
+
+        :param str name: Name of discovered host.
+        :param str ip_address: A valid ip address.
+        :param str mac_address: A valid mac address.
+        :param dict options: additional facts to add to discovered host
+        :return: dict of ``entities.DiscoveredHost`` facts.
+        """
+        if name is None:
+            name = gen_string('alpha')
+        if ip_address is None:
+            ip_address = gen_ipaddr()
+        if mac_address is None:
+            mac_address = gen_mac(multicast=False)
+        if options is None:
+            options = {}
+        facts = {
+            'name': name,
+            'discovery_bootip': ip_address,
+            'discovery_bootif': mac_address,
+            'interfaces': 'eth0',
+            'ipaddress': ip_address,
+            'ipaddress_eth0': ip_address,
+            'macaddress': mac_address,
+            'macaddress_eth0': mac_address,
+        }
+        facts.update(options)
+        return self._satellite.api.DiscoveredHost().facts(json={'facts': facts})
+
+    def update_vm_host_location(self, vm_client, location_id):
+        """Update vm client host location.
+
+        :param vm_client: A subscribed Virtual Machine client instance.
+        :param location_id: The location id to update the vm_client host with.
+        """
+        host = self._satellite.api.Host().search(query={'search': f'name={vm_client.hostname}'})[0]
+        host.location = self._satellite.api.Location(id=location_id)
+        host.update(['location'])
+
+    def check_create_os_with_title(self, os_title):
+        """Check if the OS is present, if not create the required OS
+
+        :param os_title: OS title to check, and create (like: RedHat 7.5)
+        :return: Created or found OS
+        """
+        # Check if OS that image needs is present or no, If not create the OS
+        result = self._satellite.api.OperatingSystem().search(
+            query={'search': f'title="{os_title}"'}
+        )
+        if result:
+            os = result[0]
+        else:
+            os_name, _, os_version = os_title.partition(' ')
+            os_version_major, os_version_minor = os_version.split('.')
+            os = self._satellite.api.OperatingSystem(
+                name=os_name, major=os_version_major, minor=os_version_minor
+            ).create()
+        return os
+
     @contextmanager
     def satellite_setting(self, key_val: str):
         """Context Manager to update the satellite setting and revert on exit
@@ -59,3 +582,67 @@ class APIFactory:
         finally:
             setting.value = old_value
             setting.update({'value'})
+
+    def update_provisioning_template(self, name=None, old=None, new=None):
+        """Update provisioning template content
+
+        :param str name: template provisioning name
+        :param str old: current content
+        :param str new: replace content
+
+        :return bool: True/False
+        """
+        temp = (
+            self._satellite.api.ProvisioningTemplate()
+            .search(query={'per_page': '1000', 'search': f'name="{name}"'})[0]
+            .read()
+        )
+        if old in temp.template:
+            with templateupdate(temp):
+                temp.template = temp.template.replace(old, new, 1)
+                update = temp.update(['template'])
+            return new in update.template
+        elif new in temp.template:
+            return True
+        else:
+            raise ValueError(f'{old} does not exists in template {name}')
+
+    def disable_syncplan(self, sync_plan):
+        """
+        Disable sync plans after a test to reduce distracting task events, logs,
+        and load on Satellite.
+        Note that only a Sync Plan with a repo would create a noticeable load.
+        You can also create sync plans in a disabled state where it is unlikely to impact the test.
+        """
+        sync_plan.enabled = False
+        sync_plan = sync_plan.update(['enabled'])
+        assert sync_plan.enabled is False
+
+
+class templateupdate:
+    """Context Manager to unlock lock template for updating"""
+
+    def __init__(self, temp):
+        """Context manager that takes entities.ProvisioningTemplate's object
+
+        :param entities.ProvisioningTemplate temp: entities.ProvisioningTemplate's object
+        """
+        self.temp = temp
+        if not isinstance(self.temp, self._satellite.api.ProvisioningTemplate):
+            raise TypeError(
+                'The template should be of type entities.ProvisioningTemplate, {} given'.format(
+                    type(temp)
+                )
+            )
+
+    def __enter__(self):
+        """Unlocks template for update"""
+        if self.temp.locked:
+            self.temp.locked = False
+            self.temp.update(['locked'])
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Locks template after update"""
+        if not self.temp.locked:
+            self.temp.locked = True
+            self.temp.update(['locked'])

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -4,7 +4,6 @@ from functools import cached_property
 from tempfile import NamedTemporaryFile
 
 from robottelo import constants
-from robottelo.api import utils
 from robottelo.config import robottelo_tmp_dir
 from robottelo.config import settings
 from robottelo.logging import logger
@@ -84,7 +83,7 @@ class VersionedContent:
         )
 
     def enable_tools_repo(self, organization_id):
-        return utils.enable_rhrepo_and_fetchid(
+        return self.satellite.api_factory.enable_rhrepo_and_fetchid(
             basearch=constants.DEFAULT_ARCHITECTURE,
             org_id=organization_id,
             product=constants.PRDS['rhel'],
@@ -94,7 +93,7 @@ class VersionedContent:
         )
 
     def enable_rhel_repo(self, organization_id):
-        return utils.enable_rhrepo_and_fetchid(
+        return self.satellite.api_factory.enable_rhrepo_and_fetchid(
             basearch=constants.DEFAULT_ARCHITECTURE,
             org_id=organization_id,
             product=constants.PRDS['rhel'],

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -29,7 +29,6 @@ from wait_for import wait_for
 from wrapanapi.entities.vm import VmState
 
 from robottelo import constants
-from robottelo.api.utils import update_provisioning_template
 from robottelo.cli.base import Base
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.config import configure_airgun
@@ -1698,9 +1697,9 @@ class Satellite(Capsule, SatelliteMixins):
         """
         old = 'yum -t -y update'
         new = 'echo "Yum update skipped for faster automation testing"'
-        update_provisioning_template(name=template, old=old, new=new)
+        self.satellite.update_provisioning_template(name=template, old=old, new=new)
         yield
-        update_provisioning_template(name=template, old=new, new=old)
+        self.satellite.update_provisioning_template(name=template, old=new, new=old)
 
     def update_setting(self, name, value):
         """changes setting value and returns the setting value before the change."""

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -25,7 +25,6 @@ from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import get_credentials
 from robottelo.config import user_nailgun_config
 from robottelo.constants import PRDS
@@ -450,7 +449,7 @@ def test_positive_fetch_product_content(
     :CaseImportance: Critical
     """
     module_target_sat.upload_manifest(module_org.id, session_entitlement_manifest.content)
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=module_org.id,
         product=PRDS['rhel'],

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -26,7 +26,6 @@ from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.constants import DataFile
 from robottelo.constants.repos import ANSIBLE_GALAXY
@@ -130,7 +129,7 @@ class TestSatelliteContentManagement:
         :BZ: 1687801
         """
         distro = 'rhel8_bos'
-        rh_repo_id = enable_rhrepo_and_fetchid(
+        rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_entitlement_manifest_org.id,
             product=constants.REPOS['kickstart'][distro]['product'],
@@ -160,7 +159,9 @@ class TestSatelliteContentManagement:
             if isinstance(ver, int)
         ],
     )
-    def test_positive_sync_kickstart_check_os(self, module_entitlement_manifest_org, distro):
+    def test_positive_sync_kickstart_check_os(
+        self, module_entitlement_manifest_org, distro, target_sat
+    ):
         """Sync rhel KS repo and assert that OS was created
 
         :id: f84bcf1b-717e-40e7-82ee-000eead45249
@@ -176,7 +177,7 @@ class TestSatelliteContentManagement:
 
         """
         distro = f'rhel{distro} + "_bos"' if distro > 7 else f'rhel{distro}'
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_entitlement_manifest_org.id,
             product=constants.REPOS['kickstart'][distro]['product'],
@@ -747,7 +748,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients')
     def test_positive_iso_library_sync(
-        self, module_capsule_configured, module_entitlement_manifest_org
+        self, module_capsule_configured, module_entitlement_manifest_org, module_target_sat
     ):
         """Ensure RH repo with ISOs after publishing to Library is synchronized
         to capsule automatically
@@ -763,7 +764,7 @@ class TestCapsuleContentManagement:
         :CaseLevel: System
         """
         # Enable & sync RH repository with ISOs
-        rh_repo_id = enable_rhrepo_and_fetchid(
+        rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_entitlement_manifest_org.id,
             product=constants.PRDS['rhsc'],
@@ -1046,7 +1047,7 @@ class TestCapsuleContentManagement:
 
         :BZ: 1992329
         """
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=function_entitlement_manifest_org.id,
             product=constants.REPOS['kickstart'][distro]['product'],
@@ -1462,7 +1463,7 @@ class TestCapsuleContentManagement:
         :BZ: 1830403
         """
         # Sync a repository to the Satellite.
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_manifest_org.id,
             product=constants.PRDS['rhel'],

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -25,8 +25,6 @@ from fauxfactory import gen_utf8
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.api.utils import apply_package_filter
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.config import user_nailgun_config
 from robottelo.constants import CONTAINER_REGISTRY_HUB
@@ -82,6 +80,29 @@ def class_published_cloned_cv(class_cloned_cv):
 @pytest.fixture
 def content_view(module_org):
     return entities.ContentView(organization=module_org).create()
+
+
+def apply_package_filter(content_view, repo, package, target_sat, inclusion=True):
+    """Apply package filter on content view
+
+    :param content_view: entity content view
+    :param repo: entity repository
+    :param str package: package name to filter
+    :param bool inclusion: True/False based on include or exclude filter
+
+    :return list : list of content view versions
+    """
+    cv_filter = entities.RPMContentViewFilter(
+        content_view=content_view, inclusion=inclusion, repository=[repo]
+    ).create()
+    cv_filter_rule = target_sat.api.ContentViewFilterRule(
+        content_view_filter=cv_filter, name=package
+    ).create()
+    assert cv_filter.id == cv_filter_rule.content_view_filter.id
+    content_view.publish()
+    content_view = content_view.read()
+    content_view_version_info = content_view.version[0].read()
+    return content_view_version_info
 
 
 class TestContentView:
@@ -821,10 +842,12 @@ class TestContentViewRedHatContent:
     """Tests for publishing and promoting content views."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def initiate_testclass(self, request, module_cv, module_entitlement_manifest_org):
+    def initiate_testclass(
+        self, request, module_cv, module_entitlement_manifest_org, module_target_sat
+    ):
         """Set up organization, product and repositories for tests."""
 
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_entitlement_manifest_org.id,
             product=PRDS['rhel'],
@@ -1374,10 +1397,10 @@ class TestContentViewRedHatOstreeContent:
 
     @pytest.mark.run_in_one_thread
     @pytest.fixture(scope='class', autouse=True)
-    def initiate_testclass(self, request, module_entitlement_manifest_org):
+    def initiate_testclass(self, request, module_entitlement_manifest_org, class_target_sat):
         """Set up organization, product and repositories for tests."""
 
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = class_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=None,
             org_id=module_entitlement_manifest_org.id,
             product=PRDS['rhah'],
@@ -1449,7 +1472,7 @@ class TestContentViewRedHatOstreeContent:
     @pytest.mark.tier2
     @pytest.mark.upgrade
     def test_positive_publish_promote_with_RH_ostree_and_other(
-        self, content_view, module_org, module_lce
+        self, content_view, module_org, module_lce, module_target_sat
     ):
         """Publish & Promote a content view with RH ostree and other contents
 
@@ -1462,7 +1485,7 @@ class TestContentViewRedHatOstreeContent:
 
         :CaseImportance: High
         """
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_org.id,
             product=PRDS['rhel'],

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -17,8 +17,6 @@
 import pytest
 import requests
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
@@ -110,7 +108,7 @@ def enable_rhel_subscriptions(module_target_sat, module_entitlement_manifest_org
     rh_repos = []
     tasks = []
     for name in repo_names:
-        rh_repo_id = enable_rhrepo_and_fetchid(
+        rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=DEFAULT_ARCHITECTURE,
             org_id=module_entitlement_manifest_org.id,
             product=REPOS[name]['product'],
@@ -124,7 +122,7 @@ def enable_rhel_subscriptions(module_target_sat, module_entitlement_manifest_org
         tasks.append(task)
         rh_repos.append(rh_repo)
     for task in tasks:
-        wait_for_tasks(
+        module_target_sat.wait_for_tasks(
             search_query=(f'id = {task["id"]}'),
             poll_timeout=2500,
         )
@@ -250,7 +248,7 @@ def test_convert2rhel_oracle(target_sat, oracle, activation_key_rhel, version):
         },
     )
     # wait for job to complete
-    wait_for_tasks(
+    target_sat.wait_for_tasks(
         f'resource_type = JobInvocation and resource_id = {job["id"]}', poll_timeout=1000
     )
     result = target_sat.api.JobInvocation(id=job['id']).read()
@@ -306,7 +304,7 @@ def test_convert2rhel_centos(target_sat, centos, activation_key_rhel, version):
         },
     )
     # wait for job to complete
-    wait_for_tasks(
+    target_sat.wait_for_tasks(
         f'resource_type = JobInvocation and resource_id = {job["id"]}', poll_timeout=1000
     )
     result = target_sat.api.JobInvocation(id=job['id']).read()

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -23,8 +23,6 @@ import pytest
 from nailgun import entities
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.cli.factory import setup_org_for_a_rh_repo
 from robottelo.cli.host import Host
@@ -203,7 +201,7 @@ def test_positive_install_in_hc(module_org, activation_key, custom_repo, target_
             'organization_id': module_org.id,
         },
     )['id']
-    wait_for_tasks(
+    target_sat.wait_for_tasks(
         search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
         search_rate=15,
         max_tries=10,
@@ -255,7 +253,7 @@ def test_positive_install_in_host(
             'organization_id': module_org.id,
         },
     )['id']
-    wait_for_tasks(
+    target_sat.wait_for_tasks(
         search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
         search_rate=15,
         max_tries=10,
@@ -311,7 +309,7 @@ def test_positive_install_multiple_in_host(
                 'organization_id': module_org.id,
             },
         )['id']
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
             search_rate=20,
             max_tries=15,
@@ -413,7 +411,7 @@ def test_positive_sorted_issue_date_and_filter_by_cve(module_org, custom_repo, t
 
 
 @pytest.fixture(scope='module')
-def setup_content_rhel6(module_entitlement_manifest_org):
+def setup_content_rhel6(module_entitlement_manifest_org, module_target_sat):
     """Setup content fot rhel6 content host
     Using `Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)`
     from manifest, SATTOOLS_REPO for host-tools and yum_9 repo as custom repo.
@@ -421,7 +419,7 @@ def setup_content_rhel6(module_entitlement_manifest_org):
     :return: Activation Key, Organization, subscription list
     """
     org = module_entitlement_manifest_org
-    rh_repo_id_rhva = enable_rhrepo_and_fetchid(
+    rh_repo_id_rhva = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=constants.PRDS['rhel'],
@@ -819,10 +817,10 @@ def test_errata_installation_with_swidtags(
 
 
 @pytest.fixture(scope='module')
-def rh_repo_module_manifest(module_entitlement_manifest_org):
+def rh_repo_module_manifest(module_entitlement_manifest_org, module_target_sat):
     """Use module manifest org, creates tools repo, syncs and returns RH repo."""
     # enable rhel repo and return its ID
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=constants.DEFAULT_ARCHITECTURE,
         org_id=module_entitlement_manifest_org.id,
         product=constants.PRDS['rhel8'],

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -25,7 +25,6 @@ from nailgun import entities
 from nailgun import entity_fields
 from requests.exceptions import HTTPError
 
-from robottelo.api.utils import one_to_one_names
 from robottelo.config import get_credentials
 from robottelo.utils.datafactory import invalid_values_list
 from robottelo.utils.datafactory import parametrized
@@ -664,7 +663,7 @@ class TestHostGroupMissingAttr:
     """
 
     @pytest.mark.tier2
-    def test_positive_get_content_source(self, hostgroup):
+    def test_positive_get_content_source(self, hostgroup, module_target_sat):
         """Read a host group. Inspect the server's response.
 
         :id: 9d42f47a-2f08-45ad-97d0-de94f0f1de2f
@@ -676,14 +675,14 @@ class TestHostGroupMissingAttr:
 
         :CaseLevel: Integration
         """
-        names = one_to_one_names('content_source')
+        names = module_target_sat.api_factory.one_to_one_names('content_source')
         hostgroup_attrs = set(hostgroup.read_json().keys())
         assert names.issubset(
             hostgroup_attrs
         ), f'{names.difference(hostgroup_attrs)} not found in {hostgroup_attrs}'
 
     @pytest.mark.tier2
-    def test_positive_get_cv(self, hostgroup):
+    def test_positive_get_cv(self, hostgroup, module_target_sat):
         """Read a host group. Inspect the server's response.
 
         :id: 7d36f33e-f161-4d2a-9ee4-8eb949ed4cbf
@@ -695,14 +694,14 @@ class TestHostGroupMissingAttr:
 
         :CaseLevel: Integration
         """
-        names = one_to_one_names('content_view')
+        names = module_target_sat.api_factory.one_to_one_names('content_view')
         hostgroup_attrs = set(hostgroup.read_json().keys())
         assert names.issubset(
             hostgroup_attrs
         ), f'{names.difference(hostgroup_attrs)} not found in {hostgroup_attrs}'
 
     @pytest.mark.tier2
-    def test_positive_get_lce(self, hostgroup):
+    def test_positive_get_lce(self, hostgroup, module_target_sat):
         """Read a host group. Inspect the server's response.
 
         :id: efa17f59-47f9-40c6-821d-c348c4d852ff
@@ -714,7 +713,7 @@ class TestHostGroupMissingAttr:
 
         :CaseLevel: Integration
         """
-        names = one_to_one_names('lifecycle_environment')
+        names = module_target_sat.api_factory.one_to_one_names('lifecycle_environment')
         hostgroup_attrs = set(hostgroup.read_json().keys())
         assert names.issubset(
             hostgroup_attrs

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -19,8 +19,6 @@
 import pytest
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import enable_sync_redhat_repo
 from robottelo.config import settings
 
 
@@ -62,7 +60,7 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
     http_proxy_id = http_proxy.id if http_proxy_type is not None else None
     http_proxy_policy = 'use_selected_http_proxy' if http_proxy_type is not None else 'none'
     # Assign http_proxy to Redhat repository and perform repository sync.
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=constants.DEFAULT_ARCHITECTURE,
         org_id=module_manifest_org.id,
         product=constants.PRDS['rhae'],
@@ -162,7 +160,9 @@ def test_positive_auto_attach_with_http_proxy(
     org = function_entitlement_manifest_org
     lce = module_target_sat.api.LifecycleEnvironment(organization=org).create()
     content_view = module_target_sat.api.ContentView(organization=org).create()
-    rh_repo_id = enable_sync_redhat_repo(constants.REPOS['rhel8_bos'], org.id)
+    rh_repo_id = module_target_sat.api_factory.enable_sync_redhat_repo(
+        constants.REPOS['rhel8_bos'], org.id
+    )
     rh_repo = module_target_sat.api.Repository(id=rh_repo_id).read()
     assert rh_repo.content_counts['rpm'] >= 1
     content_view = module_target_sat.api.ContentView(

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -18,7 +18,6 @@
 """
 import pytest
 
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.hosts import get_sat_version
 from robottelo.utils import ohsnap
@@ -62,7 +61,7 @@ def test_positive_run_capsule_upgrade_playbook(module_capsule_configured, target
             'search_query': f'name = {module_capsule_configured.hostname}',
         },
     )
-    wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
     result = target_sat.api.JobInvocation(id=job['id']).read()
     assert result.succeeded == 1
     result = target_sat.execute('satellite-maintain health check')
@@ -149,7 +148,7 @@ def test_negative_time_to_pickup(
             'time_to_pickup': '5',
         },
     )
-    wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    module_target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
     result = module_target_sat.api.JobInvocation(id=job['id']).read()
     assert result.succeeded == 1
     # stop yggdrasil client on host
@@ -178,7 +177,7 @@ def test_negative_time_to_pickup(
             'time_to_pickup': '10',
         },
     )
-    wait_for_tasks(
+    module_target_sat.wait_for_tasks(
         f'resource_type = JobInvocation and resource_id = {job["id"]}', must_succeed=False
     )
     result = module_target_sat.api.JobInvocation(id=job['id']).read()
@@ -207,7 +206,7 @@ def test_negative_time_to_pickup(
             'search_query': f'name = {rhel_contenthost.hostname}',
         },
     )
-    wait_for_tasks(
+    module_target_sat.wait_for_tasks(
         f'resource_type = JobInvocation and resource_id = {job["id"]}', must_succeed=False
     )
     result = module_target_sat.api.JobInvocation(id=job['id']).read()

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -23,7 +23,6 @@ from nailgun import entities
 from requests import HTTPError
 from wait_for import wait_for
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -35,9 +34,9 @@ from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
-def setup_content(module_entitlement_manifest_org):
+def setup_content(module_entitlement_manifest_org, module_target_sat):
     org = module_entitlement_manifest_org
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=PRDS['rhel'],

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -20,7 +20,6 @@ import pytest
 from requests.exceptions import HTTPError
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.constants import MIRRORING_POLICIES
 from robottelo.utils.datafactory import parametrized
@@ -41,7 +40,7 @@ def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, ta
 
     :expectedresults: A message should be thrown saying you cannot disable the Repo
     """
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=constants.DEFAULT_ARCHITECTURE,
         org_id=module_entitlement_manifest_org.id,
         product=constants.PRDS['rhel8'],

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -33,7 +33,6 @@ from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.constants import DataFile
 from robottelo.constants import repos as repo_constants
@@ -1170,7 +1169,7 @@ class TestRepository:
         :expectedresults: foreman-rake katello:correct_repositories COMMIT=true recreates deleted
          repos with no TaskErrors
         """
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_entitlement_manifest_org.id,
             product=constants.PRDS['rhel'],
@@ -1200,7 +1199,7 @@ class TestRepositorySync:
     """Tests for ``/katello/api/repositories/:id/sync``."""
 
     @pytest.mark.tier2
-    def test_positive_sync_rh(self, module_entitlement_manifest_org):
+    def test_positive_sync_rh(self, module_entitlement_manifest_org, target_sat):
         """Sync RedHat Repository.
 
         :id: d69c44cd-753c-4a75-9fd5-a8ed963b5e04
@@ -1209,7 +1208,7 @@ class TestRepositorySync:
 
         :CaseLevel: Integration
         """
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_entitlement_manifest_org.id,
             product=constants.PRDS['rhel'],
@@ -1284,7 +1283,7 @@ class TestRepositorySync:
         """
         repo_ids = []
         for repo in constants.BULK_REPO_LIST:
-            repo_id = enable_rhrepo_and_fetchid(
+            repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
                 basearch='x86_64',
                 org_id=module_entitlement_manifest_org.id,
                 product=repo['product'],
@@ -1366,7 +1365,7 @@ class TestRepositorySync:
 
         :CaseAutomation: Automated
         """
-        repo_id = enable_rhrepo_and_fetchid(
+        repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_entitlement_manifest_org.id,
             product=constants.PRDS['rhel'],

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -28,7 +28,6 @@ from nailgun.config import ServerConfig
 from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
@@ -41,8 +40,8 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
-def rh_repo(module_sca_manifest_org):
-    rh_repo_id = enable_rhrepo_and_fetchid(
+def rh_repo(module_sca_manifest_org, module_target_sat):
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=module_sca_manifest_org.id,
         product=PRDS['rhel'],
@@ -417,7 +416,7 @@ def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel7_conte
     rhel7_contenthost.unregister()
     # syncing content with the content host unregistered should invalidate
     # the previous client SCA cert
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=module_sca_manifest_org.id,
         product=PRDS['rhel'],

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -31,9 +31,6 @@ from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.api.utils import disable_syncplan
-from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import get_credentials
 from robottelo.config import get_url
 from robottelo.constants import PRDS
@@ -68,14 +65,14 @@ def valid_sync_interval():
     return {i.replace(' ', '_'): i for i in ['hourly', 'daily', 'weekly', 'custom cron']}
 
 
-def validate_task_status(repo_id, org_id, max_tries=6):
+def validate_task_status(sat, repo_id, org_id, max_tries=6):
     """Wait for foreman_tasks to complete or timeout
 
     :param repo_id: Repository Id to identify the correct task
     :param max_tries: Max tries to poll for the task creation
     :param org_id: Org ID to ensure valid check on busy Satellite
     """
-    wait_for_tasks(
+    sat.wait_for_tasks(
         search_query='Actions::Katello::Repository::Sync'
         f' and organization_id = {org_id}'
         f' and resource_id = {repo_id}'
@@ -142,7 +139,7 @@ def test_positive_get_routes():
 @pytest.mark.build_sanity
 @pytest.mark.parametrize("enabled", [False, True])
 @pytest.mark.tier1
-def test_positive_create_enabled_disabled(module_org, enabled, request):
+def test_positive_create_enabled_disabled(module_org, enabled, request, target_sat):
     """Create sync plan with different 'enabled' field values.
 
     :id: df5837e7-3d0f-464a-bd67-86b423c16eb4
@@ -155,7 +152,7 @@ def test_positive_create_enabled_disabled(module_org, enabled, request):
     :CaseImportance: Critical
     """
     sync_plan = entities.SyncPlan(enabled=enabled, organization=module_org).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     sync_plan = sync_plan.read()
     assert sync_plan.enabled == enabled
 
@@ -299,7 +296,7 @@ def test_negative_create_with_empty_interval(module_org):
 
 @pytest.mark.parametrize("enabled", [False, True])
 @pytest.mark.tier1
-def test_positive_update_enabled(module_org, enabled, request):
+def test_positive_update_enabled(module_org, enabled, request, target_sat):
     """Create sync plan and update it with opposite 'enabled' value.
 
     :id: 325c0ef5-c0e8-4cb9-b85e-87eb7f42c2f8
@@ -311,7 +308,7 @@ def test_positive_update_enabled(module_org, enabled, request):
     :CaseImportance: Critical
     """
     sync_plan = entities.SyncPlan(enabled=not enabled, organization=module_org).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     sync_plan.enabled = enabled
     sync_plan.update(['enabled'])
     sync_plan = sync_plan.read()
@@ -570,7 +567,7 @@ def test_positive_remove_products(module_org):
 
 
 @pytest.mark.tier2
-def test_positive_repeatedly_add_remove(module_org, request):
+def test_positive_repeatedly_add_remove(module_org, request, target_sat):
     """Repeatedly add and remove a product from a sync plan.
 
     :id: b67536ba-3a36-4bb7-a405-0e12081d5a7e
@@ -583,7 +580,7 @@ def test_positive_repeatedly_add_remove(module_org, request):
     :BZ: 1199150
     """
     sync_plan = entities.SyncPlan(organization=module_org).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     product = entities.Product(organization=module_org).create()
     for _ in range(5):
         sync_plan.add_products(data={'product_ids': [product.id]})
@@ -593,7 +590,7 @@ def test_positive_repeatedly_add_remove(module_org, request):
 
 
 @pytest.mark.tier2
-def test_positive_add_remove_products_custom_cron(module_org, request):
+def test_positive_add_remove_products_custom_cron(module_org, request, target_sat):
     """Create a sync plan with two products having custom cron interval
     and then remove both products from it.
 
@@ -609,7 +606,7 @@ def test_positive_add_remove_products_custom_cron(module_org, request):
     sync_plan = entities.SyncPlan(
         organization=module_org, interval='custom cron', cron_expression=cron_expression
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     products = [entities.Product(organization=module_org).create() for _ in range(2)]
     sync_plan.add_products(data={'product_ids': [product.id for product in products]})
     assert len(sync_plan.read().product) == 2
@@ -618,7 +615,7 @@ def test_positive_add_remove_products_custom_cron(module_org, request):
 
 
 @pytest.mark.tier4
-def test_negative_synchronize_custom_product_past_sync_date(module_org, request):
+def test_negative_synchronize_custom_product_past_sync_date(module_org, request, target_sat):
     """Verify product won't get synced immediately after adding association
     with a sync plan which has already been started
 
@@ -634,22 +631,22 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request)
     repo = entities.Repository(product=product).create()
     # Verify product is not synced and doesn't have any content
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, module_org.id, max_tries=2)
+        validate_task_status(target_sat, repo.id, module_org.id, max_tries=2)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Create and Associate sync plan with product
     sync_plan = entities.SyncPlan(
         organization=module_org, enabled=True, sync_date=datetime.utcnow().replace(second=0)
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Verify product was not synced right after it was added to sync plan
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, module_org.id, max_tries=2)
+        validate_task_status(target_sat, repo.id, module_org.id, max_tries=2)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
 
 
 @pytest.mark.tier4
-def test_positive_synchronize_custom_product_past_sync_date(module_org, request):
+def test_positive_synchronize_custom_product_past_sync_date(module_org, request, target_sat):
     """Create a sync plan with past datetime as a sync date, add a
     custom product and verify the product gets synchronized on the next
     sync occurrence
@@ -673,7 +670,7 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request)
         interval='hourly',
         sync_date=datetime.utcnow().replace(second=0) - timedelta(seconds=interval - delay),
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
@@ -683,7 +680,7 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request)
     sleep(delay / 4)
     # Verify product is not synced and doesn't have any content
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, module_org.id, max_tries=1)
+        validate_task_status(target_sat, repo.id, module_org.id, max_tries=1)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Wait until the next recurrence
     logger.info(
@@ -692,12 +689,12 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request)
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
-    validate_task_status(repo.id, module_org.id)
+    validate_task_status(target_sat, repo.id, module_org.id)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
 @pytest.mark.tier4
-def test_positive_synchronize_custom_product_future_sync_date(module_org, request):
+def test_positive_synchronize_custom_product_future_sync_date(module_org, request, target_sat):
     """Create a sync plan with sync date in a future and sync one custom
     product with it automatically.
 
@@ -714,7 +711,7 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     repo = entities.Repository(product=product).create()
     # Verify product is not synced and doesn't have any content
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, module_org.id, max_tries=1)
+        validate_task_status(target_sat, repo.id, module_org.id, max_tries=1)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Create and Associate sync plan with product
     # BZ:1695733 is closed WONTFIX so apply this workaround
@@ -723,7 +720,7 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     sync_plan = entities.SyncPlan(
         organization=module_org, enabled=True, sync_date=sync_date
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
@@ -733,7 +730,7 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     sleep(delay / 4)
     # Verify product has not been synced yet
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, module_org.id, max_tries=1)
+        validate_task_status(target_sat, repo.id, module_org.id, max_tries=1)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
@@ -742,13 +739,13 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
-    validate_task_status(repo.id, module_org.id)
+    validate_task_status(target_sat, repo.id, module_org.id)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_custom_products_future_sync_date(module_org, request):
+def test_positive_synchronize_custom_products_future_sync_date(module_org, request, target_sat):
     """Create a sync plan with sync date in a future and sync multiple
     custom products with multiple repos automatically.
 
@@ -773,7 +770,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
     )
     for repo in repos:
         with pytest.raises(AssertionError):
-            validate_task_status(repo.id, module_org.id, max_tries=1)
+            validate_task_status(target_sat, repo.id, module_org.id, max_tries=1)
     # Create and Associate sync plan with products
     # BZ:1695733 is closed WONTFIX so apply this workaround
     logger.info('Need to set seconds to zero because BZ#1695733')
@@ -781,7 +778,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
     sync_plan = entities.SyncPlan(
         organization=module_org, enabled=True, sync_date=sync_date
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     sync_plan.add_products(data={'product_ids': [product.id for product in products]})
     # Wait quarter of expected time
     logger.info(
@@ -792,7 +789,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
     # Verify products has not been synced yet
     for repo in repos:
         with pytest.raises(AssertionError):
-            validate_task_status(repo.id, module_org.id, max_tries=1)
+            validate_task_status(target_sat, repo.id, module_org.id, max_tries=1)
     # Wait the rest of expected time
     logger.info(
         f"Waiting {(delay * 3 / 4)} seconds to check products {products[0].name}"
@@ -801,13 +798,15 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
     for repo in repos:
-        validate_task_status(repo.id, module_org.id)
+        validate_task_status(target_sat, repo.id, module_org.id)
         validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
-def test_positive_synchronize_rh_product_past_sync_date(request, function_entitlement_manifest_org):
+def test_positive_synchronize_rh_product_past_sync_date(
+    request, function_entitlement_manifest_org, target_sat
+):
     """Create a sync plan with past datetime as a sync date, add a
     RH product and verify the product gets synchronized on the next sync
     occurrence
@@ -825,7 +824,7 @@ def test_positive_synchronize_rh_product_past_sync_date(request, function_entitl
     interval = 60 * 60  # 'hourly' sync interval in seconds
     delay = 2 * 60
     org = function_entitlement_manifest_org
-    repo_id = enable_rhrepo_and_fetchid(
+    repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=PRDS['rhel'],
@@ -841,7 +840,7 @@ def test_positive_synchronize_rh_product_past_sync_date(request, function_entitl
         interval='hourly',
         sync_date=datetime.utcnow() - timedelta(seconds=interval - delay),
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Associate sync plan with product
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
@@ -852,7 +851,7 @@ def test_positive_synchronize_rh_product_past_sync_date(request, function_entitl
     sleep(delay / 4)
     # Verify product has not been synced yet
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, org.id, max_tries=1)
+        validate_task_status(target_sat, repo.id, org.id, max_tries=1)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Wait until the next recurrence
     logger.info(
@@ -861,7 +860,7 @@ def test_positive_synchronize_rh_product_past_sync_date(request, function_entitl
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
-    validate_task_status(repo.id, org.id)
+    validate_task_status(target_sat, repo.id, org.id)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
     # Add disassociate RH product from sync plan check for BZ#1879537
     assert len(sync_plan.read().product) == 1
@@ -876,7 +875,7 @@ def test_positive_synchronize_rh_product_past_sync_date(request, function_entitl
 @pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_rh_product_future_sync_date(
-    request, function_entitlement_manifest_org
+    request, function_entitlement_manifest_org, target_sat
 ):
     """Create a sync plan with sync date in a future and sync one RH
     product with it automatically.
@@ -889,7 +888,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
     """
     delay = 2 * 60  # delay for sync date in seconds
     org = function_entitlement_manifest_org
-    repo_id = enable_rhrepo_and_fetchid(
+    repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=PRDS['rhel'],
@@ -905,12 +904,12 @@ def test_positive_synchronize_rh_product_future_sync_date(
     sync_plan = entities.SyncPlan(
         organization=org, enabled=True, interval='hourly', sync_date=sync_date
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Create and Associate sync plan with product
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Verify product is not synced and doesn't have any content
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, org.id, max_tries=1)
+        validate_task_status(target_sat, repo.id, org.id, max_tries=1)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Wait quarter of expected time
     logger.info(
@@ -920,7 +919,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
     sleep(delay / 4)
     # Verify product has not been synced yet
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, org.id, max_tries=1)
+        validate_task_status(target_sat, repo.id, org.id, max_tries=1)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
@@ -929,12 +928,12 @@ def test_positive_synchronize_rh_product_future_sync_date(
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
-    validate_task_status(repo.id, org.id)
+    validate_task_status(target_sat, repo.id, org.id)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
 @pytest.mark.tier3
-def test_positive_synchronize_custom_product_daily_recurrence(module_org, request):
+def test_positive_synchronize_custom_product_daily_recurrence(module_org, request, target_sat):
     """Create a daily sync plan with current datetime as a sync date,
     add a custom product and verify the product gets synchronized on
     the next sync occurrence
@@ -953,7 +952,7 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     sync_plan = entities.SyncPlan(
         organization=module_org, enabled=True, interval='daily', sync_date=start_date
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
@@ -963,7 +962,7 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     sleep(delay / 4)
     # Verify product is not synced and doesn't have any content
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, module_org.id, max_tries=1)
+        validate_task_status(target_sat, repo.id, module_org.id, max_tries=1)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
@@ -972,12 +971,12 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
-    validate_task_status(repo.id, module_org.id)
+    validate_task_status(target_sat, repo.id, module_org.id)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 
 @pytest.mark.tier3
-def test_positive_synchronize_custom_product_weekly_recurrence(module_org, request):
+def test_positive_synchronize_custom_product_weekly_recurrence(module_org, request, target_sat):
     """Create a weekly sync plan with a past datetime as a sync date,
     add a custom product and verify the product gets synchronized on
     the next sync occurrence
@@ -998,7 +997,7 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
     sync_plan = entities.SyncPlan(
         organization=module_org, enabled=True, interval='weekly', sync_date=start_date
     ).create()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     sync_plan.add_products(data={'product_ids': [product.id]})
     # Wait quarter of expected time
     logger.info(
@@ -1008,7 +1007,7 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
     sleep(delay / 4)
     # Verify product is not synced and doesn't have any content
     with pytest.raises(AssertionError):
-        validate_task_status(repo.id, module_org.id, max_tries=1)
+        validate_task_status(target_sat, repo.id, module_org.id, max_tries=1)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
@@ -1017,7 +1016,7 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
-    validate_task_status(repo.id, module_org.id)
+    validate_task_status(target_sat, repo.id, module_org.id)
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
 
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -25,7 +25,6 @@ from nailgun import entities
 from wrapanapi.entities.vm import VmState
 
 from robottelo import constants
-from robottelo.api.utils import create_sync_custom_repo
 from robottelo.cli import factory as cli_factory
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
@@ -988,7 +987,7 @@ class TestContentView:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    def test_positive_add_module_stream_filter_rule(self, module_org):
+    def test_positive_add_module_stream_filter_rule(self, module_org, target_sat):
         """Associate module stream content to a content view and create filter rule
 
         :id: 8186a4b2-1c11-11ea-99cf-d46d6dd3b5b2
@@ -1005,7 +1004,7 @@ class TestContentView:
         """
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
-        create_sync_custom_repo(
+        target_sat.api_factory.create_sync_custom_repo(
             module_org.id,
             repo_name=repo_name,
             repo_url=settings.repos.module_stream_1.url,

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -22,7 +22,6 @@ from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from fauxfactory import gen_url
 
-from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.defaults import Defaults
 from robottelo.cli.factory import CLIFactoryError
@@ -46,7 +45,7 @@ from robottelo.utils.datafactory import valid_labels_list
 @pytest.mark.tier1
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_CRUD(module_org):
+def test_positive_CRUD(module_org, target_sat):
     """Check if product can be created, updated, synchronized and deleted
 
     :id: 9d7b5ec8-59d0-4371-b5d2-d43145e4e2db
@@ -120,7 +119,7 @@ def test_positive_CRUD(module_org):
     product = Product.info({'id': product['id'], 'organization-id': module_org.id})
     assert len(product['sync-plan-id']) == 0
     Product.delete({'id': product['id']})
-    wait_for_tasks(
+    target_sat.wait_for_tasks(
         search_query="label = Actions::Katello::Product::Destroy"
         f" and resource_id = {product['id']}",
         max_tries=10,

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -24,8 +24,6 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import disable_syncplan
-from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_product
@@ -97,14 +95,14 @@ def valid_name_interval_update_tests():
     ]
 
 
-def validate_task_status(repo_id, org_id, max_tries=10):
+def validate_task_status(sat, repo_id, org_id, max_tries=10):
     """Wait for foreman_tasks to complete or timeout
 
     :param repo_id: Repository Id to identify the correct task
     :param max_tries: Max tries to poll for the task creation
     :param org_id: Org ID to ensure valid check on busy Satellite
     """
-    wait_for_tasks(
+    sat.wait_for_tasks(
         search_query='Actions::Katello::Repository::Sync'
         f' and organization_id = {org_id}'
         f' and resource_id = {repo_id}'
@@ -230,7 +228,7 @@ def test_positive_update_description(module_org, new_desc):
 
 @pytest.mark.parametrize('test_data', **parametrized(valid_name_interval_update_tests()))
 @pytest.mark.tier1
-def test_positive_update_interval(module_org, test_data, request):
+def test_positive_update_interval(module_org, test_data, request, target_sat):
     """Check if syncplan interval can be updated
 
     :id: d676d7f3-9f7c-4375-bb8b-277d71af94b4
@@ -250,7 +248,7 @@ def test_positive_update_interval(module_org, test_data, request):
         }
     )
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     SyncPlan.update({'id': new_sync_plan['id'], 'interval': test_data['new-interval']})
     result = SyncPlan.info({'id': new_sync_plan['id']})
     assert result['interval'] == test_data['new-interval']
@@ -258,7 +256,7 @@ def test_positive_update_interval(module_org, test_data, request):
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_update_sync_date(module_org, request):
+def test_positive_update_sync_date(module_org, request, target_sat):
     """Check if syncplan sync date can be updated
 
     :id: f0c17d7d-3e86-4b64-9747-6cba6809815e
@@ -280,7 +278,7 @@ def test_positive_update_sync_date(module_org, request):
         }
     )
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Assert that sync date matches data passed
     assert new_sync_plan['start-date'] == today.strftime("%Y/%m/%d %H:%M:%S")
     # Set sync date 5 days in the future
@@ -316,7 +314,7 @@ def test_positive_delete_by_id(module_org, name):
 
 
 @pytest.mark.tier1
-def test_positive_info_enabled_field_is_displayed(module_org, request):
+def test_positive_info_enabled_field_is_displayed(module_org, request, target_sat):
     """Check if Enabled field is displayed in sync-plan info output
 
     :id: 54e3a4ea-315c-4026-8101-c4605ca6b874
@@ -327,7 +325,7 @@ def test_positive_info_enabled_field_is_displayed(module_org, request):
     """
     new_sync_plan = make_sync_plan({'organization-id': module_org.id})
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     result = SyncPlan.info({'id': new_sync_plan['id']})
     assert result.get('enabled') is not None
 
@@ -370,7 +368,7 @@ def test_positive_info_with_assigned_product(module_org):
 
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_negative_synchronize_custom_product_past_sync_date(module_org, request):
+def test_negative_synchronize_custom_product_past_sync_date(module_org, request, target_sat):
     """Verify product won't get synced immediately after adding association
     with a sync plan which has already been started
 
@@ -390,17 +388,17 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request)
         }
     )
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     product = make_product({'organization-id': module_org.id})
     repo = make_repository({'product-id': product['id']})
     Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})
     with pytest.raises(AssertionError):
-        validate_task_status(repo['id'], module_org.id, max_tries=2)
+        validate_task_status(target_sat, repo['id'], module_org.id, max_tries=2)
 
 
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_custom_product_past_sync_date(module_org, request):
+def test_positive_synchronize_custom_product_past_sync_date(module_org, request, target_sat):
     """Create a sync plan with a past datetime as a sync date, add a
     custom product and verify the product gets synchronized on the next
     sync occurrence
@@ -428,7 +426,7 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request)
         }
     )
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Associate sync plan with product
     Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})
     # Wait quarter of expected time
@@ -454,7 +452,7 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request)
 
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_custom_product_future_sync_date(module_org, request):
+def test_positive_synchronize_custom_product_future_sync_date(module_org, request, target_sat):
     """Create a sync plan with sync date in a future and sync one custom
     product with it automatically.
 
@@ -485,7 +483,7 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
         }
     )
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Verify product is not synced and doesn't have any content
     validate_repo_content(repo, ['errata', 'packages'], after_sync=False)
     # Associate sync plan with product
@@ -498,7 +496,7 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     sleep(delay / 4)
     # Verify product has not been synced yet
     with pytest.raises(AssertionError):
-        validate_task_status(repo['id'], module_org.id, max_tries=1)
+        validate_task_status(target_sat, repo['id'], module_org.id, max_tries=1)
     validate_repo_content(repo, ['errata', 'packages'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
@@ -507,13 +505,13 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
-    validate_task_status(repo['id'], module_org.id)
+    validate_task_status(target_sat, repo['id'], module_org.id)
     validate_repo_content(repo, ['errata', 'package-groups', 'packages'])
 
 
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_custom_products_future_sync_date(module_org, request):
+def test_positive_synchronize_custom_products_future_sync_date(module_org, request, target_sat):
     """Create a sync plan with sync date in a future and sync multiple
     custom products with multiple repos automatically.
 
@@ -546,7 +544,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
         }
     )
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Verify products have not been synced yet
     logger.info(
         f"Check products {products[0]['name']} and {products[1]['name']}"
@@ -625,7 +623,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
         }
     )
     sync_plan = entities.SyncPlan(organization=org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Associate sync plan with product
     Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})
     # Wait quarter of expected time
@@ -697,7 +695,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
         }
     )
     sync_plan = entities.SyncPlan(organization=org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Verify product is not synced and doesn't have any content
     with pytest.raises(AssertionError):
         validate_task_status(repo['id'], org.id, max_tries=1)
@@ -727,7 +725,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_synchronize_custom_product_daily_recurrence(module_org, request):
+def test_positive_synchronize_custom_product_daily_recurrence(module_org, request, target_sat):
     """Create a daily sync plan with a past datetime as a sync date,
     add a custom product and verify the product gets synchronized on
     the next sync occurrence
@@ -751,7 +749,7 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
         }
     )
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Associate sync plan with product
     Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})
     # Wait quarter of expected time
@@ -762,7 +760,7 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     sleep(delay / 4)
     # Verify product has not been synced yet
     with pytest.raises(AssertionError):
-        validate_task_status(repo['id'], module_org.id, max_tries=1)
+        validate_task_status(target_sat, repo['id'], module_org.id, max_tries=1)
     validate_repo_content(repo, ['errata', 'packages'], after_sync=False)
     # Wait until the first recurrence
     logger.info(
@@ -771,12 +769,12 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     )
     sleep(delay * 3 / 4)
     # Verify product was synced successfully
-    validate_task_status(repo['id'], module_org.id)
+    validate_task_status(target_sat, repo['id'], module_org.id)
     validate_repo_content(repo, ['errata', 'package-groups', 'packages'])
 
 
 @pytest.mark.tier3
-def test_positive_synchronize_custom_product_weekly_recurrence(module_org, request):
+def test_positive_synchronize_custom_product_weekly_recurrence(module_org, request, target_sat):
     """Create a weekly sync plan with a past datetime as a sync date,
     add a custom product and verify the product gets synchronized on
     the next sync occurrence
@@ -802,7 +800,7 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
         }
     )
     sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     # Associate sync plan with product
     Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})
     # Wait quarter of expected time

--- a/tests/foreman/destructive/test_contentview.py
+++ b/tests/foreman/destructive/test_contentview.py
@@ -20,8 +20,6 @@ import pytest
 from nailgun.entity_mixins import TaskFailedError
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import wait_for_tasks
 
 pytestmark = pytest.mark.destructive
 
@@ -45,7 +43,7 @@ def test_positive_reboot_recover_cv_publish(target_sat, function_entitlement_man
     :CaseAutomation: Automated
     """
     org = function_entitlement_manifest_org
-    rhel7_extra = enable_rhrepo_and_fetchid(
+    rhel7_extra = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=constants.PRDS['rhel'],
@@ -53,7 +51,7 @@ def test_positive_reboot_recover_cv_publish(target_sat, function_entitlement_man
         reposet=constants.REPOSET['rhel7_extra'],
         releasever=None,
     )
-    rhel7_optional = enable_rhrepo_and_fetchid(
+    rhel7_optional = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=constants.PRDS['rhel'],
@@ -61,7 +59,7 @@ def test_positive_reboot_recover_cv_publish(target_sat, function_entitlement_man
         reposet=constants.REPOSET['rhel7_optional'],
         releasever=constants.REPOS['rhel7_optional']['releasever'],
     )
-    rhel7_sup = enable_rhrepo_and_fetchid(
+    rhel7_sup = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=constants.PRDS['rhel'],
@@ -82,14 +80,14 @@ def test_positive_reboot_recover_cv_publish(target_sat, function_entitlement_man
     try:
         publish_task = cv.publish(synchronous=False)
         target_sat.power_control(state='reboot', ensure=True)
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             search_query=(f'id = {publish_task["id"]}'),
             search_rate=30,
             max_tries=60,
         )
     except TaskFailedError:
         target_sat.api.ForemanTask().bulk_resume(data={"task_ids": [publish_task['id']]})
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             search_query=(f'id = {publish_task["id"]}'),
             search_rate=30,
             max_tries=60,

--- a/tests/foreman/destructive/test_repository.py
+++ b/tests/foreman/destructive/test_repository.py
@@ -20,8 +20,6 @@ import pytest
 from nailgun.entity_mixins import TaskFailedError
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import wait_for_tasks
 
 pytestmark = pytest.mark.destructive
 
@@ -44,7 +42,7 @@ def test_positive_reboot_recover_sync(target_sat, function_entitlement_manifest_
     :CaseAutomation: Automated
     """
     org = function_entitlement_manifest_org
-    rhel7_extra = enable_rhrepo_and_fetchid(
+    rhel7_extra = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=constants.PRDS['rhel'],
@@ -56,14 +54,14 @@ def test_positive_reboot_recover_sync(target_sat, function_entitlement_manifest_
     sync_task = rhel7_extra.sync(synchronous=False)
     target_sat.power_control(state='reboot', ensure=True)
     try:
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             search_query=(f'id = {sync_task["id"]}'),
             search_rate=15,
             max_tries=10,
         )
     except TaskFailedError:
         sync_task = rhel7_extra.sync(synchronous=False)
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             search_query=(f'id = {sync_task["id"]}'),
             search_rate=15,
             max_tries=10,

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -28,7 +28,6 @@ from nailgun import client
 from nailgun import entities
 
 from robottelo import constants
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import get_credentials
 from robottelo.config import get_url
 from robottelo.config import setting_is_set
@@ -1119,7 +1118,7 @@ class TestEndToEnd:
         # step 2.6: Enable a Red Hat repository
         if fake_manifest_is_set:
             rhel_repo = target_sat.api.Repository(
-                id=enable_rhrepo_and_fetchid(
+                id=target_sat.api_factory.enable_rhrepo_and_fetchid(
                     basearch='x86_64',
                     org_id=org.id,
                     product=constants.PRDS['rhel'],

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -22,8 +22,6 @@ from datetime import timedelta
 import pytest
 from nailgun import entities
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
@@ -62,9 +60,9 @@ def qe_lce(module_manifest_org, dev_lce):
 
 
 @pytest.fixture(scope='module')
-def rhel7_sat6tools_repo(module_manifest_org):
+def rhel7_sat6tools_repo(module_manifest_org, module_target_sat):
     """Enable Sat tools repository"""
-    rhel7_sat6tools_repo_id = enable_rhrepo_and_fetchid(
+    rhel7_sat6tools_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=DEFAULT_ARCHITECTURE,
         org_id=module_manifest_org.id,
         product=PRDS['rhel'],
@@ -153,7 +151,7 @@ def host(
     rhel7_contenthost_module.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE}')
     rhel7_contenthost_module.execute('katello-package-upload')
     # Wait for applicability update event (in case Satellite system slow)
-    wait_for_tasks(
+    module_target_sat.wait_for_tasks(
         search_query='label = Actions::Katello::Applicability::Hosts::BulkGenerate'
         f' and started_at >= "{timestamp}"'
         f' and state = stopped'

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -21,7 +21,6 @@ from broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.ansible import Ansible
 from robottelo.cli.arfreport import Arfreport
 from robottelo.cli.factory import make_hostgroup
@@ -237,7 +236,7 @@ def test_positive_oscap_run_via_ansible(
             }
         )
         job_id = Host.ansible_roles_play({'name': vm.hostname.lower()})[0].get('id')
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             f'resource_type = JobInvocation and resource_id = {job_id} and action ~ "hosts job"'
         )
         try:
@@ -356,7 +355,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
             }
         )
         job_id = Host.ansible_roles_play({'name': vm.hostname.lower()})[0].get('id')
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             f'resource_type = JobInvocation and resource_id = {job_id} and action ~ "hosts job"'
         )
         try:

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -15,7 +15,6 @@ import pytest
 from fauxfactory import gen_string
 from wrapanapi import VMWareSystem
 
-from robottelo.api.utils import configure_provisioning
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.factory import make_host
@@ -50,14 +49,14 @@ def vmware():
 
 
 @pytest.fixture(scope="module")
-def provisioning(module_org, module_location):
+def provisioning(module_org, module_location, module_target_sat):
     os = None
     if hasattr(settings, 'rhev') and hasattr(settings.rhev, 'image_os') and settings.rhev.image_os:
         os = settings.rhev.image_os
     provisioning = type("", (), {})()
     provisioning.org_name = module_org.name
     provisioning.loc_name = module_location.name
-    provisioning.config_env = configure_provisioning(
+    provisioning.config_env = module_target_sat.api_factory.configure_provisioning(
         compute=True, org=module_org, loc=module_location, os=os
     )
     provisioning.os_name = provisioning.config_env['os']

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -18,7 +18,6 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import create_role_permissions
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import ENVIRONMENT
 
@@ -205,7 +204,7 @@ def test_positive_add_event(session, module_org):
 @pytest.mark.skip_if_open("BZ:1701118")
 @pytest.mark.skip_if_open("BZ:1701132")
 @pytest.mark.tier2
-def test_positive_create_role_filter(session, module_org):
+def test_positive_create_role_filter(session, module_org, target_sat):
     """Update a role with new filter and check that corresponding event
     appeared in the audit log
 
@@ -231,7 +230,7 @@ def test_positive_create_role_filter(session, module_org):
         assert values['action_type'] == 'create'
         assert values['resource_type'] == 'ROLE'
         assert values['resource_name'] == role.name
-        create_role_permissions(
+        target_sat.api_factory.create_role_permissions(
             role, {'Architecture': ['view_architectures', 'edit_architectures']}
         )
         values = session.audit.search('type=filter')

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -20,7 +20,6 @@ import pytest
 from nailgun import entities
 from wait_for import wait_for
 
-from robottelo.api.utils import check_create_os_with_title
 from robottelo.config import setting_is_set
 from robottelo.config import settings
 from robottelo.constants import COMPUTE_PROFILE_LARGE
@@ -379,7 +378,7 @@ def test_positive_update_organization(session, rhev_data, module_location):
 
 
 @pytest.mark.tier2
-def test_positive_image_end_to_end(session, rhev_data, module_location):
+def test_positive_image_end_to_end(session, rhev_data, module_location, target_sat):
     """Perform end to end testing for compute resource RHV component image.
 
     :id: 62a5c52f-dd15-45e7-8200-c64bb335474f
@@ -393,7 +392,7 @@ def test_positive_image_end_to_end(session, rhev_data, module_location):
     cr_name = gen_string('alpha')
     image_name = gen_string('alpha')
     new_image_name = gen_string('alpha')
-    check_create_os_with_title(rhev_data['image_os'])
+    target_sat.check_create_os_with_title(rhev_data['image_os'])
     with session:
         session.computeresource.create(
             {

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -27,7 +27,6 @@ from wait_for import wait_for
 from wrapanapi.systems.virtualcenter import vim
 from wrapanapi.systems.virtualcenter import VMWareSystem
 
-from robottelo.api.utils import check_create_os_with_title
 from robottelo.config import settings
 from robottelo.constants import COMPUTE_PROFILE_LARGE
 from robottelo.constants import FOREMAN_PROVIDERS
@@ -223,7 +222,7 @@ def test_positive_retrieve_virtual_machine_list(session, module_vmware_settings)
 
 
 @pytest.mark.tier2
-def test_positive_image_end_to_end(session, module_vmware_settings):
+def test_positive_image_end_to_end(session, module_vmware_settings, target_sat):
     """Perform end to end testing for compute resource VMware component image.
 
     :id: 6b7949ef-c684-40aa-b181-11f8d4cd39c6
@@ -235,7 +234,7 @@ def test_positive_image_end_to_end(session, module_vmware_settings):
     cr_name = gen_string('alpha')
     image_name = gen_string('alpha')
     new_image_name = gen_string('alpha')
-    check_create_os_with_title(module_vmware_settings['image_os'])
+    target_sat.check_create_os_with_title(module_vmware_settings['image_os'])
     image_user_data = choice((False, True))
     with session:
         session.computeresource.create(

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -27,7 +27,6 @@ from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.factory import make_fake_host
 from robottelo.cli.factory import make_virt_who_config
@@ -276,7 +275,7 @@ def test_positive_end_to_end_bulk_update(session, default_location, vm, target_s
             action_via='via remote execution',
         )
         # Wait for applicability update event (in case Satellite system slow)
-        wait_for_tasks(
+        target_sat.wait_for_tasks(
             search_query='label = Actions::Katello::Applicability::Hosts::BulkGenerate'
             f' and started_at >= "{timestamp}"'
             f' and state = stopped'
@@ -1299,7 +1298,7 @@ def test_module_status_update_from_content_host_to_satellite(
     indirect=True,
 )
 def test_module_status_update_without_force_upload_package_profile(
-    session, default_location, vm_module_streams
+    session, default_location, vm_module_streams, target_sat
 ):
     """Verify you do not have to run dnf upload-profile or restart rhsmcertd
     to update the module stream status to Satellite and that the web UI will also be updated.
@@ -1327,7 +1326,7 @@ def test_module_status_update_without_force_upload_package_profile(
         vm_module_streams,
     )
     # Wait for applicability update event (in case Satellite system slow)
-    wait_for_tasks(
+    target_sat.wait_for_tasks(
         search_query='label = Actions::Katello::Applicability::Hosts::BulkGenerate'
         f' and started_at >= "{timestamp}"'
         f' and state = stopped'

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -32,9 +32,6 @@ from navmazing import NavigationTriesExceeded
 from productmd.common import parse_nvra
 
 from robottelo import constants
-from robottelo.api.utils import create_role_permissions
-from robottelo.api.utils import create_sync_custom_repo
-from robottelo.api.utils import enable_sync_redhat_repo
 from robottelo.cli.contentview import ContentView
 from robottelo.config import settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
@@ -100,7 +97,7 @@ def test_positive_add_custom_content(session):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, module_org):
+def test_positive_end_to_end(session, module_org, target_sat):
     """Create content view with yum repo, publish it and promote it to Library
         +1 env
 
@@ -123,7 +120,7 @@ def test_positive_end_to_end(session, module_org):
     env_name = gen_string('alpha')
     cv_name = gen_string('alpha')
     # Creates a CV along with product and sync'ed repository
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         # Create Life-cycle environment
         session.lifecycleenvironment.create({'name': env_name})
@@ -193,7 +190,7 @@ def test_positive_publish_version_changes_in_source_env(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_repo_count_for_composite_cv(session, module_org):
+def test_positive_repo_count_for_composite_cv(session, module_org, target_sat):
     """Create some content views with synchronized repositories and
     promoted to one lce. Add them to composite content view and check repo
     count for it.
@@ -213,7 +210,7 @@ def test_positive_repo_count_for_composite_cv(session, module_org):
     ccv_name = gen_string('alpha')
     repo_name = gen_string('alpha')
     # Create a product and sync'ed repository
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         # Creates a composite CV
         session.contentview.create({'name': ccv_name, 'composite_view': True})
@@ -243,7 +240,9 @@ def test_positive_repo_count_for_composite_cv(session, module_org):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_create_composite(session, module_prod, module_entitlement_manifest_org):
+def test_positive_create_composite(
+    session, module_prod, module_entitlement_manifest_org, target_sat
+):
     """Create a composite content views
 
     :id: 550f1970-5cbd-4571-bb7b-17e97639b715
@@ -271,7 +270,7 @@ def test_positive_create_composite(session, module_prod, module_entitlement_mani
         url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
 
-    enable_sync_redhat_repo(rh_repo, org.id)
+    target_sat.api_factory.enable_sync_redhat_repo(rh_repo, org.id)
     docker_repo.sync()
     with session:
         session.organization.select(org.name)
@@ -297,7 +296,7 @@ def test_positive_create_composite(session, module_prod, module_entitlement_mani
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_positive_add_rh_content(session, function_entitlement_manifest_org):
+def test_positive_add_rh_content(session, function_entitlement_manifest_org, target_sat):
     """Add Red Hat content to a content view
 
     :id: c370fd79-0c0d-4685-99cb-848556c786c1
@@ -320,7 +319,7 @@ def test_positive_add_rh_content(session, function_entitlement_manifest_org):
     }
     # Create new org to import manifest
     org = function_entitlement_manifest_org
-    enable_sync_redhat_repo(rh_repo, org.id)
+    target_sat.api_factory.enable_sync_redhat_repo(rh_repo, org.id)
     with session:
         # Create content-view
         session.organization.select(org.name)
@@ -865,7 +864,7 @@ def test_positive_check_composite_cv_addition_list_versions(session):
 
 
 @pytest.mark.tier2
-def test_negative_add_dupe_repos(session, module_org):
+def test_negative_add_dupe_repos(session, module_org, target_sat):
     """attempt to associate the same repo multiple times within a
     content view
 
@@ -879,7 +878,7 @@ def test_negative_add_dupe_repos(session, module_org):
     """
     cv_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         session.contentview.create({'name': cv_name})
         assert session.contentview.search(cv_name)[0]['Name'] == cv_name
@@ -892,7 +891,7 @@ def test_negative_add_dupe_repos(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_publish_with_custom_content(session, module_org):
+def test_positive_publish_with_custom_content(session, module_org, target_sat):
     """Attempt to publish a content view containing custom content
 
     :id: 66b5efc7-2e43-438e-bd80-a754814222f9
@@ -907,7 +906,7 @@ def test_positive_publish_with_custom_content(session, module_org):
     """
     repo_name = gen_string('alpha')
     cv_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         session.contentview.create({'name': cv_name})
         assert session.contentview.search(cv_name)[0]['Name'] == cv_name
@@ -921,7 +920,7 @@ def test_positive_publish_with_custom_content(session, module_org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_positive_publish_with_rh_content(session, function_entitlement_manifest_org):
+def test_positive_publish_with_rh_content(session, function_entitlement_manifest_org, target_sat):
     """Attempt to publish a content view containing RH content
 
     :id: bd24dc13-b6c4-4a9b-acb2-cd6df30f436c
@@ -943,7 +942,7 @@ def test_positive_publish_with_rh_content(session, function_entitlement_manifest
         'releasever': None,
     }
     org = function_entitlement_manifest_org
-    enable_sync_redhat_repo(rh_repo, org.id)
+    target_sat.api_factory.enable_sync_redhat_repo(rh_repo, org.id)
     with session:
         session.organization.select(org.name)
         session.contentview.create({'name': cv_name})
@@ -959,7 +958,9 @@ def test_positive_publish_with_rh_content(session, function_entitlement_manifest
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_publish_composite_with_custom_content(session, function_entitlement_manifest_org):
+def test_positive_publish_composite_with_custom_content(
+    session, function_entitlement_manifest_org, target_sat
+):
     """Attempt to publish composite content view containing custom content
 
     :id: 73947204-408e-4e2e-b87f-ba2e52ee50b6
@@ -998,13 +999,13 @@ def test_positive_publish_composite_with_custom_content(session, function_entitl
     docker_repo1.sync()
     docker_repo2.sync()
     # Enable and sync RH repository
-    enable_sync_redhat_repo(rh7_repo, org.id)
+    target_sat.api_factory.enable_sync_redhat_repo(rh7_repo, org.id)
     # Create custom yum repositories
     for name, url in (
         (custom_repo1_name, custom_repo1_url),
         (custom_repo2_name, custom_repo2_url),
     ):
-        create_sync_custom_repo(repo_name=name, repo_url=url, org_id=org.id)
+        target_sat.api_factory.create_sync_custom_repo(repo_name=name, repo_url=url, org_id=org.id)
     with session:
         session.organization.select(org.name)
         # create the first content view
@@ -1042,7 +1043,7 @@ def test_positive_publish_composite_with_custom_content(session, function_entitl
 
 
 @pytest.mark.tier2
-def test_positive_publish_version_changes_in_target_env(session, module_org):
+def test_positive_publish_version_changes_in_target_env(session, module_org, target_sat):
     # Dev notes:
     # If Dev has version x, then when I promote version y into
     # Dev, version x goes away (ie when I promote version 1 to Dev,
@@ -1073,7 +1074,7 @@ def test_positive_publish_version_changes_in_target_env(session, module_org):
     repo_names = [gen_string('alphanumeric') for _ in range(versions_count)]
     # before each content view publishing add a new repository
     for repo_name in repo_names:
-        create_sync_custom_repo(module_org.id, repo_name=repo_name)
+        target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         # create content view
         session.contentview.create({'name': cv_name})
@@ -1102,7 +1103,7 @@ def test_positive_publish_version_changes_in_target_env(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_promote_with_custom_content(session, module_org):
+def test_positive_promote_with_custom_content(session, module_org, target_sat):
     """Attempt to promote a content view containing custom content,
         check dashboard
 
@@ -1121,7 +1122,7 @@ def test_positive_promote_with_custom_content(session, module_org):
     repo_name = gen_string('alpha')
     cv_name = gen_string('alpha')
     lce = entities.LifecycleEnvironment(organization=module_org).create()
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         session.contentview.create({'name': cv_name})
         assert session.contentview.search(cv_name)[0]['Name'] == cv_name
@@ -1148,7 +1149,7 @@ def test_positive_promote_with_custom_content(session, module_org):
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_positive_promote_with_rh_content(session, function_entitlement_manifest_org):
+def test_positive_promote_with_rh_content(session, function_entitlement_manifest_org, target_sat):
     """Attempt to promote a content view containing RH content
 
     :id: 82f71639-3580-49fd-bd5a-8dba568b98d1
@@ -1170,7 +1171,7 @@ def test_positive_promote_with_rh_content(session, function_entitlement_manifest
         'releasever': None,
     }
     org = function_entitlement_manifest_org
-    enable_sync_redhat_repo(rh_repo, org.id)
+    target_sat.api_factory.enable_sync_redhat_repo(rh_repo, org.id)
     lce = entities.LifecycleEnvironment(organization=org).create()
     with session:
         session.organization.select(org.name)
@@ -1187,7 +1188,9 @@ def test_positive_promote_with_rh_content(session, function_entitlement_manifest
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_promote_composite_with_custom_content(session, function_entitlement_manifest_org):
+def test_positive_promote_composite_with_custom_content(
+    session, function_entitlement_manifest_org, target_sat
+):
     """Attempt to promote composite content view containing custom content
 
     :id: 35efbd83-d32e-4831-9d5b-1adb15289f54
@@ -1221,13 +1224,13 @@ def test_positive_promote_composite_with_custom_content(session, function_entitl
     # create a life cycle environment
     lce = entities.LifecycleEnvironment(organization=org).create()
     # Enable and sync RH repository
-    enable_sync_redhat_repo(rh7_repo, org.id)
+    target_sat.api_factory.enable_sync_redhat_repo(rh7_repo, org.id)
     # Create custom yum repositories
     for name, url in (
         (custom_repo1_name, custom_repo1_url),
         (custom_repo2_name, custom_repo2_url),
     ):
-        create_sync_custom_repo(repo_name=name, repo_url=url, org_id=org.id)
+        target_sat.api_factory.create_sync_custom_repo(repo_name=name, repo_url=url, org_id=org.id)
     # Create docker repo and sync
     docker_repo1 = entities.Repository(
         url=CONTAINER_REGISTRY_HUB, product=product, content_type=REPO_TYPE['docker']
@@ -1323,7 +1326,7 @@ def test_positive_publish_rh_content_with_errata_by_date_filter(session, target_
 
 
 @pytest.mark.tier3
-def test_negative_add_same_package_filter_twice(session, module_org):
+def test_negative_add_same_package_filter_twice(session, module_org, target_sat):
     """Update version of package inside exclusive cv package filter
 
     :id: 5a97de5a-679e-4150-adf7-b4a28290b834
@@ -1337,7 +1340,7 @@ def test_negative_add_same_package_filter_twice(session, module_org):
     cv_name = gen_string('alpha')
     repo_name = gen_string('alpha')
     package_name = 'walrus'
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         session.contentview.create({'name': cv_name})
         for filter_type in FILTER_TYPE['exclude'], FILTER_TYPE['include']:
@@ -1362,7 +1365,7 @@ def test_negative_add_same_package_filter_twice(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_remove_cv_version_from_default_env(session, module_org):
+def test_positive_remove_cv_version_from_default_env(session, module_org, target_sat):
     """Remove content view version from Library environment
 
     :id: 43c83c15-c883-45a7-be05-d9b26da99e3c
@@ -1383,7 +1386,7 @@ def test_positive_remove_cv_version_from_default_env(session, module_org):
     """
     cv_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         # create a content view
         session.contentview.create({'name': cv_name})
@@ -1623,7 +1626,7 @@ def test_positive_delete_cv_promoted_to_multi_env(session, module_org, target_sa
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_delete_composite_version(session, module_org):
+def test_positive_delete_composite_version(session, module_org, target_sat):
     """Delete a composite content-view version associated to 'Library'
 
     :id: b2d9b21d-1e0d-40f1-9bbc-3c88cddd4f5e
@@ -1639,7 +1642,7 @@ def test_positive_delete_composite_version(session, module_org):
     cv_name = gen_string('alpha')
     ccv_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         # create a content view
         session.contentview.create({'name': cv_name})
@@ -1660,7 +1663,7 @@ def test_positive_delete_composite_version(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_delete_non_default_version(session):
+def test_positive_delete_non_default_version(session, target_sat):
     """Delete a content-view version associated to non-default
     environment
 
@@ -1674,7 +1677,7 @@ def test_positive_delete_non_default_version(session):
     """
     repo_name = gen_string('alpha')
     org = entities.Organization().create()
-    create_sync_custom_repo(org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': org.id})[0]
     cv = entities.ContentView(organization=org, repository=[repo]).create()
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -1733,7 +1736,7 @@ def test_positive_delete_version_with_ak(session):
 
 
 @pytest.mark.tier2
-def test_positive_clone_within_same_env(session, module_org):
+def test_positive_clone_within_same_env(session, module_org, target_sat):
     """attempt to create new content view based on existing
     view within environment
 
@@ -1750,7 +1753,7 @@ def test_positive_clone_within_same_env(session, module_org):
     repo_name = gen_string('alpha')
     cv_name = gen_string('alpha')
     copy_cv_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     with session:
         session.contentview.create({'name': cv_name})
         assert session.contentview.search(cv_name)[0]['Name'] == cv_name
@@ -1765,7 +1768,7 @@ def test_positive_clone_within_same_env(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_clone_within_diff_env(session, module_org):
+def test_positive_clone_within_diff_env(session, module_org, target_sat):
     """attempt to create new content view based on existing
     view, inside a different environment
 
@@ -1782,7 +1785,7 @@ def test_positive_clone_within_diff_env(session, module_org):
     """
     repo_name = gen_string('alpha')
     copy_cv_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()
     lce = entities.LifecycleEnvironment(organization=module_org).create()
@@ -1837,7 +1840,7 @@ def test_positive_remove_filter(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_add_package_filter(session, module_org):
+def test_positive_add_package_filter(session, module_org, target_sat):
     """Add package to content views filter
 
     :id: 1cc8d921-92e5-4b51-8050-a7e775095f97
@@ -1857,7 +1860,7 @@ def test_positive_add_package_filter(session, module_org):
     )
     filter_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()
     with session:
@@ -1881,7 +1884,7 @@ def test_positive_add_package_filter(session, module_org):
 
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
-def test_positive_add_package_inclusion_filter_and_publish(session, module_org):
+def test_positive_add_package_inclusion_filter_and_publish(session, module_org, target_sat):
     """Add package to inclusion content views filter, publish CV and verify
     package was actually filtered
 
@@ -1897,7 +1900,7 @@ def test_positive_add_package_inclusion_filter_and_publish(session, module_org):
     repo_name = gen_string('alpha')
     package1_name = 'cow'
     package2_name = 'bear'
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()
     with session:
@@ -1927,7 +1930,7 @@ def test_positive_add_package_inclusion_filter_and_publish(session, module_org):
 
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
-def test_positive_add_package_exclusion_filter_and_publish(session, module_org):
+def test_positive_add_package_exclusion_filter_and_publish(session, module_org, target_sat):
     """Add package to exclusion content views filter, publish CV and verify
     package was actually filtered
 
@@ -1943,7 +1946,7 @@ def test_positive_add_package_exclusion_filter_and_publish(session, module_org):
     repo_name = gen_string('alpha')
     package1_name = 'cow'
     package2_name = 'bear'
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()
     with session:
@@ -2023,7 +2026,7 @@ def test_positive_remove_package_from_exclusion_filter(session, module_org, targ
 
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
-def test_positive_update_inclusive_filter_package_version(session, module_org):
+def test_positive_update_inclusive_filter_package_version(session, module_org, target_sat):
     """Update version of package inside inclusive cv package filter
 
     :id: 8d6801de-ab82-49d6-bdeb-0f6e5c95b906
@@ -2038,7 +2041,7 @@ def test_positive_update_inclusive_filter_package_version(session, module_org):
     filter_name = gen_string('alpha')
     repo_name = gen_string('alpha')
     package_name = 'walrus'
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()
     with session:
@@ -2085,7 +2088,7 @@ def test_positive_update_inclusive_filter_package_version(session, module_org):
 
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
-def test_positive_update_exclusive_filter_package_version(session, module_org):
+def test_positive_update_exclusive_filter_package_version(session, module_org, target_sat):
     """Update version of package inside exclusive cv package filter
 
     :id: a8aa8864-190a-46c3-aeed-4953c8f3f601
@@ -2100,7 +2103,7 @@ def test_positive_update_exclusive_filter_package_version(session, module_org):
     filter_name = gen_string('alpha')
     repo_name = gen_string('alpha')
     package_name = 'walrus'
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()
     with session:
@@ -2352,7 +2355,7 @@ def test_positive_add_all_security_errata_by_id_filter(session, module_org):
 
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
-def test_positive_add_errata_filter(session, module_org):
+def test_positive_add_errata_filter(session, module_org, target_sat):
     """add errata to content views filter
 
     :id: bb9eef30-62c4-435c-9573-9f31210b8d7d
@@ -2366,7 +2369,7 @@ def test_positive_add_errata_filter(session, module_org):
     """
     filter_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()
     with session:
@@ -2391,7 +2394,7 @@ def test_positive_add_errata_filter(session, module_org):
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_add_module_stream_filter(session, module_org):
+def test_positive_add_module_stream_filter(session, module_org, target_sat):
     """add module stream filter in a content view
 
     :id: 343c543e-5773-4ea4-aff4-27e0ed6be19e
@@ -2405,7 +2408,7 @@ def test_positive_add_module_stream_filter(session, module_org):
     """
     filter_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    create_sync_custom_repo(
+    target_sat.api_factory.create_sync_custom_repo(
         module_org.id, repo_name=repo_name, repo_url=settings.repos.module_stream_1.url
     )
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
@@ -2432,7 +2435,7 @@ def test_positive_add_module_stream_filter(session, module_org):
 
 
 @pytest.mark.tier3
-def test_positive_add_package_group_filter(session, module_org):
+def test_positive_add_package_group_filter(session, module_org, target_sat):
     """add package group to content views filter
 
     :id: 8c02a432-8b2a-4ba3-9613-7070b2dc2bcb
@@ -2447,7 +2450,7 @@ def test_positive_add_package_group_filter(session, module_org):
     filter_name = gen_string('alpha')
     repo_name = gen_string('alpha')
     package_group = 'mammals'
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo]).create()
     with session:
@@ -2467,7 +2470,7 @@ def test_positive_add_package_group_filter(session, module_org):
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_update_filter_affected_repos(session, module_org):
+def test_positive_update_filter_affected_repos(session, module_org, target_sat):
     """Update content view package filter affected repos
 
     :id: 8f095b11-fd63-4a23-9586-a85d6191314f
@@ -2485,8 +2488,10 @@ def test_positive_update_filter_affected_repos(session, module_org):
     repo2_name = gen_string('alpha')
     repo1_package_name = 'dolphin'
     repo2_package_name = 'dolphin'
-    create_sync_custom_repo(module_org.id, repo_name=repo1_name, repo_url=settings.repos.yum_3.url)
-    create_sync_custom_repo(module_org.id, repo_name=repo2_name)
+    target_sat.api_factory.create_sync_custom_repo(
+        module_org.id, repo_name=repo1_name, repo_url=settings.repos.yum_3.url
+    )
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo2_name)
     repo1 = entities.Repository(name=repo1_name).search(query={'organization_id': module_org.id})[0]
     repo2 = entities.Repository(name=repo2_name).search(query={'organization_id': module_org.id})[0]
     cv = entities.ContentView(organization=module_org, repository=[repo1, repo2]).create()
@@ -2551,7 +2556,7 @@ def test_positive_search_composite(session):
 
 
 @pytest.mark.tier3
-def test_positive_publish_with_repo_with_disabled_http(session, module_org):
+def test_positive_publish_with_repo_with_disabled_http(session, module_org, target_sat):
     """Attempt to publish content view with repository that set
     'Unprotected' to False
 
@@ -2580,7 +2585,7 @@ def test_positive_publish_with_repo_with_disabled_http(session, module_org):
     product_name = gen_string('alpha')
     cv_name = gen_string('alpha')
     # Creates a CV along with product and sync'ed repository
-    create_sync_custom_repo(
+    target_sat.api_factory.create_sync_custom_repo(
         module_org.id, product_name=product_name, repo_name=repo_name, repo_unprotected=True
     )
     with session:
@@ -2722,7 +2727,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(
 @pytest.mark.upgrade
 @pytest.mark.tier3
 def test_positive_rh_mixed_content_end_to_end(
-    session, module_prod, module_entitlement_manifest_org
+    session, module_prod, module_entitlement_manifest_org, target_sat
 ):
     """Create a CV with docker repo as well as RH yum contents and publish and promote
     them to next environment. Remove promoted version afterwards
@@ -2749,7 +2754,7 @@ def test_positive_rh_mixed_content_end_to_end(
         'basearch': 'x86_64',
         'releasever': None,
     }
-    enable_sync_redhat_repo(rh_st_repo, module_entitlement_manifest_org.id)
+    target_sat.api_factory.enable_sync_redhat_repo(rh_st_repo, module_entitlement_manifest_org.id)
     docker_repo.sync()
     lce = entities.LifecycleEnvironment(organization=module_entitlement_manifest_org).create()
     with session:
@@ -2955,7 +2960,7 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, target_
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_module_stream_end_to_end(session, module_org):
+def test_positive_module_stream_end_to_end(session, module_org, target_sat):
     """Create content view with custom module_stream contents, publish and promote it
     to Library +1 env. Then disassociate repository from that content view
 
@@ -2978,7 +2983,7 @@ def test_positive_module_stream_end_to_end(session, module_org):
     env_name = gen_string('alpha')
     cv_name = gen_string('alpha')
     # Creates a CV along with product and sync'ed repository
-    create_sync_custom_repo(
+    target_sat.api_factory.create_sync_custom_repo(
         module_org.id, repo_name=repo_name, repo_url=settings.repos.module_stream_1.url
     )
     with session:
@@ -3005,7 +3010,7 @@ def test_positive_module_stream_end_to_end(session, module_org):
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_search_module_streams_in_content_view(session, module_org):
+def test_positive_search_module_streams_in_content_view(session, module_org, target_sat):
     """Search module streams in content view version
 
     :id: 7f5273ff-e80f-459d-adf4-b517b6d60fdc
@@ -3019,7 +3024,7 @@ def test_positive_search_module_streams_in_content_view(session, module_org):
     """
     repo_name = gen_string('alpha')
     module_stream = 'walrus'
-    create_sync_custom_repo(
+    target_sat.api_factory.create_sync_custom_repo(
         module_org.id, repo_name=repo_name, repo_url=settings.repos.module_stream_1.url
     )
     repo = entities.Repository(name=repo_name).search(query={'organization_id': module_org.id})[0]
@@ -3041,7 +3046,7 @@ def test_positive_search_module_streams_in_content_view(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_non_admin_user_actions(session, module_org, test_name):
+def test_positive_non_admin_user_actions(session, module_org, test_name, target_sat):
     """Attempt to manage content views
 
     :id: c4d270fc-a3e6-4ae2-a338-41d864a5622a
@@ -3074,8 +3079,10 @@ def test_positive_non_admin_user_actions(session, module_org, test_name):
     lce = entities.LifecycleEnvironment(organization=module_org).create()
     # create a role with all content views permissions
     role = entities.Role().create()
-    create_role_permissions(role, {'Katello::ContentView': PERMISSIONS['Katello::ContentView']})
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
+        role, {'Katello::ContentView': PERMISSIONS['Katello::ContentView']}
+    )
+    target_sat.api_factory.create_role_permissions(
         role,
         {
             'Katello::KTEnvironment': [
@@ -3094,7 +3101,7 @@ def test_positive_non_admin_user_actions(session, module_org, test_name):
         password=user_password,
         mail='test@test.com',
     ).create()
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     # create a content view with the main admin account
     with session:
         session.contentview.create({'name': cv_name})
@@ -3134,7 +3141,7 @@ def test_positive_non_admin_user_actions(session, module_org, test_name):
 
 
 @pytest.mark.tier2
-def test_positive_readonly_user_actions(module_org, test_name):
+def test_positive_readonly_user_actions(module_org, test_name, target_sat):
     """Attempt to view content views
 
     :id: ebdc37ed-7887-4f64-944c-f2f92c58a206
@@ -3156,8 +3163,10 @@ def test_positive_readonly_user_actions(module_org, test_name):
     user_password = gen_string('alphanumeric')
     # create a role with content views read only permissions
     role = entities.Role().create()
-    create_role_permissions(role, {'Katello::ContentView': ['view_content_views']})
-    create_role_permissions(role, {'Katello::Product': ['view_products']})
+    target_sat.api_factory.create_role_permissions(
+        role, {'Katello::ContentView': ['view_content_views']}
+    )
+    target_sat.api_factory.create_role_permissions(role, {'Katello::Product': ['view_products']})
     # create a user and assign the above created role
     entities.User(
         default_organization=module_org,
@@ -3166,7 +3175,7 @@ def test_positive_readonly_user_actions(module_org, test_name):
         login=user_login,
         password=user_password,
     ).create()
-    repo_id = create_sync_custom_repo(module_org.id)
+    repo_id = target_sat.api_factory.create_sync_custom_repo(module_org.id)
     yum_repo = entities.Repository(id=repo_id).read()
     cv = entities.ContentView(organization=module_org, repository=[yum_repo]).create()
     cv.publish()
@@ -3182,7 +3191,7 @@ def test_positive_readonly_user_actions(module_org, test_name):
 
 
 @pytest.mark.tier2
-def test_negative_read_only_user_actions(session, module_org, test_name):
+def test_negative_read_only_user_actions(session, module_org, test_name, target_sat):
     """Attempt to manage content views
 
     :id: aae6eede-b40e-4e06-a5f7-59d9251aa35d
@@ -3212,8 +3221,10 @@ def test_negative_read_only_user_actions(session, module_org, test_name):
     lce = entities.LifecycleEnvironment(organization=module_org).create()
     # create a role with content views read only permissions
     role = entities.Role().create()
-    create_role_permissions(role, {'Katello::ContentView': ['view_content_views']})
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
+        role, {'Katello::ContentView': ['view_content_views']}
+    )
+    target_sat.api_factory.create_role_permissions(
         role,
         {
             'Katello::KTEnvironment': [
@@ -3231,7 +3242,7 @@ def test_negative_read_only_user_actions(session, module_org, test_name):
         login=user_login,
         password=user_password,
     ).create()
-    repo_id = create_sync_custom_repo(module_org.id)
+    repo_id = target_sat.api_factory.create_sync_custom_repo(module_org.id)
     yum_repo = entities.Repository(id=repo_id).read()
     repo_name = 'fakerepo01'
     cv = entities.ContentView(organization=module_org, repository=[yum_repo]).create()
@@ -3292,7 +3303,7 @@ def test_negative_read_only_user_actions(session, module_org, test_name):
 
 
 @pytest.mark.tier2
-def test_negative_non_readonly_user_actions(module_org, test_name):
+def test_negative_non_readonly_user_actions(module_org, test_name, target_sat):
     """Attempt to view content views
 
     :id: 9cbc661a-dbe3-4b88-af27-4cf7b9544074
@@ -3313,7 +3324,7 @@ def test_negative_non_readonly_user_actions(module_org, test_name):
     lce = entities.LifecycleEnvironment(organization=module_org).create()
     cv = entities.ContentView(organization=module_org).create()
     role = entities.Role().create()
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         role,
         {
             'Katello::ContentView': [
@@ -3325,7 +3336,7 @@ def test_negative_non_readonly_user_actions(module_org, test_name):
             ]
         },
     )
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         role,
         {
             'Katello::KTEnvironment': [
@@ -3362,7 +3373,7 @@ def test_negative_non_readonly_user_actions(module_org, test_name):
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_conservative_solve_dependencies(session, module_org):
+def test_positive_conservative_solve_dependencies(session, module_org, target_sat):
     """Performing solve dependencies on a package that is required by another
     package.  Then performing solve dependencies on a root package with
     its corresponding dependency.
@@ -3395,7 +3406,9 @@ def test_positive_conservative_solve_dependencies(session, module_org):
     package1_name = 'duck'
     package2_name = 'cockateel'
     arch = 'noarch'
-    create_sync_custom_repo(module_org.id, repo_name=repo_name, repo_url=settings.repos.yum_0.url)
+    target_sat.api_factory.create_sync_custom_repo(
+        module_org.id, repo_name=repo_name, repo_url=settings.repos.yum_0.url
+    )
     with session:
         session.settings.update(f'name = {property_name}', param_value)
         session.contentview.create({'name': cv_name, 'solve_dependencies': True})
@@ -3437,7 +3450,9 @@ def test_positive_conservative_solve_dependencies(session, module_org):
 
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
-def test_positive_conservative_dep_solving_with_multiversion_packages(session, module_org):
+def test_positive_conservative_dep_solving_with_multiversion_packages(
+    session, module_org, target_sat
+):
     """Performing solve dependencies on a package with multiple versions that is required
     by another package.
 
@@ -3465,7 +3480,9 @@ def test_positive_conservative_dep_solving_with_multiversion_packages(session, m
     repo_name = gen_string('alpha')
     package_name = 'walrus'
     arch = 'noarch'
-    create_sync_custom_repo(module_org.id, repo_name=repo_name, repo_url=settings.repos.yum_0.url)
+    target_sat.api_factory.create_sync_custom_repo(
+        module_org.id, repo_name=repo_name, repo_url=settings.repos.yum_0.url
+    )
     with session:
         session.settings.update(f'name = {property_name}', param_value)
         session.contentview.create({'name': cv_name, 'solve_dependencies': True})
@@ -3505,7 +3522,7 @@ def test_positive_conservative_dep_solving_with_multiversion_packages(session, m
 @pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_depsolve_with_module_errata(session, module_org):
+def test_positive_depsolve_with_module_errata(session, module_org, target_sat):
     """Allowing users to filter module streams in content views.  This test case does not test
     against RHEL8 repos because it is known that RHEL8 filtering with depsolving creates
     inconsistent results.  The custom repo used in this test case has consistent results based
@@ -3535,10 +3552,10 @@ def test_positive_depsolve_with_module_errata(session, module_org):
     ms_version = '0.71'
     rpm_pack = ['shark', 'stork', 'walrus', 'whale']
     mod_stream = 'walrus'
-    create_sync_custom_repo(
+    target_sat.api_factory.create_sync_custom_repo(
         module_org.id, repo_name=repo_name_1, repo_url=settings.repos.yum_10.url
     )
-    create_sync_custom_repo(
+    target_sat.api_factory.create_sync_custom_repo(
         module_org.id, repo_name=repo_name_2, repo_url=settings.repos.yum_11.url
     )
     content = '4 Packages 1 Errata ( 1 0 0 ) 1 Module Streams'
@@ -3597,7 +3614,7 @@ def test_positive_filter_by_pkg_group_name(session, module_org, target_sat):
     repo_name = gen_string('alpha')
     package_group = 'birds'
     expected_packages = [('cockateel'), ('duck'), ('penguin'), ('stork')]
-    create_sync_custom_repo(module_org.id, repo_name=repo_name)
+    target_sat.api_factory.create_sync_custom_repo(module_org.id, repo_name=repo_name)
     repo = target_sat.api.Repository(name=repo_name).search(
         query={'organization_id': module_org.id}
     )[0]
@@ -3735,7 +3752,7 @@ def test_positive_no_duplicate_key_violate_unique_constraint_using_filters(
         'katello-host-tools',
         'katello-host-tools-fact-plugin',
     ]
-    enable_sync_redhat_repo(rh_repo, module_entitlement_manifest_org.id)
+    target_sat.api_factory.enable_sync_redhat_repo(rh_repo, module_entitlement_manifest_org.id)
     with session:
         session.contentview.create({'name': cv})
         session.contentview.add_yum_repo(cv, rh_repo['name'])

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -21,7 +21,6 @@ from airgun.session import Session
 from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 
-from robottelo.api.utils import create_role_permissions
 from robottelo.config import settings
 from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
 from robottelo.utils.datafactory import gen_string
@@ -239,7 +238,7 @@ def test_positive_user_access_with_host_filter(
         None: ['access_dashboard'],
         'Host': ['view_hosts'],
     }
-    create_role_permissions(role, user_permissions)
+    target_sat.api_factory.create_role_permissions(role, user_permissions)
     # create a user and assign the above created role
     entities.User(
         default_organization=org,

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -19,8 +19,6 @@ from fauxfactory import gen_ipaddr
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import configure_provisioning
-from robottelo.api.utils import create_discovered_host
 from robottelo.utils import ssh
 
 pytestmark = [pytest.mark.run_in_one_thread]
@@ -54,7 +52,7 @@ def discovery_location(module_location):
 def provisioning_env(module_target_sat, discovery_org, discovery_location):
     # Build PXE default template to get default PXE file
     module_target_sat.cli.ProvisioningTemplate().build_pxe_default()
-    return configure_provisioning(
+    return module_target_sat.api_factory.configure_provisioning(
         org=discovery_org,
         loc=discovery_location,
         os='Redhat {}'.format(module_target_sat.cli_factory.RHELRepository().repo_data['version']),
@@ -62,8 +60,8 @@ def provisioning_env(module_target_sat, discovery_org, discovery_location):
 
 
 @pytest.fixture
-def discovered_host():
-    return create_discovered_host()
+def discovered_host(target_sat):
+    return target_sat.create_discovered_host()
 
 
 @pytest.fixture(scope='module')
@@ -221,7 +219,7 @@ def test_positive_update_name(
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_auto_provision_host_with_rule(
-    session, discovery_org, discovery_location, module_host_group
+    session, discovery_org, discovery_location, module_host_group, target_sat
 ):
     """Create a new discovery rule and automatically create host from discovered host using that
     discovery rule.
@@ -239,7 +237,7 @@ def test_positive_auto_provision_host_with_rule(
     :CaseImportance: High
     """
     host_ip = gen_ipaddr()
-    discovered_host_name = create_discovered_host(ip_address=host_ip)['name']
+    discovered_host_name = target_sat.create_discovered_host(ip_address=host_ip)['name']
     domain = module_host_group.domain.read()
     discovery_rule = entities.DiscoveryRule(
         max_count=1,
@@ -283,7 +281,7 @@ def test_positive_delete(session, discovery_org, discovery_location, discovered_
 
 
 @pytest.mark.tier3
-def test_positive_update_default_taxonomies(session, discovery_org, discovery_location):
+def test_positive_update_default_taxonomies(session, discovery_org, discovery_location, target_sat):
     """Change the default organization and location of more than one
     discovered hosts from 'Select Action' drop down
 
@@ -298,7 +296,7 @@ def test_positive_update_default_taxonomies(session, discovery_org, discovery_lo
 
     :CaseImportance: High
     """
-    host_names = [create_discovered_host()['name'] for _ in range(2)]
+    host_names = [target_sat.create_discovered_host()['name'] for _ in range(2)]
     new_org = entities.Organization().create()
     discovery_location.organization.append(new_org)
     discovery_location.update(['organization'])

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -23,8 +23,6 @@ from fauxfactory import gen_ipaddr
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import create_discovered_host
-
 
 @pytest.fixture(scope='module')
 def manager_loc():
@@ -193,7 +191,7 @@ def test_negative_delete_rule_with_non_admin_user(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_positive_list_host_based_on_rule_search_query(
-    session, module_org, module_location, module_discovery_env
+    session, module_org, module_location, module_discovery_env, target_sat
 ):
     """List all the discovered hosts resolved by given rule's search query
     e.g. all discovered hosts with cpu_count = 2, and list rule's associated
@@ -238,11 +236,11 @@ def test_positive_list_host_based_on_rule_search_query(
         location=[module_location],
         priority=gen_int32(),
     ).create()
-    discovered_host = create_discovered_host(
+    discovered_host = target_sat.create_discovered_host(
         ip_address=ip_address, options={'physicalprocessorcount': cpu_count}
     )
     # create an other discovered host with an other cpu count
-    create_discovered_host(options={'physicalprocessorcount': cpu_count + 1})
+    target_sat.create_discovered_host(options={'physicalprocessorcount': cpu_count + 1})
     provisioned_host_name = '{}.{}'.format(discovered_host['name'], host.domain.read().name)
     with session:
         values = session.discoveryrule.read_all()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -31,9 +31,6 @@ from airgun.session import Session
 from wait_for import wait_for
 
 from robottelo import constants
-from robottelo.api.utils import create_role_permissions
-from robottelo.api.utils import cv_publish_promote
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import DEFAULT_CV
@@ -638,7 +635,9 @@ def test_positive_view_hosts_with_non_admin_user(
     """
     user_password = gen_string('alpha')
     role = target_sat.api.Role(organization=[module_org]).create()
-    create_role_permissions(role, {'Organization': ['view_organizations'], 'Host': ['view_hosts']})
+    target_sat.api_factory.create_role_permissions(
+        role, {'Organization': ['view_organizations'], 'Host': ['view_hosts']}
+    )
     user = target_sat.api.User(
         role=[role],
         admin=False,
@@ -676,7 +675,7 @@ def test_positive_remove_parameter_non_admin_user(
     user_password = gen_string('alpha')
     parameter = {'name': gen_string('alpha'), 'value': gen_string('alpha')}
     role = target_sat.api.Role(organization=[module_org]).create()
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         role,
         {
             'Parameter': PERMISSIONS['Parameter'],
@@ -733,7 +732,7 @@ def test_negative_remove_parameter_non_admin_user(
     user_password = gen_string('alpha')
     parameter = {'name': gen_string('alpha'), 'value': gen_string('alpha')}
     role = target_sat.api.Role(organization=[module_org]).create()
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         role,
         {
             'Parameter': ['view_params'],
@@ -801,7 +800,7 @@ def test_positive_check_permissions_affect_create_procedure(
     filter_hg = target_sat.api.HostGroup(organization=[function_org]).create()
     # Create lifecycle environment permissions and select one specific
     # environment user will have access to
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         function_role,
         {
             'Katello::KTEnvironment': [
@@ -813,7 +812,7 @@ def test_positive_check_permissions_affect_create_procedure(
         search=f'name = {filter_lc_env.name}',
     )
     # Add necessary permissions for content view as we did for lce
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         function_role,
         {
             'Katello::ContentView': [
@@ -826,21 +825,21 @@ def test_positive_check_permissions_affect_create_procedure(
         search=f'name = {filter_cv.name}',
     )
     # Add necessary permissions for hosts as we did for lce
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         function_role,
         {'Host': ['create_hosts', 'view_hosts']},
         # allow access only to the mentioned here host group
         search=f'hostgroup_fullname = {filter_hg.name}',
     )
     # Add necessary permissions for host groups as we did for lce
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         function_role,
         {'Hostgroup': ['view_hostgroups']},
         # allow access only to the mentioned here host group
         search=f'name = {filter_hg.name}',
     )
     # Add permissions for Organization and Location
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         function_role,
         {'Organization': PERMISSIONS['Organization'], 'Location': PERMISSIONS['Location']},
     )
@@ -1102,7 +1101,7 @@ def test_positive_validate_inherited_cv_lce(session, target_sat, module_host_tem
     """
     cv_name = gen_string('alpha')
     lce_name = gen_string('alphanumeric')
-    cv = cv_publish_promote(
+    cv = target_sat.api_factory.cv_publish_promote(
         name=cv_name, env_name=lce_name, org_id=module_host_template.organization.id
     )
     lce = (
@@ -1325,7 +1324,7 @@ def test_positive_global_registration_end_to_end(
         .read()
     )
     # make sure that task is finished
-    task_result = wait_for_tasks(
+    task_result = target_sat.wait_for_tasks(
         search_query=(f'id = {result.task.id}'), search_rate=2, max_tries=60
     )
     assert task_result[0].result == 'success'
@@ -2190,7 +2189,7 @@ def test_rex_new_ui(session, target_sat, rex_contenthost):
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         session.host_new.schedule_job(hostname, job_args)
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(f'Remote action: Run ls on {hostname}'),
             search_rate=2,
             max_tries=30,
@@ -2266,7 +2265,7 @@ def test_positive_update_delete_package(
             client.run('subscription-manager repos')
         # install package
         session.host_new.install_package(client.hostname, FAKE_8_CUSTOM_PACKAGE_NAME)
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(f'Install package(s) on {client.hostname}'),
             search_rate=4,
             max_tries=60,
@@ -2298,7 +2297,7 @@ def test_positive_update_delete_package(
         session.host_new.apply_package_action(
             client.hostname, FAKE_8_CUSTOM_PACKAGE_NAME, "Upgrade via remote execution"
         )
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(f'Update package(s) {FAKE_8_CUSTOM_PACKAGE_NAME} on {client.hostname}'),
             search_rate=2,
             max_tries=60,
@@ -2310,7 +2309,7 @@ def test_positive_update_delete_package(
 
         # remove package
         session.host_new.apply_package_action(client.hostname, FAKE_8_CUSTOM_PACKAGE_NAME, "Remove")
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(f'Remove package(s) {FAKE_8_CUSTOM_PACKAGE_NAME} on {client.hostname}'),
             search_rate=2,
             max_tries=60,
@@ -2386,7 +2385,7 @@ def test_positive_apply_erratum(
         assert erratas['content']['errata']['table'][0]['Errata'] == errata_id
         # apply errata
         session.host_new.apply_erratas(client.hostname, f"errata_id == {errata_id}")
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(
                 f'"Install errata errata_id == {errata_id.lower()} '
                 f'and type=security on {client.hostname}"'
@@ -2456,7 +2455,7 @@ def test_positive_crud_module_streams(
 
         # enable module stream
         session.host_new.apply_module_streams_action(client.hostname, module_name, "Enable")
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(f'Module enable {module_name} on {client.hostname}'),
             search_rate=5,
             max_tries=60,
@@ -2469,7 +2468,7 @@ def test_positive_crud_module_streams(
 
         # install
         session.host_new.apply_module_streams_action(client.hostname, module_name, "Install")
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(f'Module install {module_name} on {client.hostname}'),
             search_rate=5,
             max_tries=60,
@@ -2481,7 +2480,7 @@ def test_positive_crud_module_streams(
 
         # remove
         session.host_new.apply_module_streams_action(client.hostname, module_name, "Remove")
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(f'Module remove {module_name} on {client.hostname}'),
             search_rate=5,
             max_tries=60,
@@ -2493,7 +2492,7 @@ def test_positive_crud_module_streams(
         assert streams[0]['Installation status'] == 'Not installed'
 
         session.host_new.apply_module_streams_action(client.hostname, module_name, "Reset")
-        task_result = wait_for_tasks(
+        task_result = target_sat.wait_for_tasks(
             search_query=(f'Module reset {module_name} on {client.hostname}'),
             search_rate=5,
             max_tries=60,

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -23,7 +23,6 @@ from broker import Broker
 from nailgun import entities
 
 from robottelo import constants
-from robottelo.api.utils import update_vm_host_location
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import gen_string
@@ -68,7 +67,7 @@ def vm_content_hosts(smart_proxy_location, module_repos_collection, module_targe
         for client in clients:
             module_repos_collection.setup_virtual_machine(client, install_katello_agent=False)
             client.add_rex_key(satellite=module_target_sat)
-            update_vm_host_location(client, smart_proxy_location.id)
+            module_target_sat.update_vm_host_location(client, smart_proxy_location.id)
         yield clients
 
 
@@ -82,7 +81,7 @@ def vm_content_hosts_module_stream(
                 client, install_katello_agent=False
             )
             client.add_rex_key(satellite=module_target_sat)
-            update_vm_host_location(client, smart_proxy_location.id)
+            module_target_sat.update_vm_host_location(client, smart_proxy_location.id)
         yield clients
 
 

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -19,7 +19,6 @@
 import pytest
 from inflection import camelize
 
-from robottelo.api.utils import update_vm_host_location
 from robottelo.utils.datafactory import gen_string
 
 
@@ -27,7 +26,7 @@ from robottelo.utils.datafactory import gen_string
 def module_rhel_client_by_ip(module_org, smart_proxy_location, rhel7_contenthost, target_sat):
     """Setup a broker rhel client to be used in remote execution by ip"""
     rhel7_contenthost.configure_rex(satellite=target_sat, org=module_org)
-    update_vm_host_location(rhel7_contenthost, location_id=smart_proxy_location.id)
+    target_sat.update_vm_host_location(rhel7_contenthost, location_id=smart_proxy_location.id)
     yield rhel7_contenthost
 
 

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -25,7 +25,6 @@ from fauxfactory import gen_url
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
 
-from robottelo.api.utils import create_role_permissions
 from robottelo.config import settings
 from robottelo.constants import CERT_PATH
 from robottelo.constants import LDAP_ATTR
@@ -258,7 +257,7 @@ def test_positive_create_org_and_loc(session, ldap_auth_source, ldap_tear_down):
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
 @pytest.mark.tier2
 def test_positive_add_katello_role(
-    test_name, session, ldap_usergroup_name, ldap_auth_source, ldap_tear_down
+    test_name, session, ldap_usergroup_name, ldap_auth_source, ldap_tear_down, target_sat
 ):
     """Associate katello roles to User Group.
     [belonging to external User Group.]
@@ -282,7 +281,7 @@ def test_positive_add_katello_role(
     ak_name = gen_string('alpha')
     user_permissions = {'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey']}
     katello_role = entities.Role().create()
-    create_role_permissions(katello_role, user_permissions)
+    target_sat.api_factory.create_role_permissions(katello_role, user_permissions)
     with session:
         session.usergroup.create(
             {
@@ -307,7 +306,7 @@ def test_positive_add_katello_role(
 @pytest.mark.upgrade
 @pytest.mark.tier2
 def test_positive_update_external_roles(
-    test_name, session, ldap_usergroup_name, ldap_auth_source, ldap_tear_down
+    test_name, session, ldap_usergroup_name, ldap_auth_source, ldap_tear_down, target_sat
 ):
     """Added AD UserGroup roles get pushed down to user
 
@@ -337,8 +336,8 @@ def test_positive_update_external_roles(
     katello_role = entities.Role().create()
     foreman_permissions = {'Location': PERMISSIONS['Location']}
     katello_permissions = {'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey']}
-    create_role_permissions(foreman_role, foreman_permissions)
-    create_role_permissions(katello_role, katello_permissions)
+    target_sat.api_factory.create_role_permissions(foreman_role, foreman_permissions)
+    target_sat.api_factory.create_role_permissions(katello_role, katello_permissions)
     with session:
         session.usergroup.create(
             {
@@ -372,7 +371,7 @@ def test_positive_update_external_roles(
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_delete_external_roles(
-    test_name, session, ldap_usergroup_name, ldap_tear_down, ldap_auth_source
+    test_name, session, ldap_usergroup_name, ldap_tear_down, ldap_auth_source, target_sat
 ):
     """Deleted AD UserGroup roles get pushed down to user
 
@@ -401,7 +400,7 @@ def test_positive_delete_external_roles(
     location_name = gen_string('alpha')
     foreman_role = entities.Role().create()
     foreman_permissions = {'Location': PERMISSIONS['Location']}
-    create_role_permissions(foreman_role, foreman_permissions)
+    target_sat.api_factory.create_role_permissions(foreman_role, foreman_permissions)
     with session:
         session.usergroup.create(
             {
@@ -433,7 +432,7 @@ def test_positive_delete_external_roles(
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
 @pytest.mark.tier2
 def test_positive_update_external_user_roles(
-    test_name, session, ldap_usergroup_name, ldap_tear_down, ldap_auth_source
+    test_name, session, ldap_usergroup_name, ldap_tear_down, ldap_auth_source, target_sat
 ):
     """Assure that user has roles/can access feature areas for
     additional roles assigned outside any roles assigned by his group
@@ -470,8 +469,8 @@ def test_positive_update_external_user_roles(
     katello_role = entities.Role().create()
     foreman_permissions = {'Location': PERMISSIONS['Location']}
     katello_permissions = {'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey']}
-    create_role_permissions(foreman_role, foreman_permissions)
-    create_role_permissions(katello_role, katello_permissions)
+    target_sat.api_factory.create_role_permissions(foreman_role, foreman_permissions)
+    target_sat.api_factory.create_role_permissions(katello_role, katello_permissions)
     with session:
         session.usergroup.create(
             {
@@ -569,6 +568,7 @@ def test_positive_add_foreman_role_with_org_loc(
     module_location,
     ldap_tear_down,
     ldap_auth_source,
+    module_target_sat,
 ):
     """Associate foreman roles to User Group with org and loc set.
     [belonging to external User Group.]
@@ -601,7 +601,7 @@ def test_positive_add_foreman_role_with_org_loc(
         'Organization': ['assign_organizations'],
     }
     foreman_role = entities.Role().create()
-    create_role_permissions(foreman_role, user_permissions)
+    module_target_sat.api_factory.create_role_permissions(foreman_role, user_permissions)
     with session:
         session.usergroup.create(
             {
@@ -635,6 +635,7 @@ def test_positive_add_katello_role_with_org(
     module_org,
     ldap_tear_down,
     ldap_auth_source,
+    target_sat,
 ):
     """Associate katello roles to User Group with org set.
     [belonging to external User Group.]
@@ -665,7 +666,7 @@ def test_positive_add_katello_role_with_org(
         'Organization': ['assign_organizations'],
     }
     katello_role = entities.Role().create()
-    create_role_permissions(katello_role, user_permissions)
+    target_sat.api_factory.create_role_permissions(katello_role, user_permissions)
     different_org = entities.Organization().create()
     with session:
         session.usergroup.create(
@@ -748,7 +749,9 @@ def test_positive_login_user_no_roles(test_name, ldap_tear_down, ldap_auth_sourc
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_login_user_basic_roles(test_name, session, ldap_tear_down, ldap_auth_source):
+def test_positive_login_user_basic_roles(
+    test_name, session, ldap_tear_down, ldap_auth_source, target_sat
+):
     """Login with LDAP for user with roles/rights
 
     :id: ef202e94-8e5d-4333-a4bc-e573b03ebfc8
@@ -766,7 +769,7 @@ def test_positive_login_user_basic_roles(test_name, session, ldap_tear_down, lda
     name = gen_string('alpha')
     role = entities.Role().create()
     permissions = {'Architecture': PERMISSIONS['Architecture']}
-    create_role_permissions(role, permissions)
+    target_sat.api_factory.create_role_permissions(role, permissions)
     with Session(
         test_name, ldap_data['ldap_user_name'], ldap_data['ldap_user_passwd']
     ) as ldapsession:
@@ -1159,7 +1162,9 @@ def test_login_failure_if_internal_user_exist(
 
 @pytest.mark.skip_if_open("BZ:1812688")
 @pytest.mark.tier2
-def test_userlist_with_external_admin(session, auth_source_ipa, ldap_tear_down, groups_teardown):
+def test_userlist_with_external_admin(
+    session, auth_source_ipa, ldap_tear_down, groups_teardown, target_sat
+):
     """All the external users should be displayed to all LDAP admins (internal and external).
 
     :id: 7c7bf34a-06f9-11eb-b174-d46d6dd3b5b2
@@ -1191,7 +1196,7 @@ def test_userlist_with_external_admin(session, auth_source_ipa, ldap_tear_down, 
     auth_source_name = f'LDAP-{auth_source_ipa.name}'
     user_permissions = {'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey']}
     katello_role = entities.Role().create()
-    create_role_permissions(katello_role, user_permissions)
+    target_sat.api_factory.create_role_permissions(katello_role, user_permissions)
     with session:
         session.usergroup.create(
             {
@@ -1224,7 +1229,13 @@ def test_userlist_with_external_admin(session, auth_source_ipa, ldap_tear_down, 
 @pytest.mark.skip_if_open('BZ:1883209')
 @pytest.mark.tier2
 def test_positive_group_sync_open_ldap_authsource(
-    test_name, session, auth_source_open_ldap, ldap_usergroup_name, ldap_tear_down, open_ldap_data
+    test_name,
+    session,
+    auth_source_open_ldap,
+    ldap_usergroup_name,
+    ldap_tear_down,
+    open_ldap_data,
+    target_sat,
 ):
     """Associate katello roles to User Group. [belonging to external OpenLDAP User Group.]
 
@@ -1244,7 +1255,7 @@ def test_positive_group_sync_open_ldap_authsource(
     auth_source_name = f'LDAP-{auth_source_open_ldap.name}'
     user_permissions = {'Katello::ActivationKey': PERMISSIONS['Katello::ActivationKey']}
     katello_role = entities.Role().create()
-    create_role_permissions(katello_role, user_permissions)
+    target_sat.api_factory.create_role_permissions(katello_role, user_permissions)
     with session:
         session.usergroup.create(
             {
@@ -1268,7 +1279,12 @@ def test_positive_group_sync_open_ldap_authsource(
 
 @pytest.mark.tier2
 def test_verify_group_permissions(
-    session, auth_source_ipa, multigroup_setting_cleanup, groups_teardown, ldap_tear_down
+    session,
+    auth_source_ipa,
+    multigroup_setting_cleanup,
+    groups_teardown,
+    ldap_tear_down,
+    target_sat,
 ):
     """Verify group permission for external linked group
 
@@ -1289,7 +1305,7 @@ def test_verify_group_permissions(
     auth_source_name = f'LDAP-{auth_source_ipa.name}'
     user_permissions = {None: ['access_dashboard']}
     katello_role = entities.Role().create()
-    create_role_permissions(katello_role, user_permissions)
+    target_sat.api_factory.create_role_permissions(katello_role, user_permissions)
     with session:
         session.usergroup.create(
             {

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -20,7 +20,6 @@ import pytest
 from airgun.session import Session
 from navmazing import NavigationTriesExceeded
 
-from robottelo.api.utils import create_role_permissions
 from robottelo.config import settings
 from robottelo.constants import ENVIRONMENT
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
@@ -299,7 +298,7 @@ def test_positive_custom_user_view_lce(session, test_name, target_sat):
             'promote_or_remove_content_views_to_environments',
         ],
     }
-    create_role_permissions(role, permissions_types_names)
+    target_sat.api_factory.create_role_permissions(role, permissions_types_names)
     target_sat.api.User(
         default_organization=org,
         organization=[org],

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -20,7 +20,6 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.constants import DataFile
 from robottelo.constants import RPM_TO_UPLOAD
@@ -64,7 +63,7 @@ def module_yum_repo2(module_product):
 def module_rh_repo(module_org, module_target_sat):
     module_target_sat.upload_manifest(module_org.id)
     rhst = module_target_sat.cli_factory.SatelliteToolsRepository(cdn=True)
-    repo_id = enable_rhrepo_and_fetchid(
+    repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=rhst.data['arch'],
         org_id=module_org.id,
         product=rhst.data['product'],

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -23,7 +23,6 @@ import pytest
 from broker import Broker
 from wait_for import wait_for
 
-from robottelo.api.utils import update_vm_host_location
 from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import gen_string
 
@@ -32,7 +31,7 @@ from robottelo.utils.datafactory import gen_string
 def module_vm_client_by_ip(rhel7_contenthost, module_org, smart_proxy_location, target_sat):
     """Setup a VM client to be used in remote execution by ip"""
     rhel7_contenthost.configure_rex(satellite=target_sat, org=module_org)
-    update_vm_host_location(rhel7_contenthost, location_id=smart_proxy_location.id)
+    target_sat.update_vm_host_location(rhel7_contenthost, location_id=smart_proxy_location.id)
     yield rhel7_contenthost
 
 
@@ -171,7 +170,7 @@ def test_positive_run_job_template_multiple_hosts_by_ip(
         for host in hosts:
             host_names.append(host.hostname)
             host.configure_rex(satellite=target_sat, org=module_org)
-            update_vm_host_location(host, location_id=smart_proxy_location.id)
+            target_sat.update_vm_host_location(host, location_id=smart_proxy_location.id)
         with session:
             session.location.select(smart_proxy_location.name)
             hosts = session.host.search(

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -27,7 +27,6 @@ import yaml
 from lxml import etree
 from nailgun import entities
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import robottelo_tmp_dir
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
@@ -38,9 +37,9 @@ from robottelo.utils.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def setup_content(module_entitlement_manifest_org):
+def setup_content(module_entitlement_manifest_org, module_target_sat):
     org = module_entitlement_manifest_org
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=PRDS['rhel'],

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -27,8 +27,6 @@ from nailgun import entities
 from navmazing import NavigationTriesExceeded
 
 from robottelo import constants
-from robottelo.api.utils import create_role_permissions
-from robottelo.api.utils import wait_for_tasks
 from robottelo.config import settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
 from robottelo.constants import DataFile
@@ -92,7 +90,7 @@ def test_positive_create_in_different_orgs(session, module_org):
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_create_as_non_admin_user(module_org, test_name):
+def test_positive_create_as_non_admin_user(module_org, test_name, target_sat):
     """Create a repository as a non admin user
 
     :id: 582949c4-b95f-4d64-b7f0-fb80b3d2bd7e
@@ -117,7 +115,7 @@ def test_positive_create_as_non_admin_user(module_org, test_name):
         ],
     }
     role = entities.Role().create()
-    create_role_permissions(role, user_permissions)
+    target_sat.api_factory.create_role_permissions(role, user_permissions)
     entities.User(
         login=user_login,
         password=user_password,
@@ -182,7 +180,7 @@ def test_positive_create_yum_repo_same_url_different_orgs(session, module_prod):
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_name):
+def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_name, target_sat):
     """Create a repository as a non admin user in a product that already
     contain a repository that is used in a published content view.
 
@@ -208,7 +206,7 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
         ],
     }
     role = entities.Role().create()
-    create_role_permissions(role, user_permissions)
+    target_sat.api_factory.create_role_permissions(role, user_permissions)
     entities.User(
         login=user_login,
         password=user_password,
@@ -1071,7 +1069,7 @@ def test_sync_status_persists_after_task_delete(session, module_prod, module_org
         assert len(result) == 1
         assert result[0] == 'Syncing Complete.'
         # Get the UUID of the sync task.
-        search_result = wait_for_tasks(
+        search_result = target_sat.wait_for_tasks(
             search_query='label = Actions::Katello::Repository::Sync'
             f' and organization_id = {module_org.id}'
             f' and started_at >= "{timestamp}"',

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -21,7 +21,6 @@ from fauxfactory import gen_string
 from wait_for import wait_for
 
 from robottelo import constants
-from robottelo.api.utils import enable_sync_redhat_repo
 from robottelo.config import settings
 from robottelo.logging import logger
 from robottelo.utils.issue_handlers import is_open
@@ -78,8 +77,12 @@ def fixture_setup_rhc_satellite(request, module_target_sat, module_rhc_org):
                 {'file': manifests_path, 'organization-id': module_rhc_org.id}
             )
         # Enable and sync required repos
-        repo1_id = enable_sync_redhat_repo(constants.REPOS['rhel8_aps'], module_rhc_org.id)
-        repo2_id = enable_sync_redhat_repo(constants.REPOS['rhel7'], module_rhc_org.id)
+        repo1_id = module_target_sat.api_factory.enable_sync_redhat_repo(
+            constants.REPOS['rhel8_aps'], module_rhc_org.id
+        )
+        repo2_id = module_target_sat.api_factory.enable_sync_redhat_repo(
+            constants.REPOS['rhel7'], module_rhc_org.id
+        )
         # Add repos to Content view
         content_view = module_target_sat.api.ContentView(
             organization=module_rhc_org, repository=[repo1_id, repo2_id]

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -24,8 +24,6 @@ from airgun.session import Session
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import create_role_permissions
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.cli.factory import make_virt_who_config
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
@@ -40,9 +38,9 @@ pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.skip_if_not_set('fake_m
 
 
 @pytest.fixture(scope='module')
-def golden_ticket_host_setup(function_entitlement_manifest_org):
+def golden_ticket_host_setup(function_entitlement_manifest_org, module_target_sat):
     org = function_entitlement_manifest_org
-    rh_repo_id = enable_rhrepo_and_fetchid(
+    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
         product=PRDS['rhel'],
@@ -149,7 +147,7 @@ def test_positive_end_to_end(session, target_sat):
 
 
 @pytest.mark.tier2
-def test_positive_access_with_non_admin_user_without_manifest(test_name):
+def test_positive_access_with_non_admin_user_without_manifest(test_name, target_sat):
     """Access subscription page with non admin user that has the necessary
     permissions to check that there is no manifest uploaded.
 
@@ -165,7 +163,7 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name):
     """
     org = entities.Organization().create()
     role = entities.Role(organization=[org]).create()
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         role,
         {
             'Katello::Subscription': [
@@ -192,7 +190,7 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name):
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_access_with_non_admin_user_with_manifest(
-    test_name, function_entitlement_manifest_org
+    test_name, function_entitlement_manifest_org, target_sat
 ):
     """Access subscription page with user that has only view_subscriptions and view organizations
     permission and organization that has a manifest uploaded.
@@ -212,7 +210,7 @@ def test_positive_access_with_non_admin_user_with_manifest(
     """
     org = function_entitlement_manifest_org
     role = entities.Role(organization=[org]).create()
-    create_role_permissions(
+    target_sat.api_factory.create_role_permissions(
         role,
         {'Katello::Subscription': ['view_subscriptions'], 'Organization': ['view_organizations']},
     )

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -20,7 +20,6 @@ import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 
-from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
 from robottelo.constants import CONTAINER_UPSTREAM_NAME
@@ -140,7 +139,7 @@ def test_positive_sync_custom_ostree_repo(session, module_custom_product):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_sync_rh_ostree_repo(session, module_org_with_manifest):
+def test_positive_sync_rh_ostree_repo(session, module_org_with_manifest, target_sat):
     """Sync CDN based ostree repository.
 
     :id: 4d28fff0-5fda-4eee-aa0c-c5af02c31de5
@@ -157,7 +156,7 @@ def test_positive_sync_rh_ostree_repo(session, module_org_with_manifest):
 
     :BZ: 1625783
     """
-    enable_rhrepo_and_fetchid(
+    target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=None,
         org_id=module_org_with_manifest.id,
         product=PRDS['rhah'],

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -24,28 +24,9 @@ import pytest
 from fauxfactory import gen_choice
 from nailgun import entities
 
-from robottelo.api.utils import disable_syncplan
-from robottelo.api.utils import wait_for_tasks
 from robottelo.constants import SYNC_INTERVAL
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.datafactory import valid_cron_expressions
-
-
-def validate_task_status(repo_id, org_id, max_tries=10):
-    """Wait for foreman_tasks to complete or timeout
-
-    :param repo_id: Repository Id to identify the correct task
-    :param max_tries: Max tries to poll for the task creation
-    :param org_id: Org ID to ensure valid check on busy Satellite
-    """
-    wait_for_tasks(
-        search_query='Actions::Katello::Repository::Sync'
-        f' and organization_id = {org_id}'
-        f' and resource_id = {repo_id}'
-        ' and resource_type = Katello::Repository',
-        max_tries=max_tries,
-        search_rate=10,
-    )
 
 
 def validate_repo_content(repo, content_types, after_sync=True):
@@ -181,7 +162,7 @@ def test_positive_end_to_end_custom_cron(session):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_search_scoped(session, request):
+def test_positive_search_scoped(session, request, target_sat):
     """Test scoped search for different sync plan parameters
 
     :id: 3a48513e-205d-47a3-978e-79b764cc74d9
@@ -205,7 +186,7 @@ def test_positive_search_scoped(session, request):
         sync_date=start_date,
     ).create()
     sync_plan = entities.SyncPlan(organization=org.id, id=sync_plan.id).read()
-    request.addfinalizer(lambda: disable_syncplan(sync_plan))
+    request.addfinalizer(lambda: target_sat.disable_syncplan(sync_plan))
     with session:
         session.organization.select(org.name)
         for query_type, query_value in [('interval', SYNC_INTERVAL['day']), ('enabled', 'true')]:
@@ -214,7 +195,7 @@ def test_positive_search_scoped(session, request):
 
 
 @pytest.mark.tier3
-def test_positive_synchronize_custom_product_custom_cron_real_time(session, module_org):
+def test_positive_synchronize_custom_product_custom_cron_real_time(session, module_org, target_sat):
     """Create a sync plan with real datetime as a sync date,
     add a custom product and verify the product gets synchronized
     on the next sync occurrence based on custom cron interval
@@ -251,12 +232,25 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
         session.syncplan.add_product(plan_name, product.name)
         # check that product was not synced
         with pytest.raises(AssertionError) as context:
-            validate_task_status(repo.id, module_org.id, max_tries=1)
+            target_sat.wait_for_tasks(
+                search_query='Actions::Katello::Repository::Sync'
+                f' and organization_id = {module_org.id}'
+                f' and resource_id = {repo.id}'
+                ' and resource_type = Katello::Repository',
+                max_tries=1,
+                search_rate=10,
+            )
         assert 'No task was found using query' in str(context.value)
         validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
         # Waiting part of delay that is left and check that product was synced
         time.sleep(next_sync)
-        validate_task_status(repo.id, module_org.id)
+        target_sat.wait_for_tasks(
+            search_query='Actions::Katello::Repository::Sync'
+            f' and organization_id = {module_org.id}'
+            f' and resource_id = {repo.id}'
+            ' and resource_type = Katello::Repository',
+            search_rate=10,
+        )
         validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
         repo_values = session.repository.read(product.name, repo.name)
         for repo_type in ['Packages', 'Errata', 'Package Groups']:
@@ -267,7 +261,9 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
 
 
 @pytest.mark.tier3
-def test_positive_synchronize_custom_product_custom_cron_past_sync_date(session, module_org):
+def test_positive_synchronize_custom_product_custom_cron_past_sync_date(
+    session, module_org, target_sat
+):
     """Create a sync plan with past datetime as a sync date,
     add a custom product and verify the product gets synchronized
     on the next sync occurrence based on custom cron interval
@@ -304,12 +300,25 @@ def test_positive_synchronize_custom_product_custom_cron_past_sync_date(session,
         session.syncplan.add_product(plan_name, product.name)
         # check that product was not synced
         with pytest.raises(AssertionError) as context:
-            validate_task_status(repo.id, module_org.id, max_tries=1)
+            target_sat.wait_for_tasks(
+                search_query='Actions::Katello::Repository::Sync'
+                f' and organization_id = {module_org.id}'
+                f' and resource_id = {repo.id}'
+                ' and resource_type = Katello::Repository',
+                max_tries=1,
+                search_rate=10,
+            )
         assert 'No task was found using query' in str(context.value)
         validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
         # Waiting part of delay that is left and check that product was synced
         time.sleep(next_sync)
-        validate_task_status(repo.id, module_org.id)
+        target_sat.wait_for_tasks(
+            search_query='Actions::Katello::Repository::Sync'
+            f' and organization_id = {module_org.id}'
+            f' and resource_id = {repo.id}'
+            ' and resource_type = Katello::Repository',
+            search_rate=10,
+        )
         validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
         repo_values = session.repository.read(product.name, repo.name)
         for repo_type in ['Packages', 'Errata', 'Package Groups']:

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -23,7 +23,6 @@ from airgun.session import Session
 from fauxfactory import gen_email
 from fauxfactory import gen_string
 
-from robottelo.api.utils import create_role_permissions
 from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import PERMISSIONS
 from robottelo.constants import ROLES
@@ -311,7 +310,9 @@ def test_positive_create_product_with_limited_user_permission(
     product_description = gen_string('alpha')
     role = target_sat.api.Role().create()
     # Calling Products and Repositoy to get all the permissions in it
-    create_role_permissions(role, {'Katello::Product': PERMISSIONS['Katello::Product']})
+    target_sat.api_factory.create_role_permissions(
+        role, {'Katello::Product': PERMISSIONS['Katello::Product']}
+    )
     target_sat.api.User(
         default_organization=module_org,
         organization=[module_org],

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -22,7 +22,6 @@ import pytest
 import requests
 from fauxfactory import gen_string
 
-from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.user import User
 from robottelo.config import settings
 from robottelo.utils.virtwho import create_http_proxy
@@ -388,7 +387,7 @@ class TestVirtWhoConfigforEsx:
         if result.status_code != 200:
             if "foreman_tasks_sync_task_timeout" in result.text:
                 task_id = re.findall('waiting for task (.*?) to finish', result.text)[-1]
-                wait_for_tasks(search_query=f'id = {task_id}', max_tries=10)
+                target_sat.wait_for_tasks(search_query=f'id = {task_id}', max_tries=10)
             else:
                 assert result.status_code == 200
 

--- a/tests/robottelo/test_api_utils.py
+++ b/tests/robottelo/test_api_utils.py
@@ -1,7 +1,1 @@
 """Unit tests for :mod:`robottelo.api.utils`."""
-from robottelo.api import utils
-
-
-def test_one_to_one_names():
-    """Test :func:`robottelo.api.utils.one_to_one_names`."""
-    assert utils.one_to_one_names('person') == {'person_name', 'person_id'}

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -24,7 +24,6 @@ from fabric.api import run
 from upgrade_tests.helpers.scenarios import rpm1
 from upgrade_tests.helpers.scenarios import rpm2
 
-from robottelo.api.utils import create_sync_custom_repo
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
 from robottelo.upgrade_utility import publish_content_view
@@ -67,7 +66,7 @@ class TestScenarioRepositoryUpstreamAuthorizationCheck:
         """
 
         org = target_sat.api.Organization().create()
-        custom_repo = create_sync_custom_repo(org_id=org.id)
+        custom_repo = target_sat.api_factory.create_sync_custom_repo(org_id=org.id)
         rake_repo = f'repo = Katello::Repository.find_by_id({custom_repo})'
         rake_username = f'; repo.root.upstream_username = "{UPSTREAM_USERNAME}"'
         rake_repo_save = '; repo.save!(validate: false)'

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -24,7 +24,6 @@ from upgrade.helpers.docker import docker_execute_command
 from upgrade_tests.helpers.scenarios import dockerize
 from wait_for import wait_for
 
-from robottelo.api.utils import attach_custom_product_subscription
 from robottelo.config import settings
 from robottelo.constants import REPOS
 from robottelo.logging import logger
@@ -34,6 +33,18 @@ from robottelo.upgrade_utility import run_goferd
 
 
 DOCKER_VM = settings.upgrade.docker_vm
+
+
+def attach_custom_product_subscription(prod_name=None, host_name=None):
+    """Attach custom product subscription to client host
+    :param str prod_name: custom product name
+    :param str host_name: client host name
+    """
+    host = entities.Host().search(query={'search': f'{host_name}'})[0]
+    product_subscription = entities.Subscription().search(query={'search': f'name={prod_name}'})[0]
+    entities.HostSubscription(host=host.id).add_subscriptions(
+        data={'subscriptions': [{'id': product_subscription.id, 'quantity': 1}]}
+    )
 
 
 class TestScenarioYumPluginsCount:


### PR DESCRIPTION
**enable_rhrepo_and_fetchid** moved to host_helpers.api_factory
Removed **create_org_admin_role** as no longer used
Removed **create_org_admin_user** as no longer used
**cv_publish_promote** moved to host_helpers.api_factory
Removed **wait_for_syncplan_tasks** as no longer used
Removed **wait_for_errata_applicability_task** as no longer used