### PR TITLE
skip and reduce tracer host tests

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2487,6 +2487,8 @@ def test_positive_tracer_list_and_resolve(tracer_host):
     :CaseImportance: Medium
 
     :CaseComponent: Katello-tracer
+
+    :bz: 2186188
     """
     client = tracer_host
     package = settings.repos["MOCK_SERVICE_RPM"]


### PR DESCRIPTION
There is BZ#2186188, also I find the api tests a bit redundant, thus removing.