### PR TITLE
[6.12.z] Bump cryptography to 39.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 betelgeuse==1.10.0
 broker[docker]==0.2.14
-cryptography==39.0.0
+cryptography==39.0.2
 deepdiff==6.2.3
 dynaconf[vault]==3.1.11
 fauxfactory==3.1.0


### PR DESCRIPTION
fixes #10870