### PR TITLE
[6.13.z] [virt-who-config]-upgrade scenario refactor

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -18,7 +18,6 @@
 """
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 
 from robottelo.cli.host import Host
 from robottelo.cli.subscription import Subscription
@@ -84,18 +83,19 @@ class TestScenarioPositiveVirtWho:
         )
         default_loc = target_sat.api.Location(id=default_loc_id).read()
         org = target_sat.api.Organization(name=ORG_DATA['name']).create()
-        default_loc.organization.append(entities.Organization(id=org.id))
+        default_loc.organization.append(target_sat.api.Organization(id=org.id))
         default_loc.update(['organization'])
+        org.sca_disable()
         target_sat.upload_manifest(org.id, function_entitlement_manifest.content)
         form_data.update({'organization_id': org.id})
-        vhd = entities.VirtWhoConfig(**form_data).create()
+        vhd = target_sat.api.VirtWhoConfig(**form_data).create()
         assert vhd.status == 'unknown'
         command = get_configure_command(vhd.id, org=org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
             command, form_data['hypervisor_type'], debug=True, org=org.label
         )
         virt_who_instance = (
-            entities.VirtWhoConfig(organization_id=org.id)
+            target_sat.api.VirtWhoConfig(organization_id=org.id)
             .search(query={'search': f'name={form_data["name"]}'})[0]
             .status
         )
@@ -113,11 +113,13 @@ class TestScenarioPositiveVirtWho:
                     if hypervisor_name.lower() in item['type']:
                         vdc_id = item['id']
                         break
-            entities.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 1}]}
+            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
+                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
             )
             result = (
-                entities.Host(organization=org.id).search(query={'search': hostname})[0].read_json()
+                target_sat.api.Host(organization=org.id)
+                .search(query={'search': hostname})[0]
+                .read_json()
             )
             assert result['subscription_status_label'] == 'Fully entitled'
 
@@ -129,7 +131,7 @@ class TestScenarioPositiveVirtWho:
         )
 
     @pytest.mark.post_upgrade(depend_on=test_pre_create_virt_who_configuration)
-    def test_post_crud_virt_who_configuration(self, form_data, pre_upgrade_data):
+    def test_post_crud_virt_who_configuration(self, form_data, pre_upgrade_data, target_sat):
         """Virt-who config is intact post upgrade and verify the config can be updated and deleted.
 
         :id: postupgrade-d7ae7b2b-3291-48c8-b412-cb54e444c7a4
@@ -146,10 +148,10 @@ class TestScenarioPositiveVirtWho:
             2. the config and guest connection have the same status.
             3. virt-who config should update and delete successfully.
         """
-        org = entities.Organization().search(query={'search': f'name={ORG_DATA["name"]}'})[0]
+        org = target_sat.api.Organization().search(query={'search': f'name={ORG_DATA["name"]}'})[0]
 
         # Post upgrade, Verify virt-who exists and has same status.
-        vhd = entities.VirtWhoConfig(organization_id=org.id).search(
+        vhd = target_sat.api.VirtWhoConfig(organization_id=org.id).search(
             query={'search': f'name={form_data["name"]}'}
         )[0]
         if not is_open('BZ:1802395'):
@@ -164,7 +166,9 @@ class TestScenarioPositiveVirtWho:
         hosts = [hypervisor_name, guest_name]
         for hostname in hosts:
             result = (
-                entities.Host(organization=org.id).search(query={'search': hostname})[0].read_json()
+                target_sat.api.Host(organization=org.id)
+                .search(query={'search': hostname})[0]
+                .read_json()
             )
             assert result['subscription_status_label'] == 'Fully entitled'
 
@@ -179,6 +183,6 @@ class TestScenarioPositiveVirtWho:
 
         # Delete virt-who config
         vhd.delete()
-        assert not entities.VirtWhoConfig(organization_id=org.id).search(
+        assert not target_sat.api.VirtWhoConfig(organization_id=org.id).search(
             query={'search': f'name={modify_name}'}
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11107

Test PASS:
```
================================================================================== 1 passed, 3 deselected, 10 warnings in 10.52s ==================================================================================
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/upgrades/test_virtwho.py  -m pre_upgrade --disable-pytest-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.2.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/virtwho/gitrepo/repo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, reportportal-5.1.5, ibutsu-2.2.4, cov-3.0.0, xdist-3.2.1
collected 2 items / 3 deselected / -1 selected                                                                                                                                                                    

tests/upgrades/test_virtwho.py .                                                                                                                                                                            [100%]

============================================================================ 1 passed, 3 deselected, 19 warnings in 119.54s (0:01:59) =============================================================================
```
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/upgrades/test_virtwho.py  -m post_upgrade  --disable-pytest-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.2.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/virtwho/gitrepo/repo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, reportportal-5.1.5, ibutsu-2.2.4, cov-3.0.0, xdist-3.2.1
collected 2 items / 3 deselected / -1 selected                                                                                                                                                                    

tests/upgrades/test_virtwho.py .                                                                                                                                                                            [100%]

================================================================================== 1 passed, 3 deselected, 10 warnings in 10.59s ==================================================================================

```