### PR TITLE
Hosts: use current Sat. host Organization and location

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -21,6 +21,20 @@ def default_location(session_target_sat):
 
 
 @pytest.fixture
+def current_sat_org(target_sat):
+    """Return the current organization assigned to the Satellite host"""
+    sat_host = target_sat.api.Host().search(query={'search': f'name={target_sat.hostname}'})[0]
+    return sat_host.organization.read().name
+
+
+@pytest.fixture
+def current_sat_location(target_sat):
+    """Return the current location assigned to the Satellite host"""
+    sat_host = target_sat.api.Host().search(query={'search': f'name={target_sat.hostname}'})[0]
+    return sat_host.location.read().name
+
+
+@pytest.fixture
 def function_org(target_sat):
     return target_sat.api.Organization().create()
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -34,7 +34,6 @@ from robottelo.config import settings
 from robottelo.constants import ANY_CONTEXT
 from robottelo.constants import DEFAULT_CV
 from robottelo.constants import DEFAULT_LOC
-from robottelo.constants import DEFAULT_ORG
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 from robottelo.constants import ENVIRONMENT
 from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
@@ -1944,7 +1943,7 @@ def test_rex_new_ui(session, target_sat, rex_contenthost):
 
 
 @pytest.mark.tier4
-def test_positive_manage_table_columns(session):
+def test_positive_manage_table_columns(session, current_sat_org, current_sat_location):
     """Set custom columns of the hosts table.
 
     :id: e5e18982-cc43-11ed-8562-000c2989e153
@@ -1975,8 +1974,8 @@ def test_positive_manage_table_columns(session):
         'Recommendations': False,
     }
     with session:
-        session.organization.select(org_name=DEFAULT_ORG)
-        session.location.select(loc_name=DEFAULT_LOC)
+        session.organization.select(org_name=current_sat_org)
+        session.location.select(loc_name=current_sat_location)
         session.host.manage_table_columns(columns)
         displayed_columns = session.host.get_displayed_table_headers()
         for column, is_displayed in columns.items():
@@ -1984,7 +1983,9 @@ def test_positive_manage_table_columns(session):
 
 
 @pytest.mark.tier4
-def test_positive_host_details_read_templates(session, target_sat):
+def test_positive_host_details_read_templates(
+    session, target_sat, current_sat_org, current_sat_location
+):
     """Check if all assigned host provisioning templates are correctly reported
     in host detail / Details tab / Provisioning templates card.
 
@@ -2003,8 +2004,8 @@ def test_positive_host_details_read_templates(session, target_sat):
     host = target_sat.api.Host().search(query={'search': f'name={target_sat.hostname}'})[0]
     api_templates = [template['name'] for template in host.list_provisioning_templates()]
     with session:
-        session.organization.select(org_name=DEFAULT_ORG)
-        session.location.select(loc_name=DEFAULT_LOC)
+        session.organization.select(org_name=current_sat_org)
+        session.location.select(loc_name=current_sat_location)
         host_detail = session.host_new.get_details(target_sat.hostname, widget_names='details')
         ui_templates = [
             row['column1'].strip()


### PR DESCRIPTION
UI tests that use the Satellite host now switch to the actual org. and location.

Don't assume that Satellite host is always in the Default Organization and Default Location.
