### PR TITLE
[6.14 RFE] Custom products disabled by default

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -112,7 +112,7 @@ def setup_content(module_org):
     ak = entities.ActivationKey(
         content_view=cv, max_hosts=100, organization=org, environment=lce, auto_attach=True
     ).create()
-    return ak, org
+    return ak, org, custom_repo
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -92,6 +92,30 @@ def repo_setup():
 
 
 @pytest.fixture(scope='module')
+def setup_content(module_org):
+    """This fixture is used to setup an activation key with a custom product attached. Used for
+    registering a host
+    """
+    org = module_org
+    custom_repo = entities.Repository(
+        product=entities.Product(organization=org).create(),
+    ).create()
+    custom_repo.sync()
+    lce = entities.LifecycleEnvironment(organization=org).create()
+    cv = entities.ContentView(
+        organization=org,
+        repository=[custom_repo.id],
+    ).create()
+    cv.publish()
+    cvv = cv.read().version[0].read()
+    cvv.promote(data={'environment_ids': lce.id, 'force': False})
+    ak = entities.ActivationKey(
+        content_view=cv, max_hosts=100, organization=org, environment=lce, auto_attach=True
+    ).create()
+    return ak, org
+
+
+@pytest.fixture(scope='module')
 def module_repository(os_path, module_product, module_target_sat):
     repo = module_target_sat.api.Repository(product=module_product, url=os_path).create()
     call_entity_method_with_timeout(module_target_sat.api.Repository(id=repo.id).sync, timeout=3600)

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -217,3 +217,30 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
         "The manifest doesn't exist on console.redhat.com. "
         "Please create and import a new manifest." in error.value.stderr
     )
+
+
+@pytest.mark.rhel_ver_list([7, 8, 9])
+@pytest.mark.tier3
+def test_positive_custom_repo_disabled_by_default(
+    setup_content,
+    rhel_contenthost,
+    target_sat,
+):
+    """Verify that custom products should be enabled by default for content hosts
+
+    :id: 84509bcc-3646-425e-905c-dbbe0325408c
+
+    :steps:
+        1. Create custom product and upload repository
+        2. Attach to activation key
+        3. Register Host
+        4. Assert that custom proudct is disabled by default
+
+    :expectedresults: Custom products should be disabled by default. "Enabled: 0"
+    """
+    ak, org = setup_content
+    rhel_contenthost.install_katello_ca(target_sat)
+    rhel_contenthost.register_contenthost(org.label, ak.name)
+    rhel_contenthost.add_rex_key(target_sat)
+    assert rhel_contenthost.subscribed
+

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -217,30 +217,3 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
         "The manifest doesn't exist on console.redhat.com. "
         "Please create and import a new manifest." in error.value.stderr
     )
-
-
-@pytest.mark.rhel_ver_list([7, 8, 9])
-@pytest.mark.tier3
-def test_positive_custom_repo_disabled_by_default(
-    setup_content,
-    rhel_contenthost,
-    target_sat,
-):
-    """Verify that custom products should be enabled by default for content hosts
-
-    :id: 84509bcc-3646-425e-905c-dbbe0325408c
-
-    :steps:
-        1. Create custom product and upload repository
-        2. Attach to activation key
-        3. Register Host
-        4. Assert that custom proudct is disabled by default
-
-    :expectedresults: Custom products should be disabled by default. "Enabled: 0"
-    """
-    ak, org = setup_content
-    rhel_contenthost.install_katello_ca(target_sat)
-    rhel_contenthost.register_contenthost(org.label, ak.name)
-    rhel_contenthost.add_rex_key(target_sat)
-    assert rhel_contenthost.subscribed
-

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -1,4 +1,4 @@
-"""Unit tests for the new ``repositories`` paths.
+"""Test module for Repositories CLI.
 
 :Requirement: Repository
 
@@ -22,6 +22,7 @@ import pytest
 @pytest.mark.rhel_ver_list([7, 8, 9])
 def test_positive_custom_products_disabled_by_default(
     setup_content,
+    default_location,
     rhel_contenthost,
     target_sat,
 ):
@@ -37,10 +38,9 @@ def test_positive_custom_products_disabled_by_default(
 
     :expectedresults: Custom products should be disabled by default. "Enabled: 0"
     """
-    ak, org = setup_content
+    ak, org, _ = setup_content
     client = rhel_contenthost
-    client.install_katello_ca(target_sat)
-    client.register_contenthost(org.label, ak.name)
+    client.register(org, default_location, ak.name, target_sat)
     assert client.subscribed
     product_details = rhel_contenthost.run('subscription-manager repos --list')
     assert "Enabled:   0" in product_details.stdout

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -26,7 +26,6 @@ def test_positive_custom_products_disabled_by_default(
     target_sat,
 ):
     """Verify that custom products should be disabled by default for content hosts
-    and activation keys
 
     :id: ba237e11-3b41-49e3-94b3-63e1f404d9e5
 

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -19,7 +19,7 @@
 import pytest
 
 
-@pytest.mark.rhel_ver_list([7, 8, 9])
+@pytest.mark.rhel_ver_match('[^6]')
 def test_positive_custom_products_disabled_by_default(
     setup_content,
     default_location,
@@ -37,10 +37,11 @@ def test_positive_custom_products_disabled_by_default(
         4. Assert that custom proudcts are disabled by default
 
     :expectedresults: Custom products should be disabled by default. "Enabled: 0"
+
+    :BZ: 1265120
     """
     ak, org, _ = setup_content
-    client = rhel_contenthost
-    client.register(org, default_location, ak.name, target_sat)
-    assert client.subscribed
+    rhel_contenthost.register(org, default_location, ak.name, target_sat)
+    assert rhel_contenthost.subscribed
     product_details = rhel_contenthost.run('subscription-manager repos --list')
     assert 'Enabled:   0' in product_details.stdout

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -43,4 +43,4 @@ def test_positive_custom_products_disabled_by_default(
     client.register(org, default_location, ak.name, target_sat)
     assert client.subscribed
     product_details = rhel_contenthost.run('subscription-manager repos --list')
-    assert "Enabled:   0" in product_details.stdout
+    assert 'Enabled:   0' in product_details.stdout

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -20,12 +20,13 @@ import pytest
 
 
 @pytest.mark.rhel_ver_list([7, 8, 9])
-def test_positive_custom_products_by_default(
+def test_positive_custom_products_disabled_by_default(
     setup_content,
     rhel_contenthost,
     target_sat,
 ):
-    """Verify that custom products should be enabled by default for content hosts
+    """Verify that custom products should be disabled by default for content hosts
+    and activation keys
 
     :id: ba237e11-3b41-49e3-94b3-63e1f404d9e5
 
@@ -33,7 +34,7 @@ def test_positive_custom_products_by_default(
         1. Create custom product and upload repository
         2. Attach to activation key
         3. Register Host
-        4. Assert that custom proudct is disabled by default
+        4. Assert that custom proudcts are disabled by default
 
     :expectedresults: Custom products should be disabled by default. "Enabled: 0"
     """

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -1,0 +1,46 @@
+"""Unit tests for the new ``repositories`` paths.
+
+:Requirement: Repository
+
+:CaseAutomation: Automated
+
+:CaseLevel: Component
+
+:CaseComponent: Repositories
+
+:team: Phoenix-content
+
+:TestType: Functional
+
+:CaseImportance: Critical
+
+:Upstream: No
+"""
+import pytest
+
+
+@pytest.mark.rhel_ver_list([7, 8, 9])
+def test_positive_custom_products_by_default(
+    setup_content,
+    rhel_contenthost,
+    target_sat,
+):
+    """Verify that custom products should be enabled by default for content hosts
+
+    :id: 05bdf790-a7a1-48b1-bbae-dc25b6ee7d58
+
+    :steps:
+        1. Create custom product and upload repository
+        2. Attach to activation key
+        3. Register Host
+        4. Assert that custom proudct is disabled by default
+
+    :expectedresults: Custom products should be disabled by default. "Enabled: 0"
+    """
+    ak, org = setup_content
+    client = rhel_contenthost
+    client.install_katello_ca(target_sat)
+    client.register_contenthost(org.label, ak.name)
+    assert client.subscribed
+    product_details = rhel_contenthost.run('subscription-manager repos --list')
+    assert "Enabled: 0" in product_details.stdout

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -28,6 +28,7 @@ def test_positive_custom_products_disabled_by_default(
     target_sat,
 ):
     """Verify that custom products should be disabled by default for content hosts
+    and activation keys
 
     :id: 05bdf790-a7a1-48b1-bbae-dc25b6ee7d58
 

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -41,11 +41,12 @@ def test_positive_custom_products_disabled_by_default(
     :expectedresults: Custom products should be disabled by default.
 
     :BZ: 1265120
+
+    :customerscenario: true
     """
     ak, org, custom_repo = setup_content
-    client = rhel_contenthost
-    client.register(org, default_location, ak.name, target_sat)
-    assert client.subscribed
+    rhel_contenthost.register(org, default_location, ak.name, target_sat)
+    assert rhel_contenthost.subscribed
     with session:
         session.organization.select(org.name)
         session.location.select(default_location.name)

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -1,4 +1,4 @@
-"""Unit tests for the new ``repositories`` paths.
+"""Test module for Repositories UI.
 
 :Requirement: Repository
 
@@ -19,7 +19,7 @@
 import pytest
 
 
-@pytest.mark.rhel_ver_list([7, 8, 9])
+@pytest.mark.rhel_ver_match('[^6]')
 def test_positive_custom_products_disabled_by_default(
     session,
     default_location,
@@ -42,8 +42,7 @@ def test_positive_custom_products_disabled_by_default(
     """
     ak, org, custom_repo = setup_content
     client = rhel_contenthost
-    client.install_katello_ca(target_sat)
-    client.register_contenthost(org.label, ak.name)
+    client.register(org, default_location, ak.name, target_sat)
     assert client.subscribed
     with session:
         session.organization.select(org.name)

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -55,6 +55,7 @@ def test_positive_custom_products_by_default(
         # host_details = session.contenthost.read(
         #     rhel_contenthost.hostname, widget_names=['repository_sets']
         # )
+        host_detail = session.host_new.get_details(target_sat.hostname, widget_names='content.repository_sets')
         ak_details = session.activationkey.read(ak.name, widget_names='repository sets')[
             'repository sets'
         ]['table'][0]

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -39,7 +39,7 @@ def test_positive_custom_products_by_default(
 
     :expectedresults: Custom products should be disabled by default. "Enabled: 0"
     """
-    ak, org = setup_content
+    ak, org, custom_repo = setup_content
     client = rhel_contenthost
     client.install_katello_ca(target_sat)
     client.register_contenthost(org.label, ak.name)
@@ -47,22 +47,13 @@ def test_positive_custom_products_by_default(
     with session:
         session.organization.select(org.name)
         session.location.select(default_location.name)
-        #assert session.contenthost.search(rhel_contenthost.hostname)[0]['Name'] == rhel_contenthost.hostname
-        # chost = session.contenthost.read(
-        #     rhel_contenthost.hostname, widget_names=['details', 'provisioning_details', 'subscriptions']
-        # )
-        # session.contenthost.update(rhel_contenthost.hostname, {'repository_sets.limit_to_lce': True})
-        # host_details = session.contenthost.read(
-        #     rhel_contenthost.hostname, widget_names=['repository_sets']
-        # )
-        host_detail = session.host_new.get_details(target_sat.hostname, widget_names='content.repository_sets')
+        repos = session.host_new.get_details(
+            rhel_contenthost.hostname, widget_names='content.repository_sets'
+        )['content']['repository_sets']['table']
+        assert repos[0]['Repository'] == custom_repo.name
+        assert repos[0]['status'] == 'Disabled'
+        assert repos[0]['Repository type'] == 'Custom'
         ak_details = session.activationkey.read(ak.name, widget_names='repository sets')[
             'repository sets'
         ]['table'][0]
         assert 'Disabled' in ak_details['Status']
-        # assert host_details != 0
-        # assert session.activationkey.search(name)[0]['Name'] == name
-        # session.activationkey.add_subscription(name, constants.DEFAULT_SUBSCRIPTION_NAME)
-        # ak = session.activationkey.read(name, widget_names='subscriptions')
-        # subs_name = ak['subscriptions']['resources']['assigned'][0]['Repository Name']
-        # assert subs_name == constants.DEFAULT_SUBSCRIPTION_NAME

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -39,6 +39,8 @@ def test_positive_custom_products_disabled_by_default(
         4. Assert that custom proudcts are disabled by default
 
     :expectedresults: Custom products should be disabled by default.
+
+    :BZ: 1265120
     """
     ak, org, custom_repo = setup_content
     client = rhel_contenthost
@@ -47,11 +49,11 @@ def test_positive_custom_products_disabled_by_default(
     with session:
         session.organization.select(org.name)
         session.location.select(default_location.name)
-        repos = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
-        assert repos[0]['Repository'] == custom_repo.name
-        assert repos[0]['Status'] == 'Disabled'
-        assert repos[0]['Repository type'] == 'Custom'
         ak_details = session.activationkey.read(ak.name, widget_names='repository sets')[
             'repository sets'
         ]['table'][0]
         assert 'Disabled' in ak_details['Status']
+        repos = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
+        assert repos[0]['Repository'] == custom_repo.name
+        assert repos[0]['Status'] == 'Disabled'
+        assert repos[0]['Repository type'] == 'Custom'

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -47,14 +47,19 @@ def test_positive_custom_products_by_default(
     with session:
         session.organization.select(org.name)
         session.location.select(default_location.name)
-        host_details = session.contenthost.read(
-            rhel_contenthost.hostname, widget_names=['repository_sets']
-        )
+        #assert session.contenthost.search(rhel_contenthost.hostname)[0]['Name'] == rhel_contenthost.hostname
+        # chost = session.contenthost.read(
+        #     rhel_contenthost.hostname, widget_names=['details', 'provisioning_details', 'subscriptions']
+        # )
+        # session.contenthost.update(rhel_contenthost.hostname, {'repository_sets.limit_to_lce': True})
+        # host_details = session.contenthost.read(
+        #     rhel_contenthost.hostname, widget_names=['repository_sets']
+        # )
         ak_details = session.activationkey.read(ak.name, widget_names='repository sets')[
             'repository sets'
         ]['table'][0]
         assert 'Disabled' in ak_details['Status']
-        assert host_details != 0
+        # assert host_details != 0
         # assert session.activationkey.search(name)[0]['Name'] == name
         # session.activationkey.add_subscription(name, constants.DEFAULT_SUBSCRIPTION_NAME)
         # ak = session.activationkey.read(name, widget_names='subscriptions')

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -20,14 +20,15 @@ import pytest
 
 
 @pytest.mark.rhel_ver_list([7, 8, 9])
-def test_positive_custom_products_by_default(
+def test_positive_custom_products_disabled_by_default(
     session,
     default_location,
     setup_content,
     rhel_contenthost,
     target_sat,
 ):
-    """Verify that custom products should be enabled by default for content hosts
+    """Verify that custom products should be disabled by default for content hosts
+    and activation keys
 
     :id: 05bdf790-a7a1-48b1-bbae-dc25b6ee7d58
 
@@ -35,9 +36,9 @@ def test_positive_custom_products_by_default(
         1. Create custom product and upload repository
         2. Attach to activation key
         3. Register Host
-        4. Assert that custom proudct is disabled by default
+        4. Assert that custom proudcts are disabled by default
 
-    :expectedresults: Custom products should be disabled by default. "Enabled: 0"
+    :expectedresults: Custom products should be disabled by default.
     """
     ak, org, custom_repo = setup_content
     client = rhel_contenthost

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -56,3 +56,45 @@ def test_positive_custom_products_disabled_by_default(
             'repository sets'
         ]['table'][0]
         assert 'Disabled' in ak_details['Status']
+
+
+@pytest.mark.rhel_ver_list([7, 8, 9])
+def test_positive_override_custom_products_on_existing_host(
+    session,
+    default_location,
+    setup_content,
+    rhel_contenthost,
+    target_sat,
+):
+    """Verify that custom products can be easily enabled/disabled on existing host
+    using "select all" method
+
+    :id: a3c9a8c8-a40f-448b-961a-7eb888883ba9
+
+    :steps:
+        1. Create custom product and upload repository
+        2. Attach to activation key
+        3. Register Host
+        4. Assert that custom proudcts are disabled by default
+        5. Override custom products to enabled using new functionality
+        6. Assert custom products are now enabled
+
+    :expectedresults: Custom products should be easily enabled.
+    """
+    ak, org, custom_repo = setup_content
+    client = rhel_contenthost
+    client.install_katello_ca(target_sat)
+    client.register_contenthost(org.label, ak.name)
+    assert client.subscribed
+    with session:
+        session.organization.select(org.name)
+        session.location.select(default_location.name)
+        repo1 = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
+        assert repo1[0]['Repository'] == custom_repo.name
+        assert repo1[0]['Status'] == 'Disabled'
+        session.host_new.bulk_override_repo_sets(
+            rhel_contenthost.hostname, 'Custom', "Override to enabled"
+        )
+        repo2 = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
+        assert repo2[0]['Repository'] == custom_repo.name
+        assert repo2[0]['Status'] == 'Enabled'

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -28,7 +28,6 @@ def test_positive_custom_products_disabled_by_default(
     target_sat,
 ):
     """Verify that custom products should be disabled by default for content hosts
-    and activation keys
 
     :id: 05bdf790-a7a1-48b1-bbae-dc25b6ee7d58
 
@@ -56,45 +55,3 @@ def test_positive_custom_products_disabled_by_default(
             'repository sets'
         ]['table'][0]
         assert 'Disabled' in ak_details['Status']
-
-
-@pytest.mark.rhel_ver_list([7, 8, 9])
-def test_positive_override_custom_products_on_existing_host(
-    session,
-    default_location,
-    setup_content,
-    rhel_contenthost,
-    target_sat,
-):
-    """Verify that custom products can be easily enabled/disabled on existing host
-    using "select all" method
-
-    :id: a3c9a8c8-a40f-448b-961a-7eb888883ba9
-
-    :steps:
-        1. Create custom product and upload repository
-        2. Attach to activation key
-        3. Register Host
-        4. Assert that custom proudcts are disabled by default
-        5. Override custom products to enabled using new functionality
-        6. Assert custom products are now enabled
-
-    :expectedresults: Custom products should be easily enabled.
-    """
-    ak, org, custom_repo = setup_content
-    client = rhel_contenthost
-    client.install_katello_ca(target_sat)
-    client.register_contenthost(org.label, ak.name)
-    assert client.subscribed
-    with session:
-        session.organization.select(org.name)
-        session.location.select(default_location.name)
-        repo1 = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
-        assert repo1[0]['Repository'] == custom_repo.name
-        assert repo1[0]['Status'] == 'Disabled'
-        session.host_new.bulk_override_repo_sets(
-            rhel_contenthost.hostname, 'Custom', "Override to enabled"
-        )
-        repo2 = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
-        assert repo2[0]['Repository'] == custom_repo.name
-        assert repo2[0]['Status'] == 'Enabled'

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -47,11 +47,9 @@ def test_positive_custom_products_by_default(
     with session:
         session.organization.select(org.name)
         session.location.select(default_location.name)
-        repos = session.host_new.get_details(
-            rhel_contenthost.hostname, widget_names='content.repository_sets'
-        )['content']['repository_sets']['table']
+        repos = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
         assert repos[0]['Repository'] == custom_repo.name
-        assert repos[0]['status'] == 'Disabled'
+        assert repos[0]['Status'] == 'Disabled'
         assert repos[0]['Repository type'] == 'Custom'
         ak_details = session.activationkey.read(ak.name, widget_names='repository sets')[
             'repository sets'

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
+:CaseLevel: Integration
 
 :CaseComponent: Repositories
 


### PR DESCRIPTION
These tests are for SAT-16805

Custom products should be disabled by default when attaching to a content host in 6.14

Wait to be Merged:
https://github.com/SatelliteQE/airgun/pull/852