### PR TITLE
Fix host_ui_options issues

### DIFF
--- a/pytest_fixtures/component/host.py
+++ b/pytest_fixtures/component/host.py
@@ -52,6 +52,15 @@ def setup_rhst_repo():
     return {'ak': ak, 'cv': cv, 'lce': lce, 'org': org, 'repo_name': repo_name}
 
 
+@pytest.fixture(scope='module')
+def module_host_template(module_org, smart_proxy_location, module_target_sat):
+    host_template = module_target_sat.api.Host(
+        organization=module_org, location=smart_proxy_location, build=True
+    )
+    host_template.create_missing()
+    return host_template
+
+
 @pytest.fixture
 def host_ui_options(module_host_template):
     os_name = (

--- a/pytest_fixtures/component/host.py
+++ b/pytest_fixtures/component/host.py
@@ -58,6 +58,7 @@ def module_host_template(module_org, smart_proxy_location, module_target_sat):
         organization=module_org, location=smart_proxy_location, build=True
     )
     host_template.create_missing()
+    host_template.name = None
     return host_template
 
 
@@ -66,8 +67,9 @@ def host_ui_options(module_host_template):
     os_name = (
         f'{module_host_template.operatingsystem.name} {module_host_template.operatingsystem.major}'
     )
+    name = gen_string('alpha').lower()
     values = {
-        'host.name': module_host_template.name,
+        'host.name': name,
         'host.organization': module_host_template.organization.name,
         'host.location': module_host_template.location.name,
         'host.lce': ENVIRONMENT,
@@ -88,5 +90,5 @@ def host_ui_options(module_host_template):
         'parameters.host_params': None,
         'additional_information.comment': 'Host with fake data',
     }
-    host_name = f'{module_host_template.name}.{module_host_template.domain.name}'
+    host_name = f'{name}.{module_host_template.domain.name}'
     return values, host_name

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -97,14 +97,6 @@ def run_remote_command_on_content_host(command, vm_module_streams):
     return result
 
 
-@pytest.fixture(scope='module')
-def module_host_template(module_org, module_location):
-    host_template = entities.Host(organization=module_org, location=module_location)
-    host_template.create_missing()
-    host_template.name = None
-    return host_template
-
-
 @pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',
@@ -1763,6 +1755,7 @@ def test_pagination_multiple_hosts_multiple_pages(session, module_host_template)
             }
         )
     with session(url=start_url):
+        session.location.select(module_host_template.location.name)
         # Search for all the hosts by os. This uses pagination to get more than one page.
         all_fake_hosts_found = session.contenthost.search(
             f'os = {module_host_template.operatingsystem.name}'

--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -21,7 +21,7 @@ from nailgun import entities
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, module_org, module_location, host_ui_options):
+def test_positive_end_to_end(session, host_ui_options):
 
     """Perform end to end testing for hardware model component
 
@@ -42,6 +42,7 @@ def test_positive_end_to_end(session, module_org, module_location, host_ui_optio
     new_name = gen_string('alpha')
     values, host_name = host_ui_options
     with session:
+        session.location.select(values['host.location'])
         # Create new hardware model
         session.hardwaremodel.create(
             {'name': name, 'hardware_model': model, 'vendor_class': vendor_class, 'info': info}

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -338,6 +338,7 @@ def test_positive_read_from_details_page(session, module_host_template):
     """
 
     template = module_host_template
+    template.name = gen_string('alpha').lower()
     host = template.create()
     os_name = f'{template.operatingsystem.name} {template.operatingsystem.major}'
     host_name = host.name
@@ -1084,7 +1085,7 @@ def test_positive_search_by_org(session, smart_proxy_location, target_sat):
 
 
 @pytest.mark.tier2
-def test_positive_validate_inherited_cv_lce(session, module_org, target_sat, module_host_template):
+def test_positive_validate_inherited_cv_lce(session, target_sat, module_host_template):
     """Create a host with hostgroup specified via CLI. Make sure host
     inherited hostgroup's lifecycle environment, content view and both
     fields are properly reflected via WebUI.


### PR DESCRIPTION
Related PR: SatelliteQE/airgun/pull/781
`module_host_template` was not visible for host_ui_options as it was defined on a lower level. The fixture was moved and removed duplicated definition in contenthost.