### PR TITLE
delete policies which are no longer needed

### DIFF
--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -475,6 +475,10 @@ class TestOpenScap:
             }
         )
         assert scap_policy['name'] == name
+        # Deleting policy which created for all valid input (ex- latin1, cjk, utf-8, etc.)
+        Scappolicy.delete({'name': scap_policy['name']})
+        with pytest.raises(CLIReturnCodeError):
+            Scappolicy.info({'name': scap_policy['name']})
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
     @pytest.mark.tier2


### PR DESCRIPTION
**Description:**
- The test module `test_postive_create_scap_policy_with_valid_name` creates policies by different names as per valid input types (ex- alfa, numberinc, latin1, cjk, utf-8, etc.)
- Due to this other test modules are getting impacted, especially when listing policies using the `hammer cli` command and reading the same name from the returned list.
- Error log from robottelo_gw1.log file > `ERROR - Skipping data chunk due to 'utf-8' codec can't decode byte 0x9b in position 0: invalid start byte`
- CI test module failure > `AssertionError: assert 'COT2aCwGDB' in []`
- This small fix will deleted policies created with other valid type of input strings as part of teardown.