### PR TITLE
[6.13.z] Fix team name in docstring for ACS

### DIFF
--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: AlternateContentSources
 
-:Team: Phoenix
+:Team: Phoenix-content
 
 :TestType: Functional
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11144

I missed this change in #11001 