### PR TITLE
Temporary workaround for dynaconf.vendor.box.exceptions.BoxKeyError: DynaBox object has no attribute host

### DIFF
--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -29,6 +29,7 @@ from robottelo.utils.io import get_report_data
 from robottelo.utils.io import get_report_metadata
 
 generate_report_task = 'ForemanInventoryUpload::Async::UploadReportJob'
+pytestmark = [pytest.mark.no_containers]
 
 
 def generate_inventory_report(satellite, org):

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -27,6 +27,8 @@ from robottelo.utils.io import get_remote_report_checksum
 
 inventory_sync_task = 'InventorySync::Async::InventoryFullSync'
 
+pytestmark = [pytest.mark.no_containers]
+
 
 @pytest.mark.tier3
 def test_positive_inventory_generate_upload_cli(

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -24,6 +24,8 @@ from wait_for import wait_for
 
 from robottelo.constants import DEFAULT_LOC
 
+pytestmark = [pytest.mark.no_containers]
+
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -28,6 +28,8 @@ from robottelo.utils.io import get_local_file_data
 from robottelo.utils.io import get_remote_report_checksum
 from robottelo.utils.io import get_report_data
 
+pytestmark = [pytest.mark.no_containers]
+
 
 def common_assertion(report_path, inventory_data, org, satellite):
     """Function to perform common assertions"""


### PR DESCRIPTION
1. I am seeing this issue when we are trying to spin two containers as a host which happens due to https://github.com/SatelliteQE/broker/blob/master/broker/broker.py#L363 when it's trying to invoke the host.setup() function in robotello/hosts.py.



```
    def setup(self):
        if not self.blank:
            self.remove_katello_ca()
            self.execute('subscription-manager clean')
```