### PR TITLE
[6.11.z] Fix selinux test failing on RHEL8

### DIFF
--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -37,7 +37,7 @@ def test_selinux_status(target_sat):
     result = target_sat.execute('getenforce')
     assert 'Enforcing' in result.stdout
     # check there are no SELinux denials
-    if not is_open('BZ:2131031'):
+    if target_sat.os_version.major == 7 or not is_open('BZ:2131031'):
         result = target_sat.execute('ausearch --input-logs -m avc -ts today --raw')
         assert result.status == 1, 'Some SELinux denials were found in journal.'
 

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -18,6 +18,8 @@
 """
 import pytest
 
+from robottelo.utils.issue_handlers import is_open
+
 
 @pytest.mark.upgrade
 def test_selinux_status(target_sat):
@@ -26,13 +28,18 @@ def test_selinux_status(target_sat):
     :id: 43218070-ac5e-4679-b74a-3e2bcb497a0a
 
     :expectedresults: SELinux is enabled and there are no denials
+
+    :customerscenario: true
+
+    :BZ: 2131031
     """
     # check SELinux is enabled
     result = target_sat.execute('getenforce')
     assert 'Enforcing' in result.stdout
     # check there are no SELinux denials
-    result = target_sat.execute('ausearch --input-logs -m avc -ts today --raw')
-    assert result.status == 1
+    if not is_open('BZ:2131031'):
+        result = target_sat.execute('ausearch --input-logs -m avc -ts today --raw')
+        assert result.status == 1, 'Some SELinux denials were found in journal.'
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
Cherrypick of commit: 6490f668be056aebeca36900d019ba45cf704189

This test seems to be failing for a while on RHEL8 systems due to the same issue as this [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2131031).
Let's skip the final assertion on RHEL8 until the BZ is resolved.