### PR TITLE
Change constant to match new letter case in sat 6.13+

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1445,7 +1445,7 @@ PERMISSIONS_UI = {
 }
 
 
-ANY_CONTEXT = {'org': "Any Organization", 'location': "Any Location"}
+ANY_CONTEXT = {'org': "Any organization", 'location': "Any location"}
 
 SUBNET_IPAM_TYPES = {'dhcp': 'DHCP', 'internal': 'Internal DB', 'none': 'None'}
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -1182,7 +1182,7 @@ def test_positive_select_org_in_any_context():
     :BZ: 1860957
 
     :Steps:
-        1. Set "Any Organization" and "Any Location" on top
+        1. Set "Any organization" and "Any location" on top
         2. Click on Content -> "Sync Status"
         3. "Select an Organization" page will come up.
         4. Select organization in dropdown and press Select


### PR DESCRIPTION
Since Sat 6.13 "Any Location" and "Any Organization" has been changed to "Any location" and "Any organization".
This change fixes `test_positive_search_by_org` test.
[Discussion about changing letter case](https://github.com/theforeman/foreman/pull/9222#issuecomment-1135786745)