### PR TITLE
Automation coverage for BZ 1908478 and 1962842

### DIFF
--- a/robottelo/cli/sm_maintenance_mode.py
+++ b/robottelo/cli/sm_maintenance_mode.py
@@ -1,0 +1,49 @@
+"""
+Usage:
+    satellite-maintain maintenance-mode [OPTIONS] SUBCOMMAND [ARG] ...
+Parameters:
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+Subcommands:
+    start                         Start maintenance-mode
+    stop                          Stop maintenance-mode
+    status                        Get maintenance-mode status
+    is-enabled                    Get maintenance-mode status code
+Options:
+    -h, --help                    print help
+"""
+from robottelo.cli.base import Base
+
+
+class MaintenanceMode(Base):
+    """Manipulates Satellite-maintain's maintenance-mode command"""
+
+    command_base = 'maintenance-mode'
+
+    @classmethod
+    def start(cls, options=None):
+        """satellite-maintain maintenance-mode start [OPTIONS]"""
+        cls.command_sub = 'start'
+        options = options or {}
+        return cls.sm_execute(cls._construct_command(options))
+
+    @classmethod
+    def stop(cls, options=None):
+        """satellite-maintain maintenance-mode stop [OPTIONS]"""
+        cls.command_sub = 'stop'
+        options = options or {}
+        return cls.sm_execute(cls._construct_command(options))
+
+    @classmethod
+    def status(cls, options=None):
+        """satellite-maintain maintenance-mode status [OPTIONS]"""
+        cls.command_sub = 'status'
+        options = options or {}
+        return cls.sm_execute(cls._construct_command(options))
+
+    @classmethod
+    def is_enabled(cls, options=None):
+        """satellite-maintain maintenance-mode is-enabled [OPTIONS]"""
+        cls.command_sub = 'is-enabled'
+        options = options or {}
+        return cls.sm_execute(cls._construct_command(options))


### PR DESCRIPTION
**Description:**
1. Automation coverage for [BZ 1908478](https://bugzilla.redhat.com/show_bug.cgi?id=1908478) and [BZ 1962842](https://bugzilla.redhat.com/show_bug.cgi?id=1962842)
2. Add f-m maintenance-mode CLI

**Test Results:**
```
(.robottelo) ➜  robottelo git:(automate-1962842) ✗ pytest -q --disable-pytest-warnings tests/foreman/maintain/test_backup_restore.py -k test_negative_backup_maintenance_mode
.                                                                                                                                                                                       [100%]
1 passed, 22 deselected, 2 warnings in 487.60s (0:08:07)
```