### PR TITLE
[6.12.z] updating robottelo constant value

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1492,7 +1492,6 @@ OSCAP_WEEKDAY = {
 OSCAP_DEFAULT_CONTENT = {
     'rhel6_content': 'Red Hat rhel6 default content',
     'rhel7_content': 'Red Hat rhel7 default content',
-    'jre_content': 'Red Hat jre default content',
     'rhel8_content': 'Red Hat rhel8 default content',
     'rhel_firefox': 'Red Hat firefox default content',
 }


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10912

- Updating robottelo > constant value for dictionary **OSCAP_DEFAULT_CONTENT**
- As latest `scap-security-guide` package doesn't provide `Red Hat jre default content`
- Related PR https://github.com/ComplianceAsCode/content/pull/9545