### PR TITLE
[6.11.z] added fix for the auto-merge do not run on master

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   automerge:
     name: Automerge auto-cherry-picked pr
-    if: contains(github.event.pull_request.labels.*.name, 'AutoMerge_Cherry_Picked')
+    if: contains(github.event.pull_request.labels.*.name, 'AutoMerge_Cherry_Picked') && contains(github.event.pull_request.labels.*.name, 'Auto_Cherry_Picked')
     runs-on: ubuntu-latest
     steps:
       - id: find-prt-comment


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10607

null