### PR TITLE
[6.11.z] skip utf8 usernames

### DIFF
--- a/robottelo/utils/datafactory.py
+++ b/robottelo/utils/datafactory.py
@@ -428,7 +428,8 @@ def valid_org_names_list():
 @filtered_datapoint
 def valid_usernames_list():
     """Returns a list of valid user names."""
-    return generate_strings_list(exclude_types=['html'], min_length=1, max_length=50)
+    # utf8 excluded due to BZ:2169988
+    return generate_strings_list(exclude_types=['html', 'utf8'], min_length=1, max_length=50)
 
 
 @filtered_datapoint

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -63,7 +63,7 @@ class TestFilteredDataPoint:
             assert len(datafactory.valid_interfaces_list()) == 3
             assert len(datafactory.valid_names_list()) == 15
             assert len(datafactory.valid_org_names_list()) == 7
-            assert len(datafactory.valid_usernames_list()) == 6
+            assert len(datafactory.valid_usernames_list()) == 5
             assert len(datafactory.valid_cron_expressions()) == 4
             assert len(datafactory.valid_docker_repository_names()) == 7
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10710

Pr excludes utf8 from valid usernames list due to bz 2169988. The way it's done is not ideal, but I hit a circular import error when trying to skip using is_open within datafactory