### PR TITLE
[6.12.5] Cherry-pick for uploading expired manifest

### DIFF
--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -24,7 +24,6 @@ from requests.exceptions import HTTPError
 
 from robottelo import constants
 from robottelo.api.utils import enable_rhrepo_and_fetchid
-from robottelo.api.utils import upload_manifest
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
@@ -197,7 +196,7 @@ def test_positive_sync_kickstart_repo(module_entitlement_manifest_org, target_sa
     assert rh_repo.content_counts['rpm'] > 0
 
 
-def test_negative_uplaod_expired_manifest(module_org, target_sat):
+def test_negative_upload_expired_manifest(module_org, target_sat):
     """Upload an expired manifest and attempt to refresh it
 
     :id: d6e652d8-5f46-4d15-9191-d842466d45d0
@@ -212,7 +211,7 @@ def test_negative_uplaod_expired_manifest(module_org, target_sat):
     manifester = Manifester(manifest_category=settings.manifest.entitlement)
     manifest = manifester.get_manifest()
     manifester.delete_subscription_allocation()
-    upload_manifest(module_org.id, manifest.content)
+    target_sat.upload_manifest(module_org.id, manifest.content)
     with pytest.raises(CLIReturnCodeError) as error:
         Subscription.refresh_manifest({'organization-id': module_org.id})
     assert (

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -215,6 +215,7 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
     with pytest.raises(CLIReturnCodeError) as error:
         target_sat.cli.Subscription.refresh_manifest({'organization-id': module_org.id})
     assert (
-        "The manifest doesn't exist on console.redhat.com. "
-        "Please create and import a new manifest." in error.value.stderr
+        'The Subscription Allocation providing the imported manifest has been removed. '
+        'Please create a new Subscription Allocation and import the new manifest'
+        in error.value.stderr
     )

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -17,12 +17,16 @@
 :Upstream: No
 """
 import pytest
+from manifester import Manifester
 from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
 from requests.exceptions import HTTPError
 
 from robottelo import constants
 from robottelo.api.utils import enable_rhrepo_and_fetchid
+from robottelo.api.utils import upload_manifest
+from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.constants import MIRRORING_POLICIES
 from robottelo.utils.datafactory import parametrized
@@ -191,3 +195,28 @@ def test_positive_sync_kickstart_repo(module_entitlement_manifest_org, target_sa
     rh_repo = rh_repo.read()
     assert rh_repo.content_counts['package_group'] > 0
     assert rh_repo.content_counts['rpm'] > 0
+
+
+def test_negative_uplaod_expired_manifest(module_org, target_sat):
+    """Upload an expired manifest and attempt to refresh it
+
+    :id: d6e652d8-5f46-4d15-9191-d842466d45d0
+
+    :Steps:
+        1. Upload a manifest
+        2. Delete the Subscription Allocation on RHSM
+        3. Attempt to refresh the manifest
+
+    :expectedresults: Manifest refresh should fail and return error message
+    """
+    manifester = Manifester(manifest_category=settings.manifest.entitlement)
+    manifest = manifester.get_manifest()
+    manifester.delete_subscription_allocation()
+    upload_manifest(module_org.id, manifest.content)
+    with pytest.raises(CLIReturnCodeError) as error:
+        Subscription.refresh_manifest({'organization-id': module_org.id})
+    assert (
+        'The Subscription Allocation providing the imported manifest has been removed. '
+        'Please create a new Subscription Allocation and import the new manifest'
+        in error.value.stderr
+    )

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -25,7 +25,6 @@ from requests.exceptions import HTTPError
 from robottelo import constants
 from robottelo.api.utils import enable_rhrepo_and_fetchid
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.subscription import Subscription
 from robottelo.config import settings
 from robottelo.constants import MIRRORING_POLICIES
 from robottelo.utils.datafactory import parametrized
@@ -214,7 +213,7 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
     target_sat.upload_manifest(module_org.id, manifest.content)
     manifester.delete_subscription_allocation()
     with pytest.raises(CLIReturnCodeError) as error:
-        Subscription.refresh_manifest({'organization-id': module_org.id})
+        target_sat.cli.Subscription.refresh_manifest({'organization-id': module_org.id})
     assert (
         "The manifest doesn't exist on console.redhat.com. "
         "Please create and import a new manifest." in error.value.stderr

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -196,6 +196,7 @@ def test_positive_sync_kickstart_repo(module_entitlement_manifest_org, target_sa
     assert rh_repo.content_counts['rpm'] > 0
 
 
+@pytest.mark.tier1
 def test_negative_upload_expired_manifest(module_org, target_sat):
     """Upload an expired manifest and attempt to refresh it
 
@@ -210,12 +211,11 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
     """
     manifester = Manifester(manifest_category=settings.manifest.entitlement)
     manifest = manifester.get_manifest()
-    manifester.delete_subscription_allocation()
     target_sat.upload_manifest(module_org.id, manifest.content)
+    manifester.delete_subscription_allocation()
     with pytest.raises(CLIReturnCodeError) as error:
         Subscription.refresh_manifest({'organization-id': module_org.id})
     assert (
-        'The Subscription Allocation providing the imported manifest has been removed. '
-        'Please create a new Subscription Allocation and import the new manifest'
-        in error.value.stderr
+        "The manifest doesn't exist on console.redhat.com. "
+        "Please create and import a new manifest." in error.value.stderr
     )


### PR DESCRIPTION
Fixing failed cherry-pick of test into 6.12.z

Parent PR: https://github.com/SatelliteQE/robottelo/pull/10428

