### PR TITLE
[6.11.z] Fix broker logging settings

### DIFF
--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -9,6 +9,7 @@ from robottelo.logging import DEFAULT_DATE_FORMAT
 from robottelo.logging import logger
 from robottelo.logging import robottelo_log_dir
 from robottelo.logging import robottelo_log_file
+from robottelo.logging import logging_yaml
 
 try:
     from pytest_reportportal import RPLogger
@@ -55,8 +56,11 @@ def configure_logging(request, worker_id):
             worker_handler.setFormatter(worker_formatter)
             worker_handler.setLevel(worker_log_level)
             logger.addHandler(worker_handler)
-
-            broker_log_setup('debug', robottelo_log_dir.joinpath(f'robottelo_{worker_id}.log'))
+            broker_log_setup(
+                level=logging_yaml.broker.level,
+                file_level=logging_yaml.broker.fileLevel,
+                path=robottelo_log_dir.joinpath(f'robottelo_{worker_id}.log'),
+            )
 
             if use_rp_logger:
                 rp_handler = RPLogHandler(request.node.config.py_test_service)

--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -7,9 +7,9 @@ from xdist import is_xdist_worker
 from robottelo.logging import broker_log_setup
 from robottelo.logging import DEFAULT_DATE_FORMAT
 from robottelo.logging import logger
+from robottelo.logging import logging_yaml
 from robottelo.logging import robottelo_log_dir
 from robottelo.logging import robottelo_log_file
-from robottelo.logging import logging_yaml
 
 try:
     from pytest_reportportal import RPLogger

--- a/robottelo/logging.py
+++ b/robottelo/logging.py
@@ -58,7 +58,11 @@ def configure_third_party_logging():
 
 
 configure_third_party_logging()
-broker_log_setup(logging_yaml.robottelo.fileLevel, str(robottelo_log_file))
+broker_log_setup(
+    level=logging_yaml.robottelo.level,
+    file_level=logging_yaml.robottelo.fileLevel,
+    path=str(robottelo_log_file),
+)
 manifester_log_setup(logging_yaml.robottelo.fileLevel, str(robottelo_log_file))
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10597

We have added a new kwarg `file_level` in `setup_logzero` method that broke robottelo as we did not supply this argument

The fix was to add that argument to the function call. Additionally the logging settings have changed in a way that robottelo now reads the log level from `logging.yaml` file. `XDIST_BEHAVIOR` was set to on-demand. I have forced xdist to distribute the test across two workers `-n 2`. The following log files were created in the empty `logs/` directory.

```
broker.log
manifester.log
robottelo_gw0.log
robottelo_gw1.log
robottelo.log
```

I have observed that broker logged in at the debug level.

```
2023-01-31 19:09:57 - gw1 - robottelo - DEBUG - Resolved deploy arguments for sat: {'deploy_snap_version': 16.0, 'deploy_sat_version': '6.12.0', 'deploy_rhel_version': 8.7}
```



### Tests

I have used `test_ping.py` which contains exactly two tests.
At the test run I had two Satellites in `settings.server.hostnames`

```
$ pytest tests/foreman/cli/test_ping.py -n 2
================================================================== test session starts ==================================================================
platform linux -- Python 3.11.1, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ogajduse/repos/robottelo, configfile: pyproject.toml
plugins: xdist-3.1.0, services-2.2.1, reportportal-5.1.3, mock-3.10.0, ibutsu-2.2.4
gw0 [2] / gw1 [2]
..                                                                                                                                                [100%]
================================================================== 2 passed in 16.36s ===================================================================
2023-01-31 19:09:50 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    vlan_networking.subnet is required in env main
2023-01-31 19:09:50 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    vlan_networking.subnet is required in env main
```

### Note

With the current implementation we are not able to set the broker log level to **TRACE**. See the following traceback.

```
File "/home/ogajduse/repos/robottelo/robottelo/config/__init__.py", line 11, in <module>
    from robottelo.logging import logger
  File "/home/ogajduse/repos/robottelo/robottelo/logging.py", line 60, in <module>
    configure_third_party_logging()
  File "/home/ogajduse/repos/robottelo/robottelo/logging.py", line 57, in configure_third_party_logging
    logging.getLogger(logger_name).setLevel(logger_levels['fileLevel'])
  File "/usr/lib64/python3.11/logging/__init__.py", line 1464, in setLevel
    self.level = _checkLevel(level)
                 ^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/logging/__init__.py", line 207, in _checkLevel
    raise ValueError("Unknown level: %r" % level)
ValueError: Unknown level: 'TRACE'
```