### PR TITLE
Moving the ansible_roles_import test_case to destructive

### DIFF
--- a/tests/foreman/destructive/test_ansible.py
+++ b/tests/foreman/destructive/test_ansible.py
@@ -46,3 +46,31 @@ def test_positive_persistent_ansible_cfg_change(target_sat):
     assert param in target_sat.execute(f'cat {ansible_cfg}').stdout.splitlines()
     target_sat.execute('satellite-installer')
     assert param in target_sat.execute(f'cat {ansible_cfg}').stdout.splitlines()
+
+
+def test_positive_import_all_roles(target_sat):
+    """Import all Ansible roles available by default.
+
+    :id: 53fe3857-a08f-493d-93c7-3fed331ed391
+
+    :Steps:
+
+        1. Navigate to the Configure > Roles page.
+        2. Click the `Import from [hostname]` button.
+        3. Get total number of importable roles from pagination.
+        4. Fill the `Select All` checkbox.
+        5. Click the `Submit` button.
+        6. Verify that number of imported roles == number of importable roles from step 3.
+        7. Verify that Ansible variables have been imported along with roles.
+        8. Delete an imported role.
+        9. Verify that the role was successfully deleted.
+
+    :expectedresults: All roles are imported successfully. One role is deleted successfully.
+    """
+    with target_sat.ui_session() as session:
+        assert session.ansibleroles.import_all_roles() == session.ansibleroles.imported_roles_count
+        assert int(session.ansiblevariables.read_total_variables()) > 0
+        # The choice of role to be deleted is arbitrary; any of the roles present on Satellite
+        # by default should work here.
+        session.ansibleroles.delete('theforeman.foreman_scap_client')
+        assert not session.ansibleroles.search('theforeman.foreman_scap_client')

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -25,34 +25,6 @@ from robottelo.config import robottelo_tmp_dir
 from robottelo.config import settings
 
 
-def test_positive_import_all_roles(target_sat):
-    """Import all Ansible roles available by default.
-
-    :id: 53fe3857-a08f-493d-93c7-3fed331ed391
-
-    :Steps:
-
-        1. Navigate to the Configure > Roles page.
-        2. Click the `Import from [hostname]` button.
-        3. Get total number of importable roles from pagination.
-        4. Fill the `Select All` checkbox.
-        5. Click the `Submit` button.
-        6. Verify that number of imported roles == number of importable roles from step 3.
-        7. Verify that Ansible variables have been imported along with roles.
-        8. Delete an imported role.
-        9. Verify that the role was successfully deleted.
-
-    :expectedresults: All roles are imported successfully. One role is deleted successfully.
-    """
-    with target_sat.ui_session() as session:
-        assert session.ansibleroles.import_all_roles() == session.ansibleroles.imported_roles_count
-        assert int(session.ansiblevariables.read_total_variables()) > 0
-        # The choice of role to be deleted is arbitrary; any of the roles present on Satellite
-        # by default should work here.
-        session.ansibleroles.delete('theforeman.foreman_scap_client')
-        assert not session.ansibleroles.search('theforeman.foreman_scap_client')
-
-
 def test_positive_create_and_delete_variable(target_sat):
     """Create an Ansible variable with the minimum required values, then delete the variable.
 


### PR DESCRIPTION
Fellow tests are getting affected as all the roles are getting imported at once , making some assertion fail as custom role is created with in the same module for some tests , so I think it's better to move this to destructive.