### PR TITLE
[6.11.z] Revert "Pin hvac to version lower than 1.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ cryptography==38.0.1
 deepdiff==5.8.1
 dynaconf[vault]==3.1.9
 fauxfactory==3.1.0
-hvac<1.0.0  # hvac 1.0.0 breaks Dynaconf. #807
 jinja2==3.1.2
 manifester==0.0.8
 navmazing==1.1.6


### PR DESCRIPTION
Cherrypick of commit: f2f8d340a8c3959a3f056bcfe4d4f490c1b14682

Reverts SatelliteQE/robottelo#10076 as https://github.com/dynaconf/dynaconf/issues/807 is fixed now 
and **released** - https://github.com/dynaconf/dynaconf/releases/tag/3.1.11