### PR TITLE
[6.11.z]Fix RHEV CR tests.

### DIFF
--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -43,7 +43,7 @@ def rhev():
         version='4.0',
         verify=False,
     )
-    rhev.cluster_id = rhev.rhv_api.get_cluster(rhev.datacenter).id
+    rhev.cluster_id = rhev.rhv_api.get_cluster(rhev.cluster).id
     rhev.storage_id = rhev.rhv_api.get_storage_domain(rhev.storage_domain).id
     if is_open('BZ:1685949'):
         dc = rhev.rhv_api._data_centers_service.list(search=f'name={rhev.datacenter}')[0]


### PR DESCRIPTION
Fixing RHEV CR tests, changing to cluster instead of datacenter.