### PR TITLE
[6.11.z] fixes in capsule upgrade playbook tests

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -19,9 +19,9 @@
 import pytest
 
 from robottelo.api.utils import wait_for_tasks
+from robottelo.hosts import get_sat_version
 
-
-CAPSULE_TARGET_VERSION = '6.10.z'
+CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
 
 @pytest.mark.tier4


### PR DESCRIPTION
Cherrypick of commit: e5886cd600493536a18e6b8a52e23851fe3318f5

fixing some test failures in tests related to capsule upgrade playbook -- the capsule target version is no longer hardcoded, incorect hostname and credentials selection is also fixed