### PR TITLE
[6.14.z] [6.14 RFE] Upgrade test for enabled repos in sca

### DIFF
--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -203,3 +203,105 @@ class TestScenarioCustomRepoCheck:
         )[0]
         result = rhel_client.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0
+
+
+class TestScenarioCustomRepoOverrideCheck:
+    """Scenario test to verify that repositories in a non-sca org set to "Enabled"
+    should be overridden to "Enabled(Override)" when upgrading to 6.14.
+
+    Test Steps:
+
+        1. Before Satellite upgrade.
+        2. Create new Organization, Location.
+        3. Create Product, Custom Repository, Content view.
+        4. Create Activation Key and add Subscription.
+        5. Create a Content Host, register it, and check Repository Sets for enabled Repository.
+        6. Upgrade Satellite.
+        7. Search Host to verify Repository Set is set to Enabled(Override).
+
+    BZ: 1265120
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_pre_scenario_custom_repo_sca_toggle(
+        self,
+        target_sat,
+        function_org,
+        function_product,
+        function_lce,
+        sat_upgrade_chost,
+        save_test_data,
+        default_location,
+    ):
+        """This is a pre-upgrade scenario test to verify that repositories in a non-sca org
+        set to "Enabled" should be overridden to "Enabled(Override)" when upgrading to 6.14.
+
+        :id: preupgrade-65e1e312-a743-4605-b226-f580f523377f
+
+        :steps:
+            1. Before Satellite upgrade.
+            2. Create new Organization, Location.
+            3. Create Product, Custom Repository, Content view.
+            4. Create Activation Key and add Subscription.
+            5. Create a Content Host, register it, and check Repository Sets for enabled Repository.
+
+        :expectedresults:
+
+            1. Custom Repository is created.
+            2. Custom Repository is enabled on Host.
+
+        """
+        repo = target_sat.api.Repository(
+            product=function_product.id, url=settings.repos.yum_1.url
+        ).create()
+        repo.sync()
+        content_view = target_sat.publish_content_view(function_org, repo)
+        content_view.version[0].promote(data={'environment_ids': function_lce.id})
+        ak = target_sat.api.ActivationKey(
+            content_view=content_view, organization=function_org.id, environment=function_lce
+        ).create()
+        if not target_sat.is_sca_mode_enabled(function_org.id):
+            subscription = target_sat.api.Subscription(organization=function_org).search(
+                query={'search': f'name={function_product.name}'}
+            )[0]
+            ak.add_subscriptions(data={'subscription_id': subscription.id})
+        sat_upgrade_chost.register(function_org, default_location, ak.name, target_sat)
+        product_details = sat_upgrade_chost.execute('subscription-manager repos --list')
+        assert 'Enabled:   1' in product_details.stdout
+
+        save_test_data(
+            {
+                'rhel_client': sat_upgrade_chost.hostname,
+                'org_name': function_org.name,
+                'product_name': function_product.name,
+                'repo_name': repo.name,
+                'product_details': product_details.stdout,
+            }
+        )
+
+    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_custom_repo_sca_toggle)
+    def test_post_scenario_custom_repo_sca_toggle(self, pre_upgrade_data):
+        """This is a post-upgrade scenario test to verify that repositories in a non-sca
+        Organization set to "Enabled" should be overridden to "Enabled(Override)"
+        when upgrading to 6.14.
+
+        :id: postupgrade-cc392ce3-f3bb-4cf3-afd5-c062e3a5d109
+
+        :steps:
+            1. After upgrade, search Host to verify Repository Set is set to
+            Enabled(Override).
+
+
+        :expectedresults: Repository on Host should be overridden.
+
+        """
+        client_hostname = pre_upgrade_data.get('rhel_client')
+        org_name = pre_upgrade_data.get('org_name')
+        product_name = pre_upgrade_data.get('product_name')
+        repo_name = pre_upgrade_data.get('repo_name')
+        rhel_client = Broker(host_class=ContentHost).from_inventory(
+            filter=f'@inv.hostname == "{client_hostname}"'
+        )[0]
+        result = rhel_client.execute('subscription-manager repo-override --list')
+        assert 'enabled: 1' in result.stdout
+        assert f'{org_name}_{product_name}_{repo_name}' in result.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11729

SAT-16805

Upgrade scenario for enabled repos in non-sca org

In a non-sca organization, enabled repos with an attached subscription should be set to "Enabled(Override)" after an upgrade to 6.14. 
