### PR TITLE
Add test for the Capsule sync deadlock issue

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -1,7 +1,4 @@
 CAPSULE:
-  # Capsule name to be used in the CapsuleVirtualMachine class (will be deprecated)
-  SATELLITE_VERSION_TAG: "@jinja {{this.robottelo.satellite_version | replace('.', '')}}"
-  INSTANCE_NAME: "@format qe-sat{this[capsule].satellite_version_tag}-rhel7-tierX-capsule"
   VERSION:
     # The full release version (6.9.2)
     RELEASE:  # populate with capsule version
@@ -13,6 +10,6 @@ CAPSULE:
     # The base os rhel version where the capsule installed
     # RHEL_VERSION:
   # The Ansible Tower workflow used to deploy a capsule
-  DEPLOY_WORKFLOW: deploy-sat-capsule
+  DEPLOY_WORKFLOW: deploy-capsule
   # Dictionary of arguments which should be passed along to the deploy workflow
-  # DEPLOY_ARGUMENTS:
+  DEPLOY_ARGUMENTS:

--- a/conf/flavors.yaml.template
+++ b/conf/flavors.yaml.template
@@ -1,0 +1,9 @@
+FLAVORS:
+  # 6 CPU, 24 GB RAM, 100 GB disk
+  DEFAULT: satqe-ssd.standard.std
+  # 16 CPU, 32 GB RAM, 160 GB disk
+  LARGE: satqe-ssd.standard.xxxl
+  # 6 CPU, 24 GB RAM, 500 GB disk
+  UPGRADE: satqe-ssd.upgrade.std
+  # 8 CPU, 32 GB RAM, 500 GB disk
+  CUSTOM_DB: satqe-ssd.customerdb.std

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -224,7 +224,7 @@ def oracle_host(request, version):
 def sat_ready_rhel(request):
     deploy_args = {
         'deploy_rhel_version': request.param,
-        'deploy_flavor': 'satqe-ssd.standard.std',
+        'deploy_flavor': settings.flavors.default,
         'promtail_config_template_file': 'config_sat.j2',
         'workflow': 'deploy-rhel',
     }

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -44,6 +44,15 @@ def capsule_host(capsule_factory):
     Broker(hosts=[new_cap]).checkin()
 
 
+@pytest.fixture
+def large_capsule_host(capsule_factory):
+    """A fixture that provides a Capsule based on config settings"""
+    new_cap = capsule_factory(deploy_flavor=settings.flavors.custom_db)
+    yield new_cap
+    new_cap.teardown()
+    Broker(hosts=[new_cap]).checkin()
+
+
 @pytest.fixture(scope='module')
 def module_capsule_host(capsule_factory):
     """A fixture that provides a Capsule based on config settings"""
@@ -67,6 +76,13 @@ def capsule_configured(capsule_host, target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     capsule_host.capsule_setup(sat_host=target_sat)
     yield capsule_host
+
+
+@pytest.fixture
+def large_capsule_configured(large_capsule_host, target_sat):
+    """Configure the capsule instance with the satellite from settings.server.hostname"""
+    large_capsule_host.capsule_setup(sat_host=target_sat)
+    yield large_capsule_host
 
 
 @pytest.fixture(scope='module')

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -66,7 +66,6 @@ VALIDATORS = dict(
         Validator('bugzilla.api_key', must_exist=True),
     ],
     capsule=[
-        Validator('capsule.instance_name', must_exist=True),
         Validator('capsule.version.release', must_exist=True),
         Validator('capsule.version.source', must_exist=True),
         Validator('capsule.deploy_workflow', must_exist=True),

--- a/tests/foreman/destructive/test_capsulecontent.py
+++ b/tests/foreman/destructive/test_capsulecontent.py
@@ -1,0 +1,93 @@
+"""Capsule-Content related tests, which require destructive Satellite
+
+:Requirement: Capsule-Content
+
+:CaseAutomation: Automated
+
+:CaseLevel: System
+
+:CaseComponent: Capsule-Content
+
+:team: Phoenix-content
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:Upstream: No
+"""
+import pytest
+from fauxfactory import gen_alpha
+
+from robottelo import constants
+
+pytestmark = [pytest.mark.destructive]
+
+
+@pytest.mark.tier4
+@pytest.mark.skip_if_not_set('capsule')
+def test_positive_sync_without_deadlock(
+    target_sat, large_capsule_configured, function_entitlement_manifest_org
+):
+    """Synchronize one bigger repo published in multiple CVs to a blank Capsule.
+    Assert that the sync task succeeds and no deadlock happens.
+
+    :id: 91c6eec9-a582-46ea-9898-bdcaebcea2f0
+
+    :setup:
+        1. A blank external capsule that has not been synced yet (!) with immediate download
+           policy and running multiple (4 and more) pulpcore workers.
+
+    :steps:
+        1. Sync one bigger repository to the Satellite.
+        2. Create a Content View, add the repository and publish it.
+        3. Create several copies of the CV and publish them.
+        4. Add the Library LCE to the Capsule.
+        5. Sync the Capsule.
+
+    :expectedresults:
+        1. Sync passes without deadlock.
+
+    :customerscenario: true
+
+    :BZ: 2062526
+
+    """
+    # Note: As of now BZ#2122872 prevents us to use the originally intended RHEL7 repo because
+    # of a memory leak causing Satellite OOM crash in this scenario. Therefore, for now we use
+    # smaller RHSCL repo instead, which was also capable to hit the deadlock issue, regardless
+    # the lower rpms count. When the BZ is fixed, reconsider upscale to RHEL7 repo or similar.
+    repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
+        basearch='x86_64',
+        org_id=function_entitlement_manifest_org.id,
+        product=constants.REPOS['rhscl7']['product'],
+        repo=constants.REPOS['rhscl7']['name'],
+        reposet=constants.REPOSET['rhscl7'],
+        releasever=constants.REPOS['rhscl7']['releasever'],
+    )
+    repo = target_sat.api.Repository(id=repo_id).read()
+    repo.sync(timeout='60m')
+
+    cv = target_sat.publish_content_view(function_entitlement_manifest_org, repo)
+
+    for i in range(4):
+        copy_id = target_sat.api.ContentView(id=cv.id).copy(data={'name': gen_alpha()})['id']
+        copy_cv = target_sat.api.ContentView(id=copy_id).read()
+        copy_cv.publish()
+
+    proxy = large_capsule_configured.nailgun_smart_proxy.read()
+    proxy.download_policy = 'immediate'
+    proxy.update(['download_policy'])
+
+    lce = target_sat.api.LifecycleEnvironment(
+        organization=function_entitlement_manifest_org
+    ).search(query={'search': f'name={constants.ENVIRONMENT}'})[0]
+    large_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
+        data={'environment_id': lce.id}
+    )
+    result = large_capsule_configured.nailgun_capsule.content_lifecycle_environments()
+    assert len(result['results']) == 1
+    assert result['results'][0]['id'] == lce.id
+
+    sync_status = large_capsule_configured.nailgun_capsule.content_sync(timeout='90m')
+    assert sync_status['result'] == 'success', 'Capsule sync task failed.'


### PR DESCRIPTION
This PR adds coverage for [BZ#2062526](https://bugzilla.redhat.com/show_bug.cgi?id=2062526)

For this scenario to run we need ~400 GiB storage on Capsule with RHEL7 repo (or ~120 GiB with RHSCL repo), so I had to use larger `deploy_flavor` for the Capsule.

Originally the scenario was intended to use RHEL7 repo, but due to another [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2122872) causing OOM extinction and sync task failure, I decided to go with half-sized RHSCL, which was capable to cause the deadlock too.

If/when the gunicorn BZ is resolved, we can get back to the RHEL7 repo and tweak the test for higher load.