### PR TITLE
handle the condition for dependancy has brackets []

### DIFF
--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -25,7 +25,7 @@ jobs:
         id: yaml
         uses: mikefarah/yq@master
         with:
-          cmd: yq e ".${{ steps.metadata.outputs.dependency-names }}" ./.github/dependency_tests.yaml
+          cmd: yq e '.["${{ steps.metadata.outputs.dependency-names }}"]' ./.github/dependency_tests.yaml
 
       - name: Add the PRT Comment
         if:  steps.yaml.outputs.result != 'null'


### PR DESCRIPTION
#### Failing PR 
https://github.com/SatelliteQE/robottelo/actions/runs/5440265424/jobs/9893025022?pr=11790
https://github.com/SatelliteQE/robottelo/pull/11790

`cmd: yq e ".broker[docker]" ./.github/dependency_tests.yaml` was not resolving the node in the yaml file. 
this fix will resolve that. Verified on the personal fork.   
 

#### Fix Tested: 
https://github.com/omkarkhatavkar/robottelo/pull/130 