### PR TITLE
Satellite maintain upgrade check negative tests

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -10,6 +10,7 @@ from broker import Broker
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
+from robottelo.hosts import Satellite
 
 
 def host_conf(request):
@@ -228,3 +229,14 @@ def sat_upgrade_chost():
     return Broker(
         container_host=settings.content_host.rhel8.container.container_host, host_class=ContentHost
     ).checkout()
+
+
+@pytest.fixture
+def custom_host(request):
+    """A rhel content host that passes custom host config through request.param"""
+    deploy_args = request.param
+    # if 'deploy_rhel_version' is not set, let's default to RHEL 8
+    deploy_args['deploy_rhel_version'] = deploy_args.get('deploy_rhel_version', '8')
+    deploy_args['workflow'] = 'deploy-base-rhel'
+    with Broker(**deploy_args, host_class=Satellite) as host:
+        yield host


### PR DESCRIPTION
Introducing a new negative test for checking system requirements on pre-upgrade check. Ideally this will pass on 6.14 when we get a build, but if we catch the failure I can come back and debug. I'm not sure what our current plan for stream is, but I assume we won't try to run this on stream or else it will (probably) fail.