### PR TITLE
[6.13.z] RFE Automation for New Report Templates

### DIFF
--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -986,3 +986,59 @@ def test_negative_generate_hostpkgcompare_nonexistent_host():
             }
         )
         assert "At least one of the hosts couldn't be found" in cm.exception.stderr
+
+
+@pytest.mark.rhel_ver_list([7, 8])
+@pytest.mark.tier3
+def test_positive_generate_installed_packages_report(
+    module_entitlement_manifest_org,
+    local_ak,
+    local_content_view,
+    local_environment,
+    rhel_contenthost,
+    target_sat,
+):
+    """Generate an report using the 'Host - All Installed Packages' Report template
+
+    :id: 47cc5528-41d9-4100-b603-e98d2ff097a8
+
+    :setup: Installed Satellite with Organization, Activation key,
+            Content View, Content Host, and custom product containing packages
+
+    :steps:
+        1. hammer report-template generate --name 'Host - All Installed Packages'
+            --organization-title '' --report-format '' --inputs 'Hosts filter = hostname'
+
+    :expectedresults: A report is generated containing all installed package
+            information for a host
+
+    :BZ: 1826648
+
+    :parametrized: yes
+
+    :customerscenario: true
+    """
+    setup_org_for_a_custom_repo(
+        {
+            'url': settings.repos.yum_6.url,
+            'organization-id': module_entitlement_manifest_org.id,
+            'content-view-id': local_content_view['id'],
+            'lifecycle-environment-id': local_environment['id'],
+            'activationkey-id': local_ak['id'],
+        }
+    )
+    client = rhel_contenthost
+    client.install_katello_ca(target_sat)
+    client.register_contenthost(module_entitlement_manifest_org.label, local_ak['name'])
+    assert client.subscribed
+    client.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE_NAME} {FAKE_1_CUSTOM_PACKAGE}')
+    result_html = target_sat.cli.ReportTemplate.generate(
+        {
+            'organization': module_entitlement_manifest_org.name,
+            'name': 'Host - All Installed Packages',
+            'report-format': 'html',
+            'inputs': f'Hosts filter={client.hostname}',
+        }
+    )
+    assert client.hostname in result_html
+    assert FAKE_1_CUSTOM_PACKAGE in result_html

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -28,7 +28,10 @@ from lxml import etree
 from nailgun import entities
 
 from robottelo.config import robottelo_tmp_dir
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
+from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
@@ -69,7 +72,7 @@ def setup_content(module_entitlement_manifest_org, module_target_sat):
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]
     ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
-    return org, ak
+    return org, ak, cv, lce
 
 
 @pytest.mark.tier3
@@ -562,3 +565,54 @@ def test_positive_gen_entitlements_reports_multiple_formats(
             tree_result = etree.tostring(tree.getroot(), pretty_print=True, method='html').decode()
         assert client.hostname in tree_result
         assert DEFAULT_SUBSCRIPTION_NAME in tree_result
+
+
+@pytest.mark.tier3
+def test_positive_generate_all_installed_packages_report(
+    session, setup_content, rhel7_contenthost, target_sat
+):
+    """Generate an report using the 'Host - All Installed Packages' Report template
+
+    :id: 63ab3246-0fc5-48b3-ba56-7becfa0c5a7b
+
+    :setup: Installed Satellite with Organization, Activation key,
+            Content View, Content Host, and custom product with installed packages
+
+    :steps:
+        1. Monitor -> Report Templates
+        2. Host - All Installed Packages -> Generate
+        3. Select Date, Output format, and Hosts filter
+
+    :expectedresults: A report is generated containing all installed package
+            information for a host
+
+    :BZ: 1826648
+
+    :customerscenario: true
+    """
+    org, ak, cv, lce = setup_content
+    target_sat.cli_factory.setup_org_for_a_custom_repo(
+        {
+            'url': settings.repos.yum_6.url,
+            'organization-id': org.id,
+            'content-view-id': cv.id,
+            'lifecycle-environment-id': lce.id,
+            'activationkey-id': ak.id,
+        }
+    )
+    client = rhel7_contenthost
+    client.install_katello_ca(target_sat)
+    client.register_contenthost(org.label, ak.name)
+    assert client.subscribed
+    client.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE_NAME} {FAKE_1_CUSTOM_PACKAGE}')
+    with session:
+        session.location.select('Default Location')
+        result_html = session.reporttemplate.generate(
+            'Host - All Installed Packages', values={'output_format': 'HTML'}
+        )
+    with open(result_html) as html_file:
+        parser = etree.HTMLParser()
+        tree = etree.parse(html_file, parser)
+        tree_result = etree.tostring(tree.getroot(), pretty_print=True, method='html').decode()
+    assert client.hostname in tree_result
+    assert FAKE_1_CUSTOM_PACKAGE in tree_result


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10937

SAT-15741
Automation for new Report Template: Host - All Installed Packages

Users should be able to download reports showing all installed package information for a given/all hosts on a satellite 
