### PR TITLE
[6.11.z] record test case start_time property before skipping the rest of the hook

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -87,6 +87,9 @@ def pytest_collection_modifyitems(session, items, config):
     deselected = []
     logger.info('Processing test items to add testimony token markers')
     for item in items:
+        item.user_properties.append(
+            ("start_time", datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME))
+        )
         if item.nodeid.startswith('tests/robottelo/') and 'test_junit' not in item.nodeid:
             # Unit test, no testimony markers
             continue
@@ -119,9 +122,6 @@ def pytest_collection_modifyitems(session, items, config):
         item.user_properties.append(("BaseOS", rhel_version))
         item.user_properties.append(("SatelliteVersion", sat_version))
         item.user_properties.append(("SnapVersion", snap_version))
-        item.user_properties.append(
-            ("start_time", datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME))
-        )
 
         # exit early if no filters were passed
         if importance or component or assignee:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10411

This makes the test_reporting to start passing again, since it operates inside `tests/robottelo` context.

```
$ pytest tests/robottelo/test_report.py 
================================================= test session starts =================================================
platform linux -- Python 3.9.12, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, configfile: pyproject.toml
plugins: xdist-3.0.2, services-2.2.1, mock-3.10.0, reportportal-5.1.3, ibutsu-2.2.4
collected 4 items                                                                                                     

tests/robottelo/test_report.py ....                                                                             [100%]

================================================== warnings summary ===================================================
tests/robottelo/test_report.py::test_junit_timestamps[dummy_test-xdist-testsuite]
tests/robottelo/test_report.py::test_junit_timestamps[dummy_test-xdist-testcase]
tests/robottelo/test_report.py::test_junit_timestamps[dummy_test-non_xdist-testsuite]
tests/robottelo/test_report.py::test_junit_timestamps[dummy_test-non_xdist-testcase]

=========================================== 4 passed, 4 warnings in 17.08s ============================================
```