### PR TITLE
Katello-tracer Alligned in CI

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -65,7 +65,7 @@ CaseComponent:
     - Installer
     - InterSatelliteSync
     - katello-agent
-    - Katello-tracer
+    - katello-tracer
     - LDAP
     - Leappintegration
     - LifecycleEnvironments

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2492,7 +2492,7 @@ def test_positive_tracer_list_and_resolve(tracer_host):
 
     :CaseImportance: Medium
 
-    :CaseComponent: Katello-tracer
+    :CaseComponent: katello-tracer
 
     :bz: 2186188
     """

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2599,7 +2599,7 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
 
     :id: c9ebd4a8-6db3-4d0e-92a2-14951c26769b
 
-    :caseComponent: Katello-tracer
+    :caseComponent: katello-tracer
 
     :Team: Phoenix
 


### PR DESCRIPTION
Making kattelo-tracer component aligned in CI to align with its team. Now it's seating in an unaligned pipeline in CI.

Now the CI can collect it right:

```
# pytest --collect-only --component katello-tracer tests/foreman/
=================== test session starts ========================
platform darwin -- Python 3.11.1, pytest-7.3.1, pluggy-1.0.0
Mandatory Requirements Available: requests==2.31.0 pytest-reportportal==5.1.8 jinja2==3.1.2
Optional Requirements Available: pre-commit==3.3.2 manage>=0.1.13 sphinx==7.0.1 redis==4.5.5 sphinx-autoapi==2.1.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/jitendrayejare/GitRepos/robottelo
configfile: pyproject.toml
plugins: ibutsu-2.2.4, mock-3.10.0, reportportal-5.1.7, xdist-3.2.1, services-2.2.1, cov-3.0.0
collected 6092 items / 6080 deselected / 12 selected                                                                                                                                                                                                                                                                                                                

<Package cli>
  <Module test_host.py>
    <Function test_positive_tracer_list_and_resolve[rhel7]>
    <Function test_positive_tracer_list_and_resolve[rhel7_fips]>
    <Function test_positive_tracer_list_and_resolve[rhel8]>
    <Function test_positive_tracer_list_and_resolve[rhel8_fips]>
    <Function test_positive_tracer_list_and_resolve[rhel9]>
    <Function test_positive_tracer_list_and_resolve[rhel9_fips]>
<Package ui>
  <Module test_host.py>
    <Function test_positive_tracer_enable_reload[rhel7]>
    <Function test_positive_tracer_enable_reload[rhel7_fips]>
    <Function test_positive_tracer_enable_reload[rhel8]>
    <Function test_positive_tracer_enable_reload[rhel8_fips]>
    <Function test_positive_tracer_enable_reload[rhel9]>
    <Function test_positive_tracer_enable_reload[rhel9_fips]>

=============== 12/6092 tests collected (6080 deselected) in 20.77s =================
```