### PR TITLE
add delay for errata check and fix wait_for parameters

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -61,7 +61,7 @@ class VersionedContent:
             settings_release.append('0')
         settings_release = '.'.join(settings_release[:3])  # keep only major.minor.patch
         if product != 'client' and release != settings_release:
-            logger.warn(
+            logger.warning(
                 'Satellite release in settings differs from the one passed to the function '
                 'or the version of the Satellite object. '
                 f'settings: {settings_release}, parameter: {release}'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -162,18 +162,35 @@ class ContentHost(Host, ContentHostMixins):
     @property
     def nailgun_host(self):
         """If this host is subscribed, provide access to its nailgun object"""
-        if self.subscribed:
+        if self.identity.get('registered_to') == self.satellite.hostname:
             try:
                 host_list = self.satellite.api.Host().search(query={'search': self.hostname})[0]
             except Exception as err:
                 logger.error(f'Failed to get nailgun host for {self.hostname}: {err}')
                 host_list = None
             return host_list
+        else:
+            logger.warning(f'Host {self.hostname} not registered to {self.satellite.hostname}')
 
     @property
     def subscribed(self):
         """Boolean representation of a content host's subscription status"""
         return 'Status: Unknown' not in self.execute('subscription-manager status').stdout
+
+    @property
+    def identity(self):
+        """A Dictionary containing RHSM identity attributes of the host"""
+        id_output = self.execute('subscription-manager identity').stdout
+        id_dict = {}
+        if id_output:
+            id_dict = {
+                i.split(':')[0].replace(' ', '_'): i.split(': ')[1]
+                for i in id_output.split('\n')[:-1]
+            }
+            regged_to = self.subscription_config['server']['hostname']
+            if regged_to:
+                id_dict['registered_to'] = regged_to
+        return id_dict
 
     @property
     def ip_addr(self):

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -26,6 +26,7 @@ from fauxfactory import gen_integer
 from fauxfactory import gen_ipaddr
 from fauxfactory import gen_mac
 from fauxfactory import gen_string
+from wait_for import TimedOutError
 from wait_for import wait_for
 
 from robottelo.cli.activationkey import ActivationKey
@@ -1773,7 +1774,7 @@ def test_positive_erratum_applicability(
     applicable_errata, _ = wait_for(
         lambda: Host.errata_list({'host-id': host_info['id']}),
         handle_exception=True,
-        failure_condition=[],
+        fail_condition=[],
         timeout=120,
         delay=5,
     )
@@ -1787,11 +1788,23 @@ def test_positive_erratum_applicability(
     result = client.run(f'yum update -y --advisory {setup_custom_repo["security_errata"]}')
     assert result.status == 0
     client.subscription_manager_list_repos()
-    applicable_erratum = Host.errata_list({'host-id': host_info['id']})
-    applicable_erratum_ids = [
-        errata['erratum-id'] for errata in applicable_erratum if errata['installable'] == 'true'
-    ]
-    assert setup_custom_repo["security_errata"] not in applicable_erratum_ids
+    # verify that the applied erratum is not present in the list of installable errata
+    try:
+        applicable_erratum, _ = wait_for(
+            lambda: setup_custom_repo["security_errata"]
+            not in [
+                errata['erratum-id']
+                for errata in Host.errata_list({'host-id': host_info['id']})
+                if errata['installable'] == 'true'
+            ],
+            handle_exception=True,
+            fail_condition=True,
+            timeout=300,
+            delay=5,
+        )
+    except TimedOutError:
+        assert False, f"timed out waiting for erratum \"{setup_custom_repo['security_errata']}\""
+        " to disappear from the list"
 
 
 @pytest.mark.cli_katello_host_tools


### PR DESCRIPTION
Asserting that the applied erratum is unlisted is hit and miss - we experience issues with timing, so I added `wait_for`.