### PR TITLE
[Host]-Refactor upgrade tests for Host

### DIFF
--- a/pytest_fixtures/component/domain.py
+++ b/pytest_fixtures/component/domain.py
@@ -13,5 +13,7 @@ def default_domain(session_target_sat, default_smart_proxy):
 
 
 @pytest.fixture(scope='module')
-def module_domain(module_org, module_location):
-    return entities.Domain(location=[module_location], organization=[module_org]).create()
+def module_domain(module_target_sat, module_org, module_location):
+    return module_target_sat.api.Domain(
+        location=[module_location], organization=[module_org]
+    ).create()

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -70,6 +70,15 @@ def gce_custom_cloudinit_uuid(googleclient, gce_cert):
     return cloudinit_uuid
 
 
+@pytest.fixture(scope='session')
+def session_default_os(session_target_sat):
+    """Default OS on the Satellite"""
+    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
+    return (
+        session_target_sat.api.OperatingSystem().search(query={'search': search_string})[0].read()
+    )
+
+
 @pytest.fixture(scope='module')
 def module_gce_compute(module_org, module_location, gce_cert):
     gce_cr = entities.GCEComputeResource(
@@ -185,6 +194,26 @@ def gce_resource_with_image(
         user_data=True,
     ).create()
     return gce_cr
+
+
+@pytest.fixture(scope='module')
+def module_gce_finishimg(
+    session_target_sat,
+    default_architecture,
+    module_gce_compute,
+    session_default_os,
+    gce_latest_rhel_uuid,
+):
+    """Creates finish image on GCE Compute Resource"""
+    finish_image = session_target_sat.api.Image(
+        architecture=default_architecture,
+        compute_resource=module_gce_compute,
+        name=gen_string('alpha'),
+        operatingsystem=session_default_os,
+        username=gen_string('alpha'),
+        uuid=gce_latest_rhel_uuid,
+    ).create()
+    return finish_image
 
 
 @pytest.fixture

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -385,7 +385,7 @@ class TestGCEHostProvisioningTestCase:
 
         :expectedresults:
             1. The host should be provisioned on Google Compute Engine
-            2. The host name should should be the same as given in data to provision the host
+            2. The host name should be the same as given in data to provision the host
             3. The host should show Installed status for provisioned host
         """
         assert class_host.name == self.fullhostname


### PR DESCRIPTION
```
/Users/okhatavk/satellite/robottelo/env/bin/python "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py" --path /Users/okhatavk/satellite/robottelo/tests/upgrades/test_host.py -- -m pre_upgrade
Testing started at 5:17 PM ...
Launching pytest with arguments -m pre_upgrade /Users/okhatavk/satellite/robottelo/tests/upgrades/test_host.py --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

============================= test session starts ==============================
collecting ... collected 2 items / 1 deselected / 1 selected

tests/upgrades/test_host.py::TestScenarioPositiveGCEHostComputeResource::test_pre_create_gce_cr_and_host 

=========== 1 passed, 1 deselected, 2 warnings in 863.75s (0:14:23) ============

Process finished with exit code 0
2023-04-10 17:18:13 - robottelo.collection - INFO - Processing test items to add testimony token markers
PASSED [100%]


/Users/okhatavk/satellite/robottelo/env/bin/python "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py" --path /Users/okhatavk/satellite/robottelo/tests/upgrades/test_host.py -- -m post_upgrade
Testing started at 5:17 PM ...
Launching pytest with arguments -m post_upgrade /Users/okhatavk/satellite/robottelo/tests/upgrades/test_host.py --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

============================= test session starts ==============================
collecting ... collected 2 items / 1 deselected / 1 selected

tests/upgrades/test_host.py::TestScenarioPositiveGCEHostComputeResource::test_post_create_gce_cr_and_host 

=========== 1 passed, 1 deselected, 2 warnings in 863.75s (0:5:23) ============

Process finished with exit code 0
2023-04-10 17:18:13 - robottelo.collection - INFO - Processing test items to add testimony token markers
PASSED [100%]


```