### PR TITLE
Introduce method to get repository definition from Ohsnap

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -45,6 +45,9 @@ class VersionedContent:
         }
 
     def _dogfood_helper(self, product, release, snap, repo=None):
+        """Function to return repository related attributes
+        based on the input and the host object
+        """
         v_major = str(self._v_major)
         if not product:
             if self.__class__.__name__ == 'ContentHost':
@@ -77,7 +80,7 @@ class VersionedContent:
         """Returns a repository definition based on the arguments provided"""
         product, release, snap, v_major, repo = self._dogfood_helper(product, release, snap, repo)
         return dogfood_repository(
-            settings.repos.ohsnap_repo_host, repo, self.arch, product, release, v_major, snap
+            settings.repos.ohsnap_repo_host, repo, product, release, v_major, snap, self.arch
         )
 
     def enable_tools_repo(self, organization_id):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -181,6 +181,10 @@ class ContentHost(Host, ContentHostMixins):
         return ipv4
 
     @cached_property
+    def arch(self):
+        return self.get_facts().get('lscpu.architecture') or self.execute('uname -m').stdout.strip()
+
+    @cached_property
     def _redhat_release(self):
         """Process redhat-release file for distro and version information"""
         result = self.execute('cat /etc/redhat-release')

--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -17,9 +17,9 @@ def ohsnap_repo_url(
         raise InvalidArgumentError(
             'Arguments "product", "release" and "os_release" must be provided.'
         )
-    if release.lower != 'client':
+    if release.lower() != 'client':
         if snap:
-            snap = "/" + snap if snap else ""
+            snap = "/" + str(snap) if snap else ""
         else:
             logger.warn(
                 'The snap version was not provided. Snap number will not be used in the URL.'

--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -1,0 +1,56 @@
+import requests
+from box import Box
+
+from robottelo import constants
+from robottelo.exceptions import InvalidArgumentError
+from robottelo.exceptions import RepositoryDataNotFound
+from robottelo.logging import logger
+
+
+def ohsnap_repo_url(
+    ohsnap_repo_host, request_type, product=None, release=None, os_release=None, snap=''
+):
+    """Returns a URL pointing to Ohsnap "repo_file" or "repositories" API endpoint"""
+    if request_type not in ['repo_file', 'repositories']:
+        raise InvalidArgumentError('Type must be one of "repo_file" or "repositories"')
+    if not all(arg for arg in [product, release, os_release]):
+        raise InvalidArgumentError(
+            'Arguments "product", "release" and "os_release" must be provided.'
+        )
+    if release.lower != 'client':
+        if snap:
+            snap = "/" + snap if snap else ""
+        else:
+            logger.warn(
+                'The snap version was not provided. Snap number will not be used in the URL.'
+            )
+        release = release.split('.')
+        if len(release) == 2:
+            release.append('0')
+        release = '.'.join(release[:3])  # keep only major.minor.patch
+
+    return (
+        f'{ohsnap_repo_host}/api/releases/'
+        f'{release}{snap}/el{os_release}/{product}/{request_type}'
+    )
+
+
+def dogfood_repofile_url(ohsnap_repo_host, product=None, release=None, os_release=None, snap=''):
+    return ohsnap_repo_url(ohsnap_repo_host, 'repo_file', product, release, os_release, snap)
+
+
+def dogfood_repository(
+    ohsnap_repo_host, repo, arch=None, product=None, release=None, os_release=None, snap=''
+):
+    """Returns a repository definition based on the arguments provided"""
+    arch = arch or constants.DEFAULT_ARCHITECTURE
+    res = requests.get(
+        ohsnap_repo_url(ohsnap_repo_host, 'repositories', product, release, os_release, snap)
+    )
+    res.raise_for_status()
+    try:
+        repository = next(r for r in res.json() if r['label'] == repo)
+    except StopIteration:
+        raise RepositoryDataNotFound(f'Repository "{repo}" is not provided by the given product')
+    repository['baseurl'] = repository['baseurl'].replace('$basearch', arch)
+    return Box(**repository)

--- a/scripts/vault_login.py
+++ b/scripts/vault_login.py
@@ -5,7 +5,6 @@ import os
 import re
 import subprocess
 import sys
-import time
 from pathlib import Path
 
 from robottelo.constants import Colored
@@ -43,7 +42,6 @@ def _vault_login(root_path, envdata):
         f"{Colored.WHITELIGHT}Warning! The browser is about to open for vault OIDC login, "
         "close the tab once the sign-in is done!"
     )
-    time.sleep(5)
     if _vault_command(command="vault login -method=oidc").returncode == 0:
         _vault_command(command="vault token renew -i 10h")
         print(f"{Colored.GREEN}Success! Vault OIDC Logged-In and extended for 10 hours!")


### PR DESCRIPTION
This PR adds a new method that users can use to get repository specs for repositories provided by the Dogfood Sat.

I am not convinced that `contenthost_mixins.VersionedContent` is the right place for all of the logic around Ohsnap.

This PR may be used by #10062. See https://github.com/SatelliteQE/robottelo/pull/10062#discussion_r999211724.