### PR TITLE
Convert cli content view tests to manifester

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -80,14 +80,14 @@ def module_org_with_manifest(module_org):
 def module_entitlement_manifest_org(module_org, module_entitlement_manifest):
     """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
     upload_manifest(module_org.id, module_entitlement_manifest.content)
-    return org
+    return module_org
 
 
 @pytest.fixture(scope='module')
 def module_sca_manifest_org(module_org, module_sca_manifest):
     """Creates an organization and uploads an SCA mode manifest generated with manifester"""
     upload_manifest(module_org.id, module_sca_manifest.content)
-    return org
+    return module_org
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -77,6 +77,22 @@ def module_org_with_manifest(module_org):
 
 
 @pytest.fixture(scope='module')
+def module_entitlement_manifest_org(module_target_sat, module_entitlement_manifest):
+    """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
+    org = module_target_sat.api.Organization().create()
+    upload_manifest(org.id, module_entitlement_manifest.content)
+    return org
+
+
+@pytest.fixture(scope='module')
+def module_sca_manifest_org(module_target_sat, module_sca_manifest):
+    """Creates an organization and uploads an SCA mode manifest generated with manifester"""
+    org = module_target_sat.api.Organization().create()
+    upload_manifest(org.id, module_sca_manifest.content)
+    return org
+
+
+@pytest.fixture(scope='module')
 def module_gt_manifest_org(module_target_sat):
     """Creates a new org and loads GT manifest in the new org"""
     org = module_target_sat.api.Organization().create()
@@ -102,6 +118,22 @@ def session_entitlement_manifest():
 
 @pytest.fixture(scope='session')
 def session_sca_manifest():
+    """Yields a manifest in entitlement mode with subscriptions determined by the
+    `manifest_category.robottelo_automation` setting in manifester_settings.yaml."""
+    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='module')
+def module_entitlement_manifest():
+    """Yields a manifest in entitlement mode with subscriptions determined by the
+    `manifest_category.robottelo_automation` setting in manifester_settings.yaml."""
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='module')
+def module_sca_manifest():
     """Yields a manifest in Simple Content Access mode with subscriptions determined by the
     `manifest_category.golden_ticket` setting in manifester_settings.yaml."""
     with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -77,18 +77,16 @@ def module_org_with_manifest(module_org):
 
 
 @pytest.fixture(scope='module')
-def module_entitlement_manifest_org(module_target_sat, module_entitlement_manifest):
+def module_entitlement_manifest_org(module_org, module_entitlement_manifest):
     """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
-    org = module_target_sat.api.Organization().create()
-    upload_manifest(org.id, module_entitlement_manifest.content)
+    upload_manifest(module_org.id, module_entitlement_manifest.content)
     return org
 
 
 @pytest.fixture(scope='module')
-def module_sca_manifest_org(module_target_sat, module_sca_manifest):
+def module_sca_manifest_org(module_org, module_sca_manifest):
     """Creates an organization and uploads an SCA mode manifest generated with manifester"""
-    org = module_target_sat.api.Organization().create()
-    upload_manifest(org.id, module_sca_manifest.content)
+    upload_manifest(module_org.id, module_sca_manifest.content)
     return org
 
 


### PR DESCRIPTION
This PR converts all tests that use manifests in cli/testcontentview.py to obtain their manifests from manifester. To support this change, this PR also adds four module-scoped fixtures (two that provide manifests and two that provide organizations with manifests imported).