### PR TITLE
Changing puppet install options for stream and 6.14

### DIFF
--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -8,12 +8,8 @@ from robottelo.utils.installer import InstallerCommand
 
 common_opts = {
     'foreman-proxy-puppetca': 'true',
-    'foreman-proxy-content-puppet': 'true',
     'foreman-proxy-puppet': 'true',
     'puppet-server': 'true',
-    'puppet-server-foreman-ssl-ca': '/etc/pki/katello/puppet/puppet_client_ca.crt',
-    'puppet-server-foreman-ssl-cert': '/etc/pki/katello/puppet/puppet_client.crt',
-    'puppet-server-foreman-ssl-key': '/etc/pki/katello/puppet/puppet_client.key',
     # Options for puppetbootstrap test
     'foreman-proxy-templates': 'true',
     'foreman-proxy-http': 'true',


### PR DESCRIPTION
The changes being documented [here](https://github.com/theforeman/foreman-documentation/pull/1947) will be added to stream next week. Updating the options now, so that we can test that everything is working on the next stream release and then cherry-pick to 6.14 when we branch.

See https://github.com/theforeman/foreman-installer/pull/828, https://github.com/theforeman/puppet-puppet/pull/862, and https://github.com/theforeman/puppet-foreman_proxy_content/pull/440 for the actual updates to remove these options from the installer.