### PR TITLE
fixing auto assigning to correct user rather SATQE bot

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,1 @@
+addAssignees: author

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -43,11 +43,14 @@ jobs:
           labels: |
             Auto_Cherry_Picked
             ${{ matrix.to_branch }}
+          assignees: "${{ github.event.pull_request.assignee.login }}"
 
   create-issue:
     runs-on: ubuntu-latest
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
     needs: auto-cherry-pick
+    env:
+      to-branch: ${{ fromJson(needs.previous-branch.outputs.previous_branch) }}
     steps:
       - name: Create Issue on Failed Auto Cherrypick
         uses: dacbd/create-issue-action@main
@@ -58,8 +61,10 @@ jobs:
             #### Auto-Cherry-Pick WorkFlow Failure:
             - [Failed Cherrypick Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             - [Parent Pull Request](https://github.com/${{ github.repository }}/pull/${{ github.event.number }})
-          labels: Failed_AutoCherryPick
-          assignees: "${{ github.event.pull_request.user.login }}"
+          labels: |
+            Failed_AutoCherryPick
+            ${{ env.to_branch }}
+          assignees: "${{ github.event.pull_request.assignee.login }}"
 
   google-chat-notification:
     runs-on: ubuntu-latest
@@ -69,6 +74,6 @@ jobs:
       - name: Google Chat Notification - Robottelo
         uses: Co-qn/google-chat-notification@releases/v1
         with:
-          name: "[Failed-AutoCherryPick] - ${{ github.event.pull_request.title }}"
+          name: "${{ github.event.pull_request.title }}"
           url: ${{ secrets.GCHAT_REVIEWERS_WEBHOOK }}
           status: failure

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -64,3 +64,13 @@ jobs:
       - name: Analysis (git diff)
         if: failure()
         run: git diff
+
+  # This needed for to create the gh issue in case of failed auto0-cherry-pick
+  add-assignees:
+    name: Add author to assignee
+    if: "!contains(github.event.pull_request.labels.*.name, 'Auto_Cherry_Picked')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.4
+        with:
+          configuration-path: '.github/auto_assign.yml'


### PR DESCRIPTION
#### PR Description 

Currently, issues are getting assigned to the SATQE bot because it is used to create the PRs. e.g. https://github.com/SatelliteQE/robottelo/issues/10238

 With this PR we are not auto-assigning the PR to pr author and it will be used across further processes creating issues. This will resolve the issue.     