### PR TITLE
Fix oscap content path and SCA failures

### DIFF
--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -27,7 +27,7 @@ def tailoring_file_path(session_target_sat):
 def oscap_content_path(session_target_sat):
     """Download scap content from satellite and return local path of it."""
     local_file = robottelo_tmp_dir.joinpath(PurePath(settings.oscap.content_path).name)
-    session_target_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
+    session_target_sat.get(remote_path=settings.oscap.content_path, local_path=str(local_file))
     return local_file
 
 

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -655,12 +655,7 @@ class CLIFactory:
                 raise CLIFactoryError(f'Failed to associate activation-key with CV\n{err.msg}')
 
         # Add custom_product subscription to activation-key, if SCA mode is disabled
-        if (
-            self._satellite.cli.Org.info({'fields': 'Simple content access', 'id': org_id})[
-                'simple-content-access'
-            ]
-            != 'Enabled'
-        ):
+        if self._satellite.is_sca_mode_enabled(org_id) is False:
             self.activationkey_add_subscription_to_repo(
                 {
                     'activationkey-id': activationkey_id,
@@ -801,12 +796,7 @@ class CLIFactory:
                 raise CLIFactoryError(f'Failed to associate activation-key with CV\n{err.msg}')
 
         # Add default subscription to activation-key, if SCA mode is disabled
-        if (
-            self._satellite.cli.Org.info({'fields': 'Simple content access', 'id': org_id})[
-                'simple-content-access'
-            ]
-            != 'Enabled'
-        ):
+        if self._satellite.is_sca_mode_enabled(org_id) is False:
             self.activationkey_add_subscription_to_repo(
                 {
                     'organization-id': org_id,
@@ -872,12 +862,7 @@ class CLIFactory:
                     raise CLIFactoryError(f'Failed to upload manifest\n{err.msg}')
 
                 # Add default subscription to activation-key, if SCA mode is disabled
-                if (
-                    self._satellite.cli.Org.info(
-                        {'fields': 'Simple content access', 'id': result['organization-id']}
-                    )['simple-content-access']
-                    != 'Enabled'
-                ):
+                if self._satellite.is_sca_mode_enabled(result['organization-id']) is False:
                     self.activationkey_add_subscription_to_repo(
                         {
                             'activationkey-id': result['activationkey-id'],

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -653,14 +653,21 @@ class CLIFactory:
                 )
             except CLIReturnCodeError as err:
                 raise CLIFactoryError(f'Failed to associate activation-key with CV\n{err.msg}')
-        # Add subscription to activation-key
-        self.activationkey_add_subscription_to_repo(
-            {
-                'activationkey-id': activationkey_id,
-                'organization-id': org_id,
-                'subscription': custom_product['name'],
-            }
-        )
+
+        # Add custom_product subscription to activation-key, if SCA mode is disabled
+        if (
+            self._satellite.cli.Org.info({'fields': 'Simple content access', 'id': org_id})[
+                'simple-content-access'
+            ]
+            != 'Enabled'
+        ):
+            self.activationkey_add_subscription_to_repo(
+                {
+                    'activationkey-id': activationkey_id,
+                    'organization-id': org_id,
+                    'subscription': custom_product['name'],
+                }
+            )
         return {
             'activationkey-id': activationkey_id,
             'content-view-id': cv_id,
@@ -792,14 +799,23 @@ class CLIFactory:
                 )
             except CLIReturnCodeError as err:
                 raise CLIFactoryError(f'Failed to associate activation-key with CV\n{err.msg}')
-        # Add subscription to activation-key
-        self.activationkey_add_subscription_to_repo(
-            {
-                'organization-id': org_id,
-                'activationkey-id': activationkey_id,
-                'subscription': options.get('subscription', constants.DEFAULT_SUBSCRIPTION_NAME),
-            }
-        )
+
+        # Add default subscription to activation-key, if SCA mode is disabled
+        if (
+            self._satellite.cli.Org.info({'fields': 'Simple content access', 'id': org_id})[
+                'simple-content-access'
+            ]
+            != 'Enabled'
+        ):
+            self.activationkey_add_subscription_to_repo(
+                {
+                    'organization-id': org_id,
+                    'activationkey-id': activationkey_id,
+                    'subscription': options.get(
+                        'subscription', constants.DEFAULT_SUBSCRIPTION_NAME
+                    ),
+                }
+            )
         return {
             'activationkey-id': activationkey_id,
             'content-view-id': cv_id,
@@ -854,14 +870,21 @@ class CLIFactory:
                     )
                 except CLIReturnCodeError as err:
                     raise CLIFactoryError(f'Failed to upload manifest\n{err.msg}')
-                # attach the default subscription to activation key
-                self.activationkey_add_subscription_to_repo(
-                    {
-                        'activationkey-id': result['activationkey-id'],
-                        'organization-id': result['organization-id'],
-                        'subscription': constants.DEFAULT_SUBSCRIPTION_NAME,
-                    }
-                )
+
+                # Add default subscription to activation-key, if SCA mode is disabled
+                if (
+                    self._satellite.cli.Org.info(
+                        {'fields': 'Simple content access', 'id': result['organization-id']}
+                    )['simple-content-access']
+                    != 'Enabled'
+                ):
+                    self.activationkey_add_subscription_to_repo(
+                        {
+                            'activationkey-id': result['activationkey-id'],
+                            'organization-id': result['organization-id'],
+                            'subscription': constants.DEFAULT_SUBSCRIPTION_NAME,
+                        }
+                    )
             return result
 
     @staticmethod

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -144,6 +144,9 @@ class ContentInfo:
             )
         return result
 
+    def is_sca_mode_enabled(self, org_id):
+        return self.api.Organization(id=org_id).read().simple_content_access
+
 
 class SystemInfo:
     """Things that needs access to satellite shell for gaining satellite system configuration"""

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1768,9 +1768,8 @@ class Satellite(Capsule, SatelliteMixins):
             f'rc: {register.status}: {register.stderr}'
         )
 
-        # attach product subscriptions to contenthost
-        # Attach subscriptions only if SCA mode is disabled
-        if self.api.Organization(id=module_org.id).read().simple_content_access is False:
+        # Attach product subscriptions to contenthost, only if SCA mode is disabled
+        if self.is_sca_mode_enabled(module_org.id) is False:
             subs = self.api.Subscription(organization=module_org, name=prod.name).search()
             assert len(subs), f'Subscription for sat client product: {prod.name} was not found.'
             subscription = subs[0]

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -31,7 +31,7 @@ def oscap_content_path(module_target_sat):
     _, file_name = os.path.split(settings.oscap.content_path)
 
     local_file = robottelo_tmp_dir.joinpath(file_name)
-    module_target_sat.get(remote_path=settings.oscap.content_path, local_path=local_file)
+    module_target_sat.get(remote_path=settings.oscap.content_path, local_path=str(local_file))
     return local_file
 
 


### PR DESCRIPTION
Description:
1. Fix oscap content path
2. Adjust  `setup_org_for_a_custom_repo` and `setup_org_for_a_rh_repo` CLI factory helpers for SCA