### PR TITLE
new hammer command and log level fix

### DIFF
--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -181,9 +181,9 @@ def test_positive_check_debug_log_levels(target_sat):
     """
     target_sat.cli.Admin.logging({'all': True, 'level-debug': True})
     # Verify value of `log4j.logger.org.candlepin` as `DEBUG`
-    result = target_sat.execute('grep DEBUG /etc/candlepin/candlepin.conf')
+    result = target_sat.execute('grep log4j.logger.org.candlepin /etc/candlepin/candlepin.conf')
     assert result.status == 0
-    assert 'log4j.logger.org.candlepin = DEBUG' in result.stdout
+    assert 'DEBUG' in result.stdout
 
     target_sat.cli.Admin.logging({"all": True, "level-production": True})
     # Verify value of `log4j.logger.org.candlepin` as `WARN`

--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -33218,6 +33218,12 @@
           "name": "configure-cdn",
           "options": [
             {
+              "help": "If product certificates should be used to authenticate to a custom CDN.",
+              "name": "custom-cdn-auth-enabled",
+              "shortname": null,
+              "value": "VALUE"
+            },
+            {
               "help": "Id of the Organization",
               "name": "id",
               "shortname": null,


### PR DESCRIPTION
new sub-command has been added within BZ#2170917, also adjusted  test_positive_check_debug_log_level for different stdout. Stream has several other new subcommands not addressed here, aiming mainly to fix 6.14