### PR TITLE
[6.13.z] delete policies which are no longer needed

### DIFF
--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -475,6 +475,10 @@ class TestOpenScap:
             }
         )
         assert scap_policy['name'] == name
+        # Deleting policy which created for all valid input (ex- latin1, cjk, utf-8, etc.)
+        Scappolicy.delete({'name': scap_policy['name']})
+        with pytest.raises(CLIReturnCodeError):
+            Scappolicy.info({'name': scap_policy['name']})
 
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
     @pytest.mark.tier2


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11872

- Opening the PR against 6.14.z and will be cherry pick in 6.13.z, as no scap package available in stream branch.

- The test module `test_postive_create_scap_policy_with_valid_name` creates policies by different names as per valid input types (ex- alfa, numberinc, latin1, cjk, utf-8, etc.)

- Due to this other test modules are getting impacted, especially when listing policies using the` hammer cli `command and reading the same name from the returned list.

-` ERROR - Skipping data chunk due to 'utf-8' codec can't decode byte 0x9b in position 0: invalid start byte`

- This small fix will deleted policies created with other valid type of input strings as part of teardown.