### PR TITLE
[6.14.z] fixed the context name for PRT status

### DIFF
--- a/.github/workflows/auto_cherry_pick_merge.yaml
+++ b/.github/workflows/auto_cherry_pick_merge.yaml
@@ -53,7 +53,7 @@ jobs:
         uses: omkarkhatavkar/wait-for-status-checks@main
         with:
           ref: ${{ github.head_ref }}
-          context: 'Robottelo Runner'
+          context: 'Robottelo-Runner'
           wait-interval: 60
           count: 100
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11621

Automerge was failing here : https://github.com/SatelliteQE/robottelo/pull/11612 

This is mainly because of not passing correct the context name 