### PR TITLE
[6.11.z] Fix 4-digit logic in download_repofile and ohsnap_repo_url

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -67,10 +67,11 @@ class VersionedContent:
                 product = self.__class__.__name__.lower()
         repo = repo or product  # if repo is not specified, set it to the same as the product is
         release = self.satellite.version if not release else str(release)
+        # issue warning if requesting repofile of different version than the product is
         settings_release = settings.server.version.release.split('.')
         if len(settings_release) == 2:
             settings_release.append('0')
-        settings_release = '.'.join(settings_release[:3])  # keep only major.minor.patch
+        settings_release = '.'.join(settings_release)
         if product != 'client' and release != settings_release:
             logger.warn(
                 'Satellite release in settings differs from the one passed to the function '

--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -62,7 +62,6 @@ def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap='')
             else:
                 logger.warning(f'Ohsnap returned no releases for the given stream: {release}')
 
-        release = '.'.join(release.split('.')[:3])  # keep only major.minor.patch
         logger.debug(f'Release string after processing: {release}')
     return (
         f'{ohsnap.host}/api/releases/'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12057

`ohsnap_repo_url()` and `download_repofile()` needlessly shortens 4 digit satellite version to 3 digits

Found when PR testing https://github.com/SatelliteQE/robottelo/pull/12049#issuecomment-1656731416