### PR TITLE
[6.13.z] virtwho UI cases to support for Content Host Legacy UI and parametrize to consolidate multiple cases with duplicated steps into one

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -68,8 +68,9 @@ def delete_host(form_data, target_sat):
 @pytest.mark.usefixtures('delete_host')
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(
-        self, default_org, form_data, virtwho_config, target_sat
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, form_data, virtwho_config, target_sat, deploy_type
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -82,67 +83,19 @@ class TestVirtWhoConfigforEsx:
         :CaseImportance: High
         """
         assert virtwho_config.status == 'unknown'
-        command = get_configure_command(virtwho_config.id, default_org.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
-        )
-        virt_who_instance = (
-            target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
-            .status
-        )
-        assert virt_who_instance == 'ok'
-        hosts = [
-            (
-                hypervisor_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
-            ),
-            (
-                guest_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
-            ),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
+        if deploy_type == "id":
+            command = get_configure_command(virtwho_config.id, default_org.name)
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
+        elif deploy_type == "script":
+            script = virtwho_config.deploy_script()
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script['virt_who_config_script'],
+                form_data['hypervisor_type'],
+                debug=True,
+                org=default_org.label,
             )
-            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
-            assert result['subscription_status_label'] == 'Fully entitled'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, form_data, virtwho_config, target_sat
-    ):
-        """Verify "GET /foreman_virt_who_configure/api/
-
-        v2/configs/:id/deploy_script"
-
-        :id: 166ec4f8-e3fa-4555-9acb-1a5d693a42bb
-
-        :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        assert virtwho_config.status == 'unknown'
-        script = virtwho_config.deploy_script()
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script['virt_who_config_script'],
-            form_data['hypervisor_type'],
-            debug=True,
-            org=default_org.label,
-        )
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
             .search(query={'search': f'name={virtwho_config.name}'})[0]

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -54,8 +54,9 @@ def virtwho_config(form_data, target_sat):
 
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(
-        self, default_org, form_data, virtwho_config, target_sat
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, form_data, virtwho_config, target_sat, deploy_type
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -68,67 +69,19 @@ class TestVirtWhoConfigforLibvirt:
         :CaseImportance: High
         """
         assert virtwho_config.status == 'unknown'
-        command = get_configure_command(virtwho_config.id, default_org.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
-        )
-        virt_who_instance = (
-            target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
-            .status
-        )
-        assert virt_who_instance == 'ok'
-        hosts = [
-            (
-                hypervisor_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
-            ),
-            (
-                guest_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
-            ),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
+        if deploy_type == "id":
+            command = get_configure_command(virtwho_config.id, default_org.name)
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
             )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
+        elif deploy_type == "script":
+            script = virtwho_config.deploy_script()
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script['virt_who_config_script'],
+                form_data['hypervisor_type'],
+                debug=True,
+                org=default_org.label,
             )
-            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
-            assert result['subscription_status_label'] == 'Fully entitled'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, form_data, virtwho_config, target_sat
-    ):
-        """Verify "GET /foreman_virt_who_configure/api/
-
-        v2/configs/:id/deploy_script"
-
-        :id: 9668b900-0d2f-42ae-b2f8-523ca292b2bd
-
-        :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        assert virtwho_config.status == 'unknown'
-        script = virtwho_config.deploy_script()
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script['virt_who_config_script'],
-            form_data['hypervisor_type'],
-            debug=True,
-            org=default_org.label,
-        )
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
             .search(query={'search': f'name={virtwho_config.name}'})[0]

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -65,11 +65,13 @@ class TestVirtWhoConfigforEsx:
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify "hammer virt-who-config deploy"
+        """Verify "hammer virt-who-config deploy & fetch"
 
         :id: 04f2cef8-c88e-4a21-9d2f-c17238eea308
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -55,69 +55,35 @@ def virtwho_config(form_data, target_sat):
 
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(
-        self, default_org, form_data, virtwho_config, target_sat
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify " hammer virt-who-config deploy"
+        """Verify " hammer virt-who-config deploy & fetch"
 
         :id: 7cc0ad4f-e185-4d63-a2f5-1cb0245faa6c
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], default_org.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=default_org.label
-        )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
-            'general-information'
-        ]['status']
-        assert virt_who_instance == 'OK'
-        hosts = [
-            (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
-            (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
+        if deploy_type == "id":
+            command = get_configure_command(virtwho_config['id'], default_org.name)
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor-type'], debug=True, org=default_org.label
             )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            result = target_sat.cli.Host.subscription_attach(
-                {'host-id': host['id'], 'subscription-id': vdc_id}
+        elif deploy_type == "script":
+            script = target_sat.cli.VirtWhoConfig.fetch(
+                {'id': virtwho_config['id']}, output_format='base'
             )
-            assert result.strip() == 'Subscription attached to the host successfully.'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, form_data, virtwho_config, target_sat
-    ):
-        """Verify " hammer virt-who-config fetch"
-
-        :id: 22dc8068-c843-4ca0-acbe-0b2aef8ece31
-
-        :expectedresults: Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        assert virtwho_config['status'] == 'No Report Yet'
-        script = target_sat.cli.VirtWhoConfig.fetch(
-            {'id': virtwho_config['id']}, output_format='base'
-        )
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True, org=default_org.label
-        )
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor-type'], debug=True, org=default_org.label
+            )
         virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
             'general-information'
         ]['status']

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -59,11 +59,13 @@ class TestVirtWhoConfigforHyperv:
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify " hammer virt-who-config deploy"
+        """Verify " hammer virt-who-config deploy & fetch"
 
         :id: ba51dd0e-39da-4afd-b7e1-d470082024ba
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -53,69 +53,35 @@ def virtwho_config(form_data, target_sat):
 
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(
-        self, default_org, form_data, virtwho_config, target_sat
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify " hammer virt-who-config deploy"
+        """Verify " hammer virt-who-config deploy & fetch"
 
         :id: d0b109f5-2699-43e4-a6cd-d682204d97a7
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], default_org.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=default_org.label
-        )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
-            'general-information'
-        ]['status']
-        assert virt_who_instance == 'OK'
-        hosts = [
-            (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
-            (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
+        if deploy_type == "id":
+            command = get_configure_command(virtwho_config['id'], default_org.name)
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor-type'], debug=True, org=default_org.label
             )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            result = target_sat.cli.Host.subscription_attach(
-                {'host-id': host['id'], 'subscription-id': vdc_id}
+        elif deploy_type == "script":
+            script = target_sat.cli.VirtWhoConfig.fetch(
+                {'id': virtwho_config['id']}, output_format='base'
             )
-            assert result.strip() == 'Subscription attached to the host successfully.'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, form_data, virtwho_config, target_sat
-    ):
-        """Verify " hammer virt-who-config fetch"
-
-        :id: 273df8e0-5ef5-47d9-9567-543157be7dd8
-
-        :expectedresults: Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        assert virtwho_config['status'] == 'No Report Yet'
-        script = target_sat.cli.VirtWhoConfig.fetch(
-            {'id': virtwho_config['id']}, output_format='base'
-        )
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True, org=default_org.label
-        )
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor-type'], debug=True, org=default_org.label
+            )
         virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
             'general-information'
         ]['status']

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -55,11 +55,13 @@ class TestVirtWhoConfigforKubevirt:
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify " hammer virt-who-config deploy"
+        """Verify " hammer virt-who-config deploy & fetch"
 
         :id: e0162dba-a50f-4356-9dc2-c928a1bed15c
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -54,69 +54,35 @@ def virtwho_config(form_data, target_sat):
 
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(
-        self, default_org, form_data, virtwho_config, target_sat
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify " hammer virt-who-config deploy"
+        """Verify " hammer virt-who-config deploy & fetch"
 
         :id: e66bf88a-bd4e-409a-91a8-bc5e005d95dd
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], default_org.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=default_org.label
-        )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
-            'general-information'
-        ]['status']
-        assert virt_who_instance == 'OK'
-        hosts = [
-            (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
-            (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
+        if deploy_type == "id":
+            command = get_configure_command(virtwho_config['id'], default_org.name)
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor-type'], debug=True, org=default_org.label
             )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            result = target_sat.cli.Host.subscription_attach(
-                {'host-id': host['id'], 'subscription-id': vdc_id}
+        elif deploy_type == "script":
+            script = target_sat.cli.VirtWhoConfig.fetch(
+                {'id': virtwho_config['id']}, output_format='base'
             )
-            assert result.strip() == 'Subscription attached to the host successfully.'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, form_data, virtwho_config, target_sat
-    ):
-        """Verify " hammer virt-who-config fetch"
-
-        :id: bd5c52ab-3dbd-4cf1-9837-b8eb6233f1cd
-
-        :expectedresults: Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        assert virtwho_config['status'] == 'No Report Yet'
-        script = target_sat.cli.VirtWhoConfig.fetch(
-            {'id': virtwho_config['id']}, output_format='base'
-        )
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True, org=default_org.label
-        )
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor-type'], debug=True, org=default_org.label
+            )
         virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
             'general-information'
         ]['status']

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -56,11 +56,13 @@ class TestVirtWhoConfigforLibvirt:
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify " hammer virt-who-config deploy"
+        """Verify " hammer virt-who-config deploy & fetch"
 
         :id: 53143fc3-97e0-4403-8114-4d7f20fde98e
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -59,69 +59,35 @@ def virtwho_config(form_data, target_sat):
 
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(
-        self, default_org, form_data, virtwho_config, target_sat
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify "hammer virt-who-config deploy"
+        """Verify "hammer virt-who-config deploy & fetch"
 
         :id: 129d8e57-b4fc-4d95-ad33-5aa6ec6fb146
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 
         :CaseImportance: High
         """
         assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], default_org.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=default_org.label
-        )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
-            'general-information'
-        ]['status']
-        assert virt_who_instance == 'OK'
-        hosts = [
-            (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
-            (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
+        if deploy_type == "id":
+            command = get_configure_command(virtwho_config['id'], default_org.name)
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor-type'], debug=True, org=default_org.label
             )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            result = target_sat.cli.Host.subscription_attach(
-                {'host-id': host['id'], 'subscription-id': vdc_id}
+        elif deploy_type == "script":
+            script = target_sat.cli.VirtWhoConfig.fetch(
+                {'id': virtwho_config['id']}, output_format='base'
             )
-            assert result.strip() == 'Subscription attached to the host successfully.'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, form_data, virtwho_config, target_sat
-    ):
-        """Verify "hammer virt-who-config fetch"
-
-        :id: d707fac0-f2b1-4493-b083-cf1edc231691
-
-        :expectedresults: Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        assert virtwho_config['status'] == 'No Report Yet'
-        script = target_sat.cli.VirtWhoConfig.fetch(
-            {'id': virtwho_config['id']}, output_format='base'
-        )
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor-type'], debug=True, org=default_org.label
-        )
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor-type'], debug=True, org=default_org.label
+            )
         virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
             'general-information'
         ]['status']

--- a/tests/foreman/virtwho/cli/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/cli/test_nutanix_sca.py
@@ -60,11 +60,13 @@ class TestVirtWhoConfigforNutanix:
     def test_positive_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
     ):
-        """Verify "hammer virt-who-config deploy"
+        """Verify "hammer virt-who-config deploy & fetch"
 
         :id: 71750104-b436-4ad4-9b6b-6f0fe8c3ee4c
 
-        :expectedresults: Config can be created and deployed
+        :expectedresults:
+            1. Config can be created and deployed
+            2. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 
@@ -120,13 +122,14 @@ class TestVirtWhoConfigforNutanix:
     def test_positive_prism_central_deploy_configure_by_id_script(
         self, module_sca_manifest_org, form_data, target_sat, deploy_type
     ):
-        """Verify "hammer virt-who-config deploy" on nutanix prism central mode
+        """Verify "hammer virt-who-config deploy & fetch" on nutanix prism central mode
 
         :id: 96fd691f-5b62-469c-adc7-f2739ddf4a62
 
         :expectedresults:
             1. Config can be created and deployed
             2. The prism_central has been set in /etc/virt-who.d/vir-who.conf file
+            3. Config can be created, fetch and deploy
 
         :CaseLevel: Integration
 

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -67,23 +67,26 @@ def virtwho_config(form_data, target_sat, session):
 
 
 @pytest.fixture(autouse=True)
-def clean_host(form_data, target_sat):
+def delete_host(form_data, target_sat):
     guest_name, _ = get_guest_info(form_data['hypervisor_type'])
     results = target_sat.api.Host().search(query={'search': guest_name})
     if results:
         target_sat.api.Host(id=results[0].read_json()['id']).delete()
 
 
-@pytest.mark.usefixtures('clean_host')
+@pytest.mark.usefixtures('delete_host')
 class TestVirtwhoConfigforEsx:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, virtwho_config, session, form_data):
-        """Verify configure created and deployed with id.
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, virtwho_config, session, form_data, deploy_type
+    ):
+        """Verify configure created and deployed with id|script.
 
         :id: 44f93ec8-a59a-42a4-ab30-edc554b022b2
 
         :expectedresults:
-            1. Config can be created and deployed by command
+            1. Config can be created and deployed by command|script
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Virtual sku can be generated and attached
@@ -95,50 +98,30 @@ class TestVirtwhoConfigforEsx:
         """
         name = form_data['name']
         values = session.virtwho_configure.read(name)
-        command = values['deploy']['command']
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
-        )
+        if deploy_type == "id":
+            command = values['deploy']['command']
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
+        elif deploy_type == "script":
+            script = values['deploy']['script']
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
         assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, virtwho_config, session, form_data
-    ):
-        """Verify configure created and deployed with script.
-
-        :id: d64332fb-a6e0-4864-9f8b-2406223fcdcc
-
-        :expectedresults:
-            1. Config can be created and deployed by script
-            2. No error msg in /var/log/rhsm/rhsm.log
-            3. Report is sent to satellite
-            4. Virtual sku can be generated and attached
-            5. Config can be deleted
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        script = values['deploy']['script']
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor_type'], debug=True, org=default_org.label
+        assert (
+            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            == 'Unsubscribed hypervisor'
         )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
         assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        assert (
+            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            == 'Unentitled'
+        )
         session.contenthost.add_subscription(guest_name, vdc_virtual)
         assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -55,13 +55,16 @@ def virtwho_config(form_data, target_sat, session):
 
 class TestVirtwhoConfigforHyperv:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, virtwho_config, session, form_data):
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, virtwho_config, session, form_data, deploy_type
+    ):
         """Verify configure created and deployed with id.
 
         :id: c8913398-c5c6-4f2c-bc53-0bbfb158b762
 
         :expectedresults:
-            1. Config can be created and deployed by command
+            1. Config can be created and deployed by command/script
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Virtual sku can be generated and attached
@@ -73,50 +76,30 @@ class TestVirtwhoConfigforHyperv:
         """
         name = form_data['name']
         values = session.virtwho_configure.read(name)
-        command = values['deploy']['command']
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
-        )
+        if deploy_type == "id":
+            command = values['deploy']['command']
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
+        elif deploy_type == "script":
+            script = values['deploy']['script']
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
         assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, virtwho_config, session, form_data
-    ):
-        """Verify configure created and deployed with script.
-
-        :id: b0401417-3a6e-4a54-b8e8-22d290813da3
-
-        :expectedresults:
-            1. Config can be created and deployed by script
-            2. No error msg in /var/log/rhsm/rhsm.log
-            3. Report is sent to satellite
-            4. Virtual sku can be generated and attached
-            5. Config can be deleted
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        script = values['deploy']['script']
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor_type'], debug=True, org=default_org.label
+        assert (
+            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            == 'Unsubscribed hypervisor'
         )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
         assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        assert (
+            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            == 'Unentitled'
+        )
         session.contenthost.add_subscription(guest_name, vdc_virtual)
         assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -54,13 +54,16 @@ def virtwho_config(form_data, target_sat, session):
 
 class TestVirtwhoConfigforLibvirt:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, virtwho_config, session, form_data):
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, virtwho_config, session, form_data, deploy_type
+    ):
         """Verify configure created and deployed with id.
 
         :id: ae37ea79-f99c-4511-ace9-a7de26d6db40
 
         :expectedresults:
-            1. Config can be created and deployed by command
+            1. Config can be created and deployed by command/script
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Virtual sku can be generated and attached
@@ -72,50 +75,30 @@ class TestVirtwhoConfigforLibvirt:
         """
         name = form_data['name']
         values = session.virtwho_configure.read(name)
-        command = values['deploy']['command']
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
-        )
+        if deploy_type == "id":
+            command = values['deploy']['command']
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
+        elif deploy_type == "script":
+            script = values['deploy']['script']
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
         assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, virtwho_config, session, form_data
-    ):
-        """Verify configure created and deployed with script.
-
-        :id: 3655a501-ab05-4724-945a-7f6e6878091d
-
-        :expectedresults:
-            1. Config can be created and deployed by script
-            2. No error msg in /var/log/rhsm/rhsm.log
-            3. Report is sent to satellite
-            4. Virtual sku can be generated and attached
-            5. Config can be deleted
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        script = values['deploy']['script']
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor_type'], debug=True, org=default_org.label
+        assert (
+            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            == 'Unsubscribed hypervisor'
         )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
         assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        assert (
+            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            == 'Unentitled'
+        )
         session.contenthost.add_subscription(guest_name, vdc_virtual)
         assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -59,7 +59,10 @@ def virtwho_config(form_data, target_sat, session):
 
 class TestVirtwhoConfigforNutanix:
     @pytest.mark.tier2
-    def test_positive_deploy_configure_by_id(self, default_org, virtwho_config, session, form_data):
+    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    def test_positive_deploy_configure_by_id_script(
+        self, default_org, virtwho_config, session, form_data, deploy_type
+    ):
         """Verify configure created and deployed with id.
 
         :id: becea4d0-db4e-4a85-93d2-d40e86da0e2f
@@ -77,50 +80,30 @@ class TestVirtwhoConfigforNutanix:
         """
         name = form_data['name']
         values = session.virtwho_configure.read(name)
-        command = values['deploy']['command']
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
-        )
+        if deploy_type == "id":
+            command = values['deploy']['command']
+            hypervisor_name, guest_name = deploy_configure_by_command(
+                command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
+        elif deploy_type == "script":
+            script = values['deploy']['script']
+            hypervisor_name, guest_name = deploy_configure_by_script(
+                script, form_data['hypervisor_type'], debug=True, org=default_org.label
+            )
         assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, virtwho_config, session, form_data
-    ):
-        """Verify configure created and deployed with script.
-
-        :id: 1c1b19c9-988c-4b86-a2b2-658fded10ccb
-
-        :expectedresults:
-            1. Config can be created and deployed by script
-            2. No error msg in /var/log/rhsm/rhsm.log
-            3. Report is sent to satellite
-            4. Virtual sku can be generated and attached
-            5. Config can be deleted
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        script = values['deploy']['script']
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script, form_data['hypervisor_type'], debug=True, org=default_org.label
+        assert (
+            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            == 'Unsubscribed hypervisor'
         )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
-        vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
-        vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
         assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        assert (
+            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            == 'Unentitled'
+        )
         session.contenthost.add_subscription(guest_name, vdc_virtual)
         assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11543

Realize the two functions:
1. virtwho UI cases to support for Content Host Legacy UI 
2. parametrize to consolidate multiple cases with duplicated steps into one

This PR depends on the the PR
https://github.com/SatelliteQE/airgun/pull/850

Cases PASS:
```
CLI：

ESX：
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx.py -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 22 deselected, 2 warnings in 308.98s (0:05:08)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_hyperv.py -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 4 deselected, 2 warnings in 204.89s (0:03:24)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_kubevirt.py -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 6 deselected, 2 warnings in 271.33s (0:04:31)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_libvirt.py -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 4 deselected, 2 warnings in 186.82s (0:03:06)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix.py -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 12 deselected, 2 warnings in 209.96s (0:03:29)


API:
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 18 deselected, 29 warnings in 152.89s (0:02:32)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_hyperv.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 4 deselected, 23 warnings in 166.79s (0:02:46)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_kubevirt.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 6 deselected, 29 warnings in 241.97s (0:04:01)

(obottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_libvirt.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 4 deselected, 23 warnings in 162.76s (0:02:42)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 12 deselected, 41 warnings in 178.21s (0:02:58)

UI:
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 32 deselected, 9 warnings in 887.60s (0:14:47)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_hyperv.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 4 deselected, 5 warnings in 893.47s (0:14:53)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_libvirt.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 4 deselected, 5 warnings in 1015.29s (0:16:55)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_kubevirt.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 4 deselected, 5 warnings in 1088.77s (0:18:08)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_nutanix.py  -k test_positive_deploy_configure_by_id_script --disable-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 12 deselected, 5 warnings in 964.59s (0:16:04)



```