### PR TITLE
Fix Puppet enable test failures

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -24,6 +24,7 @@ class EnablePluginsSatellite:
     """Miscellaneous settings helper methods"""
 
     def enable_puppet_satellite(self):
+        self.register_to_cdn()
         enable_satellite_cmd = InstallerCommand(
             installer_args=PUPPET_SATELLITE_INSTALLER,
             installer_opts=PUPPET_COMMON_INSTALLER_OPTS,

--- a/tests/foreman/destructive/test_puppetplugin.py
+++ b/tests/foreman/destructive/test_puppetplugin.py
@@ -98,7 +98,6 @@ def test_positive_enable_disable_logic(target_sat, capsule_configured):
     assert 'failed to load one or more features (Puppet)' in result.stdout
 
     # Enable puppet on Satellite and check it succeeded.
-    target_sat.register_to_cdn()
     target_sat.enable_puppet_satellite()
     assert_puppet_status(target_sat, expected=True)
 


### PR DESCRIPTION
Puppet enable fails due to a change in the Java version in the latest Candlepin release in a recent stream snap, whereas Puppet still requires an old Java version, DNF tries to resolve it while installing `puppetserver` and requires CDN repos to install. Here `session_puppet_enabled_sat` uses `enable_puppet_satellite` where added simple step for registering sat to CDN for RHEL content repos.