### PR TITLE
[6.11.z] fix in update_entities location test

### DIFF
--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -212,7 +212,6 @@ class TestLocation:
 
         location.domain = [make_entities["domain"]]
         location.subnet = [make_entities["subnet"]]
-        location.environment = [make_entities["env"]]
         location.hostgroup = [make_entities["host_group"]]
         location.provisioning_template = [make_entities["template"]]
         location.compute_resource = [make_entities["test_cr"]]
@@ -220,7 +219,6 @@ class TestLocation:
 
         assert location.update(['domain']).domain[0].id == make_entities["domain"].id
         assert location.update(['subnet']).subnet[0].id == make_entities["subnet"].id
-        assert location.update(['environment']).environment[0].id == make_entities["env"].id
         assert location.update(['hostgroup']).hostgroup[0].id == make_entities["host_group"].id
         ct_list = [
             ct


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10695

The make_entities helper doesn't create puppet env, probably it was updated some time ago, but the consuming test wasn't. 