### PR TITLE
[6.11.z] Move rh_cloud_utils to robottelo/utils/local_io

### DIFF
--- a/robottelo/utils/io/__init__.py
+++ b/robottelo/utils/io/__init__.py
@@ -1,35 +1,8 @@
-"""Utility module for RH cloud inventory tests"""
+# Helper methods for tests requiring I/0
 import hashlib
 import json
 import tarfile
 from pathlib import Path
-
-
-def get_host_counts(tarobj):
-    """Returns hosts count from tar file.
-
-    Args:
-        tarobj: tar file to get host count from
-    """
-    metadata_counts = {}
-    slices_counts = {}
-    for file_ in tarobj.getmembers():
-        file_name = Path(file_.name).name
-        if not file_name.endswith('.json'):
-            continue
-        json_data = json.load(tarobj.extractfile(file_))
-        if file_name == 'metadata.json':
-            metadata_counts = {
-                f'{key}.json': value['number_hosts']
-                for key, value in json_data['report_slices'].items()
-            }
-        else:
-            slices_counts[file_name] = len(json_data['hosts'])
-
-    return {
-        'metadata_counts': metadata_counts,
-        'slices_counts': slices_counts,
-    }
 
 
 def get_local_file_data(path):
@@ -61,6 +34,33 @@ def get_local_file_data(path):
         'extractable': extractable,
         'json_files_parsable': json_files_parsable,
         **host_counts,
+    }
+
+
+def get_host_counts(tarobj):
+    """Returns hosts count from tar file.
+
+    Args:
+        tarobj: tar file to get host count from
+    """
+    metadata_counts = {}
+    slices_counts = {}
+    for file_ in tarobj.getmembers():
+        file_name = Path(file_.name).name
+        if not file_name.endswith('.json'):
+            continue
+        json_data = json.load(tarobj.extractfile(file_))
+        if file_name == 'metadata.json':
+            metadata_counts = {
+                f'{key}.json': value['number_hosts']
+                for key, value in json_data['report_slices'].items()
+            }
+        else:
+            slices_counts[file_name] = len(json_data['hosts'])
+
+    return {
+        'metadata_counts': metadata_counts,
+        'slices_counts': slices_counts,
     }
 
 

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -24,9 +24,9 @@ from fauxfactory import gen_string
 from wait_for import wait_for
 
 from robottelo.config import robottelo_tmp_dir
-from robottelo.rh_cloud_utils import get_local_file_data
-from robottelo.rh_cloud_utils import get_report_data
-from robottelo.rh_cloud_utils import get_report_metadata
+from robottelo.utils.io import get_local_file_data
+from robottelo.utils.io import get_report_data
+from robottelo.utils.io import get_report_metadata
 
 generate_report_task = 'ForemanInventoryUpload::Async::UploadReportJob'
 

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -22,8 +22,8 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.config import robottelo_tmp_dir
-from robottelo.rh_cloud_utils import get_local_file_data
-from robottelo.rh_cloud_utils import get_remote_report_checksum
+from robottelo.utils.io import get_local_file_data
+from robottelo.utils.io import get_remote_report_checksum
 
 inventory_sync_task = 'InventorySync::Async::InventoryFullSync'
 

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -24,9 +24,9 @@ from airgun.session import Session
 from wait_for import wait_for
 
 from robottelo.constants import DEFAULT_LOC
-from robottelo.rh_cloud_utils import get_local_file_data
-from robottelo.rh_cloud_utils import get_remote_report_checksum
-from robottelo.rh_cloud_utils import get_report_data
+from robottelo.utils.io import get_local_file_data
+from robottelo.utils.io import get_remote_report_checksum
+from robottelo.utils.io import get_report_data
 
 
 def common_assertion(report_path, inventory_data, org, satellite):


### PR DESCRIPTION
Cherrypick of commit: 20e673db616f43c805d763d1c44d20a98928ef02

Simple work here, moving rh_cloud_utils under robottelo/utils and creating a new module there, local_io for any future similar operations. 

I'm not sure if this is the best way to do this, but these util methods have a real case to be external to tests ( several unique dependencies only used for the IO, shared amongst the tests in the class ).