### PR TITLE
[6.12.z] Cherry pick of #10493 - CI checks with Python 3.11, removed 3.8

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v3

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     license='GNU GPL v3.0',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    python_requires="~=3.6",  # We run on 3.8, relaxed lower limit
+    python_requires="~=3.9",
     classifiers=(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -25,6 +25,5 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
     ),
 )


### PR DESCRIPTION
cherry-pick of #10493

Closes #10510

(cherry picked from commit dc3b9c8b2f74a31aec4f4c14e01f2cdde70e344b)