### PR TITLE
Use target_sat for test_positive_configure_cloud_connector api test

### DIFF
--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -22,25 +22,23 @@ from fauxfactory import gen_string
 from robottelo.utils.issue_handlers import is_open
 
 
-@pytest.fixture(scope='module')
-def fixture_enable_rhc_repos(module_target_sat):
+@pytest.fixture
+def fixture_enable_rhc_repos(target_sat):
     """Enable repos required for configuring RHC."""
     # subscribe rhc satellite to cdn.
-    module_target_sat.register_to_cdn()
-    if module_target_sat.os_version.major > 7:
-        module_target_sat.enable_repo(module_target_sat.REPOS['rhel_bos']['id'])
-        module_target_sat.enable_repo(module_target_sat.REPOS['rhel_aps']['id'])
+    target_sat.register_to_cdn()
+    if target_sat.os_version.major > 7:
+        target_sat.enable_repo(target_sat.REPOS['rhel_bos']['id'])
+        target_sat.enable_repo(target_sat.REPOS['rhel_aps']['id'])
     else:
-        module_target_sat.enable_repo(module_target_sat.REPOS['rhscl']['id'])
-        module_target_sat.enable_repo(module_target_sat.REPOS['rhel']['id'])
+        target_sat.enable_repo(target_sat.REPOS['rhscl']['id'])
+        target_sat.enable_repo(target_sat.REPOS['rhel']['id'])
 
 
 @pytest.mark.e2e
 @pytest.mark.tier3
 @pytest.mark.destructive
-def test_positive_configure_cloud_connector(
-    module_target_sat, module_org, fixture_enable_rhc_repos
-):
+def test_positive_configure_cloud_connector(target_sat, default_org, fixture_enable_rhc_repos):
     """
     Enable RH Cloud Connector through API
 
@@ -58,45 +56,43 @@ def test_positive_configure_cloud_connector(
 
     # Delete old satellite  hostname if BZ#2130173 is open
     if is_open('BZ:2130173'):
-        host = module_target_sat.api.Host().search(
-            query={'search': f"! {module_target_sat.hostname}"}
-        )[0]
+        host = target_sat.api.Host().search(query={'search': f"! {target_sat.hostname}"})[0]
         host.delete()
 
     # Copy foreman-proxy user's key to root@localhost user's authorized_keys
-    module_target_sat.add_rex_key(satellite=module_target_sat)
+    target_sat.add_rex_key(satellite=target_sat)
 
     # Set Host parameter source_display_name to something random.
     # To avoid 'name has already been taken' error when run multiple times
     # on a machine with the same hostname.
-    host = module_target_sat.api.Host().search(query={'search': module_target_sat.hostname})[0]
+    host = target_sat.api.Host().search(query={'search': target_sat.hostname})[0]
     parameters = [{'name': 'source_display_name', 'value': gen_string('alpha')}]
     host.host_parameters_attributes = parameters
     host.update(['host_parameters_attributes'])
 
-    enable_connector = module_target_sat.api.RHCloud(organization=module_org).enable_connector()
+    enable_connector = target_sat.api.RHCloud(organization=default_org).enable_connector()
 
     template_name = 'Configure Cloud Connector'
     invocation_id = (
-        module_target_sat.api.JobInvocation()
+        target_sat.api.JobInvocation()
         .search(query={'search': f'description="{template_name}"'})[0]
         .id
     )
     task_id = enable_connector['task_id']
-    module_target_sat.wait_for_tasks(
+    target_sat.wait_for_tasks(
         search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
         search_rate=15,
     )
 
-    job_output = module_target_sat.cli.JobInvocation.get_output(
-        {'id': invocation_id, 'host': module_target_sat.hostname}
+    job_output = target_sat.cli.JobInvocation.get_output(
+        {'id': invocation_id, 'host': target_sat.hostname}
     )
     # get rhc status
-    rhc_status = module_target_sat.execute('rhc status')
+    rhc_status = target_sat.execute('rhc status')
     # get rhcd log
-    rhcd_log = module_target_sat.execute('journalctl --unit=rhcd')
+    rhcd_log = target_sat.execute('journalctl --unit=rhcd')
 
-    assert module_target_sat.api.JobInvocation(id=invocation_id).read().status == 0
+    assert target_sat.api.JobInvocation(id=invocation_id).read().status == 0
     assert "Install yggdrasil-worker-forwarder and rhc" in job_output
     assert "Restart rhcd" in job_output
     assert 'Exit status: 0' in job_output


### PR DESCRIPTION
Using `target_sat` fixture for the test as `module_target_sat` fixture can't be used with `destructive` marker.