### PR TITLE
must_succeed flag for task intended to pass/fail

### DIFF
--- a/robottelo/api/utils.py
+++ b/robottelo/api/utils.py
@@ -455,7 +455,9 @@ def create_role_permissions(role, permissions_types_names, search=None):  # prag
         entities.Filter(permission=permissions_entities, role=role, search=search).create()
 
 
-def wait_for_tasks(search_query, search_rate=1, max_tries=10, poll_rate=None, poll_timeout=None):
+def wait_for_tasks(
+    search_query, search_rate=1, max_tries=10, poll_rate=None, poll_timeout=None, must_succeed=True
+):
     """Search for tasks by specified search query and poll them to ensure that
     task has finished.
 
@@ -474,7 +476,7 @@ def wait_for_tasks(search_query, search_rate=1, max_tries=10, poll_rate=None, po
         tasks = entities.ForemanTask().search(query={'search': search_query})
         if len(tasks) > 0:
             for task in tasks:
-                task.poll(poll_rate=poll_rate, timeout=poll_timeout)
+                task.poll(poll_rate=poll_rate, timeout=poll_timeout, must_succeed=must_succeed)
             break
         else:
             time.sleep(search_rate)

--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -28,7 +28,13 @@ class CapsuleInfo:
     """Miscellaneous Capsule helper methods"""
 
     def wait_for_tasks(
-        self, search_query, search_rate=1, max_tries=10, poll_rate=None, poll_timeout=None
+        self,
+        search_query,
+        search_rate=1,
+        max_tries=10,
+        poll_rate=None,
+        poll_timeout=None,
+        must_succeed=True,
     ):
         """Search for tasks by specified search query and poll them to ensure that
         task has finished.
@@ -40,6 +46,7 @@ class CapsuleInfo:
             the start of the next check-up. Parameter for ``sat.api.ForemanTask.poll()`` method.
         :param poll_timeout: Maximum number of seconds to wait until timing out.
             Parameter for ``sat.api.ForemanTask.poll()`` method.
+        :param must_succeed: Assert success result on finished task.
         :return: List of ``sat.api.ForemanTasks`` entities.
         :raises: ``AssertionError``. If not tasks were found until timeout.
         """
@@ -47,7 +54,7 @@ class CapsuleInfo:
             tasks = self.satellite.api.ForemanTask().search(query={'search': search_query})
             if tasks:
                 for task in tasks:
-                    task.poll(poll_rate=poll_rate, timeout=poll_timeout)
+                    task.poll(poll_rate=poll_rate, timeout=poll_timeout, must_succeed=must_succeed)
                 break
             else:
                 time.sleep(search_rate)


### PR DESCRIPTION
Kind of cherry pick for the previous implementation of the `must_succeed` flag for` wait_for_tasks` method

PR's for reference - https://github.com/SatelliteQE/robottelo/pull/10657/files
                                   https://github.com/SatelliteQE/robottelo/pull/10647/files
                                   
 PR's failed because of its absence - https://github.com/SatelliteQE/robottelo/pull/11602
                                   
