### PR TITLE
Add a test to check pulp status via pulp-cli

### DIFF
--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -16,6 +16,9 @@
 
 :Upstream: No
 """
+import json
+from datetime import datetime
+
 import pytest
 
 
@@ -96,3 +99,39 @@ def test_pulp_workers_status(target_sat):
     output = target_sat.execute('systemctl status pulpcore-worker* | grep Active')
     result = output.stdout.rstrip().splitlines()
     assert all('Active: active (running)' in r for r in result)
+
+
+@pytest.mark.tier1
+def test_pulp_status(target_sat):
+    """Test pulp status via pulp-cli.
+
+    :id: aa7fda5a-cfa1-4fa1-8714-8d5a2e2f89d9
+
+    :steps:
+        1. Run pulp status command and parse the output.
+
+    :expectedresults:
+        1. Pulp-cli is installed and configured to work properly.
+        2. The pulp components are alive according to provided status.
+    """
+    result = target_sat.execute('pulp status')
+    now = datetime.utcnow()
+    assert not result.status
+    status = json.loads(result.stdout)
+    assert status['database_connection']['connected']
+    assert status['redis_connection']['connected']
+
+    workers_beats = [
+        datetime.strptime(worker['last_heartbeat'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        for worker in status['online_workers']
+    ]
+    assert all(
+        (now - beat).seconds < 20 for beat in workers_beats
+    ), 'Some pulp workers seem to me dead!'
+    apps_beats = [
+        datetime.strptime(app['last_heartbeat'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        for app in status['online_content_apps']
+    ]
+    assert all(
+        (now - beat).seconds < 20 for beat in apps_beats
+    ), 'Some content apps seem to me dead!'


### PR DESCRIPTION
Since 6.12 the [pulp-cli](https://github.com/pulp/pulp-cli) is installed by default on the Satellite. In this test we check that:
1) The pulp-cli is installed and configured to work properly.
2) The pulp components are alive according to provided status.