### PR TITLE
Add e2e markers for tests, and update 2 tests to use Katello-tracer

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1080,6 +1080,7 @@ def test_positive_admin_user_actions(
         content_view.read()
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 def test_positive_readonly_user_actions(target_sat, function_role, content_view, module_org):
     """Attempt to view content views

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1539,6 +1539,7 @@ class TestHostBulkAction:
 class TestHostTraces:
     """Tests for host tracer"""
 
+    @pytest.mark.e2e
     @pytest.mark.tier4
     @pytest.mark.rhel_ver_match('[^6].*')
     def test_positive_tracer_list_and_resolve(self, tracer_host):
@@ -1556,6 +1557,8 @@ class TestHostTraces:
         :parametrized: yes
 
         :CaseImportance: Medium
+
+        :CaseComponent: Katello-tracer
         """
         host = tracer_host.nailgun_host
         package = settings.repos["MOCK_SERVICE_RPM"]

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2485,6 +2485,8 @@ def test_positive_tracer_list_and_resolve(tracer_host):
     :parametrized: yes
 
     :CaseImportance: Medium
+
+    :CaseComponent: Katello-tracer
     """
     client = tracer_host
     package = settings.repos["MOCK_SERVICE_RPM"]

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -106,6 +106,7 @@ def run_remote_command_on_content_host(command, vm_module_streams):
     return result
 
 
+@pytest.mark.e2e
 @pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -53,6 +53,7 @@ def validate_repo_content(repo, content_types, after_sync=True):
             ), 'Repository contains invalid number of content entities.'
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_org):
     """Perform end to end scenario for sync plan component


### PR DESCRIPTION
Marking up several components for e2e, as well as updating two tests to use Katello-tracer component.

I realize that there are 2 UI tests here, and we are primarily considering API/CLI tests for e2e status, but in one case (ContentHosts) there are no other tests in robottelo aside from UI. In the other case (SyncPlans), it's by far the best, most "end-to-end" test that exists, and it's fairly extensive. 

I'd argue for the inclusion of both of these. 