### PR TITLE
[6.11.z] Redundant code cleaning.

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -199,7 +199,6 @@ class ContentHost(Host, ContentHostMixins):
     def setup(self):
         if not self.blank:
             self.remove_katello_ca()
-            self.execute('subscription-manager clean')
 
     def teardown(self):
         if not self.blank:


### PR DESCRIPTION
Cherrypick of commit: 0feaaab14c93a80e4dc540f5a562ba62b0f768f1

`we have self.execute('subscription-manager clean') in remove_katello_ca() method`


Signed-off-by: Adarsh Dubey <addubey@redhat.com>