### PR TITLE
[6.11.z] Implementing PXE-less Discovery test

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -1,5 +1,6 @@
 import ipaddress
 import os
+import re
 from tempfile import mkstemp
 
 import pytest
@@ -203,7 +204,7 @@ def module_ssh_key_file():
 def provisioning_host(module_ssh_key_file, request):
     """Fixture to check out blank VM"""
     vlan_id = settings.provisioning.vlan_id
-    vm_firmware = 'bios' if not hasattr(request, 'param') else request.param
+    vm_firmware = getattr(request, 'param', 'bios')
     cd_iso = (
         ""  # TODO: Make this an optional fixture parameter (update vm_firmware when adding this)
     )
@@ -220,3 +221,43 @@ def provisioning_host(module_ssh_key_file, request):
         yield prov_host
         # Set host as non-blank to run teardown of the host
         prov_host.blank = getattr(prov_host, 'blank', False)
+
+
+@pytest.fixture()
+def pxeless_discovery_host(provisioning_host, module_discovery_sat):
+    """Fixture for returning a pxe-less discovery host for provisioning"""
+    sat = module_discovery_sat.sat
+    image_name = f"{gen_string('alpha')}-{module_discovery_sat.iso}"
+    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    # Remaster and upload discovery image to automatically input values
+    result = sat.execute(
+        'cd /var/www/html/pub && '
+        f'discovery-remaster {module_discovery_sat.iso} '
+        f'"proxy.type=foreman proxy.url=https://{sat.hostname}:443 fdi.pxmac={mac} fdi.pxauto=1"'
+    )
+    pattern = re.compile(r"foreman-discovery-image\S+")
+    fdi = pattern.findall(result.stdout)[0]
+    Broker(
+        workflow='import-disk-image',
+        import_disk_image_name=image_name,
+        import_disk_image_url=(f'https://{sat.hostname}/pub/{fdi}'),
+    ).execute()
+    # Change host to boot from CD ISO
+    Broker(
+        job_template='configure-pxe-boot-rhv',
+        target_host=provisioning_host.name,
+        target_vlan_id=settings.provisioning.vlan_id,
+        target_vm_firmware=provisioning_host._broker_args['target_vm_firmware'],
+        target_vm_cd_iso=image_name,
+        target_boot_scenario='pxeless_pre',
+    ).execute()
+    yield provisioning_host
+    # Remove ISO from host and delete disk image
+    Broker(
+        job_template='configure-pxe-boot-rhv',
+        target_host=provisioning_host.name,
+        target_vlan_id=settings.provisioning.vlan_id,
+        target_vm_firmware=provisioning_host._broker_args['target_vm_firmware'],
+        target_boot_scenario='pxeless_pre',
+    ).execute()
+    Broker(workflow='remove-disk-image', remove_disk_image_name=image_name).execute()

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 import pytest
+from box import Box
 from broker import Broker
 from wait_for import wait_for
 
@@ -193,7 +194,6 @@ def session_capsule_configured(session_capsule_host, session_target_sat):
 
 @pytest.fixture(scope='module')
 def module_discovery_sat(
-    module_provisioning_rhel_content,
     module_provisioning_sat,
     module_sca_manifest_org,
     module_location,
@@ -231,4 +231,4 @@ def module_discovery_sat(
     discovery_auto.value = 'true'
     discovery_auto.update(['value'])
 
-    return sat
+    return Box(sat=sat, iso=disc_img_name)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10297

Adding a new fixture for creating a provisioning host that is able to boot from a remastered FDI. All 6 tests are passing locally.