### PR TITLE
[6.11.z] Changed use_containers to no_containers in contenhosts.py

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -183,7 +183,7 @@ def centos_host(request, version):
     request.param = {
         "rhel_version": version.split('.')[0],
         "distro": "centos",
-        "use_containers": False,
+        "no_containers": True,
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         yield host
@@ -194,7 +194,7 @@ def oracle_host(request, version):
     request.param = {
         "rhel_version": version.split('.')[0],
         "distro": "oracle",
-        "use_containers": False,
+        "no_containers": True,
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         yield host


### PR DESCRIPTION
Cherrypick of commit: 0925d27d79d9bc115f05ba2d8b436d5fd54b8330

I have changed "use_containers" to "no_containers" in contenhosts.py