### PR TITLE
[6.13.z] Cast rhel_version to string at the settings validation time

### DIFF
--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -13,6 +13,7 @@ VALIDATORS = dict(
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
         Validator('server.version.source', must_exist=True),
+        Validator('server.version.rhel_version', must_exist=True, cast=str),
         Validator(
             'server.xdist_behavior', must_exist=True, is_in=['run-on-one', 'balance', 'on-demand']
         ),

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -83,7 +83,7 @@ def get_sat_rhel_version():
     if not available fallback to robottelo configuration."""
 
     try:
-        rhel_version = Satellite().os_version
+        return Satellite().os_version
     except (AuthenticationError, ContentHostError, BoxKeyError):
         if hasattr(settings.server.version, 'rhel_version'):
             rhel_version = str(settings.server.version.rhel_version)


### PR DESCRIPTION
(cherry picked from commit 0f8b115317ee269bdde2154fdda8f4229ca3acd5)

Fixes #11307

This PR is a cherry-pick of #11300.