### PR TITLE
[6.13.z] Added a skip marker for failing tests of fact component

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -25,6 +25,7 @@ from robottelo.cli.fact import Fact
 pytestmark = [pytest.mark.tier1]
 
 
+@pytest.mark.skip_if_open('BZ:2161294')
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'fact', ['uptime', 'os::family', 'uptime_seconds', 'memorysize', 'ipaddress']
@@ -37,6 +38,8 @@ def test_positive_list_by_name(fact):
     :expectedresults: Fact List is displayed
 
     :parametrized: yes
+
+    :BZ: 2161294
     """
     facts = Fact().list(options={'search': f'fact={fact}'})
     assert facts[0]['fact'] == fact


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10548

Found a bug while doing the Test analysis of the issues present in the 'test_fact' component. Specifically few API calls were broken to the hammer commands
Therefore added the skip marker and filled the BZ 2161294