### PR TITLE
add delete org before run virt-who config upgrade cases

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -78,6 +78,9 @@ class TestScenarioPositiveVirtWho:
             3. Report is sent to satellite.
             4. Virtual sku can be generated and attached.
         """
+        org = target_sat.api.Organization().search(query={'search': f'name={ORG_DATA["name"]}'})
+        if org:
+            target_sat.api.Organization(id=org[0].id).delete()
         default_loc_id = (
             target_sat.api.Location().search(query={'search': f'name="{DEFAULT_LOC}"'})[0].id
         )

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -48,7 +48,7 @@ def form_data(target_sat):
     }
 
 
-ORG_DATA = {'name': 'virtwho_upgrade_org_name'}
+ORG_DATA = {'name': f'virtwho_upgrade_{gen_string("alpha")}'}
 
 
 class TestScenarioPositiveVirtWho:
@@ -130,6 +130,7 @@ class TestScenarioPositiveVirtWho:
             {
                 'hypervisor_name': hypervisor_name,
                 'guest_name': guest_name,
+                'org_id': org.id,
             }
         )
 
@@ -151,10 +152,10 @@ class TestScenarioPositiveVirtWho:
             2. the config and guest connection have the same status.
             3. virt-who config should update and delete successfully.
         """
-        org = target_sat.api.Organization().search(query={'search': f'name={ORG_DATA["name"]}'})[0]
+        org_id = pre_upgrade_data.get('org_id')
 
         # Post upgrade, Verify virt-who exists and has same status.
-        vhd = target_sat.api.VirtWhoConfig(organization_id=org.id).search(
+        vhd = target_sat.api.VirtWhoConfig(organization_id=org_id).search(
             query={'search': f'name={form_data["name"]}'}
         )[0]
         if not is_open('BZ:1802395'):
@@ -169,7 +170,7 @@ class TestScenarioPositiveVirtWho:
         hosts = [hypervisor_name, guest_name]
         for hostname in hosts:
             result = (
-                target_sat.api.Host(organization=org.id)
+                target_sat.api.Host(organization=org_id)
                 .search(query={'search': hostname})[0]
                 .read_json()
             )
@@ -186,6 +187,6 @@ class TestScenarioPositiveVirtWho:
 
         # Delete virt-who config
         vhd.delete()
-        assert not target_sat.api.VirtWhoConfig(organization_id=org.id).search(
+        assert not target_sat.api.VirtWhoConfig(organization_id=org_id).search(
             query={'search': f'name={modify_name}'}
         )


### PR DESCRIPTION
Because ORG_DATA = {'name': 'virtwho_upgrade_org_name'} exist will effect the pre-upgrade case, so clean it before run the case, not use the dynamic name ,because post-upgrade will also this name
case : PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/upgrades/test_virtwho.py  -m pre_upgrade --disable-pytest-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.3.2, pluggy-1.0.0
Mandatory Requirements are up to date.
Optional Requirements are up to date.
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/virtwho/repository/robottelo
configfile: pyproject.toml
plugins: cov-4.1.0, ibutsu-2.2.4, xdist-3.3.1, mock-3.11.1, services-2.2.1, reportportal-5.1.9
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_virtwho.py .                                                                                                                                                                            [100%]

============================================================================ 1 passed, 1 deselected, 25 warnings in 131.65s (0:02:11) =============================================================================
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$  pytest ./tests/upgrades/test_virtwho.py  -m post_upgrade --disable-pytest-warnings
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.3.2, pluggy-1.0.0
Mandatory Requirements are up to date.
Optional Requirements are up to date.
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/virtwho/repository/robottelo
configfile: pyproject.toml
plugins: cov-4.1.0, ibutsu-2.2.4, xdist-3.3.1, mock-3.11.1, services-2.2.1, reportportal-5.1.9
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_virtwho.py .                                                                                                                                                                            [100%]

================================================================================== 1 passed, 1 deselected, 9 warnings in 11.21s ===================================================================================

```