### PR TITLE
[6.11.z] Rhcloud plugin integration tests with capsule

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -91,3 +91,10 @@ def inventory_settings(rhcloud_sat_host):
     rhcloud_sat_host.update_setting('obfuscate_inventory_ips', ip_setting)
     rhcloud_sat_host.update_setting('exclude_installed_packages', packages_setting)
     rhcloud_sat_host.update_setting('include_parameter_tags', parameter_tags_setting)
+
+
+@pytest.fixture
+def rhcloud_capsule(capsule_host, rhcloud_sat_host):
+    """Configure the capsule instance with the satellite from settings.server.hostname"""
+    capsule_host.capsule_setup(sat_host=rhcloud_sat_host)
+    yield capsule_host


### PR DESCRIPTION
Cherrypick of commit: 6fbb365b6e635cc8137d3b09801a8fcde55a39f9

```
pytest tests/foreman/ui/test_rhcloud_insights.py -k test_insights_registration_with_capsule
=============================================================================================== test session starts ===============================================================================================
collected 11 items / 10 deselected / 1 selected                                                                                                                                                                   

tests/foreman/ui/test_rhcloud_insights.py .                                                                                                                                                                 [100%]
============================================================================ 1 passed, 10 deselected, 3 warnings in 2905.10s (0:48:25) ===========================================================================

```


Signed-off-by: Adarsh Dubey <addubey@redhat.com>