### PR TITLE
[6.11.z] Run fixture for adding selinux port policy on puppet sat

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2536,7 +2536,7 @@ def test_positive_host_with_puppet(
 
 
 @pytest.fixture(scope="function")
-def function_proxy(session_puppet_enabled_sat):
+def function_proxy(session_puppet_enabled_sat, puppet_proxy_port_range):
     proxy = session_puppet_enabled_sat.cli_factory.make_proxy()
     yield proxy
     session_puppet_enabled_sat.cli.Proxy.delete({'id': proxy['id']})


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10365

The test was failing on permission error. Adding selinux policy should fix this issue.