### PR TITLE
[6.12.z] Attempt to resolve check annotation error

### DIFF
--- a/tests/robottelo/test_func_shared.py
+++ b/tests/robottelo/test_func_shared.py
@@ -151,7 +151,7 @@ class NotRestorableException(Exception):
 @shared
 def simple_shared_counter_with_exception_not_restored(index=0):
     """Raise exception that should not be restorable"""
-    raise NotRestorableException('error', 'I am not restorable')
+    raise NotRestorableException(msg='error', details='I am not restorable')
 
 
 class TestFuncShared:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10503

The idea behind this is that the check isn't expecting multiple arguments being passed into an exception class (positionally).