### PR TITLE
[6.11.z] Extend sync timeout for a docker image

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1131,7 +1131,7 @@ class TestCapsuleContentManagement:
                 product=function_product,
                 url='https://quay.io',
             ).create()
-            repo.sync(timeout=600)
+            repo.sync(timeout='20m')
             repos.append(repo)
 
         # Associate LCE with the capsule


### PR DESCRIPTION
Cherrypick of commit: b10f84c3b6db31e864aae2822f9407e61f462b4a

Not sure why this particular test case fails on OSP with
```
E   nailgun.entity_mixins.TaskTimedOutError: Timed out polling task 44652687-aa37-472f-bf51-74a268e588d1.
```
but passes locally (on RHEV host) without any changes. Anyway, PRT seems happy with this change, let's see how it does in standard run.