### PR TITLE
[6.13.z] vault-login: check for error code instead of error message

### DIFF
--- a/scripts/vault_login.py
+++ b/scripts/vault_login.py
@@ -22,7 +22,7 @@ def _vault_command(command: str):
     vcommand = subprocess.run(command, capture_output=True, shell=True)
     if vcommand.returncode != 0:
         verror = str(vcommand.stderr)
-        if 'vault: command not found' in verror:
+        if vcommand.returncode == 127:
             print(f"{Colored.REDDARK}Error! {HELP_TEXT}")
             sys.exit(1)
         elif 'Error revoking token' in verror:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10661

Check for error code instead of error message. The error message is different across locales (it's different in czech, so i didn't get the help_text), error code is still the same.