### PR TITLE
[6.14.z] Fix test_content_access_after_stopped_foreman

### DIFF
--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -46,13 +46,6 @@ def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
     """
     org = target_sat.api.Organization().create()
     org.sca_disable()
-    # adding remote_execution_connect_by_ip=Yes at org level
-    target_sat.api.Parameter(
-        name='remote_execution_connect_by_ip',
-        value='Yes',
-        parameter_type='boolean',
-        organization=org.id,
-    ).create()
     lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     repos_collection = target_sat.cli_factory.RepositoryCollection(
         distro='rhel7',
@@ -60,7 +53,7 @@ def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
             target_sat.cli_factory.YumRepository(url=settings.repos.yum_1.url),
         ],
     )
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=False)
+    repos_collection.setup_content(org.id, lce.id, upload_manifest=False, override=True)
     repos_collection.setup_virtual_machine(rhel7_contenthost, install_katello_agent=False)
     result = rhel7_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12013

The test wants to consume custom repo by AK but sets no repo override on AK (repo is assigned but disabled)

Fixes:
```
        result = rhel7_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
>       assert result.status == 0
E       assert 1 == 0
E        +  where 1 = stdout:\nLoaded plugins: ovl, product-id, search-disabled-repos, subscription-manager\nNo package walrus-0.71-1.noarch available.\n\nstderr:\nError: Nothing to do\n\nstatus: 1.status

tests/foreman/destructive/test_contenthost.py:66: AssertionError
```