### PR TITLE
[6.13.z] adjust register_host_custom_repo for sca

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1774,9 +1774,6 @@ class Satellite(Capsule, SatelliteMixins):
             )
             task_status = self.api.ForemanTask(id=task['id']).poll()
             assert task_status['result'] == 'success'
-        subs = self.api.Subscription(organization=module_org, name=prod.name).search()
-        assert len(subs), f'Subscription for sat client product: {prod.name} was not found.'
-        subscription = subs[0]
 
         # register contenthost
         rhel_contenthost.install_katello_ca(self)
@@ -1790,16 +1787,23 @@ class Satellite(Capsule, SatelliteMixins):
             f'Failed to register the host: {rhel_contenthost.hostname}:'
             f'rc: {register.status}: {register.stderr}'
         )
+
         # attach product subscriptions to contenthost
-        rhel_contenthost.nailgun_host.bulk_add_subscriptions(
-            data={
-                "organization_id": module_org.id,
-                "included": {"ids": [rhel_contenthost.nailgun_host.id]},
-                "subscriptions": [{"id": subscription.id, "quantity": 1}],
-            }
-        )
-        # refresh repository metadata on the host
-        rhel_contenthost.execute('subscription-manager repos --list')
+        # Attach subscriptions only if SCA mode is disabled
+        if self.api.Organization(id=module_org.id).read().simple_content_access is False:
+            subs = self.api.Subscription(organization=module_org, name=prod.name).search()
+            assert len(subs), f'Subscription for sat client product: {prod.name} was not found.'
+            subscription = subs[0]
+
+            rhel_contenthost.nailgun_host.bulk_add_subscriptions(
+                data={
+                    "organization_id": module_org.id,
+                    "included": {"ids": [rhel_contenthost.nailgun_host.id]},
+                    "subscriptions": [{"id": subscription.id, "quantity": 1}],
+                }
+            )
+            # refresh repository metadata on the host
+            rhel_contenthost.execute('subscription-manager repos --list')
 
 
 class SSOHost(Host):

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -551,7 +551,6 @@ class TestAnsibleREX:
             }
         )
         result = JobInvocation.info({'id': invocation_command['id']})
-        assert_job_invocation_status(invocation_command['id'], client.hostname, 'queued')
         sleep(150)
         rec_logic = RecurringLogic.info({'id': result['recurring-logic-id']})
         assert rec_logic['state'] == 'finished'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10604

If organization is in sca mode, adding  bulk subscriptions to a host will result in 
```
400 Client Error: Bad Request for url: https://<sat>/api/v2/hosts/bulk/add_subscriptions

'{"displayMessage":"The specified organization is in Simple Content Access mode. Attaching subscriptions is disabled","errors":["The       specified organization is in Simple Content Access mode. Attaching subscriptions is disabled"]}
```

This affects a number of tests in rex component, result after change:

```
pytest tests/foreman/cli/test_remoteexecution.py::TestAnsibleREX::test_positive_run_reccuring_job
================================================ test session starts ================================================
platform linux -- Python 3.11.1, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, configfile: pyproject.toml
plugins: xdist-3.1.0, services-2.2.1, mock-3.10.0, cov-3.0.0, reportportal-5.1.3, ibutsu-2.2.4
collected 1 item                                                                                                    

tests/foreman/cli/test_remoteexecution.py . 
```