### PR TITLE
Cast rhel_version to string at the settings validation time

### DIFF
--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -13,7 +13,7 @@ VALIDATORS = dict(
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
         Validator('server.version.source', must_exist=True),
-        Validator('server.version.rhel_version', cast=int),
+        Validator('server.version.rhel_version', must_exist=True, cast=str),
         Validator(
             'server.xdist_behavior', must_exist=True, is_in=['run-on-one', 'balance', 'on-demand']
         ),

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -13,6 +13,7 @@ VALIDATORS = dict(
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
         Validator('server.version.source', must_exist=True),
+        Validator('server.version.rhel_version', cast=int),
         Validator(
             'server.xdist_behavior', must_exist=True, is_in=['run-on-one', 'balance', 'on-demand']
         ),

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -88,7 +88,7 @@ def get_sat_rhel_version():
     if not available fallback to robottelo configuration."""
 
     try:
-        rhel_version = Satellite().os_version
+        return Satellite().os_version
     except (AuthenticationError, ContentHostError, BoxKeyError):
         if hasattr(settings.server.version, 'rhel_version'):
             rhel_version = str(settings.server.version.rhel_version)


### PR DESCRIPTION
Cast settings.server.version.rhel_version to string to explicitly state that string is the expected type.

I have also fixed `get_sat_rhel_version` function. `Satellite`'s `os_version` property returns Version object, so it fails if the function tries to do `Version(Version('1.1'))`

`6.11.z` cherry-pick would need an extra commit with the following patch:
```diff

diff --git a/tests/foreman/destructive/test_clone.py b/tests/foreman/destructive/test_clone.py
index 329dbb3b3..b6183404d 100644
--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -22,12 +22,13 @@ from robottelo import constants
 from robottelo.config import settings
 from robottelo.hosts import Satellite
 
+from robottelo.hosts import get_sat_rhel_version
 SSH_PASS = settings.server.ssh_password
 pytestmark = pytest.mark.destructive
 
 
 @pytest.mark.parametrize(
-    "sat_ready_rhel", [7, 8] if settings.server.version.rhel_version < 8 else [8], indirect=True
+    "sat_ready_rhel", [7, 8] if get_sat_rhel_version().major < 8 else [8], indirect=True
 )
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
 @pytest.mark.parametrize('skip_pulp', [False, True], ids=['include_pulp', 'skip_pulp'])
 ```
