### PR TITLE
[6.13.z] Fix for PytestAssertRewriteWarning

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -2,12 +2,10 @@ import pytest
 from broker import Broker
 from wait_for import wait_for
 
-from pytest_fixtures.component.satellite_auth import disenroll_idm
-from pytest_fixtures.component.satellite_auth import enroll_ad_and_configure_external_auth
-from pytest_fixtures.component.satellite_auth import enroll_idm_and_configure_external_auth
 from pytest_fixtures.core.broker import _resolve_deploy_args
 from robottelo.config import settings
 from robottelo.hosts import Capsule
+from robottelo.hosts import IPAHost
 
 
 @pytest.fixture
@@ -149,13 +147,14 @@ def parametrized_enrolled_sat(
 ):
     """Yields a Satellite enrolled into [IDM, AD] as parameter."""
     new_sat = satellite_factory()
+    ipa_host = IPAHost(new_sat)
     new_sat.register_to_cdn()
     if 'IDM' in request.param:
-        enroll_idm_and_configure_external_auth(new_sat)
+        ipa_host.enroll_idm_and_configure_external_auth()
         yield new_sat
-        disenroll_idm(new_sat)
+        ipa_host.disenroll_idm()
     else:
-        enroll_ad_and_configure_external_auth(request, ad_data, new_sat)
+        new_sat.enroll_ad_and_configure_external_auth(ad_data)
         yield new_sat
     new_sat.unregister()
     new_sat.teardown()

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -132,6 +132,10 @@ class SatelliteHostError(Exception):
     pass
 
 
+class IPAHostError(Exception):
+    pass
+
+
 class ContentHost(Host, ContentHostMixins):
     run = Host.execute
     default_timeout = settings.server.ssh_client.command_timeout
@@ -1863,6 +1867,118 @@ class Satellite(Capsule, SatelliteMixins):
             # refresh repository metadata on the host
             rhel_contenthost.execute('subscription-manager repos --list')
 
+    def enroll_ad_and_configure_external_auth(self, ad_data):
+        """Enroll Satellite Server to an AD Server.
+
+        :param ad_data: Callable method that returns AD server details
+        :type ad_data: Callable
+        """
+        ad_data = ad_data()
+        packages = (
+            'sssd adcli realmd ipa-python-compat krb5-workstation '
+            'samba-common-tools gssproxy nfs-utils ipa-client'
+        )
+        realm = ad_data.realm
+        workgroup = ad_data.workgroup
+
+        default_content = f'[global]\nserver = unused\nrealm = {realm}'
+        keytab_content = (
+            f'[global]\nworkgroup = {workgroup}\nrealm = {realm}'
+            f'\nkerberos method = system keytab\nsecurity = ads'
+        )
+
+        # install the required packages
+        assert (
+            self.execute(f'yum -y --disableplugin=foreman-protector install {packages}').status == 0
+        )
+
+        # update the AD name server
+        assert self.execute('chattr -i /etc/resolv.conf').status == 0
+        line_number = int(
+            self.execute(
+                "awk -v search='nameserver' '$0~search{print NR; exit}' /etc/resolv.conf"
+            ).stdout
+        )
+        assert (
+            self.execute(
+                f'sed -i "{line_number}i nameserver {ad_data.nameserver}" /etc/resolv.conf'
+            ).status
+            == 0
+        )
+        assert self.execute('chattr +i /etc/resolv.conf').status == 0
+
+        # join the realm
+        assert (
+            self.execute(
+                f'echo {settings.ldap.password} | realm join -v {realm} --membership-software=samba'
+            ).status
+            == 0
+        )
+        assert self.execute('touch /etc/ipa/default.conf').status == 0
+        assert self.execute(f'echo "{default_content}" > /etc/ipa/default.conf').status == 0
+        assert self.execute(f'echo "{keytab_content}" > /etc/net-keytab.conf').status == 0
+
+        # gather the apache id
+        id_apache = str(self.execute('id -u apache')).strip()
+        http_conf_content = (
+            f'[service/HTTP]\nmechs = krb5\ncred_store = keytab:/etc/krb5.keytab'
+            f'\ncred_store = ccache:/var/lib/gssproxy/clients/krb5cc_%U'
+            f'\neuid = {id_apache}'
+        )
+
+        # register the satellite as client for external auth
+        assert self.execute(f'echo "{http_conf_content}" > /etc/gssproxy/00-http.conf').status == 0
+        token_command = (
+            'KRB5_KTNAME=FILE:/etc/httpd/conf/http.keytab net ads keytab add HTTP '
+            '-U administrator -d3 -s /etc/net-keytab.conf'
+        )
+        assert self.execute(f'echo {settings.ldap.password} | {token_command}').status == 0
+        assert self.execute('chown root.apache /etc/httpd/conf/http.keytab').status == 0
+        assert self.execute('chmod 640 /etc/httpd/conf/http.keytab').status == 0
+
+        # enable the foreman-ipa-authentication feature
+        result = self.install(InstallerCommand('foreman-ipa-authentication true'))
+        assert result.status == 0
+
+        # add foreman ad_gp_map_service (BZ#2117523)
+        line_number = int(
+            self.execute(
+                "awk -v search='domain/' '$0~search{print NR; exit}' /etc/sssd/sssd.conf"
+            ).stdout
+        )
+        assert (
+            self.execute(
+                f'sed -i "{line_number + 1}i ad_gpo_map_service = +foreman" /etc/sssd/sssd.conf'
+            ).status
+            == 0
+        )
+        assert self.execute('systemctl restart sssd.service').status == 0
+
+        # unset GssapiLocalName (BZ#1787630)
+        assert (
+            self.execute(
+                'sed -i -e "s/GssapiLocalName.*On/GssapiLocalName Off/g" '
+                '/etc/httpd/conf.d/05-foreman-ssl.d/auth_gssapi.conf'
+            ).status
+            == 0
+        )
+        assert self.execute('systemctl restart gssproxy.service').status == 0
+        assert self.execute('systemctl enable gssproxy.service').status == 0
+
+        # restart the deamon and httpd services
+        httpd_service_content = (
+            '.include /lib/systemd/system/httpd.service\n[Service]' '\nEnvironment=GSS_USE_PROXY=1'
+        )
+        assert (
+            self.execute(
+                f'echo "{httpd_service_content}" > /etc/systemd/system/httpd.service'
+            ).status
+            == 0
+        )
+        assert (
+            self.execute('systemctl daemon-reload && systemctl restart httpd.service').status == 0
+        )
+
 
 class SSOHost(Host):
     """Class for RHSSO functions and setup"""
@@ -2028,3 +2144,101 @@ class SSOHost(Host):
             ]
         }
         self.update_client_configuration(client_config)
+
+
+class IPAHost(Host):
+    def __init__(self, sat_obj, **kwargs):
+        self.satellite = sat_obj
+        kwargs['hostname'] = kwargs.get('hostname', settings.ipa.hostname)
+        # Allow the class to be constructed from kwargs
+        kwargs['from_dict'] = True
+        kwargs.update(
+            {
+                'base_dn': settings.ipa.basedn,
+                'disabled_user_ipa': settings.ipa.disabled_ipa_user,
+                'group_base_dn': settings.ipa.grpbasedn,
+                'group_users': settings.ipa.group_users,
+                'groups': settings.ipa.groups,
+                'ipa_otp_username': settings.ipa.otp_user,
+                'ldap_user_cn': settings.ipa.username,
+                'ldap_user_name': settings.ipa.user,
+                'ldap_user_passwd': settings.ipa.password,
+                'time_based_secret': settings.ipa.time_based_secret,
+            }
+        )
+        super().__init__(**kwargs)
+
+    def disenroll_idm(self):
+        self.execute(f'ipa service-del HTTP/{self.satellite.hostname}')
+        self.execute(f'ipa host-del {self.satellite.hostname}')
+
+    def enroll_idm_and_configure_external_auth(self):
+        """Enroll the Satellite Server to an IDM Server."""
+        result = self.satellite.execute(
+            'yum -y --disableplugin=foreman-protector install ipa-client ipa-admintools'
+        )
+        if result.status != 0:
+            raise SatelliteHostError('Failed to install ipa client')
+        self._kinit_admin()
+        result = self.execute(f'ipa host-find {self.satellite.hostname}')
+        if result.status == 0:
+            self.disenroll_idm()
+        result = self.execute(f'ipa host-add --random {self.satellite.hostname}')
+        for line in result.stdout.splitlines():
+            if 'Random password' in line:
+                _, password = line.split(': ', 2)
+                break
+        self.execute(f'ipa service-add HTTP/{self.satellite.hostname}')
+        _, domain = self.hostname.split('.', 1)
+        result = self.satellite.execute(
+            f"ipa-client-install --password '{password}' "
+            f'--domain {domain} '
+            f'--server {self.hostname} '
+            f'--realm {domain.upper()} -U'
+        )
+        if result.status not in [0, 3]:
+            raise SatelliteHostError('Failed to enable ipa client')
+        result = self.satellite.install(InstallerCommand('foreman-ipa-authentication true'))
+        assert result.status == 0, 'Installer failed to enable IPA authentication.'
+        self.satellite.cli.Service.restart()
+
+    def _kinit_admin(self):
+        result = self.execute(f'echo {self.ldap_user_passwd} | kinit admin')
+        if result.status != 0:
+            raise IPAHostError('Failed to login to the IPA server with admin credentials')
+
+    def create_user(self, username):
+        self._kinit_admin()
+        add_user_cmd = (
+            f'echo {self.ldap_user_passwd} | ipa user-add {username} --first'
+            f'={username} --last={username} --password'
+        )
+        result = self.execute(add_user_cmd)
+        if result.status != 0:
+            raise IPAHostError('Failed to create the user')
+
+    def delete_user(self, username):
+        result = self.execute(f'ipa user-del {username}')
+        if result.status != 0:
+            raise IPAHostError('Failed to delete the user')
+
+    def find_user(self, username):
+        self._kinit_admin()
+        result = self.execute(f"ipa user-find --login {username}")
+        if result.status != 0:
+            raise IPAHostError('Failed to find the user')
+        return result.stdout
+
+    def add_user_to_usergroup(self, member_username, member_group):
+        self._kinit_admin()
+        result = self.execute(f'ipa group-add-member {member_group} --users={member_username}')
+        if result.status != 0:
+            raise IPAHostError('Failed to add the user to usergroup')
+
+    def remove_user_from_usergroup(self, member_username, member_group):
+        self._kinit_admin()
+        result = self.execute(
+            f'ipa group-remove-member {member_group} --users={member_username}',
+        )
+        if result.status != 0:
+            raise IPAHostError('Failed to remove the user from user group')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11445

## Issue statement
Every time GH Actions run  `pytest tests/robottelo/` we see the following warning message multiple times in one run. See [the following GitHub Actions run](https://github.com/SatelliteQE/robottelo/actions/runs/4892389046/jobs/8734088618#step:8:891)

```
PASSED
2023-05-05 10:30:21 - robottelo.collection - INFO - Processing test items to add testimony token markers
tests/robottelo/test_report.py::test_junit_timestamps[dummy_test-non_xdist-testcase] ..                                                                       [100%]
=============================== warnings summary ===============================
../../../../../opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/_pytest/config/__init__.py:747
  /opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/_pytest/config/__init__.py:747: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: pytest_fixtures.component.satellite_auth
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated xml file: /home/runner/work/robottelo/robottelo/report_PMOyAWKpYi.xml - 2 passed, 1 warning in 0.02s
PASSED
tests/robottelo/test_ssh.py::TestSSH::test_command PASSED
```

This message is printed out as we import functions from the module that also contains pytest fixtures.
https://github.com/SatelliteQE/robottelo/blob/892ae8b23a574e5fd39b47de0cab126bac3d460f/pytest_fixtures/core/sat_cap_factory.py#L5-L7


There is also another warning which comes from https://github.com/reportportal/agent-python-pytest/.
```
/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pytest_reportportal/plugin.py:46: PytestDeprecationWarning: The hookimpl pytest_configure_node uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.optionalhook

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

## Solution
This PR :tada:
I have moved the functions out of the `satellite_auth.py` fixture module and put them into a newly created `IPAHost` and the good ol' `Satellite` host objects. The `IPAHost` object could be used as the `SSOHost` and could contain more functions and properties eventually.

### Additional enhancements
* Wrap the "ipa" cli commands as IPAHost methods.
* Add a new exception to represent errors in IPAHost.
* Put "kinit admin" in its own function.
* Use the IPAHost object properties instead of the data from ipa_data
  fixture.


I have also created a PR https://github.com/reportportal/agent-python-pytest/pull/337 in the plugin repo that fixes the deprecation.

## Note
I am open to moving some of the stuff to mixins to not bloat `hosts.py`.