### PR TITLE
[6.14.z] Just check for presence of IP address

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -615,7 +615,7 @@ def test_positive_virt_card(
         assert virt_card['datacenter'] == module_vmware_settings['datacenter']
         assert virt_card['cluster'] == module_vmware_settings['cluster']
         assert virt_card['memory'] == '2 GB'
-        assert virt_card['public_ip_address'] != ''
+        assert 'public_ip_address' in virt_card
         assert virt_card['mac_address'] == module_vmware_settings['mac_address']
         assert virt_card['cpus'] == '1'
         if 'disk_label' in virt_card:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12415

Good grief. Seems that IP address still has a chance to be empty, so I'm just checking that it's a field at all. Please dear lord let this be the last PR to address this dumb card. 