### PR TITLE
Mark test cases end-to-end for Rocket team components

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -21,6 +21,7 @@ import pytest
 from robottelo.config import settings
 
 
+@pytest.mark.e2e
 def test_fetch_and_sync_ansible_playbooks(target_sat):
     """
     Test Ansible Playbooks api for fetching and syncing playbooks

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -80,13 +80,13 @@ def module_puppet(session_puppet_enabled_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.e2e
 @pytest.mark.skipif(
     not settings.robottelo.repos_hosting_url, reason='repos_hosting_url is not defined'
 )
 class TestSmartClassParameters:
     """Implements Smart Class Parameter tests in API"""
 
+    @pytest.mark.e2e
     @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize('data', **parametrized(valid_sc_parameters_data()))
@@ -150,6 +150,7 @@ class TestSmartClassParameters:
         assert sc_param.read().default_value != test_data['value']
         assert 'Validation failed: Default value is invalid' in context.value.response.text
 
+    @pytest.mark.e2e
     @pytest.mark.tier1
     def test_positive_validate_default_value_required_check(
         self, session_puppet_enabled_sat, module_puppet
@@ -237,6 +238,7 @@ class TestSmartClassParameters:
         assert 'Validation failed: Default value is invalid' in context.value.response.text
         assert sc_param.read().default_value != value
 
+    @pytest.mark.e2e
     @pytest.mark.tier1
     def test_positive_validate_default_value_with_regex(
         self, session_puppet_enabled_sat, module_puppet
@@ -305,6 +307,7 @@ class TestSmartClassParameters:
         assert 'Validation failed: Lookup values is invalid' in context.value.response.text
         assert sc_param.read().default_value != 50
 
+    @pytest.mark.e2e
     @pytest.mark.tier1
     def test_positive_validate_matcher_value_with_list(
         self, session_puppet_enabled_sat, module_puppet
@@ -331,6 +334,7 @@ class TestSmartClassParameters:
         sc_param.update(['override', 'default_value', 'validator_type', 'validator_rule'])
         assert sc_param.read().default_value == 'example'
 
+    @pytest.mark.e2e
     @pytest.mark.tier1
     def test_positive_validate_matcher_value_with_default_type(
         self, session_puppet_enabled_sat, module_puppet
@@ -388,6 +392,7 @@ class TestSmartClassParameters:
             in context.value.response.text
         )
 
+    @pytest.mark.e2e
     @pytest.mark.tier1
     def test_positive_create_and_remove_matcher_puppet_default_value(
         self, session_puppet_enabled_sat, module_puppet
@@ -421,6 +426,7 @@ class TestSmartClassParameters:
         override.delete()
         assert len(sc_param.read().override_values) == 0
 
+    @pytest.mark.e2e
     @pytest.mark.tier1
     def test_positive_enable_merge_overrides_default_checkboxes(self, module_puppet):
         """Enable Merge Overrides, Merge Default checkbox for supported types.

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -256,6 +256,7 @@ class TestAzureRMHostProvisioningTestCase:
 
         return azurermclient.get_vm(name=class_host_ft.name.split('.')[0])
 
+    @pytest.mark.e2e
     @pytest.mark.upgrade
     @pytest.mark.tier3
     @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -367,6 +367,7 @@ class TestGCEHostProvisioningTestCase:
         """Returns the Google Client Host object to perform the assertions"""
         return googleclient.get_vm(name='{}'.format(self.fullhostname.replace('.', '-')))
 
+    @pytest.mark.e2e
     @pytest.mark.tier1
     def test_positive_gce_host_provisioned(self, class_host):
         """Host can be provisioned on Google Cloud

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -206,6 +206,7 @@ def version(request):
     return settings.content_host.get(request.param).vm.release
 
 
+@pytest.mark.e2e
 @pytest.mark.parametrize(
     "version",
     ['oracle7', 'oracle8'],
@@ -265,6 +266,7 @@ def test_convert2rhel_oracle(target_sat, oracle, activation_key_rhel, version):
     assert host_content['subscription_status'] == 0
 
 
+@pytest.mark.e2e
 @pytest.mark.parametrize("version", ['centos7', 'centos8'], indirect=True)
 def test_convert2rhel_centos(target_sat, centos, activation_key_rhel, version):
     """Convert Centos linux to RHEL

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -32,6 +32,7 @@ from robottelo.utils.datafactory import valid_data_list
 from robottelo.utils.issue_handlers import is_open
 
 
+@pytest.mark.e2e
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
 @pytest.mark.on_premises_provisioning
 @pytest.mark.rhel_ver_match('[^6]')

--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -226,6 +226,7 @@ class TestProvisioningTemplate:
             updated.read()
         assert e3.value.response.status_code == 404
 
+    @pytest.mark.e2e
     @pytest.mark.tier2
     @pytest.mark.upgrade
     @pytest.mark.run_in_one_thread
@@ -309,6 +310,7 @@ class TestProvisioningTemplate:
         provision_template = host.read_template(data={'template_kind': 'provision'})
         assert 'ifcfg-$sanitized_real' in str(provision_template)
 
+    @pytest.mark.e2e
     @pytest.mark.parametrize('module_sync_kickstart_content', [7, 8, 9], indirect=True)
     def test_positive_template_check_ipxe(
         self,

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -383,6 +383,7 @@ class TestAzureRMFinishTemplateProvisioning:
         """Returns the AzureRM Client Host object to perform the assertions"""
         return azurermclient.get_vm(name=class_host_ft['name'].split('.')[0])
 
+    @pytest.mark.e2e
     @pytest.mark.upgrade
     @pytest.mark.tier3
     @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -376,6 +376,7 @@ def test_negative_add_image_rhev_with_invalid_name(rhev, module_os):
         )
 
 
+@pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -29,6 +29,8 @@ from robottelo.cli.repository import Repository
 from robottelo.config import settings
 from robottelo.logging import logger
 
+pytestmark = pytest.mark.e2e
+
 
 def cut_lines(start_line, end_line, source_file, out_file, host):
     """Given start and end line numbers, cut lines from source file


### PR DESCRIPTION
Component | Status
Ansible - Done
Provisioning Templates - Done
Puppet - Done
Registration - Done
Discovery Image - Done
Discovery Plugin - Done
Provisioning - Done
Convert2Rhel - Done 
Compute Resources - CNV - No automated test case 
Compute Resources - VMWare - Pending(No test has end-to-end coverage)
Compute Resources - Libvirt - Pending(No test has end-to-end coverage)
Compute Resources - EC2 - Pending(No test has end-to-end coverage)
Compute Resources -RHEV - Done
Compute Resources -GCE - Done
Compute Resources -OpenStack - Pending (CRUD test case marked, No test has end-to-end coverage)
Compute Resources -Azure - Done
SCAP Plugin - Done
Bootdisk Plugin - Pending(No test has end-to-end coverage)
DHCPDNS - Pending(No test has end-to-end coverage)
Host Form - Not needed
Infoblox integration - Pending(No test has end-to-end coverage)
Notifications - Pending(No test has end-to-end coverage)
Compute Resources - Pending(No test has end-to-end coverage)
Fact - Pending(No test has end-to-end coverage)
Logging - Done
Networking - Done
Parameters - Pending(No test has end-to-end coverage)
Settings - Pending(No test has end-to-end coverage)
TFTP - Pending(No test has end-to-end coverage)
Pulp - Not needed
Candlepin - Not needed