### PR TITLE
[6.13.z] adding support for parameterization upgrade scenarios

### DIFF
--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -104,7 +104,7 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
         5. Check if the Errata Count in Satellite after the upgrade.
     """
 
-    @pytest.mark.rhel_ver_list([8])
+    @pytest.mark.rhel_ver_list([7, 8, 9])
     @pytest.mark.no_containers
     @pytest.mark.pre_upgrade
     def test_pre_scenario_generate_errata_for_client(
@@ -193,6 +193,7 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
             }
         )
 
+    @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_generate_errata_for_client)
     def test_post_scenario_errata_count_installation(self, target_sat, pre_upgrade_data):
         """Post-upgrade scenario that applies errata on the RHEL client that was set up

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -33,7 +33,7 @@ class TestScenarioREXCapsule:
         4. Check if REX job still getting success.
     """
 
-    @pytest.mark.rhel_ver_list([8])
+    @pytest.mark.rhel_ver_list([7, 8, 9])
     @pytest.mark.no_containers
     @pytest.mark.pre_upgrade
     def test_pre_scenario_remote_execution_external_capsule(
@@ -110,6 +110,7 @@ class TestScenarioREXCapsule:
             }
         )
 
+    @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remote_execution_external_capsule)
     def test_post_scenario_remote_execution_external_capsule(self, target_sat, pre_upgrade_data):
         """Run a REX job on pre-upgrade created client registered
@@ -154,7 +155,7 @@ class TestScenarioREXSatellite:
         7. Check if REX job still getting success.
     """
 
-    @pytest.mark.rhel_ver_list([8])
+    @pytest.mark.rhel_ver_list([7, 8, 9])
     @pytest.mark.no_containers
     @pytest.mark.pre_upgrade
     def test_pre_scenario_remote_execution_satellite(
@@ -220,6 +221,7 @@ class TestScenarioREXSatellite:
             }
         )
 
+    @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remote_execution_satellite)
     def test_post_scenario_remote_execution_satellite(self, target_sat, pre_upgrade_data):
         """Run a REX job on pre-upgrade created client registered

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -84,7 +84,7 @@ class TestSubscriptionAutoAttach:
     upgrade.
     """
 
-    @pytest.mark.rhel_ver_list('8')
+    @pytest.mark.rhel_ver_list([7, 8, 9])
     @pytest.mark.no_containers
     @pytest.mark.pre_upgrade
     def test_pre_subscription_scenario_auto_attach(
@@ -113,9 +113,14 @@ class TestSubscriptionAutoAttach:
         org = upgrade_entitlement_manifest_org
         rhel_contenthost._skip_context_checkin = True
         lce = target_sat.api.LifecycleEnvironment(organization=org).create()
-        rh_repo_id = target_sat.api_factory.enable_sync_redhat_repo(
-            constants.REPOS['rhel8_bos'], org.id
-        )
+        if rhel_contenthost.os_version.major > 7:
+            rh_repo_id = target_sat.api_factory.enable_sync_redhat_repo(
+                constants.REPOS[f'rhel{rhel_contenthost.os_version.major}_bos'], org.id
+            )
+        else:
+            rh_repo_id = target_sat.api_factory.enable_sync_redhat_repo(
+                constants.REPOS[f'rhel{rhel_contenthost.os_version.major}'], org.id
+            )
         rh_repo = target_sat.api.Repository(id=rh_repo_id).read()
         assert rh_repo.content_counts['rpm'] >= 1
         content_view = target_sat.publish_content_view(org, rh_repo)
@@ -142,6 +147,7 @@ class TestSubscriptionAutoAttach:
             }
         )
 
+    @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
     @pytest.mark.post_upgrade(depend_on=test_pre_subscription_scenario_auto_attach)
     def test_post_subscription_scenario_auto_attach(self, request, target_sat, pre_upgrade_data):
         """Run subscription auto-attach on pre-upgrade content host registered


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11504

### PR Description:
This pull request introduces enhanced support for parameterization upgrade scenarios. The upgrade process now involves saving data in the scenarios_entities file for each parameter during the pre-upgrade steps. This allows for more flexible and efficient handling of upgrades involving parameterization. Additionally, the implementation includes a mechanism to retry the upgrade process using the post-upgrade steps, ensuring a robust and reliable upgrade experience.

#### Key Changes:

- Data Persistence: The upgrade process now saves relevant data in the scenarios_entities file for each parameter involved in the upgrade. This enables seamless tracking and management of parameterization upgrade scenarios.
- Pre-upgrade Steps: The codebase has been updated while executing pre-upgrade steps data is stored w.r.t parameters passed while running the tests.  
- Post-upgrade Retry: The implementation now includes an improved mechanism for retrying the upgrade process using the post-upgrade steps.
- These enhancements significantly enhance the upgrade process by providing a more structured and systematic approach to handling parameterization upgrade scenarios. By persisting data, the reliability and efficiency of the upgrade process are greatly improved.

#### How to Use?

- while pre-upgrade parameterization 
```
    @pytest.mark.rhel_ver_list([7, 8, 9])
    @pytest.mark.no_containers
    @pytest.mark.pre_upgrade
    def test_pre_scenario_remote_execution_external_capsule( self,
        rhel_contenthost,

```

- while accessing post-upgrade 

```
    @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_remote_execution_external_capsule)
    def test_post_scenario_remote_execution_external_capsule(self, target_sat, pre_upgrade_data):
```

#### Test Results
```

/Users/okhatavk/satellite/robottelo/env/bin/python "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py" --path /Users/okhatavk/satellite/robottelo/tests/upgrades/test_errata.py -- -m pre_upgrade
Testing started at 3:39 PM ...
Launching pytest with arguments -m pre_upgrade /Users/okhatavk/satellite/robottelo/tests/upgrades/test_errata.py --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

============================= test session starts ==============================
collecting ... collected 6 items / 3 deselected / 3 selected

tests/upgrades/test_errata.py::TestScenarioErrataCount::test_pre_scenario_generate_errata_for_client[rhel7] 
tests/upgrades/test_errata.py::TestScenarioErrataCount::test_pre_scenario_generate_errata_for_client[rhel8] 
tests/upgrades/test_errata.py::TestScenarioErrataCount::test_pre_scenario_generate_errata_for_client[rhel9] 2023-05-22 15:39:23 - robottelo.collection - INFO - Processing test items to add testimony token markers
PASSED [ 33%]PASSED [ 66%]PASSED [100%]

========== 3 passed, 3 deselected, 371 warnings in 2542.37s (0:42:22) ==========

Process finished with exit code 0


/Users/okhatavk/satellite/robottelo/env/bin/python "/Applications/PyCharm CE.app/Contents/plugins/python-ce/helpers/pycharm/_jb_pytest_runner.py" --path /Users/okhatavk/satellite/robottelo/tests/upgrades/test_errata.py -- -m post_upgrade
Testing started at 4:22 PM ...
Launching pytest with arguments -m post_upgrade /Users/okhatavk/satellite/robottelo/tests/upgrades/test_errata.py --no-header --no-summary -q in /Users/okhatavk/satellite/robottelo

============================= test session starts ==============================
collecting ... collected 6 items / 3 deselected / 3 selected

tests/upgrades/test_errata.py::TestScenarioErrataCount::test_post_scenario_errata_count_installation[rhel7] 
tests/upgrades/test_errata.py::TestScenarioErrataCount::test_post_scenario_errata_count_installation[rhel8] 
tests/upgrades/test_errata.py::TestScenarioErrataCount::test_post_scenario_errata_count_installation[rhel9] 

=========== 3 passed, 3 deselected, 86 warnings in 310.18s (0:05:10) ===========

Process finished with exit code 0
2023-05-22 16:23:23 - robottelo.collection - INFO - Processing test items to add testimony token markers
PASSED [ 33%]PASSED [ 66%]PASSED [100%]
```
 


