### PR TITLE
Test for creating EPEL Repositories with different mirroring policies

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -11,6 +11,21 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 
 
+@pytest.fixture(scope='module')
+def module_repo_options(request, module_org, module_product):
+    """Return the options that were passed as indirect parameters."""
+    options = getattr(request, 'param', {}).copy()
+    options['organization'] = module_org
+    options['product'] = module_product
+    return options
+
+
+@pytest.fixture(scope='module')
+def module_repo(module_repo_options, module_target_sat):
+    """Create a new repository."""
+    return module_target_sat.api.Repository(**module_repo_options).create()
+
+
 @pytest.fixture(scope='function')
 def function_product(function_org):
     return entities.Product(organization=function_org).create()

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -127,7 +127,7 @@ def test_positive_epel_repositories_with_mirroring_policy(
 
     :Steps:
         1. Create a Epel repository with mirroring_policy set
-        2. Sync the Repository and returns its content_counts for rpm
+        2. Sync the Repository and return its content_counts for rpm
         3. Assert content was synced and mirroring policy type is correct
 
     :expectedresults: All Epel repositories with mirroring policy options set should have content

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -22,6 +22,8 @@ from requests.exceptions import HTTPError
 from robottelo import constants
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.config import settings
+from robottelo.constants import MIRRORING_POLICIES
+from robottelo.utils.datafactory import parametrized
 
 
 @pytest.mark.skip_if_open('BZ:2137950')
@@ -100,3 +102,43 @@ def test_positive_update_repository_metadata(module_org, target_sat):
         .content_counts['rpm']
     )
     assert content_counts_before_update != content_counts_after_update
+
+
+@pytest.mark.parametrize(
+    'module_repo_options',
+    **parametrized(
+        [
+            {
+                'content_type': 'yum',
+                'mirroring_policy': policy,
+                'url': settings.repos.mock_service_repo.rhel7,
+            }
+            for policy in MIRRORING_POLICIES
+        ]
+    ),
+    indirect=True,
+)
+def test_positive_epel_repositories_with_mirroring_policy(
+    module_org, module_repo_options, module_repo, target_sat
+):
+    """Create an Epel Repository with different mirroring policies set and confirm content exist
+
+    :id: 5c4e0ba4-4486-4eaf-b6ad-62831b7353a4
+
+    :Steps:
+        1. Create a Epel repository with mirroring_policy set
+        2. Sync the Repository and returns its content_counts for rpm
+        3. Assert content was synced and mirroring policy type is correct
+
+    :expectedresults: All Epel repositories with mirroring policy options set should have content
+
+    :CaseImportance: Critical
+
+    :CaseAutomation: Automated
+    """
+    module_repo.sync()
+    repodata = target_sat.api.Repository(name=module_repo.name).search(
+        query={'organization_id': module_org.id}
+    )[0]
+    assert repodata.content_counts['rpm'] != 0
+    assert module_repo_options['mirroring_policy'] == repodata.mirroring_policy

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -131,10 +131,6 @@ def test_positive_epel_repositories_with_mirroring_policy(
         3. Assert content was synced and mirroring policy type is correct
 
     :expectedresults: All Epel repositories with mirroring policy options set should have content
-
-    :CaseImportance: Critical
-
-    :CaseAutomation: Automated
     """
     module_repo.sync()
     repodata = target_sat.api.Repository(name=module_repo.name).search(


### PR DESCRIPTION
This test is a part of the Repository rewrite. SAT-13262 

Creates an EPEL Repository with different Mirroring Policies set. Content should be accessible by all mirroring policies 