### PR TITLE
Tweaks for the Satellite version properties

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -146,12 +146,12 @@ def module_provisioning_sat(
     provisioning_domain_name = f"{gen_string('alpha').lower()}.foo"
 
     broker_data_out = Broker().execute(
-        workflow="configure-install-sat-provisioning-rhv",
-        artifacts="last",
+        workflow='configure-install-sat-provisioning-rhv',
+        artifacts='last',
         target_vlan_id=settings.provisioning.vlan_id,
         target_host=sat.name,
         provisioning_dns_zone=provisioning_domain_name,
-        sat_version=sat.version,
+        sat_version='stream' if sat.is_stream else sat.version,
     )
 
     broker_data_out = Box(**broker_data_out['data_out'])

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1397,8 +1397,7 @@ class Capsule(ContentHost, CapsuleMixins):
     @cached_property
     def version(self):
         if not self.is_upstream:
-            version = self.execute('rpm -q satellite-capsule').stdout
-            return 'stream' if 'stream' in version else version.split('-')[2]
+            return self.execute('rpm -q satellite-capsule').stdout.split('-')[2]
         else:
             return 'upstream'
 
@@ -1673,8 +1672,7 @@ class Satellite(Capsule, SatelliteMixins):
     @cached_property
     def version(self):
         if not self.is_upstream:
-            version = self.execute('rpm -q satellite').stdout
-            return 'stream' if 'stream' in version else version.split('-')[1]
+            return self.execute('rpm -q satellite').stdout.split('-')[1]
         else:
             return 'upstream'
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1394,7 +1394,7 @@ class Capsule(ContentHost, CapsuleMixins):
         :return: True if no downstream satellite RPMS are installed
         :rtype: bool
         """
-        return self.execute(f'rpm -q {self.product_rpm_name} &>/dev/null').status != 0
+        return self.execute(f'rpm -q {self.product_rpm_name}').status != 0
 
     @cached_property
     def is_stream(self):
@@ -1403,12 +1403,16 @@ class Capsule(ContentHost, CapsuleMixins):
         :return: True if the Capsule is a stream release
         :rtype: bool
         """
-        return 'stream' in self.execute(f'rpm -q {self.product_rpm_name}').stdout.strip()
+        if self.is_upstream:
+            return False
+        return (
+            'stream' in self.execute(f'rpm -q --qf "%{{RELEASE}}" {self.product_rpm_name}').stdout
+        )
 
     @cached_property
     def version(self):
         rpm_name = self.upstream_rpm_name if self.is_upstream else self.product_rpm_name
-        return self.execute(f'rpm -q {rpm_name}').stdout.split('-')[2]
+        return self.execute(f'rpm -q --qf "%{{VERSION}}" {rpm_name}').stdout
 
     @cached_property
     def url(self):

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -917,7 +917,7 @@ def test_positive_list_with_nested_hostgroup(target_sat):
     logger.info(f'Host info: {host}')
     assert host['operating-system']['medium'] == options.medium.name
     assert host['operating-system']['partition-table'] == options.ptable.name  # inherited
-    if not is_open('BZ:2215294') or target_sat.version != 'stream':
+    if not is_open('BZ:2215294') or not target_sat.is_stream:
         assert 'id' in host['content-information']['lifecycle-environment']
         assert int(host['content-information']['lifecycle-environment']['id']) == int(lce.id)
         assert int(host['content-information']['content-view']['id']) == int(


### PR DESCRIPTION
This patch reverts commit 8ece887 - "Handle stream versions in version cached_property (#11467)".

## Problem statement
#11467 has updated the `version` property to return the `stream` string if the respective Satellite/Capsule is a stream release.
This breaks the compatibility of this method in most places where we use it.

Two places where #11467 broke the logic:

* `is_open` method throws `packaging.version.InvalidVersion: Invalid version: 'stream'` if the Sat release is stream.

* With 6.15 which will start supporting RHEL 9, we will need to change the parametrization of `test_positive_leapp`. There we check for `get_sat_version().minor != 11` which will change to `get_sat_version().minor != 15`.  The patch in #11571 does not help as `get_sat_version` would return `Version('9999')` which has no minor version.

Both use `get_sat_version`.

### Original motivation of #11467
When Sat Stream was 6.14, we executed the `configure-install-sat-provisioning-rhv` WF passing `sat_version=sat_object.version`, where `sat_object.version` property returned `6.14` - which is correct.
But Satlab did not know about 6.14 at that time.


## Solution

* revert #11467 and stick to the original behavior of the `version` property

* Introduce `is_stream` property to simplify the way to distinguish if the release `is_stream`. 

* Change `sat_version=sat.version` to `sat_version='stream' if sat.is_stream else sat.version`. Another solution might be to create symlink `6.Y.yml` in `playbooks/utils/satellite/` that would point to `stream.yml`. This symlink would be created once we branch Satellite from Stream. `Y` equals to `Y version of the release that was branched from Stream` + `1`.


