### PR TITLE
[6.13.z] Fix ISS fixture

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -193,6 +193,15 @@ def function_entitlement_manifest():
 
 
 @pytest.fixture(scope='function')
+def function_secondary_entitlement_manifest():
+    """Yields a manifest in entitlement mode with subscriptions determined by the
+    `manifest_category.entitlement` setting in conf/manifest.yaml.
+    A different one than is used in `function_entitlement_manifest_org`."""
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='function')
 def function_sca_manifest():
     """Yields a manifest in Simple Content Access mode with subscriptions determined by the
     `manifest_category.golden_ticket` setting in conf/manifest.yaml."""

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1003,7 +1003,7 @@ class TestContentViewSync:
         export_import_cleanup_function,
         config_export_import_settings,
         function_entitlement_manifest_org,
-        duplicate_entitlement_manifest,
+        function_secondary_entitlement_manifest,
         target_sat,
     ):
         """Export CV version redhat contents in directory and Import them
@@ -1094,7 +1094,7 @@ class TestContentViewSync:
         assert result.stdout != ''
         target_sat.upload_manifest(
             importing_org.id,
-            duplicate_entitlement_manifest,
+            function_secondary_entitlement_manifest,
             interface='CLI',
             timeout=7200000,
         )
@@ -1136,7 +1136,7 @@ class TestContentViewSync:
         config_export_import_settings,
         target_sat,
         function_entitlement_manifest_org,
-        duplicate_entitlement_manifest,
+        function_secondary_entitlement_manifest,
     ):
         """Export CV version redhat contents in directory and Import them
 
@@ -1219,7 +1219,7 @@ class TestContentViewSync:
         # Import and verify content
         target_sat.upload_manifest(
             importing_org.id,
-            duplicate_entitlement_manifest,
+            function_secondary_entitlement_manifest,
             interface='CLI',
             timeout=7200000,
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11291

The `duplicate_entitlement_manifest` fixture was probably removed by accident earlier.
Here we add it back in pytest_fixtures (renamed) and use in two modules where I found it used.