### PR TITLE
[6.10.z] [6.11.z] Do not pin the release to the latest one explicitly

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1086,14 +1086,11 @@ class ContentHost(Host):
     def register_to_cdn(self):
         """Subscribe Satellite/Capsule/ContentHost to CDN"""
         self.remove_katello_ca()
-        major_version = self.os_version.major
-        release_version = f'{major_version}Server' if major_version < 8 else f'{major_version}'
         cmd_result = self.register_contenthost(
             org=None,
             lce=None,
             username=settings.subscription.rhn_username,
             password=settings.subscription.rhn_password,
-            releasever=release_version,
         )
         if cmd_result.status != 0:
             raise ContentHostError(


### PR DESCRIPTION
Cherrypick of commit: 026918f317a21c13eda069a79aedeadf5b24fc57

Cherrypick of commit: 40c12c5d42b5955f23ee080d88cc3a378ca8f6a0

Simple patch. There is no need to explicitly state what is implicit.