### PR TITLE
[6.13.z] exports added to api paths

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -348,6 +348,7 @@ API_PATHS = {
         '/katello/api/errata/compare',
         '/katello/api/errata/:id',
     ),
+    'exports': (),
     'external_usergroups': (
         '/api/usergroups/:usergroup_id/external_usergroups',
         '/api/usergroups/:usergroup_id/external_usergroups',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11462

```
pytest tests/foreman/endtoend/test_api_endtoend.py -k test_positive_get_links
================================================ test session starts =================================================

collected 6 items / 5 deselected / 1 selected                                                                        

tests/foreman/endtoend/test_api_endtoend.py .                                                                  [100%]
```