### PR TITLE
Fixed failing activation key tests due to new param requirements

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -201,9 +201,8 @@ def test_positive_update_name(new_name, target_sat):
     """
     act_key = target_sat.api.ActivationKey().create()
     updated = target_sat.api.ActivationKey(
-        id=act_key.id, name=new_name, organization_id=act_key.organization_id).update(
-        ['name', 'organization_id']
-    )
+        id=act_key.id, name=new_name, organization_id=act_key.organization_id
+    ).update(['name', 'organization_id'])
     assert new_name == updated.name
 
 
@@ -225,7 +224,11 @@ def test_negative_update_limit(max_host, target_sat):
     :parametrized: yes
     """
     act_key = target_sat.api.ActivationKey().create()
-    want = {'max_hosts': act_key.max_hosts, 'unlimited_hosts': act_key.unlimited_hosts, 'organization_id': act_key.organization_id}
+    want = {
+        'max_hosts': act_key.max_hosts,
+        'unlimited_hosts': act_key.unlimited_hosts,
+        'organization_id': act_key.organization_id,
+    }
     act_key.max_hosts = max_host
     act_key.unlimited_hosts = False
     with pytest.raises(HTTPError):
@@ -252,9 +255,8 @@ def test_negative_update_name(new_name, target_sat):
     act_key = target_sat.api.ActivationKey().create()
     with pytest.raises(HTTPError):
         target_sat.api.ActivationKey(
-            id=act_key.id, name=new_name, organization_id=act_key.organization_id).update(
-            ['name', 'organization_id']
-        )
+            id=act_key.id, name=new_name, organization_id=act_key.organization_id
+        ).update(['name', 'organization_id'])
     new_key = target_sat.api.ActivationKey(id=act_key.id).read()
     assert new_key.name != new_name
     assert new_key.name == act_key.name
@@ -274,9 +276,8 @@ def test_negative_update_max_hosts(target_sat):
     act_key = target_sat.api.ActivationKey(max_hosts=1).create()
     with pytest.raises(HTTPError):
         target_sat.api.ActivationKey(
-            id=act_key.id, max_hosts='foo', organization_id=act_key.organization_id).update(
-            ['max_hosts', 'organization_id']
-        )
+            id=act_key.id, max_hosts='foo', organization_id=act_key.organization_id
+        ).update(['max_hosts', 'organization_id'])
     assert act_key.read().max_hosts == 1
 
 
@@ -396,9 +397,10 @@ def test_positive_update_auto_attach(target_sat):
     """
     act_key = target_sat.api.ActivationKey().create()
     act_key_2 = target_sat.api.ActivationKey(
-        id=act_key.id, auto_attach=(not act_key.auto_attach), organization_id=act_key.organization_id).update(
-        ['auto_attach', 'organization_id']
-    )
+        id=act_key.id,
+        auto_attach=(not act_key.auto_attach),
+        organization_id=act_key.organization_id,
+    ).update(['auto_attach', 'organization_id'])
     assert act_key.auto_attach != act_key_2.auto_attach
 
 

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -201,8 +201,9 @@ def test_positive_update_name(new_name, target_sat):
     """
     act_key = target_sat.api.ActivationKey().create()
     updated = target_sat.api.ActivationKey(
-        id=act_key.id, name=new_name, organization_id=act_key.organization.id
-    ).update(['name', 'organization_id'])
+        id=act_key.id, name=new_name, organization_id=act_key.organization_id).update(
+        ['name', 'organization_id']
+    )
     assert new_name == updated.name
 
 
@@ -224,11 +225,7 @@ def test_negative_update_limit(max_host, target_sat):
     :parametrized: yes
     """
     act_key = target_sat.api.ActivationKey().create()
-    want = {
-        'max_hosts': act_key.max_hosts,
-        'unlimited_hosts': act_key.unlimited_hosts,
-        'organization_id': act_key.organization_id,
-    }
+    want = {'max_hosts': act_key.max_hosts, 'unlimited_hosts': act_key.unlimited_hosts, 'organization_id': act_key.organization_id}
     act_key.max_hosts = max_host
     act_key.unlimited_hosts = False
     with pytest.raises(HTTPError):
@@ -255,8 +252,9 @@ def test_negative_update_name(new_name, target_sat):
     act_key = target_sat.api.ActivationKey().create()
     with pytest.raises(HTTPError):
         target_sat.api.ActivationKey(
-            id=act_key.id, name=new_name, organization_id=act_key.organization_id
-        ).update(['name', 'organization_id'])
+            id=act_key.id, name=new_name, organization_id=act_key.organization_id).update(
+            ['name', 'organization_id']
+        )
     new_key = target_sat.api.ActivationKey(id=act_key.id).read()
     assert new_key.name != new_name
     assert new_key.name == act_key.name
@@ -276,8 +274,9 @@ def test_negative_update_max_hosts(target_sat):
     act_key = target_sat.api.ActivationKey(max_hosts=1).create()
     with pytest.raises(HTTPError):
         target_sat.api.ActivationKey(
-            id=act_key.id, max_hosts='foo', organization_id=act_key.organization_id
-        ).update(['max_hosts', 'organization_id'])
+            id=act_key.id, max_hosts='foo', organization_id=act_key.organization_id).update(
+            ['max_hosts', 'organization_id']
+        )
     assert act_key.read().max_hosts == 1
 
 
@@ -397,10 +396,9 @@ def test_positive_update_auto_attach(target_sat):
     """
     act_key = target_sat.api.ActivationKey().create()
     act_key_2 = target_sat.api.ActivationKey(
-        id=act_key.id,
-        auto_attach=(not act_key.auto_attach),
-        organization_id=act_key.organization_id,
-    ).update(['auto_attach', 'organization_id'])
+        id=act_key.id, auto_attach=(not act_key.auto_attach), organization_id=act_key.organization_id).update(
+        ['auto_attach', 'organization_id']
+    )
     assert act_key.auto_attach != act_key_2.auto_attach
 
 

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -17,6 +17,9 @@
 :Upstream: No
 """
 import pytest
+import time
+from requests.exceptions import HTTPError
+
 
 
 @pytest.mark.rhel_ver_match('[^6]')
@@ -47,3 +50,43 @@ def test_positive_custom_products_disabled_by_default(
     assert rhel_contenthost.subscribed
     product_details = rhel_contenthost.run('subscription-manager repos --list')
     assert 'Enabled:   0' in product_details.stdout
+
+
+def test_negative_invalid_repo_fails_publish(
+    module_repository,
+    module_org,
+    target_sat,
+):
+    """Verify that an invalid repository fails when trying to publish in a content view
+
+    :id: 64e03f28-8213-467a-a229-44c8cbfaaef1
+
+    :steps:
+        1. Create custom product and upload repository
+        2. Run Katello commands to make repository invalid
+        3. Create content view and add repository 
+        4. Verify Publish fails 
+
+    :expectedresults: Publishing a content view with an invalid repository fails
+
+    :customerscenario: true
+
+    :BZ: 2032040
+    """
+    repo = module_repository
+    with target_sat.session.shell() as sh:
+            sh.send('foreman-rake console')
+            time.sleep(30)  # sleep to allow time for console to open
+            sh.send(f'root = ::Katello::RootRepository.last')
+            time.sleep(3)  # give enough time for the command to complete
+            sh.send(f'::Katello::Resources::Candlepin::Product.remove_content(root.product.organization.label, root.product.cp_id, root.content_id)')
+            time.sleep(3)
+            sh.send(f'::Katello::Resources::Candlepin::Content.destroy(root.product.organization.label, root.content_id)') 
+            time.sleep(3)  
+    cv = target_sat.api.ContentView(
+        organization=module_org.name,
+        repository=[repo.id],
+    ).create()
+    with pytest.raises(HTTPError) as context:
+        cv.publish()
+    assert 'Remove the invalid repository before publishing again' in context.value.response.text

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -17,8 +17,6 @@
 :Upstream: No
 """
 import pytest
-import time
-from requests.exceptions import HTTPError
 
 
 
@@ -50,43 +48,3 @@ def test_positive_custom_products_disabled_by_default(
     assert rhel_contenthost.subscribed
     product_details = rhel_contenthost.run('subscription-manager repos --list')
     assert 'Enabled:   0' in product_details.stdout
-
-
-def test_negative_invalid_repo_fails_publish(
-    module_repository,
-    module_org,
-    target_sat,
-):
-    """Verify that an invalid repository fails when trying to publish in a content view
-
-    :id: 64e03f28-8213-467a-a229-44c8cbfaaef1
-
-    :steps:
-        1. Create custom product and upload repository
-        2. Run Katello commands to make repository invalid
-        3. Create content view and add repository 
-        4. Verify Publish fails 
-
-    :expectedresults: Publishing a content view with an invalid repository fails
-
-    :customerscenario: true
-
-    :BZ: 2032040
-    """
-    repo = module_repository
-    with target_sat.session.shell() as sh:
-            sh.send('foreman-rake console')
-            time.sleep(30)  # sleep to allow time for console to open
-            sh.send(f'root = ::Katello::RootRepository.last')
-            time.sleep(3)  # give enough time for the command to complete
-            sh.send(f'::Katello::Resources::Candlepin::Product.remove_content(root.product.organization.label, root.product.cp_id, root.content_id)')
-            time.sleep(3)
-            sh.send(f'::Katello::Resources::Candlepin::Content.destroy(root.product.organization.label, root.content_id)') 
-            time.sleep(3)  
-    cv = target_sat.api.ContentView(
-        organization=module_org.name,
-        repository=[repo.id],
-    ).create()
-    with pytest.raises(HTTPError) as context:
-        cv.publish()
-    assert 'Remove the invalid repository before publishing again' in context.value.response.text

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -19,7 +19,6 @@
 import pytest
 
 
-
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_custom_products_disabled_by_default(
     setup_content,


### PR DESCRIPTION
activation key .update() actions had missing parameters ```organization_id```. 

Updated all tests that call .update() and added ```organization_id``` into the ActivationKey entity