### PR TITLE
[6.12.z] Switch CLIFactoryError import for cli/test_capsule.py

### DIFF
--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -21,8 +21,8 @@ from fauxfactory import gen_alphanumeric
 from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
 from robottelo.cli.proxy import Proxy
+from robottelo.host_helpers.cli_factory import CLIFactoryError
 from robottelo.utils.datafactory import parametrized
 from robottelo.utils.datafactory import valid_data_list
 from robottelo.utils.issue_handlers import is_open


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12239

`make_proxy` uses the `CLIFactoryError` from `cli_factory` not the error from `cli.factory`. I haven't investigated if this is a problem in other areas, but we should reconsider having two of the same error.