### PR TITLE
Change constant to match new letter case in sat 6.13+ (PART2)

### DIFF
--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -19,6 +19,8 @@
 import pytest
 from airgun.exceptions import NoSuchElementException
 
+from robottelo.constants import ANY_CONTEXT
+
 
 class TestHostCockpit:
     """Tests for cockpit plugin"""
@@ -56,7 +58,7 @@ class TestHostCockpit:
         """
         with class_cockpit_sat.ui_session() as session:
             session.organization.select(org_name=class_org.name)
-            session.location.select(loc_name='Any location')
+            session.location.select(loc_name=ANY_CONTEXT['location'])
             kill_process = class_cockpit_sat.execute('pkill -f cockpit-ws')
             assert kill_process.status == 0
             # Verify if getting 503 error

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -56,7 +56,7 @@ class TestHostCockpit:
         """
         with class_cockpit_sat.ui_session() as session:
             session.organization.select(org_name=class_org.name)
-            session.location.select(loc_name='Any Location')
+            session.location.select(loc_name='Any location')
             kill_process = class_cockpit_sat.execute('pkill -f cockpit-ws')
             assert kill_process.status == 0
             # Verify if getting 503 error

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2624,7 +2624,7 @@ def test_positive_create_with_puppet_class(
     }
     with session_puppet_enabled_sat.ui_session() as session:
         session.organization.select(org_name=module_puppet_org.name)
-        session.location.select(loc_name='Any Location')
+        session.location.select(loc_name='Any location')
         session.host.create(values)
         assert session.host.search(host_name)[0]['Name'] == host_name
         values = session.host.read(host_name, widget_names='puppet_enc')

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2624,7 +2624,7 @@ def test_positive_create_with_puppet_class(
     }
     with session_puppet_enabled_sat.ui_session() as session:
         session.organization.select(org_name=module_puppet_org.name)
-        session.location.select(loc_name='Any location')
+        session.location.select(loc_name=ANY_CONTEXT['location'])
         session.host.create(values)
         assert session.host.search(host_name)[0]['Name'] == host_name
         values = session.host.read(host_name, widget_names='puppet_enc')

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -487,7 +487,7 @@ def test_positive_update_external_user_roles(
             ldapsession.location.create({'name': location_name})
             location = entities.Location().search(query={'search': f'name="{location_name}"'})[0]
             assert location.name == location_name
-        session.location.select('Any Location')
+        session.location.select('Any location')
         session.user.update(
             ldap_data['ldap_user_name'], {'roles.resources.assigned': [katello_role.name]}
         )

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -26,6 +26,7 @@ from nailgun import entities
 from navmazing import NavigationTriesExceeded
 
 from robottelo.config import settings
+from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import CERT_PATH
 from robottelo.constants import LDAP_ATTR
 from robottelo.constants import PERMISSIONS
@@ -487,7 +488,7 @@ def test_positive_update_external_user_roles(
             ldapsession.location.create({'name': location_name})
             location = entities.Location().search(query={'search': f'name="{location_name}"'})[0]
             assert location.name == location_name
-        session.location.select('Any location')
+        session.location.select(ANY_CONTEXT['location'])
         session.user.update(
             ldap_data['ldap_user_name'], {'roles.resources.assigned': [katello_role.name]}
         )


### PR DESCRIPTION
Fixing other tests that are failing due to new letter cases in 6.13 taxonomies.

I have missed some places where `Any Location` was supposed to be renamed to `Any location`. See #10741 for reference.
![image](https://user-images.githubusercontent.com/62888716/223066574-be434c96-5c0e-4bfd-a73b-ce1f53ed0855.png)
