### PR TITLE
[6.14.z] Fix double yielding for capsule conf fixture

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -170,10 +170,8 @@ def module_capsule_configured(module_capsule_host, module_target_sat):
 @pytest.fixture(scope='session')
 def session_capsule_configured(session_capsule_host, session_target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
-    if session_capsule_host:
-        session_capsule_host.capsule_setup(sat_host=session_target_sat)
-        yield session_capsule_host
-    yield
+    session_capsule_host.capsule_setup(sat_host=session_target_sat)
+    yield session_capsule_host
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/11977

Fixed:

```
failed on teardown with "Failed: fixture function has more than one 'yield':

    @pytest.fixture(scope='session')
    def session_capsule_configured(session_capsule_host, session_target_sat):
        """Configure the capsule instance with the satellite from settings.server.hostname"""
        if session_capsule_host:
            session_capsule_host.capsule_setup(sat_host=session_target_sat)
            yield session_capsule_host
        yield
/opt/app-root/src/robottelo/pytest_fixtures/core/sat_cap_factory.py:170"
```

