### PR TITLE
Adding service status coverage to backup and restore

### DIFF
--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -127,6 +127,10 @@ def test_positive_backup_split_pulp_tar(
         1. backup succeeds
         2. expected files are present in the backup
         3. size of the pulp_data.tar smaller than provided value
+
+    :customerscenario: true
+
+    :BZ: 2164413
     """
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
     instance = 'satellite' if type(sat_maintain) is Satellite else 'capsule'
@@ -523,7 +527,9 @@ def test_positive_backup_restore(
         4. system health check succeeds
         5. content is present after restore
 
-    :BZ: 2172540
+    :customerscenario: true
+
+    :BZ: 2172540, 1978764, 1979045
     """
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
     instance = 'satellite' if type(sat_maintain) is Satellite else 'capsule'
@@ -560,6 +566,10 @@ def test_positive_backup_restore(
     result = sat_maintain.cli.Health.check(
         options={'whitelist': 'foreman-tasks-not-paused', 'assumeyes': True, 'plaintext': True}
     )
+    assert result.status == 0
+
+    result = sat_maintain.cli.Service.status()
+    assert 'FAIL' not in result.stdout
     assert result.status == 0
 
     # Check that content is present after restore


### PR DESCRIPTION
Coverage for https://bugzilla.redhat.com/show_bug.cgi?id=1978764. The backup and restore tests are what we run with remote DB so this should automatically cover the scenario in the BZ.