### PR TITLE
Port/refactor of f-m maintenance-mode tests from testfm

### DIFF
--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -22,7 +22,6 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo.config import settings
-from robottelo.logging import logger
 
 pytestmark = pytest.mark.destructive
 
@@ -70,7 +69,6 @@ def test_positive_backup_preserve_directory(
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True, 'preserve-directory': True},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -117,7 +115,6 @@ def test_positive_backup_split_pulp_tar(
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True, 'split-pulp-tar': f'{set_size}k'},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -165,7 +162,6 @@ def test_positive_backup_caspule_features(
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True, 'features': features},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -205,7 +201,6 @@ def test_positive_backup_all(sat_maintain, setup_backup_tests, module_synced_rep
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -225,7 +220,6 @@ def test_positive_backup_all(sat_maintain, setup_backup_tests, module_synced_rep
             'features': 'dns,tfp,dhcp,openscap',
         },
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -249,7 +243,6 @@ def test_positive_backup_offline_logical(sat_maintain, setup_backup_tests, modul
         backup_type='offline',
         options={'assumeyes': True, 'plaintext': True, 'include-db-dumps': True},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -282,7 +275,6 @@ def test_negative_backup_nodir(sat_maintain, setup_backup_tests, module_synced_r
         backup_type='offline',
         options={'assumeyes': True, 'plaintext': True},
     )
-    logger.info(result.stdout)
     assert result.status != 0
     assert NODIR_MSG in str(result.stderr)
 
@@ -306,7 +298,6 @@ def test_negative_backup_incremental_nodir(sat_maintain, setup_backup_tests, bac
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True, 'incremental': subdir},
     )
-    logger.info(result.stdout)
     assert result.status != 0
     assert NOPREV_MSG in str(result.stderr)
 
@@ -332,7 +323,6 @@ def test_negative_backup_maintenance_mode(sat_maintain, setup_backup_tests):
         backup_type='snapshot',
         options={'assumeyes': True, 'plaintext': True},
     )
-    logger.info(result.stdout)
     assert result.status != 0
     assert "Backup didn't finish. Incomplete backup was removed." in result.stdout
 
@@ -357,7 +347,6 @@ def test_negative_restore_nodir(sat_maintain, setup_backup_tests):
         backup_dir='',
         options={'assumeyes': True, 'plaintext': True},
     )
-    logger.info(result.stdout)
     assert result.status != 0
     assert NODIR_MSG in str(result.stderr)
 
@@ -378,7 +367,6 @@ def test_negative_restore_baddir(sat_maintain, setup_backup_tests):
         backup_dir=subdir,
         options={'assumeyes': True, 'plaintext': True},
     )
-    logger.info(result.stdout)
     assert result.status != 0
     assert BADDIR_MSG in str(result.stdout)
 
@@ -416,7 +404,6 @@ def test_positive_backup_restore(
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True, 'skip-pulp-content': skip_pulp},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -445,8 +432,6 @@ def test_positive_backup_restore(
         backup_dir=backup_dir,
         options={'assumeyes': True, 'plaintext': True},
     )
-
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -454,7 +439,6 @@ def test_positive_backup_restore(
     result = sat_maintain.cli.Health.check(
         options={'whitelist': 'foreman-tasks-not-paused', 'assumeyes': True, 'plaintext': True}
     )
-    logger.info(result.stdout)
     assert result.status == 0
 
     # Check that content is present after restore
@@ -504,7 +488,6 @@ def test_positive_backup_restore_incremental(
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -523,7 +506,6 @@ def test_positive_backup_restore_incremental(
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True, 'incremental': init_backup_dir},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
@@ -547,14 +529,12 @@ def test_positive_backup_restore_incremental(
         backup_dir=init_backup_dir,
         options={'assumeyes': True, 'plaintext': True},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
     result = sat_maintain.cli.Health.check(
         options={'whitelist': 'foreman-tasks-not-paused', 'assumeyes': True, 'plaintext': True}
     )
-    logger.info(result.stdout)
     assert result.status == 0
 
     # check that the additional content is missing at this point
@@ -566,14 +546,12 @@ def test_positive_backup_restore_incremental(
         backup_dir=inc_backup_dir,
         options={'assumeyes': True, 'plaintext': True},
     )
-    logger.info(result.stdout)
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
     result = sat_maintain.cli.Health.check(
         options={'whitelist': 'foreman-tasks-not-paused', 'assumeyes': True, 'plaintext': True}
     )
-    logger.info(result.stdout)
     assert result.status == 0
 
     # check the initial and additional content was restored

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -1,0 +1,154 @@
+"""Test class for satellite-maintain maintenance-mode functionality
+
+:Requirement: foreman-maintain
+
+:CaseAutomation: Automated
+
+:CaseLevel: Component
+
+:CaseComponent: ForemanMaintain
+
+:Assignee: gtalreja
+
+:TestType: Functional
+
+:CaseImportance: Critical
+
+:Upstream: No
+"""
+import pytest
+import yaml
+
+from robottelo.config import robottelo_tmp_dir
+
+pytestmark = pytest.mark.destructive
+
+
+@pytest.mark.tier2
+def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
+    """Test satellite-maintain maintenance-mode subcommand
+
+    :id: 51d76219-d3cc-43c0-9894-7bcb75c163c3
+
+    :setup:
+        1. Create a sync-plans which is enabled
+        2. set ':manage_crond: true' in /etc/foreman-maintain/foreman_maintain.yml
+
+    :steps:
+        1. Verify that maintenance-mode is Off.
+        2. Start maintenance-mode.
+        3. Verify that active sync-plans got disabled or not.
+        4. Verify that FOREMAN_MAINTAIN_TABLE is mentioned in nftables list.
+        5. Verify that crond.service is stopped.
+        6. Validate maintenance-mode status command's output.
+        7. Validate maintenance-mode is-enabled command's output.
+        8. Stop maintenance-mode.
+        9. Verify that disabled sync-plans got re-enabled or not.
+        10. Verify that FOREMAN_MAINTAIN_TABLE is not mentioned in nftables list.
+        11. Verify that crond.service is running.
+        12. Validate maintenance-mode status command's output.
+        13. Validate maintenance-mode is-enabled command's output.
+
+    :expectedresults: satellite-maintain maintenance-mode start/stop able
+        to disable/enable sync-plan, stop/start crond.service and is able to add
+        FOREMAN_MAINTAIN_TABLE rule in nftables.
+    """
+    enable_sync_ids = setup_sync_plan
+    data_yml_path = '/var/lib/foreman-maintain/data.yml'
+    local_data_yml_path = f'{robottelo_tmp_dir}/data.yml'
+
+    maintenance_mode_off = [
+        'Status of maintenance-mode: Off',
+        'Nftables table: absent',
+        'sync plans: enabled',
+        'cron jobs: running',
+    ]
+    maintenance_mode_on = [
+        'Status of maintenance-mode: On',
+        'Nftables table: present',
+        'sync plans: disabled',
+        'cron jobs: not running',
+    ]
+
+    # Verify maintenance-mode status
+    result = sat_maintain.cli.MaintenanceMode.status()
+    assert 'FAIL' not in result.stdout
+    assert 'OK' in result.stdout
+    assert result.status == 0
+
+    # Verify maintenance-mode is-enabled
+    result = sat_maintain.cli.MaintenanceMode.is_enabled()
+    assert 'FAIL' not in result.stdout
+    assert 'OK' in result.stdout
+    assert result.status == 1
+    assert 'Maintenance mode is Off' in result.stdout
+
+    # Verify maintenance-mode start
+    result = sat_maintain.cli.MaintenanceMode.start()
+    assert 'FAIL' not in result.stdout
+    assert result.status == 0
+    assert f'Total {len(enable_sync_ids)} sync plans are now disabled.' in result.stdout
+    sat_maintain.get(remote_path=data_yml_path, local_path=local_data_yml_path)
+    with open(local_data_yml_path) as f:
+        data_yml = yaml.safe_load(f)
+    assert len(enable_sync_ids) == len(data_yml[':default'][':sync_plans'][':disabled'])
+
+    # Assert FOREMAN_MAINTAIN_TABLE listed in nftables
+    result = sat_maintain.execute('nft list tables')
+    assert 'FOREMAN_MAINTAIN_TABLE' in result.stdout
+
+    result = sat_maintain.cli.Service.status(options={'only': 'crond.service'})
+    assert result.status == 1
+    assert 'Active: inactive (dead)' in result.stdout
+
+    # Verify maintenance-mode status
+    result = sat_maintain.cli.MaintenanceMode.status()
+    assert 'FAIL' not in result.stdout
+    assert 'OK' in result.stdout
+    assert result.status == 0
+    for i in maintenance_mode_on:
+        assert i in result.stdout
+
+    # Verify maintenance-mode is-enabled
+    result = sat_maintain.cli.MaintenanceMode.is_enabled()
+    assert 'FAIL' not in result.stdout
+    assert 'OK' in result.stdout
+    assert result.status == 0
+    assert 'Maintenance mode is On' in result.stdout
+
+    # Verify maintenance-mode stop
+    result = sat_maintain.cli.MaintenanceMode.stop()
+    assert 'FAIL' not in result.stdout
+    assert result.status == 0
+    assert f'Total {len(enable_sync_ids)} sync plans are now enabled.' in result.stdout
+    sat_maintain.get(remote_path=data_yml_path, local_path=local_data_yml_path)
+    with open(local_data_yml_path) as f:
+        data_yml = yaml.safe_load(f)
+    assert len(enable_sync_ids) == len(data_yml[':default'][':sync_plans'][':enabled'])
+
+    # Assert FOREMAN_MAINTAIN_TABLE not listed in nftables
+    result = sat_maintain.execute('nft list tables')
+    assert 'FOREMAN_MAINTAIN_TABLE' not in result.stdout
+
+    result = sat_maintain.cli.Service.status(options={'only': 'crond.service'})
+    assert result.status == 0
+    assert 'Active: active (running)' in result.stdout
+
+    # Verify maintenance-mode status
+    result = sat_maintain.cli.MaintenanceMode.status()
+    assert 'FAIL' not in result.stdout
+    assert 'OK' in result.stdout
+    assert result.status == 0
+    for i in maintenance_mode_off:
+        assert i in result.stdout
+
+    # Verify maintenance-mode is-enabled
+    result = sat_maintain.cli.MaintenanceMode.is_enabled()
+    assert 'FAIL' not in result.stdout
+    assert 'OK' in result.stdout
+    assert result.status == 1
+    assert 'Maintenance mode is Off' in result.stdout
+
+    @request.addfinalizer
+    def _finalize():
+        assert sat_maintain.cli.MaintenanceMode.stop().status == 0


### PR DESCRIPTION
Description:

1. Port/refactor f-m maintenance-mode subcommand tests from TestFM to robottelo
https://github.com/SatelliteQE/testfm/blob/master/tests/test_maintenance_mode.py


It includes changes from https://github.com/SatelliteQE/robottelo/pull/10227, and it will be rebased when either PR is merged

Signed-off-by: Gaurav Talreja <gauravtalreja1@gmail.com>