### PR TITLE
[6.14.z] Add Libvirt CR API e2e test and some refactor

### DIFF
--- a/pytest_fixtures/component/provision_libvirt.py
+++ b/pytest_fixtures/component/provision_libvirt.py
@@ -1,15 +1,14 @@
 # Compute resource - Libvirt entities
 import pytest
-from nailgun import entities
 
 
-@pytest.fixture(scope="module")
-def module_cr_libvirt(module_org, module_location):
-    return entities.LibvirtComputeResource(
+@pytest.fixture(scope='module')
+def module_cr_libvirt(module_target_sat, module_org, module_location):
+    return module_target_sat.api.LibvirtComputeResource(
         organization=[module_org], location=[module_location]
     ).create()
 
 
-@pytest.fixture(scope="module")
-def module_libvirt_image(module_cr_libvirt):
-    return entities.Image(compute_resource=module_cr_libvirt).create()
+@pytest.fixture(scope='module')
+def module_libvirt_image(module_target_sat, module_cr_libvirt):
+    return module_target_sat.api.Image(compute_resource=module_cr_libvirt).create()

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -58,7 +58,6 @@ FOREMAN_PROVIDERS = {
     'ec2': 'EC2',
     'vmware': 'VMware',
     'openstack': 'RHEL OpenStack Platform',
-    'rackspace': 'Rackspace',
     'google': 'Google',
     'azurerm': 'Azure Resource Manager',
 }

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -423,7 +423,6 @@ def test_positive_create_and_update_with_subnet(module_location, module_org, mod
 
 
 @pytest.mark.tier2
-@pytest.mark.on_premises_provisioning
 def test_positive_create_and_update_with_compresource(
     module_org, module_location, module_cr_libvirt
 ):
@@ -689,7 +688,6 @@ def test_positive_end_to_end_with_host_parameters(module_org, module_location):
 
 @pytest.mark.tier2
 @pytest.mark.e2e
-@pytest.mark.on_premises_provisioning
 def test_positive_end_to_end_with_image(
     module_org, module_location, module_cr_libvirt, module_libvirt_image
 ):
@@ -721,7 +719,6 @@ def test_positive_end_to_end_with_image(
 
 
 @pytest.mark.tier1
-@pytest.mark.on_premises_provisioning
 @pytest.mark.parametrize('method', ['build', 'image'])
 def test_positive_create_with_provision_method(
     method, module_org, module_location, module_cr_libvirt

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -223,7 +223,6 @@ def test_positive_create_with_all_users(session):
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_update_compresource(session):
     """Add/Remove compute resource from/to organization.


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12208

**Description:**
1. Add Libvirt CR API e2e test
2. Remove tests which are being covered in e2e test.
3. Merge test_positive_create_with_locs and test_positive_create_with_orgs into single test.
4. Use module_org, module_location fixtures and LIBVIRT_URL constant instead of setup fixture.
5. Remove unnecessary use of on_premises_provisioning marker from tests.