### PR TITLE
[6.12.z] Fix host content virtwho

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -409,7 +409,8 @@ def hypervisor_json_create(hypervisors, guests):
                     "attributes": {"active": 1, "virtWhoType": "esx"},
                 }
             )
-        hypervisor = {"guestIds": guest_list}
+        name = str(uuid.uuid4())
+        hypervisor = {"guestIds": guest_list, "name": name, "hypervisorId": {"hypervisorId": name}}
         hypervisors_list.append(hypervisor)
     mapping = {"hypervisors": hypervisors_list}
     return mapping

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -1798,7 +1798,7 @@ def test_search_for_virt_who_hypervisors(session, default_location):
         assert not session.contenthost.search('hypervisor = true')
         # create virt-who hypervisor through the fake json conf
         data = create_fake_hypervisor_content(org.label, hypervisors=1, guests=1)
-        hypervisor_name = data['hypervisors'][0]['hypervisorId']
+        hypervisor_name = data['hypervisors'][0]['name']
         hypervisor_display_name = f'virt-who-{hypervisor_name}-{org.id}'
         # Search with hypervisor=True gives the correct result.
         assert (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11183

Revert/rework of https://github.com/SatelliteQE/robottelo/pull/9831 - this PR removed "hypervisorId" from the virtwho helper, and resulted in the tests mentioned there still passing. This unfortunately broke another test, in test_contenthosts.py

This readds that portion of the JSON payload, based on comments in this BZ - https://bugzilla.redhat.com/show_bug.cgi?id=2083444

All tests will still pass, I'll get PRT in here to confirm. 

(Note: This got mixed in with commits from another PR, so I'll need to resolve that/get that PR Merged first. It is already approved, so it should be fine) 