### PR TITLE
Add service list check

### DIFF
--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -23,8 +23,32 @@ from robottelo.config import settings
 from robottelo.constants import HAMMER_CONFIG
 from robottelo.constants import MAINTAIN_HAMMER_YML
 from robottelo.constants import SATELLITE_ANSWER_FILE
+from robottelo.hosts import Satellite
 
 pytestmark = pytest.mark.destructive
+
+SATELLITE_SERVICES = [
+    "dynflow-sidekiq@.service",
+    "foreman-proxy.service",
+    "foreman.service",
+    "httpd.service",
+    "postgresql.service",
+    "pulpcore-api.service",
+    "pulpcore-content.service",
+    "pulpcore-worker@.service",
+    "redis.service",
+    "tomcat.service",
+]
+
+CAPSULE_SERVICES = [
+    "foreman-proxy.service",
+    "httpd.service",
+    "postgresql.service",
+    "pulpcore-api.service",
+    "pulpcore-content.service",
+    "pulpcore-worker@.service",
+    "redis.service",
+]
 
 
 @pytest.fixture
@@ -64,6 +88,9 @@ def test_positive_service_list(sat_maintain):
     result = sat_maintain.cli.Service.list()
     assert 'FAIL' not in result.stdout
     assert result.status == 0
+    services = SATELLITE_SERVICES if type(sat_maintain) is Satellite else CAPSULE_SERVICES
+    for service in services:
+        assert service in result.stdout
 
 
 @pytest.mark.include_capsule


### PR DESCRIPTION
During the component evaluation SD recommended adding a check for each service being listed to this test as they have found it sometimes will report `[OK]` but miss some services.