### PR TITLE
Pytest verifies and log-in into vault

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,18 +46,25 @@ jobs:
 
       - name: Collect Tests
         run: |
+          # To skip vault login in pull request checks
+          export VAULT_SECRET_ID_FOR_DYNACONF=somesecret
           pytest --collect-only --disable-pytest-warnings tests/foreman/ tests/robottelo/
           pytest --collect-only --disable-pytest-warnings -m pre_upgrade tests/upgrades/
           pytest --collect-only --disable-pytest-warnings -m post_upgrade tests/upgrades/
 
       - name: Collect Tests with xdist
         run: |
+          # To skip vault login in pull request checks
+          export VAULT_SECRET_ID_FOR_DYNACONF=somesecret
           pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 tests/foreman/ tests/robottelo/
           pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 -m pre_upgrade tests/upgrades/
           pytest --collect-only --setup-plan --disable-pytest-warnings -n 2 -m post_upgrade tests/upgrades/
 
       - name: Run Robottelo's Tests
-        run: pytest -sv tests/robottelo/
+        run: |
+          # To skip vault login in pull request checks
+          export VAULT_SECRET_ID_FOR_DYNACONF=somesecret
+          pytest -sv tests/robottelo/
 
       - name: Make Docs
         run: |

--- a/conftest.py
+++ b/conftest.py
@@ -1,7 +1,6 @@
 """Global Configurations for py.test runner"""
 import pytest
 
-
 pytest_plugins = [
     # Plugins
     'pytest_plugins.auto_vault',

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,10 @@
 """Global Configurations for py.test runner"""
 import pytest
 
+
 pytest_plugins = [
     # Plugins
+    'pytest_plugins.auto_vault',
     'pytest_plugins.disable_rp_params',
     'pytest_plugins.external_logging',
     'pytest_plugins.fixture_markers',

--- a/pytest_plugins/auto_vault.py
+++ b/pytest_plugins/auto_vault.py
@@ -1,20 +1,10 @@
 """Plugin enables pytest to notify and update the requirements"""
-import os
-import re
 import subprocess
-from pathlib import Path
-from robottelo.logging import robottelo_root_dir
+
+from robottelo.utils.vault import Vault
 
 
 def pytest_addoption(parser):
     """Options to allow user to update the requirements"""
-    envpath = robottelo_root_dir.joinpath('.env')
-    # check if this is being executed by a user and not automation/CI
-    if (
-        re.search(r'\s*#.*VAULT_SECRET_ID_FOR_DYNACONF', envpath.read_text())
-        and 'VAULT_SECRET_ID_FOR_DYNACONF' not in os.environ
-    ):
-        vstatus = subprocess.run("make vault-status", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).returncode
-        if vstatus != 0:
-            print('Vault token is expired, Browser opening to logging you in ...')
-            subprocess.run('make vault-login', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    vclient = Vault()
+    vclient.login(stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/pytest_plugins/auto_vault.py
+++ b/pytest_plugins/auto_vault.py
@@ -1,0 +1,20 @@
+"""Plugin enables pytest to notify and update the requirements"""
+import os
+import re
+import subprocess
+from pathlib import Path
+from robottelo.logging import robottelo_root_dir
+
+
+def pytest_addoption(parser):
+    """Options to allow user to update the requirements"""
+    envpath = robottelo_root_dir.joinpath('.env')
+    # check if this is being executed by a user and not automation/CI
+    if (
+        re.search(r'\s*#.*VAULT_SECRET_ID_FOR_DYNACONF', envpath.read_text())
+        and 'VAULT_SECRET_ID_FOR_DYNACONF' not in os.environ
+    ):
+        vstatus = subprocess.run("make vault-status", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE).returncode
+        if vstatus != 0:
+            print('Vault token is expired, Browser opening to logging you in ...')
+            subprocess.run('make vault-login', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/pytest_plugins/auto_vault.py
+++ b/pytest_plugins/auto_vault.py
@@ -6,5 +6,5 @@ from robottelo.utils.vault import Vault
 
 def pytest_addoption(parser):
     """Options to allow user to update the requirements"""
-    vclient = Vault()
-    vclient.login(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    with Vault() as vclient:
+        vclient.login(stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/robottelo/utils/__init__.py
+++ b/robottelo/utils/__init__.py
@@ -1,33 +1,11 @@
 # General utility functions which does not fit into other util modules OR
 # Independent utility functions that doesnt need separate module
 import base64
-import os
-from pathlib import Path
 import re
 
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-
-from robottelo.constants import Colored
-from robottelo.exceptions import InvalidVaultURLForOIDC
-
-
-def export_vault_env_vars(filename=None, envdata=None):
-    if not envdata:
-        envdata = Path(filename or '.env').read_text()
-    vaulturl = re.findall('VAULT_URL_FOR_DYNACONF=(.*)', envdata)[0]
-
-    # Vault CLI Env Var
-    os.environ['VAULT_ADDR'] = vaulturl
-
-    # Dynaconf Vault Env Vars
-    if re.findall('VAULT_ENABLED_FOR_DYNACONF=(.*)', envdata)[0] == 'true':
-        if 'localhost:8200' in vaulturl:
-            raise InvalidVaultURLForOIDC(
-                f"{Colored.REDDARK}{vaulturl} doesnt supports OIDC login,"
-                "please change url to corp vault in env file!"
-            )
 
 
 def gen_ssh_keypairs():

--- a/scripts/vault_login.py
+++ b/scripts/vault_login.py
@@ -4,7 +4,6 @@ import sys
 
 from robottelo.utils.vault import Vault
 
-
 if __name__ == '__main__':
     with Vault() as vclient:
         if sys.argv[-1] == '--login':

--- a/scripts/vault_login.py
+++ b/scripts/vault_login.py
@@ -1,85 +1,15 @@
 #!/usr/bin/env python
 # This Enables and Disables individuals OIDC token to access secrets from vault
-import json
-import os
-from pathlib import Path
-import re
-import subprocess
 import sys
 
-from robottelo.constants import Colored
-from robottelo.utils import export_vault_env_vars
-
-HELP_TEXT = (
-    "Vault CLI in not installed in your system, "
-    "refer link https://learn.hashicorp.com/tutorials/vault/getting-started-install to "
-    "install vault CLI as per your system spec!"
-)
-
-
-def _vault_command(command: str):
-    vcommand = subprocess.run(command, capture_output=True, shell=True)
-    if vcommand.returncode != 0:
-        verror = str(vcommand.stderr)
-        if vcommand.returncode == 127:
-            print(f"{Colored.REDDARK}Error! {HELP_TEXT}")
-            sys.exit(1)
-        elif 'Error revoking token' in verror:
-            print(f"{Colored.GREEN}Token is alredy revoked!")
-            sys.exit(0)
-        elif 'Error looking up token' in verror:
-            print(f"{Colored.YELLOW}Warning! Vault not logged in, please run 'make vault-login'!")
-            sys.exit(2)
-        else:
-            print(f"{Colored.REDDARK}Error! {verror}")
-            sys.exit(1)
-    return vcommand
-
-
-def _vault_login(root_path, envdata):
-    print(
-        f"{Colored.WHITELIGHT}Warning! The browser is about to open for vault OIDC login, "
-        "close the tab once the sign-in is done!"
-    )
-    if _vault_command(command="vault login -method=oidc").returncode == 0:
-        _vault_command(command="vault token renew -i 10h")
-        print(f"{Colored.GREEN}Success! Vault OIDC Logged-In and extended for 10 hours!")
-    # Fetching token
-    token = _vault_command("vault token lookup --format json").stdout
-    token = json.loads(str(token.decode('UTF-8')))['data']['id']
-    # Setting new token in env file
-    envdata = re.sub('.*VAULT_TOKEN_FOR_DYNACONF=.*', f"VAULT_TOKEN_FOR_DYNACONF={token}", envdata)
-    with open(root_path, 'w') as envfile:
-        envfile.write(envdata)
-    print(
-        f"{Colored.GREEN}Success! New OIDC token added to .env file to access secrets from vault!"
-    )
-
-
-def _vault_logout(root_path, envdata):
-    # Teardown - Setting dymmy token in env file
-    envdata = re.sub('.*VAULT_TOKEN_FOR_DYNACONF=.*', "# VAULT_TOKEN_FOR_DYNACONF=myroot", envdata)
-    with open(root_path, 'w') as envfile:
-        envfile.write(envdata)
-    _vault_command('vault token revoke -self')
-    print(f"{Colored.GREEN}Success! OIDC token removed from Env file successfully!")
-
-
-def _vault_status():
-    vstatus = _vault_command('vault token lookup')
-    if vstatus.returncode == 0:
-        print(str(vstatus.stdout.decode('UTF-8')))
+from robottelo.utils.vault import Vault
 
 
 if __name__ == '__main__':
-    root_path = Path('.env')
-    envdata = root_path.read_text()
-    export_vault_env_vars(envdata=envdata)
-    if sys.argv[-1] == '--login':
-        _vault_login(root_path, envdata)
-    elif sys.argv[-1] == '--status':
-        _vault_status()
-    else:
-        _vault_logout(root_path, envdata)
-    # Unsetting VAULT URL
-    del os.environ['VAULT_ADDR']
+    with Vault() as vclient:
+        if sys.argv[-1] == '--login':
+            vclient.login()
+        elif sys.argv[-1] == '--status':
+            vclient.status()
+        else:
+            vclient.logout()

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -25,9 +25,7 @@ from requests.exceptions import HTTPError
 from robottelo import constants
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import MIRRORING_POLICIES
-from robottelo.constants import REPOS
+from robottelo.constants import DEFAULT_ARCHITECTURE, MIRRORING_POLICIES, REPOS
 from robottelo.utils.datafactory import parametrized
 
 


### PR DESCRIPTION
Pytest session now verifies the vault session first.

- If the session expired, it takes you to login, and once logged in, it continues to the next step
- If the session is running, it just continues
- This only works for local execution and not in CI as CI has AppRole credentials directly!

Pytest STDOUT:
```
# pytest -s --collect-only tests/foreman/api/test_product.py
2023-09-11 14:02:28 - robottelo - WARNING - Warning! Vault not logged in!
2023-09-11 14:02:28 - robottelo - WARNING - Warning! The browser is about to open for vault OIDC login, close the tab once the sign-in is done!
2023-08-28 17:55:47 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    certs.cert_file is required in env main
2023-08-28 17:55:47 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    certs.cert_file is required in env main
=========== test session starts ==============
platform darwin -- Python 3.11.1, pytest-7.4.0, pluggy-1.0.0
Mandatory Requirements Mismatch: tenacity==8.2.3 dynaconf[vault]==3.2.1
Optional Requirements Mismatch: redis==5.0.0 sphinx==7.2.3
To update mismatched requirements, run the pytest command with '--upgrade-required-reqs' OR '--upgrade-all-reqs' option.
.
.
.
.
```