### PR TITLE
[6.12.z] Adding a missed fixture file in conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,6 +20,7 @@ pytest_plugins = [
     'pytest_plugins.factory_collection',
     # Fixtures
     'pytest_fixtures.core.broker',
+    'pytest_fixtures.core.sat_cap_factory',
     'pytest_fixtures.core.contenthosts',
     'pytest_fixtures.core.reporting',
     'pytest_fixtures.core.sys',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10728

Adding a missed fixture file reference in conftest file. Due to which tests are failing with error:


```
fixture 'module_capsule_configured' not found
```

Test e.g: `tests.foreman.cli.test_registration.test_host_registration_end_to_end[rhel6]`