### PR TITLE
[6.11.z] Bump dynaconf[vault] from 3.1.11 to 3.1.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ betelgeuse==1.10.0
 broker[docker]==0.2.14
 cryptography==39.0.2
 deepdiff==6.2.1
-dynaconf[vault]==3.1.11
+dynaconf[vault]==3.1.12
 fauxfactory==3.1.0
 jinja2==3.1.2
 manifester==0.0.11


### PR DESCRIPTION
fixes #10875