### PR TITLE
[6.13.z] change how client repo is sourced in rex tests

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -48,6 +48,7 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.hosts import ContentHost
 from robottelo.logging import logger
+from robottelo.utils import ohsnap
 
 
 @pytest.fixture()
@@ -975,21 +976,13 @@ class TestPullProviderRex:
 
         :parametrized: yes
         """
-        result = rhel_contenthost.execute(
-            f'curl -o /etc/pki/ca-trust/source/anchors/satellite-sat-engineering-ca.crt \
-                    {settings.repos["DOGFOOD_REPO_HOST"]}/pub/katello-server-ca.crt \
-                    && update-ca-trust'
+        client_repo = ohsnap.dogfood_repository(
+            settings.repos.ohsnap_repo_host,
+            product='client',
+            repo='client',
+            release='Client',
+            os_release=rhel_contenthost.os_version.major,
         )
-        assert result.status == 0, 'Failed to download certificate'
-        client_repo = (
-            f'{settings.repos["DOGFOOD_REPO_HOST"].replace("http", "https")}/pulp/content/'
-            'Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/'
-            f'Satellite_Client_RHEL{rhel_contenthost.os_version.major}_x86_64/'
-        )
-        # TODO client_repo should be changed to
-        # settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
-        # when/if the new dogfood url pattern settles
-
         # register host with rex, enable client repo, install katello-agent
         result = rhel_contenthost.register(
             module_capsule_configured_mqtt,
@@ -997,7 +990,7 @@ class TestPullProviderRex:
             smart_proxy_location,
             module_ak_with_cv.name,
             packages=['katello-agent'],
-            repo=client_repo,
+            repo=client_repo.baseurl,
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
 
@@ -1070,21 +1063,13 @@ class TestPullProviderRex:
 
         :parametrized: yes
         """
-        result = rhel_contenthost.execute(
-            f'curl -o /etc/pki/ca-trust/source/anchors/satellite-sat-engineering-ca.crt \
-                    {settings.repos["DOGFOOD_REPO_HOST"]}/pub/katello-server-ca.crt \
-                    && update-ca-trust'
+        client_repo = ohsnap.dogfood_repository(
+            settings.repos.ohsnap_repo_host,
+            product='client',
+            repo='client',
+            release='Client',
+            os_release=rhel_contenthost.os_version.major,
         )
-        assert result.status == 0, 'Failed to download certificate'
-        client_repo = (
-            f'{settings.repos["DOGFOOD_REPO_HOST"].replace("http", "https")}/pulp/content/'
-            'Satellite_Engineering/QA/Satellite_Client/custom/Satellite_Client_Composes/'
-            f'Satellite_Client_RHEL{rhel_contenthost.os_version.major}_x86_64/'
-        )
-        # TODO client_repo should be changed to
-        # settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
-        # when/if the new dogfood url pattern settles
-
         # register host with pull provider rex (SAT-1677)
         result = rhel_contenthost.register(
             module_capsule_configured_mqtt,
@@ -1092,7 +1077,7 @@ class TestPullProviderRex:
             smart_proxy_location,
             module_ak_with_cv.name,
             setup_remote_execution_pull=True,
-            repo=client_repo,
+            repo=client_repo.baseurl,
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
         # check mqtt client is running


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10404

removes a workaround from pull provider rex tests:
```
pytest  tests/foreman/cli/test_remoteexecution.py -k test_positive_run_job_on_host_converted_to_pull_provider[rhel8]
=================================================== test session starts ===================================================
platform linux -- Python 3.10.8, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, ibutsu-2.2.4, forked-1.4.0, cov-3.0.0, mock-3.10.0, xdist-3.0.2, reportportal-5.1.3
collected 47 items / 46 deselected / 1 selected                                                                           

tests/foreman/cli/test_remoteexecution.py .                                                                         [100%]
```
