### PR TITLE
Fix host creation issue for test_positive_create_with_inherited_params

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -573,7 +573,7 @@ def test_positive_create_with_inherited_params(
         organization=function_org, location=function_location_with_org
     )
     host_template.create_missing()
-    host = target_sat.api.Host().create()
+    host = host_template.create()
     host_name = host.name
     with session:
         session.organization.update(function_org.name, {'parameters.resources': org_param})


### PR DESCRIPTION
There was a template created but not used. The host was created directly and was missing correct taxonomies.