### PR TITLE
Don't use containers on rex hosts

### DIFF
--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -17,7 +17,7 @@ def pytest_generate_tests(metafunc):
     content_host_fixture = ''.join([i for i in TARGET_FIXTURES if i in metafunc.fixturenames])
     if content_host_fixture in metafunc.fixturenames:
         function_marks = getattr(metafunc.function, 'pytestmark', [])
-        no_containers = 'no_containers' in function_marks
+        no_containers = any('no_containers' == mark.name for mark in function_marks)
         # process eventual rhel_version_list markers
         matchers = [i.args for i in function_marks if i.name == 'rhel_ver_list']
         list_params = []

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1815,7 +1815,7 @@ def test_positive_apply_security_erratum(katello_host_tools_host, setup_custom_r
 @pytest.mark.cli_katello_host_tools
 @pytest.mark.tier3
 def test_positive_install_package_via_rex(
-    module_org, katello_host_tools_host, target_sat, setup_custom_repo
+    module_org, rex_contenthost, target_sat, setup_custom_repo
 ):
     """Install a package to a host remotely using remote execution,
     install package using Katello SSH job template, host package list is used to verify that
@@ -1828,7 +1828,7 @@ def test_positive_install_package_via_rex(
 
     :parametrized: yes
     """
-    client = katello_host_tools_host
+    client = rex_contenthost
     host_info = Host.info({'name': client.hostname})
     client.configure_rex(satellite=target_sat, org=module_org, register=False)
     # Apply errata to the host collection using job invocation

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -28,6 +28,7 @@ class TestHostCockpit:
     @pytest.mark.upgrade
     @pytest.mark.rhel_ver_match('[^6].*')
     @pytest.mark.tier2
+    @pytest.mark.no_containers
     def test_positive_cockpit(self, cockpit_host, class_cockpit_sat, class_org):
         """Install cockpit plugin and test whether webconsole button and cockpit integration works.
         also verify if cockpit service is restarted after the service restart.


### PR DESCRIPTION
Cockpit and rex hosts require actual VM, those are not able to run as containers.
Add fix for no_containers marker