### PR TITLE
[6.14.z] Test exercising new Virtualization card

### DIFF
--- a/conf/vmware.yaml.template
+++ b/conf/vmware.yaml.template
@@ -8,8 +8,15 @@ VMWARE:
   PASSWORD:
   # vmware datacenter
   DATACENTER:
+  # cluster: vmware cluster
+  CLUSTER:
   # Name of VM that should be used
   VM_NAME:
+  # mac_address: Mac address of the vm
+  MAC_ADDRESS:
+  # hypervisor: IP address of the hypervisor
+  HYPERVISOR:
+
 
   # Vmware Compute resource image data
   # Operating system of the image


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11748

Uses the structure of a preexisting test, the vm_import test, to get Satellite in a state where you can view the newly added Virtualization card. Having some issues running this locally, going to get it put up and see if PRT has the same issues. 

Requires https://github.com/SatelliteQE/airgun/pull/869