### PR TITLE
[6.13.z] Ansible_Job api test coverage [e2e]

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -16,6 +16,9 @@
 
 :Upstream: No
 """
+import pytest
+
+from robottelo.config import settings
 
 
 def test_fetch_and_sync_ansible_playbooks(target_sat):
@@ -59,3 +62,61 @@ def test_fetch_and_sync_ansible_playbooks(target_sat):
     )
     assert task_details[0].result == 'success'
     assert len(task_details[0].output['result']['created']) == playbooks_count
+
+
+@pytest.mark.e2e
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('[^6].*')
+def test_positive_ansible_job_on_host(target_sat, module_org, rhel_contenthost):
+    """
+    Test successful execution of Ansible Job on host.
+
+    :id: c8dcdc54-cb98-4b24-bff9-049a6cc36acb
+
+    :Steps:
+        1. Register a content host with satellite
+        2. Import a role into satellite
+        3. Assign that role to a host
+        4. Assert that the role was assigned to the host successfully
+        5. Run the Ansible playbook associated with that role
+        6. Check if the job is executed.
+
+    :expectedresults:
+        1. Host should be assigned the proper role.
+        2. Job execution must be successful.
+
+    :CaseAutomation: Automated
+    """
+    SELECTED_ROLE = 'RedHatInsights.insights-client'
+    if rhel_contenthost.os_version.major <= 7:
+        rhel_contenthost.create_custom_repos(rhel7=settings.repos.rhel7_os)
+        assert rhel_contenthost.execute('yum install -y insights-client').status == 0
+    rhel_contenthost.install_katello_ca(target_sat)
+    rhel_contenthost.register_contenthost(module_org.label, force=True)
+    assert rhel_contenthost.subscribed
+    rhel_contenthost.add_rex_key(satellite=target_sat)
+    id = target_sat.nailgun_smart_proxy.id
+    target_host = rhel_contenthost.nailgun_host
+    target_sat.api.AnsibleRoles().sync(data={'proxy_id': id, 'role_names': [SELECTED_ROLE]})
+    target_host.assign_ansible_roles(data={'ansible_role_ids': [1]})
+    host_roles = target_host.list_ansible_roles()
+    assert host_roles[0]['name'] == SELECTED_ROLE
+    assert target_host.name == rhel_contenthost.hostname
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Ansible Roles - Ansible Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'targeting_type': 'static_query',
+            'search_query': f'name = {rhel_contenthost.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}', poll_timeout=1000
+    )
+    result = target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 1


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10497

**Test results:**

```
pytest tests/foreman/api/test_ansible.py -k test_positive_ansible_job_on_host
============================================================== test session starts ===============================================================
platform linux -- Python 3.8.13, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: forked-1.4.0, services-2.2.1, cov-3.0.0, xdist-3.1.0, ibutsu-2.2.4, reportportal-5.1.3, mock-3.10.0
collected 4 items / 1 deselected / 3 selected                                                                                                    

tests/foreman/api/test_ansible.py ...                                                                                                      [100%]
============================================ 3 passed, 1 deselected, 5 warnings in 1487.51s (0:24:47) ============================================

```
Signed-off-by: Adarsh Dubey <addubey@redhat.com>