### PR TITLE
[6.12.z] Improve doc build speed ~10 times

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,8 +4,12 @@ The full set of configuration options is listed on the Sphinx website:
 http://sphinx-doc.org/config.html
 
 """
+import builtins
 import os
 import sys
+
+# Set the __sphinx_build__ variable to True. This is used to skip config generation
+builtins.__sphinx_build__ = True
 
 
 def skip_data(app, what, name, obj, skip, options):

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -1,3 +1,4 @@
+import builtins
 import logging
 import os
 from pathlib import Path
@@ -21,24 +22,30 @@ def get_settings():
 
     :return: A validated Lazy settings object
     """
-    settings = LazySettings(
-        envvar_prefix="ROBOTTELO",
-        core_loaders=["YAML"],
-        settings_file="settings.yaml",
-        preload=["conf/*.yaml"],
-        includes=["settings.local.yaml", ".secrets.yaml", ".secrets_*.yaml"],
-        envless_mode=True,
-        lowercase_read=True,
-        load_dotenv=True,
-    )
-    settings.validators.register(**VALIDATORS)
-
     try:
-        settings.validators.validate()
-    except ValidationError as err:
-        logger.warning(f'Dynaconf validation failed, continuing for the sake of unit tests\n{err}')
+        if builtins.__sphinx_build__:
+            settings = None
+    except AttributeError:
+        settings = LazySettings(
+            envvar_prefix="ROBOTTELO",
+            core_loaders=["YAML"],
+            settings_file="settings.yaml",
+            preload=["conf/*.yaml"],
+            includes=["settings.local.yaml", ".secrets.yaml", ".secrets_*.yaml"],
+            envless_mode=True,
+            lowercase_read=True,
+            load_dotenv=True,
+        )
+        settings.validators.register(**VALIDATORS)
 
-    return settings
+        try:
+            settings.validators.validate()
+        except ValidationError as err:
+            logger.warning(
+                f'Dynaconf validation failed, continuing for the sake of unit tests\n{err}'
+            )
+
+        return settings
 
 
 settings = get_settings()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12131

```
$ time make docs
"Copying broker_config.yaml to avoid warnings"
cp: cannot stat './broker_settings.yaml': No such file or directory
make[1]: Entering directory '/home/ogajduse/repos/robottelo/docs'
sphinx-build -W -b html -d _build/doctrees   . _build/html
Running Sphinx v7.1.2
making output directory... done

... output omitted ...

writing output... [100%] reviewing_PRs
generating indices... genindex py-modindex done
highlighting module code... [100%] robottelo.utils.version
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in _build/html.

Build finished. The HTML pages are in _build/html.
make[1]: Leaving directory '/home/ogajduse/repos/robottelo/docs'

real    0m23.055s
user    0m21.851s
sys     0m0.744s
```

Compared to current 4 minutes: https://github.com/SatelliteQE/robottelo/actions/runs/5759744767/job/15614372283?pr=12124