### PR TITLE
Convert manifest-dependent API tests to manifester

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ broker[docker]==0.2.9
 cryptography==38.0.3
 deepdiff==6.2.1
 dynaconf[vault]==3.1.11
-epdb==0.15.1
 fauxfactory==3.1.0
 jinja2==3.1.2
 manifester==0.0.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ broker[docker]==0.2.9
 cryptography==38.0.3
 deepdiff==6.2.1
 dynaconf[vault]==3.1.11
+epdb==0.15.1
 fauxfactory==3.1.0
 jinja2==3.1.2
 manifester==0.0.10

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1096,7 +1096,8 @@ class TestCapsuleContentManagement:
             else f'{distro}/{constants.REPOS["kickstart"][distro]["version"]}/x86_64/baseos/kickstart'  # noqa:E501
         )
         url_base = (
-            f'pulp/content/{module_entitlement_manifest_org.label}/{lce.label}/{cv.label}/content/dist/{tail}'
+            f'pulp/content/{module_entitlement_manifest_org.label}/{lce.label}/{cv.label}/content/'
+            f'dist/{tail}'
         )
 
         # Check kickstart specific files

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -16,6 +16,7 @@
 
 :Upstream: No
 """
+import epdb
 import re
 import uuid
 from datetime import datetime
@@ -142,6 +143,7 @@ class TestSatelliteContentManagement:
         rh_repo = entities.Repository(id=rh_repo_id).read()
         rh_repo.sync()
         rh_repo.download_policy = 'immediate'
+        epdb.serve(port=9000)
         rh_repo = rh_repo.update(['download_policy'])
         call_entity_method_with_timeout(rh_repo.sync, timeout=600)
         result = target_sat.execute(

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -102,7 +102,7 @@ class TestSatelliteContentManagement:
         assert response, f"Repository {repo} failed to sync."
 
     @pytest.mark.tier4
-    def test_positive_sync_kickstart_repo(self, module_manifest_org, target_sat):
+    def test_positive_sync_kickstart_repo(self, module_entitlement_manifest_org, target_sat):
         """No encoding gzip errors on kickstart repositories
         sync.
 
@@ -133,7 +133,7 @@ class TestSatelliteContentManagement:
         distro = 'rhel8'
         rh_repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_manifest_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=constants.REPOS['kickstart'][distro]['product'],
             reposet=constants.REPOSET['kickstart'][distro],
             repo=constants.REPOS['kickstart'][distro]['name'],
@@ -161,7 +161,7 @@ class TestSatelliteContentManagement:
             if isinstance(ver, int)
         ],
     )
-    def test_positive_sync_kickstart_check_os(self, module_manifest_org, distro):
+    def test_positive_sync_kickstart_check_os(self, module_entitlement_manifest_org, distro):
         """Sync rhel KS repo and assert that OS was created
 
         :id: f84bcf1b-717e-40e7-82ee-000eead45249
@@ -178,7 +178,7 @@ class TestSatelliteContentManagement:
         """
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_manifest_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=constants.REPOS['kickstart'][distro]['product'],
             reposet=constants.REPOSET['kickstart'][distro],
             repo=constants.REPOS['kickstart'][distro]['name'],
@@ -744,8 +744,10 @@ class TestCapsuleContentManagement:
         assert sat_files == caps_files
 
     @pytest.mark.tier4
-    @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_iso_library_sync(self, module_capsule_configured, module_manifest_org):
+    @pytest.mark.skip_if_not_set('capsule', 'clients')
+    def test_positive_iso_library_sync(
+        self, module_capsule_configured, module_entitlement_manifest_org
+    ):
         """Ensure RH repo with ISOs after publishing to Library is synchronized
         to capsule automatically
 
@@ -762,7 +764,7 @@ class TestCapsuleContentManagement:
         # Enable & sync RH repository with ISOs
         rh_repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_manifest_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=constants.PRDS['rhsc'],
             repo=constants.REPOS['rhsc7_iso']['name'],
             reposet=constants.REPOSET['rhsc7_iso'],
@@ -771,7 +773,7 @@ class TestCapsuleContentManagement:
         rh_repo = entities.Repository(id=rh_repo_id).read()
         call_entity_method_with_timeout(rh_repo.sync, timeout=2500)
         # Find "Library" lifecycle env for specific organization
-        lce = entities.LifecycleEnvironment(organization=module_manifest_org).search(
+        lce = entities.LifecycleEnvironment(organization=module_entitlement_manifest_org).search(
             query={'search': f'name={constants.ENVIRONMENT}'}
         )[0]
 
@@ -785,7 +787,9 @@ class TestCapsuleContentManagement:
         assert lce.id in [capsule_lce['id'] for capsule_lce in result['results']]
 
         # Create a content view with the repository
-        cv = entities.ContentView(organization=module_manifest_org, repository=[rh_repo]).create()
+        cv = entities.ContentView(
+            organization=module_entitlement_manifest_org, repository=[rh_repo]
+        ).create()
         # Publish new version of the content view
         cv.publish()
         cv = cv.read()
@@ -800,8 +804,9 @@ class TestCapsuleContentManagement:
 
         # Verify all the ISOs are present on capsule
         caps_path = (
-            f'{module_capsule_configured.url}/pulp/content/{module_manifest_org.label}/{lce.label}'
-            f'/{cv.label}/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/6.4/iso/'
+            f'{module_capsule_configured.url}/pulp/content/{module_entitlement_manifest_org.label}'
+            f'/{lce.label}/{cv.label}/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/6.4/'
+            'iso/'
         )
         caps_isos = get_repo_files_by_url(caps_path, extension='iso')
         assert len(caps_isos) == 4
@@ -1016,10 +1021,10 @@ class TestCapsuleContentManagement:
             assert b'katello-server-ca.crt' in response.content
 
     @pytest.mark.tier4
-    @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
+    @pytest.mark.skip_if_not_set('capsule', 'clients')
     @pytest.mark.parametrize('distro', ['rhel7', 'rhel8', 'rhel9'])
     def test_positive_sync_kickstart_repo(
-        self, target_sat, module_capsule_configured, module_manifest_org, distro
+        self, target_sat, module_capsule_configured, module_entitlement_manifest_org, distro
     ):
         """Sync kickstart repository to the capsule.
 
@@ -1042,14 +1047,14 @@ class TestCapsuleContentManagement:
         """
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_manifest_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=constants.REPOS['kickstart'][distro]['product'],
             reposet=constants.REPOSET['kickstart'][distro],
             repo=constants.REPOS['kickstart'][distro]['name'],
             releasever=constants.REPOS['kickstart'][distro]['version'],
         )
         repo = entities.Repository(id=repo_id).read()
-        lce = entities.LifecycleEnvironment(organization=module_manifest_org).create()
+        lce = entities.LifecycleEnvironment(organization=module_entitlement_manifest_org).create()
         # Associate the lifecycle environment with the capsule
         module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
             data={'environment_id': lce.id}
@@ -1063,7 +1068,9 @@ class TestCapsuleContentManagement:
         self.update_capsule_download_policy(module_capsule_configured, 'on_demand')
 
         # Create a content view with the repository
-        cv = entities.ContentView(organization=module_manifest_org, repository=[repo]).create()
+        cv = entities.ContentView(
+            organization=module_entitlement_manifest_org, repository=[repo]
+        ).create()
         # Sync repository
         repo.sync(timeout='10m')
         repo = repo.read()
@@ -1089,7 +1096,7 @@ class TestCapsuleContentManagement:
             else f'{distro}/{constants.REPOS["kickstart"][distro]["version"]}/x86_64/baseos/kickstart'  # noqa:E501
         )
         url_base = (
-            f'pulp/content/{module_manifest_org.label}/{lce.label}/{cv.label}/content/dist/{tail}'
+            f'pulp/content/{module_entitlement_manifest_org.label}/{lce.label}/{cv.label}/content/dist/{tail}'
         )
 
         # Check kickstart specific files

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -16,7 +16,6 @@
 
 :Upstream: No
 """
-import epdb
 import re
 import uuid
 from datetime import datetime
@@ -143,7 +142,6 @@ class TestSatelliteContentManagement:
         rh_repo = entities.Repository(id=rh_repo_id).read()
         rh_repo.sync()
         rh_repo.download_policy = 'immediate'
-        epdb.serve(port=9000)
         rh_repo = rh_repo.update(['download_policy'])
         call_entity_method_with_timeout(rh_repo.sync, timeout=600)
         result = target_sat.execute(

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -821,16 +821,12 @@ class TestContentViewRedHatContent:
     """Tests for publishing and promoting content views."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def initiate_testclass(self, request, module_org, module_cv, module_entitlement_manifest):
+    def initiate_testclass(self, request, module_cv, module_entitlement_manifest_org):
         """Set up organization, product and repositories for tests."""
 
-        entities.Subscription().upload(
-            data={'organization_id': module_org.id},
-            files={'content': module_entitlement_manifest.content},
-        )
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=PRDS['rhel'],
             repo=REPOS['rhst7']['name'],
             reposet=REPOSET['rhst7'],
@@ -1378,16 +1374,12 @@ class TestContentViewRedHatOstreeContent:
 
     @pytest.mark.run_in_one_thread
     @pytest.fixture(scope='class', autouse=True)
-    def initiate_testclass(self, request, module_org, module_entitlement_manifest):
+    def initiate_testclass(self, request, module_entitlement_manifest_org):
         """Set up organization, product and repositories for tests."""
 
-        entities.Subscription().upload(
-            data={'organization_id': module_org.id},
-            files={'content': module_entitlement_manifest.content},
-        )
         repo_id = enable_rhrepo_and_fetchid(
             basearch=None,
-            org_id=module_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=PRDS['rhah'],
             repo=REPOS['rhaht']['name'],
             reposet=REPOSET['rhaht'],

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -25,7 +25,6 @@ from fauxfactory import gen_utf8
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo import manifests
 from robottelo.api.utils import apply_package_filter
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
@@ -823,14 +822,13 @@ class TestContentViewRedHatContent:
 
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.fixture(scope='class', autouse=True)
-    def initiate_testclass(self, request, module_org, module_cv):
+    def initiate_testclass(self, request, module_org, module_cv, module_entitlement_manifest):
         """Set up organization, product and repositories for tests."""
 
-        with manifests.clone() as manifest:
-            entities.Subscription().upload(
-                data={'organization_id': module_org.id},
-                files={'content': manifest.content},
-            )
+        entities.Subscription().upload(
+            data={'organization_id': module_org.id},
+            files={'content': module_entitlement_manifest.content},
+        )
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_org.id,
@@ -1382,14 +1380,13 @@ class TestContentViewRedHatOstreeContent:
     @pytest.mark.run_in_one_thread
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.fixture(scope='class', autouse=True)
-    def initiate_testclass(self, request, module_org):
+    def initiate_testclass(self, request, module_org, module_entitlement_manifest):
         """Set up organization, product and repositories for tests."""
 
-        with manifests.clone() as manifest:
-            entities.Subscription().upload(
-                data={'organization_id': module_org.id},
-                files={'content': manifest.content},
-            )
+        entities.Subscription().upload(
+            data={'organization_id': module_org.id},
+            files={'content': module_entitlement_manifest.content},
+        )
         repo_id = enable_rhrepo_and_fetchid(
             basearch=None,
             org_id=module_org.id,

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -820,7 +820,6 @@ class TestContentViewDelete:
 class TestContentViewRedHatContent:
     """Tests for publishing and promoting content views."""
 
-    @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.fixture(scope='class', autouse=True)
     def initiate_testclass(self, request, module_org, module_cv, module_entitlement_manifest):
         """Set up organization, product and repositories for tests."""
@@ -1378,7 +1377,6 @@ class TestContentViewRedHatOstreeContent:
     """Tests for publishing and promoting cv with RH ostree contents."""
 
     @pytest.mark.run_in_one_thread
-    @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.fixture(scope='class', autouse=True)
     def initiate_testclass(self, request, module_org, module_entitlement_manifest):
         """Set up organization, product and repositories for tests."""

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -98,7 +98,7 @@ def activation_key_rhel(target_sat, module_org, module_lce, module_promoted_cv, 
 
 
 @pytest.fixture(scope='module')
-def enable_rhel_subscriptions(module_target_sat, module_org_with_manifest, version):
+def enable_rhel_subscriptions(module_target_sat, module_entitlement_manifest_org, version):
     """Enable and sync RHEL rpms repos"""
     major = version.split('.')[0]
     minor = ""
@@ -113,7 +113,7 @@ def enable_rhel_subscriptions(module_target_sat, module_org_with_manifest, versi
     for name in repo_names:
         rh_repo_id = enable_rhrepo_and_fetchid(
             basearch=DEFAULT_ARCHITECTURE,
-            org_id=module_org_with_manifest.id,
+            org_id=module_entitlement_manifest_org.id,
             product=REPOS[name]['product'],
             repo=REPOS[name]['name'] + minor,
             reposet=REPOS[name]['reposet'],

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -23,9 +23,7 @@ import pytest
 from nailgun import entities
 
 from robottelo import constants
-from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import upload_manifest
 from robottelo.api.utils import wait_for_tasks
 from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.cli.factory import setup_org_for_a_rh_repo
@@ -53,18 +51,17 @@ def activation_key(module_org, module_lce):
 
 
 @pytest.fixture(scope='module')
-def rh_repo(module_org, module_lce, module_cv, activation_key):
+def rh_repo(module_entitlement_manifest_org, module_lce, module_cv, activation_key):
     return setup_org_for_a_rh_repo(
         {
             'product': constants.PRDS['rhel'],
             'repository-set': constants.REPOSET['rhst7'],
             'repository': constants.REPOS['rhst7']['name'],
-            'organization-id': module_org.id,
+            'organization-id': module_entitlement_manifest_org.id,
             'content-view-id': module_cv.id,
             'lifecycle-environment-id': module_lce.id,
             'activationkey-id': activation_key.id,
         },
-        force_manifest_upload=True,
     )
 
 
@@ -415,17 +412,14 @@ def test_positive_sorted_issue_date_and_filter_by_cve(module_org, custom_repo, t
 
 
 @pytest.fixture(scope='module')
-def setup_content_rhel6():
+def setup_content_rhel6(module_entitlement_manifest_org):
     """Setup content fot rhel6 content host
     Using `Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)`
     from manifest, SATTOOLS_REPO for host-tools and yum_9 repo as custom repo.
 
     :return: Activation Key, Organization, subscription list
     """
-    org = entities.Organization().create()
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
-
+    org = module_entitlement_manifest_org
     rh_repo_id_rhva = enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
@@ -825,12 +819,12 @@ def test_errata_installation_with_swidtags(
 
 
 @pytest.fixture(scope='module')
-def rh_repo_module_manifest(module_manifest_org):
+def rh_repo_module_manifest(module_entitlement_manifest_org):
     """Use module manifest org, creates tools repo, syncs and returns RH repo."""
     # enable rhel repo and return its ID
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch=constants.DEFAULT_ARCHITECTURE,
-        org_id=module_manifest_org.id,
+        org_id=module_entitlement_manifest_org.id,
         product=constants.PRDS['rhel8'],
         repo=constants.REPOS['rhst8']['name'],
         reposet=constants.REPOSET['rhst8'],
@@ -843,24 +837,24 @@ def rh_repo_module_manifest(module_manifest_org):
 
 
 @pytest.fixture(scope='module')
-def rhel8_custom_repo_cv(module_manifest_org):
+def rhel8_custom_repo_cv(module_entitlement_manifest_org):
     """Create repo and publish CV so that packages are in Library"""
     return setup_org_for_a_custom_repo(
         {
             'url': settings.repos.module_stream_1.url,
-            'organization-id': module_manifest_org.id,
+            'organization-id': module_entitlement_manifest_org.id,
         }
     )
 
 
 @pytest.fixture(scope='module')
 def rhel8_module_ak(
-    module_manifest_org, default_lce, rh_repo_module_manifest, rhel8_custom_repo_cv
+    module_entitlement_manifest_org, default_lce, rh_repo_module_manifest, rhel8_custom_repo_cv
 ):
     rhel8_module_ak = entities.ActivationKey(
-        content_view=module_manifest_org.default_content_view,
-        environment=entities.LifecycleEnvironment(id=module_manifest_org.library.id),
-        organization=module_manifest_org,
+        content_view=module_entitlement_manifest_org.default_content_view,
+        environment=entities.LifecycleEnvironment(id=module_entitlement_manifest_org.library.id),
+        organization=module_entitlement_manifest_org,
     ).create()
     # Ensure tools repo is enabled in the activation key
     rhel8_module_ak.content_override(
@@ -869,17 +863,17 @@ def rhel8_module_ak(
         }
     )
     # Fetch available subscriptions
-    subs = entities.Subscription(organization=module_manifest_org).search(
+    subs = entities.Subscription(organization=module_entitlement_manifest_org).search(
         query={'search': f'{constants.DEFAULT_SUBSCRIPTION_NAME}'}
     )
     assert subs
     # Add default subscription to activation key
     rhel8_module_ak.add_subscriptions(data={'subscription_id': subs[0].id})
     # Add custom subscription to activation key
-    product = entities.Product(organization=module_manifest_org).search(
+    product = entities.Product(organization=module_entitlement_manifest_org).search(
         query={'search': "redhat=false"}
     )
-    custom_sub = entities.Subscription(organization=module_manifest_org).search(
+    custom_sub = entities.Subscription(organization=module_entitlement_manifest_org).search(
         query={'search': f"name={product[0].name}"}
     )
     rhel8_module_ak.add_subscriptions(data={'subscription_id': custom_sub[0].id})
@@ -888,7 +882,7 @@ def rhel8_module_ak(
 
 @pytest.mark.tier2
 def test_apply_modular_errata_using_default_content_view(
-    module_manifest_org,
+    module_entitlement_manifest_org,
     default_lce,
     rhel8_contenthost,
     rhel8_module_ak,
@@ -926,12 +920,14 @@ def test_apply_modular_errata_using_default_content_view(
     version = '20180704244205'
 
     rhel8_contenthost.install_katello_ca(target_sat)
-    rhel8_contenthost.register_contenthost(module_manifest_org.label, rhel8_module_ak.name)
+    rhel8_contenthost.register_contenthost(
+        module_entitlement_manifest_org.label, rhel8_module_ak.name
+    )
     assert rhel8_contenthost.subscribed
     host = rhel8_contenthost.nailgun_host
     host = host.read()
     # Assert no errata on host, no packages applicable or installable
-    errata = _fetch_available_errata(module_manifest_org, host, expected_amount=0)
+    errata = _fetch_available_errata(module_entitlement_manifest_org, host, expected_amount=0)
     assert len(errata) == 0
     rhel8_contenthost.install_katello_host_tools()
     # Install older version of module stream to generate the errata
@@ -940,7 +936,7 @@ def test_apply_modular_errata_using_default_content_view(
     )
     assert result.status == 0
     # Check that there is now two errata applicable
-    errata = _fetch_available_errata(module_manifest_org, host, 2)
+    errata = _fetch_available_errata(module_entitlement_manifest_org, host, 2)
     Host.errata_recalculate({'host-id': rhel8_contenthost.nailgun_host.id})
     assert len(errata) == 2
     # Assert that errata package is required
@@ -951,5 +947,5 @@ def test_apply_modular_errata_using_default_content_view(
     )
     assert result.status == 0
     # Check that there is now no errata applicable
-    errata = _fetch_available_errata(module_manifest_org, host, 0)
+    errata = _fetch_available_errata(module_entitlement_manifest_org, host, 0)
     assert len(errata) == 0

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -29,8 +29,6 @@ from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo import manifests
-from robottelo.api.utils import upload_manifest
 from robottelo.config import get_credentials
 from robottelo.constants import DEFAULT_ORG
 from robottelo.utils.datafactory import filtered_datapoint
@@ -133,7 +131,7 @@ class TestOrganization:
             entities.Organization(name=name).create()
 
     @pytest.mark.tier1
-    def test_negative_check_org_endpoint(self):
+    def test_negative_check_org_endpoint(self, module_entitlement_manifest_org):
         """Check manifest cert is not exposed in api endpoint
 
         :id: 24130e54-cd7a-41de-ac78-6e89aebabe30
@@ -146,9 +144,7 @@ class TestOrganization:
 
         :CaseImportance: High
         """
-        org = entities.Organization().create()
-        with manifests.clone() as manifest:
-            upload_manifest(org.id, manifest.content)
+        org = module_entitlement_manifest_org
         orgstring = json.dumps(org.read_json())
         assert 'BEGIN CERTIFICATE' not in orgstring
         assert 'BEGIN RSA PRIVATE KEY' not in orgstring

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -144,8 +144,7 @@ class TestOrganization:
 
         :CaseImportance: High
         """
-        org = module_entitlement_manifest_org
-        orgstring = json.dumps(org.read_json())
+        orgstring = json.dumps(module_entitlement_manifest_org.read_json())
         assert 'BEGIN CERTIFICATE' not in orgstring
         assert 'BEGIN RSA PRIVATE KEY' not in orgstring
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -24,8 +24,6 @@ from fauxfactory import gen_string
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo import manifests
-from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
 from robottelo.constants import CONTAINER_UPSTREAM_NAME
@@ -370,7 +368,7 @@ def test_positive_sync_several_repos(module_org):
 
 
 @pytest.mark.tier2
-def test_positive_filter_product_list():
+def test_positive_filter_product_list(module_entitlement_manifest_org):
     """Filter products based on param 'custom/redhat_only'
 
     :id: e61fb63a-4552-4915-b13d-23ab80138249
@@ -381,12 +379,8 @@ def test_positive_filter_product_list():
 
     :BZ: 1667129
     """
-    org = entities.Organization().create()
+    org = module_entitlement_manifest_org
     product = entities.Product(organization=org).create()
-    # Manifest upload to create RH Product
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
-
     custom_products = entities.Product(organization=org).search(query={'custom': True})
     rh_products = entities.Product(organization=org).search(
         query={'redhat_only': True, 'per_page': 1000}

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -23,9 +23,7 @@ from nailgun import entities
 from requests import HTTPError
 from wait_for import wait_for
 
-from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import upload_manifest
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -37,10 +35,8 @@ from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
-def setup_content():
-    org = entities.Organization().create()
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
+def setup_content(module_entitlement_manifest_org):
+    org = module_entitlement_manifest_org
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -33,7 +33,6 @@ from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 
 from robottelo import constants
-from robottelo import datafactory
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
 from robottelo.constants import DataFile

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -33,9 +33,8 @@ from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 
 from robottelo import constants
-from robottelo import manifests
+from robottelo import datafactory
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import upload_manifest
 from robottelo.config import settings
 from robottelo.constants import DataFile
 from robottelo.constants import repos as repo_constants
@@ -1159,7 +1158,7 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.read()
 
-    def test_positive_recreate_pulp_repositories(self, module_org, target_sat):
+    def test_positive_recreate_pulp_repositories(self, module_entitlement_manifest_org, target_sat):
         """Verify that deleted Pulp Repositories can be recreated using the
         command 'foreman-rake katello:correct_repositories COMMIT=true'
 
@@ -1172,11 +1171,9 @@ class TestRepository:
         :expectedresults: foreman-rake katello:correct_repositories COMMIT=true recreates deleted
          repos with no TaskErrors
         """
-        with manifests.clone() as manifest:
-            upload_manifest(module_org.id, manifest.content)
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=constants.PRDS['rhel'],
             repo=constants.REPOS['rhst7']['name'],
             reposet=constants.REPOSET['rhst7'],
@@ -1204,8 +1201,7 @@ class TestRepositorySync:
     """Tests for ``/katello/api/repositories/:id/sync``."""
 
     @pytest.mark.tier2
-    @pytest.mark.skip_if_not_set('fake_manifest')
-    def test_positive_sync_rh(self, module_org):
+    def test_positive_sync_rh(self, module_entitlement_manifest_org):
         """Sync RedHat Repository.
 
         :id: d69c44cd-753c-4a75-9fd5-a8ed963b5e04
@@ -1214,11 +1210,9 @@ class TestRepositorySync:
 
         :CaseLevel: Integration
         """
-        with manifests.clone() as manifest:
-            upload_manifest(module_org.id, manifest.content)
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=constants.PRDS['rhel'],
             repo=constants.REPOS['rhst7']['name'],
             reposet=constants.REPOSET['rhst7'],
@@ -1260,7 +1254,6 @@ class TestRepositorySync:
 
     @pytest.mark.stubbed
     @pytest.mark.tier2
-    @pytest.mark.skip_if_not_set('fake_manifest')
     def test_positive_sync_rh_app_stream(self):
         """Sync RedHat Appstream Repository.
 
@@ -1274,7 +1267,7 @@ class TestRepositorySync:
         pass
 
     @pytest.mark.tier3
-    def test_positive_bulk_cancel_sync(self, target_sat, module_manifest_org):
+    def test_positive_bulk_cancel_sync(self, target_sat, module_entitlement_manifest_org):
         """Bulk cancel 10+ repository syncs
 
         :id: f9bb1c95-d60f-4c93-b32e-09d58ebce80e
@@ -1294,7 +1287,7 @@ class TestRepositorySync:
         for repo in constants.BULK_REPO_LIST:
             repo_id = enable_rhrepo_and_fetchid(
                 basearch='x86_64',
-                org_id=module_manifest_org.id,
+                org_id=module_entitlement_manifest_org.id,
                 product=repo['product'],
                 repo=repo['name'],
                 reposet=repo['reposet'],
@@ -1356,7 +1349,7 @@ class TestRepositorySync:
         assert result.status == 1
 
     @pytest.mark.tier2
-    def test_positive_sync_repo_null_contents_changed(self, module_manifest_org, target_sat):
+    def test_positive_sync_repo_null_contents_changed(self, module_entitlement_manifest_org, target_sat):
         """test for null contents_changed parameter on actions::katello::repository::sync.
 
         :id: f3923940-e097-4da3-aba7-b14dbcda857b
@@ -1374,7 +1367,7 @@ class TestRepositorySync:
         """
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_manifest_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=constants.PRDS['rhel'],
             repo=constants.REPOS['rhst7']['name'],
             reposet=constants.REPOSET['rhst7'],

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1349,7 +1349,9 @@ class TestRepositorySync:
         assert result.status == 1
 
     @pytest.mark.tier2
-    def test_positive_sync_repo_null_contents_changed(self, module_entitlement_manifest_org, target_sat):
+    def test_positive_sync_repo_null_contents_changed(
+        self, module_entitlement_manifest_org, target_sat
+    ):
         """test for null contents_changed parameter on actions::katello::repository::sync.
 
         :id: f3923940-e097-4da3-aba7-b14dbcda857b

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -22,8 +22,6 @@ https://theforeman.org/plugins/katello/3.16/api/apidoc/v2/repository_sets.html
 import pytest
 from nailgun import entities
 
-from robottelo import manifests
-from robottelo.api.utils import upload_manifest
 from robottelo.constants import PRDS
 from robottelo.constants import REPOSET
 
@@ -36,23 +34,11 @@ RELEASE = '6Server'
 
 
 @pytest.fixture
-def org():
-    """Create organization."""
-    return entities.Organization().create()
-
-
-@pytest.fixture
-def manifest_org(org):
-    """Upload manifest to organization."""
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
-    return org
-
-
-@pytest.fixture
-def product(manifest_org):
+def product(function_entitlement_manifest_org):
     """Find and return the product matching PRODUCT_NAME."""
-    return entities.Product(name=PRODUCT_NAME, organization=manifest_org).search()[0]
+    return entities.Product(
+        name=PRODUCT_NAME, organization=function_entitlement_manifest_org
+    ).search()[0]
 
 
 @pytest.fixture

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -22,15 +22,16 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 """
 import pytest
 from fauxfactory import gen_string
+from manifester import Manifester
 from nailgun import entities
 from nailgun.config import ServerConfig
 from nailgun.entity_mixins import TaskFailedError
 from requests.exceptions import HTTPError
 
-from robottelo import manifests
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import upload_manifest
 from robottelo.cli.subscription import Subscription
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -41,12 +42,10 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
-def rh_repo(module_org):
-    with manifests.clone(name='golden_ticket') as manifest:
-        upload_manifest(module_org.id, manifest.content)
+def rh_repo(module_sca_manifest_org):
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
-        org_id=module_org.id,
+        org_id=module_sca_manifest_org.id,
         product=PRDS['rhel'],
         repo=REPOS['rhst7']['name'],
         reposet=REPOSET['rhst7'],
@@ -58,31 +57,38 @@ def rh_repo(module_org):
 
 
 @pytest.fixture(scope='module')
-def custom_repo(rh_repo, module_org):
+def custom_repo(rh_repo, module_sca_manifest_org):
     custom_repo = entities.Repository(
-        product=entities.Product(organization=module_org).create(),
+        product=entities.Product(organization=module_sca_manifest_org).create(),
     ).create()
     custom_repo.sync()
     return custom_repo
 
 
 @pytest.fixture(scope='module')
-def module_ak(module_org, rh_repo, custom_repo):
+def module_ak(module_sca_manifest_org, rh_repo, custom_repo):
     """rh_repo and custom_repo are included here to ensure their execution before the AK"""
     module_ak = entities.ActivationKey(
-        content_view=module_org.default_content_view,
+        content_view=module_sca_manifest_org.default_content_view,
         max_hosts=100,
-        organization=module_org,
-        environment=entities.LifecycleEnvironment(id=module_org.library.id),
+        organization=module_sca_manifest_org,
+        environment=entities.LifecycleEnvironment(id=module_sca_manifest_org.library.id),
         auto_attach=True,
     ).create()
     return module_ak
 
 
-@pytest.mark.skip_if_not_set('fake_manifest')
+@pytest.fixture(scope='function')
+def duplicate_manifest():
+    """Provides a function-scoped manifest that can be used alongside function_entitlement_manifest
+    when two manifests are required in a single test"""
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
 @pytest.mark.tier1
 @pytest.mark.pit_server
-def test_positive_create():
+def test_positive_create(module_entitlement_manifest):
     """Upload a manifest.
 
     :id: 6faf9d96-9b45-4bdc-afa9-ec3fbae83d41
@@ -92,14 +98,11 @@ def test_positive_create():
     :CaseImportance: Critical
     """
     org = entities.Organization().create()
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
+    upload_manifest(org.id, module_entitlement_manifest.content)
 
 
-@pytest.mark.skip('Skipping due to manifest refresh issues')
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier1
-def test_positive_refresh(request):
+def test_positive_refresh(function_entitlement_manifest_org):
     """Upload a manifest and refresh it afterwards.
 
     :id: cd195db6-e81b-42cb-a28d-ec0eb8a53341
@@ -108,19 +111,14 @@ def test_positive_refresh(request):
 
     :CaseImportance: Critical
     """
-    org = entities.Organization().create()
+    org = function_entitlement_manifest_org
     sub = entities.Subscription(organization=org)
-    with manifests.original_manifest() as manifest:
-        upload_manifest(org.id, manifest.content)
-    request.addfinalizer(lambda: sub.delete_manifest(data={'organization_id': org.id}))
     sub.refresh_manifest(data={'organization_id': org.id})
     assert sub.search()
 
 
-@pytest.mark.skip('Skipping due to manifest refresh issues')
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier1
-def test_positive_create_after_refresh(function_org):
+def test_positive_create_after_refresh(function_entitlement_manifest_org, duplicate_manifest):
     """Upload a manifest,refresh it and upload a new manifest to an other
      organization.
 
@@ -134,22 +132,20 @@ def test_positive_create_after_refresh(function_org):
 
     :CaseImportance: Critical
     """
-    org_sub = entities.Subscription(organization=function_org)
+    org_sub = entities.Subscription(organization=function_entitlement_manifest_org)
     new_org = entities.Organization().create()
     new_org_sub = entities.Subscription(organization=new_org)
-    upload_manifest(function_org.id, manifests.original_manifest().content)
     try:
-        org_sub.refresh_manifest(data={'organization_id': function_org.id})
+        org_sub.refresh_manifest(data={'organization_id': function_entitlement_manifest_org.id})
         assert org_sub.search()
-        upload_manifest(new_org.id, manifests.clone().content)
+        upload_manifest(new_org.id, duplicate_manifest.content)
         assert new_org_sub.search()
     finally:
-        org_sub.delete_manifest(data={'organization_id': function_org.id})
+        org_sub.delete_manifest(data={'organization_id': function_entitlement_manifest_org.id})
 
 
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier1
-def test_positive_delete(function_org):
+def test_positive_delete(function_entitlement_manifest_org):
     """Delete an Uploaded manifest.
 
     :id: 4c21c7c9-2b26-4a65-a304-b978d5ba34fc
@@ -158,17 +154,14 @@ def test_positive_delete(function_org):
 
     :CaseImportance: Critical
     """
-    sub = entities.Subscription(organization=function_org)
-    with manifests.clone() as manifest:
-        upload_manifest(function_org.id, manifest.content)
+    sub = entities.Subscription(organization=function_entitlement_manifest_org)
     assert sub.search()
-    sub.delete_manifest(data={'organization_id': function_org.id})
+    sub.delete_manifest(data={'organization_id': function_entitlement_manifest_org.id})
     assert len(sub.search()) == 0
 
 
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_negative_upload():
+def test_negative_upload(function_entitlement_manifest):
     """Upload the same manifest to two organizations.
 
     :id: 60ca078d-cfaf-402e-b0db-34d8901449fe
@@ -177,7 +170,7 @@ def test_negative_upload():
         organization.
     """
     orgs = [entities.Organization().create() for _ in range(2)]
-    with manifests.clone() as manifest:
+    with function_entitlement_manifest as manifest:
         upload_manifest(orgs[0].id, manifest.content)
         with pytest.raises(TaskFailedError):
             upload_manifest(orgs[1].id, manifest.content)
@@ -185,7 +178,9 @@ def test_negative_upload():
 
 
 @pytest.mark.tier2
-def test_positive_delete_manifest_as_another_user(function_org, target_sat):
+def test_positive_delete_manifest_as_another_user(
+    function_org, function_entitlement_manifest, target_sat
+):
     """Verify that uploaded manifest if visible and deletable
         by a different user than the one who uploaded it
 
@@ -224,7 +219,7 @@ def test_positive_delete_manifest_as_another_user(function_org, target_sat):
         verify=False,
     )
     # use the first admin to upload a manifest
-    with manifests.clone() as manifest:
+    with function_entitlement_manifest as manifest:
         entities.Subscription(sc1, organization=function_org).upload(
             data={'organization_id': function_org.id}, files={'content': manifest.content}
         )
@@ -236,7 +231,9 @@ def test_positive_delete_manifest_as_another_user(function_org, target_sat):
 
 
 @pytest.mark.tier2
-def test_positive_subscription_status_disabled(module_ak, rhel_contenthost, module_org, target_sat):
+def test_positive_subscription_status_disabled(
+    module_ak, rhel_contenthost, module_sca_manifest_org, target_sat
+):
     """Verify that Content host Subscription status is set to 'Disabled'
      for a golden ticket manifest
 
@@ -251,7 +248,7 @@ def test_positive_subscription_status_disabled(module_ak, rhel_contenthost, modu
     :CaseImportance: Medium
     """
     rhel_contenthost.install_katello_ca(target_sat)
-    rhel_contenthost.register_contenthost(module_org.label, module_ak.name)
+    rhel_contenthost.register_contenthost(module_sca_manifest_org.label, module_ak.name)
     assert rhel_contenthost.subscribed
     host_content = entities.Host(id=rhel_contenthost.nailgun_host.id).read_raw().content
     assert 'Simple Content Access' in str(host_content)
@@ -260,7 +257,9 @@ def test_positive_subscription_status_disabled(module_ak, rhel_contenthost, modu
 @pytest.mark.tier2
 @pytest.mark.pit_client
 @pytest.mark.pit_server
-def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custom_repo, target_sat):
+def test_sca_end_to_end(
+    module_ak, rhel7_contenthost, module_sca_manifest_org, rh_repo, custom_repo, target_sat
+):
     """Perform end to end testing for Simple Content Access Mode
 
     :id: c6c4b68c-a506-46c9-bd1d-22e4c1926ef8
@@ -275,12 +274,12 @@ def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custo
     :CaseImportance: Critical
     """
     rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(module_org.label, module_ak.name)
+    rhel7_contenthost.register_contenthost(module_sca_manifest_org.label, module_ak.name)
     assert rhel7_contenthost.subscribed
     # Check to see if Organization is in SCA Mode
-    assert entities.Organization(id=module_org.id).read().simple_content_access is True
+    assert entities.Organization(id=module_sca_manifest_org.id).read().simple_content_access is True
     # Verify that you cannot attach a subscription to an activation key in SCA Mode
-    subscription = entities.Subscription(organization=module_org).search(
+    subscription = entities.Subscription(organization=module_sca_manifest_org).search(
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]
     with pytest.raises(HTTPError) as ak_context:
@@ -293,7 +292,7 @@ def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custo
         )
     assert 'Simple Content Access' in host_context.value.response.text
     # Create a content view with repos and check to see that the client has access
-    content_view = entities.ContentView(organization=module_org).create()
+    content_view = entities.ContentView(organization=module_sca_manifest_org).create()
     content_view.repository = [rh_repo, custom_repo]
     content_view.update(['repository'])
     content_view.publish()
@@ -311,7 +310,9 @@ def test_sca_end_to_end(module_ak, rhel7_contenthost, module_org, rh_repo, custo
 
 
 @pytest.mark.tier2
-def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, function_org, target_sat):
+def test_positive_candlepin_events_processed_by_stomp(
+    rhel7_contenthost, function_entitlement_manifest, function_org, target_sat
+):
     """Verify that Candlepin events are being read and processed by
         attaching subscriptions, validating host subscriptions status,
         and viewing processed and failed Candlepin events
@@ -354,7 +355,7 @@ def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, functio
     host_id = host[0].id
     host_content = entities.Host(id=host_id).read_json()
     assert host_content['subscription_status'] == 2
-    with manifests.clone() as manifest:
+    with function_entitlement_manifest as manifest:
         upload_manifest(function_org.id, manifest.content)
     subscription = entities.Subscription(organization=function_org).search(
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
@@ -369,7 +370,7 @@ def test_positive_candlepin_events_processed_by_stomp(rhel7_contenthost, functio
     assert '0 Failed' in response['message']
 
 
-def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, target_sat):
+def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel7_contenthost, target_sat):
     """Verify that a content host with an expired SCA cert can
         re-register successfully
 
@@ -396,26 +397,26 @@ def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, targe
 
     :CaseImportance: High
     """
-    with manifests.clone(name='golden_ticket') as manifest:
-        upload_manifest(module_org.id, manifest.content)
     ak = entities.ActivationKey(
-        content_view=module_org.default_content_view,
+        content_view=module_sca_manifest_org.default_content_view,
         max_hosts=100,
-        organization=module_org,
-        environment=entities.LifecycleEnvironment(id=module_org.library.id),
+        organization=module_sca_manifest_org,
+        environment=entities.LifecycleEnvironment(id=module_sca_manifest_org.library.id),
         auto_attach=True,
     ).create()
     # registering the content host with no content enabled/synced in the org
     # should create a client SCA cert with no content
     rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(org=module_org.label, activation_key=ak.name)
+    rhel7_contenthost.register_contenthost(
+        org=module_sca_manifest_org.label, activation_key=ak.name
+    )
     assert rhel7_contenthost.subscribed
     rhel7_contenthost.unregister()
     # syncing content with the content host unregistered should invalidate
     # the previous client SCA cert
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
-        org_id=module_org.id,
+        org_id=module_sca_manifest_org.id,
         product=PRDS['rhel'],
         repo=REPOS['rhst7']['name'],
         reposet=REPOSET['rhst7'],
@@ -425,7 +426,7 @@ def test_positive_expired_SCA_cert_handling(module_org, rhel7_contenthost, targe
     rh_repo.sync()
     # re-registering the host should test whether Candlepin gracefully handles
     # registration of a host with an expired SCA cert
-    rhel7_contenthost.register_contenthost(module_org.label, ak.name)
+    rhel7_contenthost.register_contenthost(module_sca_manifest_org.label, ak.name)
     assert rhel7_contenthost.subscribed
 
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -102,7 +102,7 @@ def test_positive_create(module_entitlement_manifest):
 
 
 @pytest.mark.tier1
-def test_positive_refresh(function_entitlement_manifest_org):
+def test_positive_refresh(function_entitlement_manifest_org, request):
     """Upload a manifest and refresh it afterwards.
 
     :id: cd195db6-e81b-42cb-a28d-ec0eb8a53341
@@ -113,6 +113,7 @@ def test_positive_refresh(function_entitlement_manifest_org):
     """
     org = function_entitlement_manifest_org
     sub = entities.Subscription(organization=org)
+    request.addfinalizer(lambda: sub.delete_manifest(data={'organization_id': org.id}))
     sub.refresh_manifest(data={'organization_id': org.id})
     assert sub.search()
 

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -31,7 +31,6 @@ from nailgun import client
 from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo import manifests
 from robottelo.api.utils import disable_syncplan
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import wait_for_tasks
@@ -808,7 +807,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
-def test_positive_synchronize_rh_product_past_sync_date(request):
+def test_positive_synchronize_rh_product_past_sync_date(request, function_entitlement_manifest_org):
     """Create a sync plan with past datetime as a sync date, add a
     RH product and verify the product gets synchronized on the next sync
     occurrence
@@ -825,11 +824,7 @@ def test_positive_synchronize_rh_product_past_sync_date(request):
     """
     interval = 60 * 60  # 'hourly' sync interval in seconds
     delay = 2 * 60
-    org = entities.Organization().create()
-    with manifests.clone() as manifest:
-        entities.Subscription().upload(
-            data={'organization_id': org.id}, files={'content': manifest.content}
-        )
+    org = function_entitlement_manifest_org
     repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
@@ -880,7 +875,9 @@ def test_positive_synchronize_rh_product_past_sync_date(request):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
 @pytest.mark.upgrade
-def test_positive_synchronize_rh_product_future_sync_date(request):
+def test_positive_synchronize_rh_product_future_sync_date(
+    request, function_entitlement_manifest_org
+):
     """Create a sync plan with sync date in a future and sync one RH
     product with it automatically.
 
@@ -891,11 +888,7 @@ def test_positive_synchronize_rh_product_future_sync_date(request):
     :CaseLevel: System
     """
     delay = 2 * 60  # delay for sync date in seconds
-    org = entities.Organization().create()
-    with manifests.clone() as manifest:
-        entities.Subscription().upload(
-            data={'organization_id': org.id}, files={'content': manifest.content}
-        )
+    org = function_entitlement_manifest_org
     repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,


### PR DESCRIPTION
This PR will convert all API tests that use manifests to obtain their manifests using manifester. I am planning on pushing one commit per module in an attempt to stay organized. The initial commit converts the `api/test_contentview.py` module. Note that, in this module, the `TestContentViewRedHatOstreeContent` class is decorated with `@pytest.mark.skip_if_open("BZ:1625783")`, but this BZ is closed WONTFIX. With the marker removed, these tests fail, but the failures are unrelated to the use of manifester.