### PR TITLE
[6.11.z] Fix test_positive_rename_satellite

### DIFF
--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -117,7 +117,7 @@ def test_positive_rename_satellite(module_org, module_product, module_target_sat
     ), 'repository published path not updated correctly'
 
     # check for any other occurences of old hostname
-    result = module_target_sat.execute(f'grep " {old_hostname}" /etc/* -r')
+    result = module_target_sat.execute(f'grep " {old_hostname}" --exclude-dir="promtail" /etc/* -r')
     assert result.status != 0, 'there are remaining instances of the old hostname'
 
     repo.sync()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11175

`test_positive_rename_satellite` is failing because `grep " {old_hostname}" /etc/* -r` finds oldhostname in `/etc/promtail/config.yml`. I think it's safe to ignore it as it's not related to Satellite itself.