### PR TITLE
[6.10.z] [6.11.z] Convert partitiontable test to use target_sat

### DIFF
--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -25,7 +25,6 @@ import random
 import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
-from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.constants import OPERATING_SYSTEMS
@@ -39,8 +38,10 @@ class TestPartitionTable:
     """Tests for the ``ptables`` path."""
 
     @pytest.mark.tier1
-    @pytest.mark.parametrize('name', **parametrized(generate_strings_list(length=1)))
-    def test_positive_create_with_one_character_name(self, name):
+    @pytest.mark.parametrize(
+        'name', **parametrized(generate_strings_list(length=1, exclude_types='alphanumeric'))
+    )
+    def test_positive_create_with_one_character_name(self, target_sat, name):
         """Create Partition table with 1 character in name
 
         :id: 71601d96-8ce8-4ecb-b053-af6f26a246ea
@@ -53,7 +54,7 @@ class TestPartitionTable:
 
         :CaseImportance: Low
         """
-        ptable = entities.PartitionTable(name=name).create()
+        ptable = target_sat.api.PartitionTable(name=name).create()
         assert ptable.name == name
 
     @pytest.mark.tier1
@@ -68,7 +69,7 @@ class TestPartitionTable:
             )
         ),
     )
-    def test_positive_crud_with_name(self, name, new_name):
+    def test_positive_crud_with_name(self, target_sat, name, new_name):
         """Create new, search, update and delete partition tables using different inputs as a name
 
         :id: 32250f23-3704-496f-83e6-6379a415650a
@@ -80,9 +81,9 @@ class TestPartitionTable:
 
         :CaseImportance: Critical
         """
-        ptable = entities.PartitionTable(name=name).create()
+        ptable = target_sat.api.PartitionTable(name=name).create()
         assert ptable.name == name
-        result = entities.PartitionTable().search(query={'search': f'name="{ptable.name}"'})
+        result = target_sat.api.PartitionTable().search(query={'search': f'name="{ptable.name}"'})
         assert len(result) == 1
         assert result[0].id == ptable.id
         ptable.name = new_name
@@ -95,7 +96,7 @@ class TestPartitionTable:
     @pytest.mark.parametrize(
         'layout, new_layout', **parametrized(list(zip(valid_data_list(), valid_data_list())))
     )
-    def test_positive_create_update_with_layout(self, layout, new_layout):
+    def test_positive_create_update_with_layout(self, target_sat, layout, new_layout):
         """Create new and update partition tables using different inputs as a
             layout
 
@@ -108,13 +109,13 @@ class TestPartitionTable:
 
         :CaseImportance: Critical
         """
-        ptable = entities.PartitionTable(layout=layout).create()
+        ptable = target_sat.api.PartitionTable(layout=layout).create()
         assert ptable.layout == layout
         ptable.layout = new_layout
         assert ptable.update(['layout']).layout == new_layout
 
     @pytest.mark.tier1
-    def test_positive_create_with_layout_length(self):
+    def test_positive_create_with_layout_length(self, target_sat):
         """Create a Partition Table with layout length more than 4096 chars
 
         :id: 7a07d70c-6130-4357-81c3-4f1254e519d2
@@ -125,11 +126,11 @@ class TestPartitionTable:
         :BZ: 1270181
         """
         layout = gen_string('alpha', 5000)
-        ptable = entities.PartitionTable(layout=layout).create()
+        ptable = target_sat.api.PartitionTable(layout=layout).create()
         assert ptable.layout == layout
 
     @pytest.mark.tier1
-    def test_positive_create_update_with_os(self):
+    def test_positive_create_update_with_os(self, target_sat):
         """Create new partition table with random operating system and update it with
             random operating system
 
@@ -140,13 +141,13 @@ class TestPartitionTable:
 
         """
         os_family = random.choice(OPERATING_SYSTEMS)
-        ptable = entities.PartitionTable(os_family=os_family).create()
+        ptable = target_sat.api.PartitionTable(os_family=os_family).create()
         assert ptable.os_family == os_family
         new_os_family = random.choice(OPERATING_SYSTEMS)
         ptable.os_family = new_os_family
         assert ptable.update(['os_family']).os_family == new_os_family
 
-    def test_positive_create_search_with_org(self):
+    def test_positive_create_search_with_org(self, target_sat, module_org):
         """Create new partition table with organization and try to find it using its name and
             organization it assigned to
 
@@ -157,18 +158,17 @@ class TestPartitionTable:
 
         :CaseImportance: Medium
         """
-        org = entities.Organization().create()
-        ptable = entities.PartitionTable(organization=[org]).create()
-        assert ptable.organization[0].read().name == org.name
-        result = entities.PartitionTable().search(
-            query={'search': ptable.name, 'organization_id': org.id}
+        ptable = target_sat.api.PartitionTable(organization=[module_org]).create()
+        assert ptable.organization[0].read().name == module_org.name
+        result = target_sat.api.PartitionTable().search(
+            query={'search': ptable.name, 'organization_id': module_org.id}
         )
         assert len(result) == 1
-        assert result[0].read().organization[0].id == org.id
+        assert result[0].read().organization[0].id == module_org.id
 
     @pytest.mark.tier1
     @pytest.mark.parametrize('name', **parametrized(invalid_values_list()))
-    def test_negative_create_with_invalid_name(self, name):
+    def test_negative_create_with_invalid_name(self, target_sat, name):
         """Try to create partition table using invalid names only
 
         :id: 02631917-2f7a-4cf7-bb2a-783349a04758
@@ -180,11 +180,11 @@ class TestPartitionTable:
         :CaseImportance: Medium
         """
         with pytest.raises(HTTPError):
-            entities.PartitionTable(name=name).create()
+            target_sat.api.PartitionTable(name=name).create()
 
     @pytest.mark.tier1
     @pytest.mark.parametrize('layout', **parametrized(('', ' ', None)))
-    def test_negative_create_with_empty_layout(self, layout):
+    def test_negative_create_with_empty_layout(self, target_sat, layout):
         """Try to create partition table with empty layout
 
         :id: 03cb7a35-e4c3-4874-841b-0760c3b8d6af
@@ -194,11 +194,11 @@ class TestPartitionTable:
         :expectedresults: Partition table was not created
         """
         with pytest.raises(HTTPError):
-            entities.PartitionTable(layout=layout).create()
+            target_sat.api.PartitionTable(layout=layout).create()
 
     @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(invalid_values_list()))
-    def test_negative_update_name(self, new_name):
+    def test_negative_update_name(self, target_sat, new_name):
         """Try to update partition table using invalid names only
 
         :id: 7e9face8-2c20-450e-890c-6def6de570ca
@@ -209,14 +209,14 @@ class TestPartitionTable:
 
         :CaseImportance: Medium
         """
-        ptable = entities.PartitionTable().create()
+        ptable = target_sat.api.PartitionTable().create()
         ptable.name = new_name
         with pytest.raises(HTTPError):
             assert ptable.update(['name']).name != new_name
 
     @pytest.mark.tier1
     @pytest.mark.parametrize('new_layout', **parametrized(('', ' ', None)))
-    def test_negative_update_layout(self, new_layout):
+    def test_negative_update_layout(self, target_sat, new_layout):
         """Try to update partition table with empty layout
 
         :id: 35c84c8f-b802-4076-89f2-4ec04cf43a31
@@ -227,7 +227,7 @@ class TestPartitionTable:
 
         :CaseImportance: Medium
         """
-        ptable = entities.PartitionTable().create()
+        ptable = target_sat.api.PartitionTable().create()
         ptable.layout = new_layout
         with pytest.raises(HTTPError):
             assert ptable.update(['layout']).layout != new_layout


### PR DESCRIPTION
Cherrypick of commit: 2eb33948a1622cf620dbaef5416f34c6e0ad2280

Cherrypick of commit: fbea60aed6916558253d32b8d249dbf9a0d2da4d

Excluding 'alphanumeric' from valid names from the test that uses just one character name, the test coverage is not changed as there are still 'numeric' and 'alpha' options.  Reason: test failed from time to time because of a conflicting name with the already existing partition table.