### PR TITLE
Add stream marker

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -14,6 +14,7 @@ def pytest_configure(config):
         "destructive: Destructive tests",
         "upgrade: Upgrade tests",
         "e2e: End to end tests",
+        "stream: Tests unique to stream builds; purged when robottelo is branched.",
         "pit_server: PIT server scenario tests",
         "pit_client: PIT client scenario tests",
         "run_in_one_thread: Sequential tests",


### PR DESCRIPTION
This change introduces a new marker that our associates can use to run new feature automation against stream builds.  This marker should be removed from all tests when branching robottelo. The marker itself should only live in the master branch.