### PR TITLE
update repo_options fixture-create a product if not exist

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1524,7 +1524,7 @@ class TestDockerRepository:
         :BZ: 1867287
         """
         repo = entities.Repository(**repo_options_custom_product).create()
-        repo.sync()
+        repo.sync(timeout=600)
         assert repo.read().content_counts['docker_manifest'] >= 1
         assert repo.product.delete()
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1495,7 +1495,7 @@ class TestDockerRepository:
 
     @pytest.mark.tier2
     @pytest.mark.parametrize(
-        'repo_options',
+        'repo_options_custom_product',
         **datafactory.parametrized(
             {
                 constants.CONTAINER_UPSTREAM_NAME: {
@@ -1508,7 +1508,7 @@ class TestDockerRepository:
         ),
         indirect=True,
     )
-    def test_positive_delete_product_with_synced_repo(self, repo, repo_options_custom_product):
+    def test_positive_delete_product_with_synced_repo(self, repo_options_custom_product):
         """Create and sync a Docker-type repository, delete the product.
 
         :id: c3d33836-54df-484d-97e1-f9fc9e22d23c
@@ -1523,6 +1523,7 @@ class TestDockerRepository:
 
         :BZ: 1867287
         """
+        repo = entities.Repository(**repo_options_custom_product).create()
         repo.sync()
         assert repo.read().content_counts['docker_manifest'] >= 1
         assert repo.product.delete()


### PR DESCRIPTION
- test function "`TestDockerRepository::test_positive_update_name`" was failing in jenkins job [1] because product was not available, this is because earlier executed test function "`test_positive_delete_product_with_synced_repo`" deleted the product.
- with this changes fixture `repo_options` at line#50 will use module_product and return product else will create new product.

- [1] reference: [satqe-jenkins-csb-satellite-qe -> TestDockerRepository/test_positive_update_name_docker](https://satqe-jenkins-csb-satellite-qe/view/6.12%20Components/job/sat-6.12-rhel8-Repositories/29/testReport/junit/tests.foreman.api.test_repository/TestDockerRepository/test_positive_update_name_docker_/)