### PR TITLE
[6.13.z] remove delete org and create a new location for virt-who upgrade scenarios

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -23,7 +23,6 @@ from robottelo.cli.host import Host
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC
 from robottelo.utils.issue_handlers import is_open
 from robottelo.utils.virtwho import deploy_configure_by_command
 from robottelo.utils.virtwho import get_configure_command
@@ -78,16 +77,8 @@ class TestScenarioPositiveVirtWho:
             3. Report is sent to satellite.
             4. Virtual sku can be generated and attached.
         """
-        org = target_sat.api.Organization().search(query={'search': f'name={ORG_DATA["name"]}'})
-        if org:
-            target_sat.api.Organization(id=org[0].id).delete()
-        default_loc_id = (
-            target_sat.api.Location().search(query={'search': f'name="{DEFAULT_LOC}"'})[0].id
-        )
-        default_loc = target_sat.api.Location(id=default_loc_id).read()
         org = target_sat.api.Organization(name=ORG_DATA['name']).create()
-        default_loc.organization.append(target_sat.api.Organization(id=org.id))
-        default_loc.update(['organization'])
+        target_sat.api.Location(organization=[org]).create()
         org.sca_disable()
         target_sat.upload_manifest(org.id, function_entitlement_manifest.content)
         form_data.update({'organization_id': org.id})


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12092

remove delete org and create a new location for virt-who upgrade scenarios
Cases : PASS
```robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/upgrades/test_virtwho.py  -m pre_upgrade 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.4.0, pluggy-1.0.0
Mandatory Requirements are up to date.
Optional Requirements are up to date.
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/virtwho/repository/robottelo
configfile: pyproject.toml
plugins: cov-4.1.0, ibutsu-2.2.4, xdist-3.3.1, mock-3.11.1, services-2.2.1, reportportal-5.2.0
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_virtwho.py .                                                                                                                                                                            [100%]

=================================================================================== 1 passed, 1 deselected in 124.62s (0:02:04) ===================================================================================
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/upgrades/test_virtwho.py  -m post_upgrade 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.4.0, pluggy-1.0.0
Mandatory Requirements are up to date.
Optional Requirements are up to date.
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/virtwho/repository/robottelo
configfile: pyproject.toml
plugins: cov-4.1.0, ibutsu-2.2.4, xdist-3.3.1, mock-3.11.1, services-2.2.1, reportportal-5.2.0
collected 2 items / 1 deselected / 1 selected                                                                                                                                                                     

tests/upgrades/test_virtwho.py .                                                                                                                                                                            [100%]

======================================================================================== 1 passed, 1 deselected in 20.05s =========================================================================================
```