### PR TITLE
Updating satellite-clone list tasks

### DIFF
--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -111,7 +111,7 @@ def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pul
         == 0
     )
     # Assert clone won't fail due to BZ
-    assert sat_ready_rhel.execute('satellite-clone --list-tasks').status == 0
+    assert sat_ready_rhel.execute('satellite-clone --assume-yes --list-tasks').status == 0
     # Run satellite-clone
     assert sat_ready_rhel.execute('satellite-clone -y', timeout='3h').status == 0
     cloned_sat = Satellite(sat_ready_rhel.hostname)
@@ -128,12 +128,12 @@ def test_positive_list_tasks(target_sat):
 
     :steps:
         1. Install satellite-clone
-        2. Run satellite-clone --list-tasks
+        2. Run satellite-clone --assume-yes --list-tasks
 
     :expectedresult:
         1. Satellite-clone ran successfully
     """
     result = target_sat.execute('dnf install -y --disableplugin=foreman-protector satellite-clone')
     assert result.status == 0
-    result = target_sat.execute('satellite-clone --list-tasks')
+    result = target_sat.execute('satellite-clone --assume-yes --list-tasks')
     assert result.status == 0


### PR DESCRIPTION
See https://github.com/RedHatSatellite/satellite-clone/pull/432#issuecomment-1503774710 for context. Although it is not merged yet, this should still work on old versions. Might as well update now for at least >= 6.13.