### PR TITLE
[6.12.z] Update sat_ready_rhel fixture to work with osp

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -219,20 +219,6 @@ def oracle_host(request, version):
         yield host
 
 
-@pytest.fixture
-def sat_ready_rhel(request):
-    request.param = {
-        "rhel_version": request.param,
-        "no_containers": True,
-        "promtail_config_template_file": "config_sat.j2",
-    }
-    deploy_args = host_conf(request)
-    deploy_args['target_cores'] = 6
-    deploy_args['target_memory'] = '20GiB'
-    with Broker(**deploy_args, host_class=ContentHost) as host:
-        yield host
-
-
 @pytest.fixture(scope="module")
 def sat_upgrade_chost():
     """A module-level fixture that provides a UBI_8 content host for upgrade scenario testing"""

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -5,7 +5,9 @@ from wait_for import wait_for
 from pytest_fixtures.core.broker import _resolve_deploy_args
 from robottelo.config import settings
 from robottelo.hosts import Capsule
+from robottelo.hosts import get_sat_rhel_version
 from robottelo.hosts import IPAHost
+from robottelo.hosts import Satellite
 
 
 @pytest.fixture
@@ -180,3 +182,25 @@ def parametrized_enrolled_sat(
     new_sat.unregister()
     new_sat.teardown()
     Broker(hosts=[new_sat]).checkin()
+
+
+def get_deploy_args(request):
+    deploy_args = {
+        'deploy_rhel_version': get_sat_rhel_version().base_version,
+        'deploy_flavor': settings.flavors.default,
+        'promtail_config_template_file': 'config_sat.j2',
+        'workflow': 'deploy-rhel',
+    }
+    if hasattr(request, 'param'):
+        if isinstance(request.param, dict):
+            deploy_args.update(request.param)
+        else:
+            deploy_args['deploy_rhel_version'] = request.param
+    return deploy_args
+
+
+@pytest.fixture
+def sat_ready_rhel(request):
+    deploy_args = get_deploy_args(request)
+    with Broker(**deploy_args, host_class=Satellite) as host:
+        yield host

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -26,7 +26,6 @@ SSH_PASS = settings.server.ssh_password
 pytestmark = pytest.mark.destructive
 
 
-@pytest.mark.parametrize("sat_ready_rhel", [8], indirect=True)
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
 @pytest.mark.parametrize('skip_pulp', [False, True], ids=['include_pulp', 'skip_pulp'])
 def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pulp):


### PR DESCRIPTION
Update sat_ready_rhel fixture to work with osp and without params.
This is to fix failing satellite-clone tests.

Cherrypick of #12048 to `6.12.z`