### PR TITLE
[6.10.z] Pin hvac to version lower than 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ cryptography==37.0.4
 deepdiff==5.8.1
 dynaconf[vault]==3.1.8
 fauxfactory==3.1.0
+hvac<1.0.0  # hvac 1.0.0 breaks Dynaconf. #807
 jinja2==3.1.2
 manifester==0.0.8
 navmazing==1.1.6


### PR DESCRIPTION
Cherrypick of commit: e0c126789cdebf9e8f2efedbc264d0bff33c6fc8

Cherrypick of commit: 4814a9936fdf2ce58ee6253611275e2c3bfc3fce

Lukas Identified an issue where Dynaconf breaks when using hvac 1.0.0. For more details, please see dynaconf/dynaconf#807 