### PR TITLE
[6.12.z] Fix ISS fixture

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -189,6 +189,15 @@ def function_entitlement_manifest():
 
 
 @pytest.fixture(scope='function')
+def function_secondary_entitlement_manifest():
+    """Yields a manifest in entitlement mode with subscriptions determined by the
+    `manifest_category.entitlement` setting in conf/manifest.yaml.
+    A different one than is used in `function_entitlement_manifest_org`."""
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='function')
 def function_sca_manifest():
     """Yields a manifest in Simple Content Access mode with subscriptions determined by the
     `manifest_category.golden_ticket` setting in conf/manifest.yaml."""

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -22,7 +22,6 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 """
 import pytest
 from fauxfactory import gen_string
-from manifester import Manifester
 from nailgun import entities
 from nailgun.config import ServerConfig
 from nailgun.entity_mixins import TaskFailedError
@@ -30,7 +29,6 @@ from requests.exceptions import HTTPError
 
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.cli.subscription import Subscription
-from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
@@ -77,14 +75,6 @@ def module_ak(module_sca_manifest_org, rh_repo, custom_repo):
     return module_ak
 
 
-@pytest.fixture(scope='function')
-def duplicate_manifest():
-    """Provides a function-scoped manifest that can be used alongside function_entitlement_manifest
-    when two manifests are required in a single test"""
-    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
-        yield manifest
-
-
 @pytest.mark.tier1
 @pytest.mark.pit_server
 def test_positive_create(module_entitlement_manifest, module_target_sat):
@@ -119,7 +109,7 @@ def test_positive_refresh(function_entitlement_manifest_org, request):
 
 @pytest.mark.tier1
 def test_positive_create_after_refresh(
-    function_entitlement_manifest_org, duplicate_manifest, target_sat
+    function_entitlement_manifest_org, function_secondary_entitlement_manifest, target_sat
 ):
     """Upload a manifest,refresh it and upload a new manifest to an other
      organization.
@@ -140,7 +130,7 @@ def test_positive_create_after_refresh(
     try:
         org_sub.refresh_manifest(data={'organization_id': function_entitlement_manifest_org.id})
         assert org_sub.search()
-        target_sat.upload_manifest(new_org.id, duplicate_manifest.content)
+        target_sat.upload_manifest(new_org.id, function_secondary_entitlement_manifest.content)
         assert new_org_sub.search()
     finally:
         org_sub.delete_manifest(data={'organization_id': function_entitlement_manifest_org.id})

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -895,7 +895,7 @@ class TestContentViewSync:
         export_import_cleanup_function,
         config_export_import_settings,
         function_entitlement_manifest_org,
-        duplicate_entitlement_manifest,
+        function_secondary_entitlement_manifest,
         target_sat,
     ):
         """Export CV version redhat contents in directory and Import them
@@ -986,7 +986,7 @@ class TestContentViewSync:
         assert result.stdout != ''
         target_sat.upload_manifest(
             importing_org.id,
-            duplicate_entitlement_manifest,
+            function_secondary_entitlement_manifest,
             interface='CLI',
             timeout=7200000,
         )
@@ -1028,7 +1028,7 @@ class TestContentViewSync:
         config_export_import_settings,
         target_sat,
         function_entitlement_manifest_org,
-        duplicate_entitlement_manifest,
+        function_secondary_entitlement_manifest,
     ):
         """Export CV version redhat contents in directory and Import them
 
@@ -1111,7 +1111,7 @@ class TestContentViewSync:
         # Import and verify content
         target_sat.upload_manifest(
             importing_org.id,
-            duplicate_entitlement_manifest,
+            function_secondary_entitlement_manifest,
             interface='CLI',
             timeout=7200000,
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11291

The `duplicate_entitlement_manifest` fixture was probably removed by accident earlier.
Here we add it back in pytest_fixtures (renamed) and use in two modules where I found it used.