### PR TITLE
[6.11.z] Fix typo in Upgrades component name

### DIFF
--- a/tests/foreman/destructive/test_leapp_satellite.py
+++ b/tests/foreman/destructive/test_leapp_satellite.py
@@ -4,7 +4,7 @@
 
 :CaseLevel: Component
 
-:CaseComponent: Upgrade
+:CaseComponent: Upgrades
 
 :Assignee: lpramuk
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10370

Typo `s/Upgrade/Upgrades`