### PR TITLE
[6.13.z] Fix Katello-tracer component case

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -65,7 +65,7 @@ CaseComponent:
     - Installer
     - InterSatelliteSync
     - katello-agent
-    - katello-tracer
+    - Katello-tracer
     - LDAP
     - Leappintegration
     - LifecycleEnvironments

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2498,7 +2498,9 @@ def test_positive_tracer_list_and_resolve(tracer_host):
 
     :CaseImportance: Medium
 
-    :CaseComponent: katello-tracer
+    :CaseComponent: Katello-tracer
+
+    :Team: Phoenix-subscriptions
 
     :bz: 2186188
     """

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2596,9 +2596,9 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
 
     :id: c9ebd4a8-6db3-4d0e-92a2-14951c26769b
 
-    :caseComponent: katello-tracer
+    :CaseComponent: Katello-tracer
 
-    :Team: Phoenix
+    :Team: Phoenix-subscriptions
 
     :CaseLevel: System
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11708

The `Katello-tracer` tests are not collected properly in automation and it seems the case is the culprit in this case.

```
05:02:40  + py.test '-m not stream' -v -rEfs --tb=short -n2 --dist loadscope tests/foreman --component Katello-tracer --junit-xml=sat-Katello-tracer-results.xml --durations=20 --durations-min=600.0 -o junit_suite_name=sat-Katello-tracer --collect-only -q
05:02:55  ============================= test session starts ==============================
...
05:03:42  collected 6093 items / 6093 deselected / 0 selected
```

Because all other components are strictly uppercase, switching this to upper too.
Plus updating the team.