### PR TITLE
[6.14.z] Adding better coverage to enable/disable stream test

### DIFF
--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -148,10 +148,17 @@ def test_positive_service_enable_disable(sat_maintain):
 
     :customerscenario: true
     """
+    result = sat_maintain.cli.Service.stop()
+    assert 'FAIL' not in result.stdout
+    assert result.status == 0
     result = sat_maintain.cli.Service.disable()
     assert 'FAIL' not in result.stdout
     assert result.status == 0
     result = sat_maintain.cli.Service.enable()
+    assert 'FAIL' not in result.stdout
+    assert result.status == 0
+    sat_maintain.power_control(state='reboot')
+    result = sat_maintain.cli.Service.status(options={'brief': True, 'only': 'foreman.service'})
     assert 'FAIL' not in result.stdout
     assert result.status == 0
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11514

https://github.com/SatelliteQE/robottelo/pull/11481 got merged before I could investigate. Apparently this test as it was before can pass on Satellite, but the case from the BZ will still fail. The original intent was to have the test case fail and then we can check automation when we get the stream snap with the fix in it. This test will now fail until the fix is added to stream.