### PR TITLE
Revert "Mark test_positive_configure_cloud_connector destructive"

### DIFF
--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -103,7 +103,6 @@ def fixture_setup_rhc_satellite(request, module_target_sat, module_rhc_org):
 
 @pytest.mark.e2e
 @pytest.mark.tier3
-@pytest.mark.destructive
 def test_positive_configure_cloud_connector(
     session,
     module_target_sat,


### PR DESCRIPTION
Reverts SatelliteQE/robottelo#12157

Reverting this change back as we need to have the master branch in the same state as the other `.z` branches before we merge #12162 and create cherry-pick PRs.