### PR TITLE
Implement retry logic in ohsnap helper methods using wait-for library

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -38,7 +38,7 @@ def read_cache(path):
 def get_repos_config(settings):
     data = {}
     # check if the Ohsnap URL is valid, our sample configuration does not contain a valid URL
-    if is_url(settings.repos.ohsnap_repo_host):
+    if is_url(settings.ohsnap.host):
         data.update(get_ohsnap_repos(settings))
     else:
         logger.error(
@@ -127,7 +127,7 @@ def get_dogfood_satclient_repos(settings):
 
 def get_ohsnap_repo_url(settings, repo, product=None, release=None, os_release=None, snap=''):
     repourl = dogfood_repository(
-        settings.repos.ohsnap_repo_host,
+        settings.ohsnap,
         repo=repo,
         product=product,
         release=release,

--- a/conf/ohsnap.yaml.template
+++ b/conf/ohsnap.yaml.template
@@ -1,0 +1,7 @@
+OHSNAP:
+  HOST: "replace by ohsnap repo host url"
+  REQUEST_RETRY:
+    # how long should we keep retrying to get data (seconds)
+    TIMEOUT: 120
+    # delay between retries (seconds)
+    DELAY: 3

--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -6,7 +6,6 @@ REPOS:
   # Provide link to RHEL6,7,8 & 9 repo here, as puppet rpm requires packages from
   # those repos and syncing the entire repo on the fly would take longer for
   # tests to run. Specify the *.repo link to an internal repo for tests to execute properly.
-  OHSNAP_REPO_HOST: replace with ohsnap repo host url
   RHEL_REPO_HOST: http://rhel_repo.example.com
   RHEL6_REPO: '@format {this[repos].rhel_repo_host}/pub/rhel6.repo'
   RHEL7_REPO: '@format {this[repos].rhel_repo_host}/pub/rhel7.repo'

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -199,6 +199,14 @@ VALIDATORS = dict(
             must_exist=True,
         ),
     ],
+    ohsnap=[
+        Validator(
+            'ohsnap.host',
+            'ohsnap.request_retry.timeout',
+            'ohsnap.request_retry.delay',
+            must_exist=True,
+        ),
+    ],
     open_ldap=[
         Validator(
             'open_ldap.base_dn',
@@ -254,7 +262,6 @@ VALIDATORS = dict(
             'repos.rhscl_repo',
             'repos.ansible_repo',
             'repos.swid_tools_repo',
-            'repos.ohsnap_repo_host',
             must_exist=True,
             is_type_of=str,
         ),

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -72,15 +72,13 @@ class VersionedContent:
     def download_repofile(self, product=None, release=None, snap=''):
         """Downloads the tools/client, capsule, or satellite repos on the machine"""
         product, release, snap, v_major, _ = self._dogfood_helper(product, release, snap)
-        url = dogfood_repofile_url(settings.repos.ohsnap_repo_host, product, release, v_major, snap)
+        url = dogfood_repofile_url(settings.ohsnap.host, product, release, v_major, snap)
         self.execute(f'curl -o /etc/yum.repos.d/dogfood.repo {url}')
 
     def dogfood_repository(self, repo=None, product=None, release=None, snap=''):
         """Returns a repository definition based on the arguments provided"""
         product, release, snap, v_major, repo = self._dogfood_helper(product, release, snap, repo)
-        return dogfood_repository(
-            settings.repos.ohsnap_repo_host, repo, product, release, v_major, snap, self.arch
-        )
+        return dogfood_repository(settings.ohsnap, repo, product, release, v_major, snap, self.arch)
 
     def enable_tools_repo(self, organization_id):
         return self.satellite.api_factory.enable_rhrepo_and_fetchid(

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -100,7 +100,7 @@ def test_negative_time_to_pickup(
     :parametrized: yes
     """
     client_repo = ohsnap.dogfood_repository(
-        settings.repos.ohsnap_repo_host,
+        settings.ohsnap,
         product='client',
         repo='client',
         release='Client',

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -989,7 +989,7 @@ class TestPullProviderRex:
         :parametrized: yes
         """
         client_repo = ohsnap.dogfood_repository(
-            settings.repos.ohsnap_repo_host,
+            settings.ohsnap,
             product='client',
             repo='client',
             release='Client',
@@ -1087,7 +1087,7 @@ class TestPullProviderRex:
         :parametrized: yes
         """
         client_repo = ohsnap.dogfood_repository(
-            settings.repos.ohsnap_repo_host,
+            settings.ohsnap,
             product='client',
             repo='client',
             release='Client',
@@ -1177,7 +1177,7 @@ class TestPullProviderRex:
         :parametrized: yes
         """
         client_repo = ohsnap.dogfood_repository(
-            settings.repos.ohsnap_repo_host,
+            settings.ohsnap,
             product='client',
             repo='client',
             release='Client',


### PR DESCRIPTION
This commit should cover us from the intermittent, short outages of `ohsnap` service.
It leverages the `wait-for` library that is used in a way that if the outage persists after the method timing out, an original Error is thrown.
In order to be able to use it this way, I had to register a [requests hook](https://docs.python-requests.org/en/latest/user/advanced/#event-hooks), that automatically runs `raise_for_status` on every response and logs the unsuccessful attempts.

Test:
I spawned my own instnace of ohsnap and simulated outage by scaling it down to 0 pods, and then back to 1 pod after a while:
```
2023-02-28 13:18:56 - urllib3.connectionpool - DEBUG - https://vault.corp.redhat.com:8200 "GET /v1/apps/data/mna-satqe-hashicorp/robottelo HTTP/1.1" 200 None
2023-02-28 13:18:58 - robottelo - WARNING - The snap version was not provided. Snap number will not be used in the URL.
2023-02-28 13:18:58 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): ohsnap-instance.foo:80
2023-02-28 13:18:58 - urllib3.connectionpool - DEBUG - http://ohsnap-instance.foo:80 "GET /api/releases/6.13.0/el8/capsule/repositories HTTP/1.1" 503 None
2023-02-28 13:18:58 - robottelo - WARNING - Request to: http://ohsnap-instance.foo/api/releases/6.13.0/el8/capsule/repositories got response: 503
2023-02-28 13:19:01 - robottelo - WARNING - The snap version was not provided. Snap number will not be used in the URL.
2023-02-28 13:19:01 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): ohsnap-instance.foo:80
2023-02-28 13:19:01 - urllib3.connectionpool - DEBUG - http://ohsnap-instance.foo:80 "GET /api/releases/6.13.0/el8/capsule/repositories HTTP/1.1" 503 None
2023-02-28 13:19:01 - robottelo - WARNING - Request to: http://ohsnap-instance.foo/api/releases/6.13.0/el8/capsule/repositories got response: 503
2023-02-28 13:19:04 - robottelo - WARNING - The snap version was not provided. Snap number will not be used in the URL.
2023-02-28 13:19:04 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): ohsnap-instance.foo:80
2023-02-28 13:19:04 - urllib3.connectionpool - DEBUG - http://ohsnap-instance.foo:80 "GET /api/releases/6.13.0/el8/capsule/repositories HTTP/1.1" 503 None
2023-02-28 13:19:04 - robottelo - WARNING - Request to: http://ohsnap-instance.foo/api/releases/6.13.0/el8/capsule/repositories got response: 503
2023-02-28 13:19:07 - robottelo - WARNING - The snap version was not provided. Snap number will not be used in the URL.
2023-02-28 13:19:07 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): ohsnap-instance.foo:80
2023-02-28 13:19:08 - urllib3.connectionpool - DEBUG - http://ohsnap-instance.foo:80 "GET /api/releases/6.13.0/el8/capsule/repositories HTTP/1.1" 503 None
2023-02-28 13:19:08 - robottelo - WARNING - Request to: http://ohsnap-instance.foo/api/releases/6.13.0/el8/capsule/repositories got response: 503
2023-02-28 13:19:11 - robottelo - WARNING - The snap version was not provided. Snap number will not be used in the URL.
2023-02-28 13:19:11 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): ohsnap-instance.foo:80
2023-02-28 13:19:11 - urllib3.connectionpool - DEBUG - http://ohsnap-instance.foo:80 "GET /api/releases/6.13.0/el8/capsule/repositories HTTP/1.1" 503 None
2023-02-28 13:19:11 - robottelo - WARNING - Request to: http://ohsnap-instance.foo/api/releases/6.13.0/el8/capsule/repositories got response: 503
...
...
...
# scaled back to 1 pod
2023-02-28 13:19:54 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): ohsnap-instance.foo:80
2023-02-28 13:20:17 - urllib3.connectionpool - DEBUG - http://ohsnap-instance.foo:80 "GET /api/releases/6.13.0/el8/satellite/repositories HTTP/1.1" 200 None
2023-02-28 13:20:17 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): dogfood.server.foo:80
2023-02-28 13:20:17 - urllib3.connectionpool - DEBUG - http://dogfood.server.foo:80 "GET /pulp/content/Satellite_Engineering/QA/Satellite_6_13_RHEL8/custom/Satellite_6_13_Composes/Satellite_6_13_RHEL8/ HTTP/1.1" 200 154
```