### PR TITLE
Modify and delete foreman-maintain tests

### DIFF
--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -165,6 +165,8 @@ def test_positive_advanced_run_hammer_setup(request, sat_maintain):
         assert default_admin_pass in result.stdout
 
 
+@pytest.mark.e2e
+@pytest.mark.upgrade
 def test_positive_advanced_run_packages(request, sat_maintain):
     """Packages install/downgrade/check-update/update using advanced procedure run
 
@@ -248,20 +250,6 @@ def test_positive_advanced_run_foreman_task_resume(sat_maintain):
     assert 'FAIL' not in result.stdout
 
 
-def test_positive_advanced_run_foreman_tasks_ui_investigate(sat_maintain):
-    """Run foreman-tasks-ui-investigate using advanced procedure run
-
-    :id: 3b4f69c6-c0a1-42e3-a099-8a6e26280d17
-
-    :steps:
-        1. Run satellite-maintain advanced procedure run foreman-tasks-ui-investigate
-
-    :expectedresults: procedure foreman-tasks-ui-investigate should work.
-    """
-    result = sat_maintain.cli.Advanced.run_foreman_tasks_ui_investigate(env_var='echo " " | ')
-    assert result.status == 0
-
-
 @pytest.mark.e2e
 def test_positive_advanced_run_sync_plan(setup_sync_plan, sat_maintain):
     """Run sync-plans-enable and sync-plans-disable using advanced procedure run
@@ -293,49 +281,6 @@ def test_positive_advanced_run_sync_plan(setup_sync_plan, sat_maintain):
     with open(local_data_yml_path) as f:
         data_yml = yaml.safe_load(f)
     assert len(enable_sync_ids) == len(data_yml[':default'][':sync_plans'][':enabled'])
-
-
-@pytest.mark.include_capsule
-def test_positive_advanced_by_tag_check_migrations(sat_maintain):
-    """Run pre-migrations and post-migrations using advanced procedure by-tag
-
-    :id: 65cacca0-f142-4a63-a644-01f76120f16c
-
-    :parametrized: yes
-
-    :steps:
-        1. Run satellite-maintain advanced procedure by-tag pre-migrations
-        2. Run satellite-maintain advanced procedure by-tag post-migrations
-
-    :expectedresults: procedures of pre-migrations tag and post-migrations tag should work.
-    """
-    result = sat_maintain.cli.AdvancedByTag.pre_migrations()
-    assert 'FAIL' not in result.stdout
-    rules = sat_maintain.execute('nft list tables')
-    assert 'FOREMAN_MAINTAIN_TABLE' in rules.stdout
-
-    result = sat_maintain.cli.AdvancedByTag.post_migrations()
-    assert 'FAIL' not in result.stdout
-    rules = sat_maintain.execute('nft list tables')
-    assert 'FOREMAN_MAINTAIN_TABLE' not in rules.stdout
-
-
-@pytest.mark.include_capsule
-def test_positive_advanced_by_tag_restore_confirmation(sat_maintain):
-    """Run restore_confirmation using advanced procedure by-tag
-
-    :id: f9e10352-04fb-49ba-8346-5b02e64fd028
-
-    :parametrized: yes
-
-    :steps:
-        1. Run satellite-maintain advanced procedure by-tag restore
-
-    :expectedresults: procedure restore_confirmation should work.
-    """
-    result = sat_maintain.cli.AdvancedByTag.restore(options={'assumeyes': True})
-    assert 'FAIL' not in result.stdout
-    assert result.status == 0
 
 
 def test_positive_sync_plan_with_hammer_defaults(request, sat_maintain, module_org):

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -159,7 +159,7 @@ def test_positive_backup_split_pulp_tar(
 
 @pytest.mark.include_capsule
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
-def test_positive_backup_caspule_features(
+def test_positive_backup_capsule_features(
     sat_maintain, setup_backup_tests, module_synced_repos, backup_type
 ):
     """Take a backup with capsule features as dns, tftp, dhcp, openscap
@@ -368,29 +368,7 @@ def test_negative_backup_maintenance_mode(sat_maintain, setup_backup_tests):
 
 
 @pytest.mark.include_capsule
-def test_negative_restore_nodir(sat_maintain, setup_backup_tests):
-    """Try to run restore with no source dir provided
-
-    :id: dadc4e32-c0b8-427f-a449-4ae66fe09268
-
-    :parametrized: yes
-
-    :steps:
-        1. try to run restore with no path argument provided
-
-    :expectedresults:
-        1. should fail with appropriate error message
-    """
-    result = sat_maintain.cli.Restore.run(
-        backup_dir='',
-        options={'assumeyes': True, 'plaintext': True},
-    )
-    assert result.status != 0
-    assert NODIR_MSG in str(result.stderr)
-
-
-@pytest.mark.include_capsule
-def test_negative_restore_baddir(sat_maintain, setup_backup_tests):
+def test_negative_restore_baddir_nodir(sat_maintain, setup_backup_tests):
     """Try to run restore with non-existing source dir provided
 
     :id: 65ccc0d0-ca43-4877-9b29-50037e378ca5
@@ -399,6 +377,7 @@ def test_negative_restore_baddir(sat_maintain, setup_backup_tests):
 
     :steps:
         1. try to run restore with non-existing path provided
+        2. try to run restore without a backup dir
 
     :expectedresults:
         1. should fail with appropriate error message
@@ -410,6 +389,12 @@ def test_negative_restore_baddir(sat_maintain, setup_backup_tests):
     )
     assert result.status != 0
     assert BADDIR_MSG in str(result.stdout)
+    result = sat_maintain.cli.Restore.run(
+        backup_dir='',
+        options={'assumeyes': True, 'plaintext': True},
+    )
+    assert result.status != 0
+    assert NODIR_MSG in str(result.stderr)
 
 
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
@@ -495,6 +480,7 @@ def test_positive_puppet_backup_restore(
 
 
 @pytest.mark.e2e
+@pytest.mark.upgrade
 @pytest.mark.include_capsule
 @pytest.mark.parametrize('skip_pulp', [False, True], ids=['include_pulp', 'skip_pulp'])
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -83,6 +83,7 @@ def test_positive_list_health_check_by_tags(sat_maintain):
 
 
 @pytest.mark.e2e
+@pytest.mark.upgrade
 @pytest.mark.include_capsule
 def test_positive_health_check(sat_maintain):
     """Verify satellite-maintain health check
@@ -164,18 +165,21 @@ def test_positive_health_check_server_ping(sat_maintain):
     assert 'FAIL' not in result.stdout
 
 
-def test_negative_health_check_server_ping(sat_maintain, request):
-    """Verify hammer ping check
+def test_health_check_server_ping(sat_maintain, request):
+    """Verify health check server-ping
 
     :id: ecdc5bfb-2adf-49f6-948d-995dae34bcd3
 
     :steps:
-        1. Run satellite maintain service stop
-        2. Run satellite-maintain health check --label server-ping
-        3. Run satellite maintain service start
+        1. Run satellite-maintain health check --label server-ping
+        2. Run satellite-maintain service stop
+        3. Run satellite-maintain health check --label server-ping
 
     :expectedresults: server-ping health check should pass
     """
+    result = sat_maintain.cli.Health.check(options={'label': 'server-ping', 'assumeyes': True})
+    assert result.status == 0
+    assert 'FAIL' not in result.stdout
     assert sat_maintain.cli.Service.stop().status == 0
     result = sat_maintain.cli.Health.check(options={'label': 'server-ping', 'assumeyes': True})
     assert result.status == 0
@@ -187,7 +191,7 @@ def test_negative_health_check_server_ping(sat_maintain, request):
 
 
 @pytest.mark.include_capsule
-def test_positive_health_check_upstream_repository(sat_maintain, request):
+def test_negative_health_check_upstream_repository(sat_maintain, request):
     """Verify upstream repository check
 
     :id: 349fcf33-2d25-4628-a6af-cff53e624b25
@@ -197,7 +201,7 @@ def test_positive_health_check_upstream_repository(sat_maintain, request):
     :steps:
         1. Run satellite-maintain health check --label check-upstream-repository
 
-    :expectedresults: check-upstream-repository health check should pass.
+    :expectedresults: check-upstream-repository health check should fail.
     """
     for name, url in upstream_url.items():
         sat_maintain.create_custom_repos(**{name: url})
@@ -231,24 +235,13 @@ def test_positive_health_check_available_space(sat_maintain):
 
     :steps:
         1. Run satellite-maintain health check --label available-space
+        2. Run satellite-maintain health check --label available-space-cp
 
     :expectedresults: available-space health check should pass.
     """
     result = sat_maintain.cli.Health.check(options={'label': 'available-space'})
     assert 'FAIL' not in result.stdout
     assert result.status == 0
-
-
-def test_positive_health_check_available_space_candlepin(sat_maintain):
-    """Verify available-space-cp check
-
-    :id: 382a2bf3-a3da-4e46-b370-a443450f93b7
-
-    :steps:
-        1. Run satellite-maintain health check --label available-space-cp
-
-    :expectedresults: available-space-cp health check should pass.
-    """
     result = sat_maintain.cli.Health.check(options={'label': 'available-space-cp'})
     assert 'FAIL' not in result.stdout
     assert result.status == 0
@@ -359,7 +352,7 @@ def test_positive_health_check_validate_yum_config(sat_maintain):
 
 
 @pytest.mark.include_capsule
-def test_positive_health_check_epel_repository(request, sat_maintain):
+def test_negative_health_check_epel_repository(request, sat_maintain):
     """Verify check-non-redhat-repository.
 
     :id: ce2d7278-d7b7-4f76-9923-79be831c0368
@@ -373,7 +366,7 @@ def test_positive_health_check_epel_repository(request, sat_maintain):
 
     :BZ: 1755755
 
-    :expectedresults: check-non-redhat-repository health check should pass.
+    :expectedresults: check-non-redhat-repository health check should fail.
     """
     epel_repo = 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm'
     sat_maintain.execute(f'dnf install -y {epel_repo}')
@@ -518,81 +511,6 @@ def test_positive_health_check_tftp_storage(sat_maintain, request):
         assert (
             sat_maintain.cli.Settings.list({'search': 'name=token_duration'})[0]['value'] == '360'
         )
-
-
-def test_positive_health_check_postgresql_checkpoint_segments(sat_maintain):
-    """Verify check-postgresql-checkpoint-segments
-
-    :id: 963a5b47-168a-4443-9fdf-bba59c9b0e97
-
-    :steps:
-        1. Have an invalid /etc/foreman-installer/custom-hiera.yaml file
-        2. Run satellite-maintain health check --label check-postgresql-checkpoint-segments.
-        3. Assert that check-postgresql-checkpoint-segments gives proper
-           error message saying an invalid yaml file
-        4. Make /etc/foreman-installer/custom-hiera.yaml file valid
-        5. Add config_entries section in /etc/foreman-installer/custom-hiera.yaml
-        6. Run satellite-maintain health check --label check-postgresql-checkpoint-segments.
-        7. Assert that check-postgresql-checkpoint-segments fails.
-        8. Add checkpoint_segments parameter in /etc/foreman-installer/custom-hiera.yaml
-        9. Run satellite-maintain health check --label check-postgresql-checkpoint-segments.
-        10. Assert that check-postgresql-checkpoint-segments fails.
-        11. Remove config_entries section from /etc/foreman-installer/custom-hiera.yaml
-        12. Run satellite-maintain health check --label check-postgresql-checkpoint-segments.
-        13. Assert that check-postgresql-checkpoint-segments pass.
-
-    :BZ: 1894149, 1899322
-
-    :customerscenario: true
-
-    :expectedresults: check-postgresql-checkpoint-segments health check should pass.
-
-    :CaseImportance: High
-    """
-    custom_hiera = '/etc/foreman-installer/custom-hiera.yaml'
-    # Create invalid yaml file
-    sat_maintain.execute(f'sed -i "s/---/----/g" {custom_hiera}')
-    result = sat_maintain.cli.Health.check(
-        options={'label': 'check-postgresql-checkpoint-segments'}
-    )
-
-    assert f'File {custom_hiera} is not a yaml file.' in result.stdout
-    assert 'FAIL' in result.stdout
-    assert result.status == 1
-    # Make yaml file valid
-    sat_maintain.execute(f'sed -i "s/----/---/g" {custom_hiera}')
-    # Add config_entries section
-    sat_maintain.execute(f'sed -i "$ a postgresql::server::config_entries:" {custom_hiera}')
-    # Run check-postgresql-checkpoint-segments check.
-    result = sat_maintain.cli.Health.check(
-        options={'label': 'check-postgresql-checkpoint-segments'}
-    )
-
-    assert "ERROR: 'postgresql::server::config_entries' cannot be null." in result.stdout
-    assert 'Please remove it from following file and re-run the command.' in result.stdout
-    assert result.status == 1
-    assert 'FAIL' in result.stdout
-    # Add checkpoint_segments
-    sat_maintain.execute(fr'sed -i "$ a\  checkpoint_segments: 32" {custom_hiera}')
-    # Run check-postgresql-checkpoint-segments check.
-    result = sat_maintain.cli.Health.check(
-        options={'label': 'check-postgresql-checkpoint-segments'}
-    )
-
-    assert "ERROR: Tuning option 'checkpoint_segments' found." in result.stdout
-    assert 'Please remove it from following file and re-run the command.' in result.stdout
-    assert result.status == 1
-    assert 'FAIL' in result.stdout
-    # Remove config_entries section
-    sat_maintain.execute(
-        fr'sed -i "/postgresql::server::config_entries\|checkpoint_segments: 32/d" {custom_hiera}'
-    )
-    # Run check-postgresql-checkpoint-segments check.
-    result = sat_maintain.cli.Health.check(
-        options={'label': 'check-postgresql-checkpoint-segments'}
-    )
-    assert result.status == 0
-    assert 'FAIL' not in result.stdout
 
 
 @pytest.mark.include_capsule
@@ -776,38 +694,6 @@ def test_positive_health_check_non_rh_packages(sat_maintain, request):
     def _finalize():
         assert sat_maintain.execute('dnf remove -y  walrus').status == 0
         assert sat_maintain.execute('rm -fr /etc/yum.repos.d/custom_repo.repo').status == 0
-
-
-@pytest.mark.stubbed
-def test_positive_health_check_available_space_postgresql12():
-    """Verify warnings when available space in /var/opt/rh/rh-postgresql12/
-    is less than consumed space of /var/lib/pgsql/
-
-    :id: 283e627d-6afc-49cb-afdb-5b77a91bbd1e
-
-    :parametrized: yes
-
-    :setup:
-        1. Have some data under /var/lib/pgsql (upgrade templates have ~565Mib data)
-        2. Create dir /var/opt/rh/rh-postgresql12/ and mount a partition of ~300Mib
-           to this dir (less than /var/lib/pgsql).
-
-    :steps:
-        1. satellite-maintain health check --label available-space-for-postgresql12
-        2. Verify Warning or Error is displayed when enough space is not
-           available under /var/opt/rh/rh-postgresql12/
-
-    :BZ: 1898108, 1973363
-
-    :expectedresults: Verify warnings when available space in /var/opt/rh/rh-postgresql12/
-                      is less than consumed space of /var/lib/pgsql/
-
-    :CaseImportance: High
-
-    :customerscenario: true
-
-    :CaseAutomation: ManualOnly
-    """
 
 
 def test_positive_health_check_duplicate_permissions(sat_maintain):

--- a/tests/foreman/maintain/test_packages.py
+++ b/tests/foreman/maintain/test_packages.py
@@ -141,6 +141,9 @@ def test_positive_lock_package_versions_with_installer(sat_maintain):
 
 
 @pytest.mark.e2e
+@pytest.mark.upgrade
+@pytest.mark.pit_client
+@pytest.mark.pit_server
 @pytest.mark.include_capsule
 def test_positive_fm_packages_install(request, sat_maintain):
     """Verify whether packages install/update work as expected.

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -18,13 +18,11 @@
 """
 import pytest
 from fauxfactory import gen_string
-from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import HAMMER_CONFIG
 from robottelo.constants import MAINTAIN_HAMMER_YML
 from robottelo.constants import SATELLITE_ANSWER_FILE
-from robottelo.hosts import Satellite
 
 pytestmark = pytest.mark.destructive
 
@@ -68,7 +66,6 @@ def test_positive_service_list(sat_maintain):
     assert result.status == 0
 
 
-@pytest.mark.e2e
 @pytest.mark.include_capsule
 def test_positive_service_stop_start(sat_maintain):
     """Start/Stop services using satellite-maintain service subcommand
@@ -99,7 +96,6 @@ def test_positive_service_stop_start(sat_maintain):
     assert result.status == 0
 
 
-@pytest.mark.e2e
 @pytest.mark.include_capsule
 def test_positive_service_stop_restart(sat_maintain):
     """Disable services using satellite-maintain service
@@ -145,10 +141,6 @@ def test_positive_service_enable_disable(sat_maintain):
         2. Run satellite-maintain service enable
 
     :expectedresults: Services should enable/disable
-
-    :BZ: 1995783
-
-    :customerscenario: true
     """
     result = sat_maintain.cli.Service.stop()
     assert 'FAIL' not in result.stdout
@@ -157,27 +149,6 @@ def test_positive_service_enable_disable(sat_maintain):
     assert 'FAIL' not in result.stdout
     assert result.status == 0
     result = sat_maintain.cli.Service.enable()
-    assert 'FAIL' not in result.stdout
-    assert result.status == 0
-    sat_maintain.power_control(state='reboot')
-    if type(sat_maintain) is Satellite:
-        result, _ = wait_for(
-            sat_maintain.cli.Service.status,
-            func_kwargs={'options': {'brief': True, 'only': 'foreman.service'}},
-            fail_condition=lambda res: "FAIL" in res.stdout,
-            handle_exception=True,
-            delay=30,
-            timeout=300,
-        )
-    else:
-        result, _ = wait_for(
-            sat_maintain.cli.Service.status,
-            func_kwargs={'options': {'brief': True}},
-            fail_condition=lambda res: "FAIL" in res.stdout,
-            handle_exception=True,
-            delay=30,
-            timeout=300,
-        )
     assert 'FAIL' not in result.stdout
     assert result.status == 0
 
@@ -242,31 +213,6 @@ def test_positive_service_restart_without_hammer_config(missing_hammer_config, s
     result = sat_maintain.cli.Service.restart()
     assert 'FAIL' not in result.stdout
     assert result.status == 0
-
-
-def test_positive_satellite_maintain_service_list_sidekiq(sat_maintain):
-    """List sidekiq services with service list
-
-    :id: 5acb68a9-c430-485d-bb45-b499adc90927
-
-    :steps:
-        1. Run satellite-maintain service list
-        2. Run satellite-maintain service restart
-
-    :expectedresults: Sidekiq services should list and should restart.
-
-    :CaseImportance: Medium
-    """
-    result = sat_maintain.cli.Service.list()
-    assert 'FAIL' not in result.stdout
-    assert result.status == 0
-    assert 'dynflow-sidekiq@.service' in result.stdout
-
-    result = sat_maintain.cli.Service.restart()
-    assert 'FAIL' not in result.stdout
-    assert result.status == 0
-    for service in ['orchestrator', 'worker', 'worker-hosts-queue']:
-        assert f'dynflow-sidekiq@{service}' in result.stdout
 
 
 def test_positive_status_rpmsave(request, sat_maintain):


### PR DESCRIPTION
Nothing crazy going on in this initial update to our foreman-maintain test suite. Tests are either being combined with another test, updated with markers / more accurate docstrings, or completely removed as identified during the component evaluation.