### PR TITLE
Redundant code cleaning.

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -201,7 +201,6 @@ class ContentHost(Host, ContentHostMixins):
     def setup(self):
         if not self.blank:
             self.remove_katello_ca()
-            self.execute('subscription-manager clean')
 
     def teardown(self):
         if not self.blank:


### PR DESCRIPTION
`we have self.execute('subscription-manager clean') in remove_katello_ca() method`


Signed-off-by: Adarsh Dubey <addubey@redhat.com>