### PR TITLE
[6.12.z] Mark FAM and satellite-clone tests for PIT

### DIFF
--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -109,3 +109,24 @@ def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pul
     assert sat_ready_rhel.execute('satellite-clone -y', timeout='3h').status == 0
     cloned_sat = Satellite(sat_ready_rhel.hostname)
     assert cloned_sat.cli.Health.check().status == 0
+
+
+@pytest.mark.pit_server
+def test_positive_list_tasks(target_sat):
+    """Test that satellite-clone --list-tasks command doesn't fail.
+
+    :id: fb34b70f-dc69-482c-bfbe-9b433cdce89e
+
+    :BZ: 2170034
+
+    :steps:
+        1. Install satellite-clone
+        2. Run satellite-clone --list-tasks
+
+    :expectedresult:
+        1. Satellite-clone ran successfully
+    """
+    result = target_sat.execute('dnf install -y --disableplugin=foreman-protector satellite-clone')
+    assert result.status == 0
+    result = target_sat.execute('satellite-clone --list-tasks')
+    assert result.status == 0

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -39,6 +39,7 @@ def sync_roles(target_sat):
         target_sat.cli.Ansible.roles_delete({'id': role_id})
 
 
+@pytest.mark.pit_server
 @pytest.mark.run_in_one_thread
 def test_positive_ansible_modules_installation(target_sat):
     """Foreman ansible modules installation test
@@ -64,6 +65,7 @@ def test_positive_ansible_modules_installation(target_sat):
     assert FOREMAN_ANSIBLE_MODULES.sort() == installed_modules.sort()
 
 
+@pytest.mark.pit_server
 @pytest.mark.tier1
 def test_positive_import_run_roles(sync_roles, target_sat):
     """Import a FAM role and run the role on the Satellite


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10853

This PR:
- Adds `test_positive_list_tasks` specifically to add coverage for [BZ#2170034](https://bugzilla.redhat.com/show_bug.cgi?id=2170034) in PIT
- Marks FAM tests for PIT