### PR TITLE
[6.12.z] Bump cryptography from 38.0.4 to 39.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Version updates managed by dependabot
 
 broker[docker]==0.2.9
-cryptography==38.0.4
-deepdiff==6.2.1
+cryptography==39.0.0
+deepdiff==6.2.2
 dynaconf[vault]==3.1.11
 fauxfactory==3.1.0
 jinja2==3.1.2


### PR DESCRIPTION
Cherry-pick of #10494 and #10472


[6.13.z] Bump pytest-xdist from 3.0.2 to 3.1.0 (#10420)

Bump pytest-xdist from 3.0.2 to 3.1.0 (#10396)

Bumps [pytest-xdist](https://github.com/pytest-dev/pytest-xdist) from 3.0.2 to 3.1.0.
- [Release notes](https://github.com/pytest-dev/pytest-xdist/releases)
- [Changelog](https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst)
- [Commits](pytest-dev/pytest-xdist@v3.0.2...v3.1.0)

---
updated-dependencies:
- dependency-name: pytest-xdist
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 83a6926)

Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit d98838c)