### PR TITLE
[6.11.z] [errata] - Upgrade scenario refactor

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -21,6 +21,7 @@ def post(settings):
                 'Config will be fetched now.'
             )
             data = get_repos_config(settings)
+            write_cache(settings_cache_path, data)
     data['dynaconf_merge'] = True
     return data
 

--- a/pytest_fixtures/component/katello_agent.py
+++ b/pytest_fixtures/component/katello_agent.py
@@ -7,18 +7,11 @@ from robottelo.utils.installer import InstallerCommand
 
 @pytest.fixture(scope='module')
 def sat_with_katello_agent(module_target_sat):
-    """Enable katello-agent on module_target_sat"""
-    module_target_sat.register_to_cdn()
-    # Enable katello-agent from satellite-installer
-    result = module_target_sat.install(
-        InstallerCommand('foreman-proxy-content-enable-katello-agent true')
-    )
-    assert result.status == 0
-    # Verify katello-agent is enabled
+    """Assert that katello-agent feature is enabled on module_target_sat"""
     result = module_target_sat.install(
         InstallerCommand(help='| grep foreman-proxy-content-enable-katello-agent')
     )
-    assert 'true' in result.stdout
+    assert 'true' in result.stdout, 'katello-agent feature is not enabled on Satellite'
     yield module_target_sat
 
 

--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -2,11 +2,6 @@
 import pytest
 from nailgun import entities
 
-from robottelo.constants import RHEL_6_MAJOR_VERSION
-from robottelo.constants import RHEL_7_MAJOR_VERSION
-from robottelo.constants import RHEL_8_MAJOR_VERSION
-from robottelo.constants import RHEL_9_MAJOR_VERSION
-
 
 @pytest.fixture(scope='session')
 def default_os(
@@ -22,10 +17,7 @@ def default_os(
     """
     os = getattr(request, 'param', None)
     if os is None:
-        search_string = (
-            f'name="RedHat" AND (major="{RHEL_6_MAJOR_VERSION}" '
-            f'OR major="{RHEL_7_MAJOR_VERSION}" OR major="{RHEL_8_MAJOR_VERSION}")'
-        )
+        search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
     else:
         version = os.split(' ')[1].split('.')
         search_string = f'family="Redhat" AND major="{version[0]}" AND minor="{version[1]}"'
@@ -48,13 +40,13 @@ def os_path(default_os):
     from robottelo.config import settings
 
     # Check what OS was found to use correct media
-    if default_os.major == str(RHEL_6_MAJOR_VERSION):
+    if default_os.major == str(6):
         os_distr_url = settings.repos.rhel6_os
-    elif default_os.major == str(RHEL_7_MAJOR_VERSION):
+    elif default_os.major == str(7):
         os_distr_url = settings.repos.rhel7_os
-    elif default_os.major == str(RHEL_8_MAJOR_VERSION):
+    elif default_os.major == str(8):
         os_distr_url = settings.repos.rhel8_os.baseos
-    elif default_os.major == str(RHEL_9_MAJOR_VERSION):
+    elif default_os.major == str(9):
         os_distr_url = settings.repos.rhel9_os.baseos
     else:
         pytest.fail('Proposed RHEL version is not supported')

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -4,9 +4,6 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import COMMON_INSTALLER_OPTS as common_opts
 from robottelo.constants import ENVIRONMENT
-from robottelo.constants import RHEL_6_MAJOR_VERSION
-from robottelo.constants import RHEL_7_MAJOR_VERSION
-from robottelo.constants import RHEL_8_MAJOR_VERSION
 from robottelo.utils.installer import InstallerCommand
 
 
@@ -126,10 +123,7 @@ def session_puppet_enabled_proxy(session_puppet_enabled_sat):
 @pytest.fixture(scope='session')
 def session_puppet_default_os(session_puppet_enabled_sat):
     """Default OS on the puppet-enabled Satellite"""
-    search_string = (
-        f'name="RedHat" AND (major="{RHEL_6_MAJOR_VERSION}" '
-        f'OR major="{RHEL_7_MAJOR_VERSION}" OR major="{RHEL_8_MAJOR_VERSION}")'
-    )
+    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
     return (
         session_puppet_enabled_sat.api.OperatingSystem()
         .search(query={'search': search_string})[0]

--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -18,8 +18,6 @@ from robottelo.constants import DEFAULT_PTABLE
 from robottelo.constants import DEFAULT_PXE_TEMPLATE
 from robottelo.constants import DEFAULT_TEMPLATE
 from robottelo.constants import REPO_TYPE
-from robottelo.constants import RHEL_6_MAJOR_VERSION
-from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.exceptions import ImproperlyConfigured
 
 
@@ -343,13 +341,7 @@ def configure_provisioning(org=None, loc=None, compute=False, os=None):
     if os is None:
         os = (
             entities.OperatingSystem()
-            .search(
-                query={
-                    'search': 'name="RedHat" AND (major="{}" OR major="{}")'.format(
-                        RHEL_6_MAJOR_VERSION, RHEL_7_MAJOR_VERSION
-                    )
-                }
-            )[0]
+            .search(query={'search': 'name="RedHat" AND (major="6" OR major="7")'})[0]
             .read()
         )
     else:

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -44,17 +44,13 @@ DISTRO_RHEL9 = "rhel9"
 DISTRO_SLES11 = "sles11"
 DISTRO_SLES12 = "sles12"
 
-RHEL_6_MAJOR_VERSION = 6
-RHEL_7_MAJOR_VERSION = 7
-RHEL_8_MAJOR_VERSION = 8
-RHEL_9_MAJOR_VERSION = 9
-
-DISTRO_DEFAULT = DISTRO_RHEL7
-DISTROS_SUPPORTED = [DISTRO_RHEL6, DISTRO_RHEL7, DISTRO_RHEL8]
+DISTRO_DEFAULT = 'rhel7'
+DISTROS_SUPPORTED = ['rhel6', 'rhel7', 'rhel8, rhel9']
 DISTROS_MAJOR_VERSION = {
-    DISTRO_RHEL6: RHEL_6_MAJOR_VERSION,
-    DISTRO_RHEL7: RHEL_7_MAJOR_VERSION,
-    DISTRO_RHEL8: RHEL_8_MAJOR_VERSION,
+    'rhel6': 6,
+    'rhel7': 7,
+    'rhel8': 8,
+    'rhel9': 9,
 }
 MAJOR_VERSION_DISTRO = {value: key for key, value in DISTROS_MAJOR_VERSION.items()}
 
@@ -347,6 +343,7 @@ MIRRORING_POLICIES = {
 PRODUCT_KEY_RHEL = 'rhel'
 PRODUCT_KEY_SAT_TOOLS = 'rhst'
 PRODUCT_KEY_SAT_CAPSULE = 'rhsc'
+PRODUCT_KEY_SAT_CLIENT = 'rhsclient'
 PRODUCT_KEY_VIRT_AGENTS = 'rhva6'
 PRODUCT_KEY_CLOUD_FORMS_TOOLS = 'rhct6'
 PRODUCT_KEY_ANSIBLE_ENGINE = 'rhae2'
@@ -396,6 +393,9 @@ REPOSET = {
     'rhsc7': 'Red Hat Satellite Capsule 6.9 (for RHEL 7 Server) (RPMs)',
     'rhsc7_iso': 'Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (ISOs)',
     'rhsc6': 'Red Hat Satellite Capsule 6.9 (for RHEL 6 Server) (RPMs)',
+    'rhsclient7': 'Red Hat Satellite Client 6 for RHEL 7 Server RPMs x86_64',
+    'rhsclient8': 'Red Hat Satellite Client 6 for RHEL 8 x86_64 RPMs',
+    'rhsclient9': 'Red Hat Satellite Client 6 for RHEL 9 x86_64 RPMs',
     'rhst7': 'Red Hat Satellite Tools 6.9 (for RHEL 7 Server) (RPMs)',
     'rhst7_64': 'Red Hat Satellite Tools 6.4 (for RHEL 7 Server) (RPMs)',
     'rhst7_65': 'Red Hat Satellite Tools 6.5 (for RHEL 7 Server) (RPMs)',
@@ -450,7 +450,7 @@ REPOS = {
         'distro': DISTRO_RHEL7,
         'reposet': REPOSET['rhel7'],
         'product': PRDS['rhel'],
-        'major_version': RHEL_7_MAJOR_VERSION,
+        'major_version': 7,
         'distro_repository': True,
         'key': 'rhel',
         'version': '7.7',
@@ -464,7 +464,7 @@ REPOS = {
         'distro': DISTRO_RHEL6,
         'reposet': REPOSET['rhel6'],
         'product': PRDS['rhel'],
-        'major_version': RHEL_6_MAJOR_VERSION,
+        'major_version': 6,
         'distro_repository': True,
         'key': 'rhel',
         'version': '6.8',
@@ -499,6 +499,33 @@ REPOS = {
         'product': PRDS['rhsc'],
         'distro': DISTRO_RHEL6,
         'key': 'rhsc',
+    },
+    'rhsclient7': {
+        'id': 'rhel-7-server-satellite-client-6-rpms',
+        'name': ('Red Hat Satellite Client 6 for RHEL 7 Server RPMs x86_64'),
+        'version': '6',
+        'reposet': REPOSET['rhsclient7'],
+        'product': PRDS['rhel'],
+        'distro': 'rhel7',
+        'key': PRODUCT_KEY_SAT_CLIENT,
+    },
+    'rhsclient8': {
+        'id': 'satellite-client-6-for-rhel-8-x86_64-rpms',
+        'name': ('Red Hat Satellite Client 6 for RHEL 8 x86_64 RPMs'),
+        'version': '6',
+        'reposet': REPOSET['rhsclient8'],
+        'product': PRDS['rhel'],
+        'distro': 'rhel8',
+        'key': PRODUCT_KEY_SAT_CLIENT,
+    },
+    'rhsclient9': {
+        'id': 'satellite-client-6-for-rhel-9-x86_64-rpms',
+        'name': ('Red Hat Satellite Client 6 for RHEL 9 x86_64 RPMs'),
+        'version': '6',
+        'reposet': REPOSET['rhsclient9'],
+        'product': PRDS['rhel'],
+        'distro': 'rhel9',
+        'key': PRODUCT_KEY_SAT_CLIENT,
     },
     'rhst7': {
         'id': 'rhel-7-server-satellite-tools-6.9-rpms',
@@ -1050,7 +1077,7 @@ FAKE_9_YUM_UPDATED_PACKAGES = [
     'duck-0.6-1.noarch',
     'gorilla-0.62-1.noarch',
     'penguin-0.9.1-1.noarch',
-    'stork-0.12-1.noarch',
+    'stork-0.12-2.noarch',
     'walrus-5.21-1.noarch',
     'kangaroo-0.2-1.noarch',
 ]

--- a/robottelo/host_helpers/__init__.py
+++ b/robottelo/host_helpers/__init__.py
@@ -1,4 +1,5 @@
 from robottelo.host_helpers.capsule_mixins import CapsuleInfo
+from robottelo.host_helpers.contenthost_mixins import HostInfo
 from robottelo.host_helpers.contenthost_mixins import SystemFacts
 from robottelo.host_helpers.contenthost_mixins import VersionedContent
 from robottelo.host_helpers.satellite_mixins import ContentInfo
@@ -7,7 +8,7 @@ from robottelo.host_helpers.satellite_mixins import Factories
 from robottelo.host_helpers.satellite_mixins import SystemInfo
 
 
-class ContentHostMixins(SystemFacts, VersionedContent):
+class ContentHostMixins(HostInfo, SystemFacts, VersionedContent):
     pass
 
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -33,3 +33,13 @@ class APIFactory:
                 password=settings.http_proxy.password,
                 organization=[org.id],
             ).create()
+
+    def update_vm_host_location(self, vm_client, location_id):
+        """Update vm client host location.
+
+        :param vm_client: A subscribed Virtual Machine client instance.
+        :param location_id: The location id to update the vm_client host with.
+        """
+        self._satellite.api.Host(
+            id=vm_client.nailgun_host.id, location=self._satellite.api.Location(id=location_id)
+        ).update(['location'])

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -297,8 +297,7 @@ def test_positive_install_multiple_in_host(
         _install_package(
             module_org, clients=[rhel_contenthost], host_ids=[host.id], package_name=package
         )
-    host = host.read()
-    applicable_errata_count = host.content_facet_attributes['errata_counts']['total']
+    applicable_errata_count = rhel_contenthost.applicable_errata_count
     assert applicable_errata_count > 1
     rhel_contenthost.add_rex_key(satellite=target_sat)
     for errata in settings.repos.yum_9.errata[1:4]:
@@ -316,9 +315,8 @@ def test_positive_install_multiple_in_host(
             search_rate=20,
             max_tries=15,
         )
-        host = host.read()
         applicable_errata_count -= 1
-        assert host.content_facet_attributes['errata_counts']['total'] == applicable_errata_count
+        assert rhel_contenthost.applicable_errata_count == applicable_errata_count
 
 
 @pytest.mark.tier3
@@ -789,9 +787,7 @@ def test_errata_installation_with_swidtags(
         return_result=True,
     )
     assert before_errata_apply_result != ''
-    host = rhel8_contenthost.nailgun_host
-    host = host.read()
-    applicable_errata_count = host.content_facet_attributes['errata_counts']['total']
+    applicable_errata_count = rhel8_contenthost.applicable_errata_count
     assert applicable_errata_count == 1
 
     # apply modular errata
@@ -800,9 +796,8 @@ def test_errata_installation_with_swidtags(
     )
     _run_remote_command_on_content_host(module_org, 'dnf -y upload-profile', rhel8_contenthost)
     Host.errata_recalculate({'host-id': rhel8_contenthost.nailgun_host.id})
-    host = host.read()
     applicable_errata_count -= 1
-    assert host.content_facet_attributes['errata_counts']['total'] == applicable_errata_count
+    assert rhel8_contenthost.applicable_errata_count == applicable_errata_count
     after_errata_apply_result = _run_remote_command_on_content_host(
         module_org,
         f"swidq -i -n {module_name} | grep 'File'| grep -o 'rpm-.*.swidtag'",

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -28,8 +28,6 @@ from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.factory import make_host
 from robottelo.cli.host import Host
 from robottelo.config import settings
-from robottelo.constants import RHEL_6_MAJOR_VERSION
-from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -574,12 +572,7 @@ def test_positive_provision_rhev_image_based_and_disassociate(
         # use some RHEL (usually latest)
         os = (
             entities.OperatingSystem()
-            .search(
-                query={
-                    'search': f'name="RedHat" AND (major="{RHEL_6_MAJOR_VERSION}" OR '
-                    f'major="{RHEL_7_MAJOR_VERSION}")'
-                }
-            )[0]
+            .search(query={'search': 'name="RedHat" AND (major="6" OR major="7")'})[0]
             .read()
         )
         image = ComputeResource.image_create(
@@ -637,7 +630,6 @@ def test_positive_provision_rhev_image_based_and_disassociate(
         assert 'compute-resource' not in host_info
 
     finally:
-
         # Now, let's just remove the host
         Host.delete({'id': host['id']})
         # Delete the VM since the disassociated VM won't get deleted

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -60,8 +60,6 @@ from robottelo.constants import PRDS
 from robottelo.constants import REPO_TYPE
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
-from robottelo.constants import RHEL_6_MAJOR_VERSION
-from robottelo.constants import RHEL_7_MAJOR_VERSION
 from robottelo.utils.datafactory import gen_string
 
 VERSION = 'Version 1.0'
@@ -2703,11 +2701,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(
     )
     # Get the OS ID
     os = entities.OperatingSystem().search(
-        query={
-            'search': 'name="RedHat" AND (major="{}" OR major="{}")'.format(
-                RHEL_6_MAJOR_VERSION, RHEL_7_MAJOR_VERSION
-            )
-        }
+        query={'search': 'name="RedHat" AND (major="6" OR major="7")'}
     )[0]
     # Update the OS to associate arch and ptable
     os.architecture = [arch]

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -239,7 +239,7 @@ def test_end_to_end(
         assert status['overview']['job_status_progress'] == '100%'
         _generate_errata_applicability(vm.hostname)
         vm = vm.nailgun_host.read()
-        assert vm.content_facet_attributes['errata_counts']['total'] == 0
+        assert vm.applicable_errata_count == 0
 
 
 @pytest.mark.tier2

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -19,13 +19,12 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :Upstream: No
 """
-import time
-
 import pytest
 from broker import Broker
 
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
 from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
+from robottelo.hosts import ContentHost
 
 
 class TestScenarioUpgradeOldClientAndPackageInstallation:
@@ -68,18 +67,6 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
 
         """
         rhel_client = katello_agent_client_for_upgrade.client
-        rhid = rhel_client.execute('subscription-manager identity')
-        assert module_org.name in rhid.stdout
-        result = rhel_client.execute('rpm -q gofer')
-        assert result.status == 0
-        assert 'package gofer is not installed' not in result.stdout
-        # Run goferd on client as its docker container
-        rhel_client._cont_inst.exec_run('goferd -f', detach=True)
-        # Holding on for 30 seconds while goferd starts
-        time.sleep(30)
-        rhel_client.execute('yum install -y procps')  # ps command needs to be installed
-        result = rhel_client.execute("ps -ef | grep goferd")
-        assert 'goferd' in result.stdout
         module_target_sat.cli.Host.package_install(
             {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_4_CUSTOM_PACKAGE_NAME}
         )
@@ -114,7 +101,9 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
             {'host-id': client_id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )
         # Verifies that package is really installed
-        rhel_client = Broker().from_inventory(filter=f'hostname={client_name}')[0]
+        rhel_client = Broker(host_class=ContentHost).from_inventory(
+            filter=f'hostname={client_name}'
+        )[0]
         result = rhel_client.execute(f"rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}")
         assert FAKE_0_CUSTOM_PACKAGE_NAME in result.stdout
 
@@ -134,7 +123,9 @@ class TestScenarioUpgradeNewClientAndPackageInstallation:
 
     @pytest.mark.post_upgrade
     def test_post_scenario_post_client_package_installation(
-        self, module_target_sat, katello_agent_client_for_upgrade, module_org
+        self,
+        module_target_sat,
+        katello_agent_client_for_upgrade,
     ):
         """Post-upgrade test that creates a client, installs a package on
         the post-upgrade created client and then verifies the package is installed.
@@ -157,18 +148,6 @@ class TestScenarioUpgradeNewClientAndPackageInstallation:
             3. The package is installed on post-upgrade client
         """
         rhel_client = katello_agent_client_for_upgrade.client
-        rhid = rhel_client.execute('subscription-manager identity')
-        assert module_org.name in rhid.stdout
-        result = rhel_client.execute('rpm -q gofer')
-        assert result.status == 0
-        assert 'package gofer is not installed' not in result.stdout
-        # Run goferd on client as its docker container
-        rhel_client._cont_inst.exec_run('goferd -f', detach=True)
-        # Holding on for 30 seconds while goferd starts
-        time.sleep(30)
-        rhel_client.execute('yum install -y procps')  # ps command needs to be installed
-        result = rhel_client.execute("ps -ef | grep goferd")
-        assert 'goferd' in result.stdout
         module_target_sat.cli.Host.package_install(
             {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -23,6 +23,7 @@ from robottelo.api.utils import create_sync_custom_repo
 from robottelo.config import settings
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
 from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
+from robottelo.hosts import ContentHost
 
 UPSTREAM_USERNAME = 'rTtest123'
 
@@ -151,8 +152,6 @@ class TestScenarioCustomRepoCheck:
             ak.add_subscriptions(data={'subscription_id': subscription.id})
         sat_upgrade_chost.install_katello_ca(target_sat)
         sat_upgrade_chost.register_contenthost(org.label, ak.name)
-        rhid = sat_upgrade_chost.execute('subscription-manager identity')
-        assert org.name in rhid.stdout
         sat_upgrade_chost.execute('subscription-manager repos --enable=*;yum clean all')
         result = sat_upgrade_chost.execute(f'yum install -y {FAKE_0_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0
@@ -200,6 +199,8 @@ class TestScenarioCustomRepoCheck:
             data={'environment_ids': lce_id}
         )
 
-        rhel_client = Broker().from_inventory(filter=f'hostname={client_hostname}')[0]
+        rhel_client = Broker(host_class=ContentHost).from_inventory(
+            filter=f'hostname={client_hostname}'
+        )[0]
         result = rhel_client.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0


### PR DESCRIPTION
closes #11172

This PR is a cherry-pick of #10930.


## Note
Additional changes to constants were done as a part of this PR due to #9858 not being cherry-picked into 6.11.z branch.


## Test results
```
$ pytest tests/upgrades/test_errata.py -m pre_upgrade
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ogajduse/repos/robottelo-6.11, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, ibutsu-2.2.4, xdist-3.2.0, reportportal-5.1.5, fixture-tools-1.1.0
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                                               

tests/upgrades/test_errata.py .                                                                                                                                                                                                       [100%]

================================================================================================ 1 passed, 1 deselected in 886.20s (0:14:46) ================================================================================================
```



```
$ pytest tests/upgrades/test_errata.py -m post_upgrade
============================================================================================================ test session starts ============================================================================================================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/ogajduse/repos/robottelo-6.11, configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, ibutsu-2.2.4, xdist-3.2.0, reportportal-5.1.5, fixture-tools-1.1.0
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                                               

tests/upgrades/test_errata.py .                                                                                                                                                                                                       [100%]

================================================================================================ 1 passed, 1 deselected in 96.91s (0:01:36) =================================================================================================

```