### PR TITLE
[6.13.z] Fix and extend ansible_collection install test

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -289,6 +289,7 @@ REPOSET = {
     'rhdt7': ('Red Hat Developer Tools RPMs for Red Hat Enterprise Linux 7 Server'),
     'rhscl7': ('Red Hat Software Collections RPMs for Red Hat Enterprise Linux 7 Server'),
     'rhae2': 'Red Hat Ansible Engine 2.9 RPMs for Red Hat Enterprise Linux 7 Server',
+    'rhae2.9_el8': 'Red Hat Ansible Engine 2.9 for RHEL 8 x86_64 (RPMs)',
     'rhst8': 'Red Hat Satellite Tools 6.9 for RHEL 8 x86_64 (RPMs)',
     'fdrh8': 'Fast Datapath for RHEL 8 x86_64 (RPMs)',
     'kickstart': {
@@ -444,6 +445,17 @@ REPOS = {
         'product': PRDS['rhae'],
         'distro': 'rhel7',
         'key': 'rhae2',
+    },
+    'rhae2.9_el8': {
+        'id': 'ansible-2.9-for-rhel-8-x86_64-rpms',
+        'name': 'Red Hat Ansible Engine 2.9 for RHEL 8 x86_64 RPMs',
+        'version': '2.9',
+        'releasever': None,
+        'arch': 'x86_64',
+        'reposet': REPOSET['rhae2.9_el8'],
+        'product': PRDS['rhae'],
+        'distro': 'rhel8',
+        'key': 'rhae2.9_el8',
     },
     'rhst8': {
         'id': 'satellite-tools-6.9-for-rhel-8-x86_64-rpms',

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -710,7 +710,7 @@ class TestAnsibleREX:
 
     @pytest.mark.tier3
     @pytest.mark.parametrize(
-        'fixture_sca_vmsetup', [{'nick': 'rhel7'}], ids=['rhel7'], indirect=True
+        'fixture_sca_vmsetup', [{'nick': 'rhel8'}], ids=['rhel8'], indirect=True
     )
     def test_positive_install_ansible_collection(
         self, fixture_sca_vmsetup, module_sca_manifest_org
@@ -718,7 +718,6 @@ class TestAnsibleREX:
         """Test whether Ansible collection can be installed via REX
 
         :Steps:
-
             1. Upload a manifest.
             2. Enable and sync Ansible repository.
             3. Register content host to Satellite.
@@ -732,28 +731,27 @@ class TestAnsibleREX:
 
         :Team: Rocket
         """
-
         # Configure repository to prepare for installing ansible on host
         RepositorySet.enable(
             {
                 'basearch': 'x86_64',
-                'name': REPOSET['rhae2'],
+                'name': REPOSET['rhae2.9_el8'],
                 'organization-id': module_sca_manifest_org.id,
                 'product': PRDS['rhae'],
-                'releasever': '7Server',
+                'releasever': '8',
             }
         )
         Repository.synchronize(
             {
-                'name': REPOS['rhae2']['name'],
+                'name': REPOS['rhae2.9_el8']['name'],
                 'organization-id': module_sca_manifest_org.id,
                 'product': PRDS['rhae'],
             }
         )
         client = fixture_sca_vmsetup
         client.execute('subscription-manager refresh')
-        client.execute(f'subscription-manager repos --enable {REPOS["rhae2"]["id"]}')
-        client.execute('yum -y install ansible')
+        client.execute(f'subscription-manager repos --enable {REPOS["rhae2.9_el8"]["id"]}')
+        client.execute('dnf -y install ansible')
         collection_job = make_job_invocation(
             {
                 'job-template': 'Ansible Collection - Install from Galaxy',
@@ -763,8 +761,21 @@ class TestAnsibleREX:
         )
         result = JobInvocation.info({'id': collection_job['id']})
         assert result['success'] == '1'
-        collection_path = str(client.execute('ls /etc/ansible/collections/ansible_collections'))
-        assert 'oasis' in collection_path
+        collection_path = client.execute('ls /etc/ansible/collections/ansible_collections').stdout
+        assert 'oasis_roles' in collection_path
+
+        # Extend test with custom collections_path advanced input field
+        collection_job = make_job_invocation(
+            {
+                'job-template': 'Ansible Collection - Install from Galaxy',
+                'inputs': 'ansible_collections_list="oasis_roles.system", collections_path="~/"',
+                'search-query': f'name ~ {client.hostname}',
+            }
+        )
+        result = JobInvocation.info({'id': collection_job['id']})
+        assert result['success'] == '1'
+        collection_path = client.execute('ls ~/ansible_collections').stdout
+        assert 'oasis_roles' in collection_path
 
 
 class TestRexUsers:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10857

Fixing test_positive_install_ansible_collection test by updating parametrization to use el8 instead of el7, el7 OSP host template has some dependency issues which need rhel server repo, which worked earlier in RHV and extending same test further to test custom collections_path input field.