### PR TITLE
[6.14.z] Applied errata template test and custom product fix

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1730,6 +1730,11 @@ def setup_org_for_a_custom_repo(options=None):
                 'subscription': custom_product['name'],
             }
         )
+    # Override custom product to true ( turned off by default in 6.14 )
+    custom_repo = Repository.info({'id': custom_repo['id']})
+    ActivationKey.content_override(
+        {'id': activationkey_id, 'content-label': custom_repo['content-label'], 'value': 'true'}
+    )
     return {
         'activationkey-id': activationkey_id,
         'content-view-id': cv_id,

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -585,6 +585,7 @@ class CLIFactory:
         4. Checks if activation key was given, otherwise creates a new one and
             associates it with the content view.
         5. Adds the custom repo subscription to the activation key
+        6. Override custom product to true ( turned off by default in 6.14 )
 
         :return: A dictionary with the entity ids of Activation key, Content view,
             Lifecycle Environment, Organization, Product and Repository
@@ -663,6 +664,11 @@ class CLIFactory:
                     'subscription': custom_product['name'],
                 }
             )
+        # Override custom product to true ( turned off by default in 6.14 )
+        custom_repo = self._satellite.cli.Repository.info({'id': custom_repo['id']})
+        self._satellite.cli.ActivationKey.content_override(
+            {'id': activationkey_id, 'content-label': custom_repo['content-label'], 'value': 'true'}
+        )
         return {
             'activationkey-id': activationkey_id,
             'content-view-id': cv_id,

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -23,7 +23,9 @@ from nailgun import entities
 from requests import HTTPError
 from wait_for import wait_for
 
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
+from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
 from robottelo.constants import PRDS
 from robottelo.constants import REPOS
 from robottelo.constants import REPOSET
@@ -369,22 +371,75 @@ def test_negative_create_report_without_name():
 
 
 @pytest.mark.tier2
-@pytest.mark.stubbed
-def test_positive_applied_errata():
+@pytest.mark.rhel_ver_match(r'^(?!6$)\d+$')
+@pytest.mark.no_containers
+def test_positive_applied_errata(
+    module_org, module_location, module_cv, module_lce, rhel_contenthost, target_sat
+):
     """Generate an Applied Errata report
 
     :id: a4b577db-141e-4871-a42e-e93887464986
 
-    :setup: User with reporting access rights, some host with applied errata
+    :setup: A Host with some applied errata.
 
     :steps:
 
-        1. POST /api/report_templates/:id/generate
+        1. Generate an Applied Errata report
 
     :expectedresults: A report is generated with all applied errata listed
 
     :CaseImportance: Medium
     """
+    activation_key = target_sat.api.ActivationKey(
+        environment=module_lce, organization=module_org
+    ).create()
+    ERRATUM_ID = str(settings.repos.yum_6.errata[2])
+    target_sat.cli_factory.setup_org_for_a_custom_repo(
+        {
+            'url': settings.repos.yum_9.url,
+            'organization-id': module_org.id,
+            'content-view-id': module_cv.id,
+            'lifecycle-environment-id': module_lce.id,
+            'activationkey-id': activation_key.id,
+        }
+    )
+    result = rhel_contenthost.register(module_org, module_location, activation_key.name, target_sat)
+    assert f'The registered system name is: {rhel_contenthost.hostname}' in result.stdout
+    assert rhel_contenthost.subscribed
+    assert rhel_contenthost.execute(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}').status == 0
+    assert rhel_contenthost.execute(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}').status == 0
+    task_id = target_sat.api.JobInvocation().run(
+        data={
+            'feature': 'katello_errata_install',
+            'inputs': {'errata': ERRATUM_ID},
+            'targeting_type': 'static_query',
+            'search_query': f'name = {rhel_contenthost.hostname}',
+            'organization_id': module_org.id,
+        },
+    )['id']
+    target_sat.wait_for_tasks(
+        search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
+        search_rate=15,
+        max_tries=10,
+    )
+    rt = (
+        target_sat.api.ReportTemplate()
+        .search(query={'search': 'name="Host - Applied Errata"'})[0]
+        .read()
+    )
+    res = rt.generate(
+        data={
+            'organization_id': module_org.id,
+            'report_format': 'json',
+            'input_values': {
+                'Filter Errata Type': 'all',
+                'Include Last Reboot': 'no',
+                'Status': 'all',
+            },
+        }
+    )
+    assert res[0]['erratum_id'] == ERRATUM_ID
+    assert res[0]['issued']
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11561

Test for Host - Applied Errata report template ( Very simple, just checking for the installed errata, and verifying the date field is there, and is correct ) 

This also includes an update to a clifactory method used to generate a custom product for use in Errata tests, as well as used within the new Applied Errata test. In 6.14, custom products were all disabled by default, and this overrides that to true. 