### PR TITLE
[6.13.z] Fix activation key setup

### DIFF
--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -596,6 +596,8 @@ class RepositoryCollection:
                 'content-view-id': content_view_id,
             }
         )
+        if self.satellite.is_sca_mode_enabled(org_id):
+            return activation_key
         # Add subscriptions to activation-key
         # Get organization subscriptions
         subscriptions = self.satellite.cli.Subscription.list(


### PR DESCRIPTION
Similar to #11667, this proposes a fix in `setup_activation_key` when the org is SCA-enabled and thus no subscription manipulation is relevant.