### PR TITLE
Auto Release Robottelo

### DIFF
--- a/.github/workflows/dispatch_release.yml
+++ b/.github/workflows/dispatch_release.yml
@@ -1,0 +1,31 @@
+### The auto release workflow triggered through dispatch request from CI
+name: auto-release
+
+# Run on workflow dispatch from CI
+on:
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        type: string
+        description: Name of the tag
+
+jobs:
+  auto-tag-and-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Git User setup
+        run: "git config --local user.email Satellite-QE.satqe.com && git config --local user.name Satellite-QE"
+
+      - name: Tag latest commit
+        run: "git tag -a ${{ github.event.inputs.tag_name }} -m 'Tagged By SatelliteQE Automation User'"
+
+      - name: Push the tag to the upstream
+        run: "git push ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}.git --tags"
+
+      - name: create a new release from the tag
+        env:
+          credentials: ${{ secrets.GH_TOKEN }}
+        run: "curl -L -X POST -H \"Authorization: Bearer ${{ secrets.SATQE_GH_TOKEN }}\" ${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/releases -d '{\"tag_name\": \"${{ github.event.inputs.tag_name }}\", \"target_commitish\":\"master\", \"name\":\"${{ github.event.inputs.tag_name }}\", \"draft\":false, \"prerelease\":true, \"generate_release_notes\": true}'"


### PR DESCRIPTION
Now, the release for changelogs will be tagged in this repo from the SatQE CI job.

How?
--------
1. Upon receiving UMB message for the new snap for a major downstream release in development, the CI job triggers.
2. The CI job sends an HTTP dispatch request to the `auto release` workflow in this repo (created in this PR)
3. Upon receiving the HTTP request, the workflow runs with new tag name and creates a new tag in the repo.
4. The same tag is then used to create a new release with automatic release notes.

So all the releases here would now be automatically created.