### PR TITLE
No-Cherrypick by default

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -56,6 +56,7 @@ jobs:
           labels: |
             Auto_Cherry_Picked
             ${{ matrix.label }}
+            No-CherryPick
           assignees: ${{ env.assignee }}
 
       - name: Add Parent PR's PRT comment to Auto_Cherry_Picked PR's


### PR DESCRIPTION
By default the AutoCherrypicked PRs to labeled branches need not to again decide for auto-cherrypicking. The decision has should have already been made in parent PR itself as to what branch the PR will be cherrypicked and assigned branch labels.