### PR TITLE
[6.11.z] Add SystemInfo class in satellite_mixins

### DIFF
--- a/robottelo/host_helpers/__init__.py
+++ b/robottelo/host_helpers/__init__.py
@@ -3,6 +3,7 @@ from robottelo.host_helpers.contenthost_mixins import SystemFacts
 from robottelo.host_helpers.contenthost_mixins import VersionedContent
 from robottelo.host_helpers.satellite_mixins import ContentInfo
 from robottelo.host_helpers.satellite_mixins import Factories
+from robottelo.host_helpers.satellite_mixins import SystemInfo
 
 
 class ContentHostMixins(SystemFacts, VersionedContent):
@@ -13,5 +14,5 @@ class CapsuleMixins(CapsuleInfo):
     pass
 
 
-class SatelliteMixins(ContentInfo, Factories):
+class SatelliteMixins(ContentInfo, Factories, SystemInfo):
     pass


### PR DESCRIPTION
Observed tests failures in 6.11.z runs for smartproxy component, which uses `available_capsule_port` property from SystemInfo class, which isn't inherited anywhere

Missed cherrypick this in PR https://github.com/SatelliteQE/robottelo/pull/10277