### PR TITLE
Fixing PXE-less discovery test

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -239,7 +239,6 @@ def module_capsule_configured_async_ssh(module_capsule_configured):
 
 @pytest.fixture(scope='module')
 def module_discovery_sat(
-    module_provisioning_rhel_content,
     module_provisioning_sat,
     module_sca_manifest_org,
     module_location,


### PR DESCRIPTION
The last PR https://github.com/SatelliteQE/robottelo/pull/10297 I had for PXE-less discovery wasn't updated with some fixture changes that were merged right before. This should fix those failures.

```
============================= test session starts ==============================
platform linux -- Python 3.9.13, pytest-7.1.3, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gsulliva/Programming/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, cov-2.12.1, xdist-2.5.0, reportportal-5.1.2, ibutsu-2.2.4, mock-3.9.0
collected 6 items

tests/foreman/api/test_discoveredhost.py ......                          [100%]

================== 6 passed, 2 warnings in 5858.62s (1:37:38) ==================
```