### PR TITLE
[6.13.z] test rex pull job against offline host

### DIFF
--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -202,6 +202,13 @@ def module_capsule_configured_mqtt(module_capsule_configured):
     result = module_capsule_configured.execute('firewall-cmd --permanent --add-port="1883/tcp"')
     assert result.status == 0, 'Failed to open mqtt port on capsule'
     module_capsule_configured.execute('firewall-cmd --reload')
+    # lower the mqtt_resend_interval interval
+    # TODO use installer command instead once merged downstream
+    module_capsule_configured.execute(
+        "echo ':mqtt_resend_interval: 30' >> /etc/foreman-proxy/settings.d/remote_execution_ssh.yml"
+    )
+    result = module_capsule_configured.cli.Service.restart(options={'only': 'foreman-proxy'})
+    assert result.status == 0, 'foreman-proxy restart unsuccessful'
     yield module_capsule_configured
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10616

New 6.13 feature for pull-provider rex jobs, if the host is offline during invocation, sat retries until i is back online or the time_to_pickup expires. I lower the resend interval on the mqtt capsule as the default is impractical for automated testing (15min)