### PR TITLE
cherrypick_label check fails for z-streams pr's

### DIFF
--- a/.github/workflows/required_labels.yml
+++ b/.github/workflows/required_labels.yml
@@ -14,4 +14,4 @@ jobs:
         with:
           mode: exactly
           count: 1
-          labels: "CherryPick, No-CherryPick"
+          labels: "CherryPick, No-CherryPick, Auto_Cherry_Picked"


### PR DESCRIPTION
Enforcing cherrypick labels check fails for the Y or Z stream AutoCherryPicked PR'S  https://github.com/SatelliteQE/robottelo/actions/runs/3326380185/jobs/5500043843