### PR TITLE
Refactor logging

### DIFF
--- a/pytest_fixtures/component/katello_certs_check.py
+++ b/pytest_fixtures/component/katello_certs_check.py
@@ -2,7 +2,7 @@
 from pathlib import Path
 
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 
 from robottelo.constants import CERT_DATA as cert_data

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -5,7 +5,7 @@ from tempfile import mkstemp
 
 import pytest
 from box import Box
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 from packaging.version import Version
 

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -1,5 +1,5 @@
 import pytest
-from broker import Broker
+from broker.broker import Broker
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -2,7 +2,7 @@ from contextlib import contextmanager
 
 import pytest
 from box import Box
-from broker import Broker
+from broker.broker import Broker
 from wait_for import wait_for
 
 from robottelo.config import settings

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -5,7 +5,7 @@ The functions in this module are read in the pytest_plugins/fixture_markers.py m
 All functions in this module will be treated as fixtures that apply the contenthost mark
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 
 from robottelo import constants
 from robottelo.config import settings

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -1,5 +1,5 @@
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from wait_for import wait_for
 
 from pytest_fixtures.component.satellite_auth import disenroll_idm

--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -4,6 +4,7 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.hosts import SatelliteHostError
+from robottelo.logging import logger
 
 
 @pytest.fixture
@@ -24,6 +25,7 @@ def allow_repo_discovery(target_sat):
 @pytest.fixture(autouse=True, scope="session")
 def relax_bfa(session_target_sat):
     """Relax BFA protection against failed login attempts"""
+    logger.info('xxx inside relax_bfa fixture body')
     if session_target_sat:
         session_target_sat.cli.Settings.set({'name': 'failed_login_attempts_limit', 'value': '0'})
 

--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -2,7 +2,7 @@
 import random
 
 import pytest
-from broker import Broker
+from broker.broker import Broker
 
 from robottelo.config import configure_airgun
 from robottelo.config import configure_nailgun

--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -1,6 +1,4 @@
 import logging
-import logzero
-import pytest
 from xdist import is_xdist_worker, get_xdist_worker_id
 
 from robottelo.logging import logger

--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -1,15 +1,11 @@
 import logging
-
 import logzero
 import pytest
-from xdist import is_xdist_worker
+from xdist import is_xdist_worker, get_xdist_worker_id
 
-from robottelo.logging import broker_log_setup
-from robottelo.logging import DEFAULT_DATE_FORMAT
 from robottelo.logging import logger
-from robottelo.logging import logging_yaml
+from robottelo.logging import defaultFormatter
 from robottelo.logging import robottelo_log_dir
-from robottelo.logging import robottelo_log_file
 
 try:
     from pytest_reportportal import RPLogger
@@ -18,58 +14,49 @@ except ImportError:
     pass
 
 
-@pytest.fixture(autouse=True, scope='session')
-def configure_logging(request, worker_id):
-    """Handle xdist and ReportPortal logging configuration at session start
+def pytest_fixture_setup(fixturedef, request):
+    if fixturedef.argname == 'worker_id':
+        return
+    worker_id = request.getfixturevalue('worker_id')
 
-    Set up a separate logger for each pytest-xdist worker
-    if worker_id != 'master' then xdist is running in multi-threading so
-    a logfile named 'robottelo_gw{worker_id}.log' will be created.
+    if request.node.nodeid:
+        log_file_name = request.node.nodeid.replace('/', '.')
+    elif request.scope == 'session':
+        log_file_name = 'session'
+    # remove other fixture or test handlers
+    handlers_to_remove = [
+        h for h in logger.handlers if h.name == 'fixture' or h.name == 'test'
+    ]
+    logger.debug(f'fixture_setup - removing handlers: {handlers_to_remove}')
+    for handler in handlers_to_remove:
+        logger.removeHandler(handler)
 
-    Add a handler for ReportPortal logging
-    """
-    worker_formatter = logzero.LogFormatter(
-        fmt=f'%(asctime)s - {worker_id} - %(name)s - %(levelname)s - %(message)s',
-        datefmt=DEFAULT_DATE_FORMAT,
+    log_handler = logging.FileHandler(
+        robottelo_log_dir.joinpath(f'fixture__{worker_id}__{log_file_name}.log')
     )
-    use_rp_logger = hasattr(request.node.config, 'py_test_service')
-    if use_rp_logger:
-        logging.setLoggerClass(RPLogger)
-
-    if is_xdist_worker(request):
-        if f'{worker_id}' not in [h.get_name() for h in logger.handlers]:
-            # Track the core logger's file handler level, set it in case core logger wasn't set
-            worker_log_level = 'INFO'
-            handlers_to_remove = [
-                h
-                for h in logger.handlers
-                if isinstance(h, logging.FileHandler)
-                and getattr(h, 'baseFilename', None) == str(robottelo_log_file)
-            ]
-            for handler in handlers_to_remove:
-                logger.removeHandler(handler)
-                worker_log_level = handler.level
-            worker_handler = logging.FileHandler(
-                robottelo_log_dir.joinpath(f'robottelo_{worker_id}.log')
-            )
-            worker_handler.set_name(f'{worker_id}')
-            worker_handler.setFormatter(worker_formatter)
-            worker_handler.setLevel(worker_log_level)
-            logger.addHandler(worker_handler)
-            broker_log_setup(
-                level=logging_yaml.broker.level,
-                file_level=logging_yaml.broker.fileLevel,
-                path=robottelo_log_dir.joinpath(f'robottelo_{worker_id}.log'),
-            )
-
-            if use_rp_logger:
-                rp_handler = RPLogHandler(request.node.config.py_test_service)
-                rp_handler.setFormatter(worker_formatter)
-                # logger.addHandler(rp_handler)
+    log_handler.name = 'fixture'
+    log_handler.setFormatter(defaultFormatter)
+    logger.addHandler(log_handler)
+    logger.info(f'Started Fixture: {request.fixturename}')
 
 
-def pytest_runtest_logstart(nodeid, location):
-    logger.info(f'Started Test: {nodeid}')
+def pytest_runtest_call(item):
+    handlers_to_remove = [
+        h for h in logger.handlers if h.name == 'fixture' or h.name == 'test'
+    ]
+    logger.debug(f'runtest_setup - attached handlers: {logger.handlers}')
+    logger.debug(f'runtest_setup - removing handlers: {handlers_to_remove}')
+    for handler in handlers_to_remove:
+        logger.removeHandler(handler)
+
+    log_handler = logging.FileHandler(
+        robottelo_log_dir.joinpath(f'test__{get_xdist_worker_id(item)}__{item.nodeid.replace("/", ".")}.log')
+    )
+    log_handler.name = 'test'
+    log_handler.setFormatter(defaultFormatter)
+    logger.addHandler(log_handler)
+    logger.info(f'Started Test: {item.nodeid}')
+    item.session.logger = logger
 
 
 def pytest_runtest_logfinish(nodeid, location):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -16,7 +16,7 @@ from urllib.parse import urlunsplit
 
 import requests
 from box import Box
-from broker import Broker
+from broker.broker import Broker
 from broker.hosts import Host
 from dynaconf.vendor.box.exceptions import BoxKeyError
 from fauxfactory import gen_alpha

--- a/robottelo/logging.py
+++ b/robottelo/logging.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import logzero
 import yaml
 from box import Box
-from broker.logger import setup_logzero as broker_log_setup
+from broker.logger import setup_logger as broker_log_setup
 from manifester.logger import setup_logzero as manifester_log_setup
 
 
@@ -24,10 +24,11 @@ defaultFormatter = logzero.LogFormatter(
 )
 
 logger = logzero.setup_logger(
+    name='robottelo',
     level=logging_yaml.robottelo.level,
     logfile=str(robottelo_log_file),
     fileLoglevel=logging_yaml.robottelo.fileLevel,
-    isRootLogger=True,
+    isRootLogger=False,
     formatter=defaultFormatter,
     maxBytes=1e8,  # 100MB
     backupCount=3,
@@ -58,18 +59,21 @@ def configure_third_party_logging():
 
 
 configure_third_party_logging()
+
 broker_log_setup(
+    name='robottelo.broker',
     level=logging_yaml.robottelo.level,
     file_level=logging_yaml.robottelo.fileLevel,
-    path=str(robottelo_log_file),
+    formatter=defaultFormatter,
+    propagate=True,
 )
-manifester_log_setup(logging_yaml.robottelo.fileLevel, str(robottelo_log_file))
+
+#manifester_log_setup(logging_yaml.robottelo.fileLevel, str(robottelo_log_file))
 
 
 collection_logger = logzero.setup_logger(
     name='robottelo.collection',
     level=logging_yaml.collection.level,
-    logfile=str(robottelo_log_file),
     fileLoglevel=logging_yaml.collection.fileLevel,
     formatter=defaultFormatter,
 )

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -20,7 +20,7 @@ from random import choice
 from random import randint
 
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from nailgun import entities
 from requests.exceptions import HTTPError
 

--- a/tests/foreman/api/test_ping.py
+++ b/tests/foreman/api/test_ping.py
@@ -19,7 +19,7 @@
 import pytest
 
 pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
-
+from robottelo.logging import logger
 
 @pytest.mark.e2e
 @pytest.mark.build_sanity
@@ -30,6 +30,7 @@ def test_positive_ping(target_sat):
 
     :expectedresults: Overall and individual services status should be 'ok'.
     """
+    logger.info("xxx inside test body")
     response = target_sat.api.Ping().search_json()
     assert response['status'] == 'ok'  # overall status
 

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -17,7 +17,7 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
 from requests import HTTPError

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -20,7 +20,7 @@ import re
 from random import choice
 
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_string
 

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -22,7 +22,7 @@ from datetime import timedelta
 from operator import itemgetter
 
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
 

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -17,7 +17,7 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 
 from robottelo.cli.activationkey import ActivationKey

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -21,7 +21,7 @@ from datetime import timedelta
 from time import sleep
 
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
 from wait_for import wait_for

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -16,7 +16,7 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_alpha
 
 from robottelo.cli.activationkey import ActivationKey

--- a/tests/foreman/cli/test_rhcloud_insights.py
+++ b/tests/foreman/cli/test_rhcloud_insights.py
@@ -17,7 +17,7 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 
 from robottelo.hosts import ContentHost
 

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -17,7 +17,7 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 
 from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.config import settings

--- a/tests/foreman/destructive/test_leapp_satellite.py
+++ b/tests/foreman/destructive/test_leapp_satellite.py
@@ -15,7 +15,7 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 
 from robottelo.hosts import get_sat_rhel_version
 from robottelo.hosts import get_sat_version

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -17,7 +17,7 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -20,7 +20,7 @@ import random
 
 import pytest
 from airgun.session import Session
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
 

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -18,7 +18,7 @@
 """
 import pytest
 from airgun.session import Session
-from broker import Broker
+from broker.broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
 

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -19,7 +19,7 @@
 import time
 
 import pytest
-from broker import Broker
+from broker.broker import Broker
 from nailgun import entities
 
 from robottelo import constants

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -20,7 +20,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
 from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -17,7 +17,7 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
+from broker.broker import Broker
 
 from robottelo.config import settings
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME


### PR DESCRIPTION
The idea is to unify and add a proper structure to the logs.
- removal of `logzero` and relying purely on native `logging` library
- external lib loggers (broker, manifester) initialization, so they use the same handlers.
- introduction of logger hierarchy per module (adds structure to the logs)
- change file-logging strategy: each fixture and test uses its own log file (makes logging to external resources possible)