### PR TITLE
[6.13.z] Fixed failing test for recreating repositories 

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1188,8 +1188,8 @@ class TestRepository:
         identifier = results.stdout.split('version_href\n"', 1)[1].split('version')[0]
         target_sat.execute(
             f'curl -X DELETE {target_sat.url}/{identifier}'
-            f' --cert /etc/pki/katello/certs/pulp-client.crt'
-            f' --key /etc/pki/katello/private/pulp-client.key'
+            f' --cert /etc/foreman/client_cert.pem'
+            f' --key /etc/foreman/client_key.pem'
         )
         command_output = target_sat.execute('foreman-rake katello:correct_repositories COMMIT=true')
         assert 'Recreating' in command_output.stdout and 'TaskError' not in command_output.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12246

Updated Cert and Key file locations for 6.13 and 6.14