### PR TITLE
More forgiving BROKER_DIRECTORY behavior

### DIFF
--- a/conf/broker.yaml.template
+++ b/conf/broker.yaml.template
@@ -1,6 +1,7 @@
 BROKER:
     # The path where your broker settings and inventory are located
-    BROKER_DIRECTORY: "."
+    # If you leave it blank, the default is the output of `broker --version`
+    BROKER_DIRECTORY:
     HOST_WORKFLOWS:
         POWER_CONTROL: vm-power-operation
         EXTEND: extend-vm

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -46,7 +46,9 @@ settings = get_settings()
 
 if not os.getenv('BROKER_DIRECTORY'):
     # set the BROKER_DIRECTORY envar so broker knows where to operate from
-    os.environ['BROKER_DIRECTORY'] = settings.broker.get('broker_directory')
+    if _broker_dir := settings.robottelo.get('BROKER_DIRECTORY'):
+        logger.debug(f'Setting BROKER_DIRECTORY to {_broker_dir}')
+        os.environ['BROKER_DIRECTORY'] = _broker_dir
 
 
 robottelo_tmp_dir = Path(settings.robottelo.tmp_dir)


### PR DESCRIPTION
With Broker 0.3 released, we can now be more forgiving about the location of the broker directory. This commit allows users to fallback to Broker's default instead of setting the envar themselves or explicitly setting the path in robottelo's config.