### PR TITLE
[6.11.z] Subscription must be divisible be 2 on containers

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1983,6 +1983,7 @@ def test_positive_attach(
         {
             'host-id': host['id'],
             'subscription-id': default_subscription.id,
+            'quantity': 2,
         }
     )
     host_subscription_client.enable_repo(module_rhst_repo)
@@ -2029,6 +2030,7 @@ def test_positive_attach_with_lce(
         {
             'host-id': host['id'],
             'subscription-id': default_subscription.id,
+            'quantity': 2,
         }
     )
     host_subscription_client.enable_repo(module_rhst_repo)


### PR DESCRIPTION
Cherrypick of commit: b1cf5aa6026d84c1f614264fda7c6a470949cac5

Containers have facts set as `virt.is_guest: False`, so it is considered a physical system that requires 2 entitlements.