### PR TITLE
[6.12.z] Fix for PytestAssertRewriteWarning

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -16,7 +16,6 @@ from robottelo.constants import LDAP_SERVER_TYPE
 from robottelo.hosts import IPAHost
 from robottelo.hosts import SSOHost
 from robottelo.utils.datafactory import gen_string
-from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
 
 

--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -5,7 +5,6 @@ import pytest
 from box import Box
 from nailgun import entities
 
-from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
 from robottelo.constants import AUDIENCE_MAPPER
 from robottelo.constants import CERT_PATH
@@ -14,7 +13,7 @@ from robottelo.constants import HAMMER_CONFIG
 from robottelo.constants import HAMMER_SESSIONS
 from robottelo.constants import LDAP_ATTR
 from robottelo.constants import LDAP_SERVER_TYPE
-from robottelo.hosts import ContentHost
+from robottelo.hosts import IPAHost
 from robottelo.hosts import SSOHost
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.installer import InstallerCommand
@@ -25,6 +24,12 @@ from robottelo.utils.issue_handlers import is_open
 def default_sso_host(module_target_sat):
     """Returns default sso host"""
     return SSOHost(module_target_sat)
+
+
+@pytest.fixture(scope='module')
+def default_ipa_host(module_target_sat):
+    """Returns default IPA host"""
+    return IPAHost(module_target_sat)
 
 
 @pytest.fixture()
@@ -120,20 +125,20 @@ def auth_source(ldap_cleanup, module_org, module_location, ad_data):
 
 
 @pytest.fixture(scope='function')
-def auth_source_ipa(ldap_cleanup, module_org, module_location, ipa_data):
+def auth_source_ipa(ldap_cleanup, default_ipa_host, module_org, module_location):
     return entities.AuthSourceLDAP(
         onthefly_register=True,
-        account=ipa_data['ldap_user_cn'],
-        account_password=ipa_data['ldap_user_passwd'],
-        base_dn=ipa_data['base_dn'],
-        groups_base=ipa_data['group_base_dn'],
+        account=default_ipa_host.ldap_user_cn,
+        account_password=default_ipa_host.ldap_user_passwd,
+        base_dn=default_ipa_host.base_dn,
+        groups_base=default_ipa_host.group_base_dn,
         attr_firstname=LDAP_ATTR['firstname'],
         attr_lastname=LDAP_ATTR['surname'],
         attr_login=LDAP_ATTR['login'],
         server_type=LDAP_SERVER_TYPE['API']['ipa'],
         attr_mail=LDAP_ATTR['mail'],
         name=gen_string('alpha'),
-        host=ipa_data['ldap_hostname'],
+        host=default_ipa_host.hostname,
         tls=False,
         port='389',
         organization=[module_org],
@@ -326,64 +331,26 @@ def enable_external_auth_rhsso(
     default_sso_host.set_the_redirect_uri()
 
 
-def enroll_idm_and_configure_external_auth(sat):
-    """Enroll the Satellite6 Server to an IDM Server."""
-    if is_open('BZ:2129096'):
-        settings.set('ipa.user', 'foreman_test')
-    ipa_host = ContentHost(settings.ipa.hostname)
-    result = sat.execute(
-        'yum -y --disableplugin=foreman-protector install ipa-client ipa-admintools'
-    )
-    if result.status != 0:
-        raise CLIReturnCodeError(result.status, result.stderr, 'Failed to install ipa client')
-    ipa_host.execute(f'echo {settings.ipa.password} | kinit admin')
-    result = ipa_host.execute(f'ipa host-find {sat.hostname}')
-    if result.status == 0:
-        disenroll_idm(sat)
-    result = ipa_host.execute(f'ipa host-add --random {sat.hostname}')
-    for line in result.stdout.splitlines():
-        if 'Random password' in line:
-            _, password = line.split(': ', 2)
-            break
-    ipa_host.execute(f'ipa service-add HTTP/{sat.hostname}')
-    _, domain = settings.ipa.hostname.split('.', 1)
-    result = sat.execute(
-        f"ipa-client-install --password '{password}' "
-        f'--domain {domain} '
-        f'--server {settings.ipa.hostname} '
-        f'--realm {domain.upper()} -U'
-    )
-    if result.status not in [0, 3]:
-        raise CLIReturnCodeError(result.status, result.stderr, 'Failed to enable ipa client')
-    result = sat.install(InstallerCommand('foreman-ipa-authentication true'))
-    assert result.status == 0, 'Installer failed to enable IPA authentication.'
-    sat.cli.Service.restart()
-
-
-def disenroll_idm(sat):
-    ipa_host = ContentHost(settings.ipa.hostname)
-    ipa_host.execute(f'ipa service-del HTTP/{sat.hostname}')
-    ipa_host.execute(f'ipa host-del {sat.hostname}')
-
-
 @pytest.mark.external_auth
 @pytest.fixture(scope='module')
 def module_enroll_idm_and_configure_external_auth(module_target_sat):
-    enroll_idm_and_configure_external_auth(module_target_sat)
+    ipa_host = IPAHost(module_target_sat)
+    ipa_host.enroll_idm_and_configure_external_auth()
     yield
-    disenroll_idm(module_target_sat)
+    ipa_host.disenroll_idm()
 
 
 @pytest.mark.external_auth
 @pytest.fixture
 def func_enroll_idm_and_configure_external_auth(target_sat):
-    enroll_idm_and_configure_external_auth(target_sat)
+    ipa_host = IPAHost(target_sat)
+    ipa_host.enroll_idm_and_configure_external_auth()
     yield
-    disenroll_idm(target_sat)
+    ipa_host.disenroll_idm()
 
 
 @pytest.fixture(scope='module')
-def configure_realm(module_target_sat):
+def configure_realm(module_target_sat, default_ipa_host):
     """Configure realm"""
     realm = settings.upgrade.vm_domain.upper()
     module_target_sat.execute(f'curl -o /root/freeipa.keytab {settings.ipa.keytab_url}')
@@ -392,7 +359,7 @@ def configure_realm(module_target_sat):
     module_target_sat.execute(
         'satellite-installer --foreman-proxy-realm true '
         f'--foreman-proxy-realm-principal realm-proxy@{realm} '
-        f'--foreman-proxy-dhcp-nameservers {socket.gethostbyname(settings.ipa.hostname)}'
+        f'--foreman-proxy-dhcp-nameservers {socket.gethostbyname(default_ipa_host.hostname)}'
     )
     module_target_sat.execute('cp /etc/ipa/ca.crt /etc/pki/ca-trust/source/anchors/ipa.crt')
     module_target_sat.execute('update-ca-trust enable ; update-ca-trust')
@@ -440,119 +407,16 @@ def rhsso_setting_setup_with_timeout(module_target_sat, rhsso_setting_setup):
     setting_entity.update({'value'})
 
 
-def enroll_ad_and_configure_external_auth(request, ad_data, sat):
-    """Enroll Satellite Server to an AD Server."""
-    ad_data = ad_data()
-    packages = (
-        'sssd adcli realmd ipa-python-compat krb5-workstation '
-        'samba-common-tools gssproxy nfs-utils ipa-client'
-    )
-    realm = ad_data.realm
-    workgroup = ad_data.workgroup
-
-    default_content = f'[global]\nserver = unused\nrealm = {realm}'
-    keytab_content = (
-        f'[global]\nworkgroup = {workgroup}\nrealm = {realm}'
-        f'\nkerberos method = system keytab\nsecurity = ads'
-    )
-
-    # install the required packages
-    assert sat.execute(f'yum -y --disableplugin=foreman-protector install {packages}').status == 0
-
-    # update the AD name server
-    assert sat.execute('chattr -i /etc/resolv.conf').status == 0
-    line_number = int(
-        sat.execute(
-            "awk -v search='nameserver' '$0~search{print NR; exit}' /etc/resolv.conf"
-        ).stdout
-    )
-    assert (
-        sat.execute(
-            f'sed -i "{line_number}i nameserver {ad_data.nameserver}" /etc/resolv.conf'
-        ).status
-        == 0
-    )
-    assert sat.execute('chattr +i /etc/resolv.conf').status == 0
-
-    # join the realm
-    assert (
-        sat.execute(
-            f'echo {settings.ldap.password} | realm join -v {realm} --membership-software=samba'
-        ).status
-        == 0
-    )
-    assert sat.execute('touch /etc/ipa/default.conf').status == 0
-    assert sat.execute(f'echo "{default_content}" > /etc/ipa/default.conf').status == 0
-    assert sat.execute(f'echo "{keytab_content}" > /etc/net-keytab.conf').status == 0
-
-    # gather the apache id
-    id_apache = str(sat.execute('id -u apache')).strip()
-    http_conf_content = (
-        f'[service/HTTP]\nmechs = krb5\ncred_store = keytab:/etc/krb5.keytab'
-        f'\ncred_store = ccache:/var/lib/gssproxy/clients/krb5cc_%U'
-        f'\neuid = {id_apache}'
-    )
-
-    # register the satellite as client for external auth
-    assert sat.execute(f'echo "{http_conf_content}" > /etc/gssproxy/00-http.conf').status == 0
-    token_command = (
-        'KRB5_KTNAME=FILE:/etc/httpd/conf/http.keytab net ads keytab add HTTP '
-        '-U administrator -d3 -s /etc/net-keytab.conf'
-    )
-    assert sat.execute(f'echo {settings.ldap.password} | {token_command}').status == 0
-    assert sat.execute('chown root.apache /etc/httpd/conf/http.keytab').status == 0
-    assert sat.execute('chmod 640 /etc/httpd/conf/http.keytab').status == 0
-
-    # enable the foreman-ipa-authentication feature
-    result = sat.install(InstallerCommand('foreman-ipa-authentication true'))
-    assert result.status == 0
-
-    # add foreman ad_gp_map_service (BZ#2117523)
-    line_number = int(
-        sat.execute(
-            "awk -v search='domain/' '$0~search{print NR; exit}' /etc/sssd/sssd.conf"
-        ).stdout
-    )
-    assert (
-        sat.execute(
-            f'sed -i "{line_number + 1}i ad_gpo_map_service = +foreman" /etc/sssd/sssd.conf'
-        ).status
-        == 0
-    )
-    assert sat.execute('systemctl restart sssd.service').status == 0
-
-    # unset GssapiLocalName (BZ#1787630)
-    assert (
-        sat.execute(
-            'sed -i -e "s/GssapiLocalName.*On/GssapiLocalName Off/g" '
-            '/etc/httpd/conf.d/05-foreman-ssl.d/auth_gssapi.conf'
-        ).status
-        == 0
-    )
-    assert sat.execute('systemctl restart gssproxy.service').status == 0
-    assert sat.execute('systemctl enable gssproxy.service').status == 0
-
-    # restart the deamon and httpd services
-    httpd_service_content = (
-        '.include /lib/systemd/system/httpd.service\n[Service]' '\nEnvironment=GSS_USE_PROXY=1'
-    )
-    assert (
-        sat.execute(f'echo "{httpd_service_content}" > /etc/systemd/system/httpd.service').status
-        == 0
-    )
-    assert sat.execute('systemctl daemon-reload && systemctl restart httpd.service').status == 0
-
-
 @pytest.mark.external_auth
 @pytest.fixture(scope='module')
-def module_enroll_ad_and_configure_external_auth(request, ad_data, module_target_sat):
-    enroll_ad_and_configure_external_auth(request, ad_data, module_target_sat)
+def module_enroll_ad_and_configure_external_auth(ad_data, module_target_sat):
+    module_target_sat.enroll_ad_and_configure_external_auth(ad_data)
 
 
 @pytest.mark.external_auth
 @pytest.fixture
-def func_enroll_ad_and_configure_external_auth(request, ad_data, target_sat):
-    enroll_ad_and_configure_external_auth(request, ad_data, target_sat)
+def func_enroll_ad_and_configure_external_auth(ad_data, target_sat):
+    target_sat.enroll_ad_and_configure_external_auth(ad_data)
 
 
 @pytest.mark.external_auth

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -2,12 +2,10 @@ import pytest
 from broker import Broker
 from wait_for import wait_for
 
-from pytest_fixtures.component.satellite_auth import disenroll_idm
-from pytest_fixtures.component.satellite_auth import enroll_ad_and_configure_external_auth
-from pytest_fixtures.component.satellite_auth import enroll_idm_and_configure_external_auth
 from pytest_fixtures.core.broker import _resolve_deploy_args
 from robottelo.config import settings
 from robottelo.hosts import Capsule
+from robottelo.hosts import IPAHost
 
 
 @pytest.fixture
@@ -154,13 +152,14 @@ def parametrized_enrolled_sat(
 ):
     """Yields a Satellite enrolled into [IDM, AD] as parameter."""
     new_sat = satellite_factory()
+    ipa_host = IPAHost(new_sat)
     new_sat.register_to_cdn()
     if 'IDM' in request.param:
-        enroll_idm_and_configure_external_auth(new_sat)
+        ipa_host.enroll_idm_and_configure_external_auth()
         yield new_sat
-        disenroll_idm(new_sat)
+        ipa_host.disenroll_idm()
     else:
-        enroll_ad_and_configure_external_auth(request, ad_data, new_sat)
+        new_sat.enroll_ad_and_configure_external_auth(ad_data)
         yield new_sat
     new_sat.unregister()
     new_sat.teardown()

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -133,6 +133,10 @@ class SatelliteHostError(Exception):
     pass
 
 
+class IPAHostError(Exception):
+    pass
+
+
 class ContentHost(Host, ContentHostMixins):
     run = Host.execute
     default_timeout = settings.server.ssh_client.command_timeout
@@ -1832,6 +1836,118 @@ class Satellite(Capsule, SatelliteMixins):
         # refresh repository metadata on the host
         rhel_contenthost.execute('subscription-manager repos --list')
 
+    def enroll_ad_and_configure_external_auth(self, ad_data):
+        """Enroll Satellite Server to an AD Server.
+
+        :param ad_data: Callable method that returns AD server details
+        :type ad_data: Callable
+        """
+        ad_data = ad_data()
+        packages = (
+            'sssd adcli realmd ipa-python-compat krb5-workstation '
+            'samba-common-tools gssproxy nfs-utils ipa-client'
+        )
+        realm = ad_data.realm
+        workgroup = ad_data.workgroup
+
+        default_content = f'[global]\nserver = unused\nrealm = {realm}'
+        keytab_content = (
+            f'[global]\nworkgroup = {workgroup}\nrealm = {realm}'
+            f'\nkerberos method = system keytab\nsecurity = ads'
+        )
+
+        # install the required packages
+        assert (
+            self.execute(f'yum -y --disableplugin=foreman-protector install {packages}').status == 0
+        )
+
+        # update the AD name server
+        assert self.execute('chattr -i /etc/resolv.conf').status == 0
+        line_number = int(
+            self.execute(
+                "awk -v search='nameserver' '$0~search{print NR; exit}' /etc/resolv.conf"
+            ).stdout
+        )
+        assert (
+            self.execute(
+                f'sed -i "{line_number}i nameserver {ad_data.nameserver}" /etc/resolv.conf'
+            ).status
+            == 0
+        )
+        assert self.execute('chattr +i /etc/resolv.conf').status == 0
+
+        # join the realm
+        assert (
+            self.execute(
+                f'echo {settings.ldap.password} | realm join -v {realm} --membership-software=samba'
+            ).status
+            == 0
+        )
+        assert self.execute('touch /etc/ipa/default.conf').status == 0
+        assert self.execute(f'echo "{default_content}" > /etc/ipa/default.conf').status == 0
+        assert self.execute(f'echo "{keytab_content}" > /etc/net-keytab.conf').status == 0
+
+        # gather the apache id
+        id_apache = str(self.execute('id -u apache')).strip()
+        http_conf_content = (
+            f'[service/HTTP]\nmechs = krb5\ncred_store = keytab:/etc/krb5.keytab'
+            f'\ncred_store = ccache:/var/lib/gssproxy/clients/krb5cc_%U'
+            f'\neuid = {id_apache}'
+        )
+
+        # register the satellite as client for external auth
+        assert self.execute(f'echo "{http_conf_content}" > /etc/gssproxy/00-http.conf').status == 0
+        token_command = (
+            'KRB5_KTNAME=FILE:/etc/httpd/conf/http.keytab net ads keytab add HTTP '
+            '-U administrator -d3 -s /etc/net-keytab.conf'
+        )
+        assert self.execute(f'echo {settings.ldap.password} | {token_command}').status == 0
+        assert self.execute('chown root.apache /etc/httpd/conf/http.keytab').status == 0
+        assert self.execute('chmod 640 /etc/httpd/conf/http.keytab').status == 0
+
+        # enable the foreman-ipa-authentication feature
+        result = self.install(InstallerCommand('foreman-ipa-authentication true'))
+        assert result.status == 0
+
+        # add foreman ad_gp_map_service (BZ#2117523)
+        line_number = int(
+            self.execute(
+                "awk -v search='domain/' '$0~search{print NR; exit}' /etc/sssd/sssd.conf"
+            ).stdout
+        )
+        assert (
+            self.execute(
+                f'sed -i "{line_number + 1}i ad_gpo_map_service = +foreman" /etc/sssd/sssd.conf'
+            ).status
+            == 0
+        )
+        assert self.execute('systemctl restart sssd.service').status == 0
+
+        # unset GssapiLocalName (BZ#1787630)
+        assert (
+            self.execute(
+                'sed -i -e "s/GssapiLocalName.*On/GssapiLocalName Off/g" '
+                '/etc/httpd/conf.d/05-foreman-ssl.d/auth_gssapi.conf'
+            ).status
+            == 0
+        )
+        assert self.execute('systemctl restart gssproxy.service').status == 0
+        assert self.execute('systemctl enable gssproxy.service').status == 0
+
+        # restart the deamon and httpd services
+        httpd_service_content = (
+            '.include /lib/systemd/system/httpd.service\n[Service]' '\nEnvironment=GSS_USE_PROXY=1'
+        )
+        assert (
+            self.execute(
+                f'echo "{httpd_service_content}" > /etc/systemd/system/httpd.service'
+            ).status
+            == 0
+        )
+        assert (
+            self.execute('systemctl daemon-reload && systemctl restart httpd.service').status == 0
+        )
+
 
 class SSOHost(Host):
     """Class for RHSSO functions and setup"""
@@ -2004,3 +2120,101 @@ class SSOHost(Host):
             ]
         }
         self.update_client_configuration(client_config)
+
+
+class IPAHost(Host):
+    def __init__(self, sat_obj, **kwargs):
+        self.satellite = sat_obj
+        kwargs['hostname'] = kwargs.get('hostname', settings.ipa.hostname)
+        # Allow the class to be constructed from kwargs
+        kwargs['from_dict'] = True
+        kwargs.update(
+            {
+                'base_dn': settings.ipa.basedn,
+                'disabled_user_ipa': settings.ipa.disabled_ipa_user,
+                'group_base_dn': settings.ipa.grpbasedn,
+                'group_users': settings.ipa.group_users,
+                'groups': settings.ipa.groups,
+                'ipa_otp_username': settings.ipa.otp_user,
+                'ldap_user_cn': settings.ipa.username,
+                'ldap_user_name': settings.ipa.user,
+                'ldap_user_passwd': settings.ipa.password,
+                'time_based_secret': settings.ipa.time_based_secret,
+            }
+        )
+        super().__init__(**kwargs)
+
+    def disenroll_idm(self):
+        self.execute(f'ipa service-del HTTP/{self.satellite.hostname}')
+        self.execute(f'ipa host-del {self.satellite.hostname}')
+
+    def enroll_idm_and_configure_external_auth(self):
+        """Enroll the Satellite Server to an IDM Server."""
+        result = self.satellite.execute(
+            'yum -y --disableplugin=foreman-protector install ipa-client ipa-admintools'
+        )
+        if result.status != 0:
+            raise SatelliteHostError('Failed to install ipa client')
+        self._kinit_admin()
+        result = self.execute(f'ipa host-find {self.satellite.hostname}')
+        if result.status == 0:
+            self.disenroll_idm()
+        result = self.execute(f'ipa host-add --random {self.satellite.hostname}')
+        for line in result.stdout.splitlines():
+            if 'Random password' in line:
+                _, password = line.split(': ', 2)
+                break
+        self.execute(f'ipa service-add HTTP/{self.satellite.hostname}')
+        _, domain = self.hostname.split('.', 1)
+        result = self.satellite.execute(
+            f"ipa-client-install --password '{password}' "
+            f'--domain {domain} '
+            f'--server {self.hostname} '
+            f'--realm {domain.upper()} -U'
+        )
+        if result.status not in [0, 3]:
+            raise SatelliteHostError('Failed to enable ipa client')
+        result = self.satellite.install(InstallerCommand('foreman-ipa-authentication true'))
+        assert result.status == 0, 'Installer failed to enable IPA authentication.'
+        self.satellite.cli.Service.restart()
+
+    def _kinit_admin(self):
+        result = self.execute(f'echo {self.ldap_user_passwd} | kinit admin')
+        if result.status != 0:
+            raise IPAHostError('Failed to login to the IPA server with admin credentials')
+
+    def create_user(self, username):
+        self._kinit_admin()
+        add_user_cmd = (
+            f'echo {self.ldap_user_passwd} | ipa user-add {username} --first'
+            f'={username} --last={username} --password'
+        )
+        result = self.execute(add_user_cmd)
+        if result.status != 0:
+            raise IPAHostError('Failed to create the user')
+
+    def delete_user(self, username):
+        result = self.execute(f'ipa user-del {username}')
+        if result.status != 0:
+            raise IPAHostError('Failed to delete the user')
+
+    def find_user(self, username):
+        self._kinit_admin()
+        result = self.execute(f"ipa user-find --login {username}")
+        if result.status != 0:
+            raise IPAHostError('Failed to find the user')
+        return result.stdout
+
+    def add_user_to_usergroup(self, member_username, member_group):
+        self._kinit_admin()
+        result = self.execute(f'ipa group-add-member {member_group} --users={member_username}')
+        if result.status != 0:
+            raise IPAHostError('Failed to add the user to usergroup')
+
+    def remove_user_from_usergroup(self, member_username, member_group):
+        self._kinit_admin()
+        result = self.execute(
+            f'ipa group-remove-member {member_group} --users={member_username}',
+        )
+        if result.status != 0:
+            raise IPAHostError('Failed to remove the user from user group')

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -30,7 +30,6 @@ from robottelo.config import settings
 from robottelo.constants import CERT_PATH
 from robottelo.constants import LDAP_ATTR
 from robottelo.constants import PERMISSIONS
-from robottelo.utils import ssh
 from robottelo.utils.datafactory import gen_string
 
 
@@ -115,36 +114,23 @@ def rhsso_groups_teardown(default_sso_host):
 
 
 @pytest.fixture()
-def multigroup_setting_cleanup():
+def multigroup_setting_cleanup(default_ipa_host):
     """Adding and removing the user to/from ipa group"""
     sat_users = settings.ipa.groups
     idm_users = settings.ipa.group_users
-    ssh.command(cmd=f'echo {settings.ipa.password} | kinit admin', hostname=settings.ipa.hostname)
-    cmd = f'ipa group-add-member {sat_users[0]} --users={idm_users[1]}'
-    ssh.command(cmd, hostname=settings.ipa.hostname)
+    default_ipa_host.add_user_to_usergroup(idm_users[1], sat_users[0])
     yield
-    cmd = f'ipa group-remove-member {sat_users[0]} --users={idm_users[1]}'
-    ssh.command(cmd, hostname=settings.ipa.hostname)
+    default_ipa_host.remove_user_from_usergroup(idm_users[1], sat_users[0])
 
 
 @pytest.fixture()
-def ipa_add_user():
+def ipa_add_user(default_ipa_host):
     """Create an IPA user and delete it"""
-    result = ssh.command(
-        cmd=f'echo {settings.ipa.password} | kinit admin', hostname=settings.ipa.hostname
-    )
-    assert result.status == 0
     test_user = gen_string('alpha')
-    add_user_cmd = (
-        f'echo {settings.ipa.password} | ipa user-add {test_user} --first'
-        f'={test_user} --last={test_user} --password'
-    )
-    result = ssh.command(cmd=add_user_cmd, hostname=settings.ipa.hostname)
-    assert result.status == 0
+    default_ipa_host.create_user(test_user)
     yield test_user
 
-    result = ssh.command(cmd=f'ipa user-del {test_user}', hostname=settings.ipa.hostname)
-    assert result.status == 0
+    default_ipa_host.delete_user(test_user)
 
 
 def generate_otp(secret):
@@ -783,7 +769,9 @@ def test_positive_login_user_basic_roles(test_name, session, ldap_tear_down, lda
 
 @pytest.mark.upgrade
 @pytest.mark.tier2
-def test_positive_login_user_password_otp(auth_source_ipa, test_name, ldap_tear_down, ipa_data):
+def test_positive_login_user_password_otp(
+    auth_source_ipa, default_ipa_host, test_name, ldap_tear_down
+):
     """Login with password with time based OTP
 
     :id: be7eb5d6-3228-4660-aa64-c56f9f3ec5e0
@@ -797,19 +785,19 @@ def test_positive_login_user_password_otp(auth_source_ipa, test_name, ldap_tear_
     :CaseImportance: Medium
     """
 
-    otp_pass = f"{ipa_data['ldap_user_passwd']}{generate_otp(ipa_data['time_based_secret'])}"
-    with Session(test_name, ipa_data['ipa_otp_username'], otp_pass) as ldapsession:
+    otp_pass = (
+        f"{default_ipa_host.ldap_user_passwd}{generate_otp(default_ipa_host.time_based_secret)}"
+    )
+    with Session(test_name, default_ipa_host.ipa_otp_username, otp_pass) as ldapsession:
         with pytest.raises(NavigationTriesExceeded):
             ldapsession.user.search('')
-    users = entities.User().search(
-        query={'search': 'login="{}"'.format(ipa_data['ipa_otp_username'])}
-    )
-    assert users[0].login == ipa_data['ipa_otp_username']
+    users = entities.User().search(query={'search': f'login="{default_ipa_host.ipa_otp_username}"'})
+    assert users[0].login == default_ipa_host.ipa_otp_username
 
 
 @pytest.mark.tier2
 def test_negative_login_user_with_invalid_password_otp(
-    auth_source_ipa, test_name, ldap_tear_down, ipa_data
+    auth_source_ipa, default_ipa_host, test_name, ldap_tear_down
 ):
     """Login with password with time based OTP
 
@@ -824,8 +812,10 @@ def test_negative_login_user_with_invalid_password_otp(
     :CaseImportance: Medium
     """
 
-    password_with_otp = f"{ipa_data['ldap_user_passwd']}{gen_string(str_type='numeric', length=6)}"
-    with Session(test_name, ipa_data['ipa_otp_username'], password_with_otp) as ldapsession:
+    password_with_otp = (
+        f"{default_ipa_host.ldap_user_passwd}{gen_string(str_type='numeric', length=6)}"
+    )
+    with Session(test_name, default_ipa_host.ipa_otp_username, password_with_otp) as ldapsession:
         with pytest.raises(NavigationTriesExceeded) as error:
             ldapsession.user.search('')
         assert error.typename == 'NavigationTriesExceeded'
@@ -879,7 +869,7 @@ def test_negative_login_with_incorrect_password(test_name, ldap_auth_source):
 
 
 @pytest.mark.tier2
-def test_negative_login_with_disable_user(ipa_data, auth_source_ipa, ldap_tear_down):
+def test_negative_login_with_disable_user(default_ipa_host, auth_source_ipa, ldap_tear_down):
     """Disabled IDM user cannot login
 
     :id: 49f28006-aa1f-11ea-90d3-4ceb42ab8dbc
@@ -891,7 +881,7 @@ def test_negative_login_with_disable_user(ipa_data, auth_source_ipa, ldap_tear_d
     :expectedresults: Login fails
     """
     with Session(
-        user=ipa_data['disabled_user_ipa'], password=ipa_data['ldap_user_passwd']
+        user=default_ipa_host.disabled_user_ipa, password=default_ipa_host.ldap_user_passwd
     ) as ldapsession:
         with pytest.raises(NavigationTriesExceeded) as error:
             ldapsession.user.search('')
@@ -899,7 +889,9 @@ def test_negative_login_with_disable_user(ipa_data, auth_source_ipa, ldap_tear_d
 
 
 @pytest.mark.tier2
-def test_email_of_the_user_should_be_copied(session, auth_source_ipa, ipa_data, ldap_tear_down):
+def test_email_of_the_user_should_be_copied(
+    session, default_ipa_host, auth_source_ipa, ldap_tear_down
+):
     """Email of the user created in idm server ( set as external authorization source )
     should be copied to the satellite.
 
@@ -914,26 +906,24 @@ def test_email_of_the_user_should_be_copied(session, auth_source_ipa, ipa_data, 
 
     :expectedresults: Email is copied to Satellite:
     """
-    ssh.command(cmd=f'echo {settings.ipa.password} | kinit admin', hostname=settings.ipa.hostname)
-    result = ssh.command(
-        cmd=f"ipa user-find --login {ipa_data['ldap_user_name']}",
-        hostname=settings.ipa.hostname,
-    )
+    result = default_ipa_host.find_user(default_ipa_host.ldap_user_name)
     for line in result.strip().splitlines():
         if 'Email' in line:
             _, result = line.split(': ', 2)
             break
     with Session(
-        user=ipa_data['ldap_user_name'], password=ipa_data['ldap_user_passwd']
+        user=default_ipa_host.ldap_user_name, password=default_ipa_host.ldap_user_passwd
     ) as ldapsession:
         ldapsession.bookmark.search('controller = hosts')
     with session:
-        user_value = session.user.read(ipa_data['ldap_user_name'], widget_names='user')
+        user_value = session.user.read(default_ipa_host.ldap_user_name, widget_names='user')
         assert user_value['user']['mail'] == result
 
 
 @pytest.mark.tier2
-def test_deleted_idm_user_should_not_be_able_to_login(auth_source_ipa, ldap_tear_down):
+def test_deleted_idm_user_should_not_be_able_to_login(
+    target_sat, default_ipa_host, auth_source_ipa, ldap_tear_down
+):
     """After deleting a user in IDM, user should not be able to login into satellite
 
     :id: 18ad0526-e083-11ea-b1ad-4ceb42ab8dbc
@@ -946,21 +936,11 @@ def test_deleted_idm_user_should_not_be_able_to_login(auth_source_ipa, ldap_tear
 
     :expectedresults: User login fails
     """
-    result = ssh.command(
-        cmd=f"echo {settings.ipa.password} | kinit admin", hostname=settings.ipa.hostname
-    )
-    assert result.status == 0
     test_user = gen_string('alpha')
-    add_user_cmd = (
-        f'echo {settings.ipa.password} | ipa user-add {test_user} --first'
-        f'={test_user} --last={test_user} --password'
-    )
-    result = ssh.command(cmd=add_user_cmd, hostname=settings.ipa.hostname)
-    assert result.status == 0
+    default_ipa_host.create_user(test_user)
     with Session(user=test_user, password=settings.ipa.password) as ldapsession:
         ldapsession.bookmark.search('controller = hosts')
-    result = ssh.command(cmd=f'ipa user-del {test_user}', hostname=settings.ipa.hostname)
-    assert result.status == 0
+    default_ipa_host.delete_user(test_user)
     with Session(user=test_user, password=settings.ipa.password) as ldapsession:
         with pytest.raises(NavigationTriesExceeded) as error:
             ldapsession.user.search('')
@@ -1315,7 +1295,9 @@ def test_verify_group_permissions(
 
 
 @pytest.mark.tier2
-def test_verify_ldap_filters_ipa(session, ipa_add_user, auth_source_ipa, ipa_data, ldap_tear_down):
+def test_verify_ldap_filters_ipa(
+    session, ipa_add_user, auth_source_ipa, default_ipa_host, ldap_tear_down
+):
     """Verifying ldap filters in authsource to restrict access
 
     :id: 0052b272-08b1-11eb-80c6-0c7a158cbff4
@@ -1331,16 +1313,16 @@ def test_verify_ldap_filters_ipa(session, ipa_add_user, auth_source_ipa, ipa_dat
 
     # 'test_user' able to login before the filter is applied.
     test_user = ipa_add_user
-    with Session(user=test_user, password=ipa_data['ldap_user_passwd']) as ldapsession:
+    with Session(user=test_user, password=default_ipa_host.ldap_user_passwd) as ldapsession:
         ldapsession.task.read_all()
 
     # updating the authsource with filter
-    group_name = ipa_data['groups'][0]
-    ldap_data = f"(memberOf=cn={group_name},{ipa_data['group_base_dn']})"
+    group_name = default_ipa_host.groups[0]
+    ldap_data = f"(memberOf=cn={group_name},{default_ipa_host.group_base_dn})"
     session.ldapauthentication.update(auth_source_ipa.name, {'account.ldap_filter': ldap_data})
 
     # 'test_user' not able login as it gets filtered out
-    with Session(user=test_user, password=ipa_data['ldap_user_passwd']) as ldapsession:
+    with Session(user=test_user, password=default_ipa_host.ldap_user_passwd) as ldapsession:
         with pytest.raises(NavigationTriesExceeded) as error:
             ldapsession.user.search('')
         assert error.typename == 'NavigationTriesExceeded'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11445

## Issue statement
Every time GH Actions run  `pytest tests/robottelo/` we see the following warning message multiple times in one run. See [the following GitHub Actions run](https://github.com/SatelliteQE/robottelo/actions/runs/4892389046/jobs/8734088618#step:8:891)

```
PASSED
2023-05-05 10:30:21 - robottelo.collection - INFO - Processing test items to add testimony token markers
tests/robottelo/test_report.py::test_junit_timestamps[dummy_test-non_xdist-testcase] ..                                                                       [100%]
=============================== warnings summary ===============================
../../../../../opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/_pytest/config/__init__.py:747
  /opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/_pytest/config/__init__.py:747: PytestAssertRewriteWarning: Module already imported so cannot be rewritten: pytest_fixtures.component.satellite_auth
    self.import_plugin(import_spec)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
- generated xml file: /home/runner/work/robottelo/robottelo/report_PMOyAWKpYi.xml - 2 passed, 1 warning in 0.02s
PASSED
tests/robottelo/test_ssh.py::TestSSH::test_command PASSED
```

This message is printed out as we import functions from the module that also contains pytest fixtures.
https://github.com/SatelliteQE/robottelo/blob/892ae8b23a574e5fd39b47de0cab126bac3d460f/pytest_fixtures/core/sat_cap_factory.py#L5-L7


There is also another warning which comes from https://github.com/reportportal/agent-python-pytest/.
```
/opt/hostedtoolcache/Python/3.11.3/x64/lib/python3.11/site-packages/pytest_reportportal/plugin.py:46: PytestDeprecationWarning: The hookimpl pytest_configure_node uses old-style configuration options (marks or attributes).
  Please use the pytest.hookimpl(optionalhook=True) decorator instead
   to configure the hooks.
   See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
    @pytest.mark.optionalhook

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

## Solution
This PR :tada:
I have moved the functions out of the `satellite_auth.py` fixture module and put them into a newly created `IPAHost` and the good ol' `Satellite` host objects. The `IPAHost` object could be used as the `SSOHost` and could contain more functions and properties eventually.

### Additional enhancements
* Wrap the "ipa" cli commands as IPAHost methods.
* Add a new exception to represent errors in IPAHost.
* Put "kinit admin" in its own function.
* Use the IPAHost object properties instead of the data from ipa_data
  fixture.


I have also created a PR https://github.com/reportportal/agent-python-pytest/pull/337 in the plugin repo that fixes the deprecation.

## Note
I am open to moving some of the stuff to mixins to not bloat `hosts.py`.