### PR TITLE
Parametrize KS repo syncing test

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -100,10 +100,12 @@ class ContentInfo:
             reached or calculation was not successful).
         """
         filename = url.split('/')[-1]
-        result = self.execute(f'wget -qO - {url} | tee {filename} | md5sum | awk \'{{print $1}}\'')
+        result = self.execute(f'wget -q --spider {url}')
         if result.status != 0:
-            raise AssertionError(f'Failed to calculate md5 checksum of {filename}')
-        return result.stdout
+            raise AssertionError(f'Failed to get `{filename}` from `{url}`.')
+        return self.execute(
+            f'wget -qO - {url} | tee {filename} | md5sum | awk \'{{print $1}}\''
+        ).stdout
 
 
 class SystemInfo:


### PR DESCRIPTION
This PR presents two changes:
1) Fixes `md5_by_url` method. The original one returned md5sum even when the file did not exist instead of raising error (sum of an empty output, same as `md5sum /dev/null`).
2) Parametrization for the three latest baseos KS repos.