### PR TITLE
[6.13.z] Ansible e2e test coverage - CLI

### DIFF
--- a/robottelo/cli/ansible.py
+++ b/robottelo/cli/ansible.py
@@ -26,12 +26,18 @@ class Ansible(Base):
     def roles_sync(cls, options=None):
         """Sync Ansible roles"""
         cls.command_sub = 'roles sync'
-        return cls.execute(cls._construct_command(options), output_format='csv')
+        return cls.execute(cls._construct_command(options))
 
     @classmethod
     def roles_delete(cls, options=None):
         """Delete Ansible roles"""
         cls.command_sub = 'roles delete'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def roles_list(cls, options=None):
+        """List ansible roles"""
+        cls.command_sub = 'roles list'
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
@@ -41,7 +47,13 @@ class Ansible(Base):
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
-    def roles_list(cls, options=None):
-        """List ansible roles"""
-        cls.command_sub = 'roles list'
+    def variables_create(cls, options=None):
+        """Create ansible variables"""
+        cls.command_sub = 'variables create'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def variables_info(cls, options=None):
+        """Information about ansible variables"""
+        cls.command_sub = 'variables info'
         return cls.execute(cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -60,6 +60,12 @@ class Host(Base):
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
+    def ansible_roles_remove(cls, options=None):
+        """Remove ansible roles"""
+        cls.command_sub = 'ansible-roles remove'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
     def disassociate(cls, options):
         """Disassociate the host from a CR."""
         cls.command_sub = 'disassociate'

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -86,6 +86,8 @@ def test_positive_ansible_job_on_host(target_sat, module_org, rhel_contenthost):
         2. Job execution must be successful.
 
     :CaseAutomation: Automated
+
+    :CaseImportance: Critical
     """
     SELECTED_ROLE = 'RedHatInsights.insights-client'
     if rhel_contenthost.os_version.major <= 7:

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -16,3 +16,90 @@
 
 :Upstream: No
 """
+import pytest
+
+from robottelo.config import settings
+
+
+@pytest.mark.e2e
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('[^6].*')
+def test_positive_ansible_e2e(target_sat, module_org, rhel_contenthost):
+    """
+    Test successful execution of Ansible Job on host.
+
+    :id: 0c52bc63-a41a-4f48-a980-fe49b4ecdbdc
+
+    :Steps:
+        1. Register a content host with satellite
+        2. Import a role into satellite
+        3. Assign that role to a host
+        4. Assert that the role and variable were assigned to the host successfully
+        5. Run the Ansible playbook associated with that role
+        6. Check if the job is executed successfully.
+        7. Disassociate the Role from the host.
+        8. Delete the assigned ansible role
+
+    :expectedresults:
+        1. Host should be assigned the proper role.
+        2. Job execution must be successful.
+        3. Operations performed with hammer must be successful.
+
+    :CaseAutomation: Automated
+
+    :CaseImportance: Critical
+    """
+    SELECTED_ROLE = 'RedHatInsights.insights-client'
+    SELECTED_VAR = 'insights_variable'
+    if rhel_contenthost.os_version.major <= 7:
+        rhel_contenthost.create_custom_repos(rhel7=settings.repos.rhel7_os)
+        assert rhel_contenthost.execute('yum install -y insights-client').status == 0
+    rhel_contenthost.install_katello_ca(target_sat)
+    rhel_contenthost.register_contenthost(module_org.label, force=True)
+    assert rhel_contenthost.subscribed
+    rhel_contenthost.add_rex_key(satellite=target_sat)
+    proxy_id = target_sat.nailgun_smart_proxy.id
+    target_host = rhel_contenthost.nailgun_host
+
+    target_sat.cli.Ansible.roles_sync({'role-names': SELECTED_ROLE, 'proxy-id': proxy_id})
+
+    target_sat.cli.Host.ansible_roles_assign({'id': target_host.id, 'ansible-roles': SELECTED_ROLE})
+
+    target_sat.cli.Ansible.variables_create(
+        {'variable': SELECTED_VAR, 'ansible-role': SELECTED_ROLE}
+    )
+
+    assert SELECTED_ROLE, (
+        SELECTED_VAR in target_sat.cli.Ansible.variables_info({'name': SELECTED_VAR}).stdout
+    )
+
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Ansible Roles - Ansible Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'targeting_type': 'static_query',
+            'search_query': f'name = {rhel_contenthost.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}', poll_timeout=1000
+    )
+    result = target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 1
+
+    result = target_sat.cli.Host.ansible_roles_remove(
+        {'id': target_host.id, 'ansible-role': SELECTED_ROLE}
+    )
+    assert 'Ansible role has been disassociated.' in result[0]['message']
+
+    result = target_sat.cli.Ansible.roles_delete({'name': SELECTED_ROLE})
+    assert f'Ansible role [{SELECTED_ROLE}] was deleted.' in result[0]['message']
+
+    assert SELECTED_ROLE, (
+        SELECTED_VAR not in target_sat.cli.Ansible.variables_info({'name': SELECTED_VAR}).stdout
+    )

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -139,6 +139,8 @@ def test_positive_config_report_ansible(session, target_sat, module_org, rhel_co
     :expectedresults:
         1. Host should be assigned the proper role.
         2. Job report should be created.
+
+    :CaseImportance: Critical
     """
     SELECTED_ROLE = 'RedHatInsights.insights-client'
     if rhel_contenthost.os_version.major <= 7:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10562

The coverage aims to test Ansible roles & variables via CLI and execute an ansible job on a registered host with satellite.

**Test results**:
```
pytest tests/foreman/cli/test_ansible.py -k test_positive_ansible_e2e
========================================================================================================= test session starts =========================================================================================================
platform linux -- Python 3.8.13, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: forked-1.4.0, services-2.2.1, cov-3.0.0, xdist-3.1.0, ibutsu-2.2.4, reportportal-5.1.3, mock-3.10.0
collected 4 items / 1 deselected / 3 selected                                                                                                                                                                                         

tests/foreman/cli/test_ansible.py ...                                                                                                                                                                                           [100%]

========================================================================================================== warnings summary ===========================================================================================================
```
Signed-off-by: Adarsh Dubey <addubey@redhat.com>