### PR TITLE
[6.13.z] patch to restart postfix.service

### DIFF
--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -394,7 +394,8 @@ def test_positive_update_email_delivery_method_sendmail(session, target_sat):
         "send_welcome_email": "Yes",
     }
     command = "grep " + f'{mail_config_new_params["email_subject_prefix"]}' + " /var/mail/root"
-
+    if target_sat.execute('systemctl status postfix').status != 0:
+        target_sat.execute('systemctl restart postfix')
     with session:
         try:
             for mail_content, mail_content_value in mail_config_new_params.items():


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10549

- One of UI test `test_positive_update_email_delivery_method_sendmail` was failing for 6.12 and 6.13 settings component 
- Figure out reason for failure which mentioned in BZ's #2080324, #2109421
- In this patch we are restarting `postfix.service` which allows to send email and new email will receive on email address configured in users email address in `/var/mail/root` 