### PR TITLE
[6.11.z] Rewrite tests to have one assertion per test

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1321,14 +1321,33 @@ def test_positive_selinux_foreman_module(target_sat):
 
 @pytest.mark.upgrade
 @pytest.mark.tier1
-def test_positive_check_installer_services(target_sat):
-    """Check if services start correctly
+@pytest.mark.parametrize('service', SATELLITE_SERVICES)
+def test_positive_check_installer_service_running(target_sat, service):
+    """Check if a service is running
+
+    :id: 5389c174-7ab1-4e9d-b2aa-66d80fd6dc5f
+
+    :steps:
+        1. Verify a service is active with systemctl is-active
+
+    :expectedresults: The service is active
+
+    :CaseImportance: Medium
+    """
+    is_active = target_sat.execute(f'systemctl is-active {service}')
+    status = target_sat.execute(f'systemctl status {service}')
+    assert is_active.status == 0, status.stdout
+
+
+@pytest.mark.upgrade
+@pytest.mark.tier1
+def test_positive_check_installer_hammer_ping(target_sat):
+    """Check if hammer ping reports all services as ok
 
     :id: 85fd4388-6d94-42f5-bed2-24be38e9f104
 
     :steps:
-        1. Run 'systemctl status SATELLITE_SERVICES' command to check services status on satellite.
-        2. Run the 'hammer ping' command on satellite.
+        1. Run the 'hammer ping' command on satellite.
 
     :BZ: 1964394
 
@@ -1338,11 +1357,6 @@ def test_positive_check_installer_services(target_sat):
 
     :CaseLevel: System
     """
-    for service in SATELLITE_SERVICES:
-        result = target_sat.execute(f'systemctl status {service}')
-        assert result.status == 0
-        assert 'Active: active (running)' in result.stdout
-
     # check status reported by hammer ping command
     result = target_sat.execute('hammer ping')
     test_result = {}
@@ -1355,8 +1369,8 @@ def test_positive_check_installer_services(target_sat):
             key, value = line.split(":", 1)
             test_result[service][key] = value
 
-    for service, result in test_result.items():
-        assert result['Status'] == 'ok', f'{service} responded with {result}'
+    not_ok = {svc: result for svc, result in test_result.items() if result['Status'] != 'ok'}
+    assert not not_ok
 
 
 @pytest.mark.upgrade


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11086

It's a best practice to only have a single assertion per test. The benefit is that all the other unrelated tests still run. This means that you get a full report of all issues, and more precise reporting.

It does this by extracting the systemctl service status checks to a separate, parametrized test. That is also rewritten to use systemctl is-active instead of parsing the output of status. It still adds the systemctl status output as context, which makes debugging easier.

The hammer ping command is then rewritten to collect all not-ok services and assert that it's empty. This gives you a complete list of services that aren't OK with their results, instead of just a single failed service.

Right now this is untested and probably doesn't comply with the Robottelo standards, but it came up in a discussion and showing code is easier than describing it.