### PR TITLE
Turn container_contenthost back to VM

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1114,6 +1114,8 @@ class TestCapsuleContentManagement:
         :parametrized: yes
 
         :CaseLevel: Integration
+
+        :BZ: 2125244
         """
         upstream_names = [
             'quay/busybox',  # schema 1


### PR DESCRIPTION
Let's move the `container_contenthost` back to a VM as it does not seem legit to run docker inside a docker container.

Passes locally with 6.11.3. With 6.12.0 it fails due to a regression [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2125244), for which a fix was already merged in upstream, so I don't `skip_if_open`. Also, I want to have it in 6.11.z regardless the BZ state.
