### PR TITLE
Fix resolv.conf hacking for AD setup

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -438,9 +438,11 @@ def enroll_ad_and_configure_external_auth(request, ad_data, sat):
 
     # update the AD name server
     sat.execute('chattr -i /etc/resolv.conf')
-    line_number = str(
-        sat.execute("awk -v search='nameserver' '$0~search{print NR; exit}' /etc/resolv.conf")
-    ).strip()
+    line_number = int(
+        sat.execute(
+            "awk -v search='nameserver' '$0~search{print NR; exit}' /etc/resolv.conf"
+        ).stdout
+    )
     sat.execute(f'sed -i "{line_number}i nameserver {ad_data.nameserver}" /etc/resolv.conf')
     sat.execute('chattr +i /etc/resolv.conf')
 


### PR DESCRIPTION
The original way of getting line number did not work properly.