### PR TITLE
[6.14.z] [6.14 RFE] Custom products disabled by default

### DIFF
--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -1,0 +1,47 @@
+"""Test module for Repositories CLI.
+
+:Requirement: Repository
+
+:CaseAutomation: Automated
+
+:CaseLevel: Component
+
+:CaseComponent: Repositories
+
+:team: Phoenix-content
+
+:TestType: Functional
+
+:CaseImportance: Critical
+
+:Upstream: No
+"""
+import pytest
+
+
+@pytest.mark.rhel_ver_match('[^6]')
+def test_positive_custom_products_disabled_by_default(
+    setup_content,
+    default_location,
+    rhel_contenthost,
+    target_sat,
+):
+    """Verify that custom products should be disabled by default for content hosts
+
+    :id: ba237e11-3b41-49e3-94b3-63e1f404d9e5
+
+    :steps:
+        1. Create custom product and upload repository
+        2. Attach to activation key
+        3. Register Host
+        4. Assert that custom proudcts are disabled by default
+
+    :expectedresults: Custom products should be disabled by default. "Enabled: 0"
+
+    :BZ: 1265120
+    """
+    ak, org, _ = setup_content
+    rhel_contenthost.register(org, default_location, ak.name, target_sat)
+    assert rhel_contenthost.subscribed
+    product_details = rhel_contenthost.run('subscription-manager repos --list')
+    assert 'Enabled:   0' in product_details.stdout

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -1,0 +1,60 @@
+"""Test module for Repositories UI.
+
+:Requirement: Repository
+
+:CaseAutomation: Automated
+
+:CaseLevel: Integration
+
+:CaseComponent: Repositories
+
+:team: Phoenix-content
+
+:TestType: Functional
+
+:CaseImportance: Critical
+
+:Upstream: No
+"""
+import pytest
+
+
+@pytest.mark.rhel_ver_match('[^6]')
+def test_positive_custom_products_disabled_by_default(
+    session,
+    default_location,
+    setup_content,
+    rhel_contenthost,
+    target_sat,
+):
+    """Verify that custom products should be disabled by default for content hosts
+    and activation keys
+
+    :id: 05bdf790-a7a1-48b1-bbae-dc25b6ee7d58
+
+    :steps:
+        1. Create custom product and upload repository
+        2. Attach to activation key
+        3. Register Host
+        4. Assert that custom proudcts are disabled by default
+
+    :expectedresults: Custom products should be disabled by default.
+
+    :BZ: 1265120
+
+    :customerscenario: true
+    """
+    ak, org, custom_repo = setup_content
+    rhel_contenthost.register(org, default_location, ak.name, target_sat)
+    assert rhel_contenthost.subscribed
+    with session:
+        session.organization.select(org.name)
+        session.location.select(default_location.name)
+        ak_details = session.activationkey.read(ak.name, widget_names='repository sets')[
+            'repository sets'
+        ]['table'][0]
+        assert 'Disabled' in ak_details['Status']
+        repos = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
+        assert repos[0]['Repository'] == custom_repo.name
+        assert repos[0]['Status'] == 'Disabled'
+        assert repos[0]['Repository type'] == 'Custom'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11380

These tests are for SAT-16805

Custom products should be disabled by default when attaching to a content host in 6.14

Wait to be Merged:
https://github.com/SatelliteQE/airgun/pull/852