### PR TITLE
Several fixes to test_contenthost and repo_mixins

### DIFF
--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -659,7 +659,7 @@ class RepositoryCollection:
         if self.need_subscription:
             # upload manifest only when needed
             if upload_manifest and not self.organization_has_manifest(org_id):
-                self.satellite.upload_manifest(org_id, interface='CLI')
+                self.satellite.upload_manifest(org_id, interface='API')
             if not rh_subscriptions:
                 # add the default subscription if no subscription provided
                 rh_subscriptions = [constants.DEFAULT_SUBSCRIPTION_NAME]

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -51,9 +51,19 @@ if not setting_is_set('clients') or not setting_is_set('fake_manifest'):
     pytest.skip('skipping tests due to missing settings', allow_module_level=True)
 
 
+@pytest.fixture(scope='module', autouse=True)
+def host_ui_default():
+    settings_object = entities.Setting().search(query={'search': 'name=host_details_ui'})[0]
+    settings_object.value = 'No'
+    settings_object.update({'value'})
+    yield
+    settings_object.value = 'Yes'
+    settings_object.update({'value'})
+
+
 @pytest.fixture(scope='module')
 def module_org():
-    org = entities.Organization().create()
+    org = entities.Organization(simple_content_access=False).create()
     # adding remote_execution_connect_by_ip=Yes at org level
     entities.Parameter(
         name='remote_execution_connect_by_ip',


### PR DESCRIPTION
Few updates here:

1. Changing the setup_content fixture to use API instead of CLI. This is because the CLI method of this helper doesn't currently work, and using the API instead provides the same functionality. 
2. Create a fixture that sets the default Host UI to the old one. This is required by all tests in the module, hence the `autouse=True`

Both of these fixes should result in much better results for the Hosts-Content component.