### PR TITLE
Return OS from fixture module_provisioning_rhel_content needed for test_rhel_pxe_provisioning

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -118,9 +118,7 @@ def module_provisioning_rhel_content(
         ],
     ).create()
 
-    return Box(
-        hostgroup=hostgroup,
-    )
+    return Box(hostgroup=hostgroup, os=os)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Return OS from fixture module_provisioning_rhel_content needed for [test_rhel_pxe_provisioning](https://github.com/SatelliteQE/robottelo/blob/dd05673ec8ec080f4a31d917774fbb7be0516aee/tests/foreman/api/test_provisioning.py#L64)