### PR TITLE
Automation coverage for BZ 2077824

### DIFF
--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -17,8 +17,8 @@
 :Upstream: No
 """
 import pytest
+from fauxfactory import gen_string
 from fauxfactory import gen_url
-from nailgun import entities
 from requests import HTTPError
 
 from robottelo.utils.datafactory import parametrized
@@ -35,7 +35,7 @@ def module_proxy_attrs(module_target_sat):
     Every Satellite has a built-in smart proxy, so searching for an
     existing smart proxy should always succeed.
     """
-    smart_proxy = entities.SmartProxy().search(
+    smart_proxy = module_target_sat.api.SmartProxy().search(
         query={'search': f'url = {module_target_sat.url}:9090'}
     )
     # Check that proxy is found and unpack it from the list
@@ -57,7 +57,7 @@ def _create_smart_proxy(request, target_sat, **kwargs):
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier1
-def test_negative_create_with_url():
+def test_negative_create_with_url(target_sat):
     """Proxy creation with random URL
 
     :id: e48a6260-97e0-4234-a69c-77bbbcde85d6
@@ -69,7 +69,7 @@ def test_negative_create_with_url():
     """
     # Create a random proxy
     with pytest.raises(HTTPError) as context:
-        entities.SmartProxy(url=gen_url(scheme='https')).create()
+        target_sat.api.SmartProxy(url=gen_url(scheme='https')).create()
     assert 'Unable to communicate' in context.value.response.text
 
 
@@ -110,7 +110,7 @@ def test_positive_delete(target_sat):
     """
     new_port = target_sat.available_capsule_port
     with target_sat.default_url_on_new_port(9090, new_port) as url:
-        proxy = entities.SmartProxy(url=url).create()
+        proxy = target_sat.api.SmartProxy(url=url).create()
         proxy.delete()
     with pytest.raises(HTTPError):
         proxy.read()
@@ -173,7 +173,7 @@ def test_positive_update_organization(request, target_sat):
     :CaseLevel: Component
 
     """
-    organizations = [entities.Organization().create() for _ in range(2)]
+    organizations = [target_sat.api.Organization().create() for _ in range(2)]
     newport = target_sat.available_capsule_port
     with target_sat.default_url_on_new_port(9090, newport) as url:
         proxy = _create_smart_proxy(request, target_sat, url=url)
@@ -194,7 +194,7 @@ def test_positive_update_location(request, target_sat):
     :CaseLevel: Component
 
     """
-    locations = [entities.Location().create() for _ in range(2)]
+    locations = [target_sat.api.Location().create() for _ in range(2)]
     new_port = target_sat.available_capsule_port
     with target_sat.default_url_on_new_port(9090, new_port) as url:
         proxy = _create_smart_proxy(request, target_sat, url=url)
@@ -243,7 +243,7 @@ def test_positive_import_puppet_classes(session_puppet_enabled_sat, puppet_proxy
     with session_puppet_enabled_sat as puppet_sat:
         new_port = puppet_sat.available_capsule_port
         with puppet_sat.default_url_on_new_port(9090, new_port) as url:
-            proxy = entities.SmartProxy(url=url).create()
+            proxy = puppet_sat.api.SmartProxy(url=url).create()
             result = proxy.import_puppetclasses()
             assert (
                 "Successfully updated environment and puppetclasses from "
@@ -251,7 +251,7 @@ def test_positive_import_puppet_classes(session_puppet_enabled_sat, puppet_proxy
             ) in result['message'] or "No changes to your environments detected" in result[
                 'message'
             ]
-        entities.SmartProxy(id=proxy.id).delete()
+        puppet_sat.api.SmartProxy(id=proxy.id).delete()
 
 
 """Tests to see if the server returns the attributes it should.
@@ -301,3 +301,24 @@ def test_positive_update_org(module_proxy_attrs):
     """
     names = {'organization', 'organization_ids', 'organizations'}
     assert len(names & module_proxy_attrs) >= 1, f'None of {names} are in {module_proxy_attrs}'
+
+
+@pytest.mark.skip_if_not_set('fake_capsules')
+@pytest.mark.tier1
+def test_positive_search_nondefault_proxy(request, target_sat):
+    """Search non-default proxy with id!=1
+
+    :id: caf51662-6b4e-11ed-baba-2b9d7b368002
+
+    :expectedresults: Non-default proxy can be searched
+
+    :BZ: 2077824
+
+    :customerscenario: true
+    """
+    with target_sat.default_url_on_new_port(9090, target_sat.available_capsule_port) as url:
+        proxy = _create_smart_proxy(request, target_sat, name=gen_string('alpha'), url=url)
+    capsules = target_sat.api.Capsule().search(query={'search': 'id != 1'})
+    assert len(capsules) == 1
+    assert capsules[0].url == proxy.url
+    assert capsules[0].name == proxy.name


### PR DESCRIPTION
Description:
1. Adding automation coverage for [BZ 2077824](https://bugzilla.redhat.com/show_bug.cgi?id=2077824)

Test Results:
```
(.robottelo) ➜  robottelo git:(automate-2077824) ✗ pytest -q --disable-pytest-warnings tests/foreman/cli/test_capsule.py -k test_positive_search_nondefault_proxy
.                                                                                                                                                     [100%]
1 passed, 28 deselected, 1 warning in 47.79s
```