### PR TITLE
Account for stream as a satellite release version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ deepdiff==6.2.3
 dynaconf[vault]==3.1.11
 fauxfactory==3.1.0
 jinja2==3.1.2
-manifester==0.0.11
+manifester==0.0.12
 navmazing==1.1.6
 productmd==1.33
 pyotp==2.8.0

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -71,11 +71,9 @@ def get_sat_version():
     try:
         sat_version = Satellite().version
     except (AuthenticationError, ContentHostError, BoxKeyError):
-        if hasattr(settings.server.version, 'release'):
-            sat_version = str(settings.server.version.release)
-        elif hasattr(settings.robottelo, 'satellite_version'):
-            sat_version = settings.robottelo.satellite_version
-        else:
+        if str(sat_version := settings.server.version.get('release')) == 'stream':
+            sat_version = str(settings.robottelo.get('satellite_version'))
+        if not sat_version:
             sat_version = SATELLITE_VERSION
     return Version('9999' if 'nightly' in sat_version else sat_version)
 


### PR DESCRIPTION
Since we are setting stream as the satellite release version, we need to fallback to the backup satellite version in config.