### PR TITLE
[6.13.z] Add Libvirt CR setup helper to fix UI E2E tests

### DIFF
--- a/robottelo/host_helpers/__init__.py
+++ b/robottelo/host_helpers/__init__.py
@@ -6,6 +6,7 @@ from robottelo.host_helpers.contenthost_mixins import VersionedContent
 from robottelo.host_helpers.satellite_mixins import ContentInfo
 from robottelo.host_helpers.satellite_mixins import EnablePluginsSatellite
 from robottelo.host_helpers.satellite_mixins import Factories
+from robottelo.host_helpers.satellite_mixins import ProvisioningSetup
 from robottelo.host_helpers.satellite_mixins import SystemInfo
 
 
@@ -17,5 +18,7 @@ class CapsuleMixins(CapsuleInfo, EnablePluginsCapsule):
     pass
 
 
-class SatelliteMixins(ContentInfo, Factories, SystemInfo, EnablePluginsSatellite):
+class SatelliteMixins(
+    ContentInfo, Factories, SystemInfo, EnablePluginsSatellite, ProvisioningSetup
+):
     pass

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -309,6 +309,33 @@ class SystemInfo:
         return result.stdout
 
 
+class ProvisioningSetup:
+    """Provisioning tests setup helper methods"""
+
+    def configure_libvirt_cr(self, server_fqdn=settings.libvirt.libvirt_hostname):
+        """Configures Libvirt ComputeResource to communicate with Satellite
+
+        :param server_fqdn: Libvirt server FQDN
+        :return: None
+        """
+        # Geneate SSH key-pair for foreman user and copy public key to libvirt server
+        self.execute('sudo -u foreman ssh-keygen -q -t rsa -f ~foreman/.ssh/id_rsa -N "" <<< y')
+        self.execute(f'ssh-keyscan -t ecdsa {server_fqdn} >> ~foreman/.ssh/known_hosts')
+        self.execute(
+            f'sshpass -p {settings.server.ssh_password} ssh-copy-id -o StrictHostKeyChecking=no '
+            f'-i ~foreman/.ssh/id_rsa root@{server_fqdn}'
+        )
+        # Install libvirt-client, and verify foreman user is able to communicate with Libvirt server
+        self.register_to_cdn()
+        self.execute('dnf -y --disableplugin=foreman-protector install libvirt-client')
+        assert (
+            self.execute(
+                f'su foreman -s /bin/bash -c "virsh -c qemu+ssh://root@{server_fqdn}/system list"'
+            ).status
+            == 0
+        )
+
+
 class Factories:
     """Mixin that provides attributes for each factory type"""
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12314

Libvirt CR creation doesn't requires this setup but after that while reading and updating compute_profile it fails to connect Libvirt, so for fixing this added a helper which can be used to setup this and will update a few more tests of host provisioning to use this helper in future PR.