### PR TITLE
[6.14.z] Convert UI manifest tests to manifester

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -235,7 +235,9 @@ def module_repos_collection_with_setup(request, module_target_sat, module_org, m
 
 
 @pytest.fixture(scope='module')
-def module_repos_collection_with_manifest(request, module_target_sat, module_org, module_lce):
+def module_repos_collection_with_manifest(
+    request, module_target_sat, module_entitlement_manifest_org, module_lce
+):
     """This fixture and its usage is very similar to repos_collection fixture above with extra
     setup_content and uploaded manifest capabilities using module_org and module_lce fixtures
 
@@ -253,7 +255,5 @@ def module_repos_collection_with_manifest(request, module_target_sat, module_org
             for repo_name, repo_params in repo.items()
         ],
     )
-    _repos_collection.setup_content(
-        module_org.id, module_lce.id, upload_manifest=True, override=True
-    )
+    _repos_collection.setup_content(module_entitlement_manifest_org.id, module_lce.id)
     return _repos_collection

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -31,7 +31,7 @@ def organization_ak_setup(rhcloud_sat_host, rhcloud_manifest_org):
         service_level='Self-Support',
         purpose_usage='test-usage',
         purpose_role='test-role',
-        auto_attach=True,
+        auto_attach=False,
     ).create()
     yield rhcloud_manifest_org, ak
     ak.delete()

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -205,7 +205,6 @@ def make_content_view_with_credentials(options=None, credentials=None):
     # Organization ID is a required field.
     if not options or not options.get('organization-id'):
         raise CLIFactoryError('Please provide a valid ORG ID.')
-
     args = {
         'component-ids': None,
         'composite': False,

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1161,8 +1161,8 @@ class ContentHost(Host, ContentHostMixins):
         ]
         repos.extend(extra_repos)
         content_setup_data = cli_factory.setup_cdn_and_custom_repos_content(
-            org['id'],
-            lce['id'],
+            org[id],
+            lce[id],
             repos,
             upload_manifest=upload_manifest,
             rh_subscriptions=[constants.DEFAULT_SUBSCRIPTION_NAME],

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -422,7 +422,6 @@ def test_positive_update_cv(session, module_org, cv2_name, target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 def test_positive_update_rh_product(function_entitlement_manifest_org, session, target_sat):
     """Update Content View in an Activation key
@@ -479,7 +478,6 @@ def test_positive_update_rh_product(function_entitlement_manifest_org, session, 
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 def test_positive_add_rh_product(function_entitlement_manifest_org, session, target_sat):
     """Test that RH product can be associated to Activation Keys
@@ -548,7 +546,6 @@ def test_positive_add_custom_product(session, module_org, target_sat):
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_add_rh_and_custom_products(
@@ -612,7 +609,6 @@ def test_positive_add_rh_and_custom_products(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_fetch_product_content(target_sat, function_entitlement_manifest_org, session):
@@ -1076,7 +1072,7 @@ def test_positive_host_associations(session, target_sat):
             assert ak2['content_hosts']['table'][0]['Name'] == vm2.hostname
 
 
-@pytest.mark.skip_if_not_set('clients', 'fake_manifest')
+@pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_service_level_subscription_with_custom_product(
@@ -1147,7 +1143,6 @@ def test_positive_service_level_subscription_with_custom_product(
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 def test_positive_delete_manifest(session, function_entitlement_manifest_org):
     """Check if deleting a manifest removes it from Activation key
@@ -1191,7 +1186,7 @@ def test_positive_delete_manifest(session, function_entitlement_manifest_org):
         assert not ak['subscriptions']['resources']['assigned']
 
 
-@pytest.mark.skip_if_not_set('clients', 'fake_manifest')
+@pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_ak_with_custom_product_on_rhel6(session, rhel6_contenthost, target_sat):

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -203,7 +203,12 @@ def test_positive_task_status(session):
     indirect=True,
 )
 def test_positive_user_access_with_host_filter(
-    test_name, module_location, rhel_contenthost, target_sat, repos_collection
+    test_name,
+    function_entitlement_manifest_org,
+    module_location,
+    rhel_contenthost,
+    target_sat,
+    repos_collection,
 ):
     """Check if user with necessary host permissions can access dashboard
     and required widgets are rendered with proper values
@@ -229,7 +234,7 @@ def test_positive_user_access_with_host_filter(
     """
     user_login = gen_string('alpha')
     user_password = gen_string('alphanumeric')
-    org = entities.Organization().create()
+    org = function_entitlement_manifest_org
     lce = entities.LifecycleEnvironment(organization=org).create()
     # create a role with necessary permissions
     role = entities.Role().create()

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -20,6 +20,7 @@ import pytest
 from airgun.session import Session
 from broker import Broker
 from fauxfactory import gen_string
+from manifester import Manifester
 from nailgun import entities
 
 from robottelo.config import settings
@@ -83,37 +84,55 @@ def _set_setting_value(setting_entity, value):
     setting_entity.update(['value'])
 
 
-def _org(module_target_sat):
-    org = entities.Organization().create()
-    # adding remote_execution_connect_by_ip=Yes at org level
-    entities.Parameter(
+@pytest.fixture(scope='module')
+def module_manifest():
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
+@pytest.fixture
+def function_manifest():
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='module')
+def module_org_with_parameter(module_target_sat, module_manifest):
+    org = module_target_sat.api.Organization(simple_content_access=False).create()
+    # org.sca_disable()
+    module_target_sat.api.Parameter(
         name='remote_execution_connect_by_ip',
         parameter_type='boolean',
         value='Yes',
         organization=org.id,
     ).create()
-    module_target_sat.upload_manifest(org.id)
+    module_target_sat.upload_manifest(org.id, module_manifest.content)
+    return org
+
+
+@pytest.fixture
+def function_org_with_parameter(target_sat, function_manifest):
+    org = target_sat.api.Organization(simple_content_access=False).create()
+    target_sat.api.Parameter(
+        name='remote_execution_connect_by_ip',
+        parameter_type='boolean',
+        value='Yes',
+        organization=org.id,
+    ).create()
+    target_sat.upload_manifest(org.id, function_manifest.content)
     return org
 
 
 @pytest.fixture(scope='module')
-def module_org():
-    return _org()
+def module_lce(module_target_sat, module_org_with_parameter):
+    return module_target_sat.api.LifecycleEnvironment(
+        organization=module_org_with_parameter
+    ).create()
 
 
 @pytest.fixture
-def org():
-    return _org()
-
-
-@pytest.fixture(scope='module')
-def module_lce(module_org):
-    return entities.LifecycleEnvironment(organization=module_org).create()
-
-
-@pytest.fixture
-def lce(org):
-    return entities.LifecycleEnvironment(organization=org).create()
+def lce(target_sat, function_org_with_parameter):
+    return target_sat.api.LifecycleEnvironment(organization=function_org_with_parameter).create()
 
 
 @pytest.fixture
@@ -160,7 +179,12 @@ def vm(module_repos_collection_with_setup, rhel7_contenthost, target_sat):
 )
 @pytest.mark.no_containers
 def test_end_to_end(
-    session, module_org, module_repos_collection_with_setup, vm, target_sat, setting_update
+    session,
+    module_org_with_parameter,
+    module_repos_collection_with_setup,
+    vm,
+    target_sat,
+    setting_update,
 ):
     """Create all entities required for errata, set up applicable host,
     read errata details and apply it to host
@@ -240,7 +264,7 @@ def test_end_to_end(
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_content_host_errata_page_pagination(session, org, lce, target_sat):
+def test_content_host_errata_page_pagination(session, function_org_with_parameter, lce, target_sat):
     """
     # Test per-page pagination for BZ#1662254
     # Test apply by REX using Select All for BZ#1846670
@@ -273,6 +297,7 @@ def test_content_host_errata_page_pagination(session, org, lce, target_sat):
     :CaseLevel: System
     """
 
+    org = function_org_with_parameter
     pkgs = ' '.join(FAKE_3_YUM_OUTDATED_PACKAGES)
     repos_collection = target_sat.cli_factory.RepositoryCollection(
         distro='rhel7',
@@ -281,7 +306,7 @@ def test_content_host_errata_page_pagination(session, org, lce, target_sat):
             target_sat.cli_factory.YumRepository(url=settings.repos.yum_3.url),
         ],
     )
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(org.id, lce.id)
     with Broker(nick=repos_collection.distro, host_class=ContentHost) as client:
         client.add_rex_key(satellite=target_sat)
         # Add repo and install packages that need errata
@@ -326,7 +351,7 @@ def test_content_host_errata_page_pagination(session, org, lce, target_sat):
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_list(session, org, lce, target_sat):
+def test_positive_list(session, function_org_with_parameter, lce, target_sat):
     """View all errata in an Org
 
     :id: 71c7a054-a644-4c1e-b304-6bc34ea143f4
@@ -343,6 +368,7 @@ def test_positive_list(session, org, lce, target_sat):
 
     :CaseLevel: Integration
     """
+    org = function_org_with_parameter
     rc = target_sat.cli_factory.RepositoryCollection(
         repositories=[target_sat.cli_factory.YumRepository(settings.repos.yum_3.url)]
     )
@@ -373,7 +399,9 @@ def test_positive_list(session, org, lce, target_sat):
     ],
     indirect=True,
 )
-def test_positive_list_permission(test_name, module_org, module_repos_collection_with_setup):
+def test_positive_list_permission(
+    test_name, module_org_with_parameter, module_repos_collection_with_setup
+):
     """Show errata only if the User has permissions to view them
 
     :id: cdb28f6a-23df-47a2-88ab-cd3b492126b2
@@ -391,6 +419,7 @@ def test_positive_list_permission(test_name, module_org, module_repos_collection
 
     :CaseLevel: Integration
     """
+    module_org = module_org_with_parameter
     role = entities.Role().create()
     entities.Filter(
         organization=[module_org],
@@ -430,7 +459,7 @@ def test_positive_list_permission(test_name, module_org, module_repos_collection
     indirect=True,
 )
 def test_positive_apply_for_all_hosts(
-    session, module_org, module_repos_collection_with_setup, target_sat
+    session, module_org_with_parameter, module_repos_collection_with_setup, target_sat
 ):
     """Apply an erratum for all content hosts
 
@@ -528,7 +557,7 @@ def test_positive_view_cve(session, module_repos_collection_with_setup):
     indirect=True,
 )
 def test_positive_filter_by_environment(
-    session, module_org, module_repos_collection_with_setup, target_sat
+    session, module_org_with_parameter, module_repos_collection_with_setup, target_sat
 ):
     """Filter Content hosts by environment
 
@@ -547,6 +576,7 @@ def test_positive_filter_by_environment(
 
     :CaseLevel: System
     """
+    module_org = module_org_with_parameter
     with Broker(
         nick=module_repos_collection_with_setup.distro, host_class=ContentHost, _count=2
     ) as clients:
@@ -604,7 +634,7 @@ def test_positive_filter_by_environment(
     indirect=True,
 )
 def test_positive_content_host_previous_env(
-    session, module_org, module_repos_collection_with_setup, vm
+    session, module_org_with_parameter, module_repos_collection_with_setup, vm
 ):
     """Check if the applicable errata are available from the content
     host's previous environment
@@ -625,6 +655,7 @@ def test_positive_content_host_previous_env(
 
     :CaseLevel: System
     """
+    module_org = module_org_with_parameter
     hostname = vm.hostname
     assert _install_client_package(vm, FAKE_1_CUSTOM_PACKAGE, errata_applicability=True)
     # Promote the latest content view version to a new lifecycle environment
@@ -663,7 +694,7 @@ def test_positive_content_host_previous_env(
     ],
     indirect=True,
 )
-def test_positive_content_host_library(session, module_org, vm):
+def test_positive_content_host_library(session, module_org_with_parameter, vm):
     """Check if the applicable errata are available from the content
     host's Library
 
@@ -777,7 +808,9 @@ def test_positive_content_host_search_type(session, erratatype_vm):
     ],
     indirect=True,
 )
-def test_positive_show_count_on_content_host_page(session, module_org, erratatype_vm):
+def test_positive_show_count_on_content_host_page(
+    session, module_org_with_parameter, erratatype_vm
+):
     """Available errata count displayed in Content hosts page
 
     :id: 8575e282-d56e-41dc-80dd-f5f6224417cb
@@ -833,7 +866,9 @@ def test_positive_show_count_on_content_host_page(session, module_org, erratatyp
     ],
     indirect=True,
 )
-def test_positive_show_count_on_content_host_details_page(session, module_org, erratatype_vm):
+def test_positive_show_count_on_content_host_details_page(
+    session, module_org_with_parameter, erratatype_vm
+):
     """Errata count on Content host Details page
 
     :id: 388229da-2b0b-41aa-a457-9b5ecbf3df4b
@@ -876,7 +911,11 @@ def test_positive_show_count_on_content_host_details_page(session, module_org, e
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize('setting_update', ['errata_status_installable'], indirect=True)
 def test_positive_filtered_errata_status_installable_param(
-    session, errata_status_installable, target_sat, setting_update
+    session,
+    function_entitlement_manifest_org,
+    errata_status_installable,
+    target_sat,
+    setting_update,
 ):
     """Filter errata for specific content view and verify that host that
     was registered using that content view has different states in
@@ -904,7 +943,7 @@ def test_positive_filtered_errata_status_installable_param(
 
     :CaseLevel: System
     """
-    org = entities.Organization().create()
+    org = function_entitlement_manifest_org
     lce = entities.LifecycleEnvironment(organization=org).create()
     repos_collection = target_sat.cli_factory.RepositoryCollection(
         distro='rhel7',
@@ -916,7 +955,7 @@ def test_positive_filtered_errata_status_installable_param(
             target_sat.cli_factory.YumRepository(url=CUSTOM_REPO_URL),
         ],
     )
-    repos_collection.setup_content(org.id, lce.id, upload_manifest=True)
+    repos_collection.setup_content(org.id, lce.id)
     with Broker(nick=repos_collection.distro, host_class=ContentHost) as client:
         repos_collection.setup_virtual_machine(client)
         assert _install_client_package(client, FAKE_1_CUSTOM_PACKAGE, errata_applicability=True)
@@ -990,7 +1029,7 @@ def test_positive_filtered_errata_status_installable_param(
     indirect=True,
 )
 def test_content_host_errata_search_commands(
-    session, module_org, module_repos_collection_with_setup, target_sat
+    session, module_org_with_parameter, module_repos_collection_with_setup, target_sat
 ):
     """View a list of affected content hosts for security (RHSA) and bugfix (RHBA) errata,
     filtered with errata status and applicable flags. Applicability is calculated using the

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -30,8 +30,7 @@ CUSTOM_REPO_ERRATA_ID = settings.repos.yum_0.errata[0]
 
 
 @pytest.fixture(scope='module')
-def module_repos_col(module_org, module_lce, module_target_sat, request):
-    module_target_sat.upload_manifest(org_id=module_org.id)
+def module_repos_col(request, module_entitlement_manifest_org, module_lce, module_target_sat):
     repos_collection = module_target_sat.cli_factory.RepositoryCollection(
         repositories=[
             # As Satellite Tools may be added as custom repo and to have a "Fully entitled" host,
@@ -39,15 +38,15 @@ def module_repos_col(module_org, module_lce, module_target_sat, request):
             module_target_sat.cli_factory.YumRepository(url=settings.repos.yum_0.url),
         ],
     )
-    repos_collection.setup_content(module_org.id, module_lce.id)
+    repos_collection.setup_content(module_entitlement_manifest_org.id, module_lce.id)
     yield repos_collection
 
     @request.addfinalizer
     def _cleanup():
         try:
-            module_target_sat.api.Subscription(organization=module_org).delete_manifest(
-                data={'organization_id': module_org.id}
-            )
+            module_target_sat.api.Subscription(
+                organization=module_entitlement_manifest_org
+            ).delete_manifest(data={'organization_id': module_entitlement_manifest_org.id})
         except Exception:
             logger.exception('Exception cleaning manifest:')
 
@@ -256,7 +255,7 @@ def test_positive_update_compresource(session):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_delete_with_manifest_lces(session, target_sat):
+def test_positive_delete_with_manifest_lces(session, target_sat, function_entitlement_manifest_org):
     """Create Organization with valid values and upload manifest.
     Then try to delete that organization.
 
@@ -268,8 +267,7 @@ def test_positive_delete_with_manifest_lces(session, target_sat):
 
     :CaseImportance: Critical
     """
-    org = entities.Organization().create()
-    target_sat.upload_manifest(org.id)
+    org = function_entitlement_manifest_org
     with session:
         session.organization.select(org.name)
         session.lifecycleenvironment.create({'name': 'DEV'})
@@ -281,11 +279,11 @@ def test_positive_delete_with_manifest_lces(session, target_sat):
         assert not session.organization.search(org.name)
 
 
-@pytest.mark.skip('Skipping due to manifest refresh issues')
-@pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_download_debug_cert_after_refresh(session, target_sat):
+def test_positive_download_debug_cert_after_refresh(
+    session, target_sat, function_entitlement_manifest_org
+):
     """Create organization with valid manifest. Download debug
     certificate for that organization and refresh added manifest for few
     times in a row
@@ -298,9 +296,8 @@ def test_positive_download_debug_cert_after_refresh(session, target_sat):
 
     :CaseImportance: High
     """
-    org = entities.Organization().create()
+    org = function_entitlement_manifest_org
     try:
-        target_sat.upload_manifest(org.id)
         with session:
             session.organization.select(org.name)
             for _ in range(3):

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -60,12 +60,11 @@ def module_yum_repo2(module_product):
 
 
 @pytest.fixture(scope='module')
-def module_rh_repo(module_org, module_target_sat):
-    module_target_sat.upload_manifest(module_org.id)
+def module_rh_repo(module_entitlement_manifest_org, module_target_sat):
     rhst = module_target_sat.cli_factory.SatelliteToolsRepository(cdn=True)
     repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=rhst.data['arch'],
-        org_id=module_org.id,
+        org_id=module_entitlement_manifest_org.id,
         product=rhst.data['product'],
         repo=rhst.data['repository'],
         reposet=rhst.data['repository-set'],

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -384,7 +384,7 @@ def test_positive_autocomplete(session):
 
 @pytest.mark.tier2
 def test_positive_schedule_generation_and_get_mail(
-    session, module_manifest_org, module_location, target_sat
+    session, module_entitlement_manifest_org, module_location, target_sat
 ):
     """Schedule generating a report. Request the result be sent via e-mail.
 
@@ -439,7 +439,9 @@ def test_positive_schedule_generation_and_get_mail(
     target_sat.get(remote_path=str(gzip_path), local_path=str(local_gzip_file))
     assert os.system(f'gunzip {local_gzip_file}') == 0
     data = json.loads(local_file.read_text())
-    subscription_search = target_sat.api.Subscription(organization=module_manifest_org).search()
+    subscription_search = target_sat.api.Subscription(
+        organization=module_entitlement_manifest_org
+    ).search()
     assert len(data) >= len(subscription_search) > 0
     keys_expected = [
         'Account number',

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -741,7 +741,7 @@ def test_positive_no_errors_on_repo_scan(target_sat, function_sca_manifest_org):
 
 
 @pytest.mark.tier2
-def test_positive_reposet_disable(session, target_sat):
+def test_positive_reposet_disable(session, target_sat, function_entitlement_manifest_org):
     """Enable RH repo, sync it and then disable
 
     :id: de596c56-1327-49e8-86d5-a1ab907f26aa
@@ -750,8 +750,7 @@ def test_positive_reposet_disable(session, target_sat):
 
     :CaseLevel: Integration
     """
-    org = entities.Organization().create()
-    target_sat.upload_manifest(org.id)
+    org = function_entitlement_manifest_org
     sat_tools_repo = target_sat.cli_factory.SatelliteToolsRepository(distro='rhel7', cdn=True)
     repository_name = sat_tools_repo.data['repository']
     with session:
@@ -782,7 +781,9 @@ def test_positive_reposet_disable(session, target_sat):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
-def test_positive_reposet_disable_after_manifest_deleted(session, target_sat):
+def test_positive_reposet_disable_after_manifest_deleted(
+    session, function_entitlement_manifest_org, target_sat
+):
     """Enable RH repo and sync it. Remove manifest and then disable
     repository
 
@@ -796,8 +797,7 @@ def test_positive_reposet_disable_after_manifest_deleted(session, target_sat):
 
     :CaseLevel: Integration
     """
-    org = entities.Organization().create()
-    target_sat.upload_manifest(org.id)
+    org = function_entitlement_manifest_org
     sub = entities.Subscription(organization=org)
     sat_tools_repo = target_sat.cli_factory.SatelliteToolsRepository(distro='rhel7', cdn=True)
     repository_name = sat_tools_repo.data['repository']
@@ -866,7 +866,7 @@ def test_positive_delete_random_docker_repo(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_delete_rhel_repo(session, module_org, target_sat):
+def test_positive_delete_rhel_repo(session, module_entitlement_manifest_org, target_sat):
     """Enable and sync a Red Hat Repository, and then delete it
 
     :id: e96f369d-3e58-4824-802e-0b7e99d6d207
@@ -880,12 +880,11 @@ def test_positive_delete_rhel_repo(session, module_org, target_sat):
     :BZ: 1152672
     """
 
-    target_sat.upload_manifest(module_org.id)
     sat_tools_repo = target_sat.cli_factory.SatelliteToolsRepository(distro='rhel7', cdn=True)
     repository_name = sat_tools_repo.data['repository']
     product_name = sat_tools_repo.data['product']
     with session:
-        session.organization.select(module_org.name)
+        session.organization.select(module_entitlement_manifest_org.name)
         session.redhatrepository.enable(
             sat_tools_repo.data['repository-set'],
             sat_tools_repo.data['arch'],
@@ -914,7 +913,7 @@ def test_positive_delete_rhel_repo(session, module_org, target_sat):
 
 
 @pytest.mark.tier2
-def test_positive_recommended_repos(session, module_org, target_sat):
+def test_positive_recommended_repos(session, module_entitlement_manifest_org):
     """list recommended repositories using
      On/Off 'Recommended Repositories' toggle.
 
@@ -929,9 +928,8 @@ def test_positive_recommended_repos(session, module_org, target_sat):
 
     :BZ: 1776108
     """
-    target_sat.upload_manifest(module_org.id)
     with session:
-        session.organization.select(module_org.name)
+        session.organization.select(module_entitlement_manifest_org.name)
         rrepos_on = session.redhatrepository.read(recommended_repo='on')
         assert REPOSET['rhel7'] in [repo['name'] for repo in rrepos_on]
         v = get_sat_version()

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -65,16 +65,18 @@ def module_rhc_org(module_target_sat):
 
 
 @pytest.fixture()
-def fixture_setup_rhc_satellite(request, module_target_sat, module_rhc_org):
+def fixture_setup_rhc_satellite(
+    request,
+    module_target_sat,
+    module_rhc_org,
+    module_entitlement_manifest,
+):
     """Create Organization and activation key after successful test execution"""
     yield
     if request.node.rep_call.passed:
         if settings.rh_cloud.crc_env == 'prod':
-            manifests_path = module_target_sat.download_file(
-                file_url=settings.fake_manifest.url['default']
-            )[0]
             module_target_sat.cli.Subscription.upload(
-                {'file': manifests_path, 'organization-id': module_rhc_org.id}
+                {'file': module_entitlement_manifest.filename, 'organization-id': module_rhc_org.id}
             )
         # Enable and sync required repos
         repo1_id = module_target_sat.api_factory.enable_sync_redhat_repo(

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -231,7 +231,9 @@ def test_positive_access_with_non_admin_user_with_manifest(
 
 
 @pytest.mark.tier2
-def test_positive_access_manifest_as_another_admin_user(test_name, target_sat):
+def test_positive_access_manifest_as_another_admin_user(
+    test_name, target_sat, function_entitlement_manifest
+):
     """Other admin users should be able to access and manage a manifest
     uploaded by a different admin.
 
@@ -258,7 +260,7 @@ def test_positive_access_manifest_as_another_admin_user(test_name, target_sat):
     ).create()
     # use the first admin to upload a manifest
     with Session(test_name, user=user1.login, password=user1_password) as session:
-        target_sat.upload_manifest(org.id)
+        target_sat.upload_manifest(org.id, function_entitlement_manifest.content)
         assert session.subscription.has_manifest
         # store subscriptions that have "Red Hat" in the name for later
         rh_subs = session.subscription.search("Red Hat")
@@ -273,7 +275,9 @@ def test_positive_access_manifest_as_another_admin_user(test_name, target_sat):
 
 
 @pytest.mark.tier3
-def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, target_sat):
+def test_positive_view_vdc_subscription_products(
+    session, rhel7_contenthost, target_sat, function_entitlement_manifest_org
+):
     """Ensure that Virtual Datacenters subscription provided products is
     not empty and that a consumed product exist in content products.
 
@@ -306,16 +310,14 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, tar
 
     :CaseLevel: System
     """
-    org = entities.Organization().create()
+    org = function_entitlement_manifest_org
     lce = entities.LifecycleEnvironment(organization=org).create()
     repos_collection = target_sat.cli_factory.RepositoryCollection(
         distro='rhel7',
         repositories=[target_sat.cli_factory.RHELAnsibleEngineRepository(cdn=True)],
     )
     product_name = repos_collection.rh_repos[0].data['product']
-    repos_collection.setup_content(
-        org.id, lce.id, upload_manifest=True, rh_subscriptions=[DEFAULT_SUBSCRIPTION_NAME]
-    )
+    repos_collection.setup_content(org.id, lce.id, rh_subscriptions=[DEFAULT_SUBSCRIPTION_NAME])
     rhel7_contenthost.contenthost_setup(
         target_sat,
         org.label,
@@ -337,7 +339,9 @@ def test_positive_view_vdc_subscription_products(session, rhel7_contenthost, tar
 
 @pytest.mark.skip_if_not_set('libvirt')
 @pytest.mark.tier3
-def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthost, target_sat):
+def test_positive_view_vdc_guest_subscription_products(
+    session, rhel7_contenthost, target_sat, function_entitlement_manifest_org
+):
     """Ensure that Virtual Data Centers guest subscription Provided
     Products and Content Products are not empty.
 
@@ -367,7 +371,7 @@ def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthos
 
     :CaseLevel: System
     """
-    org = entities.Organization().create()
+    org = function_entitlement_manifest_org
     lce = entities.LifecycleEnvironment(organization=org).create()
     provisioning_server = settings.libvirt.libvirt_hostname
     rh_product_repository = target_sat.cli_factory.RHELAnsibleEngineRepository(cdn=True)
@@ -390,6 +394,7 @@ def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthos
         hypervisor_hostname=provisioning_server,
         configure_ssh=True,
         subscription_name=VDC_SUBSCRIPTION_NAME,
+        upload_manifest=False,
         extra_repos=[rh_product_repository.data],
     )
     virt_who_hypervisor_host = virt_who_data['virt_who_hypervisor_host']
@@ -416,7 +421,9 @@ def test_positive_view_vdc_guest_subscription_products(session, rhel7_contenthos
 
 
 @pytest.mark.tier3
-def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(session):
+def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(
+    session, function_org, function_entitlement_manifest
+):
     """Ensures that no column headers from checkboxes show up in the table after
     unticking everything from selectable customizable column
 
@@ -450,28 +457,20 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(session):
         'Consumed': False,
         'Entitlements': False,
     }
-    org = entities.Organization().create()
-    _, temporary_local_manifest_path = mkstemp(prefix='manifest-', suffix='.zip')
-    with clone() as manifest:
-        with open(temporary_local_manifest_path, 'wb') as file_handler:
-            file_handler.write(manifest.content.read())
-
+    org = function_org
     with session:
         session.organization.select(org.name)
-        # Ignore "Danger alert: Katello::Errors::UpstreamConsumerNotFound" as server will connect
-        # to upstream subscription service to verify
-        # the consumer uuid, that will be displayed in flash error messages
-        # Note: this happen only when using clone manifest.
         session.subscription.add_manifest(
-            temporary_local_manifest_path,
+            function_entitlement_manifest.path,
             ignore_error_messages=['Danger alert: Katello::Errors::UpstreamConsumerNotFound'],
         )
         headers = session.subscription.filter_columns(checkbox_dict)
-        assert not headers
+        assert headers == ('Select all rows',)
         assert len(checkbox_dict) == 9
         time.sleep(3)
         checkbox_dict.update((k, True) for k in checkbox_dict)
         col = session.subscription.filter_columns(checkbox_dict)
+        checkbox_dict.update({'Select all rows': ''})
         assert set(col) == set(checkbox_dict)
 
 

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -40,13 +40,6 @@ def module_custom_product(module_org):
     return entities.Product(organization=module_org).create()
 
 
-@pytest.fixture(scope='module')
-def module_org_with_manifest(module_target_sat):
-    org = entities.Organization().create()
-    module_target_sat.upload_manifest(org.id)
-    return org
-
-
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_sync_custom_repo(session, module_custom_product):
@@ -69,7 +62,7 @@ def test_positive_sync_custom_repo(session, module_custom_product):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_sync_rh_repos(session, target_sat, module_org_with_manifest):
+def test_positive_sync_rh_repos(session, target_sat, module_entitlement_manifest_org):
     """Create Content RedHat Sync with two repos.
 
     :id: e30f6509-0b65-4bcc-a522-b4f3089d3911
@@ -88,7 +81,7 @@ def test_positive_sync_rh_repos(session, target_sat, module_org_with_manifest):
         for distro, repo in zip(distros, repos)
     ]
     for repo_collection in repo_collections:
-        repo_collection.setup(module_org_with_manifest.id, synchronize=False)
+        repo_collection.setup(module_entitlement_manifest_org.id, synchronize=False)
     repo_paths = [
         (
             repo.repo_data['product'],
@@ -99,7 +92,7 @@ def test_positive_sync_rh_repos(session, target_sat, module_org_with_manifest):
         for repo in repos
     ]
     with session:
-        session.organization.select(org_name=module_org_with_manifest.name)
+        session.organization.select(org_name=module_entitlement_manifest_org.name)
         results = session.sync_status.synchronize(repo_paths)
         assert len(results) == len(repo_paths)
         assert all([result == 'Syncing Complete.' for result in results])
@@ -139,7 +132,7 @@ def test_positive_sync_custom_ostree_repo(session, module_custom_product):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_sync_rh_ostree_repo(session, module_org_with_manifest, target_sat):
+def test_positive_sync_rh_ostree_repo(session, target_sat, module_entitlement_manifest_org):
     """Sync CDN based ostree repository.
 
     :id: 4d28fff0-5fda-4eee-aa0c-c5af02c31de5
@@ -158,14 +151,14 @@ def test_positive_sync_rh_ostree_repo(session, module_org_with_manifest, target_
     """
     target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch=None,
-        org_id=module_org_with_manifest.id,
+        org_id=module_entitlement_manifest_org.id,
         product=PRDS['rhah'],
         repo=REPOS['rhaht']['name'],
         reposet=REPOSET['rhaht'],
         releasever=None,
     )
     with session:
-        session.organization.select(org_name=module_org_with_manifest.name)
+        session.organization.select(org_name=module_entitlement_manifest_org.name)
         results = session.sync_status.synchronize([(PRDS['rhah'], REPOS['rhaht']['name'])])
         assert len(results) == 1
         assert results[0] == 'Syncing Complete.'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/10394

This PR will convert all UI tests that use manifests to obtain those manifests via manifester. I will aim to push one commit for each module that I'm converting. The PR will remain in draft state until I have converted all affected modules. The list of UI modules that I will be converting is as follows:
```
test_repository.py
test_activationkey.py
test_contenthost.py
test_dashboard.py
test_errata.py
test_hostcollection.py
test_host.py
test_organization.py
test_package.py
test_reporttemplates.py
test_rhcloud_insights.py
test_rhcloud_inventory.py
test_rhc.py
test_subscription.py
test_sync.py
```