### PR TITLE
[6.11.z] Removing codecov dependency

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,5 +1,4 @@
 # For running tests and checking code quality using these modules.
-codecov==2.1.12
 flake8==6.0.0
 pytest-cov==3.0.0
 redis==4.5.4


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11226

Removing codecov dependency as the repository is archived and we don't need that for Robottelo