### PR TITLE
[6.13.z] Fixing test by changing manifest scope to function instead of module

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -458,7 +458,9 @@ def test_positive_os_restriction_on_repos():
     """
 
 
-def test_positive_async_endpoint_for_manifest_refresh(target_sat, module_entitlement_manifest_org):
+def test_positive_async_endpoint_for_manifest_refresh(
+    target_sat, function_entitlement_manifest_org
+):
     """Verify that manifest refresh is using an async endpoint. Previously this was a single,
     synchronous endpoint. The endpoint to retrieve manifests is now split into two: an async
     endpoint to start "exporting" the manifest, and a second endpoint to download the
@@ -477,12 +479,12 @@ def test_positive_async_endpoint_for_manifest_refresh(target_sat, module_entitle
 
     :BZ: 2066323
     """
-    sub = target_sat.api.Subscription(organization=module_entitlement_manifest_org)
+    sub = target_sat.api.Subscription(organization=function_entitlement_manifest_org)
     # set log level to 'debug' and restart services
     target_sat.cli.Admin.logging({'all': True, 'level-debug': True})
     target_sat.cli.Service.restart()
     # refresh manifest and assert new log message to confirm async endpoint
-    sub.refresh_manifest(data={'organization_id': module_entitlement_manifest_org.id})
+    sub.refresh_manifest(data={'organization_id': function_entitlement_manifest_org.id})
     results = target_sat.execute(
         'grep "Sending GET request to upstream Candlepin" /var/log/foreman/production.log'
     )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11247

Lets try this one more time. Test was failing in Jenkins due to multiple orgs using same subscription

Moving manifest scope to function. 
