### PR TITLE
[6.11.z] Remove failing contentcredential tests from 6.11.z 6.12.z

### DIFF
--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -16,8 +16,6 @@
 
 :Upstream: No
 """
-from copy import copy
-
 import pytest
 from fauxfactory import gen_string
 from nailgun import entities
@@ -229,49 +227,3 @@ def test_positive_delete(module_org):
     gpg_key.delete()
     with pytest.raises(HTTPError):
         gpg_key.read()
-
-
-@pytest.mark.tier3
-def test_positive_block_delete_key_in_use(module_org, target_sat, capfd):
-    """Create a GPG key with valid content. Create a new product and
-        associated repository, assigning the GPG key to both. Attempt to delete the
-        GPG key in use.
-
-    :id: b79fd3ff-8cdb-4cdd-94e5-76de742ec967
-
-    :expectedresults: Blocked deletion of gpg key in use, it remains
-        unmodified, is still associated with product and repo.
-
-    :BZ: 2052904
-
-    :CaseImportance: Critical
-    """
-    gpg_key = target_sat.api.GPGKey(organization=module_org, content=key_content).create()
-    gpg_copy = copy(gpg_key)
-    # Create new product with gpg, and a single associated repository
-    product = target_sat.api.Product(gpg_key=gpg_key, organization=module_org).create()
-    repo = target_sat.api.Repository(product=product).create()
-    product.sync()
-
-    # Assert the same gpg key is associated with new product and repo
-    assert product.gpg_key.id == gpg_key.id
-    assert repo.gpg_key.id == gpg_key.id
-    assert product.gpg_key.id == repo.gpg_key.id
-
-    # Attempt to delete gpg in use
-    with pytest.raises(HTTPError) as err:
-        gpg_key.delete()
-
-    # Check for 500 error and display message
-    err_message = capfd.readouterr()[1]
-    assert '500' in str(err.value)
-    assert 'Cannot delete' in str(err_message)
-
-    # Assert gpg matches unmodified copy
-    assert gpg_key.id == gpg_copy.id
-    assert gpg_key.organization == gpg_copy.organization
-    assert gpg_key.content == gpg_copy.content
-    # Assert gpg remains associated with product and repo
-    assert product.gpg_key.id == repo.gpg_key.id
-    assert product.gpg_key.id == gpg_key.id
-    assert repo.gpg_key.id == gpg_key.id

--- a/tests/foreman/cli/test_contentcredentials.py
+++ b/tests/foreman/cli/test_contentcredentials.py
@@ -102,50 +102,6 @@ def test_positive_get_info_by_name(module_org):
     assert gpg_key['name'] == name
 
 
-@pytest.mark.tier1
-def test_positive_block_delete_key_in_use(module_org, target_sat):
-    """Create a product and single associated repository. Create a new gpg key and associate
-        it with the product and repository. Attempt to delete the gpg key in use
-
-    :id: 022555fd-e6f2-4c95-80d7-cae26993ca8f
-
-    :expectedresults: Block deletion of gpg in use, remains unmodified,
-        and still associated with the product and repository
-
-    :BZ: 2052904
-
-    :CaseImportance: Critical
-    """
-    name = gen_string('utf8')
-    product = make_product({'organization-id': module_org.id})
-    repo = make_repository({'product-id': product['id']})
-    gpg_key = make_content_credential(
-        {'key': VALID_GPG_KEY_FILE_PATH, 'name': name, 'organization-id': module_org.id}
-    )
-
-    # Associate repo with the product, gpg key with product and repo
-    target_sat.cli.Product.update(
-        {'gpg-key-id': gpg_key['id'], 'id': product['id'], 'organization-id': module_org.id}
-    )
-    # Attempt to delete gpg in use
-    with pytest.raises(CLIReturnCodeError) as e:
-        target_sat.cli.ContentCredential.delete({'name': name, 'organization-id': module_org.id})
-    assert 'Cannot delete' in str(e.value)
-    # Assert gpg still exist
-    result = target_sat.cli.ContentCredential.exists(
-        {'organization-id': module_org.id}, (search_key, gpg_key[search_key])
-    )
-    assert gpg_key[search_key] == result[search_key]
-
-    # Assert gpg is still associated with the product and repository
-    product_info = target_sat.cli.Product.info(
-        {'id': product['id'], 'organization-id': module_org.id}
-    )
-    repo_info = target_sat.cli.Repository.info({'id': repo['id']})
-    assert product_info['gpg']['gpg-key-id'] == gpg_key['id']
-    assert repo_info['gpg-key']['id'] == gpg_key['id']
-
-
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
 @pytest.mark.tier1
 def test_positive_create_with_default_org(name, module_org, default_org):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11099

BZ: [2052904](https://bugzilla.redhat.com/show_bug.cgi?id=2052904)
test_positive_block_delete_key_in_use, api & cli/test_contentcredentials.py

-The feature associated with these tests was not extended to 6.12.z or 6.11.z and as such they're failing, requested to remove from these streams.
-Tests should remain in 6.13.z+ along with the associated feature.