### PR TITLE
team tags updated for realm

### DIFF
--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Authentication
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 

--- a/tests/foreman/destructive/test_realm.py
+++ b/tests/foreman/destructive/test_realm.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Authentication
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 


### PR DESCRIPTION
Well, I'm not 100% sure about this, the fact is that these tests started to appear in Endeavor results pile, which is correct if they truly belong under the Authentication component (CaseComponent clearly takes precedence over Team). Though there used to be a Realm component but I no longer see it in ohsnap, but still exists in BZ