### PR TITLE
Revert change to activation key creation in tests

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -73,7 +73,7 @@ def test_positive_create_with_name(module_target_sat, module_entitlement_manifes
 
     :parametrized: yes
     """
-    new_ak = make_activation_key(
+    new_ak = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_entitlement_manifest_org.id, 'name': name}
     )
     assert new_ak['name'] == name

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -73,7 +73,7 @@ def test_positive_create_with_name(module_target_sat, module_entitlement_manifes
 
     :parametrized: yes
     """
-    new_ak = module_target_sat.cli.make_activation_key(
+    new_ak = make_activation_key(
         {'organization-id': module_entitlement_manifest_org.id, 'name': name}
     )
     assert new_ak['name'] == name


### PR DESCRIPTION
https://github.com/SatelliteQE/robottelo/pull/10209 introduced a change to a CLI activation key test that was erroneous and is now causing test failures. This PR reverts that change.