### PR TITLE
Add e2e markers for CC, ACS, ISS

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -229,6 +229,7 @@ class TestCapsuleContentManagement:
         assert "sha256" not in checksum_types
 
     @pytest.mark.skip_if_open("BZ:2025494")
+    @pytest.mark.e2e
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_updated_repo(
@@ -330,6 +331,7 @@ class TestCapsuleContentManagement:
         assert sat_files == caps_files
         assert len(caps_files) == 2
 
+    @pytest.mark.e2e
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_capsule_sync(
@@ -747,6 +749,7 @@ class TestCapsuleContentManagement:
             # check that one of the files is in the content
             assert b'katello-server-ca.crt' in response.content
 
+    @pytest.mark.e2e
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients')
     @pytest.mark.parametrize('distro', ['rhel7', 'rhel8_bos', 'rhel9_bos'])

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -5,7 +5,7 @@ interactions and use capsule.
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
+:CaseLevel: System
 
 :CaseComponent: Capsule-Content
 
@@ -67,8 +67,6 @@ class TestCapsuleContentManagement:
         :expectedresults: `redhat-access-insights-puppet` package is delivered
             in capsule repo and is available for installation on capsule via
             yum
-
-        :CaseLevel: System
         """
         package_name = 'redhat-access-insights-puppet'
         result = module_capsule_configured.run(f'yum list {package_name} | grep @capsule')
@@ -92,8 +90,6 @@ class TestCapsuleContentManagement:
         :BZ: 1340686
 
         :expectedresults: custom content is present on external capsule
-
-        :CaseLevel: System
         """
         repo = entities.Repository(product=function_product, url=None).create()
         # Associate the lifecycle environment with the capsule
@@ -151,8 +147,6 @@ class TestCapsuleContentManagement:
 
         :expectedresults: checksum type is updated in repodata of corresponding
             repository on capsule
-
-        :CaseLevel: System
 
         :CaseImportance: Critical
         """
@@ -257,8 +251,6 @@ class TestCapsuleContentManagement:
             1. Capsule is synced successfully.
             2. Content is present at the Capsule side.
 
-        :CaseLevel: Integration
-
         :customerscenario: true
 
         :BZ: 2025494
@@ -357,8 +349,6 @@ class TestCapsuleContentManagement:
                second repo sync with no changes
             5. Syncing repository which was updated will update the content on
                capsule
-
-        :CaseLevel: System
         """
         repo_url = settings.repos.yum_1.url
         repo = entities.Repository(product=function_product, url=repo_url).create()
@@ -489,8 +479,6 @@ class TestCapsuleContentManagement:
         :BZ: 1303102, 1480358, 1303103, 1734312
 
         :expectedresults: ISOs are present on external capsule
-
-        :CaseLevel: System
         """
         # Enable & sync RH repository with ISOs
         rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
@@ -561,8 +549,6 @@ class TestCapsuleContentManagement:
                is automatically synced to the Capsule
             3. Package is successfully downloaded from the Capsule, its checksum matches
                the original package from the upstream repo
-
-        :CaseLevel: System
         """
         repo_url = settings.repos.yum_3.url
         packages_count = constants.FAKE_3_YUM_REPOS_COUNT
@@ -642,8 +628,6 @@ class TestCapsuleContentManagement:
 
         :expectedresults: content was successfully synchronized - capsule
             filesystem contains valid links to packages
-
-        :CaseLevel: System
         """
         repo_url = settings.repos.yum_1.url
         packages_count = constants.FAKE_1_YUM_REPOS_COUNT
@@ -736,8 +720,6 @@ class TestCapsuleContentManagement:
         :expectedresults: capsule pub url is accessible
 
         :BZ: 1463810, 2122780
-
-        :CaseLevel: System
         """
         https_pub_url = f'https://{module_capsule_configured.ip_addr}/pub'
         http_pub_url = f'http://{module_capsule_configured.ip_addr}/pub'
@@ -770,8 +752,6 @@ class TestCapsuleContentManagement:
 
         :expectedresults:
             1. The kickstart repo is successfully synced to the Capsule.
-
-        :CaseLevel: Integration
 
         :BZ: 1992329
         """
@@ -873,8 +853,6 @@ class TestCapsuleContentManagement:
             2. The image is successfully pulled from Capsule to a host.
 
         :parametrized: yes
-
-        :CaseLevel: Integration
 
         :BZ: 2125244, 2148813
 
@@ -1006,8 +984,6 @@ class TestCapsuleContentManagement:
 
         :parametrized: yes
 
-        :CaseLevel: Integration
-
         :BZ: 2121583
         """
         requirements = '''
@@ -1096,8 +1072,6 @@ class TestCapsuleContentManagement:
             1. Both capsule syncs succeed.
             2. Content is accessible on both, Satellite and Capsule.
 
-        :CaseLevel: Integration
-
         :BZ: 1985122
         """
         repo = entities.Repository(
@@ -1183,8 +1157,6 @@ class TestCapsuleContentManagement:
 
         :expectedresults:
             1. All capsule syncs succeed.
-
-        :CaseLevel: Integration
 
         :customerscenario: true
 

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -625,11 +625,7 @@ def _import_entities(product, repo, cv, mos='no'):
 
 
 class TestContentViewSync:
-    """Implements Content View Export Import tests in CLI
-
-    :CaseComponent: ContentViews
-
-    """
+    """Implements Content View Export Import tests in CLI"""
 
     @pytest.mark.tier3
     @pytest.mark.e2e
@@ -659,10 +655,6 @@ class TestContentViewSync:
 
             1. CV version custom contents has been exported to directory
             2. All The exported custom contents has been imported in org/satellite
-
-        :CaseAutomation: Automated
-
-        :CaseComponent: ContentViews
 
         :CaseImportance: High
 
@@ -753,10 +745,6 @@ class TestContentViewSync:
 
             1. Default Organization View version custom contents has been exported to directory
             2. All The exported custom contents has been imported in org/satellite
-
-        :CaseAutomation: Automated
-
-        :CaseComponent: ContentViews
 
         :CaseImportance: High
 
@@ -855,8 +843,6 @@ class TestContentViewSync:
 
             1. Filtered CV version custom contents has been exported to directory
             2. Filtered exported custom contents has been imported in org/satellite
-
-        :CaseAutomation: Automated
 
         :CaseImportance: High
 
@@ -998,6 +984,7 @@ class TestContentViewSync:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
+    @pytest.mark.e2e
     def test_positive_export_import_redhat_cv(
         self,
         export_import_cleanup_function,
@@ -1025,11 +1012,7 @@ class TestContentViewSync:
 
         :BZ: 1655239, 2040870
 
-        :CaseAutomation: Automated
-
         :customerscenario: true
-
-        :CaseComponent: ContentViews
 
         :CaseImportance: High
 
@@ -1156,10 +1139,6 @@ class TestContentViewSync:
             2. All The exported redhat contents has been imported in org/satellite
 
         :BZ: 1655239
-
-        :CaseAutomation: Automated
-
-        :CaseComponent: ContentViews
 
         :CaseImportance: Critical
 


### PR DESCRIPTION
This PR
1) Adds few e2e markers to Capsule-Content and ACS tests
2) Moves CV export/import tests under ISS component (and ads one e2e too)