### PR TITLE
Deprecate install_katello_ca method in favor of the register method

### DIFF
--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -47,7 +47,7 @@ class CapsuleInfo:
         :param poll_timeout: Maximum number of seconds to wait until timing out.
             Parameter for ``sat.api.ForemanTask.poll()`` method.
         :param must_succeed: Assert success result on finished task.
-        :return: List of ``sat.api.ForemanTasks`` entities.
+        :return: List of ``sat.api.ForemanTask`` entities.
         :raises: ``AssertionError``. If not tasks were found until timeout.
         """
         for _ in range(max_tries):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -4,6 +4,7 @@ import json
 import random
 import re
 import time
+import warnings
 from configparser import ConfigParser
 from contextlib import contextmanager
 from functools import cached_property
@@ -504,6 +505,10 @@ class ContentHost(Host, ContentHostMixins):
         :raises robottelo.hosts.ContentHostError: If katello-ca wasn't
             installed.
         """
+        warnings.warn(
+            message='The install_katello_ca method is deprecated, use the register method instead.',
+            category=DeprecationWarning,
+        )
         self._satellite = satellite
         self.execute(
             f'curl --insecure --output katello-ca-consumer-latest.noarch.rpm \
@@ -547,6 +552,13 @@ class ContentHost(Host, ContentHostMixins):
         :raises robottelo.hosts.ContentHostError: If katello-ca wasn't
             installed.
         """
+        warnings.warn(
+            message=(
+                'The install_capsule_katello_ca method is deprecated, '
+                'use the register method instead.'
+            ),
+            category=DeprecationWarning,
+        )
         url = urlunsplit(('http', capsule, 'pub/', '', ''))
         ca_url = urljoin(url, 'katello-ca-consumer-latest.noarch.rpm')
         result = self.execute(f'rpm -Uvh {ca_url}')


### PR DESCRIPTION
## Problem statement
* robottelo contributors keep using the deprecated method of registration in new tests that they are adding.
* as a consequence, the QE framework keeps using the `install_katello_ca` combined with `register_host` instead of using the Satellite's Global Registration feature.

## Solution
* Add a `DeprecationWarning` to the `install_katello_ca` method. Every time it is called, a deprecation warning is generated.

## Expectations
* When teams add new tests and run the test session, they will be notified about the deprecation if they call `install_katello_ca` in their test/s.
* Once we start seeing the deprecation warnings, we will be more aware of the need to port (most of) the existing tests to Global Registration.

## pytest logs
```
============================================================================================================== warnings summary ==============================================================================================================
tests/foreman/api/test_registration.py::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel6]
tests/foreman/api/test_registration.py::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel7]
tests/foreman/api/test_registration.py::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel7_fips]
tests/foreman/api/test_registration.py::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel8]
tests/foreman/api/test_registration.py::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel8_fips]
tests/foreman/api/test_registration.py::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel9]
tests/foreman/api/test_registration.py::test_positive_allow_reregistration_when_dmi_uuid_changed[rhel9_fips]
  /home/ogajduse/repos/robottelo/robottelo/hosts.py:508: DeprecationWarning: The install_katello_ca method is deprecated, use register_host instead.
    warnings.warn(
```
