### PR TITLE
[6.12.z] Close-loop BZ 1955421

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -55,6 +55,7 @@ from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
 from robottelo.constants import SM_OVERALL_STATUS
 from robottelo.hosts import ContentHostError
+from robottelo.logging import logger
 from robottelo.utils.datafactory import invalid_values_list
 from robottelo.utils.datafactory import valid_data_list
 from robottelo.utils.datafactory import valid_hosts_list
@@ -870,7 +871,7 @@ def test_positive_list_with_nested_hostgroup(target_sat):
     :expectedresults: Host is successfully listed and has both parent and
         nested host groups names in its hostgroup parameter
 
-    :BZ: 1427554
+    :BZ: 1427554, 1955421
 
     :CaseLevel: System
     """
@@ -884,11 +885,13 @@ def test_positive_list_with_nested_hostgroup(target_sat):
     content_view.publish()
     content_view.read().version[0].promote(data={'environment_ids': lce.id, 'force': False})
     parent_hg = target_sat.api.HostGroup(
-        name=parent_hg_name, organization=[options.organization]
+        name=parent_hg_name,
+        organization=[options.organization],
+        content_view=content_view,
+        ptable=options.ptable,
     ).create()
     nested_hg = target_sat.api.HostGroup(
         architecture=options.architecture,
-        content_view=content_view,
         domain=options.domain,
         lifecycle_environment=lce,
         location=[options.location],
@@ -897,7 +900,6 @@ def test_positive_list_with_nested_hostgroup(target_sat):
         operatingsystem=options.operatingsystem,
         organization=[options.organization],
         parent=parent_hg,
-        ptable=options.ptable,
     ).create()
     make_host(
         {
@@ -909,6 +911,16 @@ def test_positive_list_with_nested_hostgroup(target_sat):
     )
     hosts = Host.list({'organization-id': options.organization.id})
     assert f'{parent_hg_name}/{nested_hg_name}' == hosts[0]['host-group']
+    host = Host.info({'id': hosts[0]['id']})
+    logger.info(f'Host info: {host}')
+    assert host['operating-system']['medium'] == options.medium.name
+    assert host['operating-system']['partition-table'] == options.ptable.name  # inherited
+    if not is_open('BZ:2215294') or target_sat.version != 'stream':
+        assert 'id' in host['content-information']['lifecycle-environment']
+        assert int(host['content-information']['lifecycle-environment']['id']) == int(lce.id)
+        assert int(host['content-information']['content-view']['id']) == int(
+            content_view.id
+        )  # inherited
 
 
 @pytest.mark.cli_host_create


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11630

```
$ pytest tests/foreman/cli/test_host.py::test_positive_list_with_nested_hostgroup
================================================================= test session starts =================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/lhellebr/git/robottelo/venv/bin/python
Mandatory Requirements Available: broker[docker]==0.3.2 requests==2.31.0 pytest-reportportal==5.1.8 pytest-xdist==3.3.1 wrapanapi==3.5.15 cryptography==41.0.1 jinja2==3.1.2
Optional Requirements Available: pre-commit==3.3.2 redis==4.5.5 manage>=0.1.13 sphinx==7.0.1
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, xdist-3.2.1, reportportal-5.1.7, mock-3.10.0, ibutsu-2.2.4
collected 1 item                                                                                                                                      

tests/foreman/cli/test_host.py::test_positive_list_with_nested_hostgroup 
PASSED                                                                 [100%]

============================================================ 1 passed in 795.01s (0:13:15) ============================================================

```