### PR TITLE
record test case start_time property before skipping the rest of the hook

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -87,6 +87,9 @@ def pytest_collection_modifyitems(session, items, config):
     deselected = []
     logger.info('Processing test items to add testimony token markers')
     for item in items:
+        item.user_properties.append(
+            ("start_time", datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME))
+        )
         if item.nodeid.startswith('tests/robottelo/'):
             # Unit test, no testimony markers
             continue
@@ -118,9 +121,6 @@ def pytest_collection_modifyitems(session, items, config):
         item.user_properties.append(("BaseOS", rhel_version))
         item.user_properties.append(("SatelliteVersion", sat_version))
         item.user_properties.append(("SnapVersion", snap_version))
-        item.user_properties.append(
-            ("start_time", datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME))
-        )
 
         # add custom ibutsu metadata fields for test case grouping and heatmaps
         if hasattr(item, "_ibutsu"):


### PR DESCRIPTION
cherrypick of https://github.com/SatelliteQE/robottelo/pull/10411

fixes #10413 


```
$ pytest tests/robottelo/test_report.py 
================================================= test session starts =================================================
platform linux -- Python 3.9.12, pytest-7.1.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/rplevka/work/rplevka/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.6.1, forked-1.4.0, xdist-2.5.0, reportportal-5.0.11, ibutsu-2.2.4
collected 4 items                                                                                                     

tests/robottelo/test_report.py ....                                                                             [100%]

================================================= 4 passed in 37.24s ==================================================
```
