### PR TITLE
[6.12.z] Cherry-pick changes from #11248 missed by #11297

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -517,11 +517,7 @@ def _import_entities(product, repo, cv, mos='no'):
 
 
 class TestContentViewSync:
-    """Implements Content View Export Import tests in CLI
-
-    :CaseComponent: ContentViews
-
-    """
+    """Implements Content View Export Import tests in CLI"""
 
     @pytest.mark.tier3
     @pytest.mark.e2e
@@ -551,10 +547,6 @@ class TestContentViewSync:
 
             1. CV version custom contents has been exported to directory
             2. All The exported custom contents has been imported in org/satellite
-
-        :CaseAutomation: Automated
-
-        :CaseComponent: ContentViews
 
         :CaseImportance: High
 
@@ -645,10 +637,6 @@ class TestContentViewSync:
 
             1. Default Organization View version custom contents has been exported to directory
             2. All The exported custom contents has been imported in org/satellite
-
-        :CaseAutomation: Automated
-
-        :CaseComponent: ContentViews
 
         :CaseImportance: High
 
@@ -747,8 +735,6 @@ class TestContentViewSync:
 
             1. Filtered CV version custom contents has been exported to directory
             2. Filtered exported custom contents has been imported in org/satellite
-
-        :CaseAutomation: Automated
 
         :CaseImportance: High
 
@@ -890,6 +876,7 @@ class TestContentViewSync:
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
+    @pytest.mark.e2e
     def test_positive_export_import_redhat_cv(
         self,
         export_import_cleanup_function,
@@ -917,11 +904,7 @@ class TestContentViewSync:
 
         :BZ: 1655239, 2040870
 
-        :CaseAutomation: Automated
-
         :customerscenario: true
-
-        :CaseComponent: ContentViews
 
         :CaseImportance: High
 
@@ -1048,10 +1031,6 @@ class TestContentViewSync:
             2. All The exported redhat contents has been imported in org/satellite
 
         :BZ: 1655239
-
-        :CaseAutomation: Automated
-
-        :CaseComponent: ContentViews
 
         :CaseImportance: Critical
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11469

In #11248 I moved the tests in `tests/foreman/cli/test_satellitesync.py::TestContentViewSync` to the file's default CaseComponent (ISS).
However, it seems this change was not cherry-picked by #11297 properly for some reason.

Let's cherry-pick it manually here and see what happens to the label based ones for 6.12 and 6.11.