### PR TITLE
[6.13.z] force register hosts for rex

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -959,6 +959,8 @@ class TestAsyncSSHProviderRex:
             module_ak_with_cv.name,
             target=module_capsule_configured_async_ssh,
             satellite=module_target_sat,
+            ignore_subman_errors=True,
+            force=True,
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
         # run script provider rex command, longer-running command is needed to
@@ -1023,6 +1025,8 @@ class TestPullProviderRex:
             satellite=module_target_sat,
             packages=['katello-agent'],
             repo=client_repo.baseurl,
+            ignore_subman_errors=True,
+            force=True,
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
 
@@ -1121,6 +1125,8 @@ class TestPullProviderRex:
             satellite=module_target_sat,
             setup_remote_execution_pull=True,
             repo=client_repo.baseurl,
+            ignore_subman_errors=True,
+            force=True,
         )
 
         assert result.status == 0, f'Failed to register host: {result.stderr}'
@@ -1210,6 +1216,8 @@ class TestPullProviderRex:
             satellite=module_target_sat,
             setup_remote_execution_pull=True,
             repo=client_repo.baseurl,
+            ignore_subman_errors=True,
+            force=True,
         )
 
         assert result.status == 0, f'Failed to register host: {result.stderr}'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10978

Occasional non-blocking subman errors can stop the whole registration process, this pr adjusts the settings for greater robustness