### PR TITLE
Updated target_sat to be module scoped 

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -458,9 +458,7 @@ def test_positive_os_restriction_on_repos():
     """
 
 
-def test_positive_async_endpoint_for_manifest_refresh(
-    target_sat, module_org, session_entitlement_manifest
-):
+def test_positive_async_endpoint_for_manifest_refresh(target_sat, module_entitlement_manifest_org):
     """Verify that manifest refresh is using an async endpoint. Previously this was a single,
     synchronous endpoint. The endpoint to retrieve manifests is now split into two: an async
     endpoint to start "exporting" the manifest, and a second endpoint to download the
@@ -479,13 +477,12 @@ def test_positive_async_endpoint_for_manifest_refresh(
 
     :BZ: 2066323
     """
-    target_sat.upload_manifest(module_org.id, session_entitlement_manifest.content)
-    sub = target_sat.api.Subscription(organization=module_org)
+    sub = target_sat.api.Subscription(organization=module_entitlement_manifest_org)
     # set log level to 'debug' and restart services
     target_sat.cli.Admin.logging({'all': True, 'level-debug': True})
     target_sat.cli.Service.restart()
     # refresh manifest and assert new log message to confirm async endpoint
-    sub.refresh_manifest(data={'organization_id': module_org.id})
+    sub.refresh_manifest(data={'organization_id': module_entitlement_manifest_org.id})
     results = target_sat.execute(
         'grep "Sending GET request to upstream Candlepin" /var/log/foreman/production.log'
     )


### PR DESCRIPTION
This test was failing in Jenkins with the issue below

```Owner has already imported from another subscription management application```

To fix this, I changed scope and updated target_sat to use module_entitlement_manifest_org