### PR TITLE
[6.13.z] Fix Upgrade Scenarios collection for Teams

### DIFF
--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ActivationKeys
 
-:team: Phoenix-subscriptions
+:Team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -11,7 +11,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :CaseComponent: Hosts-Content
 
-:team: Phoenix-subscriptions
+:Team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ContentViews
 
-:team: Phoenix-content
+:Team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: ErrataManagement
 
-:team: Phoenix-content
+:Team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Host-Content
 
-:team: Phoenix-subscriptions
+:Team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -6,7 +6,9 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Performance
+:CaseComponent: Installer
+
+:Team: Platform
 
 :TestType: Functional
 

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Repositories
 
-:team: Phoenix-content
+:Team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/upgrades/test_satellitesync.py
+++ b/tests/upgrades/test_satellitesync.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: InterSatelliteSync
 
-:team: Phoenix-subscriptions
+:Team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SubscriptionManagement
 
-:team: Phoenix-subscriptions
+:Team: Phoenix-subscriptions
 
 :TestType: Functional
 

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SyncPlans
 
-:team: Phoenix-content
+:Team: Phoenix-content
 
 :TestType: Functional
 

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:team: Phoenix-subscriptions
+:Team: Phoenix-subscriptions
 
 :TestType: Functional
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11453

Upgrade Scenarios were having some issues in collecting them by teams, this PR fixes it and which were caused by:
- Missing team docstring in a test failing entire collection
- Small case team docstring token

Now collection looks like:

```
# pytest --collect-only -s -m pre_upgrade --team phoenix-subscriptions tests/upgrades/
====================== test session starts ================
platform darwin -- Python 3.11.1, pytest-7.2.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/jitendrayejare/GitRepos/robottelo, configfile: pyproject.toml
plugins: ibutsu-2.2.4, reportportal-5.1.6, mock-3.10.0, xdist-3.2.1, services-2.2.1, cov-3.0.0
collecting ... 2023-05-11 14:50:31 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 83 items / 76 deselected / 7 selected                                                                                                                            

<Package upgrades>
  <Module test_activation_key.py>
    <Class TestActivationKey>
      <Function test_pre_create_activation_key[test_pre_create_activation_key]>
  <Module test_client.py>
    <Class TestScenarioUpgradeOldClientAndPackageInstallation>
      <Function test_pre_scenario_pre_client_package_installation>
  <Module test_hostcontent.py>
    <Class TestScenarioDBseedHostMismatch>
      <Function test_pre_db_seed_host_mismatch[rhel7_contenthost_module0]>
  <Module test_satellitesync.py>
    <Class TestSatelliteSync>
      <Function test_pre_version_cv_export_import>
  <Module test_subscription.py>
    <Class TestManifestScenarioRefresh>
      <Function test_pre_manifest_scenario_refresh>
    <Class TestSubscriptionAutoAttach>
      <Function test_pre_subscription_scenario_auto_attach[rhel8]>
  <Module test_virtwho.py>
    <Class TestScenarioPositiveVirtWho>
      <Function test_pre_create_virt_who_configuration>
====================== 7/83 tests collected (76 deselected) in 21.23s ==========================
```