### PR TITLE
[6.13.z] added support to auto-merge the auto-cherry-pick pr

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -1,0 +1,62 @@
+name: automerge auto-cherry-picked pr's
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - unlabeled
+      - edited
+      - ready_for_review
+    branches-ignore:
+      - master
+  issue_comment:
+    types:
+      - created
+      - deleted
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+
+jobs:
+  automerge:
+    name: Automerge auto-cherry-picked pr
+    if: contains(github.event.pull_request.labels.*.name, 'AutoMerge_Cherry_Picked')
+    runs-on: ubuntu-latest
+    steps:
+      - id: find-prt-comment
+        name: Find the prt comment
+        uses: peter-evans/find-comment@v2
+        with:
+          issue-number: ${{ github.event.number }}
+          body-includes: "trigger: test-robottelo"
+          direction: last
+
+      - name: Fail automerge if PRT was not initiated
+        if: steps.find-prt-comment.outputs.comment-body == ""
+        run: |
+          echo "::error PRT comment not added the PR"
+
+      - name: Wait for PRT checks to get initiated
+        run: |
+          if [ "${{ github.event_name }}" == "issue_comment" ]; then
+            echo "Waiting for 5 min, PRT to be initiated." && sleep 300
+          fi
+
+      - id: automerge
+        name: Auto merge of cherry-picked PRs.
+        uses: "pascalgn/automerge-action@v0.15.5"
+        env:
+          GITHUB_TOKEN: "${{ secrets.CHERRYPICK_PAT }}"
+          MERGE_LABELS: "AutoMerge_Cherry_Picked, Auto_Cherry_Picked"
+          MERGE_METHOD: "squash"
+          MERGE_RETRIES: 5
+          MERGE_RETRY_SLEEP: 900000
+
+      - name: Auto Merge Status
+        run: |
+          if [ "${{ steps.automerge.outputs.mergeResult }}" == 'merged' ]; then
+            echo "Pull request ${{ steps.automerge.outputs.pullRequestNumber }} is Auto Merged !"
+          else
+            echo "::error Auto Merge of Pull request ${{ steps.automerge.outputs.pullRequestNumber }} is ${{steps.automerge.outputs.mergeResult}} !"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10372

#### PR Description 

This PR adds support to auto-merge the auto-cherry-pick PRs. This might need PRT Comment and Passing all test checks.   

#### Tested Action 
https://github.com/omkarkhatavkar/github-action-test-repo/pull/111
https://github.com/omkarkhatavkar/github-action-test-repo/actions/runs/3591634233

 