### PR TITLE
Test fixes for compute_resource docker

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -196,7 +196,8 @@ def container_contenthost(request, target_sat):
         host.create_custom_repos(**repos)
         for service in constants.CONTAINER_CLIENTS:
             host.execute(f'yum -y install {service}')
-            host.execute(f'systemctl start {service}')
+            if service == 'docker':
+                host.execute(f'systemctl start {service}')
         yield host
 
 


### PR DESCRIPTION
This PR fixes the test_positive_upload_image failing because the container was not initiated to create an image from it.