### PR TITLE
Add e2e tests for Global Registration

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -19,7 +19,7 @@ from robottelo.hosts import ContentHost
 @pytest.fixture(scope='module')
 def module_provisioning_capsule(module_target_sat, module_location):
     """Assigns the `module_location` to Satellite's internal capsule and returns it"""
-    capsule = module_target_sat.internal_capsule
+    capsule = module_target_sat.nailgun_smart_proxy
     capsule.location = [module_location]
     return capsule.update(['location'])
 

--- a/robottelo/cli/host_registration.py
+++ b/robottelo/cli/host_registration.py
@@ -1,0 +1,28 @@
+"""
+Usage:
+    hammer host-registration [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+ SUBCOMMAND                    Subcommand
+ [ARG] ...                     Subcommand arguments
+
+Subcommands:
+ generate-command              Generate global registration command
+
+Options:
+ -h, --help                    Print help
+
+"""
+from robottelo.cli.base import Base
+
+
+class HostRegistration(Base):
+    """Manipulates hammer host-registration command"""
+
+    command_base = 'host-registration'
+
+    @classmethod
+    def generate_command(cls, options):
+        """Generate global registration command"""
+        cls.command_sub = 'generate-command'
+        return cls.execute(cls._construct_command(options))

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -18,6 +18,12 @@ class Colored(Box):
 SATELLITE_VERSION = "6.14"
 SATELLITE_OS_VERSION = "8"
 
+# Default system ports
+HTTPS_PORT = '443'
+
+# Client port for HTTP traffic for Satellite & Capsule
+CLIENT_PORT = HTTPS_PORT
+
 LOCALES = (
     'cs_CZ',
     'de',

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import random
 import re
 
@@ -125,7 +126,7 @@ class ContentInfo:
             # Set the timeout to 1500 seconds to align with the API timeout.
             timeout = 1500000
         if interface == 'CLI':
-            if isinstance(manifest.content, bytes):
+            if isinstance(manifest.content, io.BytesIO):
                 self.put(f'{manifest.path}', f'{manifest.name}')
                 result = self.cli.Subscription.upload(
                     {'file': manifest.name, 'organization-id': org_id}, timeout=timeout
@@ -136,7 +137,7 @@ class ContentInfo:
                     {'file': manifest.filename, 'organization-id': org_id}, timeout=timeout
                 )
         else:
-            if not isinstance(manifest, bytes):
+            if not isinstance(manifest, io.BytesIO):
                 manifest = manifest.content
             result = self.api.Subscription().upload(
                 data={'organization_id': org_id}, files={'content': manifest}

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1,15 +1,16 @@
 import importlib
+import io
 import json
 import random
 import re
 import time
+from configparser import ConfigParser
 from contextlib import contextmanager
 from functools import cached_property
 from functools import lru_cache
 from pathlib import Path
 from pathlib import PurePath
 from tempfile import NamedTemporaryFile
-from urllib.parse import urlencode
 from urllib.parse import urljoin
 from urllib.parse import urlunsplit
 
@@ -363,6 +364,14 @@ class ContentHost(Host, ContentHostMixins):
             result.append(self.execute(f'subscription-manager attach --pool={pool}'))
         return result
 
+    @property
+    def subscription_config(self):
+        "Returns subscription config for the host as ConfigParser object"
+        config = self.execute('cat /etc/rhsm/rhsm.conf').stdout
+        cp = ConfigParser()
+        cp.read_file(io.StringIO(config))
+        return cp
+
     def create_custom_repos(self, **kwargs):
         """Create custom repofiles.
         Each ``kwargs`` item will result in one repository file created. Where
@@ -509,7 +518,7 @@ class ContentHost(Host, ContentHostMixins):
         loc,
         activation_keys,
         satellite=None,
-        target=satellite,
+        target=None,
         setup_insights=False,
         setup_remote_execution=True,
         setup_remote_execution_pull=False,
@@ -523,18 +532,16 @@ class ContentHost(Host, ContentHostMixins):
         ignore_subman_errors=False,
         force=False,
         insecure=True,
-        username=settings.server.admin_username,
-        password=settings.server.admin_password,
         hostgroup=None,
     ):
         """Registers content host to the Satellite or Capsule server
         using a global registration template.
 
         :param target: Satellite or Capusle hostname to register to, required.
+        :param satellite: Satellite object, used for running hammer CLI when target is smart_proxy.
         :param org: Organization to register content host for, required.
         :param loc: Location to register content host for, required.
-        :param activation_keys: Activation key name to register content host
-            with, required.
+        :param activation_keys: Activation key name to register content host with, required.
         :param setup_insights: Install and register Insights client, requires OS repo.
         :param setup_remote_execution: Copy remote execution SSH key.
         :param setup_remote_execution_pull: Deploy pull provider client on host
@@ -548,12 +555,8 @@ class ContentHost(Host, ContentHostMixins):
         :param ignore_subman_errors: Ignore subscription manager errors.
         :param force: Register the content host even if it's already registered.
         :param insecure: Don't verify server authenticity.
-        :param username: Satellite admin username
-        :param password: Satellite admin password
         :param hostgroup: hostgroup to register with
-        :param port: Capsule port, if unset template is pulled straight from Satellite
-        :return: SSHCommandResult instance filled with the result of the
-            registration.
+        :return: SSHCommandResult instance filled with the result of the registration
         """
         options = {
             'activation-keys': activation_keys,
@@ -564,6 +567,9 @@ class ContentHost(Host, ContentHostMixins):
         }
         if target.__class__.__name__ == 'Capsule':
             options['smart-proxy'] = target.hostname
+        elif target is not None and target.__class__.__name__ not in ['Capsule', 'Satellite']:
+            raise ValueError('Global registration method can be used with Satellite/Capsule only')
+
         if lifecycle_environment is not None:
             options['lifecycle_environment_id'] = lifecycle_environment.id
         if operating_system is not None:
@@ -573,7 +579,7 @@ class ContentHost(Host, ContentHostMixins):
         if packages is not None:
             options['packages'] = '+'.join(packages)
         if repo is not None:
-            options['repo'] = urlencode({'repo': repo})
+            options['repo'] = repo
         if setup_insights is not None:
             options['setup-insights'] = str(setup_insights).lower()
         if setup_remote_execution is not None:
@@ -1294,9 +1300,11 @@ class Capsule(ContentHost, CapsuleMixins):
 
     @property
     def nailgun_capsule(self):
-        from nailgun.entities import Capsule as NailgunCapsule
+        return self.satellite.api.Capsule().search(query={'search': f'name={self.hostname}'})[0]
 
-        return NailgunCapsule().search(query={'search': f'name={self.hostname}'})[0]
+    @property
+    def nailgun_smart_proxy(self):
+        return self.satellite.api.SmartProxy().search(query={'search': f'name={self.hostname}'})[0]
 
     @cached_property
     def is_upstream(self):
@@ -1448,8 +1456,6 @@ class Capsule(ContentHost, CapsuleMixins):
 
 class Satellite(Capsule, SatelliteMixins):
     def __init__(self, hostname=None, **kwargs):
-        from robottelo.config import settings
-
         hostname = hostname or settings.server.hostname  # instance attr set by broker.Host
         self.port = kwargs.get('port', settings.server.port)
         super().__init__(hostname=hostname, **kwargs)
@@ -1516,11 +1522,6 @@ class Satellite(Capsule, SatelliteMixins):
                         # not everything has an mro method, we don't care about them
                         pass
         return self._cli
-
-    @property
-    def internal_capsule(self):
-        capsule_list = self.api.SmartProxy().search(query={'search': f'name={self.hostname}'})
-        return None if not capsule_list else capsule_list[0]
 
     def ui_session(self, testname=None, user=None, password=None, url=None, login=True):
         """Initialize an airgun Session object and store it as self.ui_session"""

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -72,9 +72,8 @@ def register_host(sat, act_key, module_org, module_loc, host, ubi=None):
         location=module_loc,
         insecure=True,
         repo=ubi,
-    ).create()['registration_command']
-    result = host.execute(command)
-    assert result.status == 0
+    ).create()
+    assert host.execute(command).status == 0
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -1,0 +1,90 @@
+"""Tests for registration.
+
+:Requirement: Registration
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Registration
+
+:CaseAutomation: Automated
+
+:CaseImportance: Critical
+
+:Assignee: sbible
+
+:TestType: Functional
+
+:Upstream: No
+"""
+import pytest
+
+from robottelo.constants import CLIENT_PORT
+from robottelo.utils.issue_handlers import is_open
+
+pytestmark = pytest.mark.tier1
+
+
+@pytest.mark.e2e
+@pytest.mark.no_containers
+def test_host_registration_end_to_end(
+    module_org,
+    module_location,
+    module_ak_with_synced_repo,
+    module_target_sat,
+    module_capsule_configured,
+    rhel_contenthost,
+):
+    """Verify content host registration with global registration
+
+    :id: 219567a8-856a-11ed-944d-03d9b43011c2
+
+    :steps:
+        1. Register host with global registration template to Satellite and Capsule
+
+    :expectedresults: Host registered successfully
+
+    :BZ: 2156926
+
+    :customerscenario: true
+    """
+    command = module_target_sat.api.RegistrationCommand(
+        organization=module_org,
+        activation_keys=[module_ak_with_synced_repo.name],
+        location=module_location,
+    ).create()
+
+    result = rhel_contenthost.execute(command)
+    if is_open('BZ:2156926') and rhel_contenthost.os_version.major == 6:
+        assert result.status == 1, f'Failed to register host: {result.stderr}'
+    else:
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    # Verify server.hostname and server.port from subscription-manager config
+    assert module_target_sat.hostname == rhel_contenthost.subscription_config['server']['hostname']
+    assert CLIENT_PORT == rhel_contenthost.subscription_config['server']['port']
+
+    # Update module_capsule_configured to include module_org/module_location
+    nc = module_capsule_configured.nailgun_smart_proxy
+    module_target_sat.api.SmartProxy(id=nc.id, organization=[module_org]).update(['organization'])
+    module_target_sat.api.SmartProxy(id=nc.id, location=[module_location]).update(['location'])
+
+    command = module_target_sat.api.RegistrationCommand(
+        smart_proxy=nc,
+        organization=module_org,
+        activation_keys=[module_ak_with_synced_repo.name],
+        location=module_location,
+        force=True,
+    ).create()
+    result = rhel_contenthost.execute(command)
+
+    if is_open('BZ:2156926') and rhel_contenthost.os_version.major == 6:
+        assert result.status == 1, f'Failed to register host: {result.stderr}'
+    else:
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    # Verify server.hostname and server.port from subscription-manager config
+    assert (
+        module_capsule_configured.hostname
+        == rhel_contenthost.subscription_config['server']['hostname']
+    )
+    assert CLIENT_PORT == rhel_contenthost.subscription_config['server']['port']

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -19,13 +19,14 @@
 import pytest
 
 from robottelo.config import settings
+from robottelo.constants import CLIENT_PORT
+from robottelo.utils.issue_handlers import is_open
 
 pytestmark = pytest.mark.tier1
 
 
 @pytest.mark.e2e
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('[^6].*')
 def test_host_registration_end_to_end(
     module_org,
     module_location,
@@ -42,11 +43,23 @@ def test_host_registration_end_to_end(
         1. Register host with global registration template to Satellite and Capsule
 
     :expectedresults: Host registered successfully
+
+    :BZ: 2156926
+
+    :customerscenario: true
     """
     result = rhel_contenthost.register(
         module_org, module_location, module_ak_with_synced_repo.name, satellite=module_target_sat
     )
-    assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    if is_open('BZ:2156926') and rhel_contenthost.os_version.major == 6:
+        assert result.status == 1, f'Failed to register host: {result.stderr}'
+    else:
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    # Verify server.hostname and server.port from subscription-manager config
+    assert module_target_sat.hostname == rhel_contenthost.subscription_config['server']['hostname']
+    assert CLIENT_PORT == rhel_contenthost.subscription_config['server']['port']
 
     # Update module_capsule_configured to include module_org/module_location
     module_target_sat.cli.Capsule.update(
@@ -64,7 +77,17 @@ def test_host_registration_end_to_end(
         satellite=module_target_sat,
         force=True,
     )
-    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    if is_open('BZ:2156926') and rhel_contenthost.os_version.major == 6:
+        assert result.status == 1, f'Failed to register host: {result.stderr}'
+    else:
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    # Verify server.hostname and server.port from subscription-manager config
+    assert (
+        module_capsule_configured.hostname
+        == rhel_contenthost.subscription_config['server']['hostname']
+    )
+    assert CLIENT_PORT == rhel_contenthost.subscription_config['server']['port']
 
 
 def test_upgrade_katello_ca_consumer_rpm(
@@ -101,9 +124,9 @@ def test_upgrade_katello_ca_consumer_rpm(
         f'rpm -Uvh "http://{target_sat.hostname}/pub/{consumer_cert_name}-1.0-1.noarch.rpm"'
     )
     # Check server URL is not Red Hat CDN's "subscription.rhsm.redhat.com"
-    result = vm.execute('grep ^hostname /etc/rhsm/rhsm.conf')
-    assert 'subscription.rhsm.redhat.com' not in result.stdout
-    assert target_sat.hostname in result.stdout
+    assert 'subscription.rhsm.redhat.com' != vm.subscription_config['server']['hostname']
+    assert target_sat.hostname == vm.subscription_config['server']['hostname']
+
     # Get consumer cert source file
     assert vm.execute(f'curl -O "http://{target_sat.hostname}/pub/{consumer_cert_src}"')
     # Install repo for build tools
@@ -122,9 +145,9 @@ def test_upgrade_katello_ca_consumer_rpm(
     # Install new rpmbuild/RPMS/noarch/katello-ca-consumer-*-2.noarch.rpm
     assert vm.execute(f'yum install -y rpmbuild/RPMS/noarch/{new_consumer_cert_rpm}')
     # Check server URL is not Red Hat CDN's "subscription.rhsm.redhat.com"
-    result = vm.execute('grep ^hostname /etc/rhsm/rhsm.conf')
-    assert 'subscription.rhsm.redhat.com' not in result.stdout
-    assert target_sat.hostname in result.stdout
+    assert 'subscription.rhsm.redhat.com' != vm.subscription_config['server']['hostname']
+    assert target_sat.hostname == vm.subscription_config['server']['hostname']
+
     # Register as final check
     vm.register_contenthost(module_org.label)
     result = vm.execute('subscription-manager identity')

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -933,6 +933,14 @@ class TestAsyncSSHProviderRex:
 
         :parametrized: yes
         """
+        # Update module_capsule_configured_async_ssh to include module_org/smart_proxy_location
+        module_target_sat.cli.Capsule.update(
+            {
+                'name': module_capsule_configured_async_ssh.hostname,
+                'organization-ids': module_org.id,
+                'location-ids': smart_proxy_location.id,
+            }
+        )
         result = rhel_contenthost.register(
             module_org,
             smart_proxy_location,
@@ -985,6 +993,14 @@ class TestPullProviderRex:
             repo='client',
             release='Client',
             os_release=rhel_contenthost.os_version.major,
+        )
+        # Update module_capsule_configured_mqtt to include module_org/smart_proxy_location
+        module_target_sat.cli.Capsule.update(
+            {
+                'name': module_capsule_configured_mqtt.hostname,
+                'organization-ids': module_org.id,
+                'location-ids': smart_proxy_location.id,
+            }
         )
         # register host with rex, enable client repo, install katello-agent
         result = rhel_contenthost.register(
@@ -1074,6 +1090,14 @@ class TestPullProviderRex:
             repo='client',
             release='Client',
             os_release=rhel_contenthost.os_version.major,
+        )
+        # Update module_capsule_configured_mqtt to include module_org/smart_proxy_location
+        module_target_sat.cli.Capsule.update(
+            {
+                'name': module_capsule_configured_mqtt.hostname,
+                'organization-ids': module_org.id,
+                'location-ids': smart_proxy_location.id,
+            }
         )
         # register host with pull provider rex (SAT-1677)
         result = rhel_contenthost.register(

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -916,6 +916,7 @@ class TestAsyncSSHProviderRex:
         module_org,
         smart_proxy_location,
         module_ak_with_cv,
+        module_target_sat,
         module_capsule_configured_async_ssh,
         rhel_contenthost,
     ):
@@ -933,10 +934,11 @@ class TestAsyncSSHProviderRex:
         :parametrized: yes
         """
         result = rhel_contenthost.register(
-            module_capsule_configured_async_ssh,
             module_org,
             smart_proxy_location,
             module_ak_with_cv.name,
+            target=module_capsule_configured_async_ssh,
+            satellite=module_target_sat,
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
         # run script provider rex command, longer-running command is needed to
@@ -963,6 +965,7 @@ class TestPullProviderRex:
         module_org,
         smart_proxy_location,
         module_ak_with_cv,
+        module_target_sat,
         module_capsule_configured_mqtt,
         rhel_contenthost,
     ):
@@ -985,10 +988,11 @@ class TestPullProviderRex:
         )
         # register host with rex, enable client repo, install katello-agent
         result = rhel_contenthost.register(
-            module_capsule_configured_mqtt,
             module_org,
             smart_proxy_location,
             module_ak_with_cv.name,
+            target=module_capsule_configured_mqtt,
+            satellite=module_target_sat,
             packages=['katello-agent'],
             repo=client_repo.baseurl,
         )
@@ -1048,6 +1052,7 @@ class TestPullProviderRex:
     def test_positive_run_job_on_host_registered_to_pull_provider(
         self,
         module_org,
+        module_target_sat,
         smart_proxy_location,
         module_ak_with_cv,
         module_capsule_configured_mqtt,
@@ -1072,13 +1077,15 @@ class TestPullProviderRex:
         )
         # register host with pull provider rex (SAT-1677)
         result = rhel_contenthost.register(
-            module_capsule_configured_mqtt,
             module_org,
             smart_proxy_location,
             module_ak_with_cv.name,
+            target=module_capsule_configured_mqtt,
+            satellite=module_target_sat,
             setup_remote_execution_pull=True,
             repo=client_repo.baseurl,
         )
+
         assert result.status == 0, f'Failed to register host: {result.stderr}'
         # check mqtt client is running
         result = rhel_contenthost.execute('yggdrasil status')

--- a/tests/foreman/destructive/test_remoteexecution.py
+++ b/tests/foreman/destructive/test_remoteexecution.py
@@ -84,7 +84,7 @@ def test_negative_run_capsule_upgrade_playbook_on_satellite(target_sat):
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([8])
 def test_positive_use_alternate_directory(
-    rhel_contenthost, target_sat, default_org, default_location
+    target_sat, rhel_contenthost, default_org, default_location
 ):
     """Use alternate working directory on client to execute rex jobs
 
@@ -105,7 +105,7 @@ def test_positive_use_alternate_directory(
             'auto-attach': False,
         }
     )
-    result = client.register(target_sat, default_org, default_location, ak.name, port=None)
+    result = client.register(default_org, default_location, ak.name, satellite=target_sat)
     assert result.status == 0, f'Failed to register host: {result.stderr}'
     testdir = gen_string('alpha')
     result = client.run(f'mkdir /{testdir}')


### PR DESCRIPTION
**Description:**
1. Add e2e tests for Global Registration CLI and API
2. Update register() helper to use hammer command for Global Registration
3.  Update REX tests to use updated register() method
4. Fix upload_manifest 