### PR TITLE
removing unwanted base branch check from auto-merging

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -8,11 +8,6 @@ on:
       - ready_for_review
     branches-ignore:
       - master
-  pull_request_review:
-    types:
-      - submitted
-    branches-ignore:
-      - master
   check_suite:
     types:
       - completed
@@ -110,7 +105,6 @@ jobs:
           MERGE_METHOD: "squash"
           MERGE_RETRIES: 5
           MERGE_RETRY_SLEEP: 900000
-          BASE_BRANCHES: "master" # avoid automerge branch
 
       - name: Auto Merge Status
         run: |


### PR DESCRIPTION
`BASE_BRANCHES: If provided, the action will be restricted in terms of base branches. Can be comma-separated list of simple branch names (i.e main,dev).` from the upstream repo. So no need for this adding check.   