### PR TITLE
Automation coverage for BZ#1908841

### DIFF
--- a/tests/foreman/destructive/test_capsule.py
+++ b/tests/foreman/destructive/test_capsule.py
@@ -1,0 +1,50 @@
+"""Test class for the capsule CLI.
+
+:Requirement: Capsule
+
+:CaseAutomation: Automated
+
+:CaseLevel: Component
+
+:CaseComponent: Capsule
+
+:Assignee: vsedmik
+
+:TestType: Functional
+
+:CaseImportance: Critical
+
+:Upstream: No
+"""
+import pytest
+from fauxfactory import gen_string
+
+from robottelo.hosts import Capsule
+from robottelo.utils.installer import InstallerCommand
+
+pytestmark = [pytest.mark.destructive]
+
+
+@pytest.mark.tier1
+def test_positive_capsule_certs_generate_with_special_char(target_sat):
+    """Verify capsule-certs-generate with special character in organization
+
+    :id: e9dc6a64-4be4-11ed-8b27-9f5cc2f1b246
+
+    :expectedresults: capsule-certs-generate works
+
+    :CaseLevel: Component
+
+    :BZ: 1908841
+
+    :customerscenario: true
+    """
+    capsule = Capsule('capsule.example.com')
+    # Create an org with a special char in its name and set it as the default using installer
+    org = target_sat.api.Organization(name=f"{gen_string('alpha')}'s").create()
+    result = target_sat.install(InstallerCommand(f'foreman-initial-organization "{org.name}"'))
+    assert result.status == 0
+    # Verify capsule-certs-generate works with special chars in org.name
+    _, result, _ = target_sat.capsule_certs_generate(capsule)
+    assert result.status == 0
+    assert f'subscription-manager register --org "{org.name}"' in result.stdout


### PR DESCRIPTION
**Description:**
1. Automation coverage for [BZ 1908841](https://bugzilla.redhat.com/show_bug.cgi?id=1908841)
2. Update capsule_certs_generate helper to return cert_file_path, result, and install_cmd to run

**Test Results:**
```
(.robottelo) ➜  robottelo git:(automate-1908841) ✗ pytest -q --disable-pytest-warnings tests/foreman/destructive/test_capsule.py
.                                                                                                                                                                          [100%]
1 passed, 2 warnings in 480.98s (0:08:00)
```


Signed-off-by: Gaurav Talreja <gauravtalreja1@gmail.com>