### PR TITLE
no need to install hosts tools as part of rex setup

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -143,10 +143,9 @@ def cockpit_host(class_target_sat, class_org, rhel_contenthost):
 def rex_contenthost(request, module_org, target_sat):
     request.param['no_containers'] = True
     with Broker(**host_conf(request), host_class=ContentHost) as host:
-        # Register content host to Satellite and install katello-host-tools on the host
+        # Register content host to Satellite
         repo = settings.repos['SATCLIENT_REPO'][f'RHEL{host.os_version.major}']
         target_sat.register_host_custom_repo(module_org, host, [repo])
-        host.install_katello_host_tools()
         # Enable remote execution on the host
         host.add_rex_key(satellite=target_sat)
         yield host


### PR DESCRIPTION
The tests relying on rex_contenthost fixture don't require katello-host-tools to be present, as far as I can see. Though having it there makes the setup sensitive to manifest-related issues. 