### PR TITLE
[6.10.z] Revert "Pin hvac to version lower than 1.0.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cryptography==37.0.4
 deepdiff==5.8.1
 dynaconf[vault]==3.1.8
 fauxfactory==3.1.0
-hvac<1.0.0  # hvac 1.0.0 breaks Dynaconf. #807
 jinja2==3.1.2
 manifester==0.0.8
 navmazing==1.1.6


### PR DESCRIPTION
Cherrypick of commit: 690481c0ae18b87feea08bb1aa26237cc7881cea

Cherrypick of commit: f2f8d340a8c3959a3f056bcfe4d4f490c1b14682

Reverts SatelliteQE/robottelo#10076 as https://github.com/dynaconf/dynaconf/issues/807 is fixed now 
and **released** - https://github.com/dynaconf/dynaconf/releases/tag/3.1.11