### PR TITLE
[6.11.z] Upgrade Scenarios to use fixtures for 'saving and using data' across scenario

### DIFF
--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -20,8 +20,6 @@ import json
 
 import pytest
 from nailgun import entities
-from upgrade_tests.helpers.scenarios import create_dict
-from upgrade_tests.helpers.scenarios import get_entity_data
 
 
 def _valid_sc_parameters_data():
@@ -54,7 +52,7 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
     """
 
     @pytest.fixture(scope="class")
-    def _setup_scenario(self, target_sat):
+    def _setup_scenario(self, target_sat, save_test_data):
         """Import some parametrized puppet classes. This is required to make
         sure that we have smart class variable available.
         Read all available smart class parameters for imported puppet class to
@@ -69,14 +67,13 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
         self.sc_params_list = entities.SmartClassParameters().search(
             query={'search': f'puppetclass="{self.puppet_class.name}"', 'per_page': 1000}
         )
-        scenario_ents = {self.__class__.__name__: {'puppet_class': self.puppet_class.name}}
-        create_dict(scenario_ents)
+        save_test_data({'puppet_class': self.puppet_class.name})
 
     @pytest.fixture(scope="class")
-    def _clean_scenario(self, request, class_target_sat):
+    def _clean_scenario(self, request, class_target_sat, pre_upgrade_data):
         @request.addfinalizer
         def _cleanup():
-            puppet_class = get_entity_data(self.__class__.__name__)['puppet_class']
+            puppet_class = pre_upgrade_data.get('puppet_class')
             class_target_sat.delete_puppet_class(puppet_class)
 
     def _validate_value(self, data, sc_param):

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -25,9 +25,7 @@ import pytest
 from fabric.api import execute
 from nailgun import entities
 from upgrade.helpers.docker import docker_execute_command
-from upgrade_tests.helpers.scenarios import create_dict
 from upgrade_tests.helpers.scenarios import dockerize
-from upgrade_tests.helpers.scenarios import get_entity_data
 
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
@@ -162,7 +160,7 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
 
     @pytest.mark.pre_upgrade
     def test_pre_scenario_preclient_package_installation(
-        default_org, pre_upgrade_cv, pre_upgrade_repo, module_ak
+        default_org, pre_upgrade_cv, pre_upgrade_repo, module_ak, save_test_data
     ):
         """Create product and repo, from which a package will be installed
         post upgrade. Create a content host and register it.
@@ -217,10 +215,10 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
         ]
         assert 'goferd' in status
         # Save client info to disk for post-upgrade test
-        create_dict({__name__: rhel7_client})
+        save_test_data({__name__: rhel7_client})
 
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_preclient_package_installation)
-    def test_post_scenario_preclient_package_installation(default_org):
+    def test_post_scenario_preclient_package_installation(default_org, pre_upgrade_data):
         """Post-upgrade install of a package on a client created and registered pre-upgrade.
 
         :id: postupgrade-eedab638-fdc9-41fa-bc81-75dd2790f7be
@@ -229,7 +227,7 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
 
         :expectedresults: The package is installed on client
         """
-        client = get_entity_data(__name__)
+        client = pre_upgrade_data.get(__name__)
         client_name = str(list(client.keys())[0]).lower()
         client_id = entities.Host().search(query={'search': f'name={client_name}'})[0].id
         entities.Host().install_content(

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -17,8 +17,6 @@
 :Upstream: No
 """
 import pytest
-from upgrade_tests.helpers.scenarios import create_dict
-from upgrade_tests.helpers.scenarios import get_entity_data
 
 
 class TestScenarioDBseedHostMismatch:
@@ -41,7 +39,7 @@ class TestScenarioDBseedHostMismatch:
 
     @pytest.mark.pre_upgrade
     def test_pre_db_seed_host_mismatch(
-        self, target_sat, function_org, function_location, rhel7_contenthost_module
+        self, target_sat, function_org, function_location, rhel7_contenthost_module, save_test_data
     ):
         """
         :id: preupgrade-28861b9f-8abd-4efc-bfd5-40b7e825a941
@@ -77,18 +75,16 @@ class TestScenarioDBseedHostMismatch:
         assert 'true' in result.stdout
         assert rhel7_contenthost_module.nailgun_host.location.id == function_location.id
 
-        global_dict = {
-            self.__class__.__name__: {
+        save_test_data(
+            {
                 'client_name': rhel7_contenthost_module.hostname,
                 'organization_id': function_org.id,
                 'location_id': function_location.id,
             }
-        }
-
-        create_dict(global_dict)
+        )
 
     @pytest.mark.post_upgrade(depend_on=test_pre_db_seed_host_mismatch)
-    def test_post_db_seed_host_mismatch(self, target_sat):
+    def test_post_db_seed_host_mismatch(self, target_sat, pre_upgrade_data):
         """
         :id: postupgrade-28861b9f-8abd-4efc-bfd5-40b7e825a941
 
@@ -102,10 +98,9 @@ class TestScenarioDBseedHostMismatch:
 
         :customerscenario: true
         """
-        data = get_entity_data(self.__class__.__name__)
-        chostname = data['client_name']
-        org_id = data['organization_id']
-        loc_id = data['location_id']
+        chostname = pre_upgrade_data['client_name']
+        org_id = pre_upgrade_data['organization_id']
+        loc_id = pre_upgrade_data['location_id']
         chost = target_sat.api.Host().search(query={'search': chostname})
 
         assert org_id == chost[0].organization.id

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -18,8 +18,6 @@
 """
 import pytest
 from nailgun import entities
-from upgrade_tests.helpers.scenarios import create_dict
-from upgrade_tests.helpers.scenarios import get_entity_data
 
 from robottelo.config import settings
 from robottelo.hosts import Capsule
@@ -67,7 +65,7 @@ class TestScenarioREXCapsule:
     @pytest.mark.pre_upgrade
     @pytest.mark.no_containers
     def test_pre_scenario_remoteexecution_external_capsule(
-        self, request, default_location, rhel7_contenthost
+        self, request, default_location, rhel7_contenthost, save_test_data
     ):
         """Run REX job on client registered with external capsule
 
@@ -112,11 +110,10 @@ class TestScenarioREXCapsule:
             }
         )
         assert job['output']['success_count'] == 1
-        global_dict = {self.__class__.__name__: {'client_name': rhel7_contenthost.hostname}}
-        create_dict(global_dict)
+        save_test_data({'client_name': rhel7_contenthost.hostname})
 
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remoteexecution_external_capsule)
-    def test_post_scenario_remoteexecution_external_capsule(self):
+    def test_post_scenario_remoteexecution_external_capsule(self, pre_upgrade_data):
         """Run a REX job on pre-upgrade created client registered
         with external capsule.
 
@@ -128,13 +125,12 @@ class TestScenarioREXCapsule:
         :expectedresults:
             1. The job should successfully executed on pre-upgrade created client.
         """
-        client_name = get_entity_data(self.__class__.__name__)['client_name']
         job = entities.JobInvocation().run(
             data={
                 'job_template_id': 89,
                 'inputs': {'command': 'ls'},
                 'targeting_type': 'static_query',
-                'search_query': f'name = {client_name}',
+                'search_query': f"name = {pre_upgrade_data['client_name']}",
             }
         )
         assert job['output']['success_count'] == 1
@@ -167,7 +163,13 @@ class TestScenarioREXSatellite:
 
     @pytest.mark.pre_upgrade
     def test_pre_scenario_remoteexecution_satellite(
-        self, request, compute_resource_setup, default_location, rhel7_contenthost, target_sat
+        self,
+        request,
+        compute_resource_setup,
+        default_location,
+        rhel7_contenthost,
+        target_sat,
+        save_test_data,
     ):
         """Run REX job on client registered with Satellite
 
@@ -209,11 +211,10 @@ class TestScenarioREXSatellite:
             }
         )
         assert job['output']['success_count'] == 1
-        global_dict = {self.__class__.__name__: {'client_name': rhel7_contenthost.hostname}}
-        create_dict(global_dict)
+        save_test_data({'client_name': rhel7_contenthost.hostname})
 
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remoteexecution_satellite)
-    def test_post_scenario_remoteexecution_satellite(self):
+    def test_post_scenario_remoteexecution_satellite(self, pre_upgrade_data):
         """Run a REX job on pre-upgrade created client registered
         with Satellite.
 
@@ -225,13 +226,12 @@ class TestScenarioREXSatellite:
         :expectedresults:
             1. The job should successfully executed on pre-upgrade created client.
         """
-        client_name = get_entity_data(self.__class__.__name__)['client_name']
         job = entities.JobInvocation().run(
             data={
                 'job_template_id': 89,
                 'inputs': {'command': 'ls'},
                 'targeting_type': 'static_query',
-                'search_query': f'name = {client_name}',
+                'search_query': f"name = {pre_upgrade_data['client_name']}",
             }
         )
         assert job['output']['success_count'] == 1

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -19,8 +19,6 @@
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
-from upgrade_tests.helpers.scenarios import create_dict
-from upgrade_tests.helpers.scenarios import get_entity_data
 
 from robottelo import manifests
 from robottelo.api.utils import upload_manifest
@@ -68,7 +66,7 @@ class TestScenarioPositiveVirtWho:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_create_virt_who_configuration(self, form_data):
+    def test_pre_create_virt_who_configuration(self, form_data, save_test_data):
         """Create and deploy virt-who configuration.
 
         :id: preupgrade-a36cbe89-47a2-422f-9881-0f86bea0e24e
@@ -122,16 +120,15 @@ class TestScenarioPositiveVirtWho:
             )
             assert result['subscription_status_label'] == 'Fully entitled'
 
-        scenario_dict = {
-            self.__class__.__name__: {
+        save_test_data(
+            {
                 'hypervisor_name': hypervisor_name,
                 'guest_name': guest_name,
             }
-        }
-        create_dict(scenario_dict)
+        )
 
     @pytest.mark.post_upgrade(depend_on=test_pre_create_virt_who_configuration)
-    def test_post_crud_virt_who_configuration(self, form_data):
+    def test_post_crud_virt_who_configuration(self, form_data, pre_upgrade_data):
         """Virt-who config is intact post upgrade and verify the config can be updated and deleted.
 
         :id: postupgrade-d7ae7b2b-3291-48c8-b412-cb54e444c7a4
@@ -161,9 +158,8 @@ class TestScenarioPositiveVirtWho:
         assert VirtWhoConfig.info({'id': vhd_cli['id']})['general-information']['status'] == 'OK'
 
         # Vefify the connection of the guest on Content host
-        entity_data = get_entity_data(self.__class__.__name__)
-        hypervisor_name = entity_data.get('hypervisor_name')
-        guest_name = entity_data.get('guest_name')
+        hypervisor_name = pre_upgrade_data.get('hypervisor_name')
+        guest_name = pre_upgrade_data.get('guest_name')
         hosts = [hypervisor_name, guest_name]
         for hostname in hosts:
             result = (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10271

Upgrade scenarios were using `create_data` in pre-upgrade and `get_entity_data` in post_upgrade tests which is not replaced by simplified fixtures:
- `save_test_data` in pre_upgrade
- `pre_upgrade_data` in post_upgrade