### PR TITLE
[6.12.z] [errata] - Upgrade scenario refactor

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -21,6 +21,7 @@ def post(settings):
                 'Config will be fetched now.'
             )
             data = get_repos_config(settings)
+            write_cache(settings_cache_path, data)
     data['dynaconf_merge'] = True
     return data
 

--- a/pytest_fixtures/component/katello_agent.py
+++ b/pytest_fixtures/component/katello_agent.py
@@ -7,18 +7,11 @@ from robottelo.utils.installer import InstallerCommand
 
 @pytest.fixture(scope='module')
 def sat_with_katello_agent(module_target_sat):
-    """Enable katello-agent on module_target_sat"""
-    module_target_sat.register_to_cdn()
-    # Enable katello-agent from satellite-installer
-    result = module_target_sat.install(
-        InstallerCommand('foreman-proxy-content-enable-katello-agent true')
-    )
-    assert result.status == 0
-    # Verify katello-agent is enabled
+    """Assert that katello-agent feature is enabled on module_target_sat"""
     result = module_target_sat.install(
         InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
     )
-    assert 'true' in result.stdout
+    assert 'true' in result.stdout, 'katello-agent feature is not enabled on Satellite'
     yield module_target_sat
 
 

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -42,11 +42,12 @@ LOCALES = (
 
 
 DISTRO_DEFAULT = 'rhel7'
-DISTROS_SUPPORTED = ['rhel6', 'rhel7', 'rhel8']
+DISTROS_SUPPORTED = ['rhel6', 'rhel7', 'rhel8, rhel9']
 DISTROS_MAJOR_VERSION = {
     'rhel6': 6,
     'rhel7': 7,
     'rhel8': 8,
+    'rhel9': 9,
 }
 MAJOR_VERSION_DISTRO = {value: key for key, value in DISTROS_MAJOR_VERSION.items()}
 
@@ -233,6 +234,7 @@ MIRRORING_POLICIES = {
 PRODUCT_KEY_RHEL = 'rhel'
 PRODUCT_KEY_SAT_TOOLS = 'rhst'
 PRODUCT_KEY_SAT_CAPSULE = 'rhsc'
+PRODUCT_KEY_SAT_CLIENT = 'rhsclient'
 PRODUCT_KEY_VIRT_AGENTS = 'rhva6'
 PRODUCT_KEY_CLOUD_FORMS_TOOLS = 'rhct6'
 PRODUCT_KEY_ANSIBLE_ENGINE = 'rhae2'
@@ -282,6 +284,9 @@ REPOSET = {
     'rhsc7': 'Red Hat Satellite Capsule 6.9 (for RHEL 7 Server) (RPMs)',
     'rhsc7_iso': 'Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (ISOs)',
     'rhsc6': 'Red Hat Satellite Capsule 6.9 (for RHEL 6 Server) (RPMs)',
+    'rhsclient7': 'Red Hat Satellite Client 6 for RHEL 7 Server RPMs x86_64',
+    'rhsclient8': 'Red Hat Satellite Client 6 for RHEL 8 x86_64 RPMs',
+    'rhsclient9': 'Red Hat Satellite Client 6 for RHEL 9 x86_64 RPMs',
     'rhst7': 'Red Hat Satellite Tools 6.9 (for RHEL 7 Server) (RPMs)',
     'rhst7_610': 'Red Hat Satellite Tools 6.10 (for RHEL 7 Server) (RPMs)',
     'rhst6': 'Red Hat Satellite Tools 6.9 (for RHEL 6 Server) (RPMs)',
@@ -375,6 +380,33 @@ REPOS = {
         'product': PRDS['rhsc'],
         'distro': 'rhel6',
         'key': 'rhsc',
+    },
+    'rhsclient7': {
+        'id': 'rhel-7-server-satellite-client-6-rpms',
+        'name': ('Red Hat Satellite Client 6 for RHEL 7 Server RPMs x86_64'),
+        'version': '6',
+        'reposet': REPOSET['rhsclient7'],
+        'product': PRDS['rhel'],
+        'distro': 'rhel7',
+        'key': PRODUCT_KEY_SAT_CLIENT,
+    },
+    'rhsclient8': {
+        'id': 'satellite-client-6-for-rhel-8-x86_64-rpms',
+        'name': ('Red Hat Satellite Client 6 for RHEL 8 x86_64 RPMs'),
+        'version': '6',
+        'reposet': REPOSET['rhsclient8'],
+        'product': PRDS['rhel'],
+        'distro': 'rhel8',
+        'key': PRODUCT_KEY_SAT_CLIENT,
+    },
+    'rhsclient9': {
+        'id': 'satellite-client-6-for-rhel-9-x86_64-rpms',
+        'name': ('Red Hat Satellite Client 6 for RHEL 9 x86_64 RPMs'),
+        'version': '6',
+        'reposet': REPOSET['rhsclient9'],
+        'product': PRDS['rhel'],
+        'distro': 'rhel9',
+        'key': PRODUCT_KEY_SAT_CLIENT,
     },
     'rhst7': {
         'id': 'rhel-7-server-satellite-tools-6.9-rpms',
@@ -747,7 +779,7 @@ FAKE_9_YUM_UPDATED_PACKAGES = [
     'duck-0.6-1.noarch',
     'gorilla-0.62-1.noarch',
     'penguin-0.9.1-1.noarch',
-    'stork-0.12-1.noarch',
+    'stork-0.12-2.noarch',
     'walrus-5.21-1.noarch',
     'kangaroo-0.2-1.noarch',
 ]

--- a/robottelo/host_helpers/__init__.py
+++ b/robottelo/host_helpers/__init__.py
@@ -1,4 +1,5 @@
 from robottelo.host_helpers.capsule_mixins import CapsuleInfo
+from robottelo.host_helpers.contenthost_mixins import HostInfo
 from robottelo.host_helpers.contenthost_mixins import SystemFacts
 from robottelo.host_helpers.contenthost_mixins import VersionedContent
 from robottelo.host_helpers.satellite_mixins import ContentInfo
@@ -7,7 +8,7 @@ from robottelo.host_helpers.satellite_mixins import Factories
 from robottelo.host_helpers.satellite_mixins import SystemInfo
 
 
-class ContentHostMixins(SystemFacts, VersionedContent):
+class ContentHostMixins(HostInfo, SystemFacts, VersionedContent):
     pass
 
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -36,6 +36,16 @@ class APIFactory:
                 organization=[org.id],
             ).create()
 
+    def update_vm_host_location(self, vm_client, location_id):
+        """Update vm client host location.
+
+        :param vm_client: A subscribed Virtual Machine client instance.
+        :param location_id: The location id to update the vm_client host with.
+        """
+        self._satellite.api.Host(
+            id=vm_client.nailgun_host.id, location=self._satellite.api.Location(id=location_id)
+        ).update(['location'])
+
     @contextmanager
     def satellite_setting(self, key_val: str):
         """Context Manager to update the satellite setting and revert on exit

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -235,7 +235,7 @@ class ContentHost(Host, ContentHostMixins):
             self.remove_katello_ca()
 
     def teardown(self):
-        if not self.blank:
+        if not self.blank and not getattr(self, '_skip_context_checkin', False):
             if self.nailgun_host:
                 self.nailgun_host.delete()
             self.unregister()
@@ -1790,6 +1790,10 @@ class Satellite(Capsule, SatelliteMixins):
             f'Failed to register the host: {rhel_contenthost.hostname}:'
             f'rc: {register.status}: {register.stderr}'
         )
+        rhsm_id = rhel_contenthost.execute('subscription-manager identity')
+        assert module_org.name in rhsm_id.stdout, 'Host is not registered to expected organization'
+        rhel_contenthost._satellite = self
+
         # attach product subscriptions to contenthost
         rhel_contenthost.nailgun_host.bulk_add_subscriptions(
             data={

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -297,8 +297,7 @@ def test_positive_install_multiple_in_host(
         _install_package(
             module_org, clients=[rhel_contenthost], host_ids=[host.id], package_name=package
         )
-    host = host.read()
-    applicable_errata_count = host.content_facet_attributes['errata_counts']['total']
+    applicable_errata_count = rhel_contenthost.applicable_errata_count
     assert applicable_errata_count > 1
     rhel_contenthost.add_rex_key(satellite=target_sat)
     for errata in settings.repos.yum_9.errata[1:4]:
@@ -316,9 +315,8 @@ def test_positive_install_multiple_in_host(
             search_rate=20,
             max_tries=15,
         )
-        host = host.read()
         applicable_errata_count -= 1
-        assert host.content_facet_attributes['errata_counts']['total'] == applicable_errata_count
+        assert rhel_contenthost.applicable_errata_count == applicable_errata_count
 
 
 @pytest.mark.tier3
@@ -788,9 +786,7 @@ def test_errata_installation_with_swidtags(
         return_result=True,
     )
     assert before_errata_apply_result != ''
-    host = rhel8_contenthost.nailgun_host
-    host = host.read()
-    applicable_errata_count = host.content_facet_attributes['errata_counts']['total']
+    applicable_errata_count = rhel8_contenthost.applicable_errata_count
     assert applicable_errata_count == 1
 
     # apply modular errata
@@ -799,9 +795,8 @@ def test_errata_installation_with_swidtags(
     )
     _run_remote_command_on_content_host(module_org, 'dnf -y upload-profile', rhel8_contenthost)
     Host.errata_recalculate({'host-id': rhel8_contenthost.nailgun_host.id})
-    host = host.read()
     applicable_errata_count -= 1
-    assert host.content_facet_attributes['errata_counts']['total'] == applicable_errata_count
+    assert rhel8_contenthost.applicable_errata_count == applicable_errata_count
     after_errata_apply_result = _run_remote_command_on_content_host(
         module_org,
         f"swidq -i -n {module_name} | grep 'File'| grep -o 'rpm-.*.swidtag'",

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -234,7 +234,7 @@ def test_end_to_end(
         assert status['overview']['job_status_progress'] == '100%'
         _generate_errata_applicability(vm.hostname)
         vm = vm.nailgun_host.read()
-        assert vm.content_facet_attributes['errata_counts']['total'] == 0
+        assert vm.applicable_errata_count == 0
 
 
 @pytest.mark.tier2

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -19,13 +19,12 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :Upstream: No
 """
-import time
-
 import pytest
 from broker import Broker
 
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
 from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
+from robottelo.hosts import ContentHost
 
 
 class TestScenarioUpgradeOldClientAndPackageInstallation:
@@ -68,18 +67,6 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
 
         """
         rhel_client = katello_agent_client_for_upgrade.client
-        rhid = rhel_client.execute('subscription-manager identity')
-        assert module_org.name in rhid.stdout
-        result = rhel_client.execute('rpm -q gofer')
-        assert result.status == 0
-        assert 'package gofer is not installed' not in result.stdout
-        # Run goferd on client as its docker container
-        rhel_client._cont_inst.exec_run('goferd -f', detach=True)
-        # Holding on for 30 seconds while goferd starts
-        time.sleep(30)
-        rhel_client.execute('yum install -y procps')  # ps command needs to be installed
-        result = rhel_client.execute("ps -ef | grep goferd")
-        assert 'goferd' in result.stdout
         module_target_sat.cli.Host.package_install(
             {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_4_CUSTOM_PACKAGE_NAME}
         )
@@ -114,7 +101,9 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
             {'host-id': client_id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )
         # Verifies that package is really installed
-        rhel_client = Broker().from_inventory(filter=f'hostname={client_name}')[0]
+        rhel_client = Broker(host_class=ContentHost).from_inventory(
+            filter=f'hostname={client_name}'
+        )[0]
         result = rhel_client.execute(f"rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}")
         assert FAKE_0_CUSTOM_PACKAGE_NAME in result.stdout
 
@@ -134,7 +123,9 @@ class TestScenarioUpgradeNewClientAndPackageInstallation:
 
     @pytest.mark.post_upgrade
     def test_post_scenario_post_client_package_installation(
-        self, module_target_sat, katello_agent_client_for_upgrade, module_org
+        self,
+        module_target_sat,
+        katello_agent_client_for_upgrade,
     ):
         """Post-upgrade test that creates a client, installs a package on
         the post-upgrade created client and then verifies the package is installed.
@@ -157,18 +148,6 @@ class TestScenarioUpgradeNewClientAndPackageInstallation:
             3. The package is installed on post-upgrade client
         """
         rhel_client = katello_agent_client_for_upgrade.client
-        rhid = rhel_client.execute('subscription-manager identity')
-        assert module_org.name in rhid.stdout
-        result = rhel_client.execute('rpm -q gofer')
-        assert result.status == 0
-        assert 'package gofer is not installed' not in result.stdout
-        # Run goferd on client as its docker container
-        rhel_client._cont_inst.exec_run('goferd -f', detach=True)
-        # Holding on for 30 seconds while goferd starts
-        time.sleep(30)
-        rhel_client.execute('yum install -y procps')  # ps command needs to be installed
-        result = rhel_client.execute("ps -ef | grep goferd")
-        assert 'goferd' in result.stdout
         module_target_sat.cli.Host.package_install(
             {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -17,75 +17,70 @@
 :Upstream: No
 """
 import pytest
-from fabric.api import execute
-from nailgun import entities
-from nailgun.entity_mixins import call_entity_method_with_timeout
-from upgrade.helpers.docker import docker_execute_command
-from upgrade_tests.helpers.scenarios import dockerize
+from broker import Broker
 from wait_for import wait_for
 
+from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import FAKE_9_YUM_OUTDATED_PACKAGES
-from robottelo.constants import FAKE_9_YUM_UPDATED_PACKAGES
-from robottelo.constants import REPOS
+from robottelo.hosts import ContentHost
 from robottelo.logging import logger
-from robottelo.upgrade_utility import host_location_update
-from robottelo.upgrade_utility import install_or_update_package
-from robottelo.upgrade_utility import publish_content_view
-from robottelo.upgrade_utility import run_goferd
 
 
 class TestScenarioErrataAbstract:
     """This is an Abstract Class whose methods are inherited by others errata
     scenarios"""
 
-    def _errata_count(self, ak):
-        """fetch the content host details.
-        :param: str ak: The activation key name
-        :return: int installable_errata_count : installable_errata count
-        """
-        host = entities.Host().search(query={'search': f'activation_key={ak}'})[0]
-        installable_errata_count = host.content_facet_attributes['errata_counts']['total']
-        return installable_errata_count
+    def _create_custom_rhel_n_client_repos(self, target_sat, product, v_major):
+        """Create custom RHEL (system) and Satellite Client repos and sync them"""
+        repos = []
+        rhel_repo_urls = [settings.repos[f'rhel{v_major}_os']]
+        if v_major > 7:
+            rhel_repo_urls = [rhel_repo_urls[0]['BASEOS'], rhel_repo_urls[0]['APPSTREAM']]
 
-    def _create_custom_rhel_tools_repos(self, product):
-        """Install packge on docker content host."""
-        rhel_repo_url = settings.repos.rhel7_os
-        tools_repo_url = settings.repos.sattools_repo['rhel7']
-        if None in [rhel_repo_url, tools_repo_url]:
-            raise ValueError('The rhel7_os or tools_rhel7 Repo url is not set in settings!')
-        tools_repo = entities.Repository(
-            product=product, content_type='yum', url=tools_repo_url
-        ).create()
-        rhel_repo = entities.Repository(
-            product=product, content_type='yum', url=rhel_repo_url
-        ).create()
-        call_entity_method_with_timeout(rhel_repo.sync, timeout=3000)
-        call_entity_method_with_timeout(tools_repo.sync, timeout=3000)
-        return tools_repo, rhel_repo
-
-    def _get_rh_rhel_tools_repos(self, org):
-        """Get list of RHEL7 and tools repos
-
-        :return: nailgun.entities.Repository: repository
-        """
-
-        from_version = settings.upgrade.from_version
-        repo2_name = 'rhst7_{}'.format(str(from_version).replace('.', ''))
-
-        repo1_id = (
-            entities.Repository(organization=org)
-            .search(query={'search': '{}'.format(REPOS['rhel7']['id'])})[0]
-            .id
+        client_repo_url = settings.repos.satclient_repo[f'rhel{v_major}']
+        if not all([all(rhel_repo_urls), client_repo_url]):
+            raise ValueError(
+                f'Repo URLs for RHEL {v_major} system repository or/and '
+                f'Satellite Client repository for RHEL {v_major} are not set.'
+            )
+        # Satellite Client repo
+        repos.append(
+            target_sat.api.Repository(
+                product=product, content_type='yum', url=client_repo_url
+            ).create()
         )
-        repo2_id = (
-            entities.Repository(organization=org)
-            .search(query={'search': '{}'.format(REPOS[repo2_name]['id'])})[0]
-            .id
-        )
+        # RHEL system repo(s)
+        for url in rhel_repo_urls:
+            repos.append(
+                target_sat.api.Repository(product=product, content_type='yum', url=url).create()
+            )
 
-        return [entities.Repository(id=repo_id) for repo_id in [repo1_id, repo2_id]]
+        for repo in repos:
+            repo.sync(timeout=3000)
+        return repos
+
+    def _get_rh_rhel_n_client_repos(self, target_sat, org, rhel_client):
+        """Get list of RHEL (system) and Satellite Client repository IDs
+
+        This method assumes that the RHEL and Satellite Client repositories
+        are already created and synced.
+
+        :return: List[entities.Repository]: repositories
+        """
+        rhel_repo_labels = (
+            ['rhel_bos', 'rhel_aps'] if rhel_client.os_version.major > 7 else ['rhel']
+        )
+        rhel_repos = [
+            target_sat.api.Repository(organization=org).search(
+                query={'search': rhel_client.REPOS[repo]['id']}
+            )[0]
+            for repo in rhel_repo_labels
+        ]
+        sat_client_repo = target_sat.api.Repository(organization=org).search(
+            query={'search': rhel_client.REPOS[constants.PRODUCT_KEY_SAT_CLIENT]['id']}
+        )[0]
+
+        return [*rhel_repos, sat_client_repo]
 
 
 class TestScenarioErrataCount(TestScenarioErrataAbstract):
@@ -102,8 +97,12 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
         5. Check if the Errata Count in Satellite after the upgrade.
     """
 
+    @pytest.mark.rhel_ver_list([8])
+    @pytest.mark.no_containers
     @pytest.mark.pre_upgrade
-    def test_pre_scenario_generate_errata_for_client(self, save_test_data):
+    def test_pre_scenario_generate_errata_for_client(
+        self, target_sat, rhel_contenthost, function_org, save_test_data
+    ):
         """Create product and repo from which the errata will be generated for the
         Satellite client or content host.
 
@@ -125,77 +124,66 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
             1. The content host is created
             2. errata count, erratum list will be generated to satellite client/content
                 host
-
         """
-        org = entities.Organization().create()
-        loc = entities.Location(organization=[org]).create()
-        environment = entities.LifecycleEnvironment(organization=org).search(
-            query={'search': 'name=Library'}
+        rhel_contenthost._skip_context_checkin = True
+        # loc = sat.api.Location(organization=[org]).create() # function_location_with_org
+        # sat.api_factory.update_vm_host_location(rhel_client, loc.id)
+        environment = target_sat.api.LifecycleEnvironment(organization=function_org).search(
+            query={'search': f'name={constants.ENVIRONMENT}'}
         )[0]
-
-        product = entities.Product(organization=org).create()
-        custom_yum_repo = entities.Repository(
+        product = target_sat.api.Product(organization=function_org).create()
+        custom_yum_repo = target_sat.api.Repository(
             product=product, content_type='yum', url=settings.repos.yum_9.url
         ).create()
         product.sync()
-
-        tools_repo, rhel_repo = self._create_custom_rhel_tools_repos(product)
-        repolist = [custom_yum_repo, tools_repo, rhel_repo]
-        content_view = publish_content_view(org=org, repolist=repolist)
-        ak = entities.ActivationKey(
-            content_view=content_view, organization=org.id, environment=environment
+        synced_repos = self._create_custom_rhel_n_client_repos(
+            target_sat, product, rhel_contenthost.os_version.major
+        )
+        repolist = [
+            custom_yum_repo,
+            *synced_repos,
+        ]
+        content_view = target_sat.publish_content_view(function_org, repolist)
+        ak = target_sat.api.ActivationKey(
+            content_view=content_view, organization=function_org, environment=environment
         ).create()
-        subscription = entities.Subscription(organization=org).search(
+        subscription = target_sat.api.Subscription(organization=function_org).search(
             query={'search': f'name={product.name}'}
         )[0]
-
         ak.add_subscriptions(data={'subscription_id': subscription.id})
-        rhel7_client = dockerize(ak_name=ak.name, distro='rhel7', org_label=org.label)
-        client_container_id = list(rhel7_client.values())[0]
-        client_container_name = [key for key in rhel7_client.keys()][0]
-        host_location_update(
-            client_container_name=client_container_name, logger_obj=logger, loc=loc
+        rhel_contenthost.install_katello_ca(target_sat)
+        rhel_contenthost.register_contenthost(org=function_org.name, activation_key=ak.name)
+        rhel_contenthost.add_rex_key(satellite=target_sat)
+        rhel_contenthost.install_katello_host_tools()
+        rhel_contenthost.execute('subscription-manager refresh')
+
+        rhel_contenthost.execute(
+            f'yum -y install {" ".join(constants.FAKE_9_YUM_OUTDATED_PACKAGES)}'
         )
-
-        docker_vm = settings.upgrade.docker_vm
-        wait_for(
-            lambda: org.name
-            in execute(
-                docker_execute_command,
-                client_container_id,
-                'subscription-manager identity',
-                host=docker_vm,
-            )[docker_vm],
-            timeout=800,
-            delay=2,
-            logger=logger,
-        )
-        install_or_update_package(client_hostname=client_container_id, package="katello-agent")
-        run_goferd(client_hostname=client_container_id)
-
-        for package in FAKE_9_YUM_OUTDATED_PACKAGES:
-            install_or_update_package(client_hostname=client_container_id, package=package)
-
-        host = entities.Host().search(query={'search': f'activation_key={ak.name}'})[0]
-        installable_errata_count = host.content_facet_attributes['errata_counts']['total']
-        assert installable_errata_count > 1
-        erratum_list = entities.Errata(repository=custom_yum_repo).search(
+        host = target_sat.api.Host().search(query={'search': f'activation_key={ak.name}'})[0]
+        assert host.id == rhel_contenthost.nailgun_host.id, 'Host not found in Satellite'
+        assert (
+            rhel_contenthost.applicable_errata_count > 1
+        ), f'No applicable errata found for host {host.name}'
+        erratum_list = target_sat.api.Errata(repository=custom_yum_repo).search(
             query={'order': 'updated ASC', 'per_page': 1000}
         )
         errata_ids = [errata.errata_id for errata in erratum_list]
         assert sorted(errata_ids) == sorted(settings.repos.yum_9.errata)
         save_test_data(
             {
-                'rhel_client': rhel7_client,
+                'rhel_client': rhel_contenthost.hostname,
                 'activation_key': ak.name,
                 'custom_repo_id': custom_yum_repo.id,
                 'product_id': product.id,
-                'conten_view_id': content_view.id,
+                'content_view_id': content_view.id,
+                'synced_repo_ids': [repo.id for repo in synced_repos],
+                'organization_id': function_org.id,
             }
         )
 
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_generate_errata_for_client)
-    def test_post_scenario_errata_count_installation(self, pre_upgrade_data):
+    def test_post_scenario_errata_count_installation(self, target_sat, pre_upgrade_data):
         """Post-upgrade scenario that installs the package on pre-upgrade
         client remotely and then verifies if the package installed.
 
@@ -215,234 +203,56 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
             1. errata count, erratum list should same after satellite upgrade
             2. Installation of errata should be pass successfully
         """
-        client = pre_upgrade_data.get('rhel_client')
-        client_container_id = list(client.values())[0]
+        client_hostname = pre_upgrade_data.get('rhel_client')
         custom_repo_id = pre_upgrade_data.get('custom_repo_id')
-        product_id = pre_upgrade_data.get('product_id')
-        conten_view_id = pre_upgrade_data.get('conten_view_id')
-        product = entities.Product(id=product_id).read()
-        content_view = entities.ContentView(id=conten_view_id).read()
-        custom_yum_repo = entities.Repository(id=custom_repo_id).read()
         activation_key = pre_upgrade_data.get('activation_key')
-        host = entities.Host().search(query={'search': f'activation_key={activation_key}'})[0]
+        organization_id = pre_upgrade_data.get('organization_id')
+        rhel_client = Broker(host_class=ContentHost).from_inventory(
+            filter=f'hostname={client_hostname}'
+        )[0]
+        custom_yum_repo = target_sat.api.Repository(id=custom_repo_id).read()
+        host = target_sat.api.Host().search(query={'search': f'activation_key={activation_key}'})[0]
+        assert host.id == rhel_client.nailgun_host.id, 'Host not found in Satellite'
+        organization = target_sat.api.Organization(id=organization_id).read()
 
-        installable_errata_count = host.content_facet_attributes['errata_counts']['total']
-        tools_repo, rhel_repo = self._create_custom_rhel_tools_repos(product)
-        call_entity_method_with_timeout(product.sync, timeout=1400)
-        for repo in (tools_repo, rhel_repo):
-            content_view.repository.append(repo)
-        content_view = content_view.update(['repository'])
-        content_view.publish()
-        install_or_update_package(
-            client_hostname=client_container_id, update=True, package="katello-agent"
-        )
-
-        run_goferd(client_hostname=client_container_id)
-        assert installable_errata_count > 1
-
-        erratum_list = entities.Errata(repository=custom_yum_repo).search(
+        # Verifying errata count has not changed on satellite
+        installable_errata_count = rhel_client.applicable_errata_count
+        assert installable_errata_count > 1, f'No applicable errata found for host {host.name}'
+        erratum_list = target_sat.api.Errata(repository=custom_yum_repo).search(
             query={'order': 'updated ASC', 'per_page': 1000}
         )
         errata_ids = [errata.errata_id for errata in erratum_list]
         assert sorted(errata_ids) == sorted(settings.repos.yum_9.errata)
 
         for errata in settings.repos.yum_9.errata:
-            host.errata_apply(data={'errata_ids': [errata]})
+            task_id = target_sat.api.JobInvocation().run(
+                data={
+                    'feature': 'katello_errata_install',
+                    'inputs': {'errata': errata},
+                    'targeting_type': 'static_query',
+                    'search_query': f'name = {rhel_client.hostname}',
+                    'organization_id': organization.id,
+                },
+            )['id']
+            target_sat.wait_for_tasks(
+                search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
+                search_rate=15,
+                max_tries=10,
+            )
             installable_errata_count -= 1
 
         # waiting for errata count to become 0, as profile uploading take some
         # amount of time
         wait_for(
-            lambda: self._errata_count(ak=activation_key) == 0,
+            lambda: rhel_client.applicable_errata_count == 0,
             timeout=400,
             delay=2,
             logger=logger,
         )
-        host = entities.Host().search(query={'search': f'activation_key={activation_key}'})[0]
-        assert host.content_facet_attributes['errata_counts']['total'] == 0
-        for package in FAKE_9_YUM_UPDATED_PACKAGES:
-            install_or_update_package(client_hostname=client_container_id, package=package)
-
-
-class TestScenarioErrataCountWithPreviousVersionKatelloAgent(TestScenarioErrataAbstract):
-    """The test class contains pre and post upgrade scenarios to test erratas count
-    and remotely install using n-1 'katello-agent' on content host.
-
-    Test Steps:
-
-        1. Before Satellite upgrade, Create a content host and register it with
-            Satellite
-        2. Install packages and down-grade them to generate errata.
-        3. Upgrade Satellite
-        4. Check if the Erratas Count in Satellite after the upgrade.
-        5. Install erratas remotely on content host and check the erratas count.
-
-    BZ: 1529682
-    """
-
-    @pytest.mark.pre_upgrade
-    def test_pre_scenario_generate_errata_with_previous_version_katello_agent_client(
-        self, default_org, save_test_data
-    ):
-        """Create product and repo from which the errata will be generated for the
-        Satellite client or content host.
-
-        :id: preupgrade-4e515f84-2582-4b8b-a625-9f6c6966aa59
-
-        :steps:
-
-            1. Create Life Cycle Environment, Product and Custom Yum Repo.
-            2. Enable/sync 'base os RHEL7' and tools repos.
-            3. Create a content view and publish it.
-            4. Create activation key and add subscription.
-            5. Registering Docker Content Host RHEL7.
-            6. Install and check katello agent and goferd service running on host.
-            7. Generate Errata by Installing Outdated/Older Packages.
-            8. Collect the Erratum list.
-
-        :expectedresults:
-
-            1. The content host is created.
-            2. errata count, erratum list will be generated to satellite client/content host.
-
-        """
-        environment = entities.LifecycleEnvironment(organization=default_org).search(
-            query={'search': 'name=Library'}
-        )[0]
-
-        product = entities.Product(organization=default_org).create()
-        custom_yum_repo = entities.Repository(
-            product=product, content_type='yum', url=settings.repos.yum_9.url
-        ).create()
-        call_entity_method_with_timeout(product.sync, timeout=1400)
-
-        repos = self._get_rh_rhel_tools_repos(default_org)
-        repos.append(custom_yum_repo)
-        content_view = publish_content_view(org=default_org, repolist=repos)
-        custom_sub = entities.Subscription(organization=default_org).search(
-            query={'search': f'name={product.name}'}
-        )[0]
-        rh_sub = entities.Subscription(organization=1).search(
-            query={'search': f'{DEFAULT_SUBSCRIPTION_NAME}'}
-        )[0]
-
-        ak = entities.ActivationKey(
-            content_view=content_view,
-            organization=default_org.id,
-            environment=environment,
-            auto_attach=False,
-        ).create()
-        ak.add_subscriptions(data={'subscription_id': custom_sub.id})
-        ak.add_subscriptions(data={'subscription_id': rh_sub.id})
-
-        rhel7_client = dockerize(ak_name=ak.name, distro='rhel7', org_label=default_org.label)
-        client_container_id = list(rhel7_client.values())[0]
-
-        docker_vm = settings.upgrade.docker_vm
-        wait_for(
-            lambda: default_org.label
-            in execute(
-                docker_execute_command,
-                client_container_id,
-                'subscription-manager identity',
-                host=docker_vm,
-            )[docker_vm],
-            timeout=800,
-            delay=2,
-            logger=logger,
-        )
-        status = execute(
-            docker_execute_command,
-            client_container_id,
-            'subscription-manager identity',
-            host=docker_vm,
-        )[docker_vm]
-
-        assert default_org.label in status
-
-        # Update OS to make errata count 0
-        execute(docker_execute_command, client_container_id, 'yum update -y', host=docker_vm)[
-            docker_vm
-        ]
-        install_or_update_package(client_hostname=client_container_id, package="katello-agent")
-        run_goferd(client_hostname=client_container_id)
-
-        for package in FAKE_9_YUM_OUTDATED_PACKAGES:
-            install_or_update_package(client_hostname=client_container_id, package=package)
-        host = entities.Host().search(query={'search': f'activation_key={ak.name}'})[0]
-
-        installable_errata_count = host.content_facet_attributes['errata_counts']['total']
-        assert installable_errata_count > 1
-
-        erratum_list = entities.Errata(repository=custom_yum_repo).search(
-            query={'order': 'updated ASC', 'per_page': 1000}
-        )
-        errata_ids = [errata.errata_id for errata in erratum_list]
-        assert sorted(errata_ids) == sorted(settings.repos.yum_9.errata)
-        save_test_data(
-            {
-                'rhel_client': rhel7_client,
-                'activation_key': ak.name,
-                'custom_repo_id': custom_yum_repo.id,
-                'product_id': product.id,
-            }
-        )
-
-    @pytest.mark.post_upgrade(
-        depend_on=test_pre_scenario_generate_errata_with_previous_version_katello_agent_client
-    )
-    def test_post_scenario_generate_errata_with_previous_version_katello_agent_client(
-        self, pre_upgrade_data
-    ):
-        """Post-upgrade scenario that installs the package on pre-upgraded client
-        remotely and then verifies if the package installed and errata counts.
-
-        :id: postupgrade-b61f8f5a-44a3-4d3e-87bb-fc399e03ba6f
-
-        :steps:
-
-            1. Recovered pre_upgrade data for post_upgrade verification.
-            2. Verifying errata count has not changed on satellite.
-            3. Restart goferd/Katello-agent running.
-            4. Verifying the errata_ids.
-            5. Verifying installation errata passes successfully.
-            6. Verifying that package installation passed successfully by remote docker
-                exec.
-
-        :expectedresults:
-            1. errata count, erratum list should same after satellite upgrade.
-            2. Installation of errata should be pass successfully and check errata counts
-                is 0.
-        """
-
-        client = pre_upgrade_data.get('rhel_client')
-        client_container_id = list(client.values())[0]
-        custom_repo_id = pre_upgrade_data.get('custom_repo_id')
-        custom_yum_repo = entities.Repository(id=custom_repo_id).read()
-        activation_key = pre_upgrade_data.get('activation_key')
-        host = entities.Host().search(query={'search': f'activation_key={activation_key}'})[0]
-
-        installable_errata_count = host.content_facet_attributes['errata_counts']['total']
-        assert installable_errata_count > 1
-
-        erratum_list = entities.Errata(repository=custom_yum_repo).search(
-            query={'order': 'updated ASC', 'per_page': 1000}
-        )
-        errata_ids = [errata.errata_id for errata in erratum_list]
-        assert sorted(errata_ids) == sorted(settings.repos.yum_9.errata)
-
+        pkg_check = rhel_client.execute(f'rpm -q {" ".join(constants.FAKE_9_YUM_UPDATED_PACKAGES)}')
+        assert pkg_check.status == 0, 'Package check failed. One or more packages were not updated'
+        errata_check = rhel_client.execute('dnf updateinfo list')
         for errata in settings.repos.yum_9.errata:
-            host.errata_apply(data={'errata_ids': [errata]})
-
-        for package in FAKE_9_YUM_UPDATED_PACKAGES:
-            install_or_update_package(client_hostname=client_container_id, package=package)
-
-        # waiting for errata count to become 0, as profile uploading take some
-        # amount of time
-        wait_for(
-            lambda: self._errata_count(ak=activation_key) == 0,
-            timeout=400,
-            delay=2,
-            logger=logger,
-        )
-        assert self._errata_count(ak=activation_key) == 0
+            assert (
+                errata not in errata_check.stdout
+            ), 'Errata check failed. One or more errata were not applied'

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -23,6 +23,7 @@ from robottelo.api.utils import create_sync_custom_repo
 from robottelo.config import settings
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
 from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
+from robottelo.hosts import ContentHost
 
 UPSTREAM_USERNAME = 'rTtest123'
 
@@ -151,8 +152,6 @@ class TestScenarioCustomRepoCheck:
             ak.add_subscriptions(data={'subscription_id': subscription.id})
         sat_upgrade_chost.install_katello_ca(target_sat)
         sat_upgrade_chost.register_contenthost(org.label, ak.name)
-        rhid = sat_upgrade_chost.execute('subscription-manager identity')
-        assert org.name in rhid.stdout
         sat_upgrade_chost.execute('subscription-manager repos --enable=*;yum clean all')
         result = sat_upgrade_chost.execute(f'yum install -y {FAKE_0_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0
@@ -200,6 +199,8 @@ class TestScenarioCustomRepoCheck:
             data={'environment_ids': lce_id}
         )
 
-        rhel_client = Broker().from_inventory(filter=f'hostname={client_hostname}')[0]
+        rhel_client = Broker(host_class=ContentHost).from_inventory(
+            filter=f'hostname={client_hostname}'
+        )[0]
         result = rhel_client.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0


### PR DESCRIPTION
This PR is a cherry-pick of #10930.

(cherry picked from commit 100f6ce7309a559ecd6af96b90d42289cd0e389f)


## Test results
```
$ pytest tests/upgrades/test_errata.py -m pre_upgrade
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ogajduse/repos/robottelo-6.12, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, ibutsu-2.2.4, xdist-3.2.0, reportportal-5.1.5, fixture-tools-1.1.0
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                                               

tests/upgrades/test_errata.py .                                                                                                                                                                                                       [100%]

============================================================================================================= warnings summary ==============================================================================================================
../../.virtualenvs/robottelo/lib/python3.11/site-packages/_pytest/config/__init__.py:747
  /home/ogajduse/.virtualenvs/robottelo/lib/python3.11/site-packages/_pytest/config/__init__.py:747: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: pytest_fixtures.component.satellite_auth
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================================== 1 passed, 1 deselected, 1 warning in 837.61s (0:13:57) ===========================================================================================




$ pytest tests/upgrades/test_errata.py -m post_upgrade
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ogajduse/repos/robottelo-6.12, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, ibutsu-2.2.4, xdist-3.2.0, reportportal-5.1.5, fixture-tools-1.1.0
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                                               

tests/upgrades/test_errata.py .                                                                                                                                                                                                       [100%]

============================================================================================================= warnings summary ==============================================================================================================
../../.virtualenvs/robottelo/lib/python3.11/site-packages/_pytest/config/__init__.py:747
  /home/ogajduse/.virtualenvs/robottelo/lib/python3.11/site-packages/_pytest/config/__init__.py:747: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: pytest_fixtures.component.satellite_auth
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================================================================== 1 passed, 1 deselected, 1 warning in 93.90s (0:01:33) ===========================================================================================
```
