### PR TITLE
[6.12.z] Close loop - Ansible job invocation shows wrong info after remote execution job

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -87,6 +87,13 @@ def rhel6_contenthost(request):
         yield host
 
 
+@pytest.fixture(params=[{'rhel_version': '9'}])
+def rhel9_contenthost(request):
+    """A fixture that provides a rhel9 content host object"""
+    with Broker(**host_conf(request), host_class=ContentHost) as host:
+        yield host
+
+
 @pytest.fixture()
 def content_hosts(request):
     """A function-level fixture that provides two rhel content hosts object"""

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -123,3 +123,75 @@ def test_positive_ansible_job_on_host(target_sat, module_org, rhel_contenthost):
     )
     result = target_sat.api.JobInvocation(id=job['id']).read()
     assert result.succeeded == 1
+
+
+@pytest.mark.no_containers
+def test_positive_ansible_job_on_multiple_host(
+    target_sat,
+    module_org,
+    rhel9_contenthost,
+    rhel8_contenthost,
+    rhel7_contenthost,
+    module_location,
+    module_ak_with_synced_repo,
+):
+    """Test execution of Ansible job on multiple hosts simultaneously.
+
+    :id: 9369feef-466c-40d3-9d0d-65520d7f21ef
+
+    :customerscenario: true
+
+    :steps:
+        1. Register multiple content hosts with satellite
+        2. Import a role into satellite
+        3. Assign that role to all host
+        4. Trigger ansible job keeping all host in a single query
+        5. Check the passing and failing of individual hosts
+        6. Check if one of the job on a host is failed resulting into whole job is marked as failed.
+
+    :expectedresults:
+        1. One of the jobs failing on a single host must impact the overall result as failed.
+
+    :BZ: 2167396, 2190464, 2184117
+
+    :CaseAutomation: Automated
+    """
+    hosts = [rhel9_contenthost, rhel8_contenthost, rhel7_contenthost]
+    SELECTED_ROLE = 'RedHatInsights.insights-client'
+    for host in hosts:
+        result = host.register(
+            module_org, module_location, module_ak_with_synced_repo.name, target_sat
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+        id = target_sat.nailgun_smart_proxy.id
+        target_host = host.nailgun_host
+        target_sat.api.AnsibleRoles().sync(data={'proxy_id': id, 'role_names': [SELECTED_ROLE]})
+        target_sat.cli.Host.ansible_roles_assign(
+            {'id': target_host.id, 'ansible-roles': SELECTED_ROLE}
+        )
+        host_roles = target_host.list_ansible_roles()
+        assert host_roles[0]['name'] == SELECTED_ROLE
+
+    template_id = (
+        target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Ansible Roles - Ansible Default"'})[0]
+        .id
+    )
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'targeting_type': 'static_query',
+            'search_query': f'name ^ ({hosts[0].hostname} && {hosts[1].hostname} '
+            f'&& {hosts[2].hostname})',
+        },
+    )
+    target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}',
+        poll_timeout=1000,
+        must_succeed=False,
+    )
+    result = target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 2  # SELECTED_ROLE working on rhel8/rhel9 clients
+    assert result.failed == 1  # SELECTED_ROLE failing  on rhel7 client
+    assert result.status_label == 'failed'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11491

Execution of Ansible job on multiple hosts simultaneously

**Test result:**

```
pytest tests/foreman/api/test_ansible.py -k test_positive_ansible_job_on_multiple_host
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.11.1, pytest-7.3.1, pluggy-1.0.0
Mandatory Requirements Available: jinja2==3.1.2
Optional Requirements Available: sphinx==7.0.1 manage>=0.1.13
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/addubey/work/robottelo
configfile: pyproject.toml
plugins: services-2.2.1, mock-3.10.0, reportportal-5.1.7, ibutsu-2.2.4, xdist-3.2.1, cov-3.0.0
collected 8 items / 7 deselected / 1 selected                                                                                                                                                                     

tests/foreman/api/test_ansible.py .                                                                                                                                                                         [100%]
============================================================================ 1 passed, 7 deselected, 2 warnings in 1714.08s (0:28:34) =============================================================================
```