### PR TITLE
Fix TypeError when using api property for user_nailgun_config

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1043,11 +1043,13 @@ def test_positive_admin_user_actions(
     cfg = user_nailgun_config(user_login, user_password)
     # Check that we cannot create random entity due permission restriction
     with pytest.raises(HTTPError):
-        target_sat.api.Domain(cfg).create()
+        target_sat.api.Domain(server_config=cfg).create()
     # Check Read functionality
-    content_view = target_sat.api.ContentView(cfg, id=content_view.id).read()
+    content_view = target_sat.api.ContentView(server_config=cfg, id=content_view.id).read()
     # Check Modify functionality
-    target_sat.api.ContentView(cfg, id=content_view.id, name=gen_string('alpha')).update(['name'])
+    target_sat.api.ContentView(
+        server_config=cfg, id=content_view.id, name=gen_string('alpha')
+    ).update(['name'])
     # Publish the content view.
     content_view.publish()
     content_view = content_view.read()
@@ -1056,7 +1058,7 @@ def test_positive_admin_user_actions(
     content_view.version[0].promote(data={'environment_ids': module_lce.id})
     # Check Delete functionality
     content_view = target_sat.api.ContentView(organization=module_org).create()
-    content_view = target_sat.api.ContentView(cfg, id=content_view.id).read()
+    content_view = target_sat.api.ContentView(server_config=cfg, id=content_view.id).read()
     content_view.delete()
     with pytest.raises(HTTPError):
         content_view.read()
@@ -1118,7 +1120,7 @@ def test_positive_readonly_user_actions(target_sat, function_role, content_view,
     cfg = user_nailgun_config(user_login, user_password)
     # Check that we can read content view repository information using user
     # with read only permissions
-    content_view = target_sat.api.ContentView(cfg, id=content_view.id).read()
+    content_view = target_sat.api.ContentView(server_config=cfg, id=content_view.id).read()
     assert len(content_view.repository) == 1
     assert content_view.repository[0].read().name == yum_repo.name
 
@@ -1176,14 +1178,14 @@ def test_negative_readonly_user_actions(
     cfg = user_nailgun_config(user_login, user_password)
     # Check that we cannot create content view due read-only permission
     with pytest.raises(HTTPError):
-        target_sat.api.ContentView(cfg, organization=module_org).create()
+        target_sat.api.ContentView(server_config=cfg, organization=module_org).create()
     # Check that we can read our content view with custom user
-    content_view = target_sat.api.ContentView(cfg, id=content_view.id).read()
+    content_view = target_sat.api.ContentView(server_config=cfg, id=content_view.id).read()
     # Check that we cannot modify content view with custom user
     with pytest.raises(HTTPError):
-        target_sat.api.ContentView(cfg, id=content_view.id, name=gen_string('alpha')).update(
-            ['name']
-        )
+        target_sat.api.ContentView(
+            server_config=cfg, id=content_view.id, name=gen_string('alpha')
+        ).update(['name'])
     # Check that we cannot delete content view due read-only permission
     with pytest.raises(HTTPError):
         content_view.delete()
@@ -1193,19 +1195,19 @@ def test_negative_readonly_user_actions(
     # Check that we cannot promote content view
     content_view = target_sat.api.ContentView(id=content_view.id).read()
     content_view.publish()
-    content_view = target_sat.api.ContentView(cfg, id=content_view.id).read()
+    content_view = target_sat.api.ContentView(server_config=cfg, id=content_view.id).read()
     assert len(content_view.version), 1
     with pytest.raises(HTTPError):
         content_view.read().version[0].promote(data={'environment_ids': module_lce.id})
     # Check that we cannot create a Product
     with pytest.raises(HTTPError):
-        target_sat.api.Product(cfg).create()
+        target_sat.api.Product(server_config=cfg).create()
     # Check that we cannot create an activation key
     with pytest.raises(HTTPError):
-        target_sat.api.ActivationKey(cfg).create()
+        target_sat.api.ActivationKey(server_config=cfg).create()
     # Check that we cannot create a host collection
     with pytest.raises(HTTPError):
-        target_sat.api.HostCollection(cfg).create()
+        target_sat.api.HostCollection(server_config=cfg).create()
 
 
 @pytest.mark.tier2
@@ -1251,9 +1253,9 @@ def test_negative_non_readonly_user_actions(target_sat, content_view, function_r
     # Check that we cannot read our content view with custom user
     user_cfg = user_nailgun_config(user_login, user_password)
     with pytest.raises(HTTPError):
-        target_sat.api.ContentView(user_cfg, id=content_view.id).read()
+        target_sat.api.ContentView(server_config=user_cfg, id=content_view.id).read()
     # Check that we have permission to remove the entity
-    target_sat.api.ContentView(user_cfg, id=content_view.id).delete()
+    target_sat.api.ContentView(server_config=user_cfg, id=content_view.id).delete()
     with pytest.raises(HTTPError):
         target_sat.api.ContentView(id=content_view.id).read()
 

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -196,9 +196,9 @@ class TestProvisioningTemplate:
 
         # update
         assert template.template_kind.id == template_kind.id, "Template kind id doesn't match"
-        updated = target_sat.api.ProvisioningTemplate(cfg, id=template.id, name=new_name).update(
-            ['name']
-        )
+        updated = target_sat.api.ProvisioningTemplate(
+            server_config=cfg, id=template.id, name=new_name
+        ).update(['name'])
         assert updated.name == new_name, "The Provisioning template wasn't properly renamed"
         # clone
 

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1091,8 +1091,8 @@ class TestEndToEnd:
         target_sat.api.User(admin=True, login=login, password=password).create()
 
         # step 2.1: Create a new organization
-        server_config = user_nailgun_config(login, password)
-        org = target_sat.api.Organization(server_config).create()
+        user_cfg = user_nailgun_config(login, password)
+        org = target_sat.api.Organization(server_config=user_cfg).create()
 
         # step 2.2: Clone and upload manifest
         if fake_manifest_is_set:
@@ -1100,15 +1100,15 @@ class TestEndToEnd:
                 upload_manifest(org.id, manifest.content)
 
         # step 2.3: Create a new lifecycle environment
-        le1 = target_sat.api.LifecycleEnvironment(server_config, organization=org).create()
+        le1 = target_sat.api.LifecycleEnvironment(server_config=user_cfg, organization=org).create()
 
         # step 2.4: Create a custom product
-        prod = target_sat.api.Product(server_config, organization=org).create()
+        prod = target_sat.api.Product(server_config=user_cfg, organization=org).create()
         repositories = []
 
         # step 2.5: Create custom YUM repository
         custom_repo = target_sat.api.Repository(
-            server_config, product=prod, content_type='yum', url=CUSTOM_RPM_REPO
+            server_config=user_cfg, product=prod, content_type='yum', url=CUSTOM_RPM_REPO
         ).create()
         repositories.append(custom_repo)
 
@@ -1130,7 +1130,7 @@ class TestEndToEnd:
             repo.sync()
 
         # step 2.8: Create content view
-        content_view = target_sat.api.ContentView(server_config, organization=org).create()
+        content_view = target_sat.api.ContentView(server_config=user_cfg, organization=org).create()
 
         # step 2.9: Associate the YUM and Red Hat repositories to new content view
         content_view.repository = repositories
@@ -1187,18 +1187,18 @@ class TestEndToEnd:
 
         # step 2.14: Create a new libvirt compute resource
         target_sat.api.LibvirtComputeResource(
-            server_config,
+            server_config=user_cfg,
             url=f'qemu+ssh://root@{settings.libvirt.libvirt_hostname}/system',
         ).create()
 
         # step 2.15: Create a new subnet
-        subnet = target_sat.api.Subnet(server_config).create()
+        subnet = target_sat.api.Subnet(server_config=user_cfg).create()
 
         # step 2.16: Create a new domain
-        domain = target_sat.api.Domain(server_config).create()
+        domain = target_sat.api.Domain(server_config=user_cfg).create()
 
         # step 2.17: Create a new hostgroup and associate previous entities to it
-        target_sat.api.HostGroup(server_config, domain=domain, subnet=subnet).create()
+        target_sat.api.HostGroup(server_config=user_cfg, domain=domain, subnet=subnet).create()
 
         # step 2.18: Provision a client
         # TODO this isn't provisioning through satellite as intended

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -185,7 +185,10 @@ def test_positive_update_bookmark_public(
     cfg = user_nailgun_config(ui_user.login, ui_user.password)
     for name in (public_name, nonpublic_name):
         target_sat.api.Bookmark(
-            cfg, name=name, controller=ui_entity['controller'], public=name == public_name
+            server_config=cfg,
+            name=name,
+            controller=ui_entity['controller'],
+            public=name == public_name,
         ).create()
     with Session(
         test_name, default_viewer_role.login, default_viewer_role.password


### PR DESCRIPTION
Using positional args for server_config when using user_nailgun_config after https://github.com/SatelliteQE/robottelo/pull/9936 to fix following typeerrors 
```
tests/foreman/endtoend/test_api_endtoend.py:1095: in test_positive_end_to_end
    org = target_sat.api.Organization(server_config).create()
E   TypeError: __init__() got multiple values for argument 'server_config'
```