### PR TITLE
[6.13.z] Switch SATELLITE_SERVICES to a list

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1281,7 +1281,7 @@ LAST_SAVED_SECTIONS = {
     '= Module puppet:',
 }
 
-SATELLITE_SERVICES = {
+SATELLITE_SERVICES = [
     'dynflow-sidekiq@orchestrator',
     'dynflow-sidekiq@worker-1',
     'dynflow-sidekiq@worker-hosts-queue-1',
@@ -1293,7 +1293,7 @@ SATELLITE_SERVICES = {
     'pulpcore-content',
     'pulpcore-worker@*',
     'tomcat',
-}
+]
 
 
 def extract_help(filter='params'):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11522

Solving this error we were seeing in the Installer pipeline that was preventing the whole pipeline from running:
```
Different tests were collected between gw0 and gw1. The difference is:
--- gw0

+++ gw1

@@ -3,16 +3,16 @@

 tests/foreman/destructive/test_installer.py::test_positive_mismatched_satellite_fqdn
 tests/foreman/installer/test_installer.py::test_positive_selinux_foreman_module
 tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[dynflow-sidekiq@orchestrator]
-tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[dynflow-sidekiq@worker-1]
-tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[postgresql]
 tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[pulpcore-content]
 tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[dynflow-sidekiq@worker-hosts-queue-1]
+tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[foreman]
+tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[dynflow-sidekiq@worker-1]
+tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[pulpcore-api]
+tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[pulpcore-worker@*]
+tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[postgresql]
+tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[httpd]
 tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[tomcat]
-tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[pulpcore-worker@*]
-tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[foreman]
-tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[httpd]
 tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[foreman-proxy]
-tests/foreman/installer/test_installer.py::test_positive_check_installer_service_running[pulpcore-api]
 tests/foreman/installer/test_installer.py::test_positive_check_installer_hammer_ping
 tests/foreman/installer/test_installer.py::test_installer_options_and_sections[params]
 tests/foreman/installer/test_installer.py::test_installer_options_and_sections[sections]
To see why this happens see Known limitations in documentation
```

See https://github.com/pytest-dev/pytest-xdist/issues/432 for more details. Seems like the test generation happens twice and compares when we split between workers, and pytest expects them to all be in the same order. Switching to a list ensures our items always come out in the same order.