### PR TITLE
[6.13.z] Ansible Test fixes

### DIFF
--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -155,27 +155,30 @@ def test_positive_config_report_ansible(session, target_sat, module_org, rhel_co
     id = target_sat.nailgun_smart_proxy.id
     target_host = rhel_contenthost.nailgun_host
     target_sat.api.AnsibleRoles().sync(data={'proxy_id': id, 'role_names': [SELECTED_ROLE]})
-    target_host.assign_ansible_roles(data={'ansible_role_ids': [1]})
+    target_sat.cli.Host.ansible_roles_assign({'id': target_host.id, 'ansible-roles': SELECTED_ROLE})
     host_roles = target_host.list_ansible_roles()
     assert host_roles[0]['name'] == SELECTED_ROLE
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Ansible Roles - Ansible Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'targeting_type': 'static_query',
+            'search_query': f'name = {rhel_contenthost.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}', poll_timeout=1000
+    )
+    result = target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 1
     with session:
-        session.organization.select(module_org.name)
         session.location.select(constants.DEFAULT_LOC)
         assert session.host.search(target_host.name)[0]['Name'] == rhel_contenthost.hostname
-        session.jobinvocation.run(
-            {
-                'job_category': 'Ansible Playbook',
-                'job_template': 'Ansible Roles - Ansible Default',
-                'search_query': f'name ^ {rhel_contenthost.hostname}',
-            }
-        )
-        session.jobinvocation.wait_job_invocation_state(
-            entity_name='Run ansible roles', host_name=rhel_contenthost.hostname
-        )
-        status = session.jobinvocation.read(
-            entity_name='Run ansible roles', host_name=rhel_contenthost.hostname
-        )
-        assert status['overview']['hosts_table'][0]['Status'] == 'success'
         session.configreport.search(rhel_contenthost.hostname)
         session.configreport.delete(rhel_contenthost.hostname)
         assert len(session.configreport.read()['table']) == 0
@@ -230,7 +233,7 @@ def test_positive_ansible_custom_role(target_sat, session, module_org, rhel_cont
     proxy_id = target_sat.nailgun_smart_proxy.id
     target_host = rhel_contenthost.nailgun_host
     target_sat.api.AnsibleRoles().sync(data={'proxy_id': proxy_id, 'role_names': [SELECTED_ROLE]})
-    target_host.assign_ansible_roles(data={'ansible_role_ids': [1]})
+    target_sat.cli.Host.ansible_roles_assign({'id': target_host.id, 'ansible-roles': SELECTED_ROLE})
     host_roles = target_host.list_ansible_roles()
     assert host_roles[0]['name'] == SELECTED_ROLE
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10936

Test results:
```
pytest tests/foreman/ui/test_ansible.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, reportportal-5.1.5, ibutsu-2.2.4, xdist-3.2.0, cov-3.0.0
collected 7 items                                                                                                                                                                                                 

tests/foreman/ui/test_ansible.py .......                                                                                                                                                                    [100%]

```