### PR TITLE
Fixing installer test failures

### DIFF
--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -57,7 +57,7 @@ def test_installer_sat_pub_directory_accessibility(target_sat):
     https_curl_command = f'curl -i {target_sat.url}/pub/ -k'
     for command in [http_curl_command, https_curl_command]:
         accessibility_check = target_sat.execute(command)
-        assert 'HTTP/1.1 200 OK' in accessibility_check.stdout.split('\r\n')
+        assert 'HTTP/1.1 200 OK' or 'HTTP/2 200 ' in accessibility_check.stdout.split('\r\n')
     target_sat.get(
         local_path='custom-hiera-satellite.yaml',
         remote_path=f'{custom_hiera_location}',
@@ -67,7 +67,7 @@ def test_installer_sat_pub_directory_accessibility(target_sat):
     assert 'Success!' in command_output.stdout
     for command in [http_curl_command, https_curl_command]:
         accessibility_check = target_sat.execute(command)
-        assert 'HTTP/1.1 200 OK' not in accessibility_check.stdout.split('\r\n')
+        assert 'HTTP/1.1 200 OK' or 'HTTP/2 200 ' not in accessibility_check.stdout.split('\r\n')
     target_sat.put(
         local_path='custom-hiera-satellite.yaml',
         remote_path=f'{custom_hiera_location}',

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -16,8 +16,6 @@
 
 :Upstream: No
 """
-import re
-
 import pytest
 
 from robottelo import ssh
@@ -1301,8 +1299,8 @@ def extract_help(filter='params'):
 
 @pytest.mark.upgrade
 @pytest.mark.tier1
-def test_positive_foreman_module(target_sat):
-    """Check if SELinux foreman module has the right version
+def test_positive_selinux_foreman_module(target_sat):
+    """Check if SELinux foreman module is installed on Satellite
 
     :id: a0736b3a-3d42-4a09-a11a-28c1d58214a5
 
@@ -1312,21 +1310,13 @@ def test_positive_foreman_module(target_sat):
 
     :CaseLevel: System
 
-    :expectedresults: Foreman RPM and SELinux module versions match
+    :expectedresults: Foreman RPM and SELinux module are both present on the satellite
     """
     rpm_result = target_sat.execute('rpm -q foreman-selinux')
     assert rpm_result.status == 0
 
     semodule_result = target_sat.execute('semodule -l | grep foreman')
     assert semodule_result.status == 0
-
-    # Sample rpm output: foreman-selinux-1.7.2.8-1.el7sat.noarch
-    version_regex = re.compile(r'((\d\.?)+[-.]\d)')
-    rpm_version = version_regex.search(rpm_result.stdout).group(1)
-    # Sample semodule output: foreman        1.7.2.8
-    semodule_version = version_regex.search(semodule_result.stdout).group(1)
-    rpm_version = rpm_version[:-2]
-    assert rpm_version.replace('-', '.') == semodule_version
 
 
 @pytest.mark.upgrade
@@ -1697,7 +1687,7 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
     https_curl_command = f'curl -i {capsule_configured.url}/pub/ -k'
     for command in [http_curl_command, https_curl_command]:
         accessibility_check = capsule_configured.execute(command)
-        assert 'HTTP/1.1 200 OK' in accessibility_check.stdout.split('\r\n')
+        assert 'HTTP/1.1 200 OK' or 'HTTP/2 200 ' in accessibility_check.stdout.split('\r\n')
     capsule_configured.get(
         local_path='custom-hiera-capsule.yaml',
         remote_path=f'{custom_hiera_location}',
@@ -1707,7 +1697,7 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
     assert 'Success!' in command_output.stdout
     for command in [http_curl_command, https_curl_command]:
         accessibility_check = capsule_configured.execute(command)
-        assert 'HTTP/1.1 200 OK' not in accessibility_check.stdout.split('\r\n')
+        assert 'HTTP/1.1 200 OK' or 'HTTP/2 200 ' not in accessibility_check.stdout.split('\r\n')
     capsule_configured.put(
         local_path='custom-hiera-capsule.yaml',
         remote_path=f'{custom_hiera_location}',


### PR DESCRIPTION
Saw some failures in the most recent installer component run that needed some quick fixes.

`test_installer_sat_pub_directory_accessibility` and `test_installer_cap_pub_directory_accessibility`

- Both of these were failing because sometimes the command returns `HTTP/2 200 ` (yes with a space) and other times you can get the `HTTP/1.1`. So just adding both to the assertion should be good. Also should be fine for cherry-picking back since we are using `or`

`test_positive_foreman_module`

- We really ought to rename this `test_positive_selinux_foreman_module`
- On RHEL 8, `semodule -l` no longer returns package version, so let's just limit this test to assert both the module and rpm are present on the satellite

Results:
```
============================= test session starts ==============================
platform linux -- Python 3.11.1, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, ibutsu-2.2.4, xdist-3.1.0, reportportal-5.1.3
collected 1 item

tests/foreman/installer/test_installer.py ..                              [100%]

================== 2 passed, 1 warning in 1277.36s (0:21:17) ===================

============================= test session starts ==============================
platform linux -- Python 3.11.1, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, ibutsu-2.2.4, xdist-3.1.0, reportportal-5.1.3
collected 1 item

tests/foreman/destructive/test_installer.py .                            [100%]

=================== 1 passed, 1 warning in 661.32s (0:11:01) ===================
```