### PR TITLE
[6.14.z] Remove Python 3.9 support from robottelo

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     include_package_data=True,
     license='GNU GPL v3.0',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    python_requires="~=3.9",
+    python_requires="~=3.10",
     classifiers=(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11953

As discussed on slack, we are removing support for Python 3.9 from our frameworks.