### PR TITLE
[6.13.z] changed string type to utf8

### DIFF
--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -113,7 +113,7 @@ class TestTailoringFiles:
 
         :CaseImportance: Medium
         """
-        name = gen_string('alphanumeric')
+        name = gen_string('utf8', length=5)
         make_tailoringfile({'name': name, 'scap-file': tailoring_file_path['satellite']})
         result = TailoringFiles.list()
         assert name in [tailoringfile['name'] for tailoringfile in result]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11305

- test `test_positive_list_tailoring_file` was failing due to the error `Skipping data chunk due to 'utf-8' codec can't decode byte`
- by changing string_type of tailing file, it is expected to read strings