### PR TITLE
[6.12.z] GCE_CR fix for available images

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ requests==2.28.2
 tenacity==8.2.1
 testimony==2.2.0
 wait-for==1.2.0
-wrapanapi==3.5.13
+wrapanapi==3.5.14
 
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git@6.12.z#egg=airgun

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -30,6 +30,7 @@ from robottelo.constants import VALID_GCE_ZONES
 
 clouduser = gen_string('alpha')
 finishuser = gen_string('alpha')
+RHEL_CLOUD_PROJECTS = ['rhel-cloud', 'rhel-sap-cloud']
 
 
 @pytest.fixture(scope='module')
@@ -207,17 +208,27 @@ class TestGCEComputeResourceTestCases:
 
     @pytest.mark.tier3
     def test_positive_check_available_images(self, module_gce_compute, googleclient):
-        """Verify all the images from GCE are available to select from
+        """Verify RHEL images from GCP are available to select in GCE CR
 
         :id: 5cdfab18-a591-4442-8c19-a01e9b10ac36
 
-        :expectedresults: All the images from Google CR should be available to select in GCE CR
+        :BZ: 2164989
+
+        :expectedresults: RHEL images from GCP are available to select in GCE CR
 
         :CaseLevel: Integration
         """
         satgce_images = module_gce_compute.available_images()
-        gcloudclinet_images = googleclient.list_templates(True)
-        assert len(satgce_images) == len(gcloudclinet_images)
+        googleclient_images = googleclient.list_templates(
+            include_public=True, public_projects=RHEL_CLOUD_PROJECTS
+        )
+        googleclient_image_names = [img.name for img in googleclient_images]
+        # Validating GCE_CR images in Google CR
+        sat_available_images = [satgce_images[i]['name'] for i in range(len(satgce_images))]
+        for image in sat_available_images:
+            assert image in googleclient_image_names
+            # Validate only rhel-images exist in GCE_CR
+            assert image.startswith('rhel-')
 
     @pytest.mark.tier3
     def test_positive_check_available_networks(self, module_gce_compute, googleclient):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10765

A enhancement done on the wrapanapi to incorporate Projects while listing images : https://github.com/RedHatQE/wrapanapi/pull/461
Test result:

```
pytest tests/foreman/api/test_computeresource_gce.py -k test_positive_check_available_images
============================================================================ test session starts ============================================================================
platform linux -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: xdist-3.1.0, services-2.2.1, mock-3.10.0, reportportal-5.1.3, ibutsu-2.2.4, cov-3.0.0
collected 9 items / 8 deselected / 1 selected                                                                                                                               

tests/foreman/api/test_computeresource_gce.py .                                                                                                                       [100%]

=============================================================== 1 passed, 8 deselected, 6 warnings in 47.16s ================================================================
```