### PR TITLE
[6.13.z] Fix container repo tests

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2500,7 +2500,7 @@ class TestTokenAuthContainerRepository:
             repo = repo.read()
             for field in 'name', 'docker_upstream_name', 'content_type', 'upstream_username':
                 assert getattr(repo, field) == repo_options[field]
-            repo.sync(timeout=600)
+            repo.sync(timeout=900)
             assert repo.read().content_counts['docker_manifest'] > 1
 
     try:

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -43,7 +43,7 @@ def module_repository(module_product):
         product=module_product,
         url=CONTAINER_REGISTRY_HUB,
     ).create()
-    repo.sync()
+    repo.sync(timeout=1440)
     return repo
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11771

Two container repo tests are failing in setup due to longer sync times than expected. This PR addds 50% extra time to the current sync times.