### PR TITLE
[6.13.z] adding skip marker for 'scapcontent' and 'oscappolicy' tests due open BZ's

### DIFF
--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -35,6 +35,8 @@ def oscap_content_path(module_target_sat):
     return local_file
 
 
+@pytest.mark.skip_if_open("BZ:2167937")
+@pytest.mark.skip_if_open("BZ:2133151")
 @pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(
@@ -84,6 +86,8 @@ def test_positive_end_to_end(
         assert not session.oscapcontent.search(new_title)
 
 
+@pytest.mark.skip_if_open("BZ:2167937")
+@pytest.mark.skip_if_open("BZ:2133151")
 @pytest.mark.tier1
 def test_negative_create_with_same_name(session, oscap_content_path, default_org, default_location):
     """Create OpenScap content with same name

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -28,6 +28,8 @@ def module_host_group(default_location, default_org):
     return entities.HostGroup(location=[default_location], organization=[default_org]).create()
 
 
+@pytest.mark.skip_if_open("BZ:2167937")
+@pytest.mark.skip_if_open("BZ:2133151")
 @pytest.mark.tier2
 def test_positive_check_dashboard(
     session,
@@ -103,6 +105,8 @@ def test_positive_check_dashboard(
         # assert policy_details['HostBreakdownChart']['hosts_breakdown'] == '100%Not audited'
 
 
+@pytest.mark.skip_if_open("BZ:2167937")
+@pytest.mark.skip_if_open("BZ:2133151")
 @pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10919

- Current tests are failing due to Open BZ's [#2167937](https://bugzilla.redhat.com/show_bug.cgi?id=2167937) & [#2133151](https://bugzilla.redhat.com/show_bug.cgi?id=2133151) , can not create new SCAP content.
- Adding a marker to avoid running these tests from execution.