### PR TITLE
Add marker and select initial end-to-end tests

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -13,6 +13,7 @@ def pytest_configure(config):
         "tier5: Tier 5 tests",  # Deprecated component tests
         "destructive: Destructive tests",
         "upgrade: Upgrade tests",
+        "e2e: End to end tests",
         "pit_server: PIT server scenario tests",
         "pit_client: PIT client scenario tests",
         "run_in_one_thread: Sequential tests",

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -1115,6 +1115,7 @@ class TestCapsuleContentManagement:
         assert sat_pkgs == caps_pkgs
 
     @pytest.mark.tier4
+    @pytest.mark.e2e
     @pytest.mark.skip_if_not_set('capsule', 'clients')
     def test_positive_sync_container_repo_end_to_end(
         self,

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -46,6 +46,7 @@ def module_org(module_org):
 
 
 @pytest.mark.tier1
+@pytest.mark.e2e
 def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup):
     """Create a new discovery rule with several attributes, update them
     and delete the rule itself.

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -379,6 +379,7 @@ def test_positive_create_with_puppet_ca_proxy(
 
 
 @pytest.mark.tier2
+@pytest.mark.e2e
 def test_positive_end_to_end_with_puppet_class(
     module_puppet_org,
     module_puppet_loc,
@@ -672,6 +673,7 @@ def test_positive_create_and_update_with_content_view(
 
 
 @pytest.mark.tier1
+@pytest.mark.e2e
 def test_positive_end_to_end_with_host_parameters(module_org, module_location):
     """Create a host with a host parameters specified
     then remove and update with the newly specified parameters
@@ -707,6 +709,7 @@ def test_positive_end_to_end_with_host_parameters(module_org, module_location):
 
 
 @pytest.mark.tier2
+@pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
 def test_positive_end_to_end_with_image(
     module_org, module_location, module_cr_libvirt, module_libvirt_image
@@ -1408,6 +1411,7 @@ class TestHostInterface:
     """Tests for Host Interfaces"""
 
     @pytest.mark.tier1
+    @pytest.mark.e2e
     def test_positive_create_end_to_end(self, module_host):
         """Create update and delete an interface with different names and minimal input
         parameters

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -25,6 +25,7 @@ from robottelo.config import settings
 
 
 @pytest.mark.tier2
+@pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize(

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -256,6 +256,7 @@ def test_positive_subscription_status_disabled(
 
 
 @pytest.mark.tier2
+@pytest.mark.e2e
 @pytest.mark.pit_client
 @pytest.mark.pit_server
 def test_sca_end_to_end(

--- a/tests/foreman/api/test_template.py
+++ b/tests/foreman/api/test_template.py
@@ -149,6 +149,7 @@ class TestProvisioningTemplate:
     """
 
     @pytest.mark.tier1
+    @pytest.mark.e2e
     @pytest.mark.upgrade
     def test_positive_end_to_end_crud(self, module_org, module_location, module_user, target_sat):
         """Create a new provisioning template with several attributes, update them,

--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -124,6 +124,7 @@ class TestWebhook:
         assert hook.http_method == method
 
     @pytest.mark.tier1
+    @pytest.mark.e2e
     def test_positive_end_to_end(self):
         """Create a new webhook.
 

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -1250,6 +1250,7 @@ class TestDockerClient:
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
+    @pytest.mark.e2e
     def test_positive_container_admin_end_to_end_search(
         self, module_org, container_contenthost, target_sat
     ):
@@ -1352,6 +1353,7 @@ class TestDockerClient:
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
+    @pytest.mark.e2e
     def test_positive_container_admin_end_to_end_pull(
         self, module_org, container_contenthost, target_sat
     ):

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2310,6 +2310,7 @@ def test_positive_unregister_host_subscription(
 @pytest.mark.pit_server
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
+@pytest.mark.e2e
 def test_syspurpose_end_to_end(
     target_sat,
     module_org,

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -54,6 +54,7 @@ def _make_fake_host_helper(module_org):
 
 @pytest.mark.upgrade
 @pytest.mark.tier2
+@pytest.mark.e2e
 def test_positive_end_to_end(module_org):
     """Check if host collection can be created with name and description,
     content host can be added and removed, host collection can be listed,

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -192,6 +192,7 @@ class TestIPAAuthSource:
     @pytest.mark.tier2
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
     @pytest.mark.upgrade
+    @pytest.mark.e2e
     def test_positive_end_to_end_with_ipa(self, ipa_data, server_name, ldap_tear_down):
         """CRUD LDAP authentication with FreeIPA
 
@@ -384,6 +385,7 @@ class TestOpenLdapAuthSource:
     """Implements OpenLDAP Auth Source tests in CLI"""
 
     @pytest.mark.tier2
+    @pytest.mark.e2e
     @pytest.mark.parametrize('server_name', **parametrized(generate_strings_list()))
     @pytest.mark.upgrade
     def test_positive_end_to_end_with_open_ldap(self, open_ldap_data, server_name):

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -709,6 +709,7 @@ class TestOpenScap:
     @pytest.mark.parametrize('deploy', **parametrized(['manual', 'ansible']))
     @pytest.mark.upgrade
     @pytest.mark.tier2
+    @pytest.mark.e2e
     def test_positive_scap_policy_end_to_end(self, deploy, scap_content):
         """List all scap policies and read info using id, name
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -171,6 +171,7 @@ def test_positive_report_help():
 
 
 @pytest.mark.tier1
+@pytest.mark.e2e
 def test_positive_end_to_end_crud_and_list():
     """CRUD test + list test for report templates
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1815,6 +1815,7 @@ class TestRepository:
 
     @pytest.mark.upgrade
     @pytest.mark.tier2
+    @pytest.mark.e2e
     def test_positive_srpm_list_end_to_end(self, repo, target_sat):
         """Create repository,  upload, list and remove an SRPM content
 

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -250,6 +250,7 @@ class TestSystemAdmin:
 
     @pytest.mark.upgrade
     @pytest.mark.tier3
+    @pytest.mark.e2e
     def test_system_admin_role_end_to_end(self):
         """Test System admin role with a end to end workflow
 

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -542,6 +542,7 @@ class TestContentViewSync:
     """
 
     @pytest.mark.tier3
+    @pytest.mark.e2e
     def test_positive_export_import_cv_end_to_end(
         self,
         class_export_entities,

--- a/tests/foreman/cli/test_webhook.py
+++ b/tests/foreman/cli/test_webhook.py
@@ -63,6 +63,7 @@ def assert_created(options, hook):
 
 class TestWebhook:
     @pytest.mark.tier3
+    @pytest.mark.e2e
     def test_positive_end_to_end(self, webhook_factory):
         """Test creation, list, update and removal of webhook
 

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1050,6 +1050,7 @@ class TestEndToEnd:
 
     @pytest.mark.skip_if_not_set('libvirt')
     @pytest.mark.tier4
+    @pytest.mark.e2e
     @pytest.mark.upgrade
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -90,6 +90,7 @@ def test_positive_cli_find_admin_user():
 
 @pytest.mark.skip_if_not_set('libvirt')
 @pytest.mark.tier4
+@pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_cli_end_to_end(fake_manifest_is_set, target_sat, rhel7_contenthost):


### PR DESCRIPTION
This adds the marker and chooses a rough initial set of end to end tests accross the API and CLI tests. UI end to end tests exist but are not included.