### PR TITLE
[6.13.z] [rex] refactored remote execution upgrade tests and skip checkin

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -222,7 +222,12 @@ class ContentHost(Host, ContentHostMixins):
                 self.nailgun_host.delete()
             self.unregister()
         # Strip most unnecessary attributes from our instance for checkin
-        keep_keys = set(self.to_dict()) | {'release', '_prov_inst', '_cont_inst'}
+        keep_keys = set(self.to_dict()) | {
+            'release',
+            '_prov_inst',
+            '_cont_inst',
+            '_skip_context_checkin',
+        }
         self.__dict__ = {k: v for k, v in self.__dict__.items() if k in keep_keys}
         self.__class__ = Host
 

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -17,33 +17,10 @@
 :Upstream: No
 """
 import pytest
-from nailgun import entities
 
-from robottelo.config import settings
 from robottelo.hosts import Capsule
 
 
-@pytest.fixture(scope='class')
-def compute_resource_setup(self, default_org):
-    self.libvirt_vm = settings.libvirt.libvirt_hostname
-    self.default_org_id = default_org.id
-    self.org = default_org
-    self.bridge = settings.vlan_networking.bridge
-    self.subnet = settings.vlan_networking.subnet
-    self.gateway = settings.vlan_networking.gateway
-    self.netmask = settings.vlan_networking.netmask
-    self.vm_domain_name = settings.upgrade.vm_domain
-    self.vm_domain = entities.Domain().search(query={'search': f'name="{self.vm_domain_name}"'})
-    self.proxy_name = settings.upgrade.capsule_hostname
-
-
-# TODO Mark with infra markers from #8391
-@pytest.mark.skipif((not settings.vlan_networking), reason='vlan_networking required')
-@pytest.mark.skipif(
-    (not settings.libvirt.libvirt_hostname),
-    reason='libvirt.libvirt_hostname required',
-)
-@pytest.mark.skipif((not settings.upgrade.vm_domain), reason='upgrade.vm_domain required')
 class TestScenarioREXCapsule:
     """Test Remote Execution job created before migration runs successfully
     post migration on a client registered with external capsule.
@@ -51,69 +28,93 @@ class TestScenarioREXCapsule:
         Test Steps:
 
         1. Before Satellite upgrade:
-           a. Create Content host.
-           b. Create a Subnet on Satellite.
-           c. Install katello-ca on content host.
-           d. Register content host to Satellite.
-           e. add_ssh_key of external capsule on content host.
-           f. run a REX job on content host.
+           a. Register content host to Capsule.
+           b. run a REX job on content host.
         2. Upgrade satellite/capsule.
-        3. Run a rex Job again with same content host.
+        3. Run a REX Job again with same content host.
         4. Check if REX job still getting success.
     """
 
-    @pytest.mark.pre_upgrade
+    @pytest.mark.rhel_ver_list([8])
     @pytest.mark.no_containers
-    def test_pre_scenario_remoteexecution_external_capsule(
-        self, request, default_location, rhel7_contenthost, save_test_data
+    @pytest.mark.pre_upgrade
+    def test_pre_scenario_remote_execution_external_capsule(
+        self,
+        rhel_contenthost,
+        target_sat,
+        module_org,
+        smart_proxy_location,
+        module_ak_with_cv,
+        save_test_data,
     ):
-        """Run REX job on client registered with external capsule
+        """
+        Run REX job on client registered with external capsule
 
         :id: preupgrade-261dd2aa-be01-4c34-b877-54b8ee346561
 
         :steps:
-            1. Create Subnet.
-            2. Create Content host.
-            3. Install katello-ca package and register to Satellite host.
-            4. add rex ssh_key of external capsule on content host.
-            5. run the REX job on client vm.
+            1. Create Content host.
+            2. add rex ssh_key of external capsule on content host.
+            3. run the REX job on client vm.
 
         :expectedresults:
             1. Content host should create with pre-required details.
             2. REX job should run on it.
 
         :parametrized: yes
+
         """
-        sn = entities.Subnet(
-            domain=self.vm_domain,
-            gateway=self.gateway,
-            ipam='DHCP',
-            location=[default_location.id],
-            mask=self.netmask,
-            network=self.subnet,
-            organization=[self.org.id],
-            remote_execution_proxy=[entities.SmartProxy(id=2)],
-        ).create()
-        rhel7_contenthost.install_capsule_katello_ca(capsule=self.proxy_name)
-        rhel7_contenthost.register_contenthost(org=self.org.label, lce='Library')
-        capsule = Capsule(self.proxy_name)
-        rhel7_contenthost.add_rex_key(satellite=capsule)
-        host = entities.Host().search(query={'search': f'name="{rhel7_contenthost.hostname}"'})
-        host[0].subnet = sn
-        host[0].update(['subnet'])
-        job = entities.JobInvocation().run(
-            data={
-                'job_template_id': 89,
-                'inputs': {'command': 'ls'},
-                'targeting_type': 'static_query',
-                'search_query': f'name = {rhel7_contenthost.hostname}',
+        rhel_contenthost._skip_context_checkin = True
+        capsule = Capsule(target_sat.api.SmartProxy(id=2).read().name)
+        target_sat.cli.Capsule.update(
+            {
+                'name': capsule.hostname,
+                'organization-ids': module_org.id,
+                'location-ids': smart_proxy_location.id,
             }
         )
-        assert job['output']['success_count'] == 1
-        save_test_data({'client_name': rhel7_contenthost.hostname})
+        # register host with rex, enable client repo, install katello-agent
+        result = rhel_contenthost.register(
+            module_org,
+            smart_proxy_location,
+            module_ak_with_cv.name,
+            target=capsule,
+            satellite=target_sat,
+            packages=['katello-agent'],
+        )
+        assert f'The registered system name is: {rhel_contenthost.hostname}' in result.stdout
+        # run rex command
+        template_id = (
+            target_sat.api.JobTemplate()
+            .search(query={'search': 'name="Run Command - Script Default"'})[0]
+            .id
+        )
+        job = target_sat.api.JobInvocation().run(
+            synchronous=False,
+            data={
+                'job_template_id': template_id,
+                'organization': module_org.name,
+                'location': smart_proxy_location.name,
+                'inputs': {
+                    'command': 'echo start; sleep 10; echo done',
+                },
+                'targeting_type': 'static_query',
+                'search_query': f'name = {rhel_contenthost.hostname}',
+                'time_to_pickup': '5',
+            },
+        )
+        target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+        result = target_sat.api.JobInvocation(id=job['id']).read()
+        assert result.succeeded == 1
+        # Save client info to disk for post-upgrade test
+        save_test_data(
+            {
+                'rhel_client': rhel_contenthost.hostname,
+            }
+        )
 
-    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remoteexecution_external_capsule)
-    def test_post_scenario_remoteexecution_external_capsule(self, pre_upgrade_data):
+    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remote_execution_external_capsule)
+    def test_post_scenario_remote_execution_external_capsule(self, target_sat, pre_upgrade_data):
         """Run a REX job on pre-upgrade created client registered
         with external capsule.
 
@@ -125,24 +126,22 @@ class TestScenarioREXCapsule:
         :expectedresults:
             1. The job should successfully executed on pre-upgrade created client.
         """
-        job = entities.JobInvocation().run(
+        template_id = (
+            target_sat.api.JobTemplate()
+            .search(query={'search': 'name="Run Command - Script Default"'})[0]
+            .id
+        )
+        job = target_sat.api.JobInvocation().run(
             data={
-                'job_template_id': 89,
+                'job_template_id': template_id,
                 'inputs': {'command': 'ls'},
                 'targeting_type': 'static_query',
-                'search_query': f"name = {pre_upgrade_data['client_name']}",
+                'search_query': f"name = {pre_upgrade_data['rhel_client']}",
             }
         )
         assert job['output']['success_count'] == 1
 
 
-# TODO Mark with infra markers from #8391
-@pytest.mark.skipif((not settings.vlan_networking), reason='vlan_networking required')
-@pytest.mark.skipif(
-    (not settings.libvirt.libvirt_hostname),
-    reason='libvirt.libvirt_hostname required',
-)
-@pytest.mark.skipif((not settings.upgrade.vm_domain), reason='upgrade.vm_domain required')
 class TestScenarioREXSatellite:
     """Test Remote Execution job created before migration runs successfully
     post migration on a client registered with Satellite.
@@ -151,24 +150,23 @@ class TestScenarioREXSatellite:
 
         1. Before Satellite upgrade:
         2. Create Content host.
-        3. Create a Subnet on Satellite.
-        4. Install katello-ca on content host.
-        5. Register content host to Satellite.
-        6. Add_ssh_key of Satellite on content host.
-        7. Run a REX job on content host.
-        8. Upgrade satellite/capsule.
-        9. Run a rex Job again with same content host.
-        10. Check if REX job still getting success.
+        3. Register content host to Satellite.
+        4. Run a REX job on content host.
+        5. Upgrade satellite/capsule.
+        6. Run a rex Job again with same content host.
+        7. Check if REX job still getting success.
     """
 
+    @pytest.mark.rhel_ver_list([8])
+    @pytest.mark.no_containers
     @pytest.mark.pre_upgrade
-    def test_pre_scenario_remoteexecution_satellite(
+    def test_pre_scenario_remote_execution_satellite(
         self,
-        request,
-        compute_resource_setup,
-        default_location,
-        rhel7_contenthost,
+        rhel_contenthost,
         target_sat,
+        module_org,
+        smart_proxy_location,
+        module_ak_with_cv,
         save_test_data,
     ):
         """Run REX job on client registered with Satellite
@@ -176,11 +174,8 @@ class TestScenarioREXSatellite:
         :id: preupgrade-3f338475-fa69-43ef-ac86-f00f4d324b33
 
         :steps:
-            1. Create Subnet.
-            2. Create Content host.
-            3. Install katello-ca package and register to Satellite host.
-            4. Add rex ssh_key of Satellite on content host.
-            5. Run the REX job on client vm.
+            1. Create Content host.
+            2. Run the REX job on client vm.
 
         :expectedresults:
             1. It should create with pre-required details.
@@ -188,33 +183,49 @@ class TestScenarioREXSatellite:
 
         :parametrized: yes
         """
-        sn = entities.Subnet(
-            domain=self.vm_domain,
-            gateway=self.gateway,
-            ipam='DHCP',
-            location=[default_location.id],
-            mask=self.netmask,
-            network=self.subnet,
-            organization=[self.org.id],
-            remote_execution_proxy=[entities.SmartProxy(id=1)],
-        ).create()
-        rhel7_contenthost.configure_rex(satellite=target_sat, org=self.org, by_ip=False)
-        host = rhel7_contenthost.nailgun_host
-        host[0].subnet = sn
-        host[0].update(['subnet'])
-        job = entities.JobInvocation().run(
+        rhel_contenthost._skip_context_checkin = True
+        # register host with rex, enable client repo, install katello-agent
+        result = rhel_contenthost.register(
+            module_org,
+            smart_proxy_location,
+            module_ak_with_cv.name,
+            target=target_sat,
+            satellite=target_sat,
+            packages=['katello-agent'],
+        )
+        assert f'The registered system name is: {rhel_contenthost.hostname}' in result.stdout
+        # run rex command
+        template_id = (
+            target_sat.api.JobTemplate()
+            .search(query={'search': 'name="Run Command - Script Default"'})[0]
+            .id
+        )
+        job = target_sat.api.JobInvocation().run(
+            synchronous=False,
             data={
-                'job_template_id': 89,
-                'inputs': {'command': 'ls'},
+                'job_template_id': template_id,
+                'organization': module_org.name,
+                'location': smart_proxy_location.name,
+                'inputs': {
+                    'command': 'echo start; sleep 10; echo done',
+                },
                 'targeting_type': 'static_query',
-                'search_query': f'name = {rhel7_contenthost.hostname}',
+                'search_query': f'name = {rhel_contenthost.hostname}',
+                'time_to_pickup': '5',
+            },
+        )
+        target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+        result = target_sat.api.JobInvocation(id=job['id']).read()
+        assert result.succeeded == 1
+        # Save client info to disk for post-upgrade test
+        save_test_data(
+            {
+                'rhel_client': rhel_contenthost.hostname,
             }
         )
-        assert job['output']['success_count'] == 1
-        save_test_data({'client_name': rhel7_contenthost.hostname})
 
-    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remoteexecution_satellite)
-    def test_post_scenario_remoteexecution_satellite(self, pre_upgrade_data):
+    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remote_execution_satellite)
+    def test_post_scenario_remote_execution_satellite(self, target_sat, pre_upgrade_data):
         """Run a REX job on pre-upgrade created client registered
         with Satellite.
 
@@ -226,12 +237,17 @@ class TestScenarioREXSatellite:
         :expectedresults:
             1. The job should successfully executed on pre-upgrade created client.
         """
-        job = entities.JobInvocation().run(
+        template_id = (
+            target_sat.api.JobTemplate()
+            .search(query={'search': 'name="Run Command - Script Default"'})[0]
+            .id
+        )
+        job = target_sat.api.JobInvocation().run(
             data={
-                'job_template_id': 89,
+                'job_template_id': template_id,
                 'inputs': {'command': 'ls'},
                 'targeting_type': 'static_query',
-                'search_query': f"name = {pre_upgrade_data['client_name']}",
+                'search_query': f"name = {pre_upgrade_data['rhel_client']}",
             }
         )
         assert job['output']['success_count'] == 1


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10929

#### PR Description 

- Refactored the upgrade tests for remote execution satellite and external capsule 
- Added support for marker `@pytest.mark.skip_checkin` so that skipping the broker check-in part of the context manager will help reuse the content host fixtures 
- broker PR needs merge  https://github.com/SatelliteQE/broker/pull/196
```
/Users/okhatavk/satellite/robottelo/env/bin/python "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py" --path /Users/okhatavk/satellite/robottelo/tests/upgrades/test_remoteexecution.py -- -m pre_upgrade
Testing started at 1:07 PM ...
Launching pytest with arguments -m pre_upgrade /Users/okhatavk/satellite/robottelo/tests/upgrades/test_remoteexecution.py --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

============================= test session starts ==============================
collecting ... collected 4 items / 2 deselected / 2 selected

tests/upgrades/test_remoteexecution.py::TestScenarioREXCapsule::test_pre_scenario_remote_execution_external_capsule[rhel8] 
tests/upgrades/test_remoteexecution.py::TestScenarioREXSatellite::test_pre_scenario_remote_execution_satellite[rhel8] 

=========== 2 passed, 2 deselected, 83 warnings in 671.44s (0:11:11) ===========

Process finished with exit code 0
2023-03-10 13:07:34 - robottelo.collection - INFO - Processing test items to add testimony token markers
PASSED [ 50%]PASSED [100%]

/Users/okhatavk/satellite/robottelo/env/bin/python "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py" --path /Users/okhatavk/satellite/robottelo/tests/upgrades/test_remoteexecution.py -- -m post_upgrade
Testing started at 1:19 PM ...
Launching pytest with arguments -m post_upgrade /Users/okhatavk/satellite/robottelo/tests/upgrades/test_remoteexecution.py --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

============================= test session starts ==============================
collecting ... collected 4 items / 2 deselected / 2 selected

tests/upgrades/test_remoteexecution.py::TestScenarioREXCapsule::test_post_scenario_remote_execution_external_capsule 
tests/upgrades/test_remoteexecution.py::TestScenarioREXSatellite::test_post_scenario_remote_execution_satellite 

================ 2 passed, 2 deselected, 14 warnings in 39.54s =================

Process finished with exit code 0
2023-03-10 13:19:25 - robottelo.collection - INFO - Processing test items to add testimony token markers
PASSED [ 50%]PASSED [100%]
```