### PR TITLE
[client, sync_plan, role] upgrade scenarios refactor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -35,6 +35,7 @@ pytest_plugins = [
     'pytest_fixtures.component.host',
     'pytest_fixtures.component.hostgroup',
     'pytest_fixtures.component.http_proxy',
+    'pytest_fixtures.component.katello_agent',
     'pytest_fixtures.component.katello_certs_check',
     'pytest_fixtures.component.lce',
     'pytest_fixtures.component.maintain',

--- a/pytest_fixtures/component/katello_agent.py
+++ b/pytest_fixtures/component/katello_agent.py
@@ -1,0 +1,53 @@
+import pytest
+from box import Box
+
+from robottelo.config import settings
+from robottelo.utils.installer import InstallerCommand
+
+
+@pytest.fixture(scope='module')
+def sat_with_katello_agent(module_target_sat):
+    """Enable katello-agent on module_target_sat"""
+    module_target_sat.register_to_cdn()
+    # Enable katello-agent from satellite-installer
+    result = module_target_sat.install(
+        InstallerCommand('foreman-proxy-content-enable-katello-agent true')
+    )
+    assert result.status == 0
+    # Verify katello-agent is enabled
+    result = module_target_sat.install(
+        InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
+    )
+    assert 'true' in result.stdout
+    yield module_target_sat
+
+
+@pytest.fixture
+def katello_agent_client_for_upgrade(sat_with_katello_agent, sat_upgrade_chost, module_org):
+    """Register content host to Satellite and install katello-agent on the host."""
+    client_repo = settings.repos['SATCLIENT_REPO'][f'RHEL{sat_upgrade_chost.os_version.major}']
+    sat_with_katello_agent.register_host_custom_repo(
+        module_org, sat_upgrade_chost, [client_repo, settings.repos.yum_1.url]
+    )
+    sat_upgrade_chost.install_katello_agent()
+    host_info = sat_with_katello_agent.cli.Host.info({'name': sat_upgrade_chost.hostname})
+    yield Box(
+        {
+            'client': sat_upgrade_chost,
+            'host_info': host_info,
+            'sat': sat_with_katello_agent,
+        }
+    )
+
+
+@pytest.fixture
+def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
+    """Register content host to Satellite and install katello-agent on the host."""
+    org = sat_with_katello_agent.api.Organization().create()
+    client_repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
+    sat_with_katello_agent.register_host_custom_repo(
+        org, rhel_contenthost, [client_repo, settings.repos.yum_1.url]
+    )
+    rhel_contenthost.install_katello_agent()
+    host_info = sat_with_katello_agent.cli.Host.info({'name': rhel_contenthost.hostname})
+    yield Box({'client': rhel_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent})

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -220,3 +220,11 @@ def sat_ready_rhel(request):
     deploy_args['target_memory'] = '20GiB'
     with Broker(**deploy_args, host_class=ContentHost) as host:
         yield host
+
+
+@pytest.fixture(scope="module")
+def sat_upgrade_chost():
+    """A module-level fixture that provides a UBI_8 content host for upgrade scenario testing"""
+    return Broker(
+        container_host=settings.content_host.rhel8.container.container_host, host_class=ContentHost
+    ).checkout()

--- a/robottelo/cli/simple_content_access.py
+++ b/robottelo/cli/simple_content_access.py
@@ -1,0 +1,45 @@
+"""
+Usage::
+
+    hammer simple-content-access [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    disable                       Disable simple content access for a manifest
+    enable                        Enable simple content access for a manifest
+    status                        Check if the specified organization has
+                                  Simple Content Access enabled
+
+"""
+from robottelo.cli.base import Base
+
+
+class SimpleContentAccess(Base):
+    """
+    Manipulates Katello engine's simple-content-access command.
+    """
+
+    command_base = 'simple-content-access'
+
+    @classmethod
+    def disable(cls, options=None, timeout=None):
+        """Disable simple content access for a manifest"""
+        cls.command_sub = 'disable'
+        return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)
+
+    @classmethod
+    def enable(cls, options=None, timeout=None):
+        """Enable simple content access for a manifest"""
+        cls.command_sub = 'enable'
+        return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)
+
+    @classmethod
+    def status(cls, options=None, timeout=None):
+        """Check if the specified organization has Simple Content Access enabled"""
+        cls.command_sub = 'status'
+        return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -1,7 +1,7 @@
 """
 Usage::
 
-    hammer sunscription [OPTIONS] SUBCOMMAND [ARG] ...
+    hammer subscription [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters::
 

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -20,7 +20,6 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.utils.installer import InstallerCommand
 
 pytestmark = [
     pytest.mark.run_in_one_thread,
@@ -28,36 +27,6 @@ pytestmark = [
     pytest.mark.tier5,
     pytest.mark.upgrade,
 ]
-
-
-@pytest.fixture(scope='module')
-def sat_with_katello_agent(module_target_sat):
-    """Enable katello-agent on module_target_sat"""
-    module_target_sat.register_to_cdn()
-    # Enable katello-agent from satellite-installer
-    result = module_target_sat.install(
-        InstallerCommand('foreman-proxy-content-enable-katello-agent true')
-    )
-    assert result.status == 0
-    # Verify katello-agent is enabled
-    result = module_target_sat.install(
-        InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
-    )
-    assert 'true' in result.stdout
-    yield module_target_sat
-
-
-@pytest.fixture
-def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
-    """Register content host to Satellite and install katello-agent on the host."""
-    org = sat_with_katello_agent.api.Organization().create()
-    client_repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
-    sat_with_katello_agent.register_host_custom_repo(
-        org, rhel_contenthost, [client_repo, settings.repos.yum_1.url]
-    )
-    rhel_contenthost.install_katello_agent()
-    host_info = sat_with_katello_agent.cli.Host.info({'name': rhel_contenthost.hostname})
-    yield {'client': rhel_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent}
 
 
 @pytest.mark.rhel_ver_match(r'[\d]+')

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -53,11 +53,6 @@ def validate_repo_content(repo, content_types, after_sync=True):
             ), 'Repository contains invalid number of content entities.'
 
 
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
-
-
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_org):
     """Perform end to end scenario for sync plan component

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -22,92 +22,10 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 import time
 
 import pytest
-from fabric.api import execute
-from upgrade.helpers.docker import docker_execute_command
-from upgrade_tests.helpers.scenarios import dockerize
+from broker import Broker
 
-from robottelo.config import settings
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE
-from robottelo.constants import REPOS
-
-
-# host machine for containers
-docker_vm = settings.upgrade.docker_vm
-
-
-@pytest.fixture(scope='module')
-def pre_upgrade_repo(module_product, module_target_sat):
-    """Enable custom errata repository"""
-    pre_upgrade_repo = module_target_sat.api.Repository(
-        url=settings.repos.yum_0.url, product=module_product
-    ).create()
-    assert pre_upgrade_repo.sync()['result'] == 'success'
-    return pre_upgrade_repo
-
-
-@pytest.fixture(scope='module')
-def post_upgrade_repo(module_product, module_target_sat):
-    """Enable custom errata repository"""
-    post_upgrade_repo = module_target_sat.api.Repository(
-        url=settings.repos.yum_9.url, product=module_product
-    ).create()
-    assert post_upgrade_repo.sync()['result'] == 'success'
-    return post_upgrade_repo
-
-
-@pytest.fixture(scope='module')
-def pre_upgrade_cv(default_org, pre_upgrade_repo, module_target_sat):
-    """Create and publish repo"""
-    pre_upgrade_cv = module_target_sat.api.ContentView(
-        organization=default_org, repository=[pre_upgrade_repo.id]
-    ).create()
-    pre_upgrade_cv.publish()
-    pre_upgrade_cv = pre_upgrade_cv.read()
-    return pre_upgrade_cv
-
-
-@pytest.fixture(scope='module')
-def post_upgrade_cv(default_org, post_upgrade_repo, module_target_sat):
-    """Create and publish repo"""
-    post_upgrade_cv = module_target_sat.api.ContentView(
-        organization=default_org, repository=[post_upgrade_repo.id]
-    ).create()
-    post_upgrade_cv.publish()
-    post_upgrade_cv = post_upgrade_cv.read()
-    return post_upgrade_cv
-
-
-@pytest.fixture(scope='module')
-def module_ak(default_org, module_lce_library, pre_upgrade_repo, module_product, module_target_sat):
-    """Create a module AK in Library LCE"""
-    ak = module_target_sat.api.ActivationKey(
-        content_view=DEFAULT_CV,
-        environment=module_lce_library,
-        organization=default_org,
-    ).create()
-    # Fetch available subscriptions
-    subs = module_target_sat.api.Subscription(organization=default_org).search()
-    assert len(subs) > 0
-    # Add default subscription to activation key
-    sub_found = False
-    for sub in subs:
-        if sub.name == DEFAULT_SUBSCRIPTION_NAME:
-            ak.add_subscriptions(data={'subscription_id': sub.id})
-            sub_found = True
-    assert sub_found
-    # Enable RHEL tools repo in activation key
-    ak.content_override(
-        data={'content_overrides': [{'content_label': REPOS['rhst7']['id'], 'value': '1'}]}
-    )
-    # Add custom subscription to activation key
-    custom_sub = module_target_sat.api.Subscription().search(
-        query={'search': f'name={module_product.name}'}
-    )
-    ak.add_subscriptions(data={'subscription_id': custom_sub[0].id})
-    return ak
+from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
+from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
 
 
 class TestScenarioUpgradeOldClientAndPackageInstallation:
@@ -124,8 +42,8 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_scenario_preclient_package_installation(
-        default_org, pre_upgrade_cv, pre_upgrade_repo, module_ak, save_test_data
+    def test_pre_scenario_pre_client_package_installation(
+        self, katello_agent_client_for_upgrade, module_org, module_target_sat, save_test_data
     ):
         """Create product and repo, from which a package will be installed
         post upgrade. Create a content host and register it.
@@ -149,42 +67,36 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
             2. The new repo is enabled on the content host.
 
         """
-        rhel7_client = dockerize(
-            ak_name=module_ak.name, distro='rhel7', org_label=default_org.label
-        )
-        client_container_id = list(rhel7_client.values())[0]
-        # Wait 60 seconds as script in /tmp takes up to 2 min inc the repo sync time
-        time.sleep(60)
-        # Use yum install again in case script was not yet finished
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            'yum -y install katello-agent',
-            host=docker_vm,
-        )[docker_vm]
-        # Assert gofer was installed after yum completes
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            'rpm -q gofer',
-            host=docker_vm,
-        )[docker_vm]
-        assert 'package gofer is not installed' not in installed_package
+        rhel_client = katello_agent_client_for_upgrade.client
+        rhid = rhel_client.execute('subscription-manager identity')
+        assert module_org.name in rhid.stdout
+        result = rhel_client.execute('rpm -q gofer')
+        assert result.status == 0
+        assert 'package gofer is not installed' not in result.stdout
         # Run goferd on client as its docker container
-        kwargs = {'async': True, 'host': docker_vm}
-        execute(docker_execute_command, client_container_id, 'goferd -f', **kwargs)
+        rhel_client._cont_inst.exec_run('goferd -f', detach=True)
         # Holding on for 30 seconds while goferd starts
         time.sleep(30)
-        status = execute(docker_execute_command, client_container_id, 'ps -aux', host=docker_vm)[
-            docker_vm
-        ]
-        assert 'goferd' in status
-        # Save client info to disk for post-upgrade test
-        save_test_data({__name__: rhel7_client})
+        rhel_client.execute('yum install -y procps')  # ps command needs to be installed
+        result = rhel_client.execute("ps -ef | grep goferd")
+        assert 'goferd' in result.stdout
+        module_target_sat.cli.Host.package_install(
+            {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_4_CUSTOM_PACKAGE_NAME}
+        )
+        result = rhel_client.execute(f"rpm -q {FAKE_4_CUSTOM_PACKAGE_NAME}")
+        assert FAKE_4_CUSTOM_PACKAGE_NAME in result.stdout
 
-    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_preclient_package_installation)
-    def test_post_scenario_preclient_package_installation(
-        default_org, module_target_sat, pre_upgrade_data
+        # Save client info to disk for post-upgrade test
+        save_test_data(
+            {
+                'rhel_client': rhel_client.hostname,
+                'org_id': module_org.id,
+            }
+        )
+
+    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_pre_client_package_installation)
+    def test_post_scenario_pre_client_package_installation(
+        self, module_target_sat, pre_upgrade_data
     ):
         """Post-upgrade install of a package on a client created and registered pre-upgrade.
 
@@ -194,27 +106,17 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
 
         :expectedresults: The package is installed on client
         """
-        client = pre_upgrade_data.get(__name__)
-        client_name = str(list(client.keys())[0]).lower()
+        client_name = pre_upgrade_data.get('rhel_client')
         client_id = (
             module_target_sat.api.Host().search(query={'search': f'name={client_name}'})[0].id
         )
-        module_target_sat.api.Host().install_content(
-            data={
-                'organization_id': default_org.id,
-                'included': {'ids': [client_id]},
-                'content_type': 'package',
-                'content': [FAKE_0_CUSTOM_PACKAGE],
-            }
+        module_target_sat.cli.Host.package_install(
+            {'host-id': client_id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )
         # Verifies that package is really installed
-        installed_package = execute(
-            docker_execute_command,
-            list(client.values())[0],
-            f'rpm -q {FAKE_0_CUSTOM_PACKAGE}',
-            host=docker_vm,
-        )[docker_vm]
-        assert FAKE_0_CUSTOM_PACKAGE in installed_package
+        rhel_client = Broker().from_inventory(filter=f'hostname={client_name}')[0]
+        result = rhel_client.execute(f"rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}")
+        assert FAKE_0_CUSTOM_PACKAGE_NAME in result.stdout
 
 
 class TestScenarioUpgradeNewClientAndPackageInstallation:
@@ -231,8 +133,8 @@ class TestScenarioUpgradeNewClientAndPackageInstallation:
     """
 
     @pytest.mark.post_upgrade
-    def test_post_scenario_postclient_package_installation(
-        default_org, post_upgrade_repo, module_ak, module_target_sat, module_lce
+    def test_post_scenario_post_client_package_installation(
+        self, module_target_sat, katello_agent_client_for_upgrade, module_org
     ):
         """Post-upgrade test that creates a client, installs a package on
         the post-upgrade created client and then verifies the package is installed.
@@ -254,53 +156,22 @@ class TestScenarioUpgradeNewClientAndPackageInstallation:
                 the content host is created
             3. The package is installed on post-upgrade client
         """
-        rhel7_client = dockerize(
-            ak_name=module_ak.name, distro='rhel7', org_label=default_org.label
-        )
-        client_container_id = list(rhel7_client.values())[0]
-        client_name = list(rhel7_client.keys())[0].lower()
-        # Wait 60 seconds as script in /tmp takes up to 2 min inc the repo sync time
-        time.sleep(60)
-        # Use yum install again in case script was not yet finished
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            'yum -y install katello-agent',
-            host=docker_vm,
-        )[docker_vm]
-        # Assert gofer was installed after yum completes
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            'rpm -q gofer',
-            host=docker_vm,
-        )[docker_vm]
-        assert 'package gofer is not installed' not in installed_package
+        rhel_client = katello_agent_client_for_upgrade.client
+        rhid = rhel_client.execute('subscription-manager identity')
+        assert module_org.name in rhid.stdout
+        result = rhel_client.execute('rpm -q gofer')
+        assert result.status == 0
+        assert 'package gofer is not installed' not in result.stdout
         # Run goferd on client as its docker container
-        kwargs = {'async': True, 'host': docker_vm}
-        execute(docker_execute_command, client_container_id, 'goferd -f', **kwargs)
+        rhel_client._cont_inst.exec_run('goferd -f', detach=True)
         # Holding on for 30 seconds while goferd starts
         time.sleep(30)
-        status = execute(docker_execute_command, client_container_id, 'ps -aux', host=docker_vm)[
-            docker_vm
-        ]
-        assert 'goferd' in status
-        client_id = (
-            module_target_sat.api.Host().search(query={'search': f'name={client_name}'})[0].id
+        rhel_client.execute('yum install -y procps')  # ps command needs to be installed
+        result = rhel_client.execute("ps -ef | grep goferd")
+        assert 'goferd' in result.stdout
+        module_target_sat.cli.Host.package_install(
+            {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )
-        module_target_sat.api.Host().install_content(
-            data={
-                'organization_id': default_org.id,
-                'included': {'ids': [client_id]},
-                'content_type': 'package',
-                'content': [FAKE_4_CUSTOM_PACKAGE],
-            }
-        )
-        # Validate if that package is really installed
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            f'rpm -q {FAKE_4_CUSTOM_PACKAGE}',
-            host=docker_vm,
-        )[docker_vm]
-        assert FAKE_4_CUSTOM_PACKAGE in installed_package
+        # Verifies that package is really installed
+        result = rhel_client.execute(f"rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}")
+        assert FAKE_0_CUSTOM_PACKAGE_NAME in result.stdout

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -17,7 +17,6 @@
 :Upstream: No
 """
 import pytest
-from nailgun import entities
 
 
 @pytest.mark.stubbed
@@ -162,7 +161,7 @@ class TestRoleAddPermission:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_default_role_added_permission(self):
+    def test_pre_default_role_added_permission(self, target_sat):
         """New permission is added to Default Role
 
         :id: preupgrade-3a350e4a-96b3-4033-b562-3130fc43a4bc
@@ -172,17 +171,17 @@ class TestRoleAddPermission:
         :expectedresults: Permission is added to existing 'Default role'.
 
         """
-        defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
-        subnetfilter = entities.Filter(
-            permission=entities.Permission().search(
+        default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
+        subnet_filter = target_sat.api.Filter(
+            permission=target_sat.api.Permission().search(
                 filters={'name': 'view_subnets'}, query={'search': 'resource_type="Subnet"'}
             ),
-            role=defaultrole,
+            role=default_role,
         ).create()
-        assert subnetfilter.id in [filt.id for filt in defaultrole.read().filters]
+        assert subnet_filter.id in [filt.id for filt in default_role.read().filters]
 
     @pytest.mark.post_upgrade(depend_on=test_pre_default_role_added_permission)
-    def test_post_default_role_added_permission(self):
+    def test_post_default_role_added_permission(self, target_sat):
         """The new permission in 'Default role' is intact post upgrade
 
         :id: postupgrade-3a350e4a-96b3-4033-b562-3130fc43a4bc
@@ -190,13 +189,13 @@ class TestRoleAddPermission:
         :expectedresults: The added permission in existing 'Default role' is
             intact post upgrade
         """
-        defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
-        subnetfilt = entities.Filter().search(
-            query={'search': f'role_id={defaultrole.id} and permission="view_subnets"'}
+        default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
+        subnet_filter = target_sat.api.Filter().search(
+            query={'search': f'role_id={default_role.id} and permission="view_subnets"'}
         )
-        assert subnetfilt
+        assert subnet_filter
         # Teardown
-        subnetfilt[0].delete()
+        subnet_filter[0].delete()
 
 
 class TestRoleAddPermissionWithFilter:
@@ -216,7 +215,7 @@ class TestRoleAddPermissionWithFilter:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_default_role_added_permission_with_filter(self):
+    def test_pre_default_role_added_permission_with_filter(self, target_sat):
         """New permission with filter is added to Default Role
 
         :id: preupgrade-b287b71c-42fd-4612-a67a-b93d47dbbb33
@@ -227,19 +226,19 @@ class TestRoleAddPermissionWithFilter:
             'Default role'
 
         """
-        defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
-        domainfilter = entities.Filter(
-            permission=entities.Permission().search(
+        default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
+        domain_filter = target_sat.api.Filter(
+            permission=target_sat.api.Permission().search(
                 filters={'name': 'view_domains'}, query={'search': 'resource_type="Domain"'}
             ),
             unlimited=False,
-            role=defaultrole,
+            role=default_role,
             search='name ~ a',
         ).create()
-        assert domainfilter.id in [filt.id for filt in defaultrole.read().filters]
+        assert domain_filter.id in [filt.id for filt in default_role.read().filters]
 
     @pytest.mark.post_upgrade(depend_on=test_pre_default_role_added_permission_with_filter)
-    def test_post_default_role_added_permission_with_filter(self):
+    def test_post_default_role_added_permission_with_filter(self, target_sat):
         """The new permission with filter in 'Default role' is intact post
             upgrade
 
@@ -248,11 +247,11 @@ class TestRoleAddPermissionWithFilter:
         :expectedresults: The added permission with filter in existing
             'Default role' is intact post upgrade
         """
-        defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
-        domainfilt = entities.Filter().search(
-            query={'search': f'role_id={defaultrole.id} and permission="view_domains"'}
+        default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
+        domain_filter = target_sat.api.Filter().search(
+            query={'search': f'role_id={default_role.id} and permission="view_domains"'}
         )
-        assert domainfilt
-        assert domainfilt[0].search == 'name ~ a'
+        assert domain_filter
+        assert domain_filter[0].search == 'name ~ a'
         # Teardown
-        domainfilt[0].delete()
+        domain_filter[0].delete()


### PR DESCRIPTION
Upgrade Scenario Refactor 

- [x] - test_role.py, test_sync_plan.py now uses the target_sat and removed the import entities 
- [x] - test_client.py now uses the broker to manage the RHEL clients 
- [x] - test_client.py moved rhel7 support to rhel8 for time being (needs to add more RHEL client support)
- [x] - refactor the test_client.py with new fixtures, for smooth running 
- [x] -  added support for simple-content-access cli 