### PR TITLE
[6.13.z] add Legacy content UI support for nutanix prism central & ahv option modification

### DIFF
--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -198,8 +198,18 @@ class TestVirtwhoConfigforNutanix:
             hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
             vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
             vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
+            assert (
+                session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions'][
+                    'status'
+                ]
+                == 'Unsubscribed hypervisor'
+            )
             session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
             assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+            assert (
+                session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+                == 'Unentitled'
+            )
             session.contenthost.add_subscription(guest_name, vdc_virtual)
             assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
             session.virtwho_configure.delete(name)
@@ -280,7 +290,7 @@ class TestVirtwhoConfigforNutanix:
         assert check_message_in_rhsm_log(message) == message
 
         # Update ahv_internal_debug option to true
-        session.virtwho_configure.edit(name, {'ahv-internal-debug': True})
+        session.virtwho_configure.edit(name, {'ahv_internal_debug': True})
         results = session.virtwho_configure.read(name)
         command = results['deploy']['command']
         assert str(results['overview']['ahv_internal_debug']) == 'True'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11812

Satellite6.14 cases :  PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest tests/foreman/virtwho/ui/test_nutanix.py -k test_positive_prism_central_deploy_configure_by_id_script  --disable-pytest-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 12 deselected, 4 warnings in 872.06s (0:14:32)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest tests/foreman/virtwho/ui/test_nutanix.py -k test_positive_ahv_internal_debug_option  --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 13 deselected, 4 warnings in 318.54s (0:05:18)

```
Satellite6.13 cases :  PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest tests/foreman/virtwho/ui/test_nutanix.py -k test_positive_prism_central_deploy_configure_by_id_script  --disable-pytest-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 12 deselected, 4 warnings in 987.70s (0:16:27)

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest tests/foreman/virtwho/ui/test_nutanix.py -k test_positive_ahv_internal_debug_option  --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 13 deselected, 4 warnings in 278.81s (0:04:38)
```