### PR TITLE
Modify entitlement manifester fixtures for 6.13

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -76,12 +76,11 @@ def module_org_with_manifest(module_org, module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_entitlement_manifest_org(module_entitlement_manifest, module_target_sat):
+def module_entitlement_manifest_org(module_org, module_entitlement_manifest, module_target_sat):
     """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
-    org = module_target_sat.api.Organization().create()
-    module_target_sat.upload_manifest(org.id, module_entitlement_manifest.content)
-    org.sca_disable()
-    return org
+    module_target_sat.upload_manifest(module_org.id, module_entitlement_manifest.content)
+    module_org.sca_disable()
+    return module_org
 
 
 @pytest.fixture(scope='module')
@@ -92,12 +91,11 @@ def module_sca_manifest_org(module_org, module_sca_manifest, module_target_sat):
 
 
 @pytest.fixture
-def function_entitlement_manifest_org(function_entitlement_manifest, target_sat):
+def function_entitlement_manifest_org(function_org, function_entitlement_manifest, target_sat):
     """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
-    org = target_sat.api.Organization().create()
-    target_sat.upload_manifest(org.id, function_entitlement_manifest.content)
-    org.sca_disable()
-    return org
+    target_sat.upload_manifest(function_org.id, function_entitlement_manifest.content)
+    function_org.sca_disable()
+    return function_org
 
 
 @pytest.fixture

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -76,10 +76,12 @@ def module_org_with_manifest(module_org, module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_entitlement_manifest_org(module_org, module_entitlement_manifest, module_target_sat):
+def module_entitlement_manifest_org(module_entitlement_manifest, module_target_sat):
     """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
-    module_target_sat.upload_manifest(module_org.id, module_entitlement_manifest.content)
-    return module_org
+    org = module_target_sat.api.Organization().create()
+    module_target_sat.upload_manifest(org.id, module_entitlement_manifest.content)
+    org.sca_disable()
+    return org
 
 
 @pytest.fixture(scope='module')
@@ -89,14 +91,16 @@ def module_sca_manifest_org(module_org, module_sca_manifest, module_target_sat):
     return module_org
 
 
-@pytest.fixture(scope='function')
-def function_entitlement_manifest_org(function_org, function_entitlement_manifest, target_sat):
+@pytest.fixture
+def function_entitlement_manifest_org(function_entitlement_manifest, target_sat):
     """Creates an organization and uploads an entitlement mode manifest generated with manifester"""
-    target_sat.upload_manifest(function_org.id, function_entitlement_manifest.content)
-    return function_org
+    org = target_sat.api.Organization().create()
+    target_sat.upload_manifest(org.id, function_entitlement_manifest.content)
+    org.sca_disable()
+    return org
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_sca_manifest_org(function_org, function_sca_manifest, target_sat):
     """Creates an organization and uploads an SCA mode manifest generated with manifester"""
     target_sat.upload_manifest(function_org.id, function_sca_manifest.content)


### PR DESCRIPTION
Satellite 6.13 changes the way that organizations and manifests interact such that it is now required to explicitly disable simple content access either at or after organization creation time in order to use entitlement mode. This PR modifies the entitlement manifester fixtures to account for this change. This should resolve some of the test failures that we are seeing as a result of the new behavior. Please note that Satellite will throw a 400 response if we attempt to change from SCA mode to entitlement mode before a manifest has been uploaded to an org, so it is necessary to upload the manifest in these fixtures before running `org.sca_disable()`.