### PR TITLE
tags added for bookmarks test

### DIFF
--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -178,6 +178,10 @@ def test_positive_update_bookmark_public(
         hidden
 
     :CaseLevel: Integration
+
+    :BZ: 2141187
+
+    :customerscenario: true
     """
     public_name = gen_string('alphanumeric')
     nonpublic_name = gen_string('alphanumeric')


### PR DESCRIPTION
the scenario already covers  2141187, adding tags for traceability
