### PR TITLE
Remove rp_ignore_errors from pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,5 +17,4 @@ exclude = '''
 
 [tool.pytest.ini_options]
 junit_logging = 'all'
-rp_ignore_errors = 'True'
 addopts = '--show-capture=no'


### PR DESCRIPTION
Remove `rp_ignore_errors` from pytest config as its removed in pytest-reportportal - https://github.com/reportportal/agent-python-pytest/issues/288
```
.robottelo/lib/python3.8/site-packages/_pytest/config/__init__.py:1253
  /Users/gtalreja/sat_workspace/robottelo/.robottelo/lib/python3.8/site-packages/_pytest/config/__init__.py:1253: PytestConfigWarning: Unknown config option: rp_ignore_errors

    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
```