### PR TITLE
make broker logger to use same format as robottelo one

### DIFF
--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -59,6 +59,7 @@ def configure_logging(request, worker_id):
             broker_log_setup(
                 level=logging_yaml.broker.level,
                 file_level=logging_yaml.broker.fileLevel,
+                formatter=worker_formatter,
                 path=robottelo_log_dir.joinpath(f'robottelo_{worker_id}.log'),
             )
 


### PR DESCRIPTION
to do:
- [x] robottelo logger code changes
- [x] https://github.com/SatelliteQE/broker/pull/205
- [x] wait for the changes to land in broker release
- [x] https://github.com/SatelliteQE/robottelo/pull/11210

Streamline the robottelo and broker log formats.
This initializes broker logger with the robottelo formatter.

before the change:
```
2023-04-04 01:16:40 - gw1 - robottelo - INFO - Finished Test: tests/foreman/api/test_ping.py::test_positive_ping[2-2]
2023-04-04 01:17:15 - gw1 - robottelo - DEBUG - Original deploy arguments for sat: {'deploy_snap_version': 'this.server.version.snap', 'deploy_sat_version': 'this.server.version.release', 'deploy_rhel_version': 'this.server.version.rhel_version'}
2023-04-04 01:17:15 - gw1 - robottelo - DEBUG - Resolved deploy arguments for sat: {'deploy_snap_version': 16.0, 'deploy_sat_version': 6.13, 'deploy_rhel_version': 8}
[D 230404 01:17:15 broker:84] Broker instantiated with kwargs={'host_class': <class 'robottelo.hosts.Satellite'>}
[D 230404 01:17:15 broker:319] reconstructing host with export: {'_broker_args': ... }
```

after the change:
```
2023-04-04 01:00:59 - gw1 - robottelo - DEBUG - Original deploy arguments for sat: {'deploy_snap_version': 'this.server.version.snap', 'deploy_sat_version': 'this.server.version.release', 'deploy_rhel_version': 'this.server.version.rhel_version'}
2023-04-04 01:00:59 - gw1 - robottelo - DEBUG - Resolved deploy arguments for sat: {'deploy_snap_version': 16.0, 'deploy_sat_version': 6.13, 'deploy_rhel_version': 8}
2023-04-04 01:00:59 - gw1 - broker - DEBUG - Broker instantiated with kwargs={'host_class': <class 'robottelo.hosts.Satellite'>}
2023-04-04 01:00:59 - gw1 - broker - DEBUG - reconstructing host with export: {'_broker_args': {'deploy_rhel_version': '8.7', 'deploy_sat_version': '6.13.0', 'deploy_snap_version': '16.0', 'host_type': 'satellite', ''os_distribution': 'RedHat', 'os_distribution_version': '8.7', 'reported_devices': {'nics': ['lo', 'eth0']}, 'template': 'tpl-sat-jenkins-6.13.0-16.0-rhel-8.7',  'host_type': 'satellite', 'os_distribution': 'RedHat', 'os_distribution_version': '8.7', 'reported_devices': {'nics': ['lo', 'eth0']}, 'template': 'tpl-sat-jenkins-6.13.0-16.0-rhel-8.7', 'type': 'host'}
```