### PR TITLE
[6.13.z] Add external-logging option

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ import pytest
 pytest_plugins = [
     # Plugins
     'pytest_plugins.disable_rp_params',
+    'pytest_plugins.external_logging',
     'pytest_plugins.fixture_markers',
     'pytest_plugins.infra_dependent_markers',
     'pytest_plugins.issue_handlers',

--- a/pytest_plugins/external_logging.py
+++ b/pytest_plugins/external_logging.py
@@ -1,0 +1,26 @@
+from robottelo.config import settings
+
+
+def pytest_addoption(parser):
+    """Adds option for enabling external logging"""
+    help_text = '''
+        Flag for enabling promtail on the spawned hosts.
+        This is used for sending of the logs to the external Loki instance
+
+        Usage: --external_logging
+    '''
+    parser.addoption("--external-logging", action="store_true", default=False, help=help_text)
+
+
+def pytest_cmdline_main(config):
+    if not config.getoption('external_logging', False):
+        return
+    settings.set('server.deploy_arguments.promtail_enable', True)
+    settings.set('capsule.deploy_arguments.promtail_enable', True)
+    ch = settings.content_host
+    for os in [i for i in ch if isinstance(ch[i], dict) and ch[i].get('vm')]:
+        ch[os]['vm']['promtail_enable'] = True
+    # update the container env too, if available
+    promtail_var = {'PROMTAIL_ENABLE': "True"}
+    for os in [i for i in ch if isinstance(ch[i], dict) and ch[i].get('container')]:
+        settings.set(f'content_host.{os}.container.environment', promtail_var)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10540

adds a cli option (`--external_logging`) for enabling external logging (promtail->loki) on the provisioned VMs and Containers.
The plugin simply adds the appropriate extra arg (for vms) or env var (for containers) for all os versions existing in `supportability.yml`, as well as to the extra vars of the satellite server deploy options