### PR TITLE
Make old foreman task 32 days older

### DIFF
--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -399,12 +399,14 @@ def test_positive_health_check_old_foreman_tasks(sat_maintain):
 
     :expectedresults: check-old-foreman-tasks health check should pass.
     """
-    rake_command = 'foreman-rake console <<< '
-    find_task = '\'t = ForemanTasks::Task.where(state: "stopped").first;'
-    update_task = "t.started_at = t.started_at - 31.day;t.save(:validate => false)'"
     error_message = 'paused or stopped task(s) older than 30 days'
     delete_message = 'Deleted old tasks:'
-    sat_maintain.execute(rake_command + find_task + update_task)
+    rake_command = (
+        't = ForemanTasks::Task.where(state: "stopped").first;'
+        't.started_at = t.started_at - 32.day;'
+        't.save(:validate => false)'
+    )
+    sat_maintain.execute(f"foreman-rake console <<< '{rake_command}'")
     result = sat_maintain.cli.Health.check(
         options={'label': 'check-old-foreman-tasks', 'assumeyes': True}
     )


### PR DESCRIPTION
Making task 31 days older is not always enough.
We have to consider long running suites (18hrs+) 

Noticed when ` test_positive_health_check_old_foreman_tasks` test was running after midnight it couldnt find old task
```
2023-08-24 00:16:21 - gw1 - broker - DEBUG - satellite.example.com executing command: foreman-rake console <<< 't = ForemanTasks::Task.where(state: "stopped").first;t.started_at = t.started_at - 31.day;t.save(:validate => false)'
2023-08-24 00:16:40 - gw1 - broker - DEBUG - satellite.example.com command result:
    stdout:
    Loading production environment (Rails 6.1.7.3)
    Switch to inspect mode.
    t = ForemanTasks::Task.where(state: "stopped").first;t.started_at = t.started_at - 31.day;t.save(:validate => false)
    true
    
    stderr:
    (0, b'')
    status: 0
2023-08-24 00:16:40 - gw1 - broker - DEBUG - Constructing host using kwargs={'hostname': 'satellite.example.com', 'username': 'root', 'password': <PASS>, 'port': 22}
2023-08-24 00:16:40 - gw1 - broker - DEBUG - satellite.example.com executing command:  satellite-maintain health check --label="check-old-foreman-tasks" --assumeyes 
2023-08-24 00:16:41 - gw1 - broker - DEBUG - satellite.example.com command result:
    stdout:
    Running ForemanMaintain::Scenario::FilteredScenario
    ================================================================================
    Check for old tasks in paused/stopped state:                          [OK]
    --------------------------------------------------------------------------------
```