### PR TITLE
[6.11.z] Cherry pick manifester fixtures

### DIFF
--- a/conf/manifest.yaml.example
+++ b/conf/manifest.yaml.example
@@ -1,0 +1,30 @@
+MANIFEST:
+  MANIFESTER_DIRECTORY: ""
+  GOLDEN_TICKET:
+    # Value of SAT_VERSION setting should be in the form "sat-X.Y", e.g. "sat-6.11"
+    SAT_VERSION: ""
+    OFFLINE_TOKEN: ""
+    # Manifests with simple content access enabled should not use a quantity higher than 1 for any subscription
+    # unless doing so is required for a test.
+    SUBSCRIPTION_DATA:
+      # NAME should be an exact match of the subscription name as listed on the Customer Portal
+      - NAME: ""
+        QUANTITY:
+      - NAME: ""
+        QUANTITY:
+    SIMPLE_CONTENT_ACCESS: "enabled"
+    URL:
+      TOKEN_REQUEST: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+      ALLOCATIONS: "https://api.access.redhat.com/management/v1/allocations"
+  ENTITLEMENT:
+    SAT_VERSION: ""
+    OFFLINE_TOKEN: ""
+    SUBSCRIPTION_DATA:
+      - NAME: ""
+        QUANTITY:
+      - NAME: ""
+        QUANTITY:
+    SIMPLE_CONTENT_ACCESS: "disabled"
+    URL:
+      TOKEN_REQUEST: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+      ALLOCATIONS: "https://api.access.redhat.com/management/v1/allocations/"

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -77,6 +77,20 @@ def module_org_with_manifest(module_org):
 
 
 @pytest.fixture(scope='module')
+def module_entitlement_manifest_org(module_org, module_entitlement_manifest):
+    """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
+    upload_manifest(module_org.id, module_entitlement_manifest.content)
+    return module_org
+
+
+@pytest.fixture(scope='module')
+def module_sca_manifest_org(module_org, module_sca_manifest):
+    """Creates an organization and uploads an SCA mode manifest generated with manifester"""
+    upload_manifest(module_org.id, module_sca_manifest.content)
+    return module_org
+
+
+@pytest.fixture(scope='module')
 def module_gt_manifest_org(module_target_sat):
     """Creates a new org and loads GT manifest in the new org"""
     org = module_target_sat.api.Organization().create()
@@ -102,6 +116,22 @@ def session_entitlement_manifest():
 
 @pytest.fixture(scope='session')
 def session_sca_manifest():
+    """Yields a manifest in entitlement mode with subscriptions determined by the
+    `manifest_category.robottelo_automation` setting in manifester_settings.yaml."""
+    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='module')
+def module_entitlement_manifest():
+    """Yields a manifest in entitlement mode with subscriptions determined by the
+    `manifest_category.robottelo_automation` setting in manifester_settings.yaml."""
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='module')
+def module_sca_manifest():
     """Yields a manifest in Simple Content Access mode with subscriptions determined by the
     `manifest_category.golden_ticket` setting in manifester_settings.yaml."""
     with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -1,8 +1,10 @@
 # Content Component fixtures
 import pytest
+from manifester import Manifester
 
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_LOC
 from robottelo.constants import DEFAULT_ORG
 
@@ -82,6 +84,28 @@ def module_gt_manifest_org(module_target_sat):
     manifests.upload_manifest_locked(org.id, manifest, interface=manifests.INTERFACE_CLI)
     org.manifest_filename = manifest.filename
     return org
+
+
+# Note: Manifester should not be used with the Satellite QE RHSM account until
+# subscription needs are scoped and sufficient subscriptions added to the
+# Satellite QE RHSM account. Manifester can be safely used locally with personal
+# or stage RHSM accounts.
+
+
+@pytest.fixture(scope='session')
+def session_entitlement_manifest():
+    """Yields a manifest in entitlement mode with subscriptions determined by the
+    `manifest_category.robottelo_automation` setting in manifester_settings.yaml."""
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='session')
+def session_sca_manifest():
+    """Yields a manifest in Simple Content Access mode with subscriptions determined by the
+    `manifest_category.golden_ticket` setting in manifester_settings.yaml."""
+    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        yield manifest
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -90,6 +90,20 @@ def module_sca_manifest_org(module_org, module_sca_manifest):
     return module_org
 
 
+@pytest.fixture(scope='function')
+def function_entitlement_manifest_org(function_org, function_entitlement_manifest):
+    """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
+    upload_manifest(function_org.id, function_entitlement_manifest.content)
+    return function_org
+
+
+@pytest.fixture(scope='function')
+def function_sca_manifest_org(function_org, function_sca_manifest):
+    """Creates an organization and uploads an SCA mode manifest generated with manifester"""
+    upload_manifest(function_org.id, function_sca_manifest.content)
+    return function_org
+
+
 @pytest.fixture(scope='module')
 def module_gt_manifest_org(module_target_sat):
     """Creates a new org and loads GT manifest in the new org"""
@@ -132,6 +146,22 @@ def module_entitlement_manifest():
 
 @pytest.fixture(scope='module')
 def module_sca_manifest():
+    """Yields a manifest in Simple Content Access mode with subscriptions determined by the
+    `manifest_category.golden_ticket` setting in manifester_settings.yaml."""
+    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='function')
+def function_entitlement_manifest():
+    """Yields a manifest in entitlement mode with subscriptions determined by the
+    `manifest_category.robottelo_automation` setting in manifester_settings.yaml."""
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='function')
+def function_sca_manifest():
     """Yields a manifest in Simple Content Access mode with subscriptions determined by the
     `manifest_category.golden_ticket` setting in manifester_settings.yaml."""
     with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,11 +6,7 @@ deepdiff==6.2.1
 dynaconf[vault]==3.1.11
 fauxfactory==3.1.0
 jinja2==3.1.2
-<<<<<<< HEAD
 manifester==0.0.10
-=======
-manifester==0.0.6
->>>>>>> cf43b9eff (Add Manifester settings and session-scoped fixtures (#9943))
 navmazing==1.1.6
 pexpect==4.8.0
 productmd==1.33

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,11 @@ deepdiff==6.2.1
 dynaconf[vault]==3.1.11
 fauxfactory==3.1.0
 jinja2==3.1.2
+<<<<<<< HEAD
 manifester==0.0.10
+=======
+manifester==0.0.6
+>>>>>>> cf43b9eff (Add Manifester settings and session-scoped fixtures (#9943))
 navmazing==1.1.6
 pexpect==4.8.0
 productmd==1.33

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -53,10 +53,10 @@ from robottelo.utils.datafactory import valid_names_list
 
 
 @pytest.fixture(scope='module')
-def module_rhel_content(module_manifest_org):
+def module_rhel_content(module_entitlement_manifest_org):
     """Returns RH repo after syncing it"""
     product = entities.Product(
-        name=constants.PRDS['rhel'], organization=module_manifest_org
+        name=constants.PRDS['rhel'], organization=module_entitlement_manifest_org
     ).search()[0]
     reposet = entities.RepositorySet(name=constants.REPOSET['rhva6'], product=product).search()[0]
     data = {'basearch': 'x86_64', 'releasever': '6Server', 'product_id': product.id}
@@ -65,14 +65,14 @@ def module_rhel_content(module_manifest_org):
     repo = Repository.info(
         {
             'name': constants.REPOS['rhva6']['name'],
-            'organization-id': module_manifest_org.id,
+            'organization-id': module_entitlement_manifest_org.id,
             'product': product.name,
         }
     )
     Repository.synchronize(
         {
             'name': constants.REPOS['rhva6']['name'],
-            'organization-id': module_manifest_org.id,
+            'organization-id': module_entitlement_manifest_org.id,
             'product': product.name,
         }
     )
@@ -909,7 +909,7 @@ class TestContentView:
     @pytest.mark.skip_if_not_set('fake_manifest')
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier1
-    def test_positive_add_rh_repo_by_id(self, module_manifest_org, module_rhel_content):
+    def test_positive_add_rh_repo_by_id(self, module_entitlement_manifest_org, module_rhel_content):
         """Associate Red Hat content to a content view
 
         :id: b31a85c3-aa56-461b-9e3a-f7754c742573
@@ -923,12 +923,14 @@ class TestContentView:
         :CaseImportance: Critical
         """
         # Create CV
-        new_cv = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        new_cv = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Associate repo to CV
         ContentView.add_repository(
             {
                 'id': new_cv['id'],
-                'organization-id': module_manifest_org.id,
+                'organization-id': module_entitlement_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -940,7 +942,7 @@ class TestContentView:
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_add_rh_repo_by_id_and_create_filter(
-        self, module_manifest_org, module_rhel_content
+        self, module_entitlement_manifest_org, module_rhel_content
     ):
         """Associate Red Hat content to a content view and create filter
 
@@ -960,12 +962,14 @@ class TestContentView:
         :BZ: 1359665
         """
         # Create CV
-        new_cv = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        new_cv = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Associate repo to CV
         ContentView.add_repository(
             {
                 'id': new_cv['id'],
-                'organization-id': module_manifest_org.id,
+                'organization-id': module_entitlement_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -1146,7 +1150,9 @@ class TestContentView:
 
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier2
-    def test_positive_promote_rh_content(self, module_manifest_org, module_rhel_content):
+    def test_positive_promote_rh_content(
+        self, module_entitlement_manifest_org, module_rhel_content
+    ):
         """attempt to promote a content view containing RH content
 
         :id: 53b3661b-b40f-466e-a742-bc4b8c1f6cd8
@@ -1160,13 +1166,17 @@ class TestContentView:
         :CaseLevel: Integration
         """
         # Create CV
-        new_cv = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        new_cv = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Associate repo to CV
         ContentView.add_repository({'id': new_cv['id'], 'repository-id': module_rhel_content['id']})
         # Publish a new version of CV
         ContentView.publish({'id': new_cv['id']})
         new_cv = ContentView.info({'id': new_cv['id']})
-        env1 = cli_factory.make_lifecycle_environment({'organization-id': module_manifest_org.id})
+        env1 = cli_factory.make_lifecycle_environment(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Promote the Published version of CV to the next env
         ContentView.version_promote(
             {'id': new_cv['versions'][0]['id'], 'to-lifecycle-environment-id': env1['id']}
@@ -1177,7 +1187,9 @@ class TestContentView:
 
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier3
-    def test_positive_promote_rh_and_custom_content(self, module_manifest_org, module_rhel_content):
+    def test_positive_promote_rh_and_custom_content(
+        self, module_entitlement_manifest_org, module_rhel_content
+    ):
         """attempt to promote a content view containing RH content and
         custom content using filters
 
@@ -1194,15 +1206,17 @@ class TestContentView:
         # Create custom repo
         new_repo = cli_factory.make_repository(
             {
-                'product-id': cli_factory.make_product({'organization-id': module_manifest_org.id})[
-                    'id'
-                ]
+                'product-id': cli_factory.make_product(
+                    {'organization-id': module_entitlement_manifest_org.id}
+                )['id']
             }
         )
         # Sync custom repo
         Repository.synchronize({'id': new_repo['id']})
         # Create CV
-        new_cv = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        new_cv = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Associate repos with CV
         ContentView.add_repository({'id': new_cv['id'], 'repository-id': module_rhel_content['id']})
         ContentView.add_repository({'id': new_cv['id'], 'repository-id': new_repo['id']})
@@ -1219,7 +1233,9 @@ class TestContentView:
         # Publish a new version of CV
         ContentView.publish({'id': new_cv['id']})
         new_cv = ContentView.info({'id': new_cv['id']})
-        env1 = cli_factory.make_lifecycle_environment({'organization-id': module_manifest_org.id})
+        env1 = cli_factory.make_lifecycle_environment(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Promote the Published version of CV to the next env
         ContentView.version_promote(
             {'id': new_cv['versions'][0]['id'], 'to-lifecycle-environment-id': env1['id']}
@@ -1382,7 +1398,9 @@ class TestContentView:
 
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier2
-    def test_positive_publish_rh_content(self, module_manifest_org, module_rhel_content):
+    def test_positive_publish_rh_content(
+        self, module_entitlement_manifest_org, module_rhel_content
+    ):
         """attempt to publish a content view containing RH content
 
         :id: d4323759-d869-4d62-ab2e-f1ea3dbb38ba
@@ -1396,7 +1414,9 @@ class TestContentView:
         :CaseLevel: Integration
         """
         # Create CV
-        new_cv = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        new_cv = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Associate repo to CV
         ContentView.add_repository({'id': new_cv['id'], 'repository-id': module_rhel_content['id']})
         # Publish a new version of CV
@@ -1409,7 +1429,9 @@ class TestContentView:
     @pytest.mark.run_in_one_thread
     @pytest.mark.pit_server
     @pytest.mark.tier3
-    def test_positive_publish_rh_and_custom_content(self, module_manifest_org, module_rhel_content):
+    def test_positive_publish_rh_and_custom_content(
+        self, module_entitlement_manifest_org, module_rhel_content
+    ):
         """attempt to publish  a content view containing a RH and custom
         repos and has filters
 
@@ -1426,15 +1448,17 @@ class TestContentView:
         # Create custom repo
         new_repo = cli_factory.make_repository(
             {
-                'product-id': cli_factory.make_product({'organization-id': module_manifest_org.id})[
-                    'id'
-                ]
+                'product-id': cli_factory.make_product(
+                    {'organization-id': module_entitlement_manifest_org.id}
+                )['id']
             }
         )
         # Sync custom repo
         Repository.synchronize({'id': new_repo['id']})
         # Create CV
-        new_cv = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        new_cv = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Associate repos with CV
         ContentView.add_repository({'id': new_cv['id'], 'repository-id': module_rhel_content['id']})
         ContentView.add_repository({'id': new_cv['id'], 'repository-id': new_repo['id']})
@@ -1606,7 +1630,7 @@ class TestContentView:
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier2
     def test_positive_republish_after_rh_content_removed(
-        self, module_manifest_org, module_rhel_content
+        self, module_entitlement_manifest_org, module_rhel_content
     ):
         """Attempt to re-publish content view after all RH associated content
         was removed from that CV
@@ -1626,12 +1650,14 @@ class TestContentView:
 
         :CaseImportance: Medium
         """
-        new_cv = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        new_cv = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         # Associate repo to CV
         ContentView.add_repository(
             {
                 'id': new_cv['id'],
-                'organization-id': module_manifest_org.id,
+                'organization-id': module_entitlement_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -1945,7 +1971,7 @@ class TestContentView:
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier3
     def test_positive_subscribe_chost_by_id_using_rh_content(
-        self, module_manifest_org, module_rhel_content
+        self, module_entitlement_manifest_org, module_rhel_content
     ):
         """Attempt to subscribe content host to content view that has
         Red Hat repository assigned to it
@@ -1959,12 +1985,16 @@ class TestContentView:
 
         :CaseImportance: Medium
         """
-        env = cli_factory.make_lifecycle_environment({'organization-id': module_manifest_org.id})
-        content_view = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        env = cli_factory.make_lifecycle_environment(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
+        content_view = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         ContentView.add_repository(
             {
                 'id': content_view['id'],
-                'organization-id': module_manifest_org.id,
+                'organization-id': module_entitlement_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -1981,7 +2011,7 @@ class TestContentView:
                 'content-view-id': content_view['id'],
                 'lifecycle-environment-id': env['id'],
                 'name': gen_alphanumeric(),
-                'organization-id': module_manifest_org.id,
+                'organization-id': module_entitlement_manifest_org.id,
             }
         )
         content_view = ContentView.info({'id': content_view['id']})
@@ -1991,7 +2021,7 @@ class TestContentView:
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_subscribe_chost_by_id_using_rh_content_and_filters(
-        self, module_manifest_org, module_rhel_content
+        self, module_entitlement_manifest_org, module_rhel_content
     ):
         """Attempt to subscribe content host to filtered content view
         that has Red Hat repository assigned to it
@@ -2007,12 +2037,16 @@ class TestContentView:
 
         :CaseImportance: Low
         """
-        env = cli_factory.make_lifecycle_environment({'organization-id': module_manifest_org.id})
-        content_view = cli_factory.make_content_view({'organization-id': module_manifest_org.id})
+        env = cli_factory.make_lifecycle_environment(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
+        content_view = cli_factory.make_content_view(
+            {'organization-id': module_entitlement_manifest_org.id}
+        )
         ContentView.add_repository(
             {
                 'id': content_view['id'],
-                'organization-id': module_manifest_org.id,
+                'organization-id': module_entitlement_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -2050,7 +2084,7 @@ class TestContentView:
                 'content-view-id': content_view['id'],
                 'lifecycle-environment-id': env['id'],
                 'name': gen_alphanumeric(),
-                'organization-id': module_manifest_org.id,
+                'organization-id': module_entitlement_manifest_org.id,
             }
         )
         content_view = ContentView.info({'id': content_view['id']})

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -25,14 +25,12 @@ from fauxfactory import gen_string
 from nailgun import entities
 
 from robottelo import constants
-from robottelo import manifests
 from robottelo.api.utils import create_role_permissions
 from robottelo.api.utils import create_sync_custom_repo
 from robottelo.api.utils import cv_publish_promote
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.api.utils import enable_sync_redhat_repo
 from robottelo.api.utils import promote
-from robottelo.api.utils import upload_manifest
 from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
@@ -84,7 +82,9 @@ def test_positive_end_to_end_crud(session, module_org):
     [{'SatelliteToolsRepository': {'distro': constants.DISTRO_RHEL7}}],
     indirect=True,
 )
-def test_positive_end_to_end_register(session, repos_collection, rhel7_contenthost, target_sat):
+def test_positive_end_to_end_register(
+    session, function_entitlement_manifest_org, repos_collection, rhel7_contenthost, target_sat
+):
     """Create activation key and use it during content host registering
 
     :id: dfaecf6a-ba61-47e1-87c5-f8966a319b41
@@ -98,9 +98,9 @@ def test_positive_end_to_end_register(session, repos_collection, rhel7_contentho
 
     :CaseImportance: High
     """
-    org = entities.Organization().create()
+    org = function_entitlement_manifest_org
     lce = entities.LifecycleEnvironment(organization=org).create()
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(org.id, lce.id, upload_manifest=False)
     ak_name = repos_collection.setup_content_data['activation_key']['name']
 
     repos_collection.setup_virtual_machine(rhel7_contenthost)
@@ -428,7 +428,7 @@ def test_positive_update_cv(session, module_org, cv2_name):
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_positive_update_rh_product(session):
+def test_positive_update_rh_product(function_entitlement_manifest_org, session):
     """Update Content View in an Activation key
 
     :id: 9b0ac209-45de-4cc4-97e8-e191f3f37239
@@ -462,9 +462,7 @@ def test_positive_update_rh_product(session):
         'basearch': 'i386',
         'releasever': constants.DEFAULT_RELEASE_VERSION,
     }
-    org = entities.Organization().create()
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
+    org = function_entitlement_manifest_org
     repo1_id = enable_sync_redhat_repo(rh_repo1, org.id)
     cv_publish_promote(cv1_name, env1_name, repo1_id, org.id)
     repo2_id = enable_sync_redhat_repo(rh_repo2, org.id)
@@ -487,7 +485,7 @@ def test_positive_update_rh_product(session):
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_positive_add_rh_product(session):
+def test_positive_add_rh_product(function_entitlement_manifest_org, session):
     """Test that RH product can be associated to Activation Keys
 
     :id: d805341b-6d2f-4e16-8cb4-902de00b9a6c
@@ -506,11 +504,7 @@ def test_positive_add_rh_product(session):
         'basearch': constants.DEFAULT_ARCHITECTURE,
         'releasever': constants.DEFAULT_RELEASE_VERSION,
     }
-    # Create new org to import manifest
-    org = entities.Organization().create()
-    # Upload manifest
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
+    org = function_entitlement_manifest_org
     # Helper function to create and promote CV to next environment
     repo_id = enable_sync_redhat_repo(rh_repo, org.id)
     cv_publish_promote(cv_name, env_name, repo_id, org.id)
@@ -559,7 +553,7 @@ def test_positive_add_custom_product(session, module_org):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_add_rh_and_custom_products(session):
+def test_positive_add_rh_and_custom_products(function_entitlement_manifest_org, session):
     """Test that RH/Custom product can be associated to Activation keys
 
     :id: 3d8876fa-1412-47ca-a7a4-bce2e8baf3bc
@@ -584,11 +578,9 @@ def test_positive_add_rh_and_custom_products(session):
     }
     custom_product_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    org = entities.Organization().create()
+    org = function_entitlement_manifest_org
     product = entities.Product(name=custom_product_name, organization=org).create()
     repo = entities.Repository(name=repo_name, product=product).create()
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
     rhel_repo_id = enable_rhrepo_and_fetchid(
         basearch=rh_repo['basearch'],
         org_id=org.id,
@@ -623,7 +615,7 @@ def test_positive_add_rh_and_custom_products(session):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_fetch_product_content(session):
+def test_positive_fetch_product_content(function_entitlement_manifest_org, session):
     """Associate RH & custom product with AK and fetch AK's product content
 
     :id: 4c37fb12-ea2a-404e-b7cc-a2735e8dedb6
@@ -635,9 +627,7 @@ def test_positive_fetch_product_content(session):
 
     :CaseLevel: Integration
     """
-    org = entities.Organization().create()
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
+    org = function_entitlement_manifest_org
     rh_repo_id = enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
@@ -1078,7 +1068,7 @@ def test_positive_host_associations(session, target_sat):
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_service_level_subscription_with_custom_product(
-    session, rhel7_contenthost, target_sat
+    session, function_entitlement_manifest_org, rhel7_contenthost, target_sat
 ):
     """Subscribe a host to activation key with Premium service level and with
     custom product
@@ -1109,8 +1099,7 @@ def test_positive_service_level_subscription_with_custom_product(
 
     :CaseLevel: System
     """
-    org = entities.Organization().create()
-    manifests.upload_manifest_locked(org.id)
+    org = function_entitlement_manifest_org
     entities_ids = setup_org_for_a_custom_repo(
         {'url': settings.repos.yum_1.url, 'organization-id': org.id}
     )
@@ -1135,7 +1124,7 @@ def test_positive_service_level_subscription_with_custom_product(
     assert rhel7_contenthost.subscribed
     result = rhel7_contenthost.run('subscription-manager list --consumed')
     assert result.status == 0
-    assert f'Subscription Name:   {product.name}' in '\n'.join(result.stdout)
+    assert f'Subscription Name:   {product.name}' in result.stdout
     with session:
         session.organization.select(org.name)
         chost = session.contenthost.read(rhel7_contenthost.hostname, widget_names='subscriptions')
@@ -1148,7 +1137,7 @@ def test_positive_service_level_subscription_with_custom_product(
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
-def test_positive_delete_manifest(session):
+def test_positive_delete_manifest(session, function_entitlement_manifest_org):
     """Check if deleting a manifest removes it from Activation key
 
     :id: 512d8e41-b937-451e-a9c6-840457d3d7d4
@@ -1163,10 +1152,7 @@ def test_positive_delete_manifest(session):
 
     :CaseLevel: Integration
     """
-    # Upload manifest
-    org = entities.Organization().create()
-    with manifests.clone() as manifest:
-        upload_manifest(org.id, manifest.content)
+    org = function_entitlement_manifest_org
     # Create activation key
     activation_key = entities.ActivationKey(organization=org).create()
     # Associate a manifest to the activation key


### PR DESCRIPTION
The PRs that added manifester fixtures to Robottelo failed to auto-cherrypick in September and October. This issue was identified this morning by both @vsedmik and @Gauravtalreja1. This PR cherry picks the corresponding commits to the 6.11.z branch.