### PR TITLE
[6.12.z] Change certs fixture to use sat_ready_rhel fixture (#12077)

### DIFF
--- a/pytest_fixtures/component/katello_certs_check.py
+++ b/pytest_fixtures/component/katello_certs_check.py
@@ -2,29 +2,18 @@
 from pathlib import Path
 
 import pytest
-from broker import Broker
 from fauxfactory import gen_string
 
 from robottelo.constants import CERT_DATA as cert_data
 from robottelo.hosts import Capsule
-from robottelo.hosts import ContentHost
 
 
 @pytest.fixture
-def certs_vm_setup(request):
-    """Create VM and register content host"""
-    target_cores = request.param.get('target_cores', 1)
-    target_memory = request.param.get('target_memory', '1GiB')
-    with Broker(
-        nick=request.param['nick'],
-        host_class=ContentHost,
-        target_cores=target_cores,
-        target_memory=target_memory,
-    ) as host:
-        cert_data['key_file_name'] = f'{host.hostname}/{host.hostname}.key'
-        cert_data['cert_file_name'] = f'{host.hostname}/{host.hostname}.crt'
-        host.custom_cert_generate(cert_data['capsule_hostname'])
-        yield cert_data, host
+def certs_data(sat_ready_rhel):
+    cert_data['key_file_name'] = f'{sat_ready_rhel.hostname}/{sat_ready_rhel.hostname}.key'
+    cert_data['cert_file_name'] = f'{sat_ready_rhel.hostname}/{sat_ready_rhel.hostname}.crt'
+    sat_ready_rhel.custom_cert_generate(cert_data['capsule_hostname'])
+    yield cert_data
 
 
 @pytest.fixture

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -260,9 +260,6 @@ OHSNAP_RHEL8_REPOS = (
     'rhel-8-for-x86_64-appstream-rpms',
 )
 
-INSTALL_RHEL7_STEPS = 'yum -y install satellite'
-INSTALL_RHEL8_STEPS = 'dnf -y module enable satellite:el8 && dnf -y install satellite'
-
 # On importing manifests, Red Hat repositories are listed like this:
 # Product -> RepositorySet -> Repository
 # We need to first select the Product, then the reposet and then the repos

--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -21,8 +21,6 @@ import re
 
 import pytest
 
-import robottelo.constants as constants
-from robottelo.config import settings
 from robottelo.utils.issue_handlers import is_open
 
 pytestmark = pytest.mark.destructive
@@ -77,63 +75,6 @@ def test_positive_update_katello_certs(cert_setup_destructive_teardown):
         # assert all services are running
         result = satellite.execute('satellite-maintain health check --label services-up -y')
         assert result.status == 0, 'Not all services are running'
-
-
-@pytest.mark.parametrize(
-    'certs_vm_setup',
-    [
-        {'nick': 'rhel8', 'target_memory': '20GiB', 'target_cores': 4},
-    ],
-    ids=['rhel8'],
-    indirect=True,
-)
-def test_positive_install_sat_with_katello_certs(certs_vm_setup):
-    """Update certificates on a currently running satellite instance.
-
-    :id: 47e3a57f-d7a2-40d2-bbc7-d1bb3d79a7e1
-
-    :steps:
-
-        1. Generate the custom certs on RHEL 7 machine
-        2. Install satellite with custom certs
-        3. Assert output does not report SSL certificate error
-        4. Assert all services are running
-
-
-    :expectedresults: Satellite should be installed using the custom certs.
-
-    :CaseAutomation: Automated
-    """
-    cert_data, rhel_vm = certs_vm_setup
-    version = rhel_vm.os_version.major
-    rhel_vm.download_repofile(product='satellite', release=settings.server.version.release)
-    rhel_vm.register_contenthost(
-        org=None,
-        lce=None,
-        username=settings.subscription.rhn_username,
-        password=settings.subscription.rhn_password,
-    )
-    result = rhel_vm.subscription_manager_attach_pool([settings.subscription.rhn_poolid])[0]
-    for repo in getattr(constants, f"OHSNAP_RHEL{version}_REPOS"):
-        rhel_vm.enable_repo(repo, force=True)
-    rhel_vm.execute('yum -y update')
-    result = rhel_vm.execute(getattr(constants, f"INSTALL_RHEL{version}_STEPS"))
-    assert result.status == 0
-    command = (
-        'satellite-installer --scenario satellite '
-        f'--certs-server-cert "/root/{cert_data["cert_file_name"]}" '
-        f'--certs-server-key "/root/{cert_data["key_file_name"]}" '
-        f'--certs-server-ca-cert "/root/{cert_data["ca_bundle_file_name"]}" '
-    )
-    result = rhel_vm.execute(command, timeout=2200000)
-    assert result.status == 0
-    # assert no hammer ping SSL cert error
-    result = rhel_vm.execute('hammer ping')
-    assert 'SSL certificate verification failed' not in result.stdout
-    assert result.stdout.count('ok') == 8
-    # assert all services are running
-    result = rhel_vm.execute('satellite-maintain health check --label services-up -y')
-    assert result.status == 0, 'Not all services are running'
 
 
 def test_regeneration_ssl_build_certs(target_sat):

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -21,6 +21,51 @@ import re
 
 import pytest
 
+from robottelo.config import settings
+from robottelo.utils.installer import InstallerCommand
+
+
+@pytest.mark.e2e
+def test_positive_install_sat_with_katello_certs(certs_data, sat_ready_rhel):
+    """Install Satellite with custom certs.
+
+    :id: 47e3a57f-d7a2-40d2-bbc7-d1bb3d79a7e1
+
+    :steps:
+
+        1. Generate the custom certs on RHEL machine
+        2. Install satellite with custom certs
+        3. Assert output does not report SSL certificate error
+        4. Assert all services are running
+
+
+    :expectedresults: Satellite should be installed using the custom certs.
+
+    :CaseAutomation: Automated
+    """
+    sat_ready_rhel.download_repofile(product='satellite', release=settings.server.version.release)
+    sat_ready_rhel.register_to_cdn()
+    sat_ready_rhel.execute('dnf -y update')
+    result = sat_ready_rhel.execute(
+        'dnf -y module enable satellite:el8 && dnf -y install satellite'
+    )
+    assert result.status == 0
+    command = InstallerCommand(
+        scenario='satellite',
+        certs_server_cert=f'/root/{certs_data["cert_file_name"]}',
+        certs_server_key=f'/root/{certs_data["key_file_name"]}',
+        certs_server_ca_cert=f'/root/{certs_data["ca_bundle_file_name"]}',
+    ).get_command()
+    result = sat_ready_rhel.execute(command, timeout='30m')
+    assert result.status == 0
+    # assert no hammer ping SSL cert error
+    result = sat_ready_rhel.execute('hammer ping')
+    assert 'SSL certificate verification failed' not in result.stdout
+    assert result.stdout.count('Status:') == result.stdout.count(' ok')
+    # assert all services are running
+    result = sat_ready_rhel.execute('satellite-maintain health check --label services-up -y')
+    assert result.status == 0, 'Not all services are running'
+
 
 @pytest.mark.run_in_one_thread
 class TestKatelloCertsCheck:


### PR DESCRIPTION
* Move test_positive_install_sat_with_katello_certs to non-destructive

* Change certs fixture to use sat_ready_rhel fixture

(cherry picked from commit 412201f14fd9cbe3f3c7b671595fe45f25aa1cd2)

Cherrypicks #12077
Fixes #12151