### PR TITLE
add recent z-stream release resolution from ohsnap

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -72,7 +72,7 @@ class VersionedContent:
     def download_repofile(self, product=None, release=None, snap=''):
         """Downloads the tools/client, capsule, or satellite repos on the machine"""
         product, release, snap, v_major, _ = self._dogfood_helper(product, release, snap)
-        url = dogfood_repofile_url(settings.ohsnap.host, product, release, v_major, snap)
+        url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap)
         self.execute(f'curl -o /etc/yum.repos.d/dogfood.repo {url}')
 
     def dogfood_repository(self, repo=None, product=None, release=None, snap=''):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -71,7 +71,7 @@ def get_sat_version():
     try:
         sat_version = Satellite().version
     except (AuthenticationError, ContentHostError, BoxKeyError):
-        if str(sat_version := settings.server.version.get('release')) == 'stream':
+        if sat_version := str(settings.server.version.get('release')) == 'stream':
             sat_version = str(settings.robottelo.get('satellite_version'))
         if not sat_version:
             sat_version = SATELLITE_VERSION


### PR DESCRIPTION
Motivation:
Required mostly by PIT pipeline as we only get X.Y version information from the trigger.

If a `GA` flag gets implemented into ohsnap, this function will be further improved to fetch the recent GA'd z-stream release, if `settings.server.version.source` will be set to `ga`.

Tests:
After setting the `settings.server.version.release` to `6.12`, logging level set to `debug` and running `pytest -s tests/foreman/api/test_ping.py`:
```
2023-03-14 10:13:24 - robottelo - WARNING - The snap version was not provided. Snap number will not be used in the URL.
2023-03-14 10:13:24 - robottelo - WARNING - .z version component not provided in the release (6.12), fetching the recent z-stream from ohsnap
2023-03-14 10:13:24 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): ohsnap.<redacted>:80
2023-03-14 10:13:24 - urllib3.connectionpool - DEBUG - http://ohsnap.<redacted>:80 "GET /api/streams HTTP/1.1" 200 None
2023-03-14 10:13:24 - robottelo - DEBUG - List of releases returned by Ohsnap: [<...>, {'id': '6.12', 'release_ids': ['6.12.0', '6.12.1', '6.12.2', '6.12.3']}, <...>]
2023-03-14 10:13:24 - robottelo - DEBUG - Release string after processing: 6.12.3
2023-03-14 10:13:24 - urllib3.connectionpool - DEBUG - Starting new HTTP connection (1): ohsnap.<redacted>:80
2023-03-14 10:13:25 - urllib3.connectionpool - DEBUG - http://ohsnap.<redacted>:80 "GET /api/releases/6.12.3/el8/satellite/repositories HTTP/1.1" 200 None
```