### PR TITLE
Update URL of flake8 repo, bump version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,11 @@
 
 repos:
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.6.0
+  rev: v3.9.0
   hooks:
   - id: reorder-python-imports
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
+  rev: v4.4.0
   hooks:
   - id: trailing-whitespace
     exclude: tests/foreman/data/
@@ -14,12 +14,12 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/asottile/pyupgrade
-  rev: v2.29.0
+  rev: v3.3.0
   hooks:
   - id: pyupgrade
     args: [--py38-plus]
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 22.10.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,8 @@ repos:
   rev: 22.3.0
   hooks:
   - id: black
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.9.2
+- repo: https://github.com/pycqa/flake8
+  rev: 6.0.0
   hooks:
   - id: flake8
 - repo: local

--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -290,7 +290,8 @@ def enroll_configure_rhsso_external_auth(module_target_sat):
     )
     module_target_sat.execute('update-ca-trust')
     module_target_sat.execute(
-        f'echo {settings.rhsso.rhsso_password} | keycloak-httpd-client-install --app-name foreman-openidc \
+        f'echo {settings.rhsso.rhsso_password} | keycloak-httpd-client-install \
+                --app-name foreman-openidc \
                 --keycloak-server-url {settings.rhsso.host_url} \
                 --keycloak-admin-username "admin" \
                 --keycloak-realm "{settings.rhsso.realm}" \

--- a/tests/foreman/api/test_contentmanagement.py
+++ b/tests/foreman/api/test_contentmanagement.py
@@ -500,8 +500,9 @@ class TestCapsuleContentManagement:
     def test_positive_sync_updated_repo(
         self, target_sat, module_capsule_configured, function_org, function_product, function_lce
     ):
-        """Sync a custom repo with no upstream url but uploaded content to the Capsule via promoted CV,
-        update content of the repo, publish and promote the CV again, resync the Capsule.
+        """Sync a custom repo with no upstream url but uploaded content to the Capsule via
+        promoted CV, update content of the repo, publish and promote the CV again, resync
+        the Capsule.
 
         :id: ddbecc80-17d9-47f6-979e-111ebd74cb90
 

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -332,7 +332,8 @@ def test_positive_export_report():
 @pytest.mark.tier2
 @pytest.mark.stubbed
 def test_positive_generate_report_sanitized():
-    """Generate report template where there are values in comma outputted which might brake CSV format
+    """Generate report template where there are values in comma outputted which might
+    break CSV format
 
     :id: a4b577db-144e-4961-a42e-e93887464986
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -83,8 +83,8 @@ def infra_host(request, target_sat, module_capsule_configured):
 
 
 def assert_job_invocation_result(invocation_command_id, client_hostname, expected_result='success'):
-    """Asserts the job invocation finished with the expected result and fetches job output when error
-    occurs. Result is one of: success, pending, error, warning"""
+    """Asserts the job invocation finished with the expected result and fetches job output
+    when error occurs. Result is one of: success, pending, error, warning"""
     result = JobInvocation.info({'id': invocation_command_id})
     try:
         assert result[expected_result] == '1'

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1310,7 +1310,8 @@ class TestContentViewSync:
     def test_negative_export_cv_with_on_demand_repo(
         self, export_import_cleanup_module, target_sat, module_org
     ):
-        """Exporting CV version having on_demand repo throws error with "fail-on-missing-content" option set
+        """Exporting CV version having on_demand repo throws error
+        with "fail-on-missing-content" option set
 
         :id: f8b86d0e-e1a7-4e19-bb82-6de7d16c6676
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1280,9 +1280,8 @@ SATELLITE_SERVICES = {
 
 
 def extract_help(filter='params'):
-    """Generator function to extract satellite installer params and sections from lines of help text.
-    In general lst is cmd.stdout, e.g., a list of strings representing host
-    stdout
+    """Generator function to extract satellite installer params and sections from lines
+    of help text. In general lst is cmd.stdout, e.g., a list of strings representing host stdout.
 
     :param string filter: Filter `sections` or `params` in full help, default is params
     :return: generator with params or sections depends on filter parameter

--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -84,7 +84,8 @@ class TestActivationKey:
 
     @pytest.mark.post_upgrade(depend_on=test_pre_create_activation_key)
     def test_post_crud_activation_key(self, dependent_scenario_name, target_sat):
-        """After Upgrade, Activation keys entities remain the same and all their functionality works.
+        """After Upgrade, Activation keys entities remain the same and
+        all their functionality works.
 
         :id: postupgrade-a7443b54-eb2e-497b-8a50-92abeae01496
 

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -57,7 +57,8 @@ class TestSyncPlan:
 
     @pytest.mark.pre_upgrade
     def test_pre_disabled_sync_plan_logic(self, request):
-        """Pre-upgrade scenario that creates a sync plan with both disabled and enabled recurring logic.
+        """Pre-upgrade scenario that creates a sync plan with both disabled and
+        enabled recurring logic.
 
         :id: preupgrade-c75bd43d-d868-461a-9fc3-a1fc7dccc77a
 


### PR DESCRIPTION
GitHub actions CI is failing due to a missing repository on the public GitLab. PyCQA seems to move the repo from GitLab over to GitHub. 

Failing action: https://github.com/SatelliteQE/robottelo/actions/runs/3630357107/jobs/6123792749