### PR TITLE
Added e2e markers for tests

### DIFF
--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -206,6 +206,7 @@ def test_positive_environment_variable_unset_set():
     """
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_assign_http_proxy_to_products(module_org):

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -32,6 +32,7 @@ from robottelo.utils.datafactory import parametrized
 from robottelo.utils.datafactory import valid_data_list
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end_crud(session, module_org):
@@ -69,6 +70,7 @@ def test_positive_end_to_end_crud(session, module_org):
         assert session.activationkey.search(new_name)[0]['Name'] != new_name
 
 
+@pytest.mark.e2e
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
@@ -656,6 +658,7 @@ def test_positive_fetch_product_content(target_sat, function_entitlement_manifes
         assert {custom_repo.name, constants.REPOSET['rhst7']} == set(reposets)
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_access_non_admin_user(session, test_name):

--- a/tests/foreman/ui/test_contentcredentials.py
+++ b/tests/foreman/ui/test_contentcredentials.py
@@ -42,6 +42,7 @@ def gpg_path():
     return DataFile.VALID_GPG_KEY_FILE
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, gpg_content):

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -73,6 +73,7 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
         assert not target_sat.api.HTTPProxy().search(query={'search': f'name={updated_proxy_name}'})
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_assign_http_proxy_to_products_repositories(


### PR DESCRIPTION
Added remaining end-to-end pytest markers for ActivationKeys, ContentCredentials, HTTPProxy