### PR TITLE
[6.14.z] katello_host_tools_host fixture fix

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -128,7 +128,15 @@ def registered_hosts(request, target_sat, module_org):
 def katello_host_tools_host(target_sat, module_org, rhel_contenthost):
     """Register content host to Satellite and install katello-host-tools on the host."""
     repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
-    target_sat.register_host_custom_repo(module_org, rhel_contenthost, [repo])
+    ak = target_sat.api.ActivationKey(
+        content_view=module_org.default_content_view,
+        max_hosts=100,
+        organization=module_org,
+        environment=target_sat.api.LifecycleEnvironment(id=module_org.library.id),
+        auto_attach=True,
+    ).create()
+
+    rhel_contenthost.register(module_org, None, ak.name, target_sat, repo=repo)
     rhel_contenthost.install_katello_host_tools()
     yield rhel_contenthost
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1624,6 +1624,7 @@ def setup_custom_repo(target_sat, module_org, katello_host_tools_host, request):
         url=settings.repos[custom_repo].url,
     ).create()
     custom_repo.sync()
+
     subs = target_sat.api.Subscription(organization=module_org, name=prod.name).search()
     assert len(subs), f'Subscription for sat client product: {prod.name} was not found.'
     custom_sub = subs[0]
@@ -1634,6 +1635,10 @@ def setup_custom_repo(target_sat, module_org, katello_host_tools_host, request):
             "included": {"ids": [katello_host_tools_host.nailgun_host.id]},
             "subscriptions": [{"id": custom_sub.id, "quantity": 1}],
         }
+    )
+    # make sure repo is enabled
+    katello_host_tools_host.enable_repo(
+        f'{module_org.name}_{prod.name}_{custom_repo.name}', force=True
     )
     # refresh repository metadata
     katello_host_tools_host.subscription_manager_list_repos()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11799

The fixture now uses global registration + it plays nicely with SCA, which fixes a bunch of tests in the host component