### PR TITLE
[6.13.z] register function made more flexible

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -562,8 +562,8 @@ class ContentHost(Host, ContentHostMixins):
         using a global registration template.
 
         :param target: Satellite or Capusle object to register to, required.
-        :param org: Organization to register content host for, required.
-        :param loc: Location to register content host for, required.
+        :param org: Organization to register content host to. Previously required, pass None to omit
+        :param loc: Location to register content host for, Previously required, pass None to omit.
         :param activation_keys: Activation key name to register content host with, required.
         :param setup_insights: Install and register Insights client, requires OS repo.
         :param setup_remote_execution: Copy remote execution SSH key.
@@ -583,11 +583,25 @@ class ContentHost(Host, ContentHostMixins):
         """
         options = {
             'activation-keys': activation_keys,
-            'organization-id': org.id,
-            'location-id': loc.id,
             'insecure': str(insecure).lower(),
             'update-packages': str(update_packages).lower(),
         }
+        if org is not None:
+            if isinstance(org, entities.Organization):
+                options['organization-id'] = org.id
+            elif isinstance(org, dict):
+                options['organization-id'] = org['id']
+            else:
+                raise ValueError('org must be a dict or an Organization object')
+
+        if loc is not None:
+            if isinstance(loc, entities.Location):
+                options['location-id'] = loc.id
+            elif isinstance(loc, dict):
+                options['location-id'] = loc['id']
+            else:
+                raise ValueError('loc must be a dict or a Location object')
+
         if target.__class__.__name__ == 'Capsule':
             options['smart-proxy'] = target.hostname
         elif target is not None and target.__class__.__name__ not in ['Capsule', 'Satellite']:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11783

The global registration dialog changed since this function was created, it is possible to not specify org and loc, which the register function didn't allow. The function also demanded org supplied as an object, which caused problems in onboarding more tests to it (some use org defined as a dict -- an output from cli helpers). PR changes the function in a way that doesn't require updating the existing callers 