### PR TITLE
Test for multiple orgs with the same repo[Repository Rewrite]

### DIFF
--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -217,3 +217,29 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
         "The manifest doesn't exist on console.redhat.com. "
         "Please create and import a new manifest." in error.value.stderr
     )
+
+
+@pytest.mark.tier1
+def test_positive_multiple_orgs_with_same_repo(target_sat):
+    """Test that multiple organizations with the same repository synced have matching metadata
+
+    :id: 39cff8ea-969d-4b8f-9fb4-33b1ba768ff2
+
+    :Steps:
+        1. Create multiple organizations
+        2. Sync the same repository to each organization
+        3. Assert that each repository from each organization contain the same content counts
+
+    :expectedresults: Each repository in each organziation should have the same content counts
+    """
+    repos = []
+    orgs = [target_sat.api.Organization().create() for _ in range(3)]
+    for org in orgs:
+        product = target_sat.api.Product(organization=org).create()
+        repo = target_sat.api.Repository(
+            content_type='yum', product=product, url=settings.repos.module_stream_1.url
+        ).create()
+        repo.sync()
+        repo_counts = target_sat.api.Repository(id=repo.id).read().content_counts
+        repos.append(repo_counts)
+    assert repos[0] == repos[1] == repos[2]

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -448,9 +448,7 @@ def test_positive_os_restriction_on_repos():
     """
 
 
-def test_positive_async_endpoint_for_manifest_refresh(
-    target_sat, function_entitlement_manifest_org
-):
+def test_positive_async_endpoint_for_manifest_refresh(target_sat, module_entitlement_manifest_org):
     """Verify that manifest refresh is using an async endpoint. Previously this was a single,
     synchronous endpoint. The endpoint to retrieve manifests is now split into two: an async
     endpoint to start "exporting" the manifest, and a second endpoint to download the
@@ -469,12 +467,12 @@ def test_positive_async_endpoint_for_manifest_refresh(
 
     :BZ: 2066323
     """
-    sub = target_sat.api.Subscription(organization=function_entitlement_manifest_org)
+    sub = target_sat.api.Subscription(organization=module_entitlement_manifest_org)
     # set log level to 'debug' and restart services
     target_sat.cli.Admin.logging({'all': True, 'level-debug': True})
     target_sat.cli.Service.restart()
     # refresh manifest and assert new log message to confirm async endpoint
-    sub.refresh_manifest(data={'organization_id': function_entitlement_manifest_org.id})
+    sub.refresh_manifest(data={'organization_id': module_entitlement_manifest_org.id})
     results = target_sat.execute(
         'grep "Sending GET request to upstream Candlepin" /var/log/foreman/production.log'
     )


### PR DESCRIPTION
This test is a part of the Repository Rewrite effort [ SAT-13253 ]

The purpose of this test to make sure the metadata for a repository is the same when synced to multiple organizations

Steps:
Create orgs with same repo, sync them, and check if the metadata information is matching all of them