### PR TITLE
AutoCherrypicked PRs author is now parent PRs author

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -25,6 +25,8 @@ jobs:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'CherryPick')
     needs: previous-branch
     runs-on: ubuntu-latest
+    env:
+      PR_AUTHOR: ${{ github.event.pull_request.user.login }}
     strategy:
       matrix:
         to_branch: ${{ fromJson(needs.previous-branch.outputs.previous_branch) }}
@@ -35,6 +37,7 @@ jobs:
       - name: Cherry pick into ${{ matrix.to_branch }}
         uses: jyejare/github-cherry-pick-action@main
         with:
+          author: ${{ env.PR_AUTHOR }} <${{ env.PR_AUTHOR }}@users.noreply.github.com>
           token: ${{ secrets.CHERRYPICK_PAT }}
           branch: ${{ matrix.to_branch }}
           labels: |


### PR DESCRIPTION
**Background:** Recently we merged the PR(https://github.com/SatelliteQE/robottelo/pull/10032) concerning AutoCherryPick GHA(or `Github Action` user) created PRs don't show `checks` status and it keeps in `waiting` state until someone closes and reopens the PR. There are multiple reasons why this happened (I have link with reasons in PR) but, we fixed it using `my Personal Access Token` and now the auto-cherrypicked PRs are showing the status of the checks successfully.

**Problem Statement:** Since ACP GHA is now using my personal access token, all the PRs created by GHA ACP is opening the PRs under my name. E.g : https://github.com/SatelliteQE/robottelo/pull/10057 and I really don't like I am owning the PRs which are just cherrypicked and someone else has put effort in it.

**Possible Solutions:**
1. Create `Machine Account` named `SatQE-Automation` and use machine accounts Personal Access Token to create AutoCherrypicked PRs.
2. ACP GHA provides flexibility to choose committer and author already, so use that and set parent PRs author by fetching that details from original PR and seed into ACP GHA configuration.
3. Something else ?

As per discussion in the Automation Gchat Group : We are going with option 2.