### PR TITLE
[6.12.z] RFE Automation for syncing exported repos

### DIFF
--- a/robottelo/cli/content_import.py
+++ b/robottelo/cli/content_import.py
@@ -50,3 +50,11 @@ class ContentImport(Base):
         """
         cls.command_sub = 'version'
         return cls.execute(cls._construct_command(options), output_format='json', timeout=timeout)
+
+    @classmethod
+    def repository(cls, options, timeout=None):
+        """
+        Make a repository import
+        """
+        cls.command_sub = 'repository'
+        return cls.execute(cls._construct_command(options), output_format='json', timeout=timeout)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11045

SAT-15864

Automation to test syncing exported repositories

Dependent on https://github.com/SatelliteQE/fedorapeople-repos/pull/13

Steps:
1. Execute hammer command
        hammer content-import repository --organization='' --path=''
2. Assert job is succesful
3. Verify repsoitory is synced and contains rpms
