### PR TITLE
[6.11.z] added missing customerscenario tag

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1122,6 +1122,8 @@ class TestCapsuleContentManagement:
         :CaseLevel: Integration
 
         :BZ: 2125244
+
+        :customerscenario: true
         """
         upstream_names = [
             'quay/busybox',  # schema 1


### PR DESCRIPTION
Cherrypick of commit: 07f640c5875971861b1676de44f90196f989c0b8

as per request from gh action, closes #10243