### PR TITLE
[6.12.z] Use module_sca_manifest_org for FM backup-restore tests

### DIFF
--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -30,12 +30,8 @@ def setup_backup_tests(request, sat_maintain):
 
 
 @pytest.fixture(scope='module')
-def module_synced_repos(session_target_sat, session_capsule_configured):
-    org = session_target_sat.api.Organization().create()
-    manifests_path = session_target_sat.download_file(
-        file_url=settings.fake_manifest.url['default']
-    )[0]
-    session_target_sat.cli.Subscription.upload({'file': manifests_path, 'organization-id': org.id})
+def module_synced_repos(session_target_sat, session_capsule_configured, module_sca_manifest_org):
+    org = module_sca_manifest_org
 
     # sync custom repo
     cust_prod = session_target_sat.api.Product(organization=org).create()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10864

The tests related to foreman-maintain backup/restore are failing on setup part.
It's failing because repository was not getting enabled, with `module_sca_manifest_org`  it works fine.