### PR TITLE
[Repository Rewrite] Added test for publishing invalid repository

### DIFF
--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -17,6 +17,9 @@
 :Upstream: No
 """
 import pytest
+import time
+from requests.exceptions import HTTPError
+
 
 
 @pytest.mark.rhel_ver_match('[^6]')
@@ -47,3 +50,43 @@ def test_positive_custom_products_disabled_by_default(
     assert rhel_contenthost.subscribed
     product_details = rhel_contenthost.run('subscription-manager repos --list')
     assert 'Enabled:   0' in product_details.stdout
+
+
+def test_negative_invalid_repo_fails_publish(
+    module_repository,
+    module_org,
+    target_sat,
+):
+    """Verify that an invalid repository fails when trying to publish in a content view
+
+    :id: 64e03f28-8213-467a-a229-44c8cbfaaef1
+
+    :steps:
+        1. Create custom product and upload repository
+        2. Run Katello commands to make repository invalid
+        3. Create content view and add repository 
+        4. Verify Publish fails 
+
+    :expectedresults: Publishing a content view with an invalid repository fails
+
+    :customerscenario: true
+
+    :BZ: 2032040
+    """
+    repo = module_repository
+    with target_sat.session.shell() as sh:
+            sh.send('foreman-rake console')
+            time.sleep(30)  # sleep to allow time for console to open
+            sh.send(f'root = ::Katello::RootRepository.last')
+            time.sleep(3)  # give enough time for the command to complete
+            sh.send(f'::Katello::Resources::Candlepin::Product.remove_content(root.product.organization.label, root.product.cp_id, root.content_id)')
+            time.sleep(3)
+            sh.send(f'::Katello::Resources::Candlepin::Content.destroy(root.product.organization.label, root.content_id)') 
+            time.sleep(3)  
+    cv = target_sat.api.ContentView(
+        organization=module_org.name,
+        repository=[repo.id],
+    ).create()
+    with pytest.raises(HTTPError) as context:
+        cv.publish()
+    assert 'Remove the invalid repository before publishing again' in context.value.response.text

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -17,9 +17,7 @@
 :Upstream: No
 """
 import pytest
-import time
 from requests.exceptions import HTTPError
-
 
 
 @pytest.mark.rhel_ver_match('[^6]')
@@ -64,8 +62,8 @@ def test_negative_invalid_repo_fails_publish(
     :steps:
         1. Create custom product and upload repository
         2. Run Katello commands to make repository invalid
-        3. Create content view and add repository 
-        4. Verify Publish fails 
+        3. Create content view and add repository
+        4. Verify Publish fails
 
     :expectedresults: Publishing a content view with an invalid repository fails
 
@@ -74,15 +72,12 @@ def test_negative_invalid_repo_fails_publish(
     :BZ: 2032040
     """
     repo = module_repository
-    with target_sat.session.shell() as sh:
-            sh.send('foreman-rake console')
-            time.sleep(30)  # sleep to allow time for console to open
-            sh.send(f'root = ::Katello::RootRepository.last')
-            time.sleep(3)  # give enough time for the command to complete
-            sh.send(f'::Katello::Resources::Candlepin::Product.remove_content(root.product.organization.label, root.product.cp_id, root.content_id)')
-            time.sleep(3)
-            sh.send(f'::Katello::Resources::Candlepin::Content.destroy(root.product.organization.label, root.content_id)') 
-            time.sleep(3)  
+    target_sat.execute(
+        'echo "root = ::Katello::RootRepository.last; ::Katello::Resources::Candlepin::Product.'
+        'remove_content(root.product.organization.label, root.product.cp_id, root.content_id); '
+        '::Katello::Resources::Candlepin::Content.destroy(root.product.organization.label, '
+        'root.content_id)" | foreman-rake console'
+    )
     cv = target_sat.api.ContentView(
         organization=module_org.name,
         repository=[repo.id],


### PR DESCRIPTION
SAT-13325

This test verifies that invalid repositories cannot be published to a Content View

 :steps:
        1. Create custom product and upload repository
        2. Run Katello commands to make repository invalid
        3. Create content view and add repository 
        4. Verify Publish fails 