### PR TITLE
Check for more columns plus fix assert failure due to caps

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -136,7 +136,26 @@ def test_positive_generate_report_nofilter():
     entities.Host(name=host_name).create()
     rt = entities.ReportTemplate().search(query={'search': 'name="Host - Statuses"'})[0].read()
     res = rt.generate()
-    assert "Service Level" in res
+    for column_name in [
+        'Name',
+        'Global',
+        'Addons',
+        'Build',
+        'Compliance',
+        'Configuration',
+        'Errata',
+        'Execution',
+        'Insights',
+        'Inventory',
+        'OVAL scan',
+        'Role',
+        'Service level',
+        'Subscription',
+        'System purpose',
+        'Traces',
+        'Usage',
+    ]:
+        assert column_name in res
     assert host_name in res
 
 
@@ -162,7 +181,26 @@ def test_positive_generate_report_filter():
     entities.Host(name=host2_name).create()
     rt = entities.ReportTemplate().search(query={'search': 'name="Host - Statuses"'})[0].read()
     res = rt.generate(data={"input_values": {"hosts": host2_name}})
-    assert "Service Level" in res
+    for column_name in [
+        'Name',
+        'Global',
+        'Addons',
+        'Build',
+        'Compliance',
+        'Configuration',
+        'Errata',
+        'Execution',
+        'Insights',
+        'Inventory',
+        'OVAL scan',
+        'Role',
+        'Service level',
+        'Subscription',
+        'System purpose',
+        'Traces',
+        'Usage',
+    ]:
+        assert column_name in res
     assert host1_name not in res
     assert host2_name in res
 


### PR DESCRIPTION
```
$ pytest tests/foreman/api/test_reporttemplates.py::test_positive_generate_report_nofilter
==================================================================== test session starts ====================================================================
platform linux -- Python 3.8.5, pytest-7.2.0, pluggy-0.13.1 -- /home/lhellebr/broker/venv/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo, configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, forked-1.3.0, reportportal-5.1.2, mock-3.10.0, ibutsu-2.2.4, xdist-3.0.2
collected 1 item                                                                                                                                            

tests/foreman/api/test_reporttemplates.py::test_positive_generate_report_nofilter PASSED                                                              [100%]

===================================================================== warnings summary ======================================================================
../../broker/venv/lib/python3.8/site-packages/trio/_core/_multierror.py:511
  /home/lhellebr/broker/venv/lib/python3.8/site-packages/trio/_core/_multierror.py:511: RuntimeWarning: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================== 1 passed, 1 warning in 59.61s ===============================================================


$ pytest tests/foreman/api/test_reporttemplates.py::tests/foreman/api/test_reporttemplates.py::test_positive_generate_report_filter
^C
(venv) (base) [lhellebr@lhellebr robottelo]$ pytest tests/foreman/api/test_reporttemplates.py::test_positive_generate_report_filter
==================================================================== test session starts ====================================================================
platform linux -- Python 3.8.5, pytest-7.2.0, pluggy-0.13.1 -- /home/lhellebr/broker/venv/bin/python
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo, configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, forked-1.3.0, reportportal-5.1.2, mock-3.10.0, ibutsu-2.2.4, xdist-3.0.2
collected 1 item                                                                                                                                            

tests/foreman/api/test_reporttemplates.py::test_positive_generate_report_filter PASSED                                                                [100%]

===================================================================== warnings summary ======================================================================
../../broker/venv/lib/python3.8/site-packages/trio/_core/_multierror.py:511
  /home/lhellebr/broker/venv/lib/python3.8/site-packages/trio/_core/_multierror.py:511: RuntimeWarning: You seem to already have a custom sys.excepthook handler installed. I'll skip installing Trio's custom handler, but this means MultiErrors will not show full tracebacks.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 1 passed, 1 warning in 83.06s (0:01:23) ==========================================================

```