### PR TITLE
Allow uploading cloned and manifester manifests

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -1,4 +1,5 @@
 import contextlib
+import io
 import random
 import re
 
@@ -125,7 +126,7 @@ class ContentInfo:
             # Set the timeout to 1500 seconds to align with the API timeout.
             timeout = 1500000
         if interface == 'CLI':
-            if isinstance(manifest.content, bytes):
+            if isinstance(manifest.content, (bytes, io.BytesIO)):
                 self.put(f'{manifest.path}', f'{manifest.name}')
                 result = self.cli.Subscription.upload(
                     {'file': manifest.name, 'organization-id': org_id}, timeout=timeout
@@ -136,7 +137,7 @@ class ContentInfo:
                     {'file': manifest.filename, 'organization-id': org_id}, timeout=timeout
                 )
         else:
-            if not isinstance(manifest, bytes):
+            if not isinstance(manifest, (bytes, io.BytesIO)):
                 manifest = manifest.content
             result = self.api.Subscription().upload(
                 data={'organization_id': org_id}, files={'content': manifest}


### PR DESCRIPTION
After my recent PR reverting the change to the `isinstance` check in `upload_manifest`, @Gauravtalreja1 pointed out to me that one of his PRs was now failing on uploading manifests. That test was using cloned manifests. This made me realize that, while the manifester conversions are still in progress, we need to account for the possibility of either type of manifest being used by a test. This PR modifies the `isinstance` check to allow either type `bytes` or type `io.BytesIO`. This should resolve both the errors that Gaurav encountered that caused him to make the change initially and the errors that I encountered after that change was merged.