### PR TITLE
[6.11.z] Do not install dogfood certs as we use CDN

### DIFF
--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -117,10 +117,6 @@ def test_positive_install_sat_with_katello_certs(certs_vm_setup):
     result = rhel_vm.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[0]
     for repo in getattr(constants, f"OHSNAP_RHEL{version}_REPOS"):
         rhel_vm.enable_repo(repo, force=True)
-    rhel_vm.execute(
-        f'yum -y localinstall {settings.repos.dogfood_repo_host}'
-        f'/pub/katello-ca-consumer-latest.noarch.rpm'
-    )
     rhel_vm.execute('yum -y update')
     result = rhel_vm.execute(getattr(constants, f"INSTALL_RHEL{version}_STEPS"))
     assert result.status == 0


### PR DESCRIPTION
Cherrypicks PR#10239 to `6.11.z`
(cherry picked from commit ae8ea81990ab77ee068c415cdbca07afe1cca11b)

Fixes #10247