### PR TITLE
An update in id field

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1892,7 +1892,7 @@ class TestContentView:
         # Ensure that version 1 is in  composite content view components
         components = ContentView.component_list({'composite-content-view-id': composite_cv['id']})
         assert len(components) == 1
-        component_id = components[0]['id']
+        component_id = components[0]['content-view-id']
         assert components[0]['version-id'] == f'{version_1_id} (Latest)'
         assert components[0]['current-version'] == '1.0'
         # Publish the content view a second time
@@ -1907,7 +1907,7 @@ class TestContentView:
         components = ContentView.component_list({'composite-content-view-id': composite_cv['id']})
         assert len(components) == 1
         # Ensure that this is the same component that is updated
-        assert component_id == components[0]['id']
+        assert component_id == components[0]['content-view-id']
         assert components[0]['version-id'] == f'{version_2_id} (Latest)'
         assert components[0]['current-version'] == '2.0'
 


### PR DESCRIPTION
The `id` has been changed to `content-view-id`.  Updating to reflect this.

```
pytest tests/foreman/cli/test_contentview.py -k test_positive_auto_update_composite_to_latest_cv_version
================== 1 passed, 128 deselected, 2 warnings in 55.99s ==================
```