### PR TITLE
[6.13.z] Fix setting_update fixture to handle None value

### DIFF
--- a/pytest_fixtures/component/settings.py
+++ b/pytest_fixtures/component/settings.py
@@ -12,7 +12,7 @@ def setting_update(request, target_sat):
     key_val = request.param
     setting, new_value = tuple(key_val.split('=')) if '=' in key_val else (key_val, None)
     setting_object = target_sat.api.Setting().search(query={'search': f'name={setting}'})[0]
-    default_setting_value = setting_object.value
+    default_setting_value = '' if setting_object.value is None else setting_object.value
     if new_value is not None:
         setting_object.value = new_value
         setting_object.update({'value'})

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -214,7 +214,6 @@ def test_set_default_http_proxy(module_org, module_location, setting_update, tar
 
     :CaseLevel: Acceptance
     """
-
     property_name = setting_update.name
 
     http_proxy_a = target_sat.api.HTTPProxy(
@@ -225,6 +224,8 @@ def test_set_default_http_proxy(module_org, module_location, setting_update, tar
     ).create()
 
     with target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
         session.settings.update(
             f'name = {property_name}', f'{http_proxy_a.name} ({http_proxy_a.url})'
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12414

setting_update fixtures fails to update the default None value, and this was previously handled, but is now broken due to my earlier PR https://github.com/SatelliteQE/robottelo/pull/11737