### PR TITLE
[6.10.z] [6.11.z] Rename /conf/manifest.yaml.example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   rev: 22.3.0
   hooks:
   - id: black
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: 3.9.2
   hooks:
   - id: flake8

--- a/conf/manifest.yaml.template
+++ b/conf/manifest.yaml.template
@@ -1,0 +1,30 @@
+MANIFEST:
+  MANIFESTER_DIRECTORY: ""
+  GOLDEN_TICKET:
+    # Value of SAT_VERSION setting should be in the form "sat-X.Y", e.g. "sat-6.11"
+    SAT_VERSION: ""
+    OFFLINE_TOKEN: ""
+    # Manifests with simple content access enabled should not use a quantity higher than 1 for any subscription
+    # unless doing so is required for a test.
+    SUBSCRIPTION_DATA:
+      # NAME should be an exact match of the subscription name as listed on the Customer Portal
+      - NAME: ""
+        QUANTITY:
+      - NAME: ""
+        QUANTITY:
+    SIMPLE_CONTENT_ACCESS: "enabled"
+    URL:
+      TOKEN_REQUEST: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+      ALLOCATIONS: "https://api.access.redhat.com/management/v1/allocations"
+  ENTITLEMENT:
+    SAT_VERSION: ""
+    OFFLINE_TOKEN: ""
+    SUBSCRIPTION_DATA:
+      - NAME: ""
+        QUANTITY:
+      - NAME: ""
+        QUANTITY:
+    SIMPLE_CONTENT_ACCESS: "disabled"
+    URL:
+      TOKEN_REQUEST: "https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token"
+      ALLOCATIONS: "https://api.access.redhat.com/management/v1/allocations/"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10386

Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10385

Currently, the manifest config file template is named manifest.yaml.example, which is inconsistent with the other template filenames. Because of this, it was skipped by the config helper script's filter for aligning symlinks. This PR renames the file to manifest.yaml.template to improve naming consistency and to enable the script to run on the file.