### PR TITLE
[6.14.z] Enable client_repo in AK for provisioning

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -124,6 +124,12 @@ def module_provisioning_rhel_content(
         environment=module_lce_library,
     ).create()
 
+    # Ensure client repo is enabled in the activation key
+    content = ak.product_content(data={'content_access_mode_all': '1'})['results']
+    client_repo_label = [repo['label'] for repo in content if repo['name'] == client_repo.name][0]
+    ak.content_override(
+        data={'content_overrides': [{'content_label': client_repo_label, 'value': '1'}]}
+    )
     return Box(os=os, ak=ak, ksrepo=ksrepo, cv=content_view)
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11735

Due to 6.14 [RFE](https://bugzilla.redhat.com/show_bug.cgi?id=1265120)  custom products are default disabled in AK/Host (being tested by @ColeHiggins2), so here for provisioning we need to override custom client repo to be enabled prior to provisioning, so host param like enable-puppet5 could install puppet-agent itself while provisioning.