### PR TITLE
Test for disabling a repository when attached to a contentview

### DIFF
--- a/tests/foreman/api/test_new_repository.py
+++ b/tests/foreman/api/test_new_repository.py
@@ -17,7 +17,6 @@
 :Upstream: No
 """
 import pytest
-from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.api.utils import enable_rhrepo_and_fetchid
@@ -74,7 +73,7 @@ def test_negative_disable_repository_with_cv(
 
 
 @pytest.mark.tier1
-def test_positive_update_repository_metadata(module_org):
+def test_positive_update_repository_metadata(module_org, target_sat):
     """Update a Repositories url and check that the rpm content counts are different.
         This process will modify the publication of a repo(metadata).
 
@@ -92,13 +91,13 @@ def test_positive_update_repository_metadata(module_org):
 
     :CaseAutomation: Automated
     """
-    product = entities.Product(organization=module_org).create()
-    repo = entities.Repository(
+    product = target_sat.api.Product(organization=module_org).create()
+    repo = target_sat.api.Repository(
         content_type='yum', product=product, url=settings.repos.module_stream_1.url
     ).create()
     repo.sync()
     repo1 = (
-        entities.Repository(name=repo.name)
+        target_sat.api.Repository(name=repo.name)
         .search(query={'organization_id': module_org.id})[0]
         .content_counts['rpm']
     )
@@ -106,7 +105,7 @@ def test_positive_update_repository_metadata(module_org):
     repo.update(['url'])
     repo.sync()
     repo2 = (
-        entities.Repository(name=repo.name)
+        target_sat.api.Repository(name=repo.name)
         .search(query={'organization_id': module_org.id})[0]
         .content_counts['rpm']
     )

--- a/tests/foreman/api/test_new_repository.py
+++ b/tests/foreman/api/test_new_repository.py
@@ -1,0 +1,54 @@
+"""Unit tests for the new ``repositories`` paths.
+
+:Requirement: Repository
+
+:CaseAutomation: Automated
+
+:CaseLevel: Component
+
+:CaseComponent: Repositories
+
+:Assignee: chiggins
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+from nailgun import entities
+from requests.exceptions import HTTPError
+
+from robottelo.api.utils import enable_rhrepo_and_fetchid
+from robottelo.api.utils import upload_manifest
+from robottelo.constants import PRDS
+from robottelo.constants import REPOS
+from robottelo.constants import REPOSET
+
+
+@pytest.mark.tier1
+def test_negative_disable_repository_with_cv(module_org, session_entitlement_manifest):
+    """"""
+    upload_manifest(module_org.id, session_entitlement_manifest.content)
+    rh_repo_id = enable_rhrepo_and_fetchid(
+        basearch='x86_64',
+        org_id=module_org.id,
+        product=PRDS['rhel'],
+        repo=REPOS['rhst7']['name'],
+        reposet=REPOSET['rhst7'],
+        releasever=None,
+    )
+    rh_repo = entities.Repository(id=rh_repo_id).read()
+    rh_repo.sync()
+    cv = entities.ContentView(organization=module_org, repository=[rh_repo_id]).create()
+    cv.publish()
+    reposet = entities.RepositorySet(name=REPOSET['rhst7'], product=rh_repo.product).search()[0]
+    data = {'basearch': 'x86_64', 'releasever': '7Server', 'product_id': rh_repo.product.id}
+    with pytest.raises(HTTPError) as error:
+        reposet.disable(data=data)
+    assert error.value.response.status_code == 500
+    assert (
+        'Repository cannot be deleted since it has already been '
+        'included in a published Content View' in error.value.response.text
+    )

--- a/tests/foreman/api/test_new_repository.py
+++ b/tests/foreman/api/test_new_repository.py
@@ -21,7 +21,7 @@ from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import upload_manifest
+from robottelo.config import settings
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
@@ -29,9 +29,25 @@ from robottelo.constants import REPOSET
 
 @pytest.mark.skip_if_open('BZ:2137950')
 @pytest.mark.tier1
-def test_negative_disable_repository_with_cv(module_org, session_entitlement_manifest):
-    """"""
-    upload_manifest(module_org.id, session_entitlement_manifest.content)
+def test_negative_disable_repository_with_cv(
+    module_org, module_entitlement_manifest_org, target_sat
+):
+    """Attempt to disable a Repository that is published in a Content View
+
+    :id: e521a7a4-2502-4fe2-b297-a13fc99e679b
+
+    :Steps:
+        1. Enable and sync a RH Repo
+        2. Create a Content View with Repository attached
+        3. Publish Content View
+        4. Attempt to disable the Repository
+
+    :expectedresults: A message should be thrown saying you cannot disable the Repo
+
+    :CaseImportance: Critical
+
+    :CaseAutomation: Automated
+    """
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=module_org.id,
@@ -40,11 +56,13 @@ def test_negative_disable_repository_with_cv(module_org, session_entitlement_man
         reposet=REPOSET['rhst7'],
         releasever=None,
     )
-    rh_repo = entities.Repository(id=rh_repo_id).read()
+    rh_repo = target_sat.api.Repository(id=rh_repo_id).read()
     rh_repo.sync()
-    cv = entities.ContentView(organization=module_org, repository=[rh_repo_id]).create()
+    cv = target_sat.api.ContentView(organization=module_org, repository=[rh_repo_id]).create()
     cv.publish()
-    reposet = entities.RepositorySet(name=REPOSET['rhst7'], product=rh_repo.product).search()[0]
+    reposet = target_sat.api.RepositorySet(name=REPOSET['rhst7'], product=rh_repo.product).search()[
+        0
+    ]
     data = {'basearch': 'x86_64', 'releasever': '7Server', 'product_id': rh_repo.product.id}
     with pytest.raises(HTTPError) as error:
         reposet.disable(data=data)
@@ -53,3 +71,43 @@ def test_negative_disable_repository_with_cv(module_org, session_entitlement_man
         'Repository cannot be deleted since it has already been '
         'included in a published Content View' in error.value.response.text
     )
+
+
+@pytest.mark.tier1
+def test_positive_update_repository_metadata(module_org):
+    """Update a Repositories url and check that the rpm content counts are different.
+        This process will modify the publication of a repo(metadata).
+
+    :id: 6fe7bb3f-1640-4904-a223-b4764534afe8
+
+    :Steps:
+        1. Create a Product and Yum Repository
+        2. Sync the Repository and returns its content_counts for rpm
+        3. Update the url to a different Repo and re-sync the Repository
+        4. assert that the rpm counts have changed
+
+    :expectedresults: Repository rpm counts are different, confirming metadata was updated
+
+    :CaseImportance: Critical
+
+    :CaseAutomation: Automated
+    """
+    product = entities.Product(organization=module_org).create()
+    repo = entities.Repository(
+        content_type='yum', product=product, url=settings.repos.module_stream_1.url
+    ).create()
+    repo.sync()
+    repo1 = (
+        entities.Repository(name=repo.name)
+        .search(query={'organization_id': module_org.id})[0]
+        .content_counts['rpm']
+    )
+    repo.url = settings.repos.module_stream_0.url
+    repo.update(['url'])
+    repo.sync()
+    repo2 = (
+        entities.Repository(name=repo.name)
+        .search(query={'organization_id': module_org.id})[0]
+        .content_counts['rpm']
+    )
+    assert repo1 != repo2

--- a/tests/foreman/api/test_new_repository.py
+++ b/tests/foreman/api/test_new_repository.py
@@ -27,6 +27,7 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 
 
+@pytest.mark.skip_if_open('BZ:2137950')
 @pytest.mark.tier1
 def test_negative_disable_repository_with_cv(module_org, session_entitlement_manifest):
     """"""
@@ -47,7 +48,7 @@ def test_negative_disable_repository_with_cv(module_org, session_entitlement_man
     data = {'basearch': 'x86_64', 'releasever': '7Server', 'product_id': rh_repo.product.id}
     with pytest.raises(HTTPError) as error:
         reposet.disable(data=data)
-    assert error.value.response.status_code == 500
+    # assert error.value.response.status_code == 500
     assert (
         'Repository cannot be deleted since it has already been '
         'included in a published Content View' in error.value.response.text

--- a/tests/foreman/api/test_new_repository.py
+++ b/tests/foreman/api/test_new_repository.py
@@ -28,9 +28,7 @@ from robottelo.constants import REPOSET
 
 @pytest.mark.skip_if_open('BZ:2137950')
 @pytest.mark.tier1
-def test_negative_disable_repository_with_cv(
-    module_org, module_entitlement_manifest_org, target_sat
-):
+def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, target_sat):
     """Attempt to disable a Repository that is published in a Content View
 
     :id: e521a7a4-2502-4fe2-b297-a13fc99e679b
@@ -49,7 +47,7 @@ def test_negative_disable_repository_with_cv(
     """
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
-        org_id=module_org.id,
+        org_id=module_entitlement_manifest_org.id,
         product=PRDS['rhel'],
         repo=REPOS['rhst7']['name'],
         reposet=REPOSET['rhst7'],
@@ -57,7 +55,9 @@ def test_negative_disable_repository_with_cv(
     )
     rh_repo = target_sat.api.Repository(id=rh_repo_id).read()
     rh_repo.sync()
-    cv = target_sat.api.ContentView(organization=module_org, repository=[rh_repo_id]).create()
+    cv = target_sat.api.ContentView(
+        organization=module_entitlement_manifest_org, repository=[rh_repo_id]
+    ).create()
     cv.publish()
     reposet = target_sat.api.RepositorySet(name=REPOSET['rhst7'], product=rh_repo.product).search()[
         0

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -12,7 +12,7 @@
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 :Upstream: No
 """
@@ -40,10 +40,6 @@ def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, ta
         4. Attempt to disable the Repository
 
     :expectedresults: A message should be thrown saying you cannot disable the Repo
-
-    :CaseImportance: Critical
-
-    :CaseAutomation: Automated
     """
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
@@ -65,11 +61,11 @@ def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, ta
     data = {'basearch': 'x86_64', 'releasever': '7Server', 'product_id': rh_repo.product.id}
     with pytest.raises(HTTPError) as error:
         reposet.disable(data=data)
-    # assert error.value.response.status_code == 500
-    assert (
-        'Repository cannot be deleted since it has already been '
-        'included in a published Content View' in error.value.response.text
-    )
+        # assert error.value.response.status_code == 500
+        assert (
+            'Repository cannot be deleted since it has already been '
+            'included in a published Content View' in error.value.response.text
+        )
 
 
 @pytest.mark.tier1
@@ -86,17 +82,13 @@ def test_positive_update_repository_metadata(module_org, target_sat):
         4. assert that the rpm counts have changed
 
     :expectedresults: Repository rpm counts are different, confirming metadata was updated
-
-    :CaseImportance: Critical
-
-    :CaseAutomation: Automated
     """
     product = target_sat.api.Product(organization=module_org).create()
     repo = target_sat.api.Repository(
         content_type='yum', product=product, url=settings.repos.module_stream_1.url
     ).create()
     repo.sync()
-    repo1 = (
+    content_counts_before_update = (
         target_sat.api.Repository(name=repo.name)
         .search(query={'organization_id': module_org.id})[0]
         .content_counts['rpm']
@@ -104,9 +96,9 @@ def test_positive_update_repository_metadata(module_org, target_sat):
     repo.url = settings.repos.module_stream_0.url
     repo.update(['url'])
     repo.sync()
-    repo2 = (
+    content_counts_after_update = (
         target_sat.api.Repository(name=repo.name)
         .search(query={'organization_id': module_org.id})[0]
         .content_counts['rpm']
     )
-    assert repo1 != repo2
+    assert content_counts_before_update != content_counts_after_update

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -19,14 +19,13 @@
 import pytest
 from requests.exceptions import HTTPError
 
+from robottelo import constants
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 
 
-@pytest.mark.skip_if_open('BZ:2137950')
+# @pytest.mark.skip_if_open('BZ:2137950')
 @pytest.mark.tier1
 def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, target_sat):
     """Attempt to disable a Repository that is published in a Content View
@@ -42,11 +41,11 @@ def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, ta
     :expectedresults: A message should be thrown saying you cannot disable the Repo
     """
     rh_repo_id = enable_rhrepo_and_fetchid(
-        basearch='x86_64',
+        basearch=constants.DEFAULT_ARCHITECTURE,
         org_id=module_entitlement_manifest_org.id,
-        product=PRDS['rhel'],
-        repo=REPOS['rhst7']['name'],
-        reposet=REPOSET['rhst7'],
+        product=constants.PRDS['rhel8'],
+        repo=constants.REPOS['rhst8']['name'],
+        reposet=constants.REPOSET['rhst8'],
         releasever=None,
     )
     rh_repo = target_sat.api.Repository(id=rh_repo_id).read()
@@ -55,7 +54,7 @@ def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, ta
         organization=module_entitlement_manifest_org, repository=[rh_repo_id]
     ).create()
     cv.publish()
-    reposet = target_sat.api.RepositorySet(name=REPOSET['rhst7'], product=rh_repo.product).search()[
+    reposet = target_sat.api.RepositorySet(name=REPOSET['rhst8'], product=rh_repo.product).search()[
         0
     ]
     data = {'basearch': 'x86_64', 'releasever': '7Server', 'product_id': rh_repo.product.id}

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -22,10 +22,9 @@ from requests.exceptions import HTTPError
 from robottelo import constants
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
-from robottelo.constants import REPOSET
 
 
-# @pytest.mark.skip_if_open('BZ:2137950')
+@pytest.mark.skip_if_open('BZ:2137950')
 @pytest.mark.tier1
 def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, target_sat):
     """Attempt to disable a Repository that is published in a Content View
@@ -54,9 +53,9 @@ def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, ta
         organization=module_entitlement_manifest_org, repository=[rh_repo_id]
     ).create()
     cv.publish()
-    reposet = target_sat.api.RepositorySet(name=REPOSET['rhst8'], product=rh_repo.product).search()[
-        0
-    ]
+    reposet = target_sat.api.RepositorySet(
+        name=constants.REPOSET['rhst8'], product=rh_repo.product
+    ).search()[0]
     data = {'basearch': 'x86_64', 'releasever': '7Server', 'product_id': rh_repo.product.id}
     with pytest.raises(HTTPError) as error:
         reposet.disable(data=data)


### PR DESCRIPTION
This PR is the first test for the new Repository Rewrite effort and includes:

Test for disabling a repository attached to a content view, Error should be thrown with a message(will update error number once BZ is closed)

Test to check that metadata gets updated when performing actions against a repository. 