### PR TITLE
[6.12.z] [user-group]-upgrade scenario refactor updated tests

### DIFF
--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -17,66 +17,81 @@
 :Upstream: No
 """
 import pytest
-from nailgun import entities
-from nailgun.config import ServerConfig
-from requests.exceptions import HTTPError
+from fauxfactory import gen_string
 
-from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
 
 
 class TestUserGroupMembership:
     """
-    Usergroup membership should exist after upgrade.
+    User-group membership should exist after upgrade.
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_create_usergroup_with_ldap_user(self, request, target_sat):
-        """Create Usergroup in preupgrade version.
+    def test_pre_create_user_group_with_ldap_user(self, ad_data, target_sat, save_test_data):
+        """Create User-group in pre_upgrade version.
 
         :id: preupgrade-4b11d883-f523-4f38-b65a-650ecd90335c
 
         :steps:
             1. Create ldap auth pre upgrade.
             2. Login with ldap User in satellite and logout.
-            3. Create usergroup and assign ldap user to it.
+            3. Create external user_group viewer role and synced ldap user gets the role.
 
         :expectedresults: The usergroup, with ldap user as member, should be created successfully.
         """
-        authsource = target_sat.api.AuthSourceLDAP(
-            onthefly_register=True,
-            account=settings.ldap.username,
-            account_password=settings.ldap.password,
-            base_dn=settings.ldap.basedn,
-            groups_base=settings.ldap.grpbasedn,
-            attr_firstname=LDAP_ATTR['firstname'],
-            attr_lastname=LDAP_ATTR['surname'],
-            attr_login=LDAP_ATTR['login_ad'],
-            server_type=LDAP_SERVER_TYPE['API']['ad'],
-            attr_mail=LDAP_ATTR['mail'],
-            name=request.node.name + "_server",
-            host=settings.ldap.hostname,
-            tls=False,
-            port='389',
-        ).create()
-        assert authsource.name == request.node.name + "_server"
-        sc = ServerConfig(
-            auth=(settings.ldap.username, settings.ldap.password),
-            url=target_sat.url,
-            verify=False,
+        ad_data = ad_data()
+        member_group = 'foobargroup'
+        LOGEDIN_MSG = "Using configured credentials for user '{0}'."
+        auth_source = target_sat.cli_factory.make_ldap_auth_source(
+            {
+                'name': gen_string('alpha'),
+                'onthefly-register': 'true',
+                'host': ad_data['ldap_hostname'],
+                'server-type': LDAP_SERVER_TYPE['CLI']['ad'],
+                'attr-login': LDAP_ATTR['login_ad'],
+                'attr-firstname': LDAP_ATTR['firstname'],
+                'attr-lastname': LDAP_ATTR['surname'],
+                'attr-mail': LDAP_ATTR['mail'],
+                'account': ad_data['ldap_user_name'],
+                'account-password': ad_data['ldap_user_passwd'],
+                'base-dn': ad_data['base_dn'],
+            }
+        )
+        viewer_role = target_sat.cli.Role.info({'name': 'Viewer'})
+        user_group = target_sat.cli_factory.make_usergroup()
+        target_sat.cli_factory.make_usergroup_external(
+            {
+                'auth-source-id': auth_source['server']['id'],
+                'user-group-id': user_group['id'],
+                'name': member_group,
+            }
+        )
+        target_sat.cli.UserGroup.add_role({'id': user_group['id'], 'role-id': viewer_role['id']})
+        user_group = target_sat.cli.UserGroup.info({'id': user_group['id']})
+        result = target_sat.cli.Auth.with_user(
+            username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
+        ).status()
+        assert LOGEDIN_MSG.format(ad_data['ldap_user_name']) in result[0]['message']
+        target_sat.cli.UserGroupExternal.refresh(
+            {'user-group-id': user_group['id'], 'name': member_group}
+        )
+        role_list = target_sat.cli.Role.with_user(
+            username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
+        ).list()
+        assert len(role_list) > 1
+        save_test_data(
+            {
+                'user_group_name': user_group['name'],
+                'auth_source_name': auth_source['server']['name'],
+            }
         )
 
-        with pytest.raises(HTTPError):
-            entities.User(sc).search()
-        user_group = target_sat.api.UserGroup(name=request.node.name + "_user_group").create()
-        user = target_sat.api.User().search(query={'search': f'login={settings.ldap.username}'})[0]
-        user_group.user = [user]
-        user_group = user_group.update(['user'])
-        assert user.login == user_group.user[0].read().login
-
-    @pytest.mark.post_upgrade(depend_on=test_pre_create_usergroup_with_ldap_user)
-    def test_post_verify_usergroup_membership(self, request, dependent_scenario_name):
+    @pytest.mark.post_upgrade(depend_on=test_pre_create_user_group_with_ldap_user)
+    def test_post_verify_user_group_membership(
+        self, request, ad_data, target_sat, pre_upgrade_data
+    ):
         """After upgrade, check the LDAP user created before the upgrade still exists and its
          update functionality should work.
 
@@ -89,15 +104,21 @@ class TestUserGroupMembership:
         :expectedresults: After upgrade, user group membership should remain the same and LDAP
         auth update should work.
         """
-        pre_test_name = dependent_scenario_name
-        user_group = entities.UserGroup().search(
-            query={'search': f'name={pre_test_name}_user_group'}
+        ad_data = ad_data()
+        user_group = target_sat.api.UserGroup().search(
+            query={'search': f'name={pre_upgrade_data["user_group_name"]}'}
         )
-        authsource = entities.AuthSourceLDAP().search(
-            query={'search': f'name={pre_test_name}_server'}
+        auth_source = target_sat.api.AuthSourceLDAP().search(
+            query={'search': f'name={pre_upgrade_data["auth_source_name"]}'}
         )[0]
-        request.addfinalizer(authsource.delete)
+        request.addfinalizer(auth_source.delete)
         request.addfinalizer(user_group[0].delete)
-        user = entities.User().search(query={'search': f'login={settings.ldap.username}'})[0]
-        request.addfinalizer(user.delete)
+        user = target_sat.api.User().search(query={'search': f'login={ad_data["ldap_user_name"]}'})[
+            0
+        ]
         assert user.read().id == user_group[0].read().user[0].id
+        request.addfinalizer(user.delete)
+        role_list = target_sat.cli.Role.with_user(
+            username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
+        ).list()
+        assert len(role_list) > 1


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10969

```
/Users/okhatavk/satellite/robottelo/env/bin/python "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py" --path /Users/okhatavk/satellite/robottelo/tests/upgrades/test_usergroup1.py -- -m post_upgrade
Testing started at 7:52 PM ...
Launching pytest with arguments -m post_upgrade /Users/okhatavk/satellite/robottelo/tests/upgrades/test_usergroup1.py --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

============================= test session starts ==============================
collecting ... collected 2 items / 1 deselected / 1 selected

tests/upgrades/test_usergroup1.py::TestUserGroupMembership::test_post_verify_user_group_membership 

================= 1 passed, 1 deselected, 2 warnings in 24.73s =================

Process finished with exit code 0
2023-03-16 19:52:40 - robottelo.collection - INFO - Processing test items to add testimony token markers
PASSED [100%]
```