### PR TITLE
[6.13.z] Test case updated for RHEL6 client registration

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -22,7 +22,6 @@ import pytest
 
 from robottelo.constants import CLIENT_PORT
 from robottelo.constants import ENVIRONMENT
-from robottelo.utils.issue_handlers import is_open
 
 pytestmark = pytest.mark.tier1
 
@@ -57,10 +56,8 @@ def test_host_registration_end_to_end(
     ).create()
 
     result = rhel_contenthost.execute(command)
-    if is_open('BZ:2156926') and rhel_contenthost.os_version.major == 6:
-        assert result.status == 1, f'Failed to register host: {result.stderr}'
-    else:
-        assert result.status == 0, f'Failed to register host: {result.stderr}'
+    rc = 1 if rhel_contenthost.os_version.major == 6 else 0
+    assert result.status == rc, f'Failed to register host: {result.stderr}'
 
     # Verify server.hostname and server.port from subscription-manager config
     assert module_target_sat.hostname == rhel_contenthost.subscription_config['server']['hostname']
@@ -80,10 +77,8 @@ def test_host_registration_end_to_end(
     ).create()
     result = rhel_contenthost.execute(command)
 
-    if is_open('BZ:2156926') and rhel_contenthost.os_version.major == 6:
-        assert result.status == 1, f'Failed to register host: {result.stderr}'
-    else:
-        assert result.status == 0, f'Failed to register host: {result.stderr}'
+    rc = 1 if rhel_contenthost.os_version.major == 6 else 0
+    assert result.status == rc, f'Failed to register host: {result.stderr}'
 
     # Verify server.hostname and server.port from subscription-manager config
     assert (

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -20,7 +20,6 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import CLIENT_PORT
-from robottelo.utils.issue_handlers import is_open
 
 pytestmark = pytest.mark.tier1
 
@@ -52,10 +51,8 @@ def test_host_registration_end_to_end(
         module_org, module_location, module_ak_with_synced_repo.name, module_target_sat
     )
 
-    if is_open('BZ:2156926') and rhel_contenthost.os_version.major == 6:
-        assert result.status == 1, f'Failed to register host: {result.stderr}'
-    else:
-        assert result.status == 0, f'Failed to register host: {result.stderr}'
+    rc = 1 if rhel_contenthost.os_version.major == 6 else 0
+    assert result.status == rc, f'Failed to register host: {result.stderr}'
 
     # Verify server.hostname and server.port from subscription-manager config
     assert module_target_sat.hostname == rhel_contenthost.subscription_config['server']['hostname']
@@ -76,10 +73,8 @@ def test_host_registration_end_to_end(
         module_capsule_configured,
         force=True,
     )
-    if is_open('BZ:2156926') and rhel_contenthost.os_version.major == 6:
-        assert result.status == 1, f'Failed to register host: {result.stderr}'
-    else:
-        assert result.status == 0, f'Failed to register host: {result.stderr}'
+    rc = 1 if rhel_contenthost.os_version.major == 6 else 0
+    assert result.status == rc, f'Failed to register host: {result.stderr}'
 
     # Verify server.hostname and server.port from subscription-manager config
     assert (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11538

Since the registration [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2156926) is closed as NOTABUG so updating the condition for RHEL6 client registration.