### PR TITLE
[6.14.z] Fix repo scraping

### DIFF
--- a/robottelo/content_info.py
+++ b/robottelo/content_info.py
@@ -46,7 +46,7 @@ def get_repo_files_urls_by_url(url, extension='rpm'):
     if result.status_code != 200:
         raise requests.HTTPError(f'{url} is not accessible')
 
-    links = re.findall(r'(?<=href=").*?(?=">)', result.text)
+    links = re.findall(r'(?<=href=")(?!\.\.).*?(?=">)', result.text)
     if 'Packages/' not in links:
         files = sorted(line for line in links if extension in line)
         return [f'{url}{file}' for file in files]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11741

### Problem description
Pulpcore 22.2.0 enhanced repository content listing by adding dates and browse up link (`../`), which broke the recursive repo scraping we use to validate the content published on both, Satellite and Capsule. See the latest Capsule-Content results:

```
tests/foreman/api/test_capsulecontent.py:129: in test_positive_uploaded_content_library_sync
    caps_files = get_repo_files_by_url(caps_repo_url)
robottelo/content_info.py:68: in get_repo_files_by_url
    return sorted([os.path.basename(f) for f in get_repo_files_urls_by_url(url, extension)])
robottelo/content_info.py:57: in get_repo_files_urls_by_url
    files.extend(get_repo_files_urls_by_url(sub, extension))
robottelo/content_info.py:57: in get_repo_files_urls_by_url
    files.extend(get_repo_files_urls_by_url(sub, extension))
...
    raise exc from None
E   RecursionError: possible causes for endless recursion:
```

The affected version is 6.14.0 snap 3 and later, but I would propose to cherry-pick the fix back to z-stream in case the enhancement is backported. At least it should not do any harm.

### More context
https://docs.pulpproject.org/pulpcore/changes.html#id111
https://github.com/pulp/pulpcore/pull/3431

### Last but not least
Content browsing is widely available through `/pulp/content/` since 6.10.0 migrated to pulp3. There is a BZ to restrict this availability: https://bugzilla.redhat.com/show_bug.cgi?id=2088559
