### PR TITLE
Adapt to the current API endpoint path for client repos

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -119,7 +119,7 @@ def get_dogfood_satclient_repos(settings):
             settings,
             repo='client',
             product='client',
-            release='Client',
+            release='client',
             os_release=ver,
         )
     return data

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -51,7 +51,7 @@ class VersionedContent:
         if not product:
             if self.__class__.__name__ == 'ContentHost':
                 product = 'client'
-                release = release or 'Client'
+                release = release or 'client'
             else:
                 product = self.__class__.__name__.lower()
         repo = repo or product  # if repo is not specified, set it to the same as the product is

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -103,7 +103,7 @@ def test_negative_time_to_pickup(
         settings.ohsnap,
         product='client',
         repo='client',
-        release='Client',
+        release='client',
         os_release=rhel_contenthost.os_version.major,
     )
     # Update module_capsule_configured_mqtt to include module_org/smart_proxy_location

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1003,7 +1003,7 @@ class TestPullProviderRex:
             settings.ohsnap,
             product='client',
             repo='client',
-            release='Client',
+            release='client',
             os_release=rhel_contenthost.os_version.major,
         )
         # Update module_capsule_configured_mqtt to include module_org/smart_proxy_location
@@ -1101,7 +1101,7 @@ class TestPullProviderRex:
             settings.ohsnap,
             product='client',
             repo='client',
-            release='Client',
+            release='client',
             os_release=rhel_contenthost.os_version.major,
         )
         # Update module_capsule_configured_mqtt to include module_org/smart_proxy_location
@@ -1191,7 +1191,7 @@ class TestPullProviderRex:
             settings.ohsnap,
             product='client',
             repo='client',
-            release='Client',
+            release='client',
             os_release=rhel_contenthost.os_version.major,
         )
         # Update module_capsule_configured_mqtt to include module_org/smart_proxy_location


### PR DESCRIPTION
## Problem statement
Client repos were defined under the `Client` release which has changed to `client` recently. See satellite/ohsnap 82be8d0acddc10f9e091e712d124f59945f19ca6 patch that introduced the change.

## Solution
Change `Client` to `client`. :shrug: 