### PR TITLE
[6.12.z] Remove redundant rhev provisioning test

### DIFF
--- a/pytest_fixtures/component/settings.py
+++ b/pytest_fixtures/component/settings.py
@@ -1,19 +1,21 @@
 # Settings Fixtures
 import pytest
-from nailgun import entities
 
 
-@pytest.fixture(scope="function")
-def setting_update(request):
+@pytest.fixture()
+def setting_update(request, target_sat):
     """
     This fixture is used to create an object of the provided settings parameter that we use in
     each test case to update their attributes and once the test case gets completed it helps to
     restore their default value
     """
-    setting_object = entities.Setting().search(query={'search': f'name={request.param}'})[0]
+    key_val = request.param
+    setting, new_value = tuple(key_val.split('=')) if '=' in key_val else (key_val, None)
+    setting_object = target_sat.api.Setting().search(query={'search': f'name={setting}'})[0]
     default_setting_value = setting_object.value
-    if default_setting_value is None:
-        default_setting_value = ''
+    if new_value is not None:
+        setting_object.value = new_value
+        setting_object.update({'value'})
     yield setting_object
     setting_object.value = default_setting_value
     setting_object.update({'value'})

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -380,7 +380,7 @@ def test_negative_add_image_rhev_with_invalid_name(rhev, module_os):
 @pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_rhev_with_host_group(
     request,
     setting_update,
@@ -548,7 +548,7 @@ def test_positive_provision_rhev_without_host_group(rhev):
 @pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
-@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_rhev_image_based_and_disassociate(
     request,
     module_provisioning_sat,
@@ -676,7 +676,6 @@ def test_positive_provision_rhev_image_based_and_disassociate(
         assert 'compute-resource' not in host_info
 
     finally:
-
         # Now, let's just remove the host
         if host is not None:
             cli.Host.delete({'id': host['id']})

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -380,8 +380,10 @@ def test_negative_add_image_rhev_with_invalid_name(rhev, module_os):
 @pytest.mark.on_premises_provisioning
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete'], indirect=True)
 def test_positive_provision_rhev_with_host_group(
     request,
+    setting_update,
     module_provisioning_sat,
     rhev,
     module_sca_manifest_org,

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -15,6 +15,7 @@ import pytest
 from fauxfactory import gen_string
 from wrapanapi import VMWareSystem
 
+from robottelo.api.utils import configure_provisioning
 from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.factory import make_host
 from robottelo.cli.host import Host

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -15,8 +15,6 @@ import pytest
 from fauxfactory import gen_string
 from wrapanapi import VMWareSystem
 
-from robottelo.api.utils import configure_provisioning
-from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.factory import make_host
 from robottelo.cli.host import Host
@@ -87,89 +85,6 @@ def tear_down(provisioning):
     hosts = Host.list({'organization': provisioning.org_name})
     for host in hosts:
         Host.delete({'id': host['id']})
-
-
-@pytest.mark.on_premises_provisioning
-@pytest.mark.vlan_networking
-@pytest.mark.tier3
-def test_positive_provision_rhev_with_host_group(rhev, provisioning, target_sat, tear_down):
-    """Provision a host on RHEV compute resource with
-    the help of hostgroup.
-
-    :Requirement: Computeresource RHV
-
-    :CaseComponent: ComputeResources-RHEV
-
-    :Team: Rocket
-
-    :id: ba78868f-5cff-462f-a55d-f6aa4d11db52
-
-    :setup: Hostgroup and provisioning setup like domain, subnet etc.
-
-    :steps:
-
-        1. Create a RHEV compute resource.
-        2. Create a host on RHEV compute resource using the Hostgroup
-        3. Use compute-attributes parameter to specify key-value parameters
-           regarding the virtual machine.
-        4. Provision the host.
-
-    :expectedresults: The host should be provisioned with host group
-
-    :BZ: 1777992
-
-    :customerscenario: true
-
-    :CaseAutomation: Automated
-    """
-    name = gen_string('alpha')
-    rhv_cr = ComputeResource.create(
-        {
-            'name': name,
-            'provider': 'Ovirt',
-            'user': rhev.rhev_username,
-            'password': rhev.rhev_password,
-            'datacenter': rhev.rhev_datacenter,
-            'url': rhev.rhev_url,
-            'ovirt-quota': rhev.quota,
-            'organizations': provisioning.org_name,
-            'locations': provisioning.loc_name,
-        }
-    )
-    assert rhv_cr['name'] == name
-    host_name = gen_string('alpha').lower()
-    host = make_host(
-        {
-            'name': f'{host_name}',
-            'root-password': gen_string('alpha'),
-            'organization': provisioning.org_name,
-            'location': provisioning.loc_name,
-            'pxe-loader': 'PXELinux BIOS',
-            'hostgroup': provisioning.config_env['host_group'],
-            'compute-resource-id': rhv_cr.get('id'),
-            'compute-attributes': "cluster={},"
-            "cores=1,"
-            "memory=1073741824,"
-            "start=1".format(rhev.cluster_id),
-            'ip': None,
-            'mac': None,
-            'interface': f"compute_name=nic1, compute_network={rhev.network_id}",
-            'volume': "size_gb=10," "storage_domain={}," "bootable=True".format(rhev.storage_id),
-            'provision-method': 'build',
-        }
-    )
-    hostname = '{}.{}'.format(host_name, provisioning.config_env['domain'])
-    assert hostname == host['name']
-    host_info = Host.info({'name': hostname})
-    host_ip = host_info.get('network').get('ipv4-address')
-    # Check on RHV, if VM exists
-    assert rhev.rhv_api.does_vm_exist(hostname)
-    # Get the information of created VM
-    rhv_vm = rhev.rhv_api.get_vm(hostname)
-    # Assert of Satellite mac address for VM and Mac of VM created is same
-    assert host_info.get('network').get('mac') == rhv_vm.get_nics()[0].mac.address
-    # Start to run a ping check if network was established on VM
-    target_sat.ping_host(host=host_ip)
 
 
 @pytest.mark.on_premises_provisioning

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -251,16 +251,7 @@ def module_activation_key(module_org_with_manifest, module_target_sat):
     return activation_key
 
 
-@pytest.fixture(scope='function')
-def remove_vm_on_delete(target_sat, setting_update):
-    setting_update.value = 'true'
-    setting_update.update({'value'})
-    assert (
-        target_sat.api.Setting().search(query={'search': 'name=destroy_vm_on_host_delete'})[0].value
-    )
-    yield
-
-
+@pytest.mark.e2e
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_global_params, target_sat, host_ui_options):
     """Create a new Host with parameters, config group. Check host presence on
@@ -1810,7 +1801,7 @@ def test_positive_provision_end_to_end(
 @pytest.mark.on_premises_provisioning
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
-@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_delete_libvirt(
     session,
     module_org,
@@ -1819,7 +1810,6 @@ def test_positive_delete_libvirt(
     module_libvirt_hostgroup,
     module_libvirt_resource,
     setting_update,
-    remove_vm_on_delete,
     target_sat,
 ):
     """Create a new Host on libvirt compute resource and delete it
@@ -1969,7 +1959,7 @@ def gce_hostgroup(
 @pytest.mark.tier4
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('gce')
-@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_gce_provision_end_to_end(
     session,
     target_sat,
@@ -1980,7 +1970,6 @@ def test_positive_gce_provision_end_to_end(
     gce_hostgroup,
     googleclient,
     setting_update,
-    remove_vm_on_delete,
 ):
     """Provision Host on GCE compute resource
 
@@ -2058,7 +2047,7 @@ def test_positive_gce_provision_end_to_end(
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('gce')
-@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_gce_cloudinit_provision_end_to_end(
     session,
     target_sat,
@@ -2069,7 +2058,6 @@ def test_positive_gce_cloudinit_provision_end_to_end(
     gce_hostgroup,
     googleclient,
     setting_update,
-    remove_vm_on_delete,
 ):
     """Provision Host on GCE compute resource
 


### PR DESCRIPTION
Cherrypick of https://github.com/SatelliteQE/robottelo/pull/11737
Fixes https://github.com/SatelliteQE/robottelo/issues/11774
