### PR TITLE
[6.11.z] Change certs fixture to use sat_ready_rhel fixture (#12077)

### DIFF
--- a/pytest_fixtures/component/katello_certs_check.py
+++ b/pytest_fixtures/component/katello_certs_check.py
@@ -2,29 +2,18 @@
 from pathlib import Path
 
 import pytest
-from broker import Broker
 from fauxfactory import gen_string
 
 from robottelo.constants import CERT_DATA as cert_data
 from robottelo.hosts import Capsule
-from robottelo.hosts import ContentHost
 
 
 @pytest.fixture
-def certs_vm_setup(request):
-    """Create VM and register content host"""
-    target_cores = request.param.get('target_cores', 1)
-    target_memory = request.param.get('target_memory', '1GiB')
-    with Broker(
-        nick=request.param['nick'],
-        host_class=ContentHost,
-        target_cores=target_cores,
-        target_memory=target_memory,
-    ) as host:
-        cert_data['key_file_name'] = f'{host.hostname}/{host.hostname}.key'
-        cert_data['cert_file_name'] = f'{host.hostname}/{host.hostname}.crt'
-        host.custom_cert_generate(cert_data['capsule_hostname'])
-        yield cert_data, host
+def certs_data(sat_ready_rhel):
+    cert_data['key_file_name'] = f'{sat_ready_rhel.hostname}/{sat_ready_rhel.hostname}.key'
+    cert_data['cert_file_name'] = f'{sat_ready_rhel.hostname}/{sat_ready_rhel.hostname}.crt'
+    sat_ready_rhel.custom_cert_generate(cert_data['capsule_hostname'])
+    yield cert_data
 
 
 @pytest.fixture

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -21,6 +21,51 @@ import re
 
 import pytest
 
+import robottelo.constants as constants
+from robottelo.config import settings
+from robottelo.utils.installer import InstallerCommand
+
+
+@pytest.mark.e2e
+def test_positive_install_sat_with_katello_certs(certs_data, sat_ready_rhel):
+    """Install Satellite with custom certs.
+
+    :id: 47e3a57f-d7a2-40d2-bbc7-d1bb3d79a7e1
+
+    :steps:
+
+        1. Generate the custom certs on RHEL machine
+        2. Install satellite with custom certs
+        3. Assert output does not report SSL certificate error
+        4. Assert all services are running
+
+
+    :expectedresults: Satellite should be installed using the custom certs.
+
+    :CaseAutomation: Automated
+    """
+    version = sat_ready_rhel.os_version.major
+    sat_ready_rhel.download_repofile(product='satellite', release=settings.server.version.release)
+    sat_ready_rhel.register_to_cdn()
+    sat_ready_rhel.execute('dnf -y update')
+    result = sat_ready_rhel.execute(getattr(constants, f"INSTALL_RHEL{version}_STEPS"))
+    assert result.status == 0
+    command = InstallerCommand(
+        scenario='satellite',
+        certs_server_cert=f'/root/{certs_data["cert_file_name"]}',
+        certs_server_key=f'/root/{certs_data["key_file_name"]}',
+        certs_server_ca_cert=f'/root/{certs_data["ca_bundle_file_name"]}',
+    ).get_command()
+    result = sat_ready_rhel.execute(command, timeout='30m')
+    assert result.status == 0
+    # assert no hammer ping SSL cert error
+    result = sat_ready_rhel.execute('hammer ping')
+    assert 'SSL certificate verification failed' not in result.stdout
+    assert result.stdout.count('Status:') == result.stdout.count(' ok')
+    # assert all services are running
+    result = sat_ready_rhel.execute('satellite-maintain health check --label services-up -y')
+    assert result.status == 0, 'Not all services are running'
+
 
 @pytest.mark.run_in_one_thread
 class TestKatelloCertsCheck:


### PR DESCRIPTION
* Move test_positive_install_sat_with_katello_certs to non-destructive

* Change certs fixture to use sat_ready_rhel fixture

(cherry picked from commit 412201f14fd9cbe3f3c7b671595fe45f25aa1cd2)

Cherrypicks #12077 
Fixes #12149 