### PR TITLE
Fix find-the-parent-prt-comment in GHA

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -27,6 +27,7 @@ jobs:
         with:
           issue-number: ${{ env.number }}
           body-includes: "trigger: test-robottelo"
+          direction: last
 
   # Auto CherryPicking and Failure Recording
   auto-cherry-pick:


### PR DESCRIPTION
As default `direction: first` is used, `peter-evans/find-comment` action finds the first PRT comment from Parent PR, and add it on the cherrypicked PR (example PR https://github.com/SatelliteQE/robottelo/pull/11847), instead we should use last comment for PRT as per previous implementation.