### PR TITLE
[6.13.z] fix in helper method

### DIFF
--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -154,7 +154,7 @@ class APIFactory:
         )
         return repo_id
 
-    def one_to_one_names(name):
+    def one_to_one_names(self, name):
         """Generate the names Satellite might use for a one to one field.
 
         Example of usage::
@@ -166,7 +166,7 @@ class APIFactory:
         :returns: A set including both ``name`` and variations on ``name``.
 
         """
-        return {name + '_name', name + '_id'}
+        return {f'{name}_name', f'{name}_id'}
 
     def configure_provisioning(self, org=None, loc=None, compute=False, os=None):
         """Create and configure org, loc, product, repo, cv, env. Update proxy,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11145

This was causing test failures in 6.13 with 
```
>       names = module_target_sat.api_factory.one_to_one_names('content_view')
E       TypeError: APIFactory.one_to_one_names() takes 1 positional argument but 2 were given
```