### PR TITLE
[6.11.z] [client, sync_plan, role] upgrade scenarios refactor (#10577)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -34,6 +34,8 @@ pytest_plugins = [
     'pytest_fixtures.component.domain',
     'pytest_fixtures.component.host',
     'pytest_fixtures.component.hostgroup',
+    'pytest_fixtures.component.http_proxy',
+    'pytest_fixtures.component.katello_agent',
     'pytest_fixtures.component.katello_certs_check',
     'pytest_fixtures.component.lce',
     'pytest_fixtures.component.maintain',

--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -1,0 +1,24 @@
+import pytest
+
+from robottelo.config import settings
+
+
+@pytest.fixture(scope='function')
+def setup_http_proxy(request, module_manifest_org, target_sat):
+    """Create a new HTTP proxy and set related settings based on proxy"""
+    http_proxy = target_sat.api_factory.make_http_proxy(module_manifest_org, request.param)
+    general_proxy = http_proxy.url if request.param is False else ''
+    if request.param:
+        general_proxy = (
+            f'http://{settings.http_proxy.username}:'
+            f'{settings.http_proxy.password}@{http_proxy.url[7:]}'
+        )
+    content_proxy_value = target_sat.update_setting(
+        'content_default_http_proxy', http_proxy.name if request.param is not None else ''
+    )
+    general_proxy_value = target_sat.update_setting(
+        'http_proxy', general_proxy if request.param is not None else ''
+    )
+    yield http_proxy, request.param
+    target_sat.update_setting('content_default_http_proxy', content_proxy_value)
+    target_sat.update_setting('http_proxy', general_proxy_value)

--- a/pytest_fixtures/component/katello_agent.py
+++ b/pytest_fixtures/component/katello_agent.py
@@ -1,0 +1,53 @@
+import pytest
+from box import Box
+
+from robottelo.config import settings
+from robottelo.utils.installer import InstallerCommand
+
+
+@pytest.fixture(scope='module')
+def sat_with_katello_agent(module_target_sat):
+    """Enable katello-agent on module_target_sat"""
+    module_target_sat.register_to_cdn()
+    # Enable katello-agent from satellite-installer
+    result = module_target_sat.install(
+        InstallerCommand('foreman-proxy-content-enable-katello-agent true')
+    )
+    assert result.status == 0
+    # Verify katello-agent is enabled
+    result = module_target_sat.install(
+        InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
+    )
+    assert 'true' in result.stdout
+    yield module_target_sat
+
+
+@pytest.fixture
+def katello_agent_client_for_upgrade(sat_with_katello_agent, sat_upgrade_chost, module_org):
+    """Register content host to Satellite and install katello-agent on the host."""
+    client_repo = settings.repos['SATCLIENT_REPO'][f'RHEL{sat_upgrade_chost.os_version.major}']
+    sat_with_katello_agent.register_host_custom_repo(
+        module_org, sat_upgrade_chost, [client_repo, settings.repos.yum_1.url]
+    )
+    sat_upgrade_chost.install_katello_agent()
+    host_info = sat_with_katello_agent.cli.Host.info({'name': sat_upgrade_chost.hostname})
+    yield Box(
+        {
+            'client': sat_upgrade_chost,
+            'host_info': host_info,
+            'sat': sat_with_katello_agent,
+        }
+    )
+
+
+@pytest.fixture
+def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
+    """Register content host to Satellite and install katello-agent on the host."""
+    org = sat_with_katello_agent.api.Organization().create()
+    client_repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
+    sat_with_katello_agent.register_host_custom_repo(
+        org, rhel_contenthost, [client_repo, settings.repos.yum_1.url]
+    )
+    rhel_contenthost.install_katello_agent()
+    host_info = sat_with_katello_agent.cli.Host.info({'name': rhel_contenthost.hostname})
+    yield Box({'client': rhel_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent})

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -220,3 +220,11 @@ def sat_ready_rhel(request):
     deploy_args['target_memory'] = '20GiB'
     with Broker(**deploy_args, host_class=ContentHost) as host:
         yield host
+
+
+@pytest.fixture(scope="module")
+def sat_upgrade_chost():
+    """A module-level fixture that provides a UBI_8 content host for upgrade scenario testing"""
+    return Broker(
+        container_host=settings.content_host.rhel8.container.container_host, host_class=ContentHost
+    ).checkout()

--- a/robottelo/cli/simple_content_access.py
+++ b/robottelo/cli/simple_content_access.py
@@ -1,0 +1,45 @@
+"""
+Usage::
+
+    hammer simple-content-access [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters::
+
+    SUBCOMMAND                    subcommand
+    [ARG] ...                     subcommand arguments
+
+Subcommands::
+
+    disable                       Disable simple content access for a manifest
+    enable                        Enable simple content access for a manifest
+    status                        Check if the specified organization has
+                                  Simple Content Access enabled
+
+"""
+from robottelo.cli.base import Base
+
+
+class SimpleContentAccess(Base):
+    """
+    Manipulates Katello engine's simple-content-access command.
+    """
+
+    command_base = 'simple-content-access'
+
+    @classmethod
+    def disable(cls, options=None, timeout=None):
+        """Disable simple content access for a manifest"""
+        cls.command_sub = 'disable'
+        return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)
+
+    @classmethod
+    def enable(cls, options=None, timeout=None):
+        """Enable simple content access for a manifest"""
+        cls.command_sub = 'enable'
+        return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)
+
+    @classmethod
+    def status(cls, options=None, timeout=None):
+        """Check if the specified organization has Simple Content Access enabled"""
+        cls.command_sub = 'status'
+        return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -1,7 +1,7 @@
 """
 Usage::
 
-    hammer sunscription [OPTIONS] SUBCOMMAND [ARG] ...
+    hammer subscription [OPTIONS] SUBCOMMAND [ARG] ...
 
 Parameters::
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -2,6 +2,9 @@
 It is not meant to be used directly, but as part of a robottelo.hosts.Satellite instance
 example: my_satellite.api_factory.api_method()
 """
+from fauxfactory import gen_string
+
+from robottelo.config import settings
 
 
 class APIFactory:
@@ -9,3 +12,24 @@ class APIFactory:
 
     def __init__(self, satellite):
         self._satellite = satellite
+
+    def make_http_proxy(self, org, http_proxy_type):
+        """
+        Creates HTTP proxy.
+        :param str org: Organization
+        :param str http_proxy_type: None, False, True
+        """
+        if http_proxy_type is False:
+            return self._satellite.api.HTTPProxy(
+                name=gen_string('alpha', 15),
+                url=settings.http_proxy.un_auth_proxy_url,
+                organization=[org.id],
+            ).create()
+        if http_proxy_type:
+            return self._satellite.api.HTTPProxy(
+                name=gen_string('alpha', 15),
+                url=settings.http_proxy.auth_proxy_url,
+                username=settings.http_proxy.username,
+                password=settings.http_proxy.password,
+                organization=[org.id],
+            ).create()

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -1,0 +1,125 @@
+"""Tests for http-proxy component.
+
+:Requirement: HttpProxy
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Repositories
+
+:Team: Phoenix
+
+:TestType: Functional
+
+:CaseImportance: High
+
+:CaseAutomation: Automated
+
+:Upstream: No
+"""
+import pytest
+
+from robottelo import constants
+from robottelo.api.utils import enable_rhrepo_and_fetchid
+from robottelo.config import settings
+
+
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.run_in_one_thread
+@pytest.mark.parametrize(
+    'setup_http_proxy',
+    [None, True, False],
+    indirect=True,
+    ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
+)
+def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifest_org):
+    """End-to-end test for HTTP Proxy related scenarios.
+
+    :id: 38df5479-9127-49f3-a30e-26b33655971a
+
+    :customerscenario: true
+
+    :steps:
+        1. Set Http proxy settings for Satellite.
+        2. Enable and sync redhat repository.
+        3. Assign Http Proxy to custom repository and perform repo sync.
+        4. Discover yum type repo.
+        5. Discover docker type repo.
+
+    :expectedresults: HTTP Proxy works with other satellite components.
+
+    :BZ: 2011303, 2042473, 2046337
+
+    :parametrized: yes
+
+    :CaseImportance: Critical
+    """
+    http_proxy, http_proxy_type = setup_http_proxy
+    http_proxy_id = http_proxy.id if http_proxy_type is not None else None
+    http_proxy_policy = 'use_selected_http_proxy' if http_proxy_type is not None else 'none'
+    # Assign http_proxy to Redhat repository and perform repository sync.
+    rh_repo_id = enable_rhrepo_and_fetchid(
+        basearch=constants.DEFAULT_ARCHITECTURE,
+        org_id=module_manifest_org.id,
+        product=constants.PRDS['rhae'],
+        repo=constants.REPOS['rhae2']['name'],
+        reposet=constants.REPOSET['rhae2'],
+        releasever=None,
+    )
+    rh_repo = module_target_sat.api.Repository(
+        id=rh_repo_id,
+        http_proxy_policy=http_proxy_policy,
+        http_proxy_id=http_proxy_id,
+        download_policy='immediate',
+    ).update()
+    assert rh_repo.http_proxy_policy == http_proxy_policy
+    assert rh_repo.http_proxy_id == http_proxy_id
+    assert rh_repo.download_policy == 'immediate'
+    rh_repo.sync()
+    assert rh_repo.read().content_counts['rpm'] >= 1
+
+    # Assign http_proxy to Repositories and perform repository sync.
+    repo_options = {
+        'http_proxy_policy': http_proxy_policy,
+        'http_proxy_id': http_proxy_id,
+    }
+    repo = module_target_sat.api.Repository(**repo_options).create()
+
+    assert repo.http_proxy_policy == http_proxy_policy
+    assert repo.http_proxy_id == http_proxy_id
+    repo.sync()
+    assert repo.read().content_counts['rpm'] >= 1
+
+    # Use global_default_http_proxy
+    repo_options['http_proxy_policy'] = 'global_default_http_proxy'
+    repo_2 = module_target_sat.api.Repository(**repo_options).create()
+    assert repo_2.http_proxy_policy == 'global_default_http_proxy'
+
+    # Update to selected_http_proxy
+    repo_2.http_proxy_policy = 'none'
+    repo_2.update(['http_proxy_policy'])
+    assert repo_2.http_proxy_policy == 'none'
+
+    # test scenario for yum type repo discovery.
+    repo_name = 'fakerepo01'
+    yum_repo = module_target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
+        data={
+            "id": module_manifest_org.id,
+            "url": settings.repos.repo_discovery.url,
+            "content_type": "yum",
+        }
+    )
+    assert len(yum_repo['output']) == 1
+    assert yum_repo['output'][0] == f'{settings.repos.repo_discovery.url}/{repo_name}/'
+
+    # test scenario for docker type repo discovery.
+    yum_repo = module_target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
+        data={
+            "id": module_manifest_org.id,
+            "url": 'quay.io',
+            "content_type": "docker",
+            "search": 'quay/busybox',
+        }
+    )
+    assert len(yum_repo['output']) >= 1
+    assert 'quay/busybox' in yum_repo['output']

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -20,7 +20,6 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.utils.installer import InstallerCommand
 
 pytestmark = [
     pytest.mark.run_in_one_thread,
@@ -28,36 +27,6 @@ pytestmark = [
     pytest.mark.tier5,
     pytest.mark.upgrade,
 ]
-
-
-@pytest.fixture(scope='module')
-def sat_with_katello_agent(module_target_sat):
-    """Enable katello-agent on module_target_sat"""
-    module_target_sat.register_to_cdn()
-    # Enable katello-agent from satellite-installer
-    result = module_target_sat.install(
-        InstallerCommand('foreman-proxy-content-enable-katello-agent true')
-    )
-    assert result.status == 0
-    # Verify katello-agent is enabled
-    result = module_target_sat.install(
-        InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
-    )
-    assert 'true' in result.stdout
-    yield module_target_sat
-
-
-@pytest.fixture
-def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
-    """Register content host to Satellite and install katello-agent on the host."""
-    org = sat_with_katello_agent.api.Organization().create()
-    client_repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
-    sat_with_katello_agent.register_host_custom_repo(
-        org, rhel_contenthost, [client_repo, settings.repos.yum_1.url]
-    )
-    rhel_contenthost.install_katello_agent()
-    host_info = sat_with_katello_agent.cli.Host.info({'name': rhel_contenthost.hostname})
-    yield {'client': rhel_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent}
 
 
 @pytest.mark.rhel_ver_match(r'[\d]+')

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -20,15 +20,15 @@ import pytest
 from fauxfactory import gen_integer
 from fauxfactory import gen_string
 from fauxfactory import gen_url
-from nailgun import entities
 
 from robottelo.config import settings
+from robottelo.constants import DOCKER_REPO_UPSTREAM_NAME
 from robottelo.constants import REPO_TYPE
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_create_update_delete(session, module_org, module_location):
+def test_positive_create_update_delete(module_org, module_location, target_sat):
     """Create new http-proxy with attributes, update and delete it.
 
     :id: 0c7cdf3d-778f-427a-9a2f-42ad7c23aa15
@@ -47,7 +47,7 @@ def test_positive_create_update_delete(session, module_org, module_location):
     password = gen_string('alpha', 15)
     username = gen_string('alpha', 15)
 
-    with session:
+    with target_sat.ui_session() as session:
         session.http_proxy.create(
             {
                 'http_proxy.name': http_proxy_name,
@@ -70,12 +70,14 @@ def test_positive_create_update_delete(session, module_org, module_location):
         assert session.http_proxy.search(updated_proxy_name)[0]['Name'] == updated_proxy_name
         # Delete http_proxy
         session.http_proxy.delete(updated_proxy_name)
-        assert not entities.HTTPProxy().search(query={'search': f'name={updated_proxy_name}'})
+        assert not target_sat.api.HTTPProxy().search(query={'search': f'name={updated_proxy_name}'})
 
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_assign_http_proxy_to_products_repositories(session, module_org, module_location):
+def test_positive_assign_http_proxy_to_products_repositories(
+    module_org, module_location, target_sat
+):
     """Assign HTTP Proxy to Products and Repositories.
 
     :id: 2b803f9c-8d5d-4467-8eba-18244ebc0201
@@ -86,13 +88,13 @@ def test_positive_assign_http_proxy_to_products_repositories(session, module_org
     :CaseImportance: Critical
     """
     # create HTTP proxies
-    http_proxy_a = entities.HTTPProxy(
+    http_proxy_a = target_sat.api.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.un_auth_proxy_url,
         organization=[module_org.id],
         location=[module_location.id],
     ).create()
-    http_proxy_b = entities.HTTPProxy(
+    http_proxy_b = target_sat.api.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.auth_proxy_url,
         username=settings.http_proxy.username,
@@ -101,14 +103,14 @@ def test_positive_assign_http_proxy_to_products_repositories(session, module_org
         location=[module_location.id],
     ).create()
     # Create products
-    product_a = entities.Product(
+    product_a = target_sat.api.Product(
         organization=module_org.id,
     ).create()
-    product_b = entities.Product(
+    product_b = target_sat.api.Product(
         organization=module_org.id,
     ).create()
     # Create repositories from UI.
-    with session:
+    with target_sat.ui_session() as session:
         repo_a1_name = gen_string('alpha')
         session.repository.create(
             product_a.name,
@@ -189,7 +191,7 @@ def test_positive_assign_http_proxy_to_products_repositories(session, module_org
 @pytest.mark.tier1
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['content_default_http_proxy'], indirect=True)
-def test_set_default_http_proxy(session, module_org, module_location, setting_update):
+def test_set_default_http_proxy(module_org, module_location, setting_update, target_sat):
     """Setting "Default HTTP proxy" to "no global default".
 
     :id: e93733e1-5c05-4b7f-89e4-253b9ce55a5a
@@ -214,14 +216,14 @@ def test_set_default_http_proxy(session, module_org, module_location, setting_up
 
     property_name = setting_update.name
 
-    http_proxy_a = entities.HTTPProxy(
+    http_proxy_a = target_sat.api.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.un_auth_proxy_url,
         organization=[module_org.id],
         location=[module_location.id],
     ).create()
 
-    with session:
+    with target_sat.ui_session() as session:
         session.settings.update(
             f'name = {property_name}', f'{http_proxy_a.name} ({http_proxy_a.url})'
         )
@@ -237,7 +239,7 @@ def test_set_default_http_proxy(session, module_org, module_location, setting_up
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['content_default_http_proxy'], indirect=True)
 def test_check_http_proxy_value_repository_details(
-    session, function_org, function_location, function_product, setting_update
+    function_org, function_location, function_product, setting_update, target_sat
 ):
 
     """Deleted Global Http Proxy is reflected in repository details page".
@@ -267,14 +269,14 @@ def test_check_http_proxy_value_repository_details(
 
     property_name = setting_update.name
     repo_name = gen_string('alpha')
-    http_proxy_a = entities.HTTPProxy(
+    http_proxy_a = target_sat.api.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.un_auth_proxy_url,
         organization=[function_org.id],
         location=[function_location.id],
     ).create()
 
-    with session:
+    with target_sat.ui_session() as session:
         session.organization.select(org_name=function_org.name)
         session.location.select(loc_name=function_location.name)
         session.settings.update(
@@ -327,3 +329,64 @@ def test_http_proxy_containing_special_characters():
 
     :CaseImportance: High
     """
+
+
+@pytest.mark.tier2
+@pytest.mark.upgrade
+@pytest.mark.run_in_one_thread
+@pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
+@pytest.mark.usefixtures('allow_repo_discovery')
+@pytest.mark.parametrize(
+    'setup_http_proxy',
+    [None, True, False],
+    indirect=True,
+    ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
+)
+def test_positive_repo_discovery(setup_http_proxy, module_target_sat, module_org):
+    """Create repository via repo discovery under new product
+
+    :id: fd385552-8cbb-49f7-8557-cc4e6ac7e79a
+
+    :expectedresults: Repository is discovered and created.
+
+    :BZ: 2011303, 2042473
+
+    :parametrized: yes
+
+    :CaseImportance: Critical
+    """
+    product_name = gen_string('alpha')
+    repo_name = 'fakerepo01'
+    with module_target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        # test scenario for yum type repo discovery.
+        session.product.discover_repo(
+            {
+                'repo_type': 'Yum Repositories',
+                'url': settings.repos.repo_discovery.url,
+                'discovered_repos.repos': repo_name,
+                'create_repo.product_type': 'New Product',
+                'create_repo.product_content.product_name': product_name,
+            }
+        )
+        assert session.product.search(product_name)[0]['Name'] == product_name
+        assert repo_name in session.repository.search(product_name, repo_name)[0]['Name']
+        # test scenario for docker type repo discovery.
+        product_name = gen_string('alpha')
+        session.product.discover_repo(
+            {
+                'repo_type': 'Container Images',
+                'create_repo.product_type': 'New Product',
+                'create_repo.product_content.product_name': product_name,
+                'registry_search': DOCKER_REPO_UPSTREAM_NAME,
+                'name': gen_string('alphanumeric', 10),
+                'username': settings.subscription.rhn_username,
+                'password': settings.subscription.rhn_password,
+                'discovered_repos.repos': DOCKER_REPO_UPSTREAM_NAME,
+            }
+        )
+        assert session.product.search(product_name)[0]['Name'] == product_name
+        assert (
+            DOCKER_REPO_UPSTREAM_NAME
+            in session.repository.search(product_name, DOCKER_REPO_UPSTREAM_NAME)[0]['Name']
+        )

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -72,11 +72,6 @@ def validate_repo_content(repo, content_types, after_sync=True):
             ), 'Repository contains invalid number of content entities.'
 
 
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
-
-
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_org):
     """Perform end to end scenario for sync plan component

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -22,92 +22,10 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 import time
 
 import pytest
-from fabric.api import execute
-from upgrade.helpers.docker import docker_execute_command
-from upgrade_tests.helpers.scenarios import dockerize
+from broker import Broker
 
-from robottelo.config import settings
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE
-from robottelo.constants import REPOS
-
-
-# host machine for containers
-docker_vm = settings.upgrade.docker_vm
-
-
-@pytest.fixture(scope='module')
-def pre_upgrade_repo(module_product, module_target_sat):
-    """Enable custom errata repository"""
-    pre_upgrade_repo = module_target_sat.api.Repository(
-        url=settings.repos.yum_0.url, product=module_product
-    ).create()
-    assert pre_upgrade_repo.sync()['result'] == 'success'
-    return pre_upgrade_repo
-
-
-@pytest.fixture(scope='module')
-def post_upgrade_repo(module_product, module_target_sat):
-    """Enable custom errata repository"""
-    post_upgrade_repo = module_target_sat.api.Repository(
-        url=settings.repos.yum_9.url, product=module_product
-    ).create()
-    assert post_upgrade_repo.sync()['result'] == 'success'
-    return post_upgrade_repo
-
-
-@pytest.fixture(scope='module')
-def pre_upgrade_cv(default_org, pre_upgrade_repo, module_target_sat):
-    """Create and publish repo"""
-    pre_upgrade_cv = module_target_sat.api.ContentView(
-        organization=default_org, repository=[pre_upgrade_repo.id]
-    ).create()
-    pre_upgrade_cv.publish()
-    pre_upgrade_cv = pre_upgrade_cv.read()
-    return pre_upgrade_cv
-
-
-@pytest.fixture(scope='module')
-def post_upgrade_cv(default_org, post_upgrade_repo, module_target_sat):
-    """Create and publish repo"""
-    post_upgrade_cv = module_target_sat.api.ContentView(
-        organization=default_org, repository=[post_upgrade_repo.id]
-    ).create()
-    post_upgrade_cv.publish()
-    post_upgrade_cv = post_upgrade_cv.read()
-    return post_upgrade_cv
-
-
-@pytest.fixture(scope='module')
-def module_ak(default_org, module_lce_library, pre_upgrade_repo, module_product, module_target_sat):
-    """Create a module AK in Library LCE"""
-    ak = module_target_sat.api.ActivationKey(
-        content_view=DEFAULT_CV,
-        environment=module_lce_library,
-        organization=default_org,
-    ).create()
-    # Fetch available subscriptions
-    subs = module_target_sat.api.Subscription(organization=default_org).search()
-    assert len(subs) > 0
-    # Add default subscription to activation key
-    sub_found = False
-    for sub in subs:
-        if sub.name == DEFAULT_SUBSCRIPTION_NAME:
-            ak.add_subscriptions(data={'subscription_id': sub.id})
-            sub_found = True
-    assert sub_found
-    # Enable RHEL tools repo in activation key
-    ak.content_override(
-        data={'content_overrides': [{'content_label': REPOS['rhst7']['id'], 'value': '1'}]}
-    )
-    # Add custom subscription to activation key
-    custom_sub = module_target_sat.api.Subscription().search(
-        query={'search': f'name={module_product.name}'}
-    )
-    ak.add_subscriptions(data={'subscription_id': custom_sub[0].id})
-    return ak
+from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
+from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
 
 
 class TestScenarioUpgradeOldClientAndPackageInstallation:
@@ -124,8 +42,8 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_scenario_preclient_package_installation(
-        default_org, pre_upgrade_cv, pre_upgrade_repo, module_ak, save_test_data
+    def test_pre_scenario_pre_client_package_installation(
+        self, katello_agent_client_for_upgrade, module_org, module_target_sat, save_test_data
     ):
         """Create product and repo, from which a package will be installed
         post upgrade. Create a content host and register it.
@@ -149,42 +67,36 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
             2. The new repo is enabled on the content host.
 
         """
-        rhel7_client = dockerize(
-            ak_name=module_ak.name, distro='rhel7', org_label=default_org.label
-        )
-        client_container_id = list(rhel7_client.values())[0]
-        # Wait 60 seconds as script in /tmp takes up to 2 min inc the repo sync time
-        time.sleep(60)
-        # Use yum install again in case script was not yet finished
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            'yum -y install katello-agent',
-            host=docker_vm,
-        )[docker_vm]
-        # Assert gofer was installed after yum completes
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            'rpm -q gofer',
-            host=docker_vm,
-        )[docker_vm]
-        assert 'package gofer is not installed' not in installed_package
+        rhel_client = katello_agent_client_for_upgrade.client
+        rhid = rhel_client.execute('subscription-manager identity')
+        assert module_org.name in rhid.stdout
+        result = rhel_client.execute('rpm -q gofer')
+        assert result.status == 0
+        assert 'package gofer is not installed' not in result.stdout
         # Run goferd on client as its docker container
-        kwargs = {'async': True, 'host': docker_vm}
-        execute(docker_execute_command, client_container_id, 'goferd -f', **kwargs)
+        rhel_client._cont_inst.exec_run('goferd -f', detach=True)
         # Holding on for 30 seconds while goferd starts
         time.sleep(30)
-        status = execute(docker_execute_command, client_container_id, 'ps -aux', host=docker_vm)[
-            docker_vm
-        ]
-        assert 'goferd' in status
-        # Save client info to disk for post-upgrade test
-        save_test_data({__name__: rhel7_client})
+        rhel_client.execute('yum install -y procps')  # ps command needs to be installed
+        result = rhel_client.execute("ps -ef | grep goferd")
+        assert 'goferd' in result.stdout
+        module_target_sat.cli.Host.package_install(
+            {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_4_CUSTOM_PACKAGE_NAME}
+        )
+        result = rhel_client.execute(f"rpm -q {FAKE_4_CUSTOM_PACKAGE_NAME}")
+        assert FAKE_4_CUSTOM_PACKAGE_NAME in result.stdout
 
-    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_preclient_package_installation)
-    def test_post_scenario_preclient_package_installation(
-        default_org, module_target_sat, pre_upgrade_data
+        # Save client info to disk for post-upgrade test
+        save_test_data(
+            {
+                'rhel_client': rhel_client.hostname,
+                'org_id': module_org.id,
+            }
+        )
+
+    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_pre_client_package_installation)
+    def test_post_scenario_pre_client_package_installation(
+        self, module_target_sat, pre_upgrade_data
     ):
         """Post-upgrade install of a package on a client created and registered pre-upgrade.
 
@@ -194,27 +106,17 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
 
         :expectedresults: The package is installed on client
         """
-        client = pre_upgrade_data.get(__name__)
-        client_name = str(list(client.keys())[0]).lower()
+        client_name = pre_upgrade_data.get('rhel_client')
         client_id = (
             module_target_sat.api.Host().search(query={'search': f'name={client_name}'})[0].id
         )
-        module_target_sat.api.Host().install_content(
-            data={
-                'organization_id': default_org.id,
-                'included': {'ids': [client_id]},
-                'content_type': 'package',
-                'content': [FAKE_0_CUSTOM_PACKAGE],
-            }
+        module_target_sat.cli.Host.package_install(
+            {'host-id': client_id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )
         # Verifies that package is really installed
-        installed_package = execute(
-            docker_execute_command,
-            list(client.values())[0],
-            f'rpm -q {FAKE_0_CUSTOM_PACKAGE}',
-            host=docker_vm,
-        )[docker_vm]
-        assert FAKE_0_CUSTOM_PACKAGE in installed_package
+        rhel_client = Broker().from_inventory(filter=f'hostname={client_name}')[0]
+        result = rhel_client.execute(f"rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}")
+        assert FAKE_0_CUSTOM_PACKAGE_NAME in result.stdout
 
 
 class TestScenarioUpgradeNewClientAndPackageInstallation:
@@ -231,8 +133,8 @@ class TestScenarioUpgradeNewClientAndPackageInstallation:
     """
 
     @pytest.mark.post_upgrade
-    def test_post_scenario_postclient_package_installation(
-        default_org, post_upgrade_repo, module_ak, module_target_sat, module_lce
+    def test_post_scenario_post_client_package_installation(
+        self, module_target_sat, katello_agent_client_for_upgrade, module_org
     ):
         """Post-upgrade test that creates a client, installs a package on
         the post-upgrade created client and then verifies the package is installed.
@@ -254,53 +156,22 @@ class TestScenarioUpgradeNewClientAndPackageInstallation:
                 the content host is created
             3. The package is installed on post-upgrade client
         """
-        rhel7_client = dockerize(
-            ak_name=module_ak.name, distro='rhel7', org_label=default_org.label
-        )
-        client_container_id = list(rhel7_client.values())[0]
-        client_name = list(rhel7_client.keys())[0].lower()
-        # Wait 60 seconds as script in /tmp takes up to 2 min inc the repo sync time
-        time.sleep(60)
-        # Use yum install again in case script was not yet finished
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            'yum -y install katello-agent',
-            host=docker_vm,
-        )[docker_vm]
-        # Assert gofer was installed after yum completes
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            'rpm -q gofer',
-            host=docker_vm,
-        )[docker_vm]
-        assert 'package gofer is not installed' not in installed_package
+        rhel_client = katello_agent_client_for_upgrade.client
+        rhid = rhel_client.execute('subscription-manager identity')
+        assert module_org.name in rhid.stdout
+        result = rhel_client.execute('rpm -q gofer')
+        assert result.status == 0
+        assert 'package gofer is not installed' not in result.stdout
         # Run goferd on client as its docker container
-        kwargs = {'async': True, 'host': docker_vm}
-        execute(docker_execute_command, client_container_id, 'goferd -f', **kwargs)
+        rhel_client._cont_inst.exec_run('goferd -f', detach=True)
         # Holding on for 30 seconds while goferd starts
         time.sleep(30)
-        status = execute(docker_execute_command, client_container_id, 'ps -aux', host=docker_vm)[
-            docker_vm
-        ]
-        assert 'goferd' in status
-        client_id = (
-            module_target_sat.api.Host().search(query={'search': f'name={client_name}'})[0].id
+        rhel_client.execute('yum install -y procps')  # ps command needs to be installed
+        result = rhel_client.execute("ps -ef | grep goferd")
+        assert 'goferd' in result.stdout
+        module_target_sat.cli.Host.package_install(
+            {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )
-        module_target_sat.api.Host().install_content(
-            data={
-                'organization_id': default_org.id,
-                'included': {'ids': [client_id]},
-                'content_type': 'package',
-                'content': [FAKE_4_CUSTOM_PACKAGE],
-            }
-        )
-        # Validate if that package is really installed
-        installed_package = execute(
-            docker_execute_command,
-            client_container_id,
-            f'rpm -q {FAKE_4_CUSTOM_PACKAGE}',
-            host=docker_vm,
-        )[docker_vm]
-        assert FAKE_4_CUSTOM_PACKAGE in installed_package
+        # Verifies that package is really installed
+        result = rhel_client.execute(f"rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}")
+        assert FAKE_0_CUSTOM_PACKAGE_NAME in result.stdout

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -17,7 +17,6 @@
 :Upstream: No
 """
 import pytest
-from nailgun import entities
 
 
 @pytest.mark.stubbed
@@ -162,7 +161,7 @@ class TestRoleAddPermission:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_default_role_added_permission(self):
+    def test_pre_default_role_added_permission(self, target_sat):
         """New permission is added to Default Role
 
         :id: preupgrade-3a350e4a-96b3-4033-b562-3130fc43a4bc
@@ -172,17 +171,17 @@ class TestRoleAddPermission:
         :expectedresults: Permission is added to existing 'Default role'.
 
         """
-        defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
-        subnetfilter = entities.Filter(
-            permission=entities.Permission().search(
+        default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
+        subnet_filter = target_sat.api.Filter(
+            permission=target_sat.api.Permission().search(
                 filters={'name': 'view_subnets'}, query={'search': 'resource_type="Subnet"'}
             ),
-            role=defaultrole,
+            role=default_role,
         ).create()
-        assert subnetfilter.id in [filt.id for filt in defaultrole.read().filters]
+        assert subnet_filter.id in [filt.id for filt in default_role.read().filters]
 
     @pytest.mark.post_upgrade(depend_on=test_pre_default_role_added_permission)
-    def test_post_default_role_added_permission(self):
+    def test_post_default_role_added_permission(self, target_sat):
         """The new permission in 'Default role' is intact post upgrade
 
         :id: postupgrade-3a350e4a-96b3-4033-b562-3130fc43a4bc
@@ -190,13 +189,13 @@ class TestRoleAddPermission:
         :expectedresults: The added permission in existing 'Default role' is
             intact post upgrade
         """
-        defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
-        subnetfilt = entities.Filter().search(
-            query={'search': f'role_id={defaultrole.id} and permission="view_subnets"'}
+        default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
+        subnet_filter = target_sat.api.Filter().search(
+            query={'search': f'role_id={default_role.id} and permission="view_subnets"'}
         )
-        assert subnetfilt
+        assert subnet_filter
         # Teardown
-        subnetfilt[0].delete()
+        subnet_filter[0].delete()
 
 
 class TestRoleAddPermissionWithFilter:
@@ -216,7 +215,7 @@ class TestRoleAddPermissionWithFilter:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_default_role_added_permission_with_filter(self):
+    def test_pre_default_role_added_permission_with_filter(self, target_sat):
         """New permission with filter is added to Default Role
 
         :id: preupgrade-b287b71c-42fd-4612-a67a-b93d47dbbb33
@@ -227,19 +226,19 @@ class TestRoleAddPermissionWithFilter:
             'Default role'
 
         """
-        defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
-        domainfilter = entities.Filter(
-            permission=entities.Permission().search(
+        default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
+        domain_filter = target_sat.api.Filter(
+            permission=target_sat.api.Permission().search(
                 filters={'name': 'view_domains'}, query={'search': 'resource_type="Domain"'}
             ),
             unlimited=False,
-            role=defaultrole,
+            role=default_role,
             search='name ~ a',
         ).create()
-        assert domainfilter.id in [filt.id for filt in defaultrole.read().filters]
+        assert domain_filter.id in [filt.id for filt in default_role.read().filters]
 
     @pytest.mark.post_upgrade(depend_on=test_pre_default_role_added_permission_with_filter)
-    def test_post_default_role_added_permission_with_filter(self):
+    def test_post_default_role_added_permission_with_filter(self, target_sat):
         """The new permission with filter in 'Default role' is intact post
             upgrade
 
@@ -248,11 +247,11 @@ class TestRoleAddPermissionWithFilter:
         :expectedresults: The added permission with filter in existing
             'Default role' is intact post upgrade
         """
-        defaultrole = entities.Role().search(query={'search': 'name="Default role"'})[0]
-        domainfilt = entities.Filter().search(
-            query={'search': f'role_id={defaultrole.id} and permission="view_domains"'}
+        default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
+        domain_filter = target_sat.api.Filter().search(
+            query={'search': f'role_id={default_role.id} and permission="view_domains"'}
         )
-        assert domainfilt
-        assert domainfilt[0].search == 'name ~ a'
+        assert domain_filter
+        assert domain_filter[0].search == 'name ~ a'
         # Teardown
-        domainfilt[0].delete()
+        domain_filter[0].delete()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10577

Upgrade Scenario Refactor 

- [x] - test_role.py, test_sync_plan.py now uses the target_sat and removed the import entities 
- [x] - test_client.py now uses the broker to manage the RHEL clients 
- [x] - test_client.py moved rhel7 support to rhel8 for time being (needs to add more RHEL client support)
- [x] - refactor the test_client.py with new fixtures, for smooth running 
- [x] -  added support for simple-content-access cli 