### PR TITLE
[6.13.z] Automate BZ 1969263

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -1387,6 +1387,31 @@ def test_positive_read_puppet_ca_proxy_name(
     assert session_puppet_enabled_proxy.name == host['puppet_ca_proxy_name']
 
 
+@pytest.mark.tier2
+def test_positive_list_hosts_thin_all(module_target_sat):
+    """List hosts with thin=true and per_page=all
+
+    :id: 00b7e603-aed5-4b19-bfec-1a179fad6743
+
+    :expectedresults: Hosts listed without ISE
+
+    :BZ: 1969263
+
+    :customerscenario: true
+    """
+    hosts = module_target_sat.api.Host().search(query={'thin': 'true', 'per_page': 'all'})
+    assert module_target_sat.hostname in [host.name for host in hosts]
+    keys = dir(hosts[0])
+    assert 'id' in keys
+    assert 'name' in keys
+    # Can't check for only id and name being present because the framework adds
+    # some data the API doesn't actually return (currently, it adds empty Environment).
+    # Instead, check for some data to be missing, as opposed to non-thin.
+    assert 'domain' not in keys
+    assert 'ip' not in keys
+    assert 'architecture' not in keys
+
+
 class TestHostInterface:
     """Tests for Host Interfaces"""
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11557

With fix not applied:
```
$ pytest tests/foreman/api/test_host.py::test_positive_list_hosts_thin_all
================================================================= test session starts =================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/lhellebr/git/robottelo/venv/bin/python
Mandatory Requirements Available: requests==2.31.0 broker[docker]==0.3.2 pytest-reportportal==5.1.8 jinja2==3.1.2 wrapanapi==3.5.15
Optional Requirements Available: sphinx==7.0.1 redis==4.5.5 pre-commit==3.3.2 manage>=0.1.13
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, xdist-3.2.1, reportportal-5.1.7, mock-3.10.0, ibutsu-2.2.4
collected 1 item                                                                                                                                      

tests/foreman/api/test_host.py::test_positive_list_hosts_thin_all FAILED                                                                        [100%]

====================================================================== FAILURES =======================================================================
__________________________________________________________ test_positive_list_hosts_thin_all __________________________________________________________

module_target_sat = Satellite(omitting_credentials=False, port=22, blank=False, hostname=<sat>,...ServerConfig(url='https://<sat>, auth=('admin', 'changeme'), verify=False))

    @pytest.mark.tier2
    def test_positive_list_hosts_thin_all(module_target_sat):
        """ List hosts with thin=true and per_page=all
    
        :id: 00b7e603-aed5-4b19-bfec-1a179fad6743
    
        :expectedresults: Hosts listed without ISE
    
        :BZ: 1969263
    
        :CaseImportance: High
        """
>       module_target_sat.api.Host().search(query={'thin': 'true', 'per_page': 'all'})

tests/foreman/api/test_host.py:1401: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
venv/lib/python3.9/site-packages/nailgun/entities.py:4652: in search
    results = self.search_json(fields, query)['results']
venv/lib/python3.9/site-packages/nailgun/entity_mixins.py:1243: in search_json
    response.raise_for_status()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Response [500]>

    def raise_for_status(self):
        """Raises :class:`HTTPError`, if one occurred."""
    
        http_error_msg = ""
        if isinstance(self.reason, bytes):
            # We attempt to decode utf-8 first because some servers
            # choose to localize their reason strings. If the string
            # isn't utf-8, we fall back to iso-8859-1 for all other
            # encodings. (See PR #3538)
            try:
                reason = self.reason.decode("utf-8")
            except UnicodeDecodeError:
                reason = self.reason.decode("iso-8859-1")
        else:
            reason = self.reason
    
        if 400 <= self.status_code < 500:
            http_error_msg = (
                f"{self.status_code} Client Error: {reason} for url: {self.url}"
            )
    
        elif 500 <= self.status_code < 600:
            http_error_msg = (
                f"{self.status_code} Server Error: {reason} for url: {self.url}"
            )
    
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://<sat>/api/v2/hosts

venv/lib/python3.9/site-packages/requests/models.py:1021: HTTPError
---------------------------------------------------------------- Captured stderr setup ----------------------------------------------------------------
2023-05-30 14:48:56 - robottelo.collection - INFO - Processing test items to add testimony token markers
----------------------------------------------------------------- Captured log setup ------------------------------------------------------------------
INFO     robottelo:xdist.py:46 xdist worker master was assigned hostname <sat>
---------------------------------------------------------------- Captured stderr call -----------------------------------------------------------------
2023-05-30 14:49:29 - nailgun.client - WARNING - Received HTTP 500 response: {
      "error": {"message":"Internal Server Error: the server was unable to finish the request. This may be caused by unavailability of some required service, incorrect API call or a server-side bug. There may be more information in the server's logs."}
    }
    
2023-05-30 14:49:29 - nailgun.client - WARNING - Received HTTP 500 response: {
      "error": {"message":"Internal Server Error: the server was unable to finish the request. This may be caused by unavailability of some required service, incorrect API call or a server-side bug. There may be more information in the server's logs."}
    }
    
------------------------------------------------------------------ Captured log call ------------------------------------------------------------------
DEBUG    nailgun.client:client.py:109 Making HTTP GET request to https://<sat>/api/v2/hosts with options {'data': '{"thin": "true", "per_page": "all"}', 'auth': None, 'verify': None, 'headers': {'content-type': 'application/json'}}, no params and no data.
WARNING  nailgun.client:client.py:131 Received HTTP 500 response: {
  "error": {"message":"Internal Server Error: the server was unable to finish the request. This may be caused by unavailability of some required service, incorrect API call or a server-side bug. There may be more information in the server's logs."}
}
=============================================================== short test summary info ===============================================================
FAILED tests/foreman/api/test_host.py::test_positive_list_hosts_thin_all - requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://<sat>/api/v2/hosts
================================================================= 1 failed in 34.15s ==================================================================
```

With fix applied:
```
$ pytest tests/foreman/api/test_host.py::test_positive_list_hosts_thin_all
================================================================= test session starts =================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/lhellebr/git/robottelo/venv/bin/python
Mandatory Requirements Available: broker[docker]==0.3.2 requests==2.31.0 pytest-reportportal==5.1.8 jinja2==3.1.2 wrapanapi==3.5.15
Optional Requirements Available: redis==4.5.5 manage>=0.1.13 pre-commit==3.3.2 sphinx==7.0.1
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, xdist-3.2.1, reportportal-5.1.7, mock-3.10.0, ibutsu-2.2.4
collected 1 item                                                                                                                                      

tests/foreman/api/test_host.py::test_positive_list_hosts_thin_all PASSED                                                                        [100%]

================================================================= 1 passed in 26.96s ==================================================================

```