### PR TITLE
Bump-fix failing assertion in test_contentcredentials : test_positive_block_delete_key_in_use 

### DIFF
--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -263,9 +263,8 @@ def test_positive_block_delete_key_in_use(module_org, target_sat):
     # Attempt to delete gpg in use, capturing api response without raising exception
     response = gpg_key.delete_raw()
     assert response.status_code == 500
-    assert 'errors' in str(response.json())
     assert 'Cannot delete record because of dependent root_repositories' in str(
-        response.json()['errors']
+        response.json().get('errors')
     )
 
     # Assert gpg matches unmodified copy

--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -261,14 +261,12 @@ def test_positive_block_delete_key_in_use(module_org, target_sat):
     assert product.gpg_key.id == repo.gpg_key.id
 
     # Attempt to delete gpg in use, check errors
-    with pytest.raises(HTTPError) as err:
+    with pytest.raises(HTTPError) as exception:
+        response = gpg_key.delete_raw().json()
         gpg_key.delete()
-
-    result = target_sat.execute(
-        'grep -m 1 "dependent root_repositories" /var/log/foreman/production.log | tail -1'
-    )
-    assert '500' in str(err.value)
-    assert 'Cannot delete record' in str(result)
+    assert '500' in str(exception.value)
+    assert 'errors' in str(response)
+    assert 'Cannot delete record because of dependent root_repositories' in str(response['errors'])
 
     # Assert gpg matches unmodified copy
     assert gpg_key.id == gpg_copy.id

--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -232,7 +232,7 @@ def test_positive_delete(module_org):
 
 
 @pytest.mark.tier3
-def test_positive_block_delete_key_in_use(module_org, target_sat, capfd):
+def test_positive_block_delete_key_in_use(module_org, target_sat):
     """Create a GPG key with valid content. Create a new product and
         associated repository, assigning the GPG key to both. Attempt to delete the
         GPG key in use.
@@ -260,14 +260,15 @@ def test_positive_block_delete_key_in_use(module_org, target_sat, capfd):
     assert repo.gpg_key.id == gpg_key.id
     assert product.gpg_key.id == repo.gpg_key.id
 
-    # Attempt to delete gpg in use
+    # Attempt to delete gpg in use, check errors
     with pytest.raises(HTTPError) as err:
         gpg_key.delete()
 
-    # Check for 500 error and display message
-    err_message = capfd.readouterr()[1]
+    result = target_sat.execute(
+        'grep -m 1 "dependent root_repositories" /var/log/foreman/production.log | tail -1'
+    )
     assert '500' in str(err.value)
-    assert 'Cannot delete' in str(err_message)
+    assert 'Cannot delete record' in str(result)
 
     # Assert gpg matches unmodified copy
     assert gpg_key.id == gpg_copy.id

--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -260,13 +260,13 @@ def test_positive_block_delete_key_in_use(module_org, target_sat):
     assert repo.gpg_key.id == gpg_key.id
     assert product.gpg_key.id == repo.gpg_key.id
 
-    # Attempt to delete gpg in use, check errors
-    with pytest.raises(HTTPError) as exception:
-        response = gpg_key.delete_raw().json()
-        gpg_key.delete()
-    assert '500' in str(exception.value)
-    assert 'errors' in str(response)
-    assert 'Cannot delete record because of dependent root_repositories' in str(response['errors'])
+    # Attempt to delete gpg in use, capturing api response without raising exception
+    response = gpg_key.delete_raw()
+    assert response.status_code == 500
+    assert 'errors' in str(response.json())
+    assert 'Cannot delete record because of dependent root_repositories' in str(
+        response.json()['errors']
+    )
 
     # Assert gpg matches unmodified copy
     assert gpg_key.id == gpg_copy.id


### PR DESCRIPTION
The initial implementation of `err_message = capfd.readouterr()[1]` [ln268] works locally but fails on jenkins runs when asserting `err_message`, it is not recorded.

I used `gpg_key.delete_raw()` to collect the error and message without the pytest.raises context manager/without raising an exception for `HTTPError`