### PR TITLE
remove rhel6 support from scap test and skip test due to bz 2211437

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -254,6 +254,7 @@ def test_positive_oscap_run_via_ansible(
         result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})
         assert result is not None
 
+
 @pytest.mark.skip_if_open('BZ:2211437')
 @pytest.mark.tier4
 def test_positive_oscap_run_via_ansible_bz_1814988(

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -132,10 +132,11 @@ def update_scap_content(module_org):
         Scapcontent.update({'title': content['title'], 'organization-ids': organization_ids})
 
 
+@pytest.mark.skip_if_open('BZ:2211437')
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.tier4
-@pytest.mark.parametrize('distro', ['rhel6', 'rhel7', 'rhel8'])
+@pytest.mark.parametrize('distro', ['rhel7', 'rhel8'])
 def test_positive_oscap_run_via_ansible(
     module_org, default_proxy, content_view, lifecycle_env, distro, target_sat
 ):
@@ -164,10 +165,7 @@ def test_positive_oscap_run_via_ansible(
 
     :CaseImportance: Critical
     """
-    if distro == 'rhel6':
-        rhel_repo = settings.repos.rhel6_os
-        profile = OSCAP_PROFILE['dsrhel6']
-    elif distro == 'rhel7':
+    if distro == 'rhel7':
         rhel_repo = settings.repos.rhel7_os
         profile = OSCAP_PROFILE['security7']
     else:
@@ -219,7 +217,7 @@ def test_positive_oscap_run_via_ansible(
                 'parameter-type': 'boolean',
             }
         )
-        if distro not in ('rhel6', 'rhel7'):
+        if distro not in ('rhel7'):
             vm.create_custom_repos(**rhel_repo)
         else:
             vm.create_custom_repos(**{distro: rhel_repo})
@@ -256,7 +254,7 @@ def test_positive_oscap_run_via_ansible(
         result = Arfreport.list({'search': f'host={vm.hostname.lower()}'})
         assert result is not None
 
-
+@pytest.mark.skip_if_open('BZ:2211437')
 @pytest.mark.tier4
 def test_positive_oscap_run_via_ansible_bz_1814988(
     module_org, default_proxy, content_view, lifecycle_env, target_sat


### PR DESCRIPTION
- Parameterised OpenSCAP test was failing due to various reasons, as per discussion we decided to remove the support for rhel6 from scap.
- Also due to regression issue/BZ #2211437 test was failing (in Stream/6.14.0) for rhel7 & rhel8 as well, so added skip marker.
- Test would not run in CI.
- In 6.12 test was failing for rhel6 after running the Ansible playbook (python version issue)