### PR TITLE
Update release from Client to client in Dynaconf_hook

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -119,7 +119,7 @@ def get_dogfood_satclient_repos(settings):
             settings,
             repo='client',
             product='client',
-            release='Client',
+            release='client',
             os_release=ver,
         )
     return data


### PR DESCRIPTION
Automation failed for 
```
File "/root/workspace/Virtwho-PluginTesting/Customized-Virtwho-Plugin-TestingTrigger/robottelo/robottelo/utils/ohsnap.py", line 21, in ohsnap_response_hook
    r.raise_for_status()
  File "/usr/local/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: [http://ohsnap.sat.engineering.****.com/api/releases/Client/el6/client/repositories](http://ohsnap.sat.engineering.%2A%2A%2A%2A.com/api/releases/Client/el6/client/repositories)
```
This is because there is no capital "Client" on http://ohsnap.sat.engineering.redhat.com/streams

Test PASS
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx.py -k test_positive_hypervisor_id_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 23 deselected, 2 warnings in 152.54s (0:02:32)

```





