### PR TITLE
[6.13.z] capsule upgrade playbook naming change

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -20,6 +20,7 @@ import pytest
 
 from robottelo.api.utils import wait_for_tasks
 from robottelo.hosts import get_sat_version
+from robottelo.utils.issue_handlers import is_open
 
 CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
@@ -36,14 +37,16 @@ def test_positive_run_capsule_upgrade_playbook(module_capsule_configured, target
 
     :expectedresults: Capsule is upgraded successfully
 
+    :BZ: 2152951
+
     :CaseImportance: Medium
     """
-    template_id = (
-        target_sat.api.JobTemplate()
-        .search(query={'search': 'name="Capsule Upgrade Playbook"'})[0]
-        .id
+    template_name = (
+        'Smart Proxy Upgrade Playbook' if is_open('BZ:2152951') else 'Capsule Upgrade Playbook'
     )
-
+    template_id = (
+        target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})[0].id
+    )
     module_capsule_configured.add_rex_key(satellite=target_sat)
     job = target_sat.api.JobInvocation().run(
         synchronous=False,

--- a/tests/foreman/destructive/test_remoteexecution.py
+++ b/tests/foreman/destructive/test_remoteexecution.py
@@ -23,6 +23,7 @@ from nailgun.entity_mixins import TaskFailedError
 
 from robottelo.config import get_credentials
 from robottelo.hosts import get_sat_version
+from robottelo.utils.issue_handlers import is_open
 
 CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
@@ -41,14 +42,16 @@ def test_negative_run_capsule_upgrade_playbook_on_satellite(target_sat):
 
     :expectedresults: Should fail
 
+    :BZ: 2152951
+
     :CaseImportance: Medium
     """
-    template_id = (
-        target_sat.api.JobTemplate()
-        .search(query={'search': 'name="Capsule Upgrade Playbook"'})[0]
-        .id
+    template_name = (
+        'Smart Proxy Upgrade Playbook' if is_open('BZ:2152951') else 'Capsule Upgrade Playbook'
     )
-
+    template_id = (
+        target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})[0].id
+    )
     target_sat.add_rex_key(satellite=target_sat)
     with pytest.raises(TaskFailedError) as error:
         target_sat.api.JobInvocation().run(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10425

Working around the branding issue in 6.13 to keep capsule upgrade playbook tested