### PR TITLE
Fix container-to-capsule sync test

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -19,6 +19,7 @@ interactions and use capsule.
 """
 import re
 from datetime import datetime
+from time import sleep
 
 import pytest
 from nailgun import client
@@ -1001,6 +1002,8 @@ class TestCapsuleContentManagement:
             target_sat.api.LifecycleEnvironment(
                 id=function_lce.id, registry_unauthenticated_pull='true'
             ).update(['registry_unauthenticated_pull'])
+
+            sleep(20)
 
             skopeo_cmd = 'skopeo --debug inspect docker://'
             for path in repo_paths:


### PR DESCRIPTION
It seems we need a little sleep when running on OSP. This was already fixed in 6.12.z, but not in master.