### PR TITLE
Revert to checking for type bytes in upload_manifest

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -1,5 +1,4 @@
 import contextlib
-import io
 import random
 import re
 
@@ -126,7 +125,7 @@ class ContentInfo:
             # Set the timeout to 1500 seconds to align with the API timeout.
             timeout = 1500000
         if interface == 'CLI':
-            if isinstance(manifest.content, io.BytesIO):
+            if isinstance(manifest.content, bytes):
                 self.put(f'{manifest.path}', f'{manifest.name}')
                 result = self.cli.Subscription.upload(
                     {'file': manifest.name, 'organization-id': org_id}, timeout=timeout
@@ -137,7 +136,7 @@ class ContentInfo:
                     {'file': manifest.filename, 'organization-id': org_id}, timeout=timeout
                 )
         else:
-            if not isinstance(manifest, io.BytesIO):
+            if not isinstance(manifest, bytes):
                 manifest = manifest.content
             result = self.api.Subscription().upload(
                 data={'organization_id': org_id}, files={'content': manifest}


### PR DESCRIPTION
https://github.com/SatelliteQE/robottelo/pull/10458 introduced a change to two conditional statements in the upload_manifest helper method in satellite_mixins.py. The statements were changed from checking for a manifest file of type `bytes` to one of `io.BytesIO`. This change causes failures in tests using the manifester org fixtures, as the `content` attribute of manifester manifests is a `bytes` object. The content of cloned manifests is an `io.BytesIO` object, but the conditionals in this method are designed around this difference, as the two types of manifests need to be processed slightly differently here. This PR reverts to checks for `bytes` objects rather than `io.BytesIO.`