### PR TITLE
rex_contenthost now using global registration

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -149,14 +149,11 @@ def cockpit_host(class_target_sat, class_org, rhel_contenthost):
 
 
 @pytest.fixture
-def rex_contenthost(request, module_org, target_sat):
+def rex_contenthost(request, module_org, target_sat, module_ak_with_cv):
     request.param['no_containers'] = True
     with Broker(**host_conf(request), host_class=ContentHost) as host:
-        # Register content host to Satellite
         repo = settings.repos['SATCLIENT_REPO'][f'RHEL{host.os_version.major}']
-        target_sat.register_host_custom_repo(module_org, host, [repo])
-        # Enable remote execution on the host
-        host.add_rex_key(satellite=target_sat)
+        host.register(module_org, None, module_ak_with_cv.name, target_sat, repo=repo)
         yield host
 
 


### PR DESCRIPTION
let the rex_contenthost fixture use the register function, needs https://github.com/SatelliteQE/robottelo/pull/11783 to get in first