### PR TITLE
[6.11.z] Requirements updates Assist and auto updates

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -18,6 +18,7 @@ pytest_plugins = [
     'pytest_plugins.fspath_plugins',
     'pytest_plugins.fixture_collection',
     'pytest_plugins.factory_collection',
+    'pytest_plugins.requirements.update_requirements',
     # Fixtures
     'pytest_fixtures.core.broker',
     'pytest_fixtures.core.sat_cap_factory',

--- a/pytest_plugins/requirements/req_updater.py
+++ b/pytest_plugins/requirements/req_updater.py
@@ -1,0 +1,70 @@
+import subprocess
+from functools import cached_property
+
+
+class ReqUpdater:
+
+    # Installed package name as key and its counterpart in requirements file as value
+    package_deviates = {
+        'Betelgeuse': 'betelgeuse',
+        'broker': 'broker[docker]',
+        'dynaconf': 'dynaconf[vault]',
+    }
+
+    @cached_property
+    def installed_packages(self):
+        """Returns the list of installed packages in venv
+
+        This also normalizes any package names that deviates in requirements file vs installed names
+        """
+        installed_pkges = subprocess.run(
+            'pip list --format=freeze', capture_output=True, shell=True
+        ).stdout.decode()
+        for pkg in self.package_deviates:
+            if pkg in installed_pkges:
+                # Replacing the installed package names with their names in requirements file
+                installed_pkges = installed_pkges.replace(pkg, self.package_deviates[pkg])
+        return installed_pkges.splitlines()
+
+    def package_filter(self, package):
+        """Filter for eliminating lines which are not requirements from files"""
+        discard_list = ('#', 'git', '--')
+        return not package.startswith(discard_list)
+
+    @cached_property
+    def requirements_packages(self):
+        """Returns list of requirements from requirements file"""
+        with open('requirements.txt') as reqf:
+            req_packages = [line.strip() for line in reqf.readlines() if line.strip()]
+        return list(filter(self.package_filter, req_packages))
+
+    @cached_property
+    def optional_packages(self):
+        """Returns list of requirements from requirements-optional file"""
+        with open('requirements-optional.txt') as reqo:
+            opt_packages = [line.strip() for line in reqo.readlines() if line.strip()]
+        return list(filter(self.package_filter, opt_packages))
+
+    @cached_property
+    def req_deviation(self):
+        """Returns new and updates available packages in requirements file"""
+        return set(self.requirements_packages).difference(self.installed_packages)
+
+    @cached_property
+    def opt_deviation(self):
+        """Returns new and updates available packages in requirements-optional file"""
+        return set(self.optional_packages).difference(self.installed_packages)
+
+    def install_req_deviations(self):
+        """Installs new and updates available packages in requirements file"""
+        if self.req_deviation:
+            subprocess.run(
+                f"pip install {' '.join(self.req_deviation)}", shell=True, stdout=subprocess.PIPE
+            )
+
+    def install_opt_deviations(self):
+        """Installs new and updates available packages in requirements-optional file"""
+        if self.opt_deviation:
+            subprocess.run(
+                f"pip install {' '.join(self.opt_deviation)}", shell=True, stdout=subprocess.PIPE
+            )

--- a/pytest_plugins/requirements/update_requirements.py
+++ b/pytest_plugins/requirements/update_requirements.py
@@ -1,0 +1,47 @@
+"""Plugin enables pytest to notify and update the requirements"""
+from .req_updater import ReqUpdater
+from robottelo.constants import Colored
+
+updater = ReqUpdater()
+
+
+def pytest_addoption(parser):
+    """Options to allow user to update the requirements"""
+    update_options = {
+        '--update-required-reqs': 'Install mandatory requirements from requirements.txt',
+        '--update-all-reqs': 'Install optional requirements from requirements-optional.txt',
+    }
+    for opt, help_text in update_options.items():
+        parser.addoption(opt, action='store_true', default=False, help=help_text)
+
+
+def pytest_report_header(config):
+    """
+    Adds a suggestion of requirements updates in to the Pytest Report Header
+
+    It also updates the requirements if pytest options are provided,
+    e.g:
+
+    # Following will update the mandatory requirements
+    # pytest tests/foreman --collect-only --upgrade-required-reqs
+
+    # Following will update the mandatory and optional requirements
+    # pytest tests/foreman --collect-only --upgrade-all-reqs
+    """
+    if updater.req_deviation:
+        print(
+            f"{Colored.REDLIGHT}Mandatory Requirements Available: "
+            f"{' '.join(updater.req_deviation)}{Colored.RESET}"
+        )
+        if config.getoption('update_required_reqs') or config.getoption('update_all_reqs'):
+            print('Updating the mandatory requirements on demand ....')
+            updater.install_req_deviations()
+
+    if updater.opt_deviation:
+        print(
+            f"{Colored.REDLIGHT}Optional Requirements Available: "
+            f"{' '.join(updater.opt_deviation)}{Colored.RESET}"
+        )
+        if config.getoption('update_all_reqs'):
+            print('Updating the optional requirements on demand ....')
+            updater.install_opt_deviations()

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,7 +4,6 @@ pytest-cov==3.0.0
 redis==4.5.4
 pre-commit==3.2.2
 
-
 # For generating documentation.
 sphinx==6.1.3
 sphinx-autoapi==2.1.0

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -12,6 +12,7 @@ class Colored(Box):
     REDDARK = '\033[1;31m'
     GREEN = '\033[1;32m'
     WHITELIGHT = '\033[1;30m'
+    RESET = '\033[0m'
 
 
 # This should be updated after each version branch


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11320

**Here Comes the Wonder** -

Problem Statement:
--------------------

Imagine you have been running test locally 100 times but failing but the same test is passing in CI or lets say vice-versa. Have been in that situation right? The main reason behind that could be the environmental changes especially requirements differences.

Realizing you had to update the requirement after retesting the tests 1000 times (not literally :P) is really annoying, we wish we would somehow know that we have to update the requirements like that we have in production would be really helpfull.

Solution:
----------

Introducing a pytest plugin to assist/notify you on requirements updates on pytest command that:
- Shows you the availble mandatory and optional requirements available to update AND
- Run the following commands to update those requirements during the pytest session itself
  - Update mandatory requirements only
  `# pytest tests/foreman/ --update-required-reqs`
  - Update mandatory as well as optional requirements
  `# pytest tests/foreman/ --update-all-reqs`


Demonstration:
----------------

```
✗) pytest -s --collect-only tests/foreman/api/test_docker.py
```
<img width="1147" alt="Screenshot 2023-04-21 at 10 11 47 PM" src="https://user-images.githubusercontent.com/11752425/233690152-a3aa242b-81bc-44ec-a4d7-79aff61094ac.png">
