### PR TITLE
Introduce and enhance robottelo.hosts features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ ven*/
 
 # pytest-fixture-tools artifacts
 artifacts/
+
+# pyvcloud artifacts
+# workaround till https://github.com/vmware/pyvcloud/pull/766 is merged and released
+**vcd_sdk.log

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -5,6 +5,7 @@ from box import Box
 from broker import Broker
 
 from robottelo.config import settings
+from robottelo.hosts import ContentHostError
 from robottelo.hosts import lru_sat_ready_rhel
 from robottelo.hosts import Satellite
 
@@ -13,12 +14,9 @@ from robottelo.hosts import Satellite
 def _default_sat(align_to_satellite):
     """Returns a Satellite object for settings.server.hostname"""
     if settings.server.hostname:
-        hosts = Broker(host_class=Satellite).from_inventory(
-            filter=f'@inv.hostname == "{settings.server.hostname}"'
-        )
-        if hosts:
-            return hosts[0]
-        else:
+        try:
+            return Satellite.get_host_by_hostname(settings.server.hostname)
+        except ContentHostError:
             return Satellite()
 
 

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -331,7 +331,5 @@ def installer_satellite(request):
     if 'sanity' not in request.config.option.markexpr:
         sanity_sat = Satellite(sat.hostname)
         sanity_sat.unregister()
-        broker_sat = Broker(host_class=Satellite).from_inventory(
-            filter=f'@inv.hostname == "{sanity_sat.hostname}"'
-        )[0]
+        broker_sat = Satellite.get_host_by_hostname(sanity_sat.hostname)
         Broker(hosts=[broker_sat]).checkin()

--- a/pytest_fixtures/core/upgrade.py
+++ b/pytest_fixtures/core/upgrade.py
@@ -38,6 +38,6 @@ def pre_configured_capsule(worker_id, session_target_sat):
     logger.debug(f'Capsules found: {intersect}')
     assert len(intersect) == 1, "More than one Capsule found in the inventory"
     target_capsule = intersect.pop()
-    hosts = Broker(host_class=Capsule).from_inventory(filter=f'@inv.hostname == "{target_capsule}"')
+    host = Capsule.get_host_by_hostname(target_capsule)
     logger.info(f'xdist worker {worker_id} was assigned pre-configured Capsule {target_capsule}')
-    return hosts[0]
+    return host

--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -19,9 +19,7 @@ def align_to_satellite(request, worker_id, satellite_factory):
         if settings.server.hostname:
             sanity_sat = Satellite(settings.server.hostname)
             sanity_sat.unregister()
-            broker_sat = Broker(host_class=Satellite).from_inventory(
-                filter=f'@inv.hostname == "{sanity_sat.hostname}"'
-            )[0]
+            broker_sat = Satellite.get_host_by_hostname(sanity_sat.hostname)
             Broker(hosts=[broker_sat]).checkin()
     else:
         # clear any hostname that may have been previously set
@@ -35,9 +33,7 @@ def align_to_satellite(request, worker_id, satellite_factory):
 
         # attempt to add potential satellites from the broker inventory file
         if settings.server.inventory_filter:
-            hosts = Broker(host_class=Satellite).from_inventory(
-                filter=settings.server.inventory_filter
-            )
+            hosts = Satellite.get_hosts_from_inventory(filter=settings.server.inventory_filter)
             settings.server.hostnames += [host.hostname for host in hosts]
 
         # attempt to align a worker to a satellite

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -20,10 +20,21 @@ class VersionedContent:
 
     @cached_property
     def REPOSET(self):
-        return {
-            'rhel': constants.REPOSET[f'rhel{self._v_major}'],
-            'rhst': constants.REPOSET[f'rhst{self._v_major}'],
-        }
+        try:
+            if self._v_major > 7:
+                sys_reposets = {
+                    'rhel_bos': constants.REPOSET[f'rhel{self._v_major}_bos'],
+                    'rhel_aps': constants.REPOSET[f'rhel{self._v_major}_aps'],
+                }
+            else:
+                sys_reposets = {
+                    'rhel': constants.REPOSET[f'rhel{self._v_major}'],
+                    'rhscl': constants.REPOSET[f'rhscl{self._v_major}'],
+                }
+            reposets = {'rhst': constants.REPOSET[f'rhst{self._v_major}']}
+        except KeyError as err:
+            raise ValueError(f'Unsupported system version: {self._v_major}') from err
+        return sys_reposets | reposets
 
     @cached_property
     def REPOS(self):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -335,7 +335,8 @@ class ContentHost(Host, ContentHostMixins):
     def clean_cached_properties(self):
         """Delete all cached properties for this class"""
         for name in self.list_cached_properties():
-            getattr(self, name).cache_clear()
+            with contextlib.suppress(KeyError):  # ignore if property is not cached
+                del self.__dict__[name]
 
     def setup(self):
         if not self.blank:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -335,8 +335,7 @@ class ContentHost(Host, ContentHostMixins):
     def clean_cached_properties(self):
         """Delete all cached properties for this class"""
         for name in self.list_cached_properties():
-            with contextlib.suppress(KeyError):  # ignore if property is not cached
-                del self.__dict__[name]
+            getattr(self, name).cache_clear()
 
     def setup(self):
         if not self.blank:
@@ -403,7 +402,7 @@ class ContentHost(Host, ContentHostMixins):
             )
         except (ConnectionRefusedError, ConnectionAbortedError, TimedOutError) as err:
             raise ContentHostError(
-                f'Unable to establsh SSH connection to host {self!r} after {timeout} seconds'
+                f'Unable to establsh SSH connection to host {self} after {timeout} seconds'
             ) from err
 
     def download_file(self, file_url, local_path=None, file_name=None):

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -104,17 +104,7 @@ def test_rhel_pxe_provisioning(
     provisioning_host.blank = False
 
     # Wait for the host to be rebooted and SSH daemon to be started.
-    try:
-        wait_for(
-            provisioning_host.connect,
-            fail_condition=lambda res: res is not None,
-            handle_exception=True,
-            raise_original=True,
-            timeout=180,
-            delay=1,
-        )
-    except ConnectionRefusedError:
-        raise ConnectionRefusedError("Timed out waiting for SSH daemon to start on the host")
+    provisioning_host.wait_for_connection()
 
     # Perform version check
     host_os = host.operatingsystem.read()

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -185,17 +185,7 @@ def test_host_provisioning_with_external_puppetserver(
     provisioning_host.blank = False
 
     # Wait for the host to be rebooted and SSH daemon to be started.
-    try:
-        wait_for(
-            provisioning_host.connect,
-            fail_condition=lambda res: res is not None,
-            handle_exception=True,
-            raise_original=True,
-            timeout=180,
-            delay=1,
-        )
-    except ConnectionRefusedError:
-        raise ConnectionRefusedError('Timed out waiting for SSH daemon to start on the host')
+    provisioning_host.wait_for_connection()
 
     # Perform version check
     host_os = host.operatingsystem.read()

--- a/tests/foreman/destructive/test_leapp_satellite.py
+++ b/tests/foreman/destructive/test_leapp_satellite.py
@@ -47,10 +47,12 @@ def test_positive_leapp(target_sat):
     )
     # Recreate the session object within a Satellite object after upgrading
     target_sat.connect()
+    # Clean cached properties after the upgrade
+    target_sat.clean_cached_properties()
     # Get RHEL version after upgrading
-    result = target_sat.execute('cat /etc/redhat-release | grep -Po "\\d"')
+    res_rhel_version = target_sat.os_version.major
     # Check if RHEL was upgraded
-    assert result.stdout[0] == str(orig_rhel_ver + 1), 'RHEL was not upgraded'
+    assert res_rhel_version == orig_rhel_ver + 1, 'RHEL was not upgraded'
     # Check satellite's health
     sat_health = target_sat.execute('satellite-maintain health check')
     assert sat_health.status == 0, 'Satellite health check failed'

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -20,7 +20,6 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 :Upstream: No
 """
 import pytest
-from broker import Broker
 
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
 from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
@@ -93,17 +92,12 @@ class TestScenarioUpgradeOldClientAndPackageInstallation:
 
         :expectedresults: The package is installed on client
         """
-        client_name = pre_upgrade_data.get('rhel_client')
-        client_id = (
-            module_target_sat.api.Host().search(query={'search': f'name={client_name}'})[0].id
-        )
+        client_hostname = pre_upgrade_data.get('rhel_client')
+        rhel_client = ContentHost.get_host_by_hostname(client_hostname)
         module_target_sat.cli.Host.package_install(
-            {'host-id': client_id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
+            {'host-id': rhel_client.nailgun_host.id, 'packages': FAKE_0_CUSTOM_PACKAGE_NAME}
         )
-        # Verifies that package is really installed
-        rhel_client = Broker(host_class=ContentHost).from_inventory(
-            filter=f'@inv.hostname == "{client_name}"'
-        )[0]
+        # Verify that package is really installed
         result = rhel_client.execute(f"rpm -q {FAKE_0_CUSTOM_PACKAGE_NAME}")
         assert FAKE_0_CUSTOM_PACKAGE_NAME in result.stdout
 

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -17,7 +17,6 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
 from wait_for import wait_for
 
 from robottelo import constants
@@ -222,9 +221,7 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
         custom_repo_id = pre_upgrade_data.get('custom_repo_id')
         activation_key = pre_upgrade_data.get('activation_key')
         organization_id = pre_upgrade_data.get('organization_id')
-        rhel_client = Broker(host_class=ContentHost).from_inventory(
-            filter=f'@inv.hostname == "{client_hostname}"'
-        )[0]
+        rhel_client = ContentHost.get_host_by_hostname(client_hostname)
         custom_yum_repo = target_sat.api.Repository(id=custom_repo_id).read()
         host = target_sat.api.Host().search(query={'search': f'activation_key={activation_key}'})[0]
         assert host.id == rhel_client.nailgun_host.id, 'Host not found in Satellite'

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -17,7 +17,6 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
 
 from robottelo.config import settings
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
@@ -198,9 +197,7 @@ class TestScenarioCustomRepoCheck:
             data={'environment_ids': lce_id}
         )
 
-        rhel_client = Broker(host_class=ContentHost).from_inventory(
-            filter=f'@inv.hostname == "{client_hostname}"'
-        )[0]
+        rhel_client = ContentHost.get_host_by_hostname(client_hostname)
         result = rhel_client.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0
 
@@ -299,9 +296,7 @@ class TestScenarioCustomRepoOverrideCheck:
         org_name = pre_upgrade_data.get('org_name')
         product_name = pre_upgrade_data.get('product_name')
         repo_name = pre_upgrade_data.get('repo_name')
-        rhel_client = Broker(host_class=ContentHost).from_inventory(
-            filter=f'@inv.hostname == "{client_hostname}"'
-        )[0]
+        rhel_client = ContentHost.get_host_by_hostname(client_hostname)
         result = rhel_client.execute('subscription-manager repo-override --list')
         assert 'enabled: 1' in result.stdout
         assert f'{org_name}_{product_name}_{repo_name}' in result.stdout

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -17,11 +17,11 @@
 :Upstream: No
 """
 import pytest
-from broker import Broker
 from manifester import Manifester
 
 from robottelo import constants
 from robottelo.config import settings
+from robottelo.hosts import ContentHost
 
 
 class TestManifestScenarioRefresh:
@@ -163,9 +163,7 @@ class TestSubscriptionAutoAttach:
             1. Pre-upgrade content host should get subscribed.
             2. All the cleanup should be completed successfully.
         """
-        rhel_contenthost = Broker().from_inventory(
-            filter=f'@inv.hostname == "{pre_upgrade_data.rhel_client}"'
-        )[0]
+        rhel_contenthost = ContentHost.get_host_by_hostname(pre_upgrade_data.rhel_client)
         host = target_sat.api.Host().search(query={'search': f'name={rhel_contenthost.hostname}'})[
             0
         ]


### PR DESCRIPTION
This PR brings new functionality, improvements and fixes:
* Fixes #12115 - Introduce `list_cached_properties`, `get_cached_properties`, `clean_cached_properties` to allow listing names, getting values and cleaning of cached properties of a ContentHost object
* Fixes #12142
* Ignore vcd_sdk.log that comes from pyvcloud (dependency of wrapanapi)
* Introduce `get_host_by_hostname` and `get_hosts_from_inventory` to make host reconstruction shorter, clearer and less repetetive
* Add RHEL 8+ support to `REPOSET`
* Wrap `wait_for` `connect in a ContentHost `wait_for_connection` method
* Use /etc/os-release to get system identification data - introduced new _os_release cached property
* Raise `NotImplementedError` on an attempt to `power_control` a container host type
* run unregister only if the host is not S