### PR TITLE
JSON serialization test failure fix

### DIFF
--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -26,7 +26,7 @@ from robottelo.datafactory import invalid_values_list
 from robottelo.datafactory import parametrized
 from robottelo.datafactory import valid_data_list
 
-key_content = DataFile.VALID_GPG_KEY_FILE.read_bytes()
+key_content = DataFile.VALID_GPG_KEY_FILE.read_text()
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
@@ -145,7 +145,7 @@ def test_positive_update_content(module_org):
     """
     gpg_key = entities.GPGKey(
         organization=module_org,
-        content=DataFile.VALID_GPG_KEY_BETA_FILE.read_bytes(),
+        content=DataFile.VALID_GPG_KEY_BETA_FILE.read_text(),
     ).create()
     gpg_key.content = key_content
     gpg_key = gpg_key.update(['content'])

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -210,7 +210,7 @@ def test_positive_delete(module_org, module_product):
 
     :CaseImportance: Critical
     """
-    key_content = DataFile.ZOO_CUSTOM_GPG_KEY.read_bytes()
+    key_content = DataFile.ZOO_CUSTOM_GPG_KEY.read_text()
     gpgkey = entities.GPGKey(content=key_content, organization=module_org).create()
     # Creates new repository with GPGKey
     repo = entities.Repository(

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -97,7 +97,7 @@ def test_positive_create_with_gpg(module_org):
     :CaseLevel: Integration
     """
     gpg_key = entities.GPGKey(
-        content=DataFile.VALID_GPG_KEY_FILE.read_bytes(),
+        content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         organization=module_org,
     ).create()
     product = entities.Product(gpg_key=gpg_key, organization=module_org).create()
@@ -227,14 +227,14 @@ def test_positive_update_gpg(module_org):
     """
     # Create a product and make it point to a GPG key.
     gpg_key_1 = entities.GPGKey(
-        content=DataFile.VALID_GPG_KEY_FILE.read_bytes(),
+        content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         organization=module_org,
     ).create()
     product = entities.Product(gpg_key=gpg_key_1, organization=module_org).create()
 
     # Update the product and make it point to a new GPG key.
     gpg_key_2 = entities.GPGKey(
-        content=DataFile.VALID_GPG_KEY_BETA_FILE.read_bytes(),
+        content=DataFile.VALID_GPG_KEY_BETA_FILE.read_text(),
         organization=module_org,
     ).create()
     product.gpg_key = gpg_key_2

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -328,7 +328,7 @@ class TestRepository:
         """
         gpg_key = entities.GPGKey(
             organization=module_org,
-            content=DataFile.VALID_GPG_KEY_FILE.read_bytes(),
+            content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         ).create()
         repo = entities.Repository(product=module_product, gpg_key=gpg_key).create()
         # Verify that the given GPG key ID is used.
@@ -688,14 +688,14 @@ class TestRepository:
         # Create a repo and make it point to a GPG key.
         gpg_key_1 = entities.GPGKey(
             organization=module_org,
-            content=DataFile.VALID_GPG_KEY_FILE.read_bytes(),
+            content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         ).create()
         repo = entities.Repository(product=module_product, gpg_key=gpg_key_1).create()
 
         # Update the repo and make it point to a new GPG key.
         gpg_key_2 = entities.GPGKey(
             organization=module_org,
-            content=DataFile.VALID_GPG_KEY_BETA_FILE.read_bytes(),
+            content=DataFile.VALID_GPG_KEY_BETA_FILE.read_text(),
         ).create()
 
         repo.gpg_key = gpg_key_2

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -55,7 +55,7 @@ def test_positive_end_to_end(session, module_org):
     product_label = gen_string('alpha')
     product_description = gen_string('alpha')
     gpg_key = entities.GPGKey(
-        content=DataFile.VALID_GPG_KEY_FILE.read_bytes(),
+        content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         organization=module_org,
     ).create()
     sync_plan = entities.SyncPlan(organization=module_org).create()
@@ -141,7 +141,7 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
     product_name = gen_string('alpha')
     product_description = gen_string('alpha')
     gpg_key = entities.GPGKey(
-        content=DataFile.VALID_GPG_KEY_FILE.read_bytes(),
+        content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         organization=module_org,
     ).create()
     plan_name = gen_string('alpha')


### PR DESCRIPTION
Many of these tests have been failing for a while due to json serialization.  Adding the `decode()` portion for this to pass.  I'll add individual results later.