### PR TITLE
Fix collection of SatelliteContentManagement cases

### DIFF
--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentManagement
 
-:Assignee: ltran
+:Assignee: vsedmik
 
 :TestType: Functional
 
@@ -155,11 +155,11 @@ class TestSatelliteContentManagement:
 
     @pytest.mark.parametrize(
         'distro',
-        {
+        [
             f'rhel{ver}'
             for ver in settings.supportability.content_hosts.rhel.versions
             if isinstance(ver, int)
-        },
+        ],
     )
     def test_positive_sync_kickstart_check_os(self, module_manifest_org, distro):
         """Sync rhel KS repo and assert that OS was created


### PR DESCRIPTION
I can't find the results for `TestSatelliteContentManagement` cases from our automation run. In Jenkins I can see they were not collected nor run with this error: `Different tests were collected between gw1 and gw0.`

It seems to happen due to parametrization using a set, which is unsorted, rather than a list, so the collections gw1 and gw0 differ.
```
Different tests were collected between gw1 and gw0. The difference is:
--- gw1

+++ gw0

@@ -1,9 +1,9 @@

 tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_repos_with_large_errata
 tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_repos_with_lots_files
+tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_check_os[rhel6]
+tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_check_os[rhel8]
 tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_check_os[rhel9]
 tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_check_os[rhel7]
-tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_check_os[rhel6]
-tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_sync_kickstart_check_os[rhel8]
 tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_mirroring_policy
 tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel6]
 tests/foreman/api/test_contentmanagement.py::TestSatelliteContentManagement::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel7]
To see why this happens see Known limitations in documentation
```

