### PR TITLE
removing the double quotes causing issue

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -58,11 +58,11 @@ jobs:
           api_endpoint="https://api.github.com/repos/${{github.repository}}/statuses/${{ github.head_ref }}"
 
           function get_status() {
-            curl -s "$api_endpoint"  | jq '[.[] | .state] | .[0]'
+            curl -s "$api_endpoint"  | jq '[.[] | .state] | .[0]' | tr -d '"'
           }
 
           function get_context() {
-            curl -s "$api_endpoint" | jq '[.[] | .context] | .[0]'
+            curl -s "$api_endpoint" | jq '[.[] | .context] | .[0]' | tr -d '"'
           }
 
           statuses_length=$(curl -s $api_endpoint | jq 'length')
@@ -92,12 +92,12 @@ jobs:
             counter=$((counter+1))
           done
 
-          if [ "$status" == "success" ]; then
-            echo "PRT Passed Successfully!"
-          else
+          if [ "$status" != "success" ]; then
             echo "Robottelo-Runner : $status"
             echo "::error PRT failed"
             exit 1
+          else
+           echo "PRT Passed Successfully!"
           fi
 
 


### PR DESCRIPTION
```
> cat test.sh
api_endpoint="https://api.github.com/repos/SatelliteQE/robottelo/statuses/cherry-pick-6.13.z-2d1d525183c71b1186104f75c63f9f1caceaf5d1"

  function get_status() {
    curl -s "$api_endpoint"  | jq '[.[] | .state] | .[0]' | tr -d '"'
  }

  function get_context() {
    curl -s "$api_endpoint" | jq '[.[] | .context] | .[0]' | tr -d '"'
  }

  statuses_length=$(curl -s $api_endpoint | jq 'length')
  if [ $statuses_length -eq 0 ]; then
      echo "PRT failed to start ! Stopping."
      exit 1
  fi

  result=$(get_status)
  context=$(get_context)

  if [ "$context" != "Robottelo-Runner" ]; then
    echo "::error Failed to get Robottelo-Runner status"
    exit 1
  fi

  counter=0
  echo "Waiting for PRT to complete....."
  while [ "$result" != "success" ] && [ "$result" != "failure" ]; do
    if [ $counter -gt 20 ]; then
      echo "PRT Timeout"
      exit 1
    fi
    sleep 300
    result=$(get_status)
    echo "Robottelo-Runner : $result"
    counter=$((counter+1))
  done

  if [ "$result" != "success" ]; then
    echo "Robottelo-Runner : $status"
    echo "::error PRT failed"
    exit 1
  else
    echo "PRT Passed Successfully!"
  fi
> sh test.sh
Waiting for PRT to complete.....
PRT Passed Successfully!
```