### PR TITLE
[6.13.z] Update sat_ready_rhel fixture to work with osp

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -224,20 +224,6 @@ def oracle_host(request, version):
         yield host
 
 
-@pytest.fixture
-def sat_ready_rhel(request):
-    request.param = {
-        "rhel_version": request.param,
-        "no_containers": True,
-        "promtail_config_template_file": "config_sat.j2",
-    }
-    deploy_args = host_conf(request)
-    deploy_args['target_cores'] = 6
-    deploy_args['target_memory'] = '20GiB'
-    with Broker(**deploy_args, host_class=ContentHost) as host:
-        yield host
-
-
 @pytest.fixture(scope='module', params=[{'rhel_version': 8, 'no_containers': True}])
 def external_puppet_server(request):
     deploy_args = host_conf(request)

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -26,7 +26,6 @@ SSH_PASS = settings.server.ssh_password
 pytestmark = pytest.mark.destructive
 
 
-@pytest.mark.parametrize("sat_ready_rhel", [8], indirect=True)
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
 @pytest.mark.parametrize('skip_pulp', [False, True], ids=['include_pulp', 'skip_pulp'])
 def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pulp):


### PR DESCRIPTION
Update sat_ready_rhel fixture to work with osp and without params.
This is to fix failing satellite-clone tests.