### PR TITLE
Org should not be an array

### DIFF
--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -283,7 +283,7 @@ def test_positive_VM_import(session, module_org, module_location, rhev_data):
         .read()
         .id
     )
-    cv = entities.ContentView(organization=[module_org.id]).create()
+    cv = entities.ContentView(organization=module_org).create()
     cv.publish()
 
     # create hostgroup


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2129950

```
$ pytest tests/foreman/ui/test_computeresource.py::test_positive_VM_import
==================================================================== test session starts ====================================================================
platform linux -- Python 3.8.5, pytest-7.2.0, pluggy-0.13.1 -- /home/lhellebr/broker/venv/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo, configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, forked-1.3.0, reportportal-5.1.2, mock-3.10.0, ibutsu-2.2.4, xdist-3.0.2
collected 1 item                                                                                                                                            

tests/foreman/ui/test_computeresource.py::test_positive_VM_import PASSED                                                                              [100%]

===================================================================== warnings summary ======================================================================
../../broker/venv/lib/python3.8/site-packages/trio/_core/_multierror.py:511
  /home/lhellebr/broker/venv/lib/python3.8/site-packages/trio/_core/_multierror.py:511: RuntimeWarning: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.
    warnings.warn(

tests/foreman/ui/test_computeresource.py::test_positive_VM_import
  /home/lhellebr/broker/venv/lib/python3.8/site-packages/webdriver_kaifuku/tries.py:33: DeprecationWarning: executable_path has been deprecated, please pass in a Service object
    return f(*args, **kwargs)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================= 1 passed, 2 warnings in 246.26s (0:04:06) =========================================================

```