### PR TITLE
[6.13.z] make wait_for_tasks must_succeed configurable also from capsule mixins

### DIFF
--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -5,7 +5,13 @@ class CapsuleInfo:
     """Miscellaneous Capsule helper methods"""
 
     def wait_for_tasks(
-        self, search_query, search_rate=1, max_tries=10, poll_rate=None, poll_timeout=None
+        self,
+        search_query,
+        search_rate=1,
+        max_tries=10,
+        poll_rate=None,
+        poll_timeout=None,
+        must_succeed=True,
     ):
         """Search for tasks by specified search query and poll them to ensure that
         task has finished.
@@ -17,6 +23,7 @@ class CapsuleInfo:
             the start of the next check-up. Parameter for ``sat.api.ForemanTask.poll()`` method.
         :param poll_timeout: Maximum number of seconds to wait until timing out.
             Parameter for ``sat.api.ForemanTask.poll()`` method.
+        :param must_succeed: Assert success result on finished task.
         :return: List of ``sat.api.ForemanTasks`` entities.
         :raises: ``AssertionError``. If not tasks were found until timeout.
         """
@@ -24,7 +31,7 @@ class CapsuleInfo:
             tasks = self.api.ForemanTask().search(query={'search': search_query})
             if tasks:
                 for task in tasks:
-                    task.poll(poll_rate=poll_rate, timeout=poll_timeout)
+                    task.poll(poll_rate=poll_rate, timeout=poll_timeout, must_succeed=must_succeed)
                 break
             else:
                 time.sleep(search_rate)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10657

As requested in https://github.com/SatelliteQE/robottelo/pull/10647, requires https://github.com/SatelliteQE/nailgun/pull/888