### PR TITLE
[6.13.z] delete tailoring files which are no longer needed

### DIFF
--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -52,6 +52,10 @@ class TestTailoringFiles:
             {'name': name, 'scap-file': tailoring_file_path['satellite']}
         )
         assert tailoring_file['name'] == name
+        # Delete tailoring files which created for all valid input (ex- latin1, cjk, utf-8, etc.)
+        TailoringFiles.delete({'id': tailoring_file['id']})
+        with pytest.raises(CLIReturnCodeError):
+            TailoringFiles.info({'id': tailoring_file['id']})
 
     @pytest.mark.tier1
     def test_positive_create_with_space(self, tailoring_file_path):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12156

- test module `test_positive_create` create tailoring files with all possible valid input type (ex- alfa, numberinc, latin1, cjk, utf-8, etc.)
- Due to this naming type other tests (ex - `test_positive_list_tailoring_file`) getting affected.
- Error log from robottelo_gw1.log file > `broker - ERROR - Skipping data chunk due to 'utf-8' codec can't decode bytes in position 1022-1023: unexpected end of data`
- CI test module failure > `AssertionError: assert '萭ﬃ#x10726#x177E5#x1863A' in []`
- `This small fix will deleted created tailoring files with other valid type of input strings`
- **Note:** Test module for 6.12.5 was failing due to this problem, this is intermittent test failure so adding 6.13 and 6.14 label into it.