### PR TITLE
Phoenix Team Groups tokens modified

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ActivationKeys
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -9,7 +9,7 @@ interactions and use capsule.
 
 :CaseComponent: Capsule-Content
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentCredentials
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentViews
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 
@@ -261,7 +261,7 @@ class TestContentView:
 
         :CaseComponent: Pulp
 
-        :Team: Phoenix
+        :team: Rocket
 
         :CaseImportance: Medium
 
@@ -681,7 +681,7 @@ class TestContentViewPublishPromote:
 
         :CaseComponent: Pulp
 
-        :Team: Phoenix
+        :team: Rocket
 
         :CaseImportance: Medium
 

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -12,7 +12,7 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 :CaseComponent: ContentViews
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentViews
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -104,7 +104,7 @@ class TestDockerRepository:
 
     :CaseComponent: Repositories
 
-    :Team: Phoenix
+    :team: Phoenix-content
     """
 
     @pytest.mark.tier1
@@ -323,7 +323,7 @@ class TestDockerContentView:
 
     :CaseComponent: ContentViews
 
-    :Team: Phoenix
+    :team: Phoenix-content
 
     :CaseLevel: Integration
     """
@@ -911,7 +911,7 @@ class TestDockerActivationKey:
 
     :CaseComponent: ActivationKeys
 
-    :Team: Phoenix
+    :team: Phoenix-subscriptions
 
     :CaseLevel: Integration
     """

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ErrataManagement
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: HostCollections
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 
@@ -50,7 +50,7 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
 
     :expectedresults: HTTP Proxy works with other satellite components.
 
-    :Team: Phoenix
+    :Team: Phoenix-content
 
     :BZ: 2011303, 2042473, 2046337
 
@@ -151,7 +151,7 @@ def test_positive_auto_attach_with_http_proxy(
     :expectedresults: host successfully subscribed, subscription
         repository enabled, and repository package installed.
 
-    :Team: Phoenix
+    :Team: Phoenix-content
 
     :BZ: 2046337
 
@@ -215,7 +215,7 @@ def test_positive_assign_http_proxy_to_products():
     :expectedresults: HTTP Proxy is assigned to all repos present
         in Products and sync operation uses assigned http-proxy.
 
-    :Team: Phoenix
+    :Team: Phoenix-content
 
     :CaseImportance: Critical
     """

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -12,7 +12,7 @@ http://www.katello.org/docs/api/apidoc/lifecycle_environments.html
 
 :CaseComponent: LifecycleEnvironments
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -11,7 +11,7 @@ http://<sat6>/apidoc/v2/products.html
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Reporting
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 
@@ -2188,7 +2188,7 @@ class TestSRPMRepositoryIgnoreContent:
 
     :customerscenario: true
 
-    :Team: Phoenix
+    :team: Phoenix-content
 
     :BZ: 1673215
     """
@@ -2448,7 +2448,7 @@ class TestTokenAuthContainerRepository:
 
     :CaseComponent: ContainerManagement-Content
 
-    :Team: Phoenix
+    :team: Phoenix-content
     """
 
     @pytest.mark.tier2

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -11,7 +11,7 @@ https://theforeman.org/plugins/katello/3.16/api/apidoc/v2/repository_sets.html
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -10,9 +10,9 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Candlepin
+:CaseComponent: SubscriptionManagement
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -12,7 +12,7 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 
 :CaseComponent: SubscriptionManagement
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 
@@ -391,7 +391,7 @@ def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel7_conte
 
     :CustomerScenario: true
 
-    :Team: Phoenix
+    :team: Phoenix-subscriptions
 
     :BZ: 1949353
 

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -12,7 +12,7 @@ API reference for sync plans can be found on your Satellite:
 
 :CaseComponent: SyncPlans
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ActivationKeys
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -6,7 +6,7 @@
 
 :TestType: Functional
 
-:Team: Phoenix
+:Team: Phoenix-content
 
 :CaseComponent: ContainerManagement-Content
 

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -8,7 +8,7 @@
 
 :CaseAutomation: Automated
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_contentcredentials.py
+++ b/tests/foreman/cli/test_contentcredentials.py
@@ -10,7 +10,7 @@ Satellite 6.8
 
 :CaseComponent: ContentCredentials
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentViews
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentViews
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -105,7 +105,7 @@ class TestDockerManifest:
 
     :CaseComponent: Repositories
 
-    :Team: Phoenix
+    :team: Phoenix-content
     """
 
     @pytest.mark.tier2
@@ -143,7 +143,7 @@ class TestDockerRepository:
 
     :CaseComponent: Repositories
 
-    :Team: Phoenix
+    :team: Phoenix-content
     """
 
     @pytest.mark.tier1
@@ -398,7 +398,7 @@ class TestDockerContentView:
 
     :CaseComponent: ContentViews
 
-    :Team: Phoenix
+    :team: Phoenix-content
 
     :CaseLevel: Integration
     """
@@ -1014,7 +1014,7 @@ class TestDockerActivationKey:
 
     :CaseComponent: ActivationKeys
 
-    :Team: Phoenix
+    :team: Phoenix-subscriptions
 
     :CaseLevel: Integration
     """

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ErrataManagement
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: HostCollections
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: LifecycleEnvironments
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -7,7 +7,7 @@
 
 :CaseComponent: Reporting
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: InterSatelliteSync
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SubscriptionManagement
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SyncPlans
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Hosts-Content
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/destructive/test_contentview.py
+++ b/tests/foreman/destructive/test_contentview.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentViews
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: katello-agent
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/destructive/test_repository.py
+++ b/tests/foreman/destructive/test_repository.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Hosts-Content
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Pulp
 
-:Team: Phoenix
+:team: Rocket
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ActivationKeys
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContainerManagement-Content
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_contentcredentials.py
+++ b/tests/foreman/ui/test_contentcredentials.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentCredentials
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Hosts-Content
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -11,7 +11,7 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 
 :CaseComponent: ContentViews
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ErrataManagement
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: HostCollections
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 
@@ -349,7 +349,7 @@ def test_positive_repo_discovery(setup_http_proxy, module_target_sat, module_org
 
     :expectedresults: Repository is discovered and created.
 
-    :Team: Phoenix
+    :team: Phoenix-content
 
     :BZ: 2011303, 2042473
 

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: LifecycleEnvironments
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Reporting
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SubscriptionManagement
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SyncPlans
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ActivationKeys
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -11,7 +11,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :CaseComponent: Hosts-Content
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentViews
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ErrataManagement
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Host-Content
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/upgrades/test_satellitesync.py
+++ b/tests/upgrades/test_satellitesync.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: InterSatelliteSync
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SubscriptionManagement
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SyncPlans
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_yum_plugins.py
+++ b/tests/upgrades/test_yum_plugins.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:Team: Phoenix
+:team: Phoenix-content
 
 :TestType: Functional
 


### PR DESCRIPTION
Phoenix Team now devided in two groups and hence the metadata for tests is also changed in this PR. This allows CI run tests based on those two groups !
- Phoenix-subscriptions
- Phoenix-content