### PR TITLE
[6.14.z] password is now redacted in the template output

### DIFF
--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -170,7 +170,7 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
     :expectedresults:
         1. Assert matching templates are exported to git repo.
 
-    :BZ: 1785613
+    :BZ: 1785613, 2013759
 
     :parametrized: yes
 
@@ -189,7 +189,10 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
                 'template.dirname': dirname,
             }
         )
-        assert export_title == f'Export to {url} and branch {git_branch} as user {session._user}'
+        assert (
+            export_title == f'Export to {url.replace(git.password, "*****")} '
+            f'and branch {git_branch} as user {session._user}'
+        )
         path = f"{dirname}/provisioning_templates/provision"
         auth = (git.username, git.password)
         api_url = f"http://{git.hostname}:{git.http_port}/api/v1/repos/{git.username}"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12195

adjusting the assertion accordingly