### PR TITLE
virt-who config cases add create & delete to virtwho_config fixture for CLI/API/UI

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -58,7 +58,7 @@ def virtwho_config(form_data, target_sat):
 
 
 @pytest.fixture(autouse=True)
-def clean_host(form_data, target_sat):
+def delete_host(form_data, target_sat):
     guest_name, _ = get_guest_info(form_data['hypervisor_type'])
     results = target_sat.api.Host().search(query={'search': guest_name})
     if results:

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -28,6 +28,7 @@ from robottelo.utils.virtwho import ETC_VIRTWHO_CONFIG
 from robottelo.utils.virtwho import get_configure_command
 from robottelo.utils.virtwho import get_configure_file
 from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import get_guest_info
 
 
 @pytest.fixture()
@@ -50,9 +51,21 @@ def form_data(default_org, target_sat):
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    return target_sat.api.VirtWhoConfig(**form_data).create()
+    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+    yield virtwho_config
+    virtwho_config.delete()
+    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
 
+@pytest.fixture(autouse=True)
+def clean_host(form_data, target_sat):
+    guest_name, _ = get_guest_info(form_data['hypervisor_type'])
+    results = target_sat.api.Host().search(query={'search': guest_name})
+    if results:
+        target_sat.api.Host(id=results[0].read_json()['id']).delete()
+
+
+@pytest.mark.usefixtures('clean_host')
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(
@@ -105,10 +118,6 @@ class TestVirtWhoConfigforEsx:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(
@@ -166,10 +175,6 @@ class TestVirtWhoConfigforEsx:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_debug_option(self, default_org, form_data, virtwho_config, target_sat):
@@ -194,10 +199,6 @@ class TestVirtWhoConfigforEsx:
                 command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_interval_option(self, default_org, form_data, virtwho_config, target_sat):
@@ -231,10 +232,6 @@ class TestVirtWhoConfigforEsx:
                 command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
@@ -263,10 +260,6 @@ class TestVirtWhoConfigforEsx:
                 command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_filter_option(self, default_org, form_data, virtwho_config, target_sat):
@@ -313,10 +306,6 @@ class TestVirtWhoConfigforEsx:
             get_configure_option('exclude_host_parents', config_file)
             == blacklist['exclude_host_parents']
         )
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_proxy_option(self, default_org, form_data, virtwho_config, target_sat):
@@ -356,10 +345,6 @@ class TestVirtWhoConfigforEsx:
         virtwho_config.update(['http_proxy_id'])
         deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_configure_organization_list(
@@ -381,10 +366,6 @@ class TestVirtWhoConfigforEsx:
         deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
         search_result = virtwho_config.get_organization_configs(data={'per_page': '1000'})
         assert [item for item in search_result['results'] if item['name'] == form_data['name']]
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_hypervisor_password_with_special_characters(
@@ -482,7 +463,3 @@ class TestVirtWhoConfigforEsx:
         env_warning = f"Ignoring unknown configuration option \"{option}\""
         result = target_sat.execute(f'grep "{env_warning}" /var/log/messages')
         assert result.status == 1
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -65,7 +65,7 @@ def delete_host(form_data, target_sat):
         target_sat.api.Host(id=results[0].read_json()['id']).delete()
 
 
-@pytest.mark.usefixtures('clean_host')
+@pytest.mark.usefixtures('delete_host')
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -47,7 +47,10 @@ def form_data(default_org, target_sat):
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    return target_sat.api.VirtWhoConfig(**form_data).create()
+    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+    yield virtwho_config
+    virtwho_config.delete()
+    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
 
 class TestVirtWhoConfigforHyperv:
@@ -102,10 +105,6 @@ class TestVirtWhoConfigforHyperv:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(
@@ -163,10 +162,6 @@ class TestVirtWhoConfigforHyperv:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
@@ -194,7 +189,3 @@ class TestVirtWhoConfigforHyperv:
                 command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -46,7 +46,10 @@ def form_data(default_org, target_sat):
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    return target_sat.api.VirtWhoConfig(**form_data).create()
+    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+    yield virtwho_config
+    virtwho_config.delete()
+    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
 
 class TestVirtWhoConfigforLibvirt:
@@ -101,10 +104,6 @@ class TestVirtWhoConfigforLibvirt:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(
@@ -162,10 +161,6 @@ class TestVirtWhoConfigforLibvirt:
             )
             result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
             assert result['subscription_status_label'] == 'Fully entitled'
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
@@ -193,7 +188,3 @@ class TestVirtWhoConfigforLibvirt:
                 command, form_data['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        virtwho_config.delete()
-        assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
-        )

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -1,4 +1,4 @@
-"""Test class for Virtwho Configure CLI
+"""Test class for Virtwho Configure API
 
 :Requirement: Virt-whoConfigurePlugin
 
@@ -26,28 +26,28 @@ from robottelo.utils.virtwho import get_configure_option
 
 
 @pytest.fixture()
-def form_data(target_sat, module_sca_manifest_org):
+def form_data(module_sca_manifest_org, target_sat):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
         'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.libvirt.hypervisor_type,
-        'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
-        'organization-id': module_sca_manifest_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
+        'hypervisor_id': 'hostname',
+        'hypervisor_type': settings.virtwho.libvirt.hypervisor_type,
+        'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
+        'organization_id': module_sca_manifest_org.id,
+        'filtering_mode': 'none',
+        'satellite_url': target_sat.hostname,
+        'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form
 
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
     yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+    virtwho_config.delete()
+    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
 
 class TestVirtWhoConfigforLibvirt:
@@ -56,9 +56,9 @@ class TestVirtWhoConfigforLibvirt:
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify " hammer virt-who-config deploy"
+        """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
-        :id: 53143fc3-97e0-4403-8114-4d7f20fde98e
+        :id: be6563e7-f714-4189-a8f5-9e99b0522a02
 
         :expectedresults: Config can be created and deployed
 
@@ -66,31 +66,36 @@ class TestVirtWhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
+        assert virtwho_config.status == 'unknown'
         if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
             )
         elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
+            script = virtwho_config.deploy_script()
             deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+                script['virt_who_config_script'],
+                form_data['hypervisor_type'],
+                debug=True,
+                org=module_sca_manifest_org.label,
             )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
-            'general-information'
-        ]['status']
-        assert virt_who_instance == 'OK'
+        virt_who_instance = (
+            target_sat.api.VirtWhoConfig()
+            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .status
+        )
+        assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat
     ):
-        """Verify hypervisor_id option by hammer virt-who-config update"
+        """Verify hypervisor_id option by "PUT
 
-        :id: e68421b5-ff3d-4f25-926d-8330b92f2cdf
+        /foreman_virt_who_configure/api/v2/configs/:id"
+
+        :id: 60f373f0-5179-4531-834d-c297f9f7ea2d
 
         :expectedresults: hypervisor_id option can be updated.
 
@@ -99,14 +104,11 @@ class TestVirtWhoConfigforLibvirt:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
-            )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
-            assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            virtwho_config.hypervisor_id = value
+            virtwho_config.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config.id)
+            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -91,9 +91,7 @@ class TestVirtWhoConfigforLibvirt:
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat
     ):
-        """Verify hypervisor_id option by "PUT
-
-        /foreman_virt_who_configure/api/v2/configs/:id"
+        """Verify hypervisor_id option by "PUT /foreman_virt_who_configure/api/v2/configs/:id"
 
         :id: 60f373f0-5179-4531-834d-c297f9f7ea2d
 

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -26,6 +26,7 @@ from robottelo.utils.virtwho import deploy_configure_by_script
 from robottelo.utils.virtwho import get_configure_command
 from robottelo.utils.virtwho import get_configure_file
 from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import get_guest_info
 from robottelo.utils.virtwho import get_hypervisor_ahv_mapping
 
 
@@ -57,6 +58,15 @@ def virtwho_config(form_data, target_sat):
     assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
 
 
+@pytest.fixture(autouse=True)
+def clean_host(form_data, target_sat):
+    guest_name, _ = get_guest_info(form_data['hypervisor_type'])
+    results = target_sat.api.Host().search(query={'search': guest_name})
+    if results:
+        target_sat.api.Host(id=results[0].read_json()['id']).delete()
+
+
+@pytest.mark.usefixtures('clean_host')
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_id(

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -47,7 +47,10 @@ def form_data(target_sat, default_org):
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+    yield virtwho_config
+    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
 
 class TestVirtWhoConfigforHyperv:
@@ -93,8 +96,6 @@ class TestVirtWhoConfigforHyperv:
                 {'host-id': host['id'], 'subscription-id': vdc_id}
             )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(
@@ -140,8 +141,6 @@ class TestVirtWhoConfigforHyperv:
                 {'host-id': host['id'], 'subscription-id': vdc_id}
             )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
@@ -170,5 +169,3 @@ class TestVirtWhoConfigforHyperv:
                 command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -45,7 +45,10 @@ def form_data(target_sat, default_org):
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+    yield virtwho_config
+    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
 
 class TestVirtWhoConfigforKubevirt:
@@ -91,8 +94,6 @@ class TestVirtWhoConfigforKubevirt:
                 {'host-id': host['id'], 'subscription-id': vdc_id}
             )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(
@@ -138,8 +139,6 @@ class TestVirtWhoConfigforKubevirt:
                 {'host-id': host['id'], 'subscription-id': vdc_id}
             )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
@@ -168,5 +167,3 @@ class TestVirtWhoConfigforKubevirt:
                 command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -46,7 +46,10 @@ def form_data(target_sat, default_org):
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+    yield virtwho_config
+    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
 
 class TestVirtWhoConfigforLibvirt:
@@ -92,8 +95,6 @@ class TestVirtWhoConfigforLibvirt:
                 {'host-id': host['id'], 'subscription-id': vdc_id}
             )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_by_script(
@@ -139,8 +140,6 @@ class TestVirtWhoConfigforLibvirt:
                 {'host-id': host['id'], 'subscription-id': vdc_id}
             )
             assert result.strip() == 'Subscription attached to the host successfully.'
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
@@ -169,5 +168,3 @@ class TestVirtWhoConfigforLibvirt:
                 command, form_data['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -1,4 +1,4 @@
-"""Test class for Virtwho Configure API
+"""Test class for Virtwho Configure CLI
 
 :Requirement: Virt-whoConfigurePlugin
 
@@ -26,28 +26,28 @@ from robottelo.utils.virtwho import get_configure_option
 
 
 @pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
+def form_data(target_sat, module_sca_manifest_org):
     form = {
         'name': gen_string('alpha'),
         'debug': 1,
         'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.libvirt.hypervisor_type,
-        'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
+        'hypervisor-id': 'hostname',
+        'hypervisor-type': settings.virtwho.libvirt.hypervisor_type,
+        'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
+        'organization-id': module_sca_manifest_org.id,
+        'filtering-mode': 'none',
+        'satellite-url': target_sat.hostname,
+        'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
     }
     return form
 
 
 @pytest.fixture()
 def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
     yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
+    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
+    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
 
 
 class TestVirtWhoConfigforLibvirt:
@@ -56,9 +56,9 @@ class TestVirtWhoConfigforLibvirt:
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify "POST /foreman_virt_who_configure/api/v2/configs"
+        """Verify " hammer virt-who-config deploy"
 
-        :id: be6563e7-f714-4189-a8f5-9e99b0522a02
+        :id: 53143fc3-97e0-4403-8114-4d7f20fde98e
 
         :expectedresults: Config can be created and deployed
 
@@ -66,36 +66,31 @@ class TestVirtWhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
+        assert virtwho_config['status'] == 'No Report Yet'
         if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
             )
         elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
+            script = target_sat.cli.VirtWhoConfig.fetch(
+                {'id': virtwho_config['id']}, output_format='base'
             )
-        virt_who_instance = (
-            target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
-            .status
-        )
-        assert virt_who_instance == 'ok'
+            deploy_configure_by_script(
+                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+            )
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+            'general-information'
+        ]['status']
+        assert virt_who_instance == 'OK'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat
     ):
-        """Verify hypervisor_id option by "PUT
+        """Verify hypervisor_id option by hammer virt-who-config update"
 
-        /foreman_virt_who_configure/api/v2/configs/:id"
-
-        :id: 60f373f0-5179-4531-834d-c297f9f7ea2d
+        :id: e68421b5-ff3d-4f25-926d-8330b92f2cdf
 
         :expectedresults: hypervisor_id option can be updated.
 
@@ -104,11 +99,14 @@ class TestVirtWhoConfigforLibvirt:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            target_sat.cli.VirtWhoConfig.update(
+                {'id': virtwho_config['id'], 'hypervisor-id': value}
+            )
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            assert result['connection']['hypervisor-id'] == value
+            config_file = get_configure_file(virtwho_config['id'])
+            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -42,9 +42,20 @@ def form_data():
     return form
 
 
+@pytest.fixture()
+def virtwho_config(form_data, target_sat, session):
+    name = gen_string('alpha')
+    form_data['name'] = name
+    with session:
+        session.virtwho_configure.create(form_data)
+        yield virtwho_config
+        session.virtwho_configure.delete(name)
+        assert not session.virtwho_configure.search(name)
+
+
 class TestVirtwhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
+    def test_positive_deploy_configure_by_id(self, default_org, virtwho_config, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: c8913398-c5c6-4f2c-bc53-0bbfb158b762
@@ -60,28 +71,25 @@ class TestVirtwhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        command = values['deploy']['command']
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, virtwho_config, session, form_data
+    ):
         """Verify configure created and deployed with script.
 
         :id: b0401417-3a6e-4a54-b8e8-22d290813da3
@@ -97,28 +105,23 @@ class TestVirtwhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        script = values['deploy']['script']
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
+    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: f2efc018-d57e-4dc5-895e-53af320237de
@@ -131,21 +134,16 @@ class TestVirtwhoConfigforHyperv:
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.name)
-            config_file = get_configure_file(config_id)
-            values = ['uuid', 'hostname']
-            for value in values:
-                session.virtwho_configure.edit(name, {'hypervisor_id': value})
-                results = session.virtwho_configure.read(name)
-                assert results['overview']['hypervisor_id'] == value
-                deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=default_org.label
-                )
-                assert get_configure_option('hypervisor_id', config_file) == value
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        config_id = get_configure_id(name)
+        config_command = get_configure_command(config_id, default_org.name)
+        config_file = get_configure_file(config_id)
+        values = ['uuid', 'hostname']
+        for value in values:
+            session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = session.virtwho_configure.read(name)
+            assert results['overview']['hypervisor_id'] == value
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=default_org.label
+            )
+            assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -40,9 +40,20 @@ def form_data():
     return form
 
 
+@pytest.fixture()
+def virtwho_config(form_data, target_sat, session):
+    name = gen_string('alpha')
+    form_data['name'] = name
+    with session:
+        session.virtwho_configure.create(form_data)
+        yield virtwho_config
+        session.virtwho_configure.delete(name)
+        assert not session.virtwho_configure.search(name)
+
+
 class TestVirtwhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
+    def test_positive_deploy_configure_by_id(self, default_org, virtwho_config, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: 7b2a1b08-f33c-44f4-ad2e-317b6c44b938
@@ -58,28 +69,25 @@ class TestVirtwhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        command = values['deploy']['command']
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, virtwho_config, session, form_data
+    ):
         """Verify configure created and deployed with script.
 
         :id: b3903ccb-04cc-4867-b7ed-d5053d2bfe03
@@ -95,28 +103,23 @@ class TestVirtwhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        script = values['deploy']['script']
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
+    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: 09826cc0-aa49-4355-8980-8097511eb7d7
@@ -129,21 +132,16 @@ class TestVirtwhoConfigforKubevirt:
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.name)
-            config_file = get_configure_file(config_id)
-            values = ['uuid', 'hostname']
-            for value in values:
-                session.virtwho_configure.edit(name, {'hypervisor_id': value})
-                results = session.virtwho_configure.read(name)
-                assert results['overview']['hypervisor_id'] == value
-                deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=default_org.label
-                )
-                assert get_configure_option('hypervisor_id', config_file) == value
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        config_id = get_configure_id(name)
+        config_command = get_configure_command(config_id, default_org.name)
+        config_file = get_configure_file(config_id)
+        values = ['uuid', 'hostname']
+        for value in values:
+            session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = session.virtwho_configure.read(name)
+            assert results['overview']['hypervisor_id'] == value
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=default_org.label
+            )
+            assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -41,9 +41,20 @@ def form_data():
     return form
 
 
+@pytest.fixture()
+def virtwho_config(form_data, target_sat, session):
+    name = gen_string('alpha')
+    form_data['name'] = name
+    with session:
+        session.virtwho_configure.create(form_data)
+        yield virtwho_config
+        session.virtwho_configure.delete(name)
+        assert not session.virtwho_configure.search(name)
+
+
 class TestVirtwhoConfigforLibvirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
+    def test_positive_deploy_configure_by_id(self, default_org, virtwho_config, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: ae37ea79-f99c-4511-ace9-a7de26d6db40
@@ -59,28 +70,25 @@ class TestVirtwhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        command = values['deploy']['command']
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, virtwho_config, session, form_data
+    ):
         """Verify configure created and deployed with script.
 
         :id: 3655a501-ab05-4724-945a-7f6e6878091d
@@ -96,28 +104,23 @@ class TestVirtwhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        script = values['deploy']['script']
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
+    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: b8b2b272-89f2-45d0-b922-6e988b20808b
@@ -130,21 +133,16 @@ class TestVirtwhoConfigforLibvirt:
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.name)
-            config_file = get_configure_file(config_id)
-            values = ['uuid', 'hostname']
-            for value in values:
-                session.virtwho_configure.edit(name, {'hypervisor_id': value})
-                results = session.virtwho_configure.read(name)
-                assert results['overview']['hypervisor_id'] == value
-                deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=default_org.label
-                )
-                assert get_configure_option('hypervisor_id', config_file) == value
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        config_id = get_configure_id(name)
+        config_command = get_configure_command(config_id, default_org.name)
+        config_file = get_configure_file(config_id)
+        values = ['uuid', 'hostname']
+        for value in values:
+            session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = session.virtwho_configure.read(name)
+            assert results['overview']['hypervisor_id'] == value
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=default_org.label
+            )
+            assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -46,9 +46,20 @@ def form_data():
     return form
 
 
+@pytest.fixture()
+def virtwho_config(form_data, target_sat, session):
+    name = gen_string('alpha')
+    form_data['name'] = name
+    with session:
+        session.virtwho_configure.create(form_data)
+        yield virtwho_config
+        session.virtwho_configure.delete(name)
+        assert not session.virtwho_configure.search(name)
+
+
 class TestVirtwhoConfigforNutanix:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, session, form_data):
+    def test_positive_deploy_configure_by_id(self, default_org, virtwho_config, session, form_data):
         """Verify configure created and deployed with id.
 
         :id: becea4d0-db4e-4a85-93d2-d40e86da0e2f
@@ -64,28 +75,25 @@ class TestVirtwhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        command = values['deploy']['command']
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(self, default_org, session, form_data):
+    def test_positive_deploy_configure_by_script(
+        self, default_org, virtwho_config, session, form_data
+    ):
         """Verify configure created and deployed with script.
 
         :id: 1c1b19c9-988c-4b86-a2b2-658fded10ccb
@@ -101,28 +109,23 @@ class TestVirtwhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-            vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-            vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        script = values['deploy']['script']
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
+        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, session, form_data):
+    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
         """Verify Hypervisor ID dropdown options.
 
         :id: e076a305-88f4-42fb-8ef2-cb55e38eb912
@@ -135,24 +138,20 @@ class TestVirtwhoConfigforNutanix:
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.name)
-            config_file = get_configure_file(config_id)
-            values = ['uuid', 'hostname']
-            for value in values:
-                session.virtwho_configure.edit(name, {'hypervisor_id': value})
-                results = session.virtwho_configure.read(name)
-                assert results['overview']['hypervisor_id'] == value
-                deploy_configure_by_command(
-                    config_command, form_data['hypervisor_type'], org=default_org.label
-                )
-                assert get_configure_option('hypervisor_id', config_file) == value
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        values = session.virtwho_configure.read(name)
+        config_id = get_configure_id(name)
+        config_command = values['deploy']['command']
+        config_file = get_configure_file(config_id)
+        values = ['uuid', 'hostname']
+        for value in values:
+            session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = session.virtwho_configure.read(name)
+            assert results['overview']['hypervisor_id'] == value
+            deploy_configure_by_command(
+                config_command, form_data['hypervisor_type'], org=default_org.label
+            )
+            assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
@@ -207,7 +206,9 @@ class TestVirtwhoConfigforNutanix:
             assert not session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
-    def test_positive_prism_central_prism_flavor_option(self, default_org, session, form_data):
+    def test_positive_prism_central_prism_flavor_option(
+        self, default_org, virtwho_config, session, form_data
+    ):
         """Verify prism_flavor dropdown options.
 
         :id: c76d94dd-25da-447d-8194-44217a36808b
@@ -220,29 +221,24 @@ class TestVirtwhoConfigforNutanix:
 
         :CaseImportance: Medium
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            results = session.virtwho_configure.read(name)
-            assert results['overview']['prism_flavor'] == "element"
-            config_id = get_configure_id(name)
-            config_command = get_configure_command(config_id, default_org.name)
-            config_file = get_configure_file(config_id)
-            session.virtwho_configure.edit(
-                name, {'hypervisor_content.prism_flavor': "Prism Central"}
-            )
-            results = session.virtwho_configure.read(name)
-            assert results['overview']['prism_flavor'] == "central"
-            deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
-            )
-            assert get_configure_option('prism_central', config_file) == 'true'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+        name = form_data['name']
+        results = session.virtwho_configure.read(name)
+        assert results['overview']['prism_flavor'] == "element"
+        config_id = get_configure_id(name)
+        config_command = get_configure_command(config_id, default_org.name)
+        config_file = get_configure_file(config_id)
+        session.virtwho_configure.edit(name, {'hypervisor_content.prism_flavor': "Prism Central"})
+        results = session.virtwho_configure.read(name)
+        assert results['overview']['prism_flavor'] == "central"
+        deploy_configure_by_command(
+            config_command, form_data['hypervisor_type'], org=default_org.label
+        )
+        assert get_configure_option('prism_central', config_file) == 'true'
 
     @pytest.mark.tier2
-    def test_positive_ahv_internal_debug_option(self, default_org, session, form_data):
+    def test_positive_ahv_internal_debug_option(
+        self, default_org, virtwho_config, session, form_data
+    ):
         """Verify ahv_internal_debug option by hammer virt-who-config"
 
         :id: af92b814-fe7a-4969-b2ab-7b68859de3ce155
@@ -262,44 +258,39 @@ class TestVirtwhoConfigforNutanix:
         :BZ: 2141719
         :customerscenario: true
         """
-        name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
-            config_id = get_configure_id(name)
-            values = session.virtwho_configure.read(name)
-            command = values['deploy']['command']
-            config_file = get_configure_file(config_id)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            results = session.virtwho_configure.read(name)
-            assert str(results['overview']['ahv_internal_debug']) == 'False'
-            # ahv_internal_debug does not set in virt-who-config-X.conf
-            option = 'ahv_internal_debug'
-            env_error = f"option {option} is not exist or not be enabled in {config_file}"
-            try:
-                get_configure_option("ahv_internal_debug", config_file)
-            except Exception as VirtWhoError:
-                assert env_error == str(VirtWhoError)
-            # check message exist in log file /var/log/rhsm/rhsm.log
-            message = 'Value for "ahv_internal_debug" not set, using default: False'
-            assert check_message_in_rhsm_log(message) == message
+        name = form_data['name']
+        config_id = get_configure_id(name)
+        values = session.virtwho_configure.read(name)
+        command = values['deploy']['command']
+        config_file = get_configure_file(config_id)
+        deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        results = session.virtwho_configure.read(name)
+        assert str(results['overview']['ahv_internal_debug']) == 'False'
+        # ahv_internal_debug does not set in virt-who-config-X.conf
+        option = 'ahv_internal_debug'
+        env_error = f"option {option} is not exist or not be enabled in {config_file}"
+        try:
+            get_configure_option("ahv_internal_debug", config_file)
+        except Exception as VirtWhoError:
+            assert env_error == str(VirtWhoError)
+        # check message exist in log file /var/log/rhsm/rhsm.log
+        message = 'Value for "ahv_internal_debug" not set, using default: False'
+        assert check_message_in_rhsm_log(message) == message
 
-            # Update ahv_internal_debug option to true
-            session.virtwho_configure.edit(name, {'ahv-internal-debug': True})
-            results = session.virtwho_configure.read(name)
-            command = results['deploy']['command']
-            assert str(results['overview']['ahv_internal_debug']) == 'True'
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-            assert (
-                get_hypervisor_ahv_mapping(form_data['hypervisor_type']) == 'Host UUID found for VM'
-            )
-            # ahv_internal_debug bas been set to true in virt-who-config-X.conf
-            config_file = get_configure_file(config_id)
-            assert get_configure_option("ahv_internal_debug", config_file) == 'true'
-            # check message does not exist in log file /var/log/rhsm/rhsm.log
-            message = 'Value for "ahv_internal_debug" not set, using default: False'
-            assert str(check_message_in_rhsm_log(message)) == 'False'
+        # Update ahv_internal_debug option to true
+        session.virtwho_configure.edit(name, {'ahv-internal-debug': True})
+        results = session.virtwho_configure.read(name)
+        command = results['deploy']['command']
+        assert str(results['overview']['ahv_internal_debug']) == 'True'
+        deploy_configure_by_command(
+            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+        )
+        assert get_hypervisor_ahv_mapping(form_data['hypervisor_type']) == 'Host UUID found for VM'
+        # ahv_internal_debug bas been set to true in virt-who-config-X.conf
+        config_file = get_configure_file(config_id)
+        assert get_configure_option("ahv_internal_debug", config_file) == 'true'
+        # check message does not exist in log file /var/log/rhsm/rhsm.log
+        message = 'Value for "ahv_internal_debug" not set, using default: False'
+        assert str(check_message_in_rhsm_log(message)) == 'False'


### PR DESCRIPTION
Add create virtwho config and delete virtwho config to virtwho_config fixture for CLI/API.UI

Test Results:PASS
API： 
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx.py --disable-pytest-warnings -q
..........                                                                                                                                                                                                  [100%]
10 passed, 10 deselected, 104 warnings in 1072.42s (0:17:52)


(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_hyperv.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 28 warnings in 259.10s (0:04:19)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_libvirt.py  --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 28 warnings in 245.95s (0:04:05)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_kubevirt.py  --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 37 warnings in 407.41s (0:06:47)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix.py  --disable-pytest-warnings -q
.......                                                                                                                                                                                                     [100%]
7 passed, 7 deselected, 100 warnings in 934.86s (0:15:34)
```


CLI
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx.py --disable-pytest-warnings -q
............                                                                                                                                                                                                [100%]
12 passed, 12 deselected, 9 warnings in 1250.01s (0:20:50)


(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_hyperv.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 2 warnings in 299.74s (0:04:59)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_libvirt.py  --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 2 warnings in 292.81s (0:04:52)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_kubevirt.py  --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 2 warnings in 430.10s (0:07:10)


(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py  --disable-pytest-warnings -q
.......                                                                                                                                                                                                     [100%]
7 passed, 7 deselected, 2 warnings in 824.36s (0:13:44)
```


UI
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py --disable-pytest-warnings -q
.................                                                                                                                                                                                           [100%]
17 passed, 17 deselected, 50 warnings in 3959.83s (1:05:59)


(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_hyperv.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 5 warnings in 645.43s (0:10:45)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_libvirt.py  --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 5 warnings in 631.60s (0:10:31)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_kubevirt.py  --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 5 warnings in 774.32s (0:12:54)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_nutanix.py  --disable-pytest-warnings -q
.......                                                                                                                                                                                                     [100%]
7 passed, 7 deselected, 5 warnings in 1537.02s (0:25:37)
```