### PR TITLE
[6.14.z] Fix activation key setup

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -229,5 +229,7 @@ def module_repos_collection_with_manifest(request, module_target_sat, module_org
             for repo_name, repo_params in repo.items()
         ],
     )
-    _repos_collection.setup_content(module_org.id, module_lce.id, upload_manifest=True)
+    _repos_collection.setup_content(
+        module_org.id, module_lce.id, upload_manifest=True, override=True
+    )
     return _repos_collection


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11667

This is just a proposal to fix the setup for `test_errata_installation_with_swidtags` test (an potentially few others using the  same fixture). The test fails in setup due to the fact that SCA is enabled and custom repos (in AK) are disabled by default in 6.14.

So I just decided to skip the subscription manipulation and do the content override on AK creation time.