### PR TITLE
[6.11.z] Parametrize KS repo syncing test

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -95,10 +95,12 @@ class ContentInfo:
             reached or calculation was not successful).
         """
         filename = url.split('/')[-1]
-        result = self.execute(f'wget -qO - {url} | tee {filename} | md5sum | awk \'{{print $1}}\'')
+        result = self.execute(f'wget -q --spider {url}')
         if result.status != 0:
-            raise AssertionError(f'Failed to calculate md5 checksum of {filename}')
-        return result.stdout
+            raise AssertionError(f'Failed to get `{filename}` from `{url}`.')
+        return self.execute(
+            f'wget -qO - {url} | tee {filename} | md5sum | awk \'{{print $1}}\''
+        ).stdout
 
 
 class Factories:

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1001,12 +1001,15 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
+    @pytest.mark.parametrize('distro', ['rhel7', 'rhel8', 'rhel9'])
     def test_positive_sync_kickstart_repo(
-        self, target_sat, module_capsule_configured, module_manifest_org
+        self, target_sat, module_capsule_configured, module_manifest_org, distro
     ):
         """Sync kickstart repository to the capsule.
 
         :id: bc97b53f-f79b-42f7-8014-b0641435bcfc
+
+        :parametrized: yes
 
         :steps:
             1. Sync a kickstart repository to Satellite.
@@ -1021,7 +1024,6 @@ class TestCapsuleContentManagement:
 
         :BZ: 1992329
         """
-        distro = 'rhel8_aps'
         repo_id = enable_rhrepo_and_fetchid(
             basearch='x86_64',
             org_id=module_manifest_org.id,
@@ -1047,7 +1049,7 @@ class TestCapsuleContentManagement:
         # Create a content view with the repository
         cv = entities.ContentView(organization=module_manifest_org, repository=[repo]).create()
         # Sync repository
-        repo.sync(timeout=600)
+        repo.sync(timeout='10m')
         repo = repo.read()
         # Publish new version of the content view
         cv.publish()
@@ -1065,9 +1067,13 @@ class TestCapsuleContentManagement:
         self.wait_for_sync(module_capsule_configured)
 
         # Check for kickstart content on SAT and CAPS
+        tail = (
+            f'rhel/server/7/{constants.REPOS["kickstart"][distro]["version"]}/x86_64/kickstart'
+            if distro == 'rhel7'
+            else f'{distro}/{constants.REPOS["kickstart"][distro]["version"]}/x86_64/baseos/kickstart'  # noqa:E501
+        )
         url_base = (
-            f'pulp/content/{module_manifest_org.label}/{lce.label}/{cv.label}/content/dist/'
-            f'rhel8/{constants.REPOS["kickstart"][distro]["version"]}/x86_64/appstream/kickstart'
+            f'pulp/content/{module_manifest_org.label}/{lce.label}/{cv.label}/content/dist/{tail}'
         )
 
         # Check kickstart specific files


### PR DESCRIPTION
Cherrypick of commit: e07c0a322aae333e06f0b9c44a5c4c676c2b6ba2

This PR presents two changes:
1) Fixes `md5_by_url` method. The original one returned md5sum even when the file did not exist instead of raising error (sum of an empty output, same as `md5sum /dev/null`).
2) Parametrization for the three latest baseos KS repos.