### PR TITLE
Another update to srpm repos

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2131,7 +2131,7 @@ class TestSRPMRepositoryIgnoreContent:
         """
         repo.sync()
         repo = repo.read()
-        assert repo.content_counts['srpm'] == 4
+        assert repo.content_counts['srpm'] == 2
 
     @pytest.mark.tier2
     @pytest.mark.skip('Uses deprecated SRPM repository')


### PR DESCRIPTION
Seems the repo has another update which only contains a count of 2.  Updating the test case to reflect this.

test result:
```
pytest tests/foreman/api/test_repository.py -k test_positive_sync_srpm_duplicate

=========== 1 passed, 161 deselected, 2 warnings in 33.17s ============
```