### PR TITLE
Rewrite tests to have one assertion per test

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1345,6 +1345,15 @@ def test_positive_selinux_foreman_module(target_sat):
 @pytest.mark.parametrize('service', SATELLITE_SERVICES)
 def test_positive_check_installer_service_running(target_sat, service):
     """Check if a service is running
+
+    :id: 5389c174-7ab1-4e9d-b2aa-66d80fd6dc5f
+
+    :steps:
+        1. Verify a service is active with systemctl is-active
+
+    :expectedresults: The service is active
+
+    :CaseImportance: Medium
     """
     is_active = target_sat.execute(f'systemctl is-active {service}')
     status = target_sat.execute(f'systemctl status {service}')


### PR DESCRIPTION
It's a best practice to only have a single assertion per test. The benefit is that all the other unrelated tests still run. This means that you get a full report of all issues, and more precise reporting.

It does this by extracting the systemctl service status checks to a separate, parametrized test. That is also rewritten to use systemctl is-active instead of parsing the output of status. It still adds the systemctl status output as context, which makes debugging easier.

The hammer ping command is then rewritten to collect all not-ok services and assert that it's empty. This gives you a complete list of services that aren't OK with their results, instead of just a single failed service.

Right now this is untested and probably doesn't comply with the Robottelo standards, but it came up in a discussion and showing code is easier than describing it.