### PR TITLE
Add autoflake in precommit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,18 @@ repos:
   rev: 6.0.0
   hooks:
   - id: flake8
+- repo: https://github.com/PyCQA/autoflake
+  rev: v2.1.1
+  hooks:
+  - id: autoflake
+    "types": [ python ]
+    require_serial: true
+    args:
+      - "--in-place"
+      - "--expand-star-imports"
+      - "--remove-duplicate-keys"
+      - "--remove-unused-variables"
+      - "--remove-all-unused-imports"
 - repo: local
   hooks:
     - id: fix-uuids


### PR DESCRIPTION
**Why do we need it?** Existing pre-commit checks doesn't remove unused imports and variables from the code. With autoflake, it remove these unused imports and variables in-place and avoids the manual effort.
