### PR TITLE
Adding PXE-based API discovery test

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -218,3 +218,46 @@ def module_capsule_configured_async_ssh(module_capsule_configured):
     enable MQTT broker"""
     module_capsule_configured.set_rex_script_mode_provider('ssh-async')
     yield module_capsule_configured
+
+
+@pytest.fixture(scope='module')
+def module_discovery_sat(
+    module_provisioning_rhel_content,
+    module_provisioning_sat,
+    module_sca_manifest_org,
+    module_location,
+):
+    """Creates a Satellite with discovery installed and configured"""
+    sat = module_provisioning_sat.sat
+    # Register to CDN and install discovery image
+    sat.register_to_cdn()
+    sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
+    sat.unregister()
+    # Symlink image so it can be uploaded for KEXEC
+    disc_img_path = sat.execute(
+        'find /usr/share/foreman-discovery-image -name "foreman-discovery-image-*.iso"'
+    ).stdout[:-1]
+    disc_img_name = disc_img_path.split("/")[-1]
+    sat.execute(f'ln -s {disc_img_path} /var/www/html/pub/{disc_img_name}')
+    # Change 'Default PXE global template entry'
+    pxe_entry = sat.api.Setting().search(query={'search': 'Default PXE global template entry'})[0]
+    if pxe_entry.value != "discovery":
+        pxe_entry.value = "discovery"
+        pxe_entry.update(['value'])
+    # Build PXE default template to get default PXE file
+    sat.api.ProvisioningTemplate().build_pxe_default()
+
+    # Update discovery taxonomies settings
+    discovery_loc = sat.api.Setting().search(query={'search': 'name=discovery_location'})[0]
+    discovery_loc.value = module_location.name
+    discovery_loc.update(['value'])
+    discovery_org = sat.api.Setting().search(query={'search': 'name=discovery_organization'})[0]
+    discovery_org.value = module_sca_manifest_org.name
+    discovery_org.update(['value'])
+
+    # Enable flag to auto provision discovered hosts via discovery rules
+    discovery_auto = sat.api.Setting().search(query={'search': 'name=discovery_auto'})[0]
+    discovery_auto.value = 'true'
+    discovery_auto.update(['value'])
+
+    return sat


### PR DESCRIPTION
Creating new fixture for configuring discovery and rewriting an old test to use the new fixtures for discovery and provisioning. My plan is to keep converting tests in this file over to the new fixtures.

Depends on https://github.com/SatelliteQE/nailgun/pull/842