### PR TITLE
Remove unnecessary failing assertion api/test_http_proxy.py

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -313,7 +313,6 @@ def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, m
 
     assert repo.http_proxy_policy == 'use_selected_http_proxy'
     assert repo.http_proxy_id == http_proxy.id
-    assert http_proxy.cacert == cacert_path
 
     response = repo.sync()
     assert response.get('errors') is None


### PR DESCRIPTION
This was addressed in the cherrypick of [this PR](https://github.com/SatelliteQE/robottelo/pull/11526), the failing assertion was only removed from 6.13.z, but not 6.14.z