### PR TITLE
[6.13.z] BZ2141719 ahv_internal_debug virt-who config support

### DIFF
--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -20,11 +20,13 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo.config import settings
+from robottelo.utils.virtwho import check_message_in_rhsm_log
 from robottelo.utils.virtwho import deploy_configure_by_command
 from robottelo.utils.virtwho import deploy_configure_by_script
 from robottelo.utils.virtwho import get_configure_command
 from robottelo.utils.virtwho import get_configure_file
 from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import get_hypervisor_ahv_mapping
 
 
 @pytest.fixture()
@@ -42,6 +44,7 @@ def form_data(default_org, target_sat):
         'hypervisor_username': settings.virtwho.ahv.hypervisor_username,
         'hypervisor_password': settings.virtwho.ahv.hypervisor_password,
         'prism_flavor': settings.virtwho.ahv.prism_flavor,
+        'ahv_internal_debug': 'false',
     }
     return form
 
@@ -295,3 +298,69 @@ class TestVirtWhoConfigforNutanix:
         command = get_configure_command(virtwho_config.id, default_org.name)
         deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
         assert get_configure_option("prism_central", config_file) == 'true'
+
+    @pytest.mark.tier2
+    def test_positive_ahv_internal_debug_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
+        """Verify ahv_internal_debug option by hammer virt-who-config"
+
+        :id: aa6a7443-62ae-4a87-8c27-4a7808f4b1da308
+
+        :expectedresults:
+            1. enable-ahv-debug option has been set to no
+            2. ahv_internal_debug bas been set to false in virt-who-config-X.conf
+            3. warning message exist in log file /var/log/rhsm/rhsm.log
+            4. ahv_internal_debug option can be updated
+            5. message Host UUID {system_uuid} found for VM: {guest_uuid} exist in rhsm.log
+            6. ahv_internal_debug bas been set to true in virt-who-config-X.conf
+            7. warning message does not exist in log file /var/log/rhsm/rhsm.log
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+
+        :BZ: 2141719
+        """
+        command = get_configure_command(virtwho_config.id, default_org.name)
+        deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        result = (
+            target_sat.api.VirtWhoConfig()
+            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .ahv_internal_debug
+        )
+        assert str(result) == 'False'
+        # ahv_internal_debug does not set in virt-who-config-X.conf
+        config_file = get_configure_file(virtwho_config.id)
+        option = 'ahv_internal_debug'
+        env_error = f"option {option} is not exist or not be enabled in {config_file}"
+        try:
+            get_configure_option("ahv_internal_debug", config_file)
+        except Exception as VirtWhoError:
+            assert env_error == str(VirtWhoError)
+        # check message exist in log file /var/log/rhsm/rhsm.log
+        message = 'Value for "ahv_internal_debug" not set, using default: False'
+        assert check_message_in_rhsm_log(message) == message
+
+        # Update ahv_internal_debug option to true
+        value = 'true'
+        virtwho_config.ahv_internal_debug = value
+        virtwho_config.update(['ahv_internal_debug'])
+        command = get_configure_command(virtwho_config.id, default_org.name)
+        deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert get_hypervisor_ahv_mapping(form_data['hypervisor_type']) == 'Host UUID found for VM'
+        result = (
+            target_sat.api.VirtWhoConfig()
+            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .ahv_internal_debug
+        )
+        assert str(result) == 'True'
+        # ahv_internal_debug bas been set to true in virt-who-config-X.conf
+        config_file = get_configure_file(virtwho_config.id)
+        assert get_configure_option("ahv_internal_debug", config_file) == 'true'
+        # check message does not exist in log file /var/log/rhsm/rhsm.log
+        message = 'Value for "ahv_internal_debug" not set, using default: False'
+        assert str(check_message_in_rhsm_log(message)) == 'False'

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -20,11 +20,13 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo.config import settings
+from robottelo.utils.virtwho import check_message_in_rhsm_log
 from robottelo.utils.virtwho import deploy_configure_by_command
 from robottelo.utils.virtwho import deploy_configure_by_script
 from robottelo.utils.virtwho import get_configure_command
 from robottelo.utils.virtwho import get_configure_file
 from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import get_hypervisor_ahv_mapping
 
 
 @pytest.fixture()
@@ -42,6 +44,7 @@ def form_data(target_sat, default_org):
         'hypervisor-username': settings.virtwho.ahv.hypervisor_username,
         'hypervisor-password': settings.virtwho.ahv.hypervisor_password,
         'prism-flavor': settings.virtwho.ahv.prism_flavor,
+        'ahv-internal-debug': 'false',
     }
     return form
 
@@ -149,7 +152,7 @@ class TestVirtWhoConfigforNutanix:
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
-        :id: 565228cd-2124-41ed-89b7-84ec6ff77213
+        :id: af92b814-fe7a-4969-b2ab-7b68859de3ce
 
         :expectedresults: hypervisor_id option can be updated.
 
@@ -255,3 +258,64 @@ class TestVirtWhoConfigforNutanix:
         command = get_configure_command(virtwho_config['id'], default_org.name)
         deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
         assert get_configure_option("prism_central", config_file) == 'true'
+
+    @pytest.mark.tier2
+    def test_positive_ahv_internal_debug_option(
+        self, default_org, form_data, virtwho_config, target_sat
+    ):
+        """Verify ahv_internal_debug option by hammer virt-who-config"
+
+        :id: a169a843-6ec7-4ef1-b471-649304e77cf1268
+
+        :expectedresults:
+            1. enable-ahv-debug option has been set to no
+            2. ahv_internal_debug bas been set to false in virt-who-config-X.conf
+            3. warning message exist in log file /var/log/rhsm/rhsm.log
+            4. ahv_internal_debug option can be updated
+            5. message Host UUID {system_uuid} found for VM: {guest_uuid} exist in rhsm.log
+            6. ahv_internal_debug bas been set to true in virt-who-config-X.conf
+            7. warning message does not exist in log file /var/log/rhsm/rhsm.log
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+
+        :BZ: 2141719
+        :customerscenario: true
+        """
+        command = get_configure_command(virtwho_config['id'], default_org.name)
+        deploy_configure_by_command(
+            command, form_data['hypervisor-type'], debug=True, org=default_org.label
+        )
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        assert result['general-information']['enable-ahv-debug'] == 'no'
+        # ahv_internal_debug does not set in virt-who-config-X.conf
+        config_file = get_configure_file(virtwho_config['id'])
+        option = 'ahv_internal_debug'
+        env_error = f"option {option} is not exist or not be enabled in {config_file}"
+        try:
+            get_configure_option("ahv_internal_debug", config_file)
+        except Exception as VirtWhoError:
+            assert env_error == str(VirtWhoError)
+        # check message exist in log file /var/log/rhsm/rhsm.log
+        message = 'Value for "ahv_internal_debug" not set, using default: False'
+        assert check_message_in_rhsm_log(message) == message
+
+        # Update ahv_internal_debug option to true
+        value = 'true'
+        result = target_sat.cli.VirtWhoConfig.update(
+            {'id': virtwho_config['id'], 'ahv-internal-debug': value}
+        )
+        assert result[0]['message'] == f"Virt Who configuration [{virtwho_config['name']}] updated"
+        command = get_configure_command(virtwho_config['id'], default_org.name)
+        deploy_configure_by_command(
+            command, form_data['hypervisor-type'], debug=True, org=default_org.label
+        )
+        assert get_hypervisor_ahv_mapping(form_data['hypervisor-type']) == 'Host UUID found for VM'
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        assert result['general-information']['enable-ahv-debug'] == 'yes'
+        # ahv_internal_debug bas been set to true in virt-who-config-X.conf
+        config_file = get_configure_file(virtwho_config['id'])
+        assert get_configure_option("ahv_internal_debug", config_file) == 'true'
+        # check message does not exist in log file /var/log/rhsm/rhsm.log
+        message = 'Value for "ahv_internal_debug" not set, using default: False'
+        assert str(check_message_in_rhsm_log(message)) == 'False'

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -20,12 +20,14 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo.config import settings
+from robottelo.utils.virtwho import check_message_in_rhsm_log
 from robottelo.utils.virtwho import deploy_configure_by_command
 from robottelo.utils.virtwho import deploy_configure_by_script
 from robottelo.utils.virtwho import get_configure_command
 from robottelo.utils.virtwho import get_configure_file
 from robottelo.utils.virtwho import get_configure_id
 from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import get_hypervisor_ahv_mapping
 
 
 @pytest.fixture()
@@ -39,6 +41,7 @@ def form_data():
         'hypervisor_content.username': settings.virtwho.ahv.hypervisor_username,
         'hypervisor_content.password': settings.virtwho.ahv.hypervisor_password,
         'hypervisor_content.prism_flavor': "Prism Element",
+        'ahv_internal_debug': False,
     }
     return form
 
@@ -237,3 +240,66 @@ class TestVirtwhoConfigforNutanix:
             assert get_configure_option('prism_central', config_file) == 'true'
             session.virtwho_configure.delete(name)
             assert not session.virtwho_configure.search(name)
+
+    @pytest.mark.tier2
+    def test_positive_ahv_internal_debug_option(self, default_org, session, form_data):
+        """Verify ahv_internal_debug option by hammer virt-who-config"
+
+        :id: af92b814-fe7a-4969-b2ab-7b68859de3ce155
+
+        :expectedresults:
+            1. enable-ahv-debug option has been set to false
+            2. ahv_internal_debug bas been set to false in virt-who-config-X.conf
+            3. warning message exist in log file /var/log/rhsm/rhsm.log
+            4. ahv_internal_debug option can be updated
+            5. message Host UUID {system_uuid} found for VM: {guest_uuid} exist in rhsm.log
+            6. ahv_internal_debug bas been set to true in virt-who-config-X.conf
+            7. warning message does not exist in log file /var/log/rhsm/rhsm.log
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+
+        :BZ: 2141719
+        :customerscenario: true
+        """
+        name = gen_string('alpha')
+        form_data['name'] = name
+        with session:
+            session.virtwho_configure.create(form_data)
+            config_id = get_configure_id(name)
+            values = session.virtwho_configure.read(name)
+            command = values['deploy']['command']
+            config_file = get_configure_file(config_id)
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
+            results = session.virtwho_configure.read(name)
+            assert str(results['overview']['ahv_internal_debug']) == 'False'
+            # ahv_internal_debug does not set in virt-who-config-X.conf
+            option = 'ahv_internal_debug'
+            env_error = f"option {option} is not exist or not be enabled in {config_file}"
+            try:
+                get_configure_option("ahv_internal_debug", config_file)
+            except Exception as VirtWhoError:
+                assert env_error == str(VirtWhoError)
+            # check message exist in log file /var/log/rhsm/rhsm.log
+            message = 'Value for "ahv_internal_debug" not set, using default: False'
+            assert check_message_in_rhsm_log(message) == message
+
+            # Update ahv_internal_debug option to true
+            session.virtwho_configure.edit(name, {'ahv-internal-debug': True})
+            results = session.virtwho_configure.read(name)
+            command = results['deploy']['command']
+            assert str(results['overview']['ahv_internal_debug']) == 'True'
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
+            assert (
+                get_hypervisor_ahv_mapping(form_data['hypervisor_type']) == 'Host UUID found for VM'
+            )
+            # ahv_internal_debug bas been set to true in virt-who-config-X.conf
+            config_file = get_configure_file(config_id)
+            assert get_configure_option("ahv_internal_debug", config_file) == 'true'
+            # check message does not exist in log file /var/log/rhsm/rhsm.log
+            message = 'Value for "ahv_internal_debug" not set, using default: False'
+            assert str(check_message_in_rhsm_log(message)) == 'False'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10615

Realize BZ2141719 ahv_internal_debug virt-who config support for virt-who plugin

Nutanix UI Cases:PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/ui/test_nutanix.py -k test_positive_ahv_internal_debug_option
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepository/robottelo, configfile: pyproject.toml
plugins: cov-3.0.0, xdist-3.1.0, services-2.2.1, mock-3.10.0, reportportal-5.1.3, ibutsu-2.2.4
collected 7 items / 13 deselected / -6 selected                                                                                                                                                                   

tests/foreman/virtwho/ui/test_nutanix.py .                                                                                                                                                                  [100%]

================================================================================================ warnings summary =================================================================================================

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================ 1 passed, 13 deselected, 4 warnings in 132.26s (0:02:12) =============================================================================
```

Nutanix  API Cases:PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix.py -k test_positive_ahv_internal_debug_option
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepository/robottelo, configfile: pyproject.toml
plugins: cov-3.0.0, xdist-3.1.0, services-2.2.1, mock-3.10.0, reportportal-5.1.3, ibutsu-2.2.4
collected 7 items / 13 deselected / -6 selected                                                                                                                                                                   

tests/foreman/virtwho/api/test_nutanix.py .                                                                                                                                                                 [100%]

================================================================================================ warnings summary =================================================================================================
-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 13 deselected, 5 warnings in 94.71s (0:01:34) =============================================================================

```

Nutanix CLI Cases:PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py -k test_positive_ahv_internal_debug_option
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepository/robottelo, configfile: pyproject.toml
plugins: cov-3.0.0, xdist-3.1.0, services-2.2.1, mock-3.10.0, reportportal-5.1.3, ibutsu-2.2.4
collected 7 items / 13 deselected / -6 selected                                                                                                                                                                   

tests/foreman/virtwho/cli/test_nutanix.py .                                                                                                                                                                 [100%]

================================================================================================ warnings summary =================================================================================================

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 13 deselected, 1 warning in 95.89s (0:01:35) ==============================================================================
(robottelo_vv) [yanpliu@yanpliu robottelo]$ 

```
