### PR TITLE
Refactor tests/foreman/ui/test_rhcloud_insights.py

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -1,32 +1,22 @@
 import pytest
-from broker import Broker
 
 
 @pytest.fixture(scope='module')
-def rhcloud_sat_host(satellite_factory):
-    """A module level fixture that provides a Satellite based on config settings"""
-    new_sat = satellite_factory()
-    yield new_sat
-    new_sat.teardown()
-    Broker(hosts=[new_sat]).checkin()
-
-
-@pytest.fixture(scope='module')
-def rhcloud_manifest_org(rhcloud_sat_host, module_sca_manifest):
+def rhcloud_manifest_org(module_target_sat, module_sca_manifest):
     """A module level fixture to get organization with manifest."""
-    org = rhcloud_sat_host.api.Organization().create()
-    rhcloud_sat_host.upload_manifest(org.id, module_sca_manifest.content)
+    org = module_target_sat.api.Organization().create()
+    module_target_sat.upload_manifest(org.id, module_sca_manifest.content)
     return org
 
 
 @pytest.fixture(scope='module')
-def organization_ak_setup(rhcloud_sat_host, rhcloud_manifest_org):
+def organization_ak_setup(module_target_sat, rhcloud_manifest_org):
     """A module-level fixture to create an Activation key in module_org"""
     purpose_addons = "test-addon1, test-addon2"
-    ak = rhcloud_sat_host.api.ActivationKey(
+    ak = module_target_sat.api.ActivationKey(
         content_view=rhcloud_manifest_org.default_content_view,
         organization=rhcloud_manifest_org,
-        environment=rhcloud_sat_host.api.LifecycleEnvironment(id=rhcloud_manifest_org.library.id),
+        environment=module_target_sat.api.LifecycleEnvironment(id=rhcloud_manifest_org.library.id),
         purpose_addons=[purpose_addons],
         service_level='Self-Support',
         purpose_usage='test-usage',
@@ -38,12 +28,12 @@ def organization_ak_setup(rhcloud_sat_host, rhcloud_manifest_org):
 
 
 @pytest.fixture(scope='module')
-def rhcloud_registered_hosts(organization_ak_setup, mod_content_hosts, rhcloud_sat_host):
+def rhcloud_registered_hosts(organization_ak_setup, mod_content_hosts, module_target_sat):
     """Fixture that registers content hosts to Satellite and Insights."""
     org, ak = organization_ak_setup
     for vm in mod_content_hosts:
         vm.configure_rhai_client(
-            satellite=rhcloud_sat_host,
+            satellite=module_target_sat,
             activation_key=ak.name,
             org=org.label,
             rhel_distro=f"rhel{vm.os_version.major}",
@@ -53,45 +43,45 @@ def rhcloud_registered_hosts(organization_ak_setup, mod_content_hosts, rhcloud_s
 
 
 @pytest.fixture
-def rhel_insights_vm(rhcloud_sat_host, organization_ak_setup, rhel_contenthost):
+def rhel_insights_vm(module_target_sat, organization_ak_setup, rhel_contenthost):
     """A function-level fixture to create rhel content host registered with insights."""
     # settings.supportability.content_hosts.rhel.versions
     org, ak = organization_ak_setup
-    rhel_contenthost.configure_rex(satellite=rhcloud_sat_host, org=org, register=False)
+    rhel_contenthost.configure_rex(satellite=module_target_sat, org=org, register=False)
     rhel_contenthost.configure_rhai_client(
-        satellite=rhcloud_sat_host,
+        satellite=module_target_sat,
         activation_key=ak.name,
         org=org.label,
         rhel_distro=f"rhel{rhel_contenthost.os_version.major}",
     )
     yield rhel_contenthost
     # Delete host
-    host = rhcloud_sat_host.api.Host().search(
+    host = module_target_sat.api.Host().search(
         query={"search": f'name={rhel_contenthost.hostname}'}
     )[0]
     host.delete()
-    assert not rhcloud_sat_host.api.Host().search(query={"search": f'name={host.name}'})
+    assert not module_target_sat.api.Host().search(query={"search": f'name={host.name}'})
 
 
 @pytest.fixture
-def inventory_settings(rhcloud_sat_host):
-    hostnames_setting = rhcloud_sat_host.update_setting('obfuscate_inventory_hostnames', False)
-    ip_setting = rhcloud_sat_host.update_setting('obfuscate_inventory_ips', False)
-    packages_setting = rhcloud_sat_host.update_setting('exclude_installed_packages', False)
-    parameter_tags_setting = rhcloud_sat_host.update_setting('include_parameter_tags', False)
+def inventory_settings(module_target_sat):
+    hostnames_setting = module_target_sat.update_setting('obfuscate_inventory_hostnames', False)
+    ip_setting = module_target_sat.update_setting('obfuscate_inventory_ips', False)
+    packages_setting = module_target_sat.update_setting('exclude_installed_packages', False)
+    parameter_tags_setting = module_target_sat.update_setting('include_parameter_tags', False)
     yield
-    rhcloud_sat_host.update_setting('obfuscate_inventory_hostnames', hostnames_setting)
-    rhcloud_sat_host.update_setting('obfuscate_inventory_ips', ip_setting)
-    rhcloud_sat_host.update_setting('exclude_installed_packages', packages_setting)
-    rhcloud_sat_host.update_setting('include_parameter_tags', parameter_tags_setting)
+    module_target_sat.update_setting('obfuscate_inventory_hostnames', hostnames_setting)
+    module_target_sat.update_setting('obfuscate_inventory_ips', ip_setting)
+    module_target_sat.update_setting('exclude_installed_packages', packages_setting)
+    module_target_sat.update_setting('include_parameter_tags', parameter_tags_setting)
 
 
 @pytest.fixture(scope='module')
-def rhcloud_capsule(module_capsule_host, rhcloud_sat_host, organization_ak_setup):
+def rhcloud_capsule(module_capsule_host, module_target_sat, organization_ak_setup):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     org, ak = organization_ak_setup
-    module_capsule_host.capsule_setup(sat_host=rhcloud_sat_host, enable_registration=True)
-    capsule = rhcloud_sat_host.api.SmartProxy(name=module_capsule_host.hostname).search()[0].read()
+    module_capsule_host.capsule_setup(sat_host=module_target_sat, enable_registration=True)
+    capsule = module_target_sat.api.SmartProxy(name=module_capsule_host.hostname).search()[0].read()
     if org.id not in [organization.id for organization in capsule.organization]:
         capsule.organization.append(org)
         capsule.update(['organization'])

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -221,15 +221,6 @@ def module_capsule_configured_async_ssh(module_capsule_configured):
     yield module_capsule_configured
 
 
-@pytest.fixture(scope='module')
-def rhcloud_sat_host(satellite_factory):
-    """A module level fixture that provides a Satellite based on config settings"""
-    new_sat = satellite_factory()
-    yield new_sat
-    new_sat.teardown()
-    Broker(hosts=[new_sat]).checkin()
-
-
 @pytest.fixture(scope='module', params=['IDM', 'AD'])
 def parametrized_enrolled_sat(
     request,

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1961,6 +1961,12 @@ WEBHOOK_METHODS = [
     "PATCH",
 ]
 
+OPENSSH_RECOMMENDATION = 'Decreased security: OpenSSH config permissions'
+DNF_RECOMMENDATION = (
+    'The dnf installs lower versions of packages when the "best" '
+    'option is not present in the /etc/dnf/dnf.conf'
+)
+
 
 # Data File Paths
 class DataFile(Box):

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -872,6 +872,10 @@ PUPPET_SATELLITE_INSTALLER = [
     'enable-foreman-cli-puppet',
 ]
 PUPPET_CAPSULE_INSTALLER = ['enable-puppet']
+CAPSULE_REGISTRATION_OPTS = {
+    'foreman-proxy-registration': 'true',
+    'foreman-proxy-templates': 'true',
+}
 
 KICKSTART_CONTENT = [
     'treeinfo',

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1597,7 +1597,7 @@ class Capsule(ContentHost, CapsuleMixins):
         """Get capsule features"""
         return requests.get(f'https://{self.hostname}:9090/features', verify=False).text
 
-    def capsule_setup(self, sat_host=None, **installer_kwargs):
+    def capsule_setup(self, sat_host=None, enable_registration=False, **installer_kwargs):
         """Prepare the host and run the capsule installer"""
         self._satellite = sat_host or Satellite()
 
@@ -1629,6 +1629,12 @@ class Capsule(ContentHost, CapsuleMixins):
         certs_tar, _, installer = self.satellite.capsule_certs_generate(self, **installer_kwargs)
         self.satellite.session.remote_copy(certs_tar, self)
         installer.update(**installer_kwargs)
+        if enable_registration:
+            opts = {
+                'foreman-proxy-registration': 'true',
+                'foreman-proxy-templates': 'true',
+            }
+            installer.update(**opts)
         result = self.install(installer)
         if result.status:
             # before exit download the capsule log file

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1598,7 +1598,7 @@ class Capsule(ContentHost, CapsuleMixins):
         """Get capsule features"""
         return requests.get(f'https://{self.hostname}:9090/features', verify=False).text
 
-    def capsule_setup(self, sat_host=None, enable_registration=False, **installer_kwargs):
+    def capsule_setup(self, sat_host=None, capsule_cert_opts=None, **installer_kwargs):
         """Prepare the host and run the capsule installer"""
         self._satellite = sat_host or Satellite()
 
@@ -1627,15 +1627,11 @@ class Capsule(ContentHost, CapsuleMixins):
             raise CapsuleHostError(f'The satellite-capsule package was not found\n{result.stdout}')
 
         # Generate certificate, copy it to Capsule, run installer, check it succeeds
-        certs_tar, _, installer = self.satellite.capsule_certs_generate(self, **installer_kwargs)
+        if not capsule_cert_opts:
+            capsule_cert_opts = {}
+        certs_tar, _, installer = self.satellite.capsule_certs_generate(self, **capsule_cert_opts)
         self.satellite.session.remote_copy(certs_tar, self)
         installer.update(**installer_kwargs)
-        if enable_registration:
-            opts = {
-                'foreman-proxy-registration': 'true',
-                'foreman-proxy-templates': 'true',
-            }
-            installer.update(**opts)
         result = self.install(installer)
         if result.status:
             # before exit download the capsule log file

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -8,6 +8,7 @@ import time
 import warnings
 from configparser import ConfigParser
 from contextlib import contextmanager
+from datetime import datetime
 from functools import cached_property
 from functools import lru_cache
 from pathlib import Path
@@ -2171,6 +2172,37 @@ class Satellite(Capsule, SatelliteMixins):
         assert (
             self.execute('systemctl daemon-reload && systemctl restart httpd.service').status == 0
         )
+
+    def generate_inventory_report(self, org):
+        """Function to perform inventory upload."""
+        generate_report_task = 'ForemanInventoryUpload::Async::UploadReportJob'
+        timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+        self.api.Organization(id=org.id).rh_cloud_generate_report()
+        wait_for(
+            lambda: self.api.ForemanTask()
+            .search(query={'search': f'{generate_report_task} and started_at >= "{timestamp}"'})[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
+        )
+
+    def sync_inventory_status(self, org):
+        """Perform inventory sync"""
+        inventory_sync = self.api.Organization(id=org.id).rh_cloud_inventory_sync()
+        wait_for(
+            lambda: self.api.ForemanTask()
+            .search(query={'search': f'id = {inventory_sync["task"]["id"]}'})[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
+        )
+        return inventory_sync
 
 
 class SSOHost(Host):

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -66,7 +66,7 @@ def common_assertion(report_path):
 @pytest.mark.tier3
 @pytest.mark.e2e
 def test_rhcloud_inventory_api_e2e(
-    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
+    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, module_target_sat
 ):
     """Generate report using rh_cloud plugin api's and verify its basic properties.
 
@@ -95,17 +95,17 @@ def test_rhcloud_inventory_api_e2e(
     virtual_host, baremetal_host = rhcloud_registered_hosts
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     # Generate report
-    generate_inventory_report(rhcloud_sat_host, org)
+    generate_inventory_report(module_target_sat, org)
     # Download report
-    rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_download_report(
+    module_target_sat.api.Organization(id=org.id).rh_cloud_download_report(
         destination=local_report_path
     )
     common_assertion(local_report_path)
     # Assert Hostnames, IP addresses, and installed packages are present in report.
     json_data = get_report_data(local_report_path)
     json_meta_data = get_report_metadata(local_report_path)
-    prefix = 'tfm-' if rhcloud_sat_host.os_version.major < 8 else ''
-    package_version = rhcloud_sat_host.run(
+    prefix = 'tfm-' if module_target_sat.os_version.major < 8 else ''
+    package_version = module_target_sat.run(
         f'rpm -qa --qf "%{{VERSION}}" {prefix}rubygem-foreman_rh_cloud'
     ).stdout.strip()
     assert json_meta_data['source_metadata']['foreman_rh_cloud_version'] == str(package_version)
@@ -139,7 +139,7 @@ def test_rhcloud_inventory_api_e2e(
 def test_rhcloud_inventory_api_hosts_synchronization(
     organization_ak_setup,
     rhcloud_registered_hosts,
-    rhcloud_sat_host,
+    module_target_sat,
 ):
     """Test RH Cloud plugin api to synchronize list of available hosts from cloud.
 
@@ -164,11 +164,11 @@ def test_rhcloud_inventory_api_hosts_synchronization(
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = rhcloud_registered_hosts
     # Generate report
-    generate_inventory_report(rhcloud_sat_host, org)
+    generate_inventory_report(module_target_sat, org)
     # Sync inventory status
-    inventory_sync = rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_inventory_sync()
+    inventory_sync = module_target_sat.api.Organization(id=org.id).rh_cloud_inventory_sync()
     wait_for(
-        lambda: rhcloud_sat_host.api.ForemanTask()
+        lambda: module_target_sat.api.ForemanTask()
         .search(query={'search': f'id = {inventory_sync["task"]["id"]}'})[0]
         .result
         == 'success',
@@ -177,7 +177,7 @@ def test_rhcloud_inventory_api_hosts_synchronization(
         silent_failure=True,
         handle_exception=True,
     )
-    task_output = rhcloud_sat_host.api.ForemanTask().search(
+    task_output = module_target_sat.api.ForemanTask().search(
         query={'search': f'id = {inventory_sync["task"]["id"]}'}
     )
     assert task_output[0].output['host_statuses']['sync'] == 2
@@ -216,7 +216,7 @@ def test_rhcloud_inventory_mtu_field():
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 def test_system_purpose_sla_field(
-    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
+    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, module_target_sat
 ):
     """Verify that system_purpose_sla field is present in the inventory report
     for the host subscribed using Activation key with service level set in it.
@@ -245,9 +245,9 @@ def test_system_purpose_sla_field(
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = rhcloud_registered_hosts
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
-    generate_inventory_report(rhcloud_sat_host, org)
+    generate_inventory_report(module_target_sat, org)
     # Download report
-    rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_download_report(
+    module_target_sat.api.Organization(id=org.id).rh_cloud_download_report(
         destination=local_report_path
     )
     json_data = get_report_data(local_report_path)
@@ -316,7 +316,7 @@ def test_inventory_upload_with_http_proxy():
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 def test_include_parameter_tags_setting(
-    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
+    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, module_target_sat
 ):
     """Verify that include_parameter_tags setting doesn't cause invalid report
     to be generated.
@@ -342,10 +342,10 @@ def test_include_parameter_tags_setting(
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = rhcloud_registered_hosts
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
-    rhcloud_sat_host.update_setting('include_parameter_tags', True)
-    generate_inventory_report(rhcloud_sat_host, org)
+    module_target_sat.update_setting('include_parameter_tags', True)
+    generate_inventory_report(module_target_sat, org)
     # Download report
-    rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_download_report(
+    module_target_sat.api.Organization(id=org.id).rh_cloud_download_report(
         destination=local_report_path
     )
     json_data = get_report_data(local_report_path)
@@ -359,7 +359,7 @@ def test_include_parameter_tags_setting(
 
 @pytest.mark.tier3
 def test_rh_cloud_tag_values(
-    inventory_settings, organization_ak_setup, rhcloud_sat_host, rhcloud_registered_hosts
+    inventory_settings, organization_ak_setup, module_target_sat, rhcloud_registered_hosts
 ):
     """Verify that tag values are escaped properly when hostgroup name
         contains " (double quote) in it.
@@ -388,16 +388,16 @@ def test_rh_cloud_tag_values(
 
     host_col_name = gen_string('alpha')
     host_name = rhcloud_registered_hosts[0].hostname
-    host = rhcloud_sat_host.api.Host().search(query={'search': host_name})[0]
-    host_collection = rhcloud_sat_host.api.HostCollection(
+    host = module_target_sat.api.Host().search(query={'search': host_name})[0]
+    host_collection = module_target_sat.api.HostCollection(
         organization=org, name=f'"{host_col_name}"', host=[host]
     ).create()
 
     assert len(host_collection.host) == 1
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     # Generate report
-    generate_inventory_report(rhcloud_sat_host, org)
-    rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_download_report(
+    generate_inventory_report(module_target_sat, org)
+    module_target_sat.api.Organization(id=org.id).rh_cloud_download_report(
         destination=local_report_path
     )
     common_assertion(local_report_path)
@@ -416,7 +416,7 @@ def test_positive_tag_values_max_length(
     inventory_settings,
     organization_ak_setup,
     rhcloud_registered_hosts,
-    rhcloud_sat_host,
+    module_target_sat,
     target_sat,
 ):
     """Verify that tags values are truncated properly for the host parameter
@@ -445,10 +445,10 @@ def test_positive_tag_values_max_length(
 
     org, ak = organization_ak_setup
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
-    rhcloud_sat_host.update_setting('include_parameter_tags', True)
-    generate_inventory_report(rhcloud_sat_host, org)
+    module_target_sat.update_setting('include_parameter_tags', True)
+    generate_inventory_report(module_target_sat, org)
     # Download report
-    rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_download_report(
+    module_target_sat.api.Organization(id=org.id).rh_cloud_download_report(
         destination=local_report_path
     )
     json_data = get_report_data(local_report_path)

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -45,7 +45,10 @@ def common_assertion(report_path):
 @pytest.mark.tier3
 @pytest.mark.e2e
 def test_rhcloud_inventory_api_e2e(
-    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, module_target_sat
+    inventory_settings,
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
+    module_target_sat,
 ):
     """Generate report using rh_cloud plugin api's and verify its basic properties.
 
@@ -70,7 +73,7 @@ def test_rhcloud_inventory_api_e2e(
 
     :customerscenario: true
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     virtual_host, baremetal_host = rhcloud_registered_hosts
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     # Generate report
@@ -116,7 +119,7 @@ def test_rhcloud_inventory_api_e2e(
 @pytest.mark.e2e
 @pytest.mark.tier3
 def test_rhcloud_inventory_api_hosts_synchronization(
-    organization_ak_setup,
+    rhcloud_manifest_org,
     rhcloud_registered_hosts,
     module_target_sat,
 ):
@@ -140,7 +143,7 @@ def test_rhcloud_inventory_api_hosts_synchronization(
 
     :CaseAutomation: Automated
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     virtual_host, baremetal_host = rhcloud_registered_hosts
     # Generate report
     module_target_sat.generate_inventory_report(org)
@@ -185,7 +188,10 @@ def test_rhcloud_inventory_mtu_field():
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 def test_system_purpose_sla_field(
-    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, module_target_sat
+    inventory_settings,
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
+    module_target_sat,
 ):
     """Verify that system_purpose_sla field is present in the inventory report
     for the host subscribed using Activation key with service level set in it.
@@ -211,7 +217,7 @@ def test_system_purpose_sla_field(
 
     :CaseAutomation: Automated
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     virtual_host, baremetal_host = rhcloud_registered_hosts
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     module_target_sat.generate_inventory_report(org)
@@ -285,7 +291,10 @@ def test_inventory_upload_with_http_proxy():
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 def test_include_parameter_tags_setting(
-    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, module_target_sat
+    inventory_settings,
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
+    module_target_sat,
 ):
     """Verify that include_parameter_tags setting doesn't cause invalid report
     to be generated.
@@ -308,7 +317,7 @@ def test_include_parameter_tags_setting(
 
     :CaseAutomation: Automated
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     virtual_host, baremetal_host = rhcloud_registered_hosts
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     module_target_sat.update_setting('include_parameter_tags', True)
@@ -328,7 +337,10 @@ def test_include_parameter_tags_setting(
 
 @pytest.mark.tier3
 def test_rh_cloud_tag_values(
-    inventory_settings, organization_ak_setup, module_target_sat, rhcloud_registered_hosts
+    inventory_settings,
+    rhcloud_manifest_org,
+    module_target_sat,
+    rhcloud_registered_hosts,
 ):
     """Verify that tag values are escaped properly when hostgroup name
         contains " (double quote) in it.
@@ -353,7 +365,7 @@ def test_rh_cloud_tag_values(
 
     :CaseAutomation: Automated
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
 
     host_col_name = gen_string('alpha')
     host_name = rhcloud_registered_hosts[0].hostname
@@ -383,7 +395,7 @@ def test_rh_cloud_tag_values(
 @pytest.mark.tier2
 def test_positive_tag_values_max_length(
     inventory_settings,
-    organization_ak_setup,
+    rhcloud_manifest_org,
     rhcloud_registered_hosts,
     module_target_sat,
     target_sat,
@@ -412,7 +424,7 @@ def test_positive_tag_values_max_length(
     param_value = gen_string('alpha', length=260)
     target_sat.api.CommonParameter(name=param_name, value=param_value).create()
 
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     module_target_sat.update_setting('include_parameter_tags', True)
     module_target_sat.generate_inventory_report(org)

--- a/tests/foreman/cli/test_rhcloud_insights.py
+++ b/tests/foreman/cli/test_rhcloud_insights.py
@@ -25,7 +25,9 @@ from robottelo.hosts import ContentHost
 @pytest.mark.e2e
 @pytest.mark.tier4
 @pytest.mark.parametrize('distro', ['rhel7', 'rhel8'])
-def test_positive_connection_option(organization_ak_setup, module_target_sat, distro):
+def test_positive_connection_option(
+    rhcloud_activation_key, rhcloud_manifest_org, module_target_sat, distro
+):
     """Verify that 'insights-client --test-connection' successfully tests the proxy connection via
     the Satellite.
 
@@ -45,9 +47,10 @@ def test_positive_connection_option(organization_ak_setup, module_target_sat, di
 
     :CaseImportance: Critical
     """
-    org, activation_key = organization_ak_setup
+    org = rhcloud_manifest_org
+    ak = rhcloud_activation_key
     with Broker(nick=distro, host_class=ContentHost) as vm:
-        vm.configure_rhai_client(module_target_sat, activation_key.name, org.label, distro)
+        vm.configure_rhai_client(module_target_sat, ak.name, org.label, distro)
         result = vm.run('insights-client --test-connection')
         assert result.status == 0, (
             'insights-client --test-connection failed.\n'

--- a/tests/foreman/cli/test_rhcloud_insights.py
+++ b/tests/foreman/cli/test_rhcloud_insights.py
@@ -25,7 +25,7 @@ from robottelo.hosts import ContentHost
 @pytest.mark.e2e
 @pytest.mark.tier4
 @pytest.mark.parametrize('distro', ['rhel7', 'rhel8'])
-def test_positive_connection_option(organization_ak_setup, rhcloud_sat_host, distro):
+def test_positive_connection_option(organization_ak_setup, module_target_sat, distro):
     """Verify that 'insights-client --test-connection' successfully tests the proxy connection via
     the Satellite.
 
@@ -47,7 +47,7 @@ def test_positive_connection_option(organization_ak_setup, rhcloud_sat_host, dis
     """
     org, activation_key = organization_ak_setup
     with Broker(nick=distro, host_class=ContentHost) as vm:
-        vm.configure_rhai_client(rhcloud_sat_host, activation_key.name, org.label, distro)
+        vm.configure_rhai_client(module_target_sat, activation_key.name, org.label, distro)
         result = vm.run('insights-client --test-connection')
         assert result.status == 0, (
             'insights-client --test-connection failed.\n'

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -33,7 +33,7 @@ generate_report_jobs = 'ForemanInventoryUpload::Async::GenerateAllReportsJob'
 @pytest.mark.tier3
 @pytest.mark.e2e
 def test_positive_inventory_generate_upload_cli(
-    organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
+    organization_ak_setup, rhcloud_registered_hosts, module_target_sat
 ):
     """Tests Insights inventory generation and upload via foreman-rake commands:
     https://github.com/theforeman/foreman_rh_cloud/blob/master/README.md
@@ -71,7 +71,7 @@ def test_positive_inventory_generate_upload_cli(
     org, _ = organization_ak_setup
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:report:generate_upload'
     upload_success_msg = f"Generated and uploaded inventory report for organization '{org.name}'"
-    result = rhcloud_sat_host.execute(cmd)
+    result = module_target_sat.execute(cmd)
     assert result.status == 0
     assert upload_success_msg in result.stdout
 
@@ -80,7 +80,7 @@ def test_positive_inventory_generate_upload_cli(
         f'/var/lib/foreman/red_hat_inventory/uploads/done/report_for_{org.id}.tar.xz'
     )
     wait_for(
-        lambda: rhcloud_sat_host.get(
+        lambda: module_target_sat.get(
             remote_path=str(remote_report_path), local_path=str(local_report_path)
         ),
         timeout=60,
@@ -89,7 +89,7 @@ def test_positive_inventory_generate_upload_cli(
         handle_exception=True,
     )
     local_file_data = get_local_file_data(local_report_path)
-    assert local_file_data['checksum'] == get_remote_report_checksum(rhcloud_sat_host, org.id)
+    assert local_file_data['checksum'] == get_remote_report_checksum(module_target_sat, org.id)
     assert local_file_data['size'] > 0
     assert local_file_data['extractable']
     assert local_file_data['json_files_parsable']
@@ -106,7 +106,7 @@ def test_positive_inventory_generate_upload_cli(
 def test_positive_inventory_recommendation_sync(
     organization_ak_setup,
     rhcloud_registered_hosts,
-    rhcloud_sat_host,
+    module_target_sat,
 ):
     """Tests Insights recommendation sync via foreman-rake commands:
     https://github.com/theforeman/foreman_rh_cloud/blob/master/README.md
@@ -130,9 +130,9 @@ def test_positive_inventory_recommendation_sync(
     org, ak = organization_ak_setup
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_insights:sync'
     timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
-    result = rhcloud_sat_host.execute(cmd)
+    result = module_target_sat.execute(cmd)
     wait_for(
-        lambda: rhcloud_sat_host.api.ForemanTask()
+        lambda: module_target_sat.api.ForemanTask()
         .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
         .result
         == 'success',
@@ -150,7 +150,7 @@ def test_positive_inventory_recommendation_sync(
 def test_positive_sync_inventory_status(
     organization_ak_setup,
     rhcloud_registered_hosts,
-    rhcloud_sat_host,
+    module_target_sat,
 ):
     """Sync inventory status via foreman-rake commands:
     https://github.com/theforeman/foreman_rh_cloud/blob/master/README.md
@@ -176,12 +176,12 @@ def test_positive_sync_inventory_status(
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:sync'
     success_msg = f"Synchronized inventory for organization '{org.name}'"
     timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
-    result = rhcloud_sat_host.execute(cmd)
+    result = module_target_sat.execute(cmd)
     assert result.status == 0
     assert success_msg in result.stdout
     # Check task details
     wait_for(
-        lambda: rhcloud_sat_host.api.ForemanTask()
+        lambda: module_target_sat.api.ForemanTask()
         .search(query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'})[0]
         .result
         == 'success',
@@ -190,7 +190,7 @@ def test_positive_sync_inventory_status(
         silent_failure=True,
         handle_exception=True,
     )
-    task_output = rhcloud_sat_host.api.ForemanTask().search(
+    task_output = module_target_sat.api.ForemanTask().search(
         query={'search': f'{inventory_sync_task} and started_at >= "{timestamp}"'}
     )
     assert task_output[0].output['host_statuses']['sync'] == 2

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -33,7 +33,7 @@ generate_report_jobs = 'ForemanInventoryUpload::Async::GenerateAllReportsJob'
 @pytest.mark.tier3
 @pytest.mark.e2e
 def test_positive_inventory_generate_upload_cli(
-    organization_ak_setup, rhcloud_registered_hosts, module_target_sat
+    rhcloud_manifest_org, rhcloud_registered_hosts, module_target_sat
 ):
     """Tests Insights inventory generation and upload via foreman-rake commands:
     https://github.com/theforeman/foreman_rh_cloud/blob/master/README.md
@@ -68,7 +68,7 @@ def test_positive_inventory_generate_upload_cli(
 
     :CaseLevel: System
     """
-    org, _ = organization_ak_setup
+    org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:report:generate_upload'
     upload_success_msg = f"Generated and uploaded inventory report for organization '{org.name}'"
     result = module_target_sat.execute(cmd)
@@ -104,7 +104,7 @@ def test_positive_inventory_generate_upload_cli(
 @pytest.mark.e2e
 @pytest.mark.tier3
 def test_positive_inventory_recommendation_sync(
-    organization_ak_setup,
+    rhcloud_manifest_org,
     rhcloud_registered_hosts,
     module_target_sat,
 ):
@@ -127,7 +127,7 @@ def test_positive_inventory_recommendation_sync(
 
     :CaseLevel: System
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_insights:sync'
     timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
     result = module_target_sat.execute(cmd)
@@ -148,7 +148,7 @@ def test_positive_inventory_recommendation_sync(
 @pytest.mark.e2e
 @pytest.mark.tier3
 def test_positive_sync_inventory_status(
-    organization_ak_setup,
+    rhcloud_manifest_org,
     rhcloud_registered_hosts,
     module_target_sat,
 ):
@@ -172,7 +172,7 @@ def test_positive_sync_inventory_status(
 
     :CaseLevel: System
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:sync'
     success_msg = f"Synchronized inventory for organization '{org.name}'"
     timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -146,7 +146,7 @@ def test_positive_configure_cloud_connector(
     host.host_parameters_attributes = parameters
     host.update(['host_parameters_attributes'])
 
-    with session:
+    with module_target_sat.ui_session() as session:
         session.organization.select(org_name=module_rhc_org.name)
         if session.cloudinventory.is_cloud_connector_configured():
             pytest.skip(

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -24,12 +24,22 @@ from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_LOC
+from robottelo.constants import DNF_RECOMMENDATION
+from robottelo.constants import OPENSSH_RECOMMENDATION
+
+
+def create_insights_vulnerability(insights_vm):
+    """Create vulnerabilities which can be remediated."""
+    insights_vm.run(
+        'chmod 777 /etc/ssh/sshd_config;dnf update -y dnf;'
+        'sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client'
+    )
 
 
 @pytest.mark.e2e
-@pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-@pytest.mark.rhel_ver_list([8, 9])
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_list([7, 8, 9])
 def test_rhcloud_insights_e2e(
     rhel_insights_vm,
     organization_ak_setup,
@@ -64,9 +74,7 @@ def test_rhcloud_insights_e2e(
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
-    # Create a vulnerability which can be remediated
-    rhel_insights_vm.run('chmod 777 /etc/ssh/sshd_config;insights-client')
-    query = 'Decreased security: OpenSSH config permissions'
+    create_insights_vulnerability(rhel_insights_vm)
     job_query = (
         f'Remote action: Insights remediations for selected issues on {rhel_insights_vm.hostname}'
     )
@@ -87,11 +95,13 @@ def test_rhcloud_insights_e2e(
         )
         # Workaround for alert message causing search to fail. See airgun issue 584.
         session.browser.refresh()
-        result = session.cloudinsights.search(query)[0]
+        result = session.cloudinsights.search(
+            f'hostname= "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'
+        )[0]
         assert result['Hostname'] == rhel_insights_vm.hostname
-        assert result['Recommendation'] == query
+        assert result['Recommendation'] == OPENSSH_RECOMMENDATION
         timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
-        session.cloudinsights.remediate(query)
+        session.cloudinsights.remediate(OPENSSH_RECOMMENDATION)
         wait_for(
             lambda: rhcloud_sat_host.api.ForemanTask()
             .search(query={'search': f'{job_query} and started_at >= "{timestamp}"'})[0]
@@ -116,7 +126,9 @@ def test_rhcloud_insights_e2e(
         )
         # Workaround for alert message causing search to fail. See airgun issue 584.
         session.browser.refresh()
-        assert not session.cloudinsights.search(query)
+        assert not session.cloudinsights.search(
+            f'hostname= "{rhel_insights_vm.hostname}" and title = "{OPENSSH_RECOMMENDATION}"'
+        )
 
 
 @pytest.mark.stubbed
@@ -220,9 +232,9 @@ def test_host_sorting_based_on_recommendation_count():
     """
 
 
-@pytest.mark.run_in_one_thread
 @pytest.mark.tier2
-@pytest.mark.rhel_ver_list([8])
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_list([7, 8, 9])
 def test_host_details_page(
     rhel_insights_vm,
     organization_ak_setup,
@@ -232,6 +244,8 @@ def test_host_details_page(
 
     :id: e079ed10-c9f5-4331-9cb3-70b224b1a584
 
+    :customerscenario: true
+
     :Steps:
         1. Prepare misconfigured machine and upload its data to Insights.
         2. Sync insights recommendations.
@@ -240,25 +254,26 @@ def test_host_details_page(
         5. Assert there is "Recommendations" column containing insights recommendation count.
         6. Check popover status of host.
         7. Assert that host properties shows reporting inventory upload status.
-        8. Click on "Recommendations" tab.
+        8. Read the recommendations listed in Insights tab present on host details page.
+        9. Click on "Recommendations" tab.
 
     :expectedresults:
         1. There's Insights column with number of recommendations.
         2. Inventory upload status is displayed in popover status of host.
         3. Insights registration status is displayed in popover status of host.
         4. Inventory upload status is present in host properties table.
-        5. Clicking on "Recommendations" tab takes user to Insights page with insights
+        5. Assert the contents of Insights tab.
+        6. Clicking on "Recommendations" tab takes user to Insights page with insights
             recommendations selected for that host.
 
-    :BZ: 1974578
+    :BZ: 1974578, 1860422, 1928652, 1865876, 1879448
 
     :parametrized: yes
 
     :CaseAutomation: Automated
     """
     org, ak = organization_ak_setup
-    # Create a vulnerability which can be remediated
-    rhel_insights_vm.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client')
+    create_insights_vulnerability(rhel_insights_vm)
     # Sync inventory status
     inventory_sync = rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_inventory_sync()
     wait_for(
@@ -275,7 +290,18 @@ def test_host_details_page(
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         # Sync insights recommendations
+        timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.sync_hits()
+        wait_for(
+            lambda: rhcloud_sat_host.api.ForemanTask()
+            .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
+            .result
+            == 'success',
+            timeout=400,
+            delay=15,
+            silent_failure=True,
+            handle_exception=True,
+        )
         result = session.host.host_status(rhel_insights_vm.hostname)
         assert 'Insights: Reporting' in result
         assert 'Inventory: Successfully uploaded to your RH cloud inventory' in result
@@ -288,225 +314,28 @@ def test_host_details_page(
             values['properties']['properties_table']['Inventory']
             == 'Successfully uploaded to your RH cloud inventory clear'
         )
+        # Read the recommendations listed in Insights tab present on host details page
+        insights_recommendations = session.host_new.insights_tab(rhel_insights_vm.hostname)
+        for recommendation in insights_recommendations:
+            if recommendation['name'] == DNF_RECOMMENDATION:
+                assert recommendation['label'] == 'Moderate'
+                assert DNF_RECOMMENDATION in recommendation['text']
+                assert len(insights_recommendations) == int(result['Recommendations'])
+        # Test Recommendation button present on host details page
         recommendations = session.host.read_insights_recommendations(rhel_insights_vm.hostname)
         assert len(recommendations), 'No recommendations were found'
         assert recommendations[0]['Hostname'] == rhel_insights_vm.hostname
         assert int(result['Recommendations']) == len(recommendations)
 
 
-@pytest.mark.run_in_one_thread
-@pytest.mark.tier2
-def test_rh_cloud_insights_clean_statuses(
-    rhel7_contenthost,
-    rhel8_contenthost,
-    organization_ak_setup,
-    rhcloud_sat_host,
-):
-    """Test rh_cloud_insights:clean_statuses rake command.
-
-    :id: 6416ed31-cafb-4278-b205-bf3da9ab2ee4
-
-    :Steps:
-        1. Prepare misconfigured machine and upload its data to Insights
-        2. Go to Hosts -> All Hosts
-        3. Assert that host properties shows reporting status for insights.
-        4. Run rh_cloud_insights:clean_statuses rake command
-        5. Assert that host properties doesn't contain insights status.
-
-    :expectedresults:
-        1. rake command deletes insights reporting status of host.
-
-    :BZ: 1962930
-
-    :parametrized: yes
-
-    :CaseAutomation: Automated
-    """
-    org, ak = organization_ak_setup
-    rhel7_contenthost.configure_rhai_client(
-        satellite=rhcloud_sat_host, activation_key=ak.name, org=org.label, rhel_distro='rhel7'
-    )
-    rhel8_contenthost.configure_rhai_client(
-        satellite=rhcloud_sat_host, activation_key=ak.name, org=org.label, rhel_distro='rhel8'
-    )
-    with Session(hostname=rhcloud_sat_host.hostname) as session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=DEFAULT_LOC)
-        values = session.host.get_details(rhel7_contenthost.hostname)
-        assert values['properties']['properties_table']['Insights'] == 'Reporting clear'
-        values = session.host.get_details(rhel8_contenthost.hostname)
-        assert values['properties']['properties_table']['Insights'] == 'Reporting clear'
-        # Clean insights status
-        result = rhcloud_sat_host.run(
-            f'foreman-rake rh_cloud_insights:clean_statuses SEARCH="{rhel7_contenthost.hostname}"'
-        )
-        assert 'Deleted 1 insights statuses' in result.stdout
-        assert result.status == 0
-        values = session.host.get_details(rhel7_contenthost.hostname)
-        with pytest.raises(KeyError):
-            values['properties']['properties_table']['Insights']
-        values = session.host.get_details(rhel8_contenthost.hostname)
-        assert values['properties']['properties_table']['Insights'] == 'Reporting clear'
-        result = rhel7_contenthost.run('insights-client')
-        assert result.status == 0
-        values = session.host.get_details(rhel7_contenthost.hostname)
-        assert values['properties']['properties_table']['Insights'] == 'Reporting clear'
-
-
-@pytest.mark.run_in_one_thread
-@pytest.mark.tier2
-@pytest.mark.rhel_ver_list([8])
-def test_delete_host_having_insights_recommendation(
-    rhel_insights_vm,
-    organization_ak_setup,
-    rhcloud_sat_host,
-):
-    """Verify that host having insights recommendations can be deleted from Satellite.
-
-    :id: 07914ff7-e230-4416-8664-7d357e9966f3
-
-    :customerscenario: true
-
-    :Steps:
-        1. Prepare misconfigured machine and upload its data to Insights.
-        2. Sync insights recommendations.
-        3. Sync RH Cloud inventory status.
-        4. Go to Hosts -> All Hosts
-        5. Assert there is "Recommendations" column containing insights recommendation count.
-        6. Try to delete host.
-
-    :expectedresults:
-        1. host having insights recommendations is deleted from Satellite.
-
-    :CaseImportance: Critical
-
-    :BZ: 1860422, 1928652
-
-    :parametrized: yes
-
-    :CaseAutomation: Automated
-    """
-    org, ak = organization_ak_setup
-    # Create a vulnerability which can be remediated
-    rhel_insights_vm.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client')
-    # Sync inventory status
-    inventory_sync = rhcloud_sat_host.api.Organization(id=org.id).rh_cloud_inventory_sync()
-    wait_for(
-        lambda: rhcloud_sat_host.api.ForemanTask()
-        .search(query={'search': f'id = {inventory_sync["task"]["id"]}'})[0]
-        .result
-        == 'success',
-        timeout=400,
-        delay=15,
-        silent_failure=True,
-        handle_exception=True,
-    )
-    with Session(hostname=rhcloud_sat_host.hostname) as session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=DEFAULT_LOC)
-        # Sync insights recommendations
-        timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
-        session.cloudinsights.sync_hits()
-        wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
-            .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
-            timeout=400,
-            delay=15,
-            silent_failure=True,
-            handle_exception=True,
-        )
-        result = session.host.search(rhel_insights_vm.hostname)[0]
-        assert result['Name'] == rhel_insights_vm.hostname
-        assert int(result['Recommendations']) > 0
-        values = session.host.get_details(rhel_insights_vm.hostname)
-        # Note: Reading host properties adds 'clear' to original value.
-        assert (
-            values['properties']['properties_table']['Inventory']
-            == 'Successfully uploaded to your RH cloud inventory clear'
-        )
-        assert values['properties']['properties_table']['Insights'] == 'Reporting clear'
-        # Delete host
-        session.host.delete(rhel_insights_vm.hostname)
-        assert not rhcloud_sat_host.api.Host().search(
-            query={'search': f'name="{rhel_insights_vm.hostname}"'}
-        )
-
-
-@pytest.mark.tier2
-@pytest.mark.rhel_ver_list([8])
-def test_insights_tab_on_host_details_page(
-    rhel_insights_vm,
-    organization_ak_setup,
-    rhcloud_sat_host,
-):
-    """Test recommendations count in hosts index is a link and contents
-        of Insights tab on host details page.
-
-    :id: d969ad38-7ee5-4c57-8538-1cf6c1705707
-
-    :Steps:
-        1. Prepare misconfigured machine and upload its data to Insights.
-        2. In Satellite UI, Configure -> Insights -> Sync now.
-        3. Go to Hosts -> All Hosts.
-        4. Click on recommendation count.
-        5. Assert the contents of Insights tab.
-
-    :expectedresults:
-        1. There's Insights recommendation column with number of recommendations and
-            link to Insights tab on host details page.
-        2. Insights tab shows recommendations for the host.
-
-    :CaseImportance: High
-
-    :BZ: 1865876, 1879448
-
-    :parametrized: yes
-
-    :CaseAutomation: Automated
-    """
-    org, ak = organization_ak_setup
-    # Create a vulnerability which can be remediated
-    rhel_insights_vm.run('dnf update -y dnf;sed -i -e "/^best/d" /etc/dnf/dnf.conf;insights-client')
-    dnf_issue = (
-        'The dnf installs lower versions of packages when the '
-        '"best" option is not present in the /etc/dnf/dnf.conf'
-    )
-    with Session(hostname=rhcloud_sat_host.hostname) as session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=DEFAULT_LOC)
-        # Sync insights recommendations
-        timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
-        session.cloudinsights.sync_hits()
-        wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
-            .search(query={'search': f'Insights full sync and started_at >= "{timestamp}"'})[0]
-            .result
-            == 'success',
-            timeout=400,
-            delay=15,
-            silent_failure=True,
-            handle_exception=True,
-        )
-        result = session.host.search(rhel_insights_vm.hostname)[0]
-        assert result['Name'] == rhel_insights_vm.hostname
-        assert int(result['Recommendations']) > 0
-        insights_recommendations = session.host.insights_tab(rhel_insights_vm.hostname)
-        for recommendation in insights_recommendations:
-            if recommendation['name'] == dnf_issue:
-                assert recommendation['label'] == 'Moderate'
-                assert dnf_issue in recommendation['text']
-                assert len(insights_recommendations) == int(result['Recommendations'])
-
-
 @pytest.mark.e2e
 @pytest.mark.no_containers
+@pytest.mark.rhel_ver_list([7, 8, 9])
 def test_insights_registration_with_capsule(
-    rhcloud_capsule, organization_ak_setup, rhcloud_sat_host, rhel7_contenthost, default_os
+    rhcloud_capsule, organization_ak_setup, rhcloud_sat_host, rhel_contenthost, default_os
 ):
     """Registering host with insights having traffic going through
-        external capsule.
+        external capsule and also test rh_cloud_insights:clean_statuses rake command.
 
     :id: 9db1d307-664c-4d4a-89de-da986224f071
 
@@ -518,17 +347,19 @@ def test_insights_registration_with_capsule(
         3. Overide Insights and Rex parameters.
         4. check host is registered successfully with selected capsule.
         5. Test insights client connection & reporting status.
+        6. Run rh_cloud_insights:clean_statuses rake command
+        7. Assert that host properties doesn't contain insights status.
 
-    :expectedresults: Host is successfully registered with capsule host,
-             having remote execution and insights.
+    :expectedresults:
+        1. Host is successfully registered with capsule host,
+            having remote execution and insights.
+        2. rake command deletes insights reporting status of host.
 
-    :BZ: 2110222, 2112386
+    :BZ: 2110222, 2112386, 1962930
+
+    :parametrized: yes
     """
     org, ak = organization_ak_setup
-    capsule = rhcloud_sat_host.api.SmartProxy(name=rhcloud_capsule.hostname).search()[0]
-    org.smart_proxy.append(capsule)
-    org.update(['smart_proxy'])
-
     with Session(hostname=rhcloud_sat_host.hostname) as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
@@ -543,11 +374,23 @@ def test_insights_registration_with_capsule(
                 'advanced.setup_rex': 'Yes (override)',
             }
         )
-        # TODO: Make this test parametirzed for all rhel versions after verifying BZ:2129254
-        rhel7_contenthost.create_custom_repos(rhel7=settings.repos.rhel7_os)
-        assert rhel7_contenthost.execute('yum install -y insights-client').status == 0
-        rhel7_contenthost.execute(cmd)
-        assert rhel7_contenthost.subscribed
-        assert rhel7_contenthost.execute('insights-client --test-connection').status == 0
-        values = session.host.get_details(rhel7_contenthost.hostname)
+        rhel_contenthost.create_custom_repos(rhel7=settings.repos.rhel7_os)
+        assert rhel_contenthost.execute('yum install -y insights-client').status == 0
+        rhel_contenthost.execute(cmd)
+        assert rhel_contenthost.subscribed
+        assert rhel_contenthost.execute('insights-client --test-connection').status == 0
+        values = session.host.get_details(rhel_contenthost.hostname)
+        assert values['properties']['properties_table']['Insights'] == 'Reporting clear'
+        # Clean insights status
+        result = rhcloud_sat_host.run(
+            f'foreman-rake rh_cloud_insights:clean_statuses SEARCH="{rhel_contenthost.hostname}"'
+        )
+        assert 'Deleted 1 insights statuses' in result.stdout
+        assert result.status == 0
+        values = session.host.get_details(rhel_contenthost.hostname)
+        with pytest.raises(KeyError):
+            values['properties']['properties_table']['Insights']
+        result = rhel_contenthost.run('insights-client')
+        assert result.status == 0
+        values = session.host.get_details(rhel_contenthost.hostname)
         assert values['properties']['properties_table']['Insights'] == 'Reporting clear'

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -59,7 +59,7 @@ def common_assertion(report_path, inventory_data, org, satellite):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_rhcloud_inventory_e2e(
-    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, rhcloud_sat_host
+    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, module_target_sat
 ):
     """Generate report and verify its basic properties
 
@@ -84,13 +84,13 @@ def test_rhcloud_inventory_e2e(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    with Session(hostname=rhcloud_sat_host.hostname) as session:
+    with Session(hostname=module_target_sat.hostname) as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
+            lambda: module_target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
@@ -107,7 +107,7 @@ def test_rhcloud_inventory_e2e(
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
 
-    common_assertion(report_path, inventory_data, org, rhcloud_sat_host)
+    common_assertion(report_path, inventory_data, org, module_target_sat)
     json_data = get_report_data(report_path)
     hostnames = [host['fqdn'] for host in json_data['hosts']]
     assert virtual_host.hostname in hostnames
@@ -130,7 +130,7 @@ def test_rhcloud_inventory_e2e(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_names(
-    rhcloud_sat_host, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
+    module_target_sat, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
 ):
     """Test whether `Obfuscate host names` setting works as expected.
 
@@ -154,7 +154,7 @@ def test_obfuscate_host_names(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    with Session(hostname=rhcloud_sat_host.hostname) as session:
+    with Session(hostname=module_target_sat.hostname) as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         # Enable obfuscate_hostnames setting on inventory page.
@@ -163,7 +163,7 @@ def test_obfuscate_host_names(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
+            lambda: module_target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
@@ -183,7 +183,7 @@ def test_obfuscate_host_names(
         # Assert that obfuscate_hostnames is enabled.
         assert inventory_data['obfuscate_hostnames'] is True
         # Assert that generated archive is valid.
-        common_assertion(report_path, inventory_data, org, rhcloud_sat_host)
+        common_assertion(report_path, inventory_data, org, module_target_sat)
         # Get report data for assertion
         json_data = get_report_data(report_path)
         hostnames = [host['fqdn'] for host in json_data['hosts']]
@@ -197,12 +197,12 @@ def test_obfuscate_host_names(
         session.cloudinventory.update({'obfuscate_hostnames': False})
 
         # Enable obfuscate_hostnames setting.
-        rhcloud_sat_host.update_setting('obfuscate_inventory_hostnames', True)
+        module_target_sat.update_setting('obfuscate_inventory_hostnames', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
+            lambda: module_target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
@@ -232,7 +232,7 @@ def test_obfuscate_host_names(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_ipv4_addresses(
-    rhcloud_sat_host, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
+    module_target_sat, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
 ):
     """Test whether `Obfuscate host ipv4 addresses` setting works as expected.
 
@@ -260,7 +260,7 @@ def test_obfuscate_host_ipv4_addresses(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    with Session(hostname=rhcloud_sat_host.hostname) as session:
+    with Session(hostname=module_target_sat.hostname) as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         # Enable obfuscate_ips setting on inventory page.
@@ -269,7 +269,7 @@ def test_obfuscate_host_ipv4_addresses(
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
+            lambda: module_target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
@@ -288,7 +288,7 @@ def test_obfuscate_host_ipv4_addresses(
         # Assert that obfuscate_ips is enabled.
         assert inventory_data['obfuscate_ips'] is True
         # Assert that generated archive is valid.
-        common_assertion(report_path, inventory_data, org, rhcloud_sat_host)
+        common_assertion(report_path, inventory_data, org, module_target_sat)
         # Get report data for assertion
         json_data = get_report_data(report_path)
         hostnames = [host['fqdn'] for host in json_data['hosts']]
@@ -308,12 +308,12 @@ def test_obfuscate_host_ipv4_addresses(
         session.cloudinventory.update({'obfuscate_ips': False})
 
         # Enable obfuscate_inventory_ips setting.
-        rhcloud_sat_host.update_setting('obfuscate_inventory_ips', True)
+        module_target_sat.update_setting('obfuscate_inventory_ips', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
+            lambda: module_target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
@@ -350,7 +350,7 @@ def test_obfuscate_host_ipv4_addresses(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_exclude_packages_setting(
-    rhcloud_sat_host, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
+    module_target_sat, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
 ):
     """Test whether `Exclude Packages` setting works as expected.
 
@@ -379,7 +379,7 @@ def test_exclude_packages_setting(
     """
     org, ak = organization_ak_setup
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    with Session(hostname=rhcloud_sat_host.hostname) as session:
+    with Session(hostname=module_target_sat.hostname) as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         # Enable exclude_packages setting on inventory page.
@@ -387,7 +387,7 @@ def test_exclude_packages_setting(
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
+            lambda: module_target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
@@ -407,7 +407,7 @@ def test_exclude_packages_setting(
         # Disable exclude_packages setting on inventory page.
         session.cloudinventory.update({'exclude_packages': False})
         # Assert that generated archive is valid.
-        common_assertion(report_path, inventory_data, org, rhcloud_sat_host)
+        common_assertion(report_path, inventory_data, org, module_target_sat)
         # Get report data for assertion
         json_data = get_report_data(report_path)
         # Assert that right hosts are present in report.
@@ -420,11 +420,11 @@ def test_exclude_packages_setting(
             assert 'installed_packages' not in host_profiles
 
         # Enable exclude_installed_packages setting.
-        rhcloud_sat_host.update_setting('exclude_installed_packages', True)
+        module_target_sat.update_setting('exclude_installed_packages', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         wait_for(
-            lambda: rhcloud_sat_host.api.ForemanTask()
+            lambda: module_target_sat.api.ForemanTask()
             .search(
                 query={
                     'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -20,7 +20,6 @@ from datetime import datetime
 from datetime import timedelta
 
 import pytest
-from airgun.session import Session
 from wait_for import wait_for
 
 from robottelo.constants import DEFAULT_LOC
@@ -59,7 +58,10 @@ def common_assertion(report_path, inventory_data, org, satellite):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_rhcloud_inventory_e2e(
-    inventory_settings, organization_ak_setup, rhcloud_registered_hosts, module_target_sat
+    inventory_settings,
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
+    module_target_sat,
 ):
     """Generate report and verify its basic properties
 
@@ -82,9 +84,9 @@ def test_rhcloud_inventory_e2e(
 
     :BZ: 1807829, 1926100
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    with Session(hostname=module_target_sat.hostname) as session:
+    with module_target_sat.ui_session() as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
@@ -130,7 +132,10 @@ def test_rhcloud_inventory_e2e(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_names(
-    module_target_sat, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
+    module_target_sat,
+    inventory_settings,
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
 ):
     """Test whether `Obfuscate host names` setting works as expected.
 
@@ -152,9 +157,9 @@ def test_obfuscate_host_names(
 
     :CaseAutomation: Automated
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    with Session(hostname=module_target_sat.hostname) as session:
+    with module_target_sat.ui_session() as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         # Enable obfuscate_hostnames setting on inventory page.
@@ -232,7 +237,10 @@ def test_obfuscate_host_names(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_obfuscate_host_ipv4_addresses(
-    module_target_sat, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
+    module_target_sat,
+    inventory_settings,
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
 ):
     """Test whether `Obfuscate host ipv4 addresses` setting works as expected.
 
@@ -258,9 +266,9 @@ def test_obfuscate_host_ipv4_addresses(
 
     :CaseAutomation: Automated
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    with Session(hostname=module_target_sat.hostname) as session:
+    with module_target_sat.ui_session() as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         # Enable obfuscate_ips setting on inventory page.
@@ -350,7 +358,10 @@ def test_obfuscate_host_ipv4_addresses(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_exclude_packages_setting(
-    module_target_sat, inventory_settings, organization_ak_setup, rhcloud_registered_hosts
+    module_target_sat,
+    inventory_settings,
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
 ):
     """Test whether `Exclude Packages` setting works as expected.
 
@@ -377,9 +388,9 @@ def test_exclude_packages_setting(
 
     :CaseAutomation: Automated
     """
-    org, ak = organization_ak_setup
+    org = rhcloud_manifest_org
     virtual_host, baremetal_host = rhcloud_registered_hosts
-    with Session(hostname=module_target_sat.hostname) as session:
+    with module_target_sat.ui_session() as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
         # Enable exclude_packages setting on inventory page.


### PR DESCRIPTION
This PR aims to refactor tests present in `tests/foreman/ui/test_rhcloud_insights.py`.
It removes `test_delete_host_having_insights_recommendation`, `test_rh_cloud_insights_clean_statuses` and `test_insights_tab_on_host_details_page` as they are covered in existing tests and updates and parameterizes others for rhel 7, 8 and 9. 
It also removes `rhcloud_sat_host` which is unnecessary.

Depends on https://github.com/SatelliteQE/airgun/pull/940