### PR TITLE
Cherrypick requirements to 6.13.z from failed cherrypicks

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -98,7 +98,7 @@ jobs:
 
       - id: automerge
         name: Auto merge of cherry-picked PRs.
-        uses: "pascalgn/automerge-action@v0.15.5"
+        uses: "pascalgn/automerge-action@v0.15.6"
         env:
           GITHUB_TOKEN: "${{ secrets.CHERRYPICK_PAT }}"
           MERGE_LABELS: "AutoMerge_Cherry_Picked, Auto_Cherry_Picked"

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,8 +2,8 @@
 codecov==2.1.12
 flake8==6.0.0
 pytest-cov==3.0.0
-redis==4.5.1
-pre-commit==3.0.4
+redis==4.5.4
+pre-commit==3.2.2
 
 
 # For generating documentation.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,12 @@
 
 betelgeuse==1.10.0
 broker[docker]==0.2.15
-cryptography==39.0.2
-deepdiff==6.2.3
+cryptography==40.0.1
+deepdiff==6.3.0
 dynaconf[vault]==3.1.12
 fauxfactory==3.1.0
 jinja2==3.1.2
-manifester==0.0.11
+manifester==0.0.12
 navmazing==1.1.6
 productmd==1.35
 pyotp==2.8.0
@@ -15,12 +15,12 @@ python-box==7.0.1
 pytest==7.2.2
 pytest-services==2.2.1
 pytest-mock==3.10.0
-pytest-reportportal==5.1.5
-pytest-xdist==3.2.0
+pytest-reportportal==5.1.6
+pytest-xdist==3.2.1
 pytest-ibutsu==2.2.4
 PyYAML==6.0
 requests==2.28.2
-tenacity==8.2.1
+tenacity==8.2.2
 testimony==2.2.0
 wait-for==1.2.0
 wrapanapi==3.5.14


### PR DESCRIPTION
Fixes issues https://github.com/SatelliteQE/robottelo/issues?q=is%3Aopen+is%3Aissue+label%3A6.13.z+bump