### PR TITLE
[6.11.z] Pin hvac to version lower than 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cryptography==38.0.1
 deepdiff==5.8.1
 dynaconf[vault]==3.1.9
 fauxfactory==3.1.0
+hvac<1.0.0  # hvac 1.0.0 breaks Dynaconf. #807
 jinja2==3.1.2
 navmazing==1.1.6
 pexpect==4.8.0


### PR DESCRIPTION
Cherrypick of commit: 4814a9936fdf2ce58ee6253611275e2c3bfc3fce

Lukas Identified an issue where Dynaconf breaks when using hvac 1.0.0. For more details, please see dynaconf/dynaconf#807 