### PR TITLE
[6.12.z] Mark test_positive_configure_cloud_connector destructive

### DIFF
--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -103,6 +103,7 @@ def fixture_setup_rhc_satellite(request, module_target_sat, module_rhc_org):
 
 @pytest.mark.e2e
 @pytest.mark.tier3
+@pytest.mark.destructive
 def test_positive_configure_cloud_connector(
     session,
     module_target_sat,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12157

null