### PR TITLE
replacing more cleaner way to handle the index error

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -58,11 +58,11 @@ jobs:
           api_endpoint="https://api.github.com/repos/${{github.repository}}/statuses/${{ github.head_ref }}"
 
           function get_status() {
-            curl -s "$api_endpoint"  | jq -r '.[0].state'
+            curl -s "$api_endpoint"  | jq '[.[] | .state] | .[0]'
           }
 
           function get_context() {
-            curl -s "$api_endpoint" | jq -r '.[0].context'
+            curl -s "$api_endpoint" | jq '[.[] | .context] | .[0]'
           }
 
           statuses_length=$(curl -s $api_endpoint | jq 'length')


### PR DESCRIPTION
This will fix the https://github.com/SatelliteQE/robottelo/actions/runs/3958806437/jobs/6780811639 error 

jq: error (at <stdin>:1): Cannot index object with number
Error: Process completed with exit code 5.