### PR TITLE
[virt-who-config]-upgrade scenario refactor

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -86,7 +86,7 @@ class TestScenarioPositiveVirtWho:
         org = target_sat.api.Organization(name=ORG_DATA['name']).create()
         default_loc.organization.append(target_sat.api.Organization(id=org.id))
         default_loc.update(['organization'])
-        SimpleContentAccess.disable({'organization-id': org.id})
+        org.sca_disable()
         target_sat.upload_manifest(org.id, function_entitlement_manifest.content)
         form_data.update({'organization_id': org.id})
         vhd = target_sat.api.VirtWhoConfig(**form_data).create()

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -20,7 +20,6 @@ import pytest
 from fauxfactory import gen_string
 
 from robottelo.cli.host import Host
-from robottelo.cli.simple_content_access import SimpleContentAccess
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings


### PR DESCRIPTION
Test PASS:
```
================================================================================== 1 passed, 3 deselected, 10 warnings in 10.52s ==================================================================================
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/upgrades/test_virtwho.py  -m pre_upgrade --disable-pytest-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.2.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/virtwho/gitrepo/repo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, reportportal-5.1.5, ibutsu-2.2.4, cov-3.0.0, xdist-3.2.1
collected 2 items / 3 deselected / -1 selected                                                                                                                                                                    

tests/upgrades/test_virtwho.py .                                                                                                                                                                            [100%]

============================================================================ 1 passed, 3 deselected, 19 warnings in 119.54s (0:01:59) =============================================================================
```
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/upgrades/test_virtwho.py  -m post_upgrade  --disable-pytest-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.2.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/virtwho/gitrepo/repo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, reportportal-5.1.5, ibutsu-2.2.4, cov-3.0.0, xdist-3.2.1
collected 2 items / 3 deselected / -1 selected                                                                                                                                                                    

tests/upgrades/test_virtwho.py .                                                                                                                                                                            [100%]

================================================================================== 1 passed, 3 deselected, 10 warnings in 10.59s ==================================================================================

```