### PR TITLE
[6.13.z] New Hosts UI - Manage columns test

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -34,6 +34,7 @@ from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import DEFAULT_CV
 from robottelo.constants import DEFAULT_LOC
+from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import ENVIRONMENT
 from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
@@ -1950,7 +1951,8 @@ def test_positive_manage_table_columns(session):
 
     :steps:
         1. Navigate to the Hosts page.
-        2. Set custom columns for the hosts table via the 'Manage columns' dialog.
+        2. Switch to default organization and location, where is at least one host (Satellite).
+        3. Set custom columns for the hosts table via the 'Manage columns' dialog.
 
     :expectedresults: Check if the custom columns were set properly, i.e., are displayed
         or not displayed in the table.
@@ -1973,6 +1975,8 @@ def test_positive_manage_table_columns(session):
         'Recommendations': False,
     }
     with session:
+        session.organization.select(org_name=DEFAULT_ORG)
+        session.location.select(loc_name=DEFAULT_LOC)
         session.host.manage_table_columns(columns)
         displayed_columns = session.host.get_displayed_table_headers()
         for column, is_displayed in columns.items():

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1941,6 +1941,7 @@ def test_rex_new_ui(session, target_sat, rex_contenthost):
         assert "Run ls" == recent_jobs['recent_jobs']['finished']['table'][0]['column0']
         assert "succeeded" == recent_jobs['recent_jobs']['finished']['table'][0]['column2']
 
+
 @pytest.mark.tier4
 def test_positive_manage_table_columns(session):
     """Set custom columns of the hosts table.
@@ -1951,7 +1952,8 @@ def test_positive_manage_table_columns(session):
         1. Navigate to the Hosts page.
         2. Set custom columns for the hosts table via the 'Manage columns' dialog.
 
-    :expectedresults: Check if the custom columns were set properly, i.e., are displayed or not displayed in the table.
+    :expectedresults: Check if the custom columns were set properly, i.e., are displayed
+        or not displayed in the table.
 
     :CaseLevel: System
     """
@@ -1968,7 +1970,7 @@ def test_positive_manage_table_columns(session):
         'Cores': True,
         'RAM': True,
         'Boot time': True,
-        'Recommendations': False
+        'Recommendations': False,
     }
     with session:
         session.host.manage_table_columns(columns)

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1941,6 +1941,41 @@ def test_rex_new_ui(session, target_sat, rex_contenthost):
         assert "Run ls" == recent_jobs['recent_jobs']['finished']['table'][0]['column0']
         assert "succeeded" == recent_jobs['recent_jobs']['finished']['table'][0]['column2']
 
+@pytest.mark.tier4
+def test_positive_manage_table_columns(session):
+    """Set custom columns of the hosts table.
+
+    :id: e5e18982-cc43-11ed-8562-000c2989e153
+
+    :steps:
+        1. Navigate to the Hosts page.
+        2. Set custom columns for the hosts table via the 'Manage columns' dialog.
+
+    :expectedresults: Check if the custom columns were set properly, i.e., are displayed or not displayed in the table.
+
+    :CaseLevel: System
+    """
+    columns = {
+        'Host group': False,
+        'Last report': False,
+        'Comment': False,
+        'Installable updates': True,
+        'Registered': True,
+        'Last checkin': True,
+        'IPv4': True,
+        'MAC': True,
+        'Sockets': True,
+        'Cores': True,
+        'RAM': True,
+        'Boot time': True,
+        'Recommendations': False
+    }
+    with session:
+        session.host.manage_table_columns(columns)
+        displayed_columns = session.host.get_displayed_table_headers()
+        for column, is_displayed in columns.items():
+            assert (column in displayed_columns) is is_displayed
+
 
 @pytest.mark.tier4
 @pytest.mark.rhel_ver_match('8')


### PR DESCRIPTION
Cherry-pick of PR: https://github.com/SatelliteQE/robottelo/pull/11077

Test case for new feature Hosts / All Hosts -> Manage columns.

This adds test case for the new feature 'Manage columns'
in new web UI Hosts / All Hosts.

It sets different custom columns to be displyed or hidden
and checks if the changes are applied to the hosts table.
