### PR TITLE
[6.13z] Bump broker from 0.2.10 to 0.2.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Version updates managed by dependabot
 
-broker[docker]==0.2.10
+broker[docker]==0.2.11
 cryptography==39.0.0
 deepdiff==6.2.3
 dynaconf[vault]==3.1.11


### PR DESCRIPTION
Missed original cherry-pick, so starting that here.