### PR TITLE
[6.13.z] Remove redundant rhev provisioning test

### DIFF
--- a/pytest_fixtures/component/settings.py
+++ b/pytest_fixtures/component/settings.py
@@ -1,19 +1,21 @@
 # Settings Fixtures
 import pytest
-from nailgun import entities
 
 
-@pytest.fixture(scope="function")
-def setting_update(request):
+@pytest.fixture()
+def setting_update(request, target_sat):
     """
     This fixture is used to create an object of the provided settings parameter that we use in
     each test case to update their attributes and once the test case gets completed it helps to
     restore their default value
     """
-    setting_object = entities.Setting().search(query={'search': f'name={request.param}'})[0]
+    key_val = request.param
+    setting, new_value = tuple(key_val.split('=')) if '=' in key_val else (key_val, None)
+    setting_object = target_sat.api.Setting().search(query={'search': f'name={setting}'})[0]
     default_setting_value = setting_object.value
-    if default_setting_value is None:
-        default_setting_value = ''
+    if new_value is not None:
+        setting_object.value = new_value
+        setting_object.update({'value'})
     yield setting_object
     setting_object.value = default_setting_value
     setting_object.update({'value'})

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -380,8 +380,10 @@ def test_negative_add_image_rhev_with_invalid_name(rhev, module_os):
 @pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_rhev_with_host_group(
     request,
+    setting_update,
     module_provisioning_sat,
     rhev,
     module_sca_manifest_org,
@@ -546,7 +548,7 @@ def test_positive_provision_rhev_without_host_group(rhev):
 @pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_rhev_image_based_and_disassociate(
     request,
     module_provisioning_sat,
@@ -674,7 +676,6 @@ def test_positive_provision_rhev_image_based_and_disassociate(
         assert 'compute-resource' not in host_info
 
     finally:
-
         # Now, let's just remove the host
         if host is not None:
             cli.Host.delete({'id': host['id']})

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -249,16 +249,6 @@ def module_activation_key(module_entitlement_manifest_org, module_target_sat):
     return activation_key
 
 
-@pytest.fixture(scope='function')
-def remove_vm_on_delete(target_sat, setting_update):
-    setting_update.value = 'true'
-    setting_update.update({'value'})
-    assert (
-        target_sat.api.Setting().search(query={'search': 'name=destroy_vm_on_host_delete'})[0].value
-    )
-    yield
-
-
 @pytest.fixture
 def tracer_install_host(rex_contenthost, target_sat):
     """Sets up a contenthost with katello-host-tools-tracer enabled,
@@ -1846,7 +1836,7 @@ def test_positive_provision_end_to_end(
 @pytest.mark.on_premises_provisioning
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
-@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_delete_libvirt(
     session,
     module_org,
@@ -1855,7 +1845,6 @@ def test_positive_delete_libvirt(
     module_libvirt_hostgroup,
     module_libvirt_resource,
     setting_update,
-    remove_vm_on_delete,
     target_sat,
 ):
     """Create a new Host on libvirt compute resource and delete it


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11737

1. Already covered https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/cli/test_computeresource_rhev.py#L411
2. Use destroy_vm_on_host_delete setting to cleanup hosts in rhevm when deleted from satellite in teardown