### PR TITLE
virtwho-config:Update whitelist&blacklist

### DIFF
--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -266,7 +266,7 @@ class TestVirtWhoConfigforEsx:
                 assert get_configure_option('filter_hosts', config_file) == regex
                 assert (
                     get_configure_option('filter_host_parents', config_file)
-                    == whitelist['filter_host_parents']
+                    == whitelist['whitelist']
                 )
                 assert result.whitelist == regex
                 assert result.filter_host_parents == regex
@@ -275,7 +275,7 @@ class TestVirtWhoConfigforEsx:
                 assert get_configure_option('exclude_hosts', config_file) == regex
                 assert (
                     get_configure_option('exclude_host_parents', config_file)
-                    == blacklist['exclude_host_parents']
+                    == blacklist['blacklist']
                 )
                 assert result.blacklist == regex
                 assert result.exclude_host_parents == regex


### PR DESCRIPTION
Modify the whiltelist and blacklist item name.
Satellite6.14 cases : PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx_sca.py -k test_positive_filter_option --disable-pytest-warnings -q
....                                                                                                                                                                                                        [100%]
4 passed, 22 deselected, 21 warnings in 192.63s (0:03:12)
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx_sca.py -k test_positive_filter_option --disable-pytest-warnings -q
....                                                                                                                                                                                                        [100%]
4 passed, 22 deselected, 22 warnings in 200.08s (0:03:20)

```
Satellite6.13 cases : PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx_sca.py -k test_positive_filter_option --disable-pytest-warnings -q
....                                                                                                                                                                                                        [100%]
4 passed, 22 deselected, 22 warnings in 200.08s (0:03:20)

```