### PR TITLE
[6.13.z] [Component Audit] Provisioning templates component refactor

### DIFF
--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -15,86 +15,49 @@
 :Upstream: No
 """
 import pytest
-from nailgun import entities
 from requests.exceptions import HTTPError
 
 
-@pytest.fixture(scope='module')
-def module_hostgroup_template(module_hostgroup):
-    """Create hostgroup to be used on TemplateCombination creation"""
-    yield {'hostgroup': module_hostgroup}
-    # Delete hostgroup used on TemplateCombination creation
-    module_hostgroup.delete()
+@pytest.mark.tier1
+@pytest.mark.upgrade
+def test_positive_end_to_end_template_combination(request, module_target_sat, module_hostgroup):
+    """Assert API template combination get/delete method works.
 
+    :id: 3a5cb370-c5f6-11e6-bb2f-68f72889dc7g
 
-@pytest.fixture(scope='function')
-def function_template_combination(module_hostgroup_template):
-    """Create ProvisioningTemplate and TemplateConfiguration for each test
-    and at the end delete ProvisioningTemplate used on tests
+    :Setup: save a template combination
+
+    :expectedresults: TemplateCombination can be created, retrieved and deleted through API
+
+    :CaseImportance: Critical
+
+    :BZ: 1369737
     """
-    template = entities.ProvisioningTemplate(
+    template = module_target_sat.api.ProvisioningTemplate(
         snippet=False,
         template_combinations=[
             {
-                'hostgroup_id': module_hostgroup_template['hostgroup'].id,
+                'hostgroup_id': module_hostgroup.id,
             }
         ],
     )
     template = template.create()
     template_combination_dct = template.template_combinations[0]
-    template_combination = entities.TemplateCombination(
+    template_combination = module_target_sat.api.TemplateCombination(
         id=template_combination_dct['id'],
         provisioning_template=template,
-        hostgroup=module_hostgroup_template['hostgroup'],
+        hostgroup=module_hostgroup,
     )
-    yield {'template': template, 'template_combination': template_combination}
-    # Clean combination if it is not already deleted
-    try:
-        template_combination.delete()
-    except HTTPError:
-        pass
-    template.delete()
+    # GET
+    combination = template_combination.read()
+    assert template.id == combination.provisioning_template.id
+    assert module_hostgroup.id == combination.hostgroup.id
 
-
-@pytest.mark.tier1
-def test_positive_get_combination(function_template_combination, module_hostgroup_template):
-    """Assert API template combination get method works.
-
-    :id: 2447674e-c37e-11e6-93cb-68f72889dc7f
-
-    :Setup: save a template combination
-
-    :expectedresults: TemplateCombination can be retrieved through API
-
-    :CaseImportance: Critical
-
-    :BZ: 1369737
-    """
-    combination = function_template_combination['template_combination'].read()
-    assert isinstance(combination, entities.TemplateCombination)
-    assert function_template_combination['template'].id == combination.provisioning_template.id
-    assert module_hostgroup_template['hostgroup'].id == combination.hostgroup.id
-
-
-@pytest.mark.tier1
-@pytest.mark.upgrade
-def test_positive_delete_combination(function_template_combination):
-    """Assert API template combination delete method works.
-
-    :id: 3a5cb370-c5f6-11e6-bb2f-68f72889dc7f
-
-    :Setup: save a template combination
-
-    :expectedresults: TemplateCombination can be deleted through API
-
-    :CaseImportance: Critical
-
-    :BZ: 1369737
-    """
-    combination = function_template_combination['template_combination'].read()
-    assert isinstance(combination, entities.TemplateCombination)
-    assert 1 == len(function_template_combination['template'].read().template_combinations)
+    # DELETE
+    assert 1 == len(template.read().template_combinations)
     combination.delete()
     with pytest.raises(HTTPError):
         combination.read()
-    assert 0 == len(function_template_combination['template'].read().template_combinations)
+    assert 0 == len(template.read().template_combinations)
+    template.delete()
+    module_hostgroup.delete()

--- a/tests/foreman/cli/test_provisioningtemplate.py
+++ b/tests/foreman/cli/test_provisioningtemplate.py
@@ -21,22 +21,21 @@ from random import randint
 
 import pytest
 from fauxfactory import gen_string
-from nailgun import entities
 
 from robottelo import constants
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_template
-from robottelo.cli.template import Template
-from robottelo.cli.user import User
 
 
 @pytest.fixture(scope='module')
-def module_os_with_minor():
-    return entities.OperatingSystem(minor=randint(0, 10)).create()
+def module_os_with_minor(module_target_sat):
+    return module_target_sat.api.OperatingSystem(minor=randint(0, 10)).create()
 
 
 @pytest.mark.e2e
-def test_positive_end_to_end_crud(module_org, module_location, module_os, target_sat):
+@pytest.mark.upgrade
+def test_positive_end_to_end_crud(
+    module_org, module_location, module_os_with_minor, module_target_sat
+):
     """Create a new provisioning template with several attributes, list, update them,
        clone the provisioning template and then delete it
 
@@ -59,14 +58,14 @@ def test_positive_end_to_end_crud(module_org, module_location, module_os, target
     cloned_template_name = gen_string('alpha')
     template_type = random.choice(constants.TEMPLATE_TYPES)
     # create
-    template = target_sat.cli_factory.make_template(
+    template = module_target_sat.cli_factory.make_template(
         {
             'name': name,
             'audit-comment': gen_string('alpha'),
             'description': gen_string('alpha'),
             'locked': 'no',
             'type': template_type,
-            'operatingsystem-ids': module_os.id,
+            'operatingsystem-ids': module_os_with_minor.id,
             'organization-ids': module_org.id,
             'location-ids': module_location.id,
         }
@@ -74,22 +73,22 @@ def test_positive_end_to_end_crud(module_org, module_location, module_os, target
     assert template['name'] == name
     assert template['locked'] == 'no'
     assert template['type'] == template_type
-    assert module_os.title in template['operating-systems']
+    assert module_os_with_minor.title in template['operating-systems']
     assert module_org.name in template['organizations']
     assert module_location.name in template['locations']
     # list
-    template_list = target_sat.cli.Template.list({'search': f'name={name}'})
+    template_list = module_target_sat.cli.Template.list({'search': f'name={name}'})
     assert template_list[0]['name'] == name
     assert template_list[0]['type'] == template_type
     # update
-    updated_pt = target_sat.cli.Template.update({'id': template['id'], 'name': new_name})
-    template = target_sat.cli.Template.info({'id': updated_pt[0]['id']})
+    updated_pt = module_target_sat.cli.Template.update({'id': template['id'], 'name': new_name})
+    template = module_target_sat.cli.Template.info({'id': updated_pt[0]['id']})
     assert new_name == template['name'], "The Provisioning template wasn't properly renamed"
     # clone
-    template_clone = target_sat.cli.Template.clone(
+    template_clone = module_target_sat.cli.Template.clone(
         {'id': template['id'], 'new-name': cloned_template_name}
     )
-    new_template = target_sat.cli.Template.info({'id': template_clone[0]['id']})
+    new_template = module_target_sat.cli.Template.info({'id': template_clone[0]['id']})
     assert new_template['name'] == cloned_template_name
     assert new_template['locked'] == template['locked']
     assert new_template['type'] == template['type']
@@ -97,47 +96,16 @@ def test_positive_end_to_end_crud(module_org, module_location, module_os, target
     assert new_template['organizations'] == template['organizations']
     assert new_template['locations'] == template['locations']
     # delete
-    target_sat.cli.Template.delete({'id': template['id']})
+    module_target_sat.cli.Template.delete({'id': template['id']})
     with pytest.raises(CLIReturnCodeError):
-        target_sat.cli.Template.info({'id': template['id']})
+        module_target_sat.cli.Template.info({'id': template['id']})
 
 
 @pytest.mark.tier1
-def test_positive_create_with_name():
-    """Check if Template can be created
-
-    :id: 77deaae8-447b-47cc-8af3-8b17476c905f
-
-    :expectedresults: Template is created
-
-    :CaseImportance: Critical
-    """
-    name = gen_string('alpha')
-    template = make_template({'name': name})
-    assert template['name'] == name
-
-
-@pytest.mark.tier1
-def test_positive_update_name():
-    """Check if Template can be updated
-
-    :id: 99bdab7b-1279-4349-a655-4294395ecbe1
-
-    :expectedresults: Template is updated
-
-    :CaseImportance: Critical
-    """
-    template = make_template()
-    updated_name = gen_string('alpha')
-    Template.update({'id': template['id'], 'name': updated_name})
-    template = Template.info({'id': template['id']})
-    assert updated_name == template['name']
-
-
-@pytest.mark.tier1
-def test_positive_update_with_manager_role(module_location, module_org):
+@pytest.mark.parametrize('role_name', ['Manager', 'Organization admin'])
+def test_positive_update_with_role(module_target_sat, module_location, module_org, role_name):
     """Create template providing the initial name, then update its name
-    with manager user role.
+    with manager/organization admin user roles.
 
     :id: 28c4357a-93cb-4b01-a445-5db50435bcc0
 
@@ -147,47 +115,35 @@ def test_positive_update_with_manager_role(module_location, module_org):
     :CaseImportance: Medium
 
     :BZ: 1277308
+
+    :parametrized: yes
     """
     new_name = gen_string('alpha')
     username = gen_string('alpha')
     password = gen_string('alpha')
-    template = make_template(
+    template = module_target_sat.cli_factory.make_template(
         {'organization-ids': module_org.id, 'location-ids': module_location.id}
     )
-    # Create user with Manager role
-    user = entities.User(
+    # Create user with Manager/Organization admin role
+    user = module_target_sat.api.User(
         login=username,
         password=password,
         admin=False,
         organization=[module_org.id],
         location=[module_location.id],
     ).create()
-    User.add_role({'id': user.id, 'role': "Manager"})
+    module_target_sat.cli.User.add_role({'id': user.id, 'role': role_name})
     # Update template name with that user
-    Template.with_user(username=username, password=password).update(
+    module_target_sat.cli.Template.with_user(username=username, password=password).update(
         {'id': template['id'], 'name': new_name}
     )
-    template = Template.info({'id': template['id']})
+    template = module_target_sat.cli.Template.info({'id': template['id']})
     assert new_name == template['name']
 
 
 @pytest.mark.tier1
-def test_positive_create_with_loc(module_location):
-    """Check if Template with Location can be created
-
-    :id: 263aba0e-4f54-4227-af97-f4bc8f5c0788
-
-    :expectedresults: Template is created and new Location has been
-        assigned
-
-    :CaseImportance: Medium
-    """
-    new_template = make_template({'location-ids': module_location.id})
-    assert module_location.name in new_template['locations']
-
-
-@pytest.mark.tier1
-def test_positive_create_locked():
+@pytest.mark.upgrade
+def test_positive_create_locked(module_target_sat):
     """Check that locked Template can be created
 
     :id: ff10e369-85c6-45f3-9cda-7e1c17a6632d
@@ -197,80 +153,41 @@ def test_positive_create_locked():
 
     :CaseImportance: Medium
     """
-    new_template = make_template({'locked': 'true', 'name': gen_string('alpha')})
+    new_template = module_target_sat.cli_factory.make_template(
+        {'locked': 'true', 'name': gen_string('alpha')}
+    )
     assert new_template['locked'] == 'yes'
 
 
 @pytest.mark.tier2
-def test_positive_create_with_org(module_org):
-    """Check if Template with Organization can be created
-
-    :id: 5de5ca76-1a39-46ac-8dd4-5d41b4b49076
-
-    :expectedresults: Template is created and new Organization has been
-        assigned
-
-    :CaseImportance: Medium
-    """
-    new_template = make_template({'name': gen_string('alpha'), 'organization-ids': module_org.id})
-    assert module_org.name in new_template['organizations']
-
-
-@pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_add_os_by_id(module_os_with_minor):
-    """Check if operating system can be added to a template
+def test_positive_add_remove_os_by_id(module_target_sat, module_os_with_minor):
+    """Check if operating system can be added and removed to a template
 
     :id: d9f481b3-9757-4208-b451-baf4792d4d70
 
-    :expectedresults: Operating system is added to the template
+    :expectedresults: Operating system is added/removed from the template
 
     :CaseLevel: Integration
     """
-    new_template = make_template()
-    Template.add_operatingsystem(
-        {'id': new_template['id'], 'operatingsystem-id': module_os_with_minor.id}
+    os = module_os_with_minor
+    os_string = f'{os.name} {os.major}.{os.minor}'
+    new_template = module_target_sat.cli_factory.make_template()
+    module_target_sat.cli.Template.add_operatingsystem(
+        {'id': new_template['id'], 'operatingsystem-id': os.id}
     )
-    new_template = Template.info({'id': new_template['id']})
-    os_string = (
-        f'{module_os_with_minor.name} {module_os_with_minor.major}.{module_os_with_minor.minor}'
-    )
+    new_template = module_target_sat.cli.Template.info({'id': new_template['id']})
     assert os_string in new_template['operating-systems']
-
-
-@pytest.mark.tier2
-def test_positive_remove_os_by_id(module_os_with_minor):
-    """Check if operating system can be removed from a template
-
-    :id: b5362565-6dce-4770-81e1-4fe3ec6f6cee
-
-    :expectedresults: Operating system is removed from template
-
-    :CaseLevel: Integration
-
-    :CaseImportance: Medium
-
-    :BZ: 1395229
-    """
-    template = make_template()
-    Template.add_operatingsystem(
-        {'id': template['id'], 'operatingsystem-id': module_os_with_minor.id}
+    module_target_sat.cli.Template.remove_operatingsystem(
+        {'id': new_template['id'], 'operatingsystem-id': os.id}
     )
-    template = Template.info({'id': template['id']})
-    os_string = (
-        f'{module_os_with_minor.name} {module_os_with_minor.major}.{module_os_with_minor.minor}'
-    )
-    assert os_string in template['operating-systems']
-    Template.remove_operatingsystem(
-        {'id': template['id'], 'operatingsystem-id': module_os_with_minor.id}
-    )
-    template = Template.info({'id': template['id']})
-    assert os_string not in template['operating-systems']
+    new_template = module_target_sat.cli.Template.info({'id': new_template['id']})
+    assert os_string not in new_template['operating-systems']
 
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_create_with_content():
+def test_positive_create_with_content(module_target_sat):
     """Check if Template can be created with specific content
 
     :id: 0fcfc46d-5e97-4451-936a-e8684acac275
@@ -281,32 +198,15 @@ def test_positive_create_with_content():
     """
     content = gen_string('alpha')
     name = gen_string('alpha')
-    template = make_template({'content': content, 'name': name})
+    template = module_target_sat.cli_factory.make_template({'content': content, 'name': name})
     assert template['name'] == name
-    template_content = Template.dump({'id': template['id']})
+    template_content = module_target_sat.cli.Template.dump({'id': template['id']})
     assert content in template_content
-
-
-@pytest.mark.tier1
-@pytest.mark.upgrade
-def test_positive_delete_by_id():
-    """Check if Template can be deleted
-
-    :id: 8e5245ee-13dd-44d4-8111-d4382cacf005
-
-    :expectedresults: Template is deleted
-
-    :CaseImportance: Critical
-    """
-    template = make_template()
-    Template.delete({'id': template['id']})
-    with pytest.raises(CLIReturnCodeError):
-        Template.info({'id': template['id']})
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_clone():
+def test_positive_clone(module_target_sat):
     """Assure ability to clone a provisioning template
 
     :id: 27d69c1e-0d83-4b99-8a3c-4f1bdec3d261
@@ -316,7 +216,9 @@ def test_positive_clone():
     :CaseLevel: Integration
     """
     cloned_template_name = gen_string('alpha')
-    template = make_template()
-    result = Template.clone({'id': template['id'], 'new-name': cloned_template_name})
-    new_template = Template.info({'id': result[0]['id']})
+    template = module_target_sat.cli_factory.make_template()
+    result = module_target_sat.cli.Template.clone(
+        {'id': template['id'], 'new-name': cloned_template_name}
+    )
+    new_template = module_target_sat.cli.Template.info({'id': result[0]['id']})
     assert new_template['name'] == cloned_template_name

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -17,10 +17,7 @@
 :Upstream: No
 """
 import pytest
-from airgun.session import Session
-from nailgun import entities
 
-from robottelo.config import settings
 from robottelo.constants import DataFile
 from robottelo.utils.datafactory import gen_string
 
@@ -31,12 +28,12 @@ def template_data():
 
 
 @pytest.fixture()
-def clone_setup(module_org, module_location):
+def clone_setup(target_sat, module_org, module_location):
     name = gen_string('alpha')
     content = gen_string('alpha')
-    os_list = [entities.OperatingSystem().create().title for _ in range(2)]
+    os_list = [target_sat.api.OperatingSystem().create().title for _ in range(2)]
     return {
-        'pt': entities.ProvisioningTemplate(
+        'pt': target_sat.api.ProvisioningTemplate(
             name=name,
             organization=[module_org],
             location=[module_location],
@@ -48,7 +45,7 @@ def clone_setup(module_org, module_location):
 
 
 @pytest.mark.tier2
-def test_positive_clone(session, clone_setup):
+def test_positive_clone(module_org, module_location, target_sat, clone_setup):
     """Assure ability to clone a provisioning template
 
     :id: 912f1619-4bb0-4e0f-88ce-88b5726fdbe0
@@ -62,7 +59,9 @@ def test_positive_clone(session, clone_setup):
     :CaseLevel: Integration
     """
     clone_name = gen_string('alpha')
-    with session:
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
         session.provisioningtemplate.clone(
             clone_setup['pt'].name,
             {
@@ -70,18 +69,14 @@ def test_positive_clone(session, clone_setup):
                 'association.applicable_os.assigned': clone_setup['os_list'],
             },
         )
-        pt = entities.ProvisioningTemplate().search(query={'search': f'name=={clone_name}'})
+        pt = target_sat.api.ProvisioningTemplate().search(query={'search': f'name=={clone_name}'})
         assigned_oses = [os.read() for os in pt[0].read().operatingsystem]
-        assert (
-            pt
-        ), 'Template {} expected to exist but is not included in the search' 'results'.format(
-            clone_name
-        )
+        assert pt, f'Template {clone_name} expected to exist but is not included in the search'
         assert set(clone_setup['os_list']) == {f'{os.name} {os.major}' for os in assigned_oses}
 
 
 @pytest.mark.tier2
-def test_positive_clone_locked(session, target_sat):
+def test_positive_clone_locked(target_sat):
     """Assure ability to clone a locked provisioning template
 
     :id: 2df8550a-fe7d-405f-ab48-2896554cda12
@@ -95,22 +90,22 @@ def test_positive_clone_locked(session, target_sat):
     :CaseLevel: Integration
     """
     clone_name = gen_string('alpha')
-    with session:
+    with target_sat.ui_session() as session:
         session.provisioningtemplate.clone(
             'Kickstart default',
             {
                 'template.name': clone_name,
             },
         )
-        pt = target_sat.api.ProvisioningTemplate().search(query={'search': f'name=={clone_name}'})
-        assert pt, (
-            f'Template {clone_name} expected to exist but is not included in the search' 'results'
-        )
+        assert target_sat.api.ProvisioningTemplate().search(
+            query={'search': f'name=={clone_name}'}
+        ), f'Template {clone_name} expected to exist but is not included in the search'
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, module_org, module_location, template_data, target_sat):
+@pytest.mark.e2e
+def test_positive_end_to_end(module_org, module_location, template_data, target_sat):
     """Perform end to end testing for provisioning template component
 
     :id: b44d4cc8-b78e-47cf-9993-0bb871ac2c96
@@ -138,7 +133,9 @@ def test_positive_end_to_end(session, module_org, module_location, template_data
             'input_content.description': gen_string('alpha'),
         }
     ]
-    with session:
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
         session.provisioningtemplate.create(
             {
                 'template.name': name,
@@ -154,10 +151,9 @@ def test_positive_end_to_end(session, module_org, module_location, template_data
                 'locations.resources.assigned': [module_location.name],
             }
         )
-        assert target_sat.api.ProvisioningTemplate().search(query={'search': f'name=={name}'}), (
-            'Provisioning template {} expected to exist but is not included in the search'
-            'results'.format(name)
-        )
+        assert target_sat.api.ProvisioningTemplate().search(
+            query={'search': f'name=={name}'}
+        ), f'Provisioning template {name} expected to exist but is not included in the search'
         pt = session.provisioningtemplate.read(name)
         assert pt['template']['name'] == name
         assert pt['template']['default'] is True
@@ -176,54 +172,13 @@ def test_positive_end_to_end(session, module_org, module_location, template_data
         updated_pt = target_sat.api.ProvisioningTemplate().search(
             query={'search': f'name=={new_name}'}
         )
-        assert updated_pt, (
-            'Provisioning template {} expected to exist but is not included in the search'
-            'results'.format(new_name)
-        )
+        assert (
+            updated_pt
+        ), f'Provisioning template {new_name} expected to exist but is not included in the search'
         updated_pt = updated_pt[0].read()
         assert updated_pt.snippet is True, 'Snippet attribute not updated for Provisioning Template'
-        assert not updated_pt.template_kind, 'Snippet template is {}'.format(
-            updated_pt.template_kind
-        )
+        assert not updated_pt.template_kind, f'Snippet template is {updated_pt.template_kind}'
         session.provisioningtemplate.delete(new_name)
         assert not target_sat.api.ProvisioningTemplate().search(
             query={'search': f'name=={new_name}'}
-        ), (
-            'Provisioning template {} expected to be removed but is included in the search '
-            'results'.format(new_name)
-        )
-
-
-@pytest.mark.skip_if_open("BZ:1767040")
-@pytest.mark.tier3
-def test_negative_template_search_using_url():
-    """Satellite should not show full trace on web_browser after invalid search in url
-
-    :id: aeb365dc-49de-11eb-bf99-d46d6dd3b5b2
-
-    :customerscenario: true
-
-    :expectedresults: Satellite should not show full trace and show correct error message
-
-    :CaseLevel: Integration
-
-    :CaseImportance: High
-
-    :BZ: 1767040
-    """
-    with Session(
-        url='/templates/provisioning_templates?search=&page=1"sadfasf', login=False
-    ) as session:
-        login_details = {
-            'username': settings.server.admin_username,
-            'password': settings.server.admin_password,
-        }
-        session.login.login(login_details)
-        error_page = session.browser.selenium.page_source
-        error_helper_message = (
-            "Please include in your report the full error log that can be acquired by running"
-        )
-        trace_link_word = "Full trace"
-        assert error_helper_message in error_page
-        assert trace_link_word not in error_page
-        assert "foreman-rake errors:fetch_log request_id=" in error_page
+        ), f'Provisioning template {new_name} expected to be removed but is included in the search'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11833

**Description**:
1. Removing redundant tests which are covered already either in e2e or in some other tests.
2. Replaced target_sat with module_target_sat to keep it consistent.
3. Used cli/api property instead of importing cli/api entities from nailgun, and api/cli_factory with sat objects.
4. Parametrized test_positive_update_with_manager_role for Manager and Org admin roles.
5. Using build_pxe_default endpoint from nailgun instead of using nailgun client to call it.
6. Combine template_combination tests to single e2e test.
7. Combined test_positive_remove_os_by_id and test_positive_add_os_by_id into single test.
8. Removing test_negative_template_search_using_url as not required suggested by SD