### PR TITLE
[6.13.z] Http-Proxy cacert automation coverage

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -313,7 +313,6 @@ def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, m
 
     assert repo.http_proxy_policy == 'use_selected_http_proxy'
     assert repo.http_proxy_id == http_proxy.id
-    assert http_proxy.cacert == cacert_path
 
     response = repo.sync()
     assert response.get('errors') is None


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11454

-Automation for http-proxy cacert (found in Infrastructure>HttpProxy>New or edit proxy)
-The test aims to create or collect a valid cacert.crt, assign the cacert to an Http-Proxy, then sync a repo with the proxy.
-Depends on nailgun PR# [924](https://github.com/SatelliteQE/nailgun/pull/924): add cacert as a field of HttpProxy
-BZ# 2144044
