### PR TITLE
[6.14.z] Fix unreliable assertion

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -618,15 +618,15 @@ def test_positive_virt_card(
         assert virt_card['public_ip_address'] != ''
         assert virt_card['mac_address'] == module_vmware_settings['mac_address']
         assert virt_card['cpus'] == '1'
-        if virt_card['disk_label']:
+        if 'disk_label' in virt_card:
             assert virt_card['disk_label'] == 'Hard disk 1'
-        if virt_card['disk_capacity']:
+        if 'disk_capacity' in virt_card:
             assert virt_card['disk_capacity'] != ''
-        if virt_card['partition_capacity']:
+        if 'partition_capacity' in virt_card:
             assert virt_card['partition_capacity'] != ''
-        if virt_card['partition_path']:
+        if 'partition_path' in virt_card:
             assert virt_card['partition_path'] == '/boot'
-        if virt_card['partition_allocation']:
+        if 'partition_allocation' in virt_card:
             assert virt_card['partition_allocation'] != ''
         assert virt_card['cores_per_socket'] == '1'
         assert virt_card['firmware'] == 'bios'

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -618,11 +618,16 @@ def test_positive_virt_card(
         assert virt_card['public_ip_address'] != ''
         assert virt_card['mac_address'] == module_vmware_settings['mac_address']
         assert virt_card['cpus'] == '1'
-        assert virt_card['disk_label'] == 'Hard disk 1'
-        assert virt_card['disk_capacity'] != ''
-        assert virt_card['partition_capacity'] != ''
-        assert virt_card['partition_path'] == '/boot'
-        assert virt_card['partition_allocation'] != ''
+        if virt_card['disk_label']:
+            assert virt_card['disk_label'] == 'Hard disk 1'
+        if virt_card['disk_capacity']:
+            assert virt_card['disk_capacity'] != ''
+        if virt_card['partition_capacity']:
+            assert virt_card['partition_capacity'] != ''
+        if virt_card['partition_path']:
+            assert virt_card['partition_path'] == '/boot'
+        if virt_card['partition_allocation']:
+            assert virt_card['partition_allocation'] != ''
         assert virt_card['cores_per_socket'] == '1'
         assert virt_card['firmware'] == 'bios'
         assert virt_card['hypervisor'] != ''

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -593,18 +593,39 @@ def test_positive_virt_card(
             module_vmware_settings['vm_name'],
         )
         host_name = module_vmware_settings['vm_name'] + '.' + domain.name
-        virt_card = session.host_new.get_details(host_name, widget_names='details.virtualization')[
-            'details'
-        ]['virtualization']
+        power_status = session.computeresource.vm_status(cr_name, module_vmware_settings['vm_name'])
+        if power_status is False:
+            session.computeresource.vm_poweron(cr_name, module_vmware_settings['vm_name'])
+            try:
+                wait_for(
+                    lambda: (
+                        session.browser.refresh(),
+                        session.computeresource.vm_status(
+                            cr_name, module_vmware_settings['vm_name']
+                        ),
+                    )[1]
+                    is not power_status,
+                    timeout=30,
+                    delay=2,
+                )
+            except TimedOutError:
+                raise AssertionError('Timed out waiting for VM to toggle power state')
+
+        virt_card = session.host_new.get_virtualization(host_name)['details']
         assert virt_card['datacenter'] == module_vmware_settings['datacenter']
         assert virt_card['cluster'] == module_vmware_settings['cluster']
         assert virt_card['memory'] == '2 GB'
-        assert virt_card['public_ip_address']
+        assert virt_card['public_ip_address'] != ''
         assert virt_card['mac_address'] == module_vmware_settings['mac_address']
         assert virt_card['cpus'] == '1'
+        assert virt_card['disk_label'] == 'Hard disk 1'
+        assert virt_card['disk_capacity'] != ''
+        assert virt_card['partition_capacity'] != ''
+        assert virt_card['partition_path'] == '/boot'
+        assert virt_card['partition_allocation'] != ''
         assert virt_card['cores_per_socket'] == '1'
         assert virt_card['firmware'] == 'bios'
-        assert virt_card['hypervisor'] == module_vmware_settings['hypervisor']
+        assert virt_card['hypervisor'] != ''
         assert virt_card['connection_state'] == 'connected'
         assert virt_card['overall_status'] == 'green'
         assert virt_card['annotation_notes'] == ''


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12176

This simply removes an assert from the test. This portion of the virtualization card doesn't reliably appear on the card, and can cause this test to be flaky. 