### PR TITLE
[6.12.z] Component audit - Modify/Delete UI OS tests

### DIFF
--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -17,49 +17,13 @@
 :Upstream: No
 """
 import pytest
-from nailgun import entities
 
-from robottelo.constants import DEFAULT_TEMPLATE
 from robottelo.constants import HASH_TYPE
 from robottelo.utils.datafactory import gen_string
 
 
-@pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
-
-
 @pytest.mark.tier2
-def test_positive_update_with_params(session):
-    """Set Operating System parameter
-
-    :id: 05b504d8-2518-4359-a53a-f577339f1ebe
-
-    :expectedresults: OS is updated with new parameter
-
-    :CaseLevel: Integration
-    """
-    name = gen_string('alpha')
-    major_version = gen_string('numeric', 2)
-    param_name = gen_string('alpha')
-    param_value = gen_string('alpha')
-    with session:
-        session.operatingsystem.create(
-            {'operating_system.name': name, 'operating_system.major': major_version}
-        )
-        os_full_name = f'{name} {major_version}'
-        assert session.operatingsystem.search(name)[0]['Title'] == os_full_name
-        session.operatingsystem.update(
-            os_full_name, {'parameters.os_params': {'name': param_name, 'value': param_value}}
-        )
-        values = session.operatingsystem.read(os_full_name)
-        assert len(values['parameters']) == 1
-        assert values['parameters']['os_params'][0]['name'] == param_name
-        assert values['parameters']['os_params'][0]['value'] == param_value
-
-
-@pytest.mark.tier2
-def test_positive_end_to_end(session):
+def test_positive_end_to_end(session, module_org, module_location, target_sat):
     """Create all possible entities that required for operating system and then
     test all scenarios like create/read/update/delete for it
 
@@ -77,18 +41,17 @@ def test_positive_end_to_end(session):
     description = gen_string('alpha')
     family = 'Red Hat'
     hash = HASH_TYPE['md5']
-    architecture = entities.Architecture().create()
-    org = entities.Organization().create()
-    loc = entities.Location().create()
-    ptable = entities.PartitionTable(
-        organization=[org], location=[loc], os_family='Redhat'
+    architecture = target_sat.api.Architecture().create()
+    ptable = target_sat.api.PartitionTable(
+        organization=[module_org], location=[module_location], os_family='Redhat'
     ).create()
-    medium = entities.Media(organization=[org], location=[loc]).create()
+    medium = target_sat.api.Media(organization=[module_org], location=[module_location]).create()
     param_name = gen_string('alpha')
     param_value = gen_string('alpha')
     with session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=loc.name)
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
+        # Create
         session.operatingsystem.create(
             {
                 'operating_system.name': name,
@@ -113,54 +76,77 @@ def test_positive_end_to_end(session):
         assert os['operating_system']['password_hash'] == hash
         assert len(os['operating_system']['architectures']['assigned']) == 1
         assert os['operating_system']['architectures']['assigned'][0] == architecture.name
+        assert os['templates']['resources']['Provisioning template'] == 'Kickstart default'
         assert ptable.name in os['partition_table']['resources']['assigned']
         assert os['installation_media']['resources']['assigned'][0] == medium.name
         assert len(os['parameters']['os_params']) == 1
         assert os['parameters']['os_params'][0]['name'] == param_name
         assert os['parameters']['os_params'][0]['value'] == param_value
+        template_name = gen_string('alpha')
         new_description = gen_string('alpha')
-        session.operatingsystem.update(
-            description, {'operating_system.description': new_description}
+        new_name = gen_string('alpha')
+        new_major_version = gen_string('numeric', 2)
+        new_minor_version = gen_string('numeric', 2)
+        new_family = 'Red Hat CoreOS'
+        new_hash = HASH_TYPE['sha512']
+        new_architecture = target_sat.api.Architecture().create()
+        new_ptable = target_sat.api.PartitionTable(
+            organization=[module_org], location=[module_location], os_family='Redhat'
+        ).create()
+        new_medium = target_sat.api.Media(
+            organization=[module_org], location=[module_location]
+        ).create()
+        new_param_value = gen_string('alpha')
+        session.provisioningtemplate.create(
+            {
+                'template.name': template_name,
+                'template.default': True,
+                'type.snippet': False,
+                'template.template_editor.editor': gen_string('alpha'),
+                'type.template_type': 'Provisioning template',
+                'association.applicable_os.assigned': [os['operating_system']['description']],
+                'organizations.resources.assigned': [module_org.name],
+                'locations.resources.assigned': [module_location.name],
+            }
         )
-        assert not session.operatingsystem.search(description)
-        assert session.operatingsystem.search(new_description)[0]['Title'] == new_description
-        assert session.partitiontable.search(ptable.name)[0]['Operating Systems'] == new_description
+        # Update
+        session.operatingsystem.update(
+            description,
+            {
+                'operating_system.name': new_name,
+                'templates.resources': {'Provisioning template': template_name},
+                'operating_system.description': new_description,
+                'operating_system.major': new_major_version,
+                'operating_system.minor': new_minor_version,
+                'operating_system.family': new_family,
+                'operating_system.password_hash': new_hash,
+                'operating_system.architectures.assigned': [new_architecture.name],
+                'partition_table.resources.assigned': [new_ptable.name],
+                'installation_media.resources.assigned': [new_medium.name],
+                'parameters.os_params': {'name': param_name, 'value': new_param_value},
+            },
+        )
+        os = session.operatingsystem.read(new_description)
+        assert os['operating_system']['name'] == new_name
+        assert os['operating_system']['major'] == new_major_version
+        assert os['operating_system']['minor'] == new_minor_version
+        assert os['operating_system']['description'] == new_description
+        assert os['operating_system']['family'] == new_family
+        assert os['operating_system']['password_hash'] == new_hash
+        assert new_architecture.name in os['operating_system']['architectures']['assigned']
+        assert new_ptable.name in os['partition_table']['resources']['assigned']
+        assert new_medium.name in os['installation_media']['resources']['assigned']
+        assert os['templates']['resources']['Provisioning template'] == template_name
+        assert len(os['parameters']['os_params']) == 1
+        assert os['parameters']['os_params'][0]['name'] == param_name
+        assert os['parameters']['os_params'][0]['value'] == new_param_value
+        # Delete
         session.operatingsystem.delete(new_description)
         assert not session.operatingsystem.search(new_description)
 
 
 @pytest.mark.tier2
-def test_positive_update_template(session, module_org):
-    """Update operating system with new provisioning template value
-
-    :id: 0b90eb24-8fc9-4e42-8709-6eee8ffbbdb5
-
-    :expectedresults: OS is updated with new template
-
-    :CaseLevel: Integration
-    """
-    name = gen_string('alpha')
-    major_version = gen_string('numeric', 2)
-    os = entities.OperatingSystem(name=name, major=major_version, family='Redhat').create()
-    template = entities.ProvisioningTemplate(
-        organization=[module_org],
-        snippet=False,
-        template_kind=entities.TemplateKind().search(query={'search': 'name="provision"'})[0],
-        operatingsystem=[os],
-    ).create()
-    with session:
-        os_full_name = f'{name} {major_version}'
-        values = session.operatingsystem.read(os_full_name)
-        assert values['templates']['resources']['Provisioning template'] == DEFAULT_TEMPLATE
-        session.operatingsystem.update(
-            os_full_name, {'templates.resources': {'Provisioning template': template.name}}
-        )
-        values = session.operatingsystem.read(os_full_name)
-        assert values['templates']['resources']['Provisioning template'] == template.name
-
-
-@pytest.mark.tier2
-def test_positive_verify_os_name(session):
+def test_positive_verify_os_name(session, target_sat):
     """Check that the Operating System name is displayed correctly
 
     :id: 2cb9cdcf-1723-4317-ab0a-971e7b2dd161
@@ -176,7 +162,7 @@ def test_positive_verify_os_name(session):
     name = gen_string('alpha')
     major_version = gen_string('numeric', 2)
     os_full_name = f"{name} {major_version}"
-    entities.OperatingSystem(name=name, major=major_version).create()
+    target_sat.api.OperatingSystem(name=name, major=major_version).create()
     with session:
         values = session.operatingsystem.search(os_full_name)
         assert values[0]['Title'] == os_full_name


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12046

This PR aims to refactor Operating System UI tests. There were some OS tests which are combined into one end-to-end test.

Removing tests which are covered already in e2e