### PR TITLE
[6.12.z] Fixing false assertion in Infrastructure test

### DIFF
--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -65,7 +65,6 @@ def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
     assert result.status == 0
     assert target_sat.cli.Service.stop(options={'only': 'foreman'}).status == 0
     assert target_sat.cli.Service.status(options={'only': 'foreman'}).status == 1
-    assert result.status == 1
     result = rhel7_contenthost.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
     assert result.status == 0
     assert target_sat.cli.Service.start(options={'only': 'foreman'}).status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10631

I'm not sure what the original intent of the assertion here was, but as you can see we store `result` as a variable for installing a package and then assert `result.status == 0`. However, a few lines later we had an assertion with the same variable (with no changes) for `result.status == 1`. This was causing a failure for the test as obviously the status is 0. I also disabled SCA as that was causing a failure on 6.13. This has passed on both 6.12 and 6.13.