### PR TITLE
[6.11.z] fix test_rhcloud_inventory_api_e2e

### DIFF
--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -106,7 +106,8 @@ def test_rhcloud_inventory_api_e2e(
     prefix = 'tfm-' if rhcloud_sat_host.os_version.major < 8 else ''
     package_version = rhcloud_sat_host.run(
         f'rpm -qa --qf "%{{VERSION}}" {prefix}rubygem-foreman_rh_cloud'
-    )
+    ).stdout.strip()
+
     assert json_meta_data['source_metadata']['foreman_rh_cloud_version'] == str(package_version)
     assert json_meta_data['source'] == 'Satellite'
     hostnames = [host['fqdn'] for host in json_data['hosts']]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10944

add `stdout.strip()` to `package_version`