### PR TITLE
Fix FM backup/restore test

### DIFF
--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -30,9 +30,9 @@ def setup_backup_tests(request, sat_maintain):
 
 
 @pytest.fixture(scope='module')
-def module_synced_repos(session_target_sat, session_capsule_configured, module_sca_manifest_org):
-    org = module_sca_manifest_org
-
+def module_synced_repos(session_target_sat, session_capsule_configured, module_sca_manifest):
+    org = session_target_sat.api.Organization().create()
+    session_target_sat.upload_manifest(org.id, module_sca_manifest.content)
     # sync custom repo
     cust_prod = session_target_sat.api.Product(organization=org).create()
     cust_repo = session_target_sat.api.Repository(


### PR DESCRIPTION
Currently, the tests fail because the organization it tries to use doesn't exist. 
I didn't notice that when trying to fix tests before in https://github.com/SatelliteQE/robottelo/pull/10864
See PRT run 2026 for the test results.