### PR TITLE
update checktime format for contenthost

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -686,7 +686,7 @@ class TestVirtwhoConfigforEsx:
         # 10 mins margin to check the Last Checkin time
         assert (
             abs(
-                datetime.strptime(checkin_time, "%B %d, %Y, %I:%M %p")
+                datetime.strptime(checkin_time, "%B %d, %Y at %I:%M %p")
                 .replace(year=datetime.utcnow().year)
                 .timestamp()
                 - time_now.timestamp()

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -334,7 +334,7 @@ class TestVirtwhoConfigforEsx:
         # 10 mins margin to check the Last Checkin time
         assert (
             abs(
-                datetime.strptime(checkin_time, "%B %d, %Y, %I:%M %p")
+                datetime.strptime(checkin_time, "%B %d, %Y at %I:%M %p")
                 .replace(year=datetime.utcnow().year)
                 .timestamp()
                 - time_now.timestamp()


### PR DESCRIPTION
Update checktime format
Satellite6.14 cases : PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py -k test_positive_last_checkin_status --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 33 deselected, 5 warnings in 188.94s (0:03:08)

```
Satellite6.13 cases : PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py -k test_positive_last_checkin_status --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 33 deselected, 7 warnings in 151.19s (0:02:31) =============================================================================
```