### PR TITLE
[6.11.z] Puppet e2e

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:CaseImportance: Medium
+
 :Team: Rocket
 
 :TestType: Functional
@@ -78,6 +80,7 @@ def module_puppet(session_puppet_enabled_sat):
 
 
 @pytest.mark.run_in_one_thread
+@pytest.mark.e2e
 @pytest.mark.skipif(
     not settings.robottelo.repos_hosting_url, reason='repos_hosting_url is not defined'
 )
@@ -97,14 +100,11 @@ class TestSmartClassParameters:
         :parametrized: yes
 
         :steps:
-
             1. Set override to True.
             2. Update the Key Type to any of available.
             3. Set a 'valid' default Value.
 
         :expectedresults: Parameter Updated with a new type successfully.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         sc_param.override = True
@@ -133,17 +133,13 @@ class TestSmartClassParameters:
         :parametrized: yes
 
         :steps:
-
             1. Set override to True.
             2. Update the Key Type.
             3. Attempt to set an 'Invalid' default Value.
 
         :expectedresults:
-
             1. Parameter not updated with string type for invalid value.
             2. Error raised for invalid default value.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         with pytest.raises(HTTPError) as context:
@@ -163,7 +159,6 @@ class TestSmartClassParameters:
         :id: 92977eb0-92c2-4734-84d9-6fda8ff9d2d8
 
         :steps:
-
             1. Set override to True.
             2. Set some default value, Not empty.
             3. Set 'required' to true.
@@ -171,8 +166,6 @@ class TestSmartClassParameters:
             5. Set some Value for matcher.
 
         :expectedresults: No error raised for non-empty default value
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         sc_param.parameter_type = 'boolean'
@@ -206,8 +199,6 @@ class TestSmartClassParameters:
             4. Set 'required' to true.
 
         :expectedresults: Error raised for blank matcher value.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         sc_param.override = True
@@ -226,7 +217,6 @@ class TestSmartClassParameters:
         :id: 99628b78-3037-4c20-95f0-7ce5455093ac
 
         :steps:
-
             1. Set override to True.
             2. Set default value that doesn't matches the regex of step 3.
             3. Validate this value with regex validator type and rule.
@@ -256,7 +246,6 @@ class TestSmartClassParameters:
         :id: d5df7804-9633-4ef8-a065-10807351d230
 
         :steps:
-
             1. Set override to True.
             2. Set default value that matches the regex of step 3.
             3. Validate this value with regex validator type and rule.
@@ -297,14 +286,11 @@ class TestSmartClassParameters:
         :id: a5e89e86-253f-4254-9ebb-eefb3dc2c2ab
 
         :steps:
-
             1. Set override to True.
             2. Create a matcher with value that doesn't match the list of step
             3. Validate this value with list validator type and rule.
 
         :expectedresults: Error raised for matcher value not in list.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         session_puppet_enabled_sat.api.OverrideValue(
@@ -328,14 +314,11 @@ class TestSmartClassParameters:
         :id: 05c1a0bb-ba27-4842-bb6a-8420114cffe7
 
         :steps:
-
             1. Set override to True.
             2. Create a matcher with value that matches the list of step 3.
             3. Validate this value with list validator type and rule.
 
         :expectedresults: Error not raised for matcher value in list.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         session_puppet_enabled_sat.api.OverrideValue(
@@ -357,14 +340,11 @@ class TestSmartClassParameters:
         :id: 77b6e90d-e38a-4973-98e3-c698eae5c534
 
         :steps:
-
             1. Set override to True.
             2. Update parameter default type with valid value.
             3. Create a matcher with value that matches the default type.
 
         :expectedresults: Error not raised for matcher value of default type.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         sc_param.override = True
@@ -387,7 +367,6 @@ class TestSmartClassParameters:
         :id: e46a12cb-b3ea-42eb-b1bb-b750655b6a4a
 
         :steps:
-
             1. Set override to True.
             2. Update parameter default type with Invalid value.
             3. Create a matcher with value that doesn't matches the default
@@ -395,8 +374,6 @@ class TestSmartClassParameters:
 
         :expectedresults: Error raised for invalid default and matcher value
             both.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         session_puppet_enabled_sat.api.OverrideValue(
@@ -429,8 +406,6 @@ class TestSmartClassParameters:
             4. Remove matcher afterwards
 
         :expectedresults: The matcher has been created and removed successfully.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         value = gen_string('alpha')
@@ -454,10 +429,7 @@ class TestSmartClassParameters:
 
         :steps: Set parameter type to array/hash.
 
-        :expectedresults: The Merge Overrides, Merge Default checks are enabled
-            to check.
-
-        :CaseImportance: Medium
+        :expectedresults: The Merge Overrides, Merge Default checks are enabled to check.
         """
         sc_param = module_puppet['sc_params'].pop()
         sc_param.override = True
@@ -482,10 +454,7 @@ class TestSmartClassParameters:
 
         :steps: Set parameter type other than array/hash.
 
-        :expectedresults: The Merge Overrides, Merge Default checks are not
-            enabled to check.
-
-        :CaseImportance: Medium
+        :expectedresults: The Merge Overrides, Merge Default checks are not enabled to check.
         """
         sc_param = module_puppet['sc_params'].pop()
         sc_param.override = True
@@ -516,13 +485,10 @@ class TestSmartClassParameters:
         :id: 80bf52df-e678-4384-a4d5-7a88928620ce
 
         :steps:
-
             1. Set parameter type to array.
             2. Set 'merge overrides' to True.
 
         :expectedresults: The Avoid Duplicates is enabled to set to True.
-
-        :CaseImportance: Medium
         """
         sc_param = module_puppet['sc_params'].pop()
         sc_param.override = True
@@ -544,13 +510,8 @@ class TestSmartClassParameters:
         :steps: Set parameter type other than array.
 
         :expectedresults:
-
-            1. The Merge Overrides checkbox is only enabled to check for type
-               hash other than array.
-            2. The Avoid duplicates checkbox not enabled to check for any type
-               than array.
-
-        :CaseImportance: Medium
+            1. Merge Overrides checkbox is only enabled to check for type hash other than array.
+            2. Avoid duplicates checkbox not enabled to check for any type than array.
         """
         sc_param = module_puppet['sc_params'].pop()
         sc_param.override = True
@@ -574,22 +535,15 @@ class TestSmartClassParameters:
         :id: 3ffbf403-dac9-4172-a586-82267765abd8
 
         :steps:
-
-            1. Set the parameter to True and create a matcher for some
-               attribute.
+            1. Set the parameter to True and create a matcher for some attribute.
             2. Delete the attribute.
             3. Recreate the attribute with same name as earlier.
 
         :expectedresults:
-
             1. The matcher for deleted attribute removed from parameter.
-            2. On recreating attribute, the matcher should not reappear in
-               parameter.
-
-        :CaseImportance: Medium
+            2. On recreating attribute, the matcher should not reappear in parameter.
 
         :BZ: 1374253
-
         """
         sc_param = module_puppet['sc_params'].pop()
         hostgroup_name = gen_string('alpha')

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -16,7 +16,7 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 :Upstream: No
 """
@@ -39,10 +39,7 @@ def test_positive_create_with_name(name, session_puppet_enabled_sat):
 
     :parametrized: yes
 
-    :expectedresults: The environment created successfully and has expected
-        name.
-
-    :CaseImportance: Critical
+    :expectedresults: The environment created successfully and has expected name
     """
     env = session_puppet_enabled_sat.api.Environment(name=name).create()
     assert env.name == name
@@ -56,10 +53,7 @@ def test_positive_create_with_org_and_loc(
 
     :id: de7e4132-5ca7-4b41-9af3-df075d31f8f4
 
-    :expectedresults: The environment created successfully and has expected
-        attributes.
-
-    :CaseImportance: Critical
+    :expectedresults: The environment created successfully and has expected attributes.
     """
     env = session_puppet_enabled_sat.api.Environment(
         name=gen_string('alphanumeric'),
@@ -82,7 +76,6 @@ def test_negative_create_with_too_long_name(name, session_puppet_enabled_sat):
     :parametrized: yes
 
     :expectedresults: The server returns an error.
-
     """
     with pytest.raises(HTTPError):
         session_puppet_enabled_sat.api.Environment(name=name).create()
@@ -98,7 +91,6 @@ def test_negative_create_with_invalid_characters(name, session_puppet_enabled_sa
     :parametrized: yes
 
     :expectedresults: The server returns an error.
-
     """
     with pytest.raises(HTTPError):
         session_puppet_enabled_sat.api.Environment(name=name).create()
@@ -115,7 +107,6 @@ def test_positive_update_name(module_puppet_environment, new_name, session_puppe
     :parametrized: yes
 
     :expectedresults: Environment entity is created and updated properly
-
     """
     env = session_puppet_enabled_sat.api.Environment(
         id=module_puppet_environment.id, name=new_name
@@ -132,10 +123,7 @@ def test_positive_update_and_remove(
 
     :id: 31e43faa-65ee-4757-ac3d-3825eba37ae5
 
-    :expectedresults: Environment entity is updated and removed
-        properly
-
-    :CaseImportance: Critical
+    :expectedresults: Environment entity is updated and removed properly
 
     :CaseLevel: Integration
     """
@@ -170,7 +158,6 @@ def test_negative_update_name(module_puppet_environment, new_name, session_puppe
     :parametrized: yes
 
     :expectedresults: Environment entity is not updated
-
     """
     with pytest.raises(HTTPError):
         session_puppet_enabled_sat.api.Environment(

--- a/tests/foreman/api/test_puppetbootstrap.py
+++ b/tests/foreman/api/test_puppetbootstrap.py
@@ -16,10 +16,12 @@
 
 :Upstream: No
 """
+import pytest
 import requests
 from fauxfactory import gen_string
 
 
+@pytest.mark.e2e
 def test_positive_puppet_bootstrap(
     session_puppet_enabled_sat,
     session_puppet_enabled_proxy,

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -8,6 +8,8 @@
 
 :CaseComponent: Puppet
 
+:CaseImportance: Medium
+
 :Team: Rocket
 
 :TestType: Functional
@@ -58,6 +60,7 @@ def module_sc_params(session_puppet_enabled_sat, module_puppet):
 
 
 @pytest.mark.run_in_one_thread
+@pytest.mark.e2e
 @pytest.mark.skipif(
     not settings.robottelo.REPOS_HOSTING_URL, reason="repos_hosting_url is not defined"
 )
@@ -80,8 +83,6 @@ class TestSmartClassParameters:
         :expectedresults: Parameters listed for specific Environment
             (by name and id), Host (name, id), Hostgroup (name, id),
             and puppetclass (name)
-
-        :CaseImportance: Medium
         """
         host = session_puppet_enabled_sat.api.Host(
             organization=module_puppet_org.id,
@@ -135,8 +136,6 @@ class TestSmartClassParameters:
         :expectedresults: Parameters listed for specific Puppet class.
 
         :BZ: 1391556
-
-        :CaseImportance: Medium
         """
         password = gen_string('alpha')
         required_user_permissions = {
@@ -186,8 +185,6 @@ class TestSmartClassParameters:
         :BZ: 1830834
 
         :customerscenario: true
-
-        :CaseImportance: Medium
         """
         sc_param_id = module_sc_params['ids'].pop()
         value = gen_string('alpha')
@@ -217,8 +214,6 @@ class TestSmartClassParameters:
         :BZ: 1830834
 
         :customerscenario: true
-
-        :CaseImportance: Medium
         """
         sc_param_id = module_sc_params['ids'].pop()
         with pytest.raises(CLIReturnCodeError):
@@ -244,8 +239,6 @@ class TestSmartClassParameters:
         :expectedresults: Error raised for default value not in list.
 
         :customerscenario: true
-
-        :CaseImportance: Medium
         """
         value = gen_string('alphanumeric')
         sc_param_id = module_sc_params['ids'].pop()
@@ -284,8 +277,6 @@ class TestSmartClassParameters:
         :customerscenario: true
 
         :BZ: 1830834
-
-        :CaseImportance: Medium
         """
         sc_param_id = module_sc_params['ids'].pop()
         session_puppet_enabled_sat.cli.SmartClassParameter.update(
@@ -320,8 +311,6 @@ class TestSmartClassParameters:
             3.  Attempt to submit the change.
 
         :expectedresults: Error raised for non existing attribute.
-
-        :CaseImportance: Medium
         """
         sc_param_id = module_sc_params['ids'].pop()
         with pytest.raises(CLIReturnCodeError):
@@ -353,8 +342,6 @@ class TestSmartClassParameters:
             6.  Remove the matcher created in step 1
 
         :expectedresults: The matcher has been created successfully.
-
-        :CaseImportance: Medium
         """
         sc_param_id = module_sc_params['ids'].pop()
         value = gen_string('alpha')
@@ -399,8 +386,6 @@ class TestSmartClassParameters:
             4.  Submit the change.
 
         :expectedresults: The matcher has been created successfully.
-
-        :CaseImportance: Medium
         """
         sc_param_id = module_sc_params['ids'].pop()
         session_puppet_enabled_sat.cli.SmartClassParameter.update(

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -12,7 +12,7 @@
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 :Upstream: No
 """
@@ -87,8 +87,6 @@ def test_negative_create_with_name(name, session_puppet_enabled_sat):
     :parametrized: yes
 
     :expectedresults: Environment is not created.
-
-    :CaseImportance: Critical
     """
     with pytest.raises(CLIReturnCodeError):
         session_puppet_enabled_sat.cli.Environment.create({'name': name})
@@ -96,6 +94,7 @@ def test_negative_create_with_name(name, session_puppet_enabled_sat):
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
+@pytest.mark.e2e
 def test_positive_CRUD_with_attributes(
     session_puppet_enabled_sat, module_puppet_org, module_locations
 ):
@@ -110,8 +109,6 @@ def test_positive_CRUD_with_attributes(
         2. Environment can be listed by parameters
         3. Environment can be updated
         4. Environment can be removed
-
-    :CaseImportance: Critical
     """
     # Create with attributes
     env_name = gen_string('alpha')
@@ -196,7 +193,6 @@ def test_negative_update_name(new_name, session_puppet_enabled_sat):
     :parametrized: yes
 
     :expectedresults: Environment is not updated
-
     """
     environment = session_puppet_enabled_sat.cli.Environment.create({'name': gen_string('alpha')})
     with pytest.raises(CLIReturnCodeError):
@@ -219,7 +215,6 @@ def test_positive_sc_params(module_import_puppet_module, session_puppet_enabled_
     :id: 32de4f0e-7b52-411c-a111-9ed472c3fc34
 
     :expectedresults: The command runs without raising an error
-
     """
     # Override one of the sc-params from puppet class
     sc_params_list = session_puppet_enabled_sat.cli.SmartClassParameter.list(

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -12,7 +12,7 @@
 
 :TestType: Functional
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 :Upstream: No
 """
@@ -21,6 +21,8 @@ import random
 import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
+
+pytestmark = pytest.mark.e2e
 
 
 @pytest.fixture(scope='module')
@@ -39,8 +41,6 @@ def test_positive_info(run_puppet_agent, session_puppet_enabled_sat):
     :id: 32646d4b-7101-421a-85e0-777d3c6b71ec
 
     :expectedresults: Puppet Report Info is displayed
-
-    :CaseImportance: Critical
     """
     result = session_puppet_enabled_sat.cli.ConfigReport.list()
     assert len(result) > 0
@@ -58,8 +58,6 @@ def test_positive_delete_by_id(run_puppet_agent, session_puppet_enabled_sat):
     :id: bf918ec9-e2d4-45d0-b913-ab939b5d5e6a
 
     :expectedresults: Puppet Report is deleted
-
-    :CaseImportance: Critical
     """
     result = session_puppet_enabled_sat.cli.ConfigReport.list()
     assert len(result) > 0
@@ -68,3 +66,46 @@ def test_positive_delete_by_id(run_puppet_agent, session_puppet_enabled_sat):
     session_puppet_enabled_sat.cli.ConfigReport.delete({'id': report['id']})
     with pytest.raises(CLIReturnCodeError):
         session_puppet_enabled_sat.cli.ConfigReport.info({'id': report['id']})
+
+
+@pytest.mark.e2e
+@pytest.mark.rhel_ver_match('[7,8]')
+def test_positive_install_configure(request, session_puppet_enabled_sat, rhel_contenthost):
+    """Test that puppet-agent can be installed from the sat-client repo
+    and configured to report back to the Satellite.
+
+    :id: 07777fbb-4f2e-4fab-ba5a-2b698f9b9f38
+
+    :setup:
+        1. Satellite with enabled puppet plugin.
+        2. Blank RHEL content host.
+
+    :steps:
+        1. Configure puppet on the content host. This creates sat-client repository,
+           installs puppet-agent, configures it, runs it to create the puppet cert,
+           signs in on the Satellite side and reruns it.
+        2. Assert that Config report was created at the Satellite for the content host.
+        3. Assert that Facts were reported for the content host.
+
+    :expectedresults:
+        1. Configuration passes without errors.
+        2. Config report is created.
+        3. Facts are acquired.
+
+    :customerscenario: true
+
+    :BZ: 2126891
+    """
+    rhel_contenthost.configure_puppet(proxy_hostname=session_puppet_enabled_sat.hostname)
+    report = session_puppet_enabled_sat.cli.ConfigReport.list(
+        {'search': f'host~{rhel_contenthost.hostname},origin=Puppet'}
+    )
+    assert len(report)
+    facts = session_puppet_enabled_sat.cli.Fact.list(
+        {'search': f'host~{rhel_contenthost.hostname}'}
+    )
+    assert len(facts)
+
+    @request.addfinalizer
+    def _finalize():
+        assert session_puppet_enabled_sat.cli.ConfigReport.delete({'id': report[0]['id']})

--- a/tests/foreman/destructive/test_puppetplugin.py
+++ b/tests/foreman/destructive/test_puppetplugin.py
@@ -34,7 +34,7 @@ puppet_cli_commands = [
 
 err_msg = 'Error: No such sub-command'
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.e2e]
 
 
 def assert_puppet_status(server, expected):
@@ -99,9 +99,6 @@ def test_positive_enable_disable_logic(target_sat, capsule_configured):
     assert result.status == 0
     assert 'Success!' in result.stdout
 
-    # workaround for BZ#2039696
-    target_sat.execute('hammer -r')
-
     assert_puppet_status(target_sat, expected=True)
 
     # Enable puppet on Capsule and check it succeeded.
@@ -131,41 +128,3 @@ def test_positive_enable_disable_logic(target_sat, capsule_configured):
     )
     assert result.status == 0
     assert_puppet_status(target_sat, expected=False)
-
-
-@pytest.mark.rhel_ver_match('[7,8]')
-def test_positive_install_configure(session_puppet_enabled_sat, rhel_contenthost):
-    """Test that puppet-agent can be installed from the sat-client repo
-    and configured to report back to the Satellite.
-
-    :id: 07777fbb-4f2e-4fab-ba5a-2b698f9b9f38
-
-    :setup:
-        1. Satellite with enabled puppet plugin.
-        2. Blank RHEL content host.
-
-    :steps:
-        1. Configure puppet on the content host. This creates sat-client repository,
-           installs puppet-agent, configures it, runs it to create the puppet cert,
-           signs in on the Satellite side and reruns it.
-        2. Assert that Config report was created at the Satellite for the content host.
-        3. Assert that Facts were reported for the content host.
-
-    :expectedresults:
-        1. Configuration passes without errors.
-        2. Config report is created.
-        3. Facts are acquired.
-
-    :customerscenario: true
-
-    :BZ: 2126891
-    """
-    rhel_contenthost.configure_puppet(proxy_hostname=session_puppet_enabled_sat.hostname)
-    reports = session_puppet_enabled_sat.cli.ConfigReport.list(
-        {'search': f'host~{rhel_contenthost.hostname},origin=Puppet'}
-    )
-    assert len(reports)
-    facts = session_puppet_enabled_sat.cli.Fact.list(
-        {'search': f'host~{rhel_contenthost.hostname}'}
-    )
-    assert len(facts)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10640

1. Mark e2e in Puppet tests and some CaseImportance changes
2. Moved test_positive_install_configure to test_reports