### PR TITLE
[6.13.z] Kubevirt:virt-who config CLI/API cases support for SCA enabled

### DIFF
--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -1,0 +1,113 @@
+"""Test class for Virtwho Configure API
+
+:Requirement: Virt-whoConfigurePlugin
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Virt-whoConfigurePlugin
+
+:Team: Phoenix
+
+:TestType: Functional
+
+:Upstream: No
+"""
+import pytest
+from fauxfactory import gen_string
+
+from robottelo.config import settings
+from robottelo.utils.virtwho import deploy_configure_by_command
+from robottelo.utils.virtwho import deploy_configure_by_script
+from robottelo.utils.virtwho import get_configure_command
+from robottelo.utils.virtwho import get_configure_file
+from robottelo.utils.virtwho import get_configure_option
+
+
+@pytest.fixture()
+def form_data(module_sca_manifest_org, target_sat):
+    form = {
+        'name': gen_string('alpha'),
+        'debug': 1,
+        'interval': '60',
+        'hypervisor_id': 'hostname',
+        'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
+        'organization_id': module_sca_manifest_org.id,
+        'filtering_mode': 'none',
+        'satellite_url': target_sat.hostname,
+        'kubeconfig_path': settings.virtwho.kubevirt.hypervisor_config_file,
+    }
+    return form
+
+
+@pytest.fixture()
+def virtwho_config(form_data, target_sat):
+    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+    yield virtwho_config
+    virtwho_config.delete()
+    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+
+
+class TestVirtWhoConfigforKubevirt:
+    @pytest.mark.tier2
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+    ):
+        """Verify "POST /foreman_virt_who_configure/api/v2/configs"
+
+        :id: bf736822-2353-49c2-a8e6-79d9b3feddc5
+
+        :expectedresults: Config can be created and deployed
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+        """
+        assert virtwho_config.status == 'unknown'
+        if deploy_type == "id":
+            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+            )
+        elif deploy_type == "script":
+            script = virtwho_config.deploy_script()
+            deploy_configure_by_script(
+                script['virt_who_config_script'],
+                form_data['hypervisor_type'],
+                debug=True,
+                org=module_sca_manifest_org.label,
+            )
+        virt_who_instance = (
+            target_sat.api.VirtWhoConfig()
+            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .status
+        )
+        assert virt_who_instance == 'ok'
+
+    @pytest.mark.tier2
+    def test_positive_hypervisor_id_option(
+        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+    ):
+        """Verify hypervisor_id option by "PUT
+
+        /foreman_virt_who_configure/api/v2/configs/:id"
+
+        :id: 9072c1c8-1ea3-4311-99c9-94d3d3a0e8d8
+
+        :expectedresults: hypervisor_id option can be updated.
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+        """
+        for value in ['uuid', 'hostname']:
+            virtwho_config.hypervisor_id = value
+            virtwho_config.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config.id)
+            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            deploy_configure_by_command(
+                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+            )
+            assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -1,0 +1,110 @@
+"""Test class for Virtwho Configure CLI
+
+:Requirement: Virt-whoConfigurePlugin
+
+:CaseAutomation: Automated
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Virt-whoConfigurePlugin
+
+:Team: Phoenix
+
+:TestType: Functional
+
+:Upstream: No
+"""
+import pytest
+from fauxfactory import gen_string
+
+from robottelo.config import settings
+from robottelo.utils.virtwho import deploy_configure_by_command
+from robottelo.utils.virtwho import deploy_configure_by_script
+from robottelo.utils.virtwho import get_configure_command
+from robottelo.utils.virtwho import get_configure_file
+from robottelo.utils.virtwho import get_configure_option
+
+
+@pytest.fixture()
+def form_data(target_sat, module_sca_manifest_org):
+    form = {
+        'name': gen_string('alpha'),
+        'debug': 1,
+        'interval': '60',
+        'hypervisor-id': 'hostname',
+        'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
+        'organization-id': module_sca_manifest_org.id,
+        'filtering-mode': 'none',
+        'satellite-url': target_sat.hostname,
+        'kubeconfig-path': settings.virtwho.kubevirt.hypervisor_config_file,
+    }
+    return form
+
+
+@pytest.fixture()
+def virtwho_config(form_data, target_sat):
+    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+    yield virtwho_config
+    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+
+
+class TestVirtWhoConfigforKubevirt:
+    @pytest.mark.tier2
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+    ):
+        """Verify " hammer virt-who-config deploy"
+
+        :id: e0162dba-a50f-4356-9dc2-c928a1bed15c
+
+        :expectedresults: Config can be created and deployed
+
+        :CaseLevel: Integration
+
+        :CaseImportance: High
+        """
+        assert virtwho_config['status'] == 'No Report Yet'
+        if deploy_type == "id":
+            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            deploy_configure_by_command(
+                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+            )
+        elif deploy_type == "script":
+            script = target_sat.cli.VirtWhoConfig.fetch(
+                {'id': virtwho_config['id']}, output_format='base'
+            )
+            deploy_configure_by_script(
+                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+            )
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+            'general-information'
+        ]['status']
+        assert virt_who_instance == 'OK'
+
+    @pytest.mark.tier2
+    def test_positive_hypervisor_id_option(
+        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+    ):
+        """Verify hypervisor_id option by hammer virt-who-config update"
+
+        :id: b60f449d-6698-4a3a-be07-7440c2d9ba20
+        :expectedresults: hypervisor_id option can be updated.
+
+        :CaseLevel: Integration
+
+        :CaseImportance: Medium
+        """
+        for value in ['uuid', 'hostname']:
+            target_sat.cli.VirtWhoConfig.update(
+                {'id': virtwho_config['id'], 'hypervisor-id': value}
+            )
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            assert result['connection']['hypervisor-id'] == value
+            config_file = get_configure_file(virtwho_config['id'])
+            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            deploy_configure_by_command(
+                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+            )
+            assert get_configure_option('hypervisor_id', config_file) == value


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10918

CLI cases PASS
```
(robottelo_vv) [root@dell-per740-68-vm-04 robottelo]# pytest ./tests/foreman/virtwho/cli/test_kubevirt_sca.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 7 warnings in 431.61s (0:07:11)

```
API cases PASS
```
(robottelo_vv) [root@dell-per740-68-vm-04 robottelo]# pytest ./tests/foreman/virtwho/api/test_kubevirt_sca.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 21 warnings in 614.58s (0:10:14)

```