### PR TITLE
Fix typo in Upgrades component name

### DIFF
--- a/tests/foreman/destructive/test_leapp_satellite.py
+++ b/tests/foreman/destructive/test_leapp_satellite.py
@@ -4,7 +4,7 @@
 
 :CaseLevel: Component
 
-:CaseComponent: Upgrade
+:CaseComponent: Upgrades
 
 :Assignee: lpramuk
 


### PR DESCRIPTION
Typo `s/Upgrade/Upgrades`