### PR TITLE
Remove e2e flag from failing UI test, and apply it to 2 api tests

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -751,6 +751,7 @@ class TestContentViewPublishPromote:
         comp_content_view_info = comp_content_view.version[0].read()
         assert comp_content_view_info.package_count == 36
 
+    @pytest.mark.e2e
     @pytest.mark.tier2
     def test_ccv_audit_scenarios(self, module_org, target_sat):
         """Check for various scenarios where a composite content view or it's component
@@ -1113,6 +1114,7 @@ class TestContentViewRedHatContent:
         content_view.read().version[0].promote(data={'environment_ids': module_lce.id})
         assert len(content_view.read().version[0].read().environment) == 2
 
+    @pytest.mark.e2e
     @pytest.mark.tier2
     def test_cv_audit_scenarios(self, module_product, target_sat):
         """Check for various scenarios where a content view's needs_publish flag

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -95,7 +95,6 @@ def test_positive_add_custom_content(session):
         assert cv['repositories']['resources']['assigned'][0]['Name'] == repo_name
 
 
-@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, target_sat):


### PR DESCRIPTION
Quick update to CV end-to-end scenarios - removing the flag from a UI test that is not going to pass, ever ( the old UI has been removed from Satellite, so until the CV component eval is finished, this test won't pass) and adding it to 2 recently added tests, that exercise a large majority of cases surrounding content views, and composite content views.