### PR TITLE
[6.12.z] Close looop BZ1896628

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -122,7 +122,7 @@ class TestRemoteExecution:
     @pytest.mark.pit_client
     @pytest.mark.pit_server
     @pytest.mark.rhel_ver_list([8])
-    def test_positive_run_default_job_template_by_ip(self, rex_contenthost):
+    def test_positive_run_default_job_template_by_ip(self, module_org, rex_contenthost):
         """Run default template on host connected by ip and list task
 
         :id: 811c7747-bec6-4a2d-8e5c-b5045d3fbc0d
@@ -130,7 +130,7 @@ class TestRemoteExecution:
         :expectedresults: Verify the job was successfully ran against the host
             and task can be listed by name and ID
 
-        :BZ: 1647582
+        :BZ: 1647582, 1896628
 
         :customerscenario: true
 
@@ -149,6 +149,15 @@ class TestRemoteExecution:
         task = Task.list_tasks({'search': command})[0]
         search = Task.list_tasks({'search': f'id={task["id"]}'})
         assert search[0]['action'] == task['action']
+        out = JobInvocation.get_output(
+            {
+                'id': invocation_command['id'],
+                'host': client.hostname,
+                'organization-id': module_org.id,
+            }
+        )
+        assert 'Exit' in out
+        assert 'Internal Server Error' not in out
 
     @pytest.mark.tier3
     @pytest.mark.pit_client


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11570

```
$ pytest tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_default_job_template_by_ip
================================================================= test session starts =================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/lhellebr/git/robottelo/venv/bin/python
Mandatory Requirements Available: pytest-reportportal==5.1.8 broker[docker]==0.3.2 wrapanapi==3.5.15 requests==2.31.0 pytest-xdist==3.3.1 jinja2==3.1.2
Optional Requirements Available: sphinx==7.0.1 redis==4.5.5 pre-commit==3.3.2 manage>=0.1.13
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, xdist-3.2.1, reportportal-5.1.7, mock-3.10.0, ibutsu-2.2.4
collected 1 item                                                                                                                                      

tests/foreman/cli/test_remoteexecution.py::TestRemoteExecution::test_positive_run_default_job_template_by_ip[rhel8] PASSED                      [100%]

============================================================ 1 passed in 769.45s (0:12:49) ============================================================
```