### PR TITLE
T2 Reviewers Auto Assign for zBranches

### DIFF
--- a/.github/workflows/t2_reviews.yaml
+++ b/.github/workflows/t2_reviews.yaml
@@ -3,6 +3,9 @@ name: Auto assign T2 Reviewers
 
 on:
   pull_request:
+    branches:
+      - master
+      - 6.*.z
     paths: ['*', '.github/**', 'conf/**', 'pytest_fixtures/core/*', 'pytest_plugins/**', 'robottelo/**', '!robottelo/constants/*', 'scripts/**']
 
 permissions:


### PR DESCRIPTION
Auto Assign T2 Reviewers to framework changes being applied to zBranches now.