### PR TITLE
Update puppet e2e tests 

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -79,6 +79,8 @@ def module_puppet(session_puppet_enabled_sat):
     session_puppet_enabled_sat.destroy_custom_environment(env_name)
 
 
+@pytest.mark.tier1
+@pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.skipif(
     not settings.robottelo.repos_hosting_url, reason='repos_hosting_url is not defined'
@@ -86,9 +88,6 @@ def module_puppet(session_puppet_enabled_sat):
 class TestSmartClassParameters:
     """Implements Smart Class Parameter tests in API"""
 
-    @pytest.mark.e2e
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
     @pytest.mark.parametrize('data', **parametrized(valid_sc_parameters_data()))
     def test_positive_update_parameter_type(self, data, module_puppet):
         """Positive Parameter Update for parameter types - Valid Value.
@@ -121,7 +120,6 @@ class TestSmartClassParameters:
         else:
             assert sc_param.default_value == data['value']
 
-    @pytest.mark.tier1
     @pytest.mark.parametrize('test_data', **parametrized(invalid_sc_parameters_data()))
     def test_negative_update_parameter_type(self, test_data, module_puppet):
         """Negative Parameter Update for parameter types - Invalid Value.
@@ -151,7 +149,6 @@ class TestSmartClassParameters:
         assert 'Validation failed: Default value is invalid' in context.value.response.text
 
     @pytest.mark.e2e
-    @pytest.mark.tier1
     def test_positive_validate_default_value_required_check(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -185,7 +182,6 @@ class TestSmartClassParameters:
         assert sc_param.required is True
         assert sc_param.override_values[0]['value'] is False
 
-    @pytest.mark.tier1
     def test_negative_validate_matcher_value_required_check(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -211,7 +207,6 @@ class TestSmartClassParameters:
             ).create()
         assert "Validation failed: Value can't be blank" in context.value.response.text
 
-    @pytest.mark.tier1
     def test_negative_validate_default_value_with_regex(self, module_puppet):
         """Error is raised for default value not matching with regex.
 
@@ -239,7 +234,6 @@ class TestSmartClassParameters:
         assert sc_param.read().default_value != value
 
     @pytest.mark.e2e
-    @pytest.mark.tier1
     def test_positive_validate_default_value_with_regex(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -279,7 +273,6 @@ class TestSmartClassParameters:
         sc_param.update(['override', 'default_value', 'validator_type', 'validator_rule'])
         assert sc_param.read().default_value == value
 
-    @pytest.mark.tier1
     def test_negative_validate_matcher_value_with_list(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -308,7 +301,6 @@ class TestSmartClassParameters:
         assert sc_param.read().default_value != 50
 
     @pytest.mark.e2e
-    @pytest.mark.tier1
     def test_positive_validate_matcher_value_with_list(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -335,7 +327,6 @@ class TestSmartClassParameters:
         assert sc_param.read().default_value == 'example'
 
     @pytest.mark.e2e
-    @pytest.mark.tier1
     def test_positive_validate_matcher_value_with_default_type(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -362,7 +353,6 @@ class TestSmartClassParameters:
         assert sc_param.override_values[0]['value'] is False
         assert sc_param.override_values[0]['match'] == 'domain=example.com'
 
-    @pytest.mark.tier1
     def test_negative_validate_matcher_and_default_value(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -393,7 +383,6 @@ class TestSmartClassParameters:
         )
 
     @pytest.mark.e2e
-    @pytest.mark.tier1
     def test_positive_create_and_remove_matcher_puppet_default_value(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -403,7 +392,6 @@ class TestSmartClassParameters:
         :id: 2b205e9c-e50c-48cd-8ebb-3b6bea09be77
 
         :steps:
-
             1. Set override to True.
             2. Set some default Value.
             3. Create matcher with valid attribute type, name and puppet
@@ -427,7 +415,6 @@ class TestSmartClassParameters:
         assert len(sc_param.read().override_values) == 0
 
     @pytest.mark.e2e
-    @pytest.mark.tier1
     def test_positive_enable_merge_overrides_default_checkboxes(self, module_puppet):
         """Enable Merge Overrides, Merge Default checkbox for supported types.
 
@@ -450,7 +437,6 @@ class TestSmartClassParameters:
         assert sc_param.merge_overrides is True
         assert sc_param.merge_default is True
 
-    @pytest.mark.tier1
     def test_negative_enable_merge_overrides_default_checkboxes(
         self, session_puppet_enabled_sat, module_puppet
     ):
@@ -484,7 +470,7 @@ class TestSmartClassParameters:
         assert sc_param.merge_overrides is False
         assert sc_param.merge_default is False
 
-    @pytest.mark.tier1
+    @pytest.mark.e2e
     def test_positive_enable_avoid_duplicates_checkbox(self, module_puppet):
         """Enable Avoid duplicates checkbox for supported type- array.
 
@@ -507,7 +493,6 @@ class TestSmartClassParameters:
         )
         assert sc_param.read().avoid_duplicates is True
 
-    @pytest.mark.tier1
     def test_negative_enable_avoid_duplicates_checkbox(self, module_puppet):
         """Disable Avoid duplicates checkbox for non supported types.
 
@@ -532,7 +517,7 @@ class TestSmartClassParameters:
         ) in context.value.response.text
         assert sc_param.read().avoid_duplicates is False
 
-    @pytest.mark.tier2
+    @pytest.mark.e2e
     def test_positive_impact_parameter_delete_attribute(
         self, session_puppet_enabled_sat, module_puppet
     ):

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -30,6 +30,83 @@ from robottelo.utils.datafactory import parametrized
 from robottelo.utils.datafactory import valid_environments_list
 
 
+@pytest.mark.e2e
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_CRUD_with_attributes(
+    session_puppet_enabled_sat, module_puppet_org, module_puppet_loc
+):
+    """Check if Environment with attributes can be created, updated and removed
+
+    :id: d2187971-86b2-40c9-a93c-66f37691ae2c
+
+    :BZ: 1337947
+
+    :expectedresults:
+        1. Environment is created and has parameters assigned
+        2. Environment can be listed by parameters
+        3. Environment can be updated
+        4. Environment can be removed
+    """
+    puppet_sat = session_puppet_enabled_sat
+    # Create with attributes
+    env_name = gen_string('alpha')
+    environment = puppet_sat.api.Environment(
+        name=env_name, organization=[module_puppet_org], location=[module_puppet_loc]
+    ).create()
+    assert env_name == environment.name
+    assert len(environment.organization) == 1
+    assert environment.organization[0].id == module_puppet_org.id
+    assert len(environment.location) == 1
+    assert environment.location[0].id == module_puppet_loc.id
+
+    # List by name
+    envs = puppet_sat.api.Environment().search(query=dict(search=f'name={env_name}'))
+    assert len(envs) == 1
+    assert envs[0].name == env_name
+
+    # List by org loc id
+    envs = puppet_sat.api.Environment().search(
+        query=dict(
+            search=f'organization_id={module_puppet_org.id} and location_id={module_puppet_loc.id}'
+        )
+    )
+    assert env_name in [res.name for res in envs]
+
+    # List by org loc name
+    envs = puppet_sat.api.Environment().search(
+        query=dict(
+            search=f'organization={module_puppet_org.name} and location={module_puppet_loc.name}'
+        )
+    )
+    assert env_name in [res.name for res in envs]
+
+    # Update org and loc
+    new_org = puppet_sat.api.Organization().create()
+    new_loc = puppet_sat.api.Location().create()
+    env = puppet_sat.api.Environment(id=environment.id, organization=[new_org]).update(
+        ['organization']
+    )
+    assert len(env.organization) == 1
+    assert env.organization[0].id == new_org.id
+    assert env.organization[0].id != module_puppet_org.id
+
+    env = puppet_sat.api.Environment(id=environment.id, location=[new_loc]).update(['location'])
+    assert len(env.location) == 1
+    assert env.location[0].id == new_loc.id
+    assert env.location[0].id != module_puppet_loc.id
+
+    # Update name
+    new_env_name = gen_string('alpha')
+    env = puppet_sat.api.Environment(id=environment.id, name=new_env_name).update(['name'])
+    assert env.name == new_env_name
+
+    # Delete
+    environment.delete()
+    with pytest.raises(HTTPError):
+        environment.read()
+
+
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_environments_list()))
 def test_positive_create_with_name(name, session_puppet_enabled_sat):
@@ -43,27 +120,6 @@ def test_positive_create_with_name(name, session_puppet_enabled_sat):
     """
     env = session_puppet_enabled_sat.api.Environment(name=name).create()
     assert env.name == name
-
-
-@pytest.mark.tier1
-def test_positive_create_with_org_and_loc(
-    module_puppet_org, module_puppet_loc, session_puppet_enabled_sat
-):
-    """Create an environment and assign it to new organization.
-
-    :id: de7e4132-5ca7-4b41-9af3-df075d31f8f4
-
-    :expectedresults: The environment created successfully and has expected attributes.
-    """
-    env = session_puppet_enabled_sat.api.Environment(
-        name=gen_string('alphanumeric'),
-        organization=[module_puppet_org],
-        location=[module_puppet_loc],
-    ).create()
-    assert len(env.organization) == 1
-    assert env.organization[0].id == module_puppet_org.id
-    assert len(env.location) == 1
-    assert env.location[0].id == module_puppet_loc.id
 
 
 @pytest.mark.tier1
@@ -112,39 +168,6 @@ def test_positive_update_name(module_puppet_environment, new_name, session_puppe
         id=module_puppet_environment.id, name=new_name
     ).update(['name'])
     assert env.name == new_name
-
-
-@pytest.mark.tier2
-def test_positive_update_and_remove(
-    module_puppet_org, module_puppet_loc, session_puppet_enabled_sat
-):
-    """Update environment and assign it to a new organization
-    and location. Delete environment afterwards.
-
-    :id: 31e43faa-65ee-4757-ac3d-3825eba37ae5
-
-    :expectedresults: Environment entity is updated and removed properly
-
-    :CaseLevel: Integration
-    """
-    env = session_puppet_enabled_sat.api.Environment().create()
-    assert len(env.organization) == 0
-    assert len(env.location) == 0
-    env = session_puppet_enabled_sat.api.Environment(
-        id=env.id, organization=[module_puppet_org]
-    ).update(['organization'])
-    assert len(env.organization) == 1
-    assert env.organization[0].id, module_puppet_org.id
-
-    env = session_puppet_enabled_sat.api.Environment(
-        id=env.id, location=[module_puppet_loc]
-    ).update(['location'])
-    assert len(env.location) == 1
-    assert env.location[0].id == module_puppet_loc.id
-
-    env.delete()
-    with pytest.raises(HTTPError):
-        env.read()
 
 
 @pytest.mark.tier1

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -84,21 +84,16 @@ def test_positive_CRUD_with_attributes(
     # Update org and loc
     new_org = puppet_sat.api.Organization().create()
     new_loc = puppet_sat.api.Location().create()
-    env = puppet_sat.api.Environment(id=environment.id, organization=[new_org]).update(
-        ['organization']
-    )
+    new_env_name = gen_string('alpha')
+    env = puppet_sat.api.Environment(
+        id=environment.id, name=new_env_name, organization=[new_org], location=[new_loc]
+    ).update(['name', 'organization', 'location'])
     assert len(env.organization) == 1
     assert env.organization[0].id == new_org.id
     assert env.organization[0].id != module_puppet_org.id
-
-    env = puppet_sat.api.Environment(id=environment.id, location=[new_loc]).update(['location'])
     assert len(env.location) == 1
     assert env.location[0].id == new_loc.id
     assert env.location[0].id != module_puppet_loc.id
-
-    # Update name
-    new_env_name = gen_string('alpha')
-    env = puppet_sat.api.Environment(id=environment.id, name=new_env_name).update(['name'])
     assert env.name == new_env_name
 
     # Delete

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -59,15 +59,16 @@ def module_sc_params(session_puppet_enabled_sat, module_puppet):
     return {'list': sc_params_list, 'ids': sc_params_ids_list}
 
 
+@pytest.mark.tier1
+@pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
-@pytest.mark.e2e
 @pytest.mark.skipif(
     not settings.robottelo.REPOS_HOSTING_URL, reason="repos_hosting_url is not defined"
 )
 class TestSmartClassParameters:
     """Implements Smart Class Parameter tests in CLI"""
 
-    @pytest.mark.tier1
+    @pytest.mark.e2e
     def test_positive_list(
         self,
         session_puppet_enabled_sat,
@@ -127,7 +128,6 @@ class TestSmartClassParameters:
                 {scp['id'] for scp in sc_params}
             ), f'Not only unique results returned for query: {query}'
 
-    @pytest.mark.tier1
     def test_positive_list_with_non_admin_user(self, session_puppet_enabled_sat, module_puppet):
         """List all the parameters for specific puppet class by id.
 
@@ -166,8 +166,7 @@ class TestSmartClassParameters:
         # Check that only unique results are returned
         assert len(sc_params) == len({scp['id'] for scp in sc_params})
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
+    @pytest.mark.e2e
     def test_positive_override(self, session_puppet_enabled_sat, module_puppet, module_sc_params):
         """Override the Default Parameter value.
 
@@ -197,14 +196,12 @@ class TestSmartClassParameters:
         assert sc_param['default-value'] == value
         assert sc_param['omit'] is True
 
-    @pytest.mark.tier1
     def test_negative_override(self, session_puppet_enabled_sat, module_sc_params):
         """Override the Default Parameter value - override Unchecked.
 
         :id: eb24c44d-0e34-40a3-aa3e-05a3cd4ed1ea
 
         :steps:
-
             1.  Don't override the parameter.
             2.  Set the new valid Default Value.
             3.  Attempt to submit the changes.
@@ -221,7 +218,6 @@ class TestSmartClassParameters:
                 {'default-value': gen_string('alpha'), 'id': sc_param_id}
             )
 
-    @pytest.mark.tier1
     def test_negative_validate_default_value_with_list(
         self, session_puppet_enabled_sat, module_puppet, module_sc_params
     ):
@@ -257,7 +253,7 @@ class TestSmartClassParameters:
         )
         assert sc_param['default-value'] != value
 
-    @pytest.mark.tier1
+    @pytest.mark.e2e
     def test_positive_validate_default_value_with_list(
         self, session_puppet_enabled_sat, module_puppet, module_sc_params
     ):
@@ -296,7 +292,6 @@ class TestSmartClassParameters:
         assert sc_param['validator']['type'] == 'list'
         assert sc_param['validator']['rule'] == '5, test'
 
-    @pytest.mark.tier1
     def test_negative_validate_matcher_non_existing_attribute(
         self, session_puppet_enabled_sat, module_sc_params
     ):
@@ -322,8 +317,7 @@ class TestSmartClassParameters:
                 }
             )
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
+    @pytest.mark.e2e
     def test_positive_create_and_remove_matcher(
         self, session_puppet_enabled_sat, module_puppet, module_sc_params
     ):
@@ -332,7 +326,6 @@ class TestSmartClassParameters:
         :id: 37fe299b-1e81-4faf-b1c3-2edfc3d53dc1
 
         :steps:
-
             1.  Override the parameter.
             2.  Set some default Value.
             3.  Create a matcher with all valid values.
@@ -368,17 +361,15 @@ class TestSmartClassParameters:
         )
         assert len(sc_param['override-values']['values']) == 0
 
-    @pytest.mark.tier1
+    @pytest.mark.e2e
     def test_positive_create_matcher_puppet_default_value(
         self, session_puppet_enabled_sat, module_puppet, module_sc_params
     ):
-        """Create matcher for attribute in parameter,
-        Where Value is puppet default value.
+        """Create matcher for attribute in parameter, where Value is puppet default value
 
         :id: c08fcf25-e5c7-411e-beed-3741a24496fd
 
         :steps:
-
             1.  Override the parameter.
             2.  Set some default Value.
             3.  Create matcher with valid attribute type, name and puppet
@@ -399,8 +390,7 @@ class TestSmartClassParameters:
         )
         assert sc_param['override-values']['values']['1']['match'] == 'domain=test.com'
 
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
+    @pytest.mark.e2e
     def test_positive_test_hidden_parameter_value(
         self, session_puppet_enabled_sat, module_puppet, module_sc_params
     ):
@@ -409,7 +399,6 @@ class TestSmartClassParameters:
         :id: 3daf662f-a0dd-469c-8088-262bfaa5246a
 
         :steps:
-
             1. Set the override flag for the parameter.
             2. Set some valid default value.
             3. Set 'Hidden Value' to true and submit.

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -22,8 +22,6 @@ import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
 
-pytestmark = pytest.mark.e2e
-
 
 @pytest.fixture(scope='module')
 def run_puppet_agent(session_puppet_enabled_sat):
@@ -34,13 +32,14 @@ def run_puppet_agent(session_puppet_enabled_sat):
     session_puppet_enabled_sat.execute('puppet agent -t')
 
 
+@pytest.mark.e2e
 @pytest.mark.tier1
-def test_positive_info(run_puppet_agent, session_puppet_enabled_sat):
-    """Test Info for Puppet report
+def test_positive_CRD_satellite(run_puppet_agent, session_puppet_enabled_sat):
+    """Test puppet-agent creates a report for satellite when its run, read and delete by its ID
 
     :id: 32646d4b-7101-421a-85e0-777d3c6b71ec
 
-    :expectedresults: Puppet Report Info is displayed
+    :expectedresults: Puppet reports are generated, readable, and deleteable
     """
     result = session_puppet_enabled_sat.cli.ConfigReport.list()
     assert len(result) > 0
@@ -48,21 +47,7 @@ def test_positive_info(run_puppet_agent, session_puppet_enabled_sat):
     report = random.choice(result)
     result = session_puppet_enabled_sat.cli.ConfigReport.info({'id': report['id']})
     assert report['id'] == result['id']
-
-
-@pytest.mark.tier1
-@pytest.mark.upgrade
-def test_positive_delete_by_id(run_puppet_agent, session_puppet_enabled_sat):
-    """Check if Puppet Report can be deleted by its ID
-
-    :id: bf918ec9-e2d4-45d0-b913-ab939b5d5e6a
-
-    :expectedresults: Puppet Report is deleted
-    """
-    result = session_puppet_enabled_sat.cli.ConfigReport.list()
-    assert len(result) > 0
-    # Grab a random report
-    report = random.choice(result)
+    # Delete ConfigReport by its ID
     session_puppet_enabled_sat.cli.ConfigReport.delete({'id': report['id']})
     with pytest.raises(CLIReturnCodeError):
         session_puppet_enabled_sat.cli.ConfigReport.info({'id': report['id']})
@@ -70,7 +55,7 @@ def test_positive_delete_by_id(run_puppet_agent, session_puppet_enabled_sat):
 
 @pytest.mark.e2e
 @pytest.mark.rhel_ver_match('[^6]')
-def test_positive_install_configure(
+def test_positive_install_configure_host(
     session_puppet_enabled_sat, session_puppet_enabled_capsule, content_hosts
 ):
     """Test that puppet-agent can be installed from the sat-client repo


### PR DESCRIPTION
Currently, there are 45+ tests running for Puppet so to make that count less and for effective stream testing for Puppet.
1. Combined ConfigReport info and delete tests into a single CRD test
2. Add e2e test in api/test_environment.py similar to cli
3. Mark tests e2e instead of class to avoid -ve tests in smart class parameters test modules.