### PR TITLE
[6.12.z] Fix assertion for test_positive_configure_cloud_connector

### DIFF
--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -185,6 +185,6 @@ def test_positive_configure_cloud_connector(
 
     assert rhc_status.status == 0
     assert "Connected to Red Hat Subscription Management" in rhc_status.stdout
-    assert "The Red Hat connector daemon is active" in rhc_status.stdout
+    assert "The Remote Host Configuration daemon is active" in rhc_status.stdout
 
     assert "error" not in rhcd_log.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11513

Test result:
```
pytest tests/foreman/ui/test_rhc.py -k test_positive_configure_cloud_connector 
============================= test session starts ==============================
platform darwin -- Python 3.9.12, pytest-7.3.1, pluggy-1.0.0
Mandatory Requirements Available: jinja2==3.1.2
Optional Requirements Available: pre-commit==3.3.2 redis==4.5.5 manage>=0.1.13 sphinx==7.0.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/jpathan/projects/robottelo
configfile: pyproject.toml
plugins: ibutsu-2.2.4, mock-3.10.0, reportportal-5.1.7, xdist-3.2.1, services-2.2.1, cov-3.0.0
collected 1 item

tests/foreman/ui/test_rhc.py .                                           [100%]
================= 1 passed, 222 warnings in 1096.50s (0:18:16) =================
```
