### PR TITLE
[6.11.z] Minor changes to account for container-based hosts

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -135,7 +135,7 @@ def cockpit_host(class_target_sat, class_org, rhel_contenthost):
 
 @pytest.fixture
 def rex_contenthost(request, module_org, target_sat):
-    request.param['use_containers'] = False
+    request.param['no_containers'] = True
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         # Register content host to Satellite and install katello-host-tools on the host
         repo = settings.repos['SATCLIENT_REPO'][f'RHEL{host.os_version.major}']

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -410,10 +410,16 @@ class ContentHost(Host, ContentHostMixins):
         result = self.execute('yum install -y katello-agent')
         if result.status != 0:
             raise ContentHostError(f'Failed to install katello-agent: {result.stdout}')
-        try:
-            wait_for(lambda: self.execute('service goferd status').status == 0)
-        except TimedOutError:
-            raise ContentHostError('katello-agent is not running')
+        if getattr(self, '_cont_inst', None):
+            # We're running in a container, goferd won't be running as a service
+            # so let's run it in the foreground, then detach from the exec
+            self._cont_inst.exec_run('goferd -f', detach=True)
+        else:
+            # We're in a traditional VM, so goferd should be running after katello-agent install
+            try:
+                wait_for(lambda: self.execute('service goferd status').status == 0)
+            except TimedOutError:
+                raise ContentHostError('katello-agent is not running')
 
     def install_katello_host_tools(self):
         """Installs Katello host tools on the broker virtual machine


### PR DESCRIPTION
Cherrypick of commit: 216538a66bb1edbddc20dbe66ea3ba1e5cfede12

Hosts where katello-agent installation was desired were basing the installation check on whether or not goferd service was running. This new change explicitly runs it on containers.
Also, fixed a param issue involving rex hosts