### PR TITLE
Update ui_session to run UI tests with new admin user

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -41,7 +41,9 @@ def function_org(target_sat):
 
 @pytest.fixture(scope='module')
 def module_org(module_target_sat):
-    return module_target_sat.api.Organization().create()
+    org = module_target_sat.api.Organization().create()
+    module_target_sat.organization = org
+    yield org
 
 
 @pytest.fixture(scope='class')
@@ -53,7 +55,9 @@ def class_org(class_target_sat):
 
 @pytest.fixture(scope='module')
 def module_location(module_target_sat, module_org):
-    return module_target_sat.api.Location(organization=[module_org]).create()
+    loc = module_target_sat.api.Location(organization=[module_org]).create()
+    module_target_sat.location = loc
+    yield loc
 
 
 @pytest.fixture(scope='class')

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -60,8 +60,6 @@ def test_positive_clone(module_org, module_location, target_sat, clone_setup):
     """
     clone_name = gen_string('alpha')
     with target_sat.ui_session() as session:
-        session.organization.select(org_name=module_org.name)
-        session.location.select(loc_name=module_location.name)
         session.provisioningtemplate.clone(
             clone_setup['pt'].name,
             {
@@ -134,8 +132,6 @@ def test_positive_end_to_end(module_org, module_location, template_data, target_
         }
     ]
     with target_sat.ui_session() as session:
-        session.organization.select(org_name=module_org.name)
-        session.location.select(loc_name=module_location.name)
         session.provisioningtemplate.create(
             {
                 'template.name': name,


### PR DESCRIPTION
**Problem:** 
`ui_session` contextmanager runs tests with default admin user, and we need to select organization and select location every time we run tests, and if we don't select default organization/default location will be selected causing tests to fail.
**Solution:** 
Creating a new admin user with assigned organization/location created with common module_org/module_location fixtures, to run UI tests similar to what we've been doing with `session` fixture, using organization/location properties we can set with org/location fixtures. It'll save about ~1minute per UI test to select org and loc.

If folks like this suggestion, we can update all org/location fixtures to set organization/location property and tests which uses `ui_session` contextmanager to remove org/location select steps