### PR TITLE
[6.11.z] Add manifester to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ deepdiff==5.8.1
 dynaconf[vault]==3.1.9
 fauxfactory==3.1.0
 jinja2==3.1.2
+manifester==0.0.8
 navmazing==1.1.6
 pexpect==4.8.0
 productmd==1.33


### PR DESCRIPTION
This PR should resolve the failure in https://github.com/SatelliteQE/robottelo/pull/10029.