### PR TITLE
[6.13.z] using installer to set mqtt resend interval

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -90,18 +90,13 @@ def module_capsule_configured_mqtt(module_capsule_configured):
     """Configure the capsule instance with the satellite from settings.server.hostname,
     enable MQTT broker"""
     module_capsule_configured.set_rex_script_mode_provider('pull-mqtt')
+    # lower the mqtt_resend_interval interval
+    module_capsule_configured.set_mqtt_resend_interval('30')
     result = module_capsule_configured.execute('systemctl status mosquitto')
     assert result.status == 0, 'MQTT broker is not running'
     result = module_capsule_configured.execute('firewall-cmd --permanent --add-port="1883/tcp"')
     assert result.status == 0, 'Failed to open mqtt port on capsule'
     module_capsule_configured.execute('firewall-cmd --reload')
-    # lower the mqtt_resend_interval interval
-    # TODO use installer command instead once merged downstream
-    module_capsule_configured.execute(
-        "echo ':mqtt_resend_interval: 30' >> /etc/foreman-proxy/settings.d/remote_execution_ssh.yml"
-    )
-    result = module_capsule_configured.cli.Service.restart(options={'only': 'foreman-proxy'})
-    assert result.status == 0, 'foreman-proxy restart unsuccessful'
     yield module_capsule_configured
 
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1427,6 +1427,22 @@ class Capsule(ContentHost, CapsuleMixins):
         if result.status != 0:
             raise SatelliteHostError(f'Failed to enable pull provider: {result.stdout}')
 
+    def set_mqtt_resend_interval(self, value):
+        """Set the time interval in seconds at which the notification should be
+        re-sent to the mqtt host until the job is picked up or cancelled"""
+        installer_opts = {
+            'foreman-proxy-plugin-remote-execution-script-mqtt-resend-interval': value,
+        }
+        enable_mqtt_command = InstallerCommand(
+            installer_opts=installer_opts,
+        )
+        result = self.execute(
+            enable_mqtt_command.get_command(),
+            timeout='20m',
+        )
+        if result.status != 0:
+            raise SatelliteHostError(f'Failed to change the mqtt resend interval: {result.stdout}')
+
     @property
     def cli(self):
         """Import only satellite-maintain robottelo cli entities and wrap them under self.cli"""


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10797

Installer now exposes this setting, no need to edit the config directly anymore. 