### PR TITLE
[6.11.z] fix runtime error introduced by 884fb93

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -12,8 +12,7 @@ from robottelo.logging import logger
 
 def _resolve_deploy_args(args_dict):
     # TODO: https://github.com/rochacbruno/dynaconf/issues/690
-    args_dict = args_dict.copy().to_dict()
-    for key, val in args_dict.items():
+    for key, val in args_dict.copy().to_dict().items():
         if isinstance(val, str) and val.startswith('this.'):
             # Args transformed into small letters and existing capital args removed
             args_dict[key.lower()] = settings.get(args_dict.pop(key).replace('this.', ''))


### PR DESCRIPTION
Cherrypick of commit: 7cb9ce090388126889057dcec285ba2cfdf4f3ba

the current implementation was causing runtime errors since the loop was messing with the dict keys