### PR TITLE
Fix clone tests to use the right sat_version

### DIFF
--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -50,7 +50,7 @@ def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pul
     :customerscenario: true
     """
     rhel_version = sat_ready_rhel._v_major
-    sat_version = target_sat.version
+    sat_version = 'stream' if target_sat.is_stream else target_sat.version
 
     # SATELLITE PART - SOURCE SERVER
     # Enabling and starting services


### PR DESCRIPTION
All of the satellite-clone tests are failing on stream, because this line resolves to `6.15.0`. Instead we want it to resolve to `stream`, so I opted to use `settings.satellite.version.release`. Only need this for stream, since it's a non-issue on our other branches.