### PR TITLE
[6.13.z] Add e2e markers for tests, and update 2 tests to use Katello-tracer

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1539,6 +1539,7 @@ class TestHostBulkAction:
 class TestHostTraces:
     """Tests for host tracer"""
 
+    @pytest.mark.e2e
     @pytest.mark.tier4
     @pytest.mark.rhel_ver_match('[^6].*')
     def test_positive_tracer_list_and_resolve(self, tracer_host):
@@ -1556,6 +1557,8 @@ class TestHostTraces:
         :parametrized: yes
 
         :CaseImportance: Medium
+
+        :CaseComponent: Katello-tracer
         """
         host = tracer_host.nailgun_host
         package = settings.repos["MOCK_SERVICE_RPM"]

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2485,6 +2485,8 @@ def test_positive_tracer_list_and_resolve(tracer_host):
     :parametrized: yes
 
     :CaseImportance: Medium
+
+    :CaseComponent: Katello-tracer
     """
     client = tracer_host
     package = settings.repos["MOCK_SERVICE_RPM"]

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -106,6 +106,7 @@ def run_remote_command_on_content_host(command, vm_module_streams):
     return result
 
 
+@pytest.mark.e2e
 @pytest.mark.tier3
 @pytest.mark.parametrize(
     'module_repos_collection_with_manifest',

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -95,6 +95,7 @@ def test_positive_add_custom_content(session):
         assert cv['repositories']['resources']['assigned'][0]['Name'] == repo_name
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, target_sat):

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -189,6 +189,7 @@ def test_positive_search_scoped(session, request, target_sat):
         assert name not in session.syncplan.search('enabled = false')
 
 
+@pytest.mark.e2e
 @pytest.mark.tier3
 def test_positive_synchronize_custom_product_custom_cron_real_time(session, module_org, target_sat):
     """Create a sync plan with real datetime as a sync date,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11294

Marking up several components for e2e, as well as updating two tests to use Katello-tracer component.

I realize that there are 2 UI tests here, and we are primarily considering API/CLI tests for e2e status, but in one case (ContentHosts) there are no other tests in robottelo aside from UI. In the other case (SyncPlans), it's by far the best, most "end-to-end" test that exists, and it's fairly extensive. 

I'd argue for the inclusion of both of these. 