### PR TITLE
[6.12.z] bypass cvv promote to lce if already promoted

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1687,13 +1687,16 @@ def setup_org_for_a_custom_repo(options=None):
         ContentView.publish({'id': cv_id})
     except CLIReturnCodeError as err:
         raise CLIFactoryError(f'Failed to publish new version of content view\n{err.msg}')
-    # Get the version id
-    cvv = ContentView.info({'id': cv_id})['versions'][-1]
+    # Get the content view info
+    cv_info = ContentView.info({'id': cv_id})
+    lce_promoted = cv_info['lifecycle-environments']
+    cvv = cv_info['versions'][-1]
     # Promote version to next env
     try:
-        ContentView.version_promote(
-            {'id': cvv['id'], 'organization-id': org_id, 'to-lifecycle-environment-id': env_id}
-        )
+        if env_id not in [int(lce['id']) for lce in lce_promoted]:
+            ContentView.version_promote(
+                {'id': cvv['id'], 'organization-id': org_id, 'to-lifecycle-environment-id': env_id}
+            )
     except CLIReturnCodeError as err:
         raise CLIFactoryError(f'Failed to promote version to next environment\n{err.msg}')
     # Create activation key if needed and associate content view with it

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -627,12 +627,19 @@ class CLIFactory:
         except CLIReturnCodeError as err:
             raise CLIFactoryError(f'Failed to publish new version of content view\n{err.msg}')
         # Get the version id
-        cvv = self._satellite.cli.ContentView.info({'id': cv_id})['versions'][-1]
+        cv_info = self._satellite.cli.ContentView.info({'id': cv_id})
+        lce_promoted = cv_info['lifecycle-environments']
+        cvv = cv_info['versions'][-1]
         # Promote version to next env
         try:
-            self._satellite.cli.ContentView.version_promote(
-                {'id': cvv['id'], 'organization-id': org_id, 'to-lifecycle-environment-id': env_id}
-            )
+            if env_id not in [int(lce['id']) for lce in lce_promoted]:
+                self._satellite.cli.ContentView.version_promote(
+                    {
+                        'id': cvv['id'],
+                        'organization-id': org_id,
+                        'to-lifecycle-environment-id': env_id,
+                    }
+                )
         except CLIReturnCodeError as err:
             raise CLIFactoryError(f'Failed to promote version to next environment\n{err.msg}')
         # Create activation key if needed and associate content view with it

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -26,7 +26,6 @@ from robottelo.cli.ansible import Ansible
 from robottelo.cli.arfreport import Arfreport
 from robottelo.cli.factory import make_hostgroup
 from robottelo.cli.factory import make_scap_policy
-from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.cli.host import Host
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.proxy import Proxy
@@ -99,7 +98,7 @@ def content_view(module_org):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def activation_key(module_org, lifecycle_env, content_view):
+def activation_key(module_target_sat, module_org, lifecycle_env, content_view):
     """Create activation keys"""
     repo_values = [
         {'repo': settings.repos.satclient_repo.rhel8, 'akname': ak_name['rhel8']},
@@ -112,7 +111,7 @@ def activation_key(module_org, lifecycle_env, content_view):
             name=repo.get('akname'), environment=lifecycle_env, organization=module_org
         ).create()
         # Setup org for a custom repo for RHEL6, RHEL7 and RHEL8.
-        setup_org_for_a_custom_repo(
+        module_target_sat.cli_factory.setup_org_for_a_custom_repo(
             {
                 'url': repo.get('repo'),
                 'organization-id': module_org.id,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12309

Upgrade test was failing with Error
`Could not promote the content view: Cannot promote environment out of sequence`
with this fix we bypass cvv promote if already promoted to lce