### PR TITLE
[6.11.z] Host content ownership

### DIFF
--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -8,7 +8,7 @@
 
 :CaseAutomation: Automated
 
-:Assignee: spusater
+:Assignee: shwsingh
 
 :TestType: Functional
 

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Hosts-Content
 
-:Assignee: spusater
+:Assignee: shwsingh
 
 :TestType: Functional
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Hosts-Content
 
-:Assignee: spusater
+:Assignee: shwsingh
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Hosts-Content
 
-:Assignee: spusater
+:Assignee: shwsingh
 
 :TestType: Functional
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -11,7 +11,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :CaseComponent: Hosts-Content
 
-:Assignee: spusater
+:Assignee: shwsingh
 
 :TestType: Functional
 

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Host-Content
 
-:Assignee: spusater
+:Assignee: shwsingh
 
 :TestType: Functional
 


### PR DESCRIPTION
Cherrypick of commit: 7a60ce888a6a36a3c264c0f6db397c2ab31cd537

Ownership updated for Host-Content