### PR TITLE
[6.12.z] Fix for filter creation with ak and search criteria

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -693,7 +693,10 @@ def test_positive_access_non_admin_user(session, test_name):
     envs_condition = ' or '.join(['environment = ' + s for s in envs_list])
     entities.Filter(
         organization=[org],
-        permission=entities.Permission(name='view_activation_keys').search(),
+        permission=entities.Permission().search(
+            filters={'name': 'view_activation_keys'},
+            query={'search': 'resource_type="Katello::ActivationKey"'},
+        ),
         role=role,
         search=f'name ~ {ak_name} and ({envs_condition})',
     ).create()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10467

- Earlier search query was failing and not able to  search
- this fix will resolve the problem