### PR TITLE
[Repository Rewrite] Sync multiple large repositories

### DIFF
--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -25,7 +25,9 @@ from requests.exceptions import HTTPError
 from robottelo import constants
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
+from robottelo.constants import DEFAULT_ARCHITECTURE
 from robottelo.constants import MIRRORING_POLICIES
+from robottelo.constants import REPOS
 from robottelo.utils.datafactory import parametrized
 
 
@@ -243,3 +245,53 @@ def test_positive_multiple_orgs_with_same_repo(target_sat):
         repo_counts = target_sat.api.Repository(id=repo.id).read().content_counts
         repos.append(repo_counts)
     assert repos[0] == repos[1] == repos[2]
+
+
+def test_positive_sync_mulitple_large_repos(module_target_sat, module_entitlement_manifest_org):
+    """Enable and bulk sync multiple large repositories
+
+    :id: b51c4a3d-d532-4342-be61-e868f7c3a723
+
+    :Steps:
+        1. Enabled multiple large Repositories
+                Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs 8
+                Red Hat Enterprise Linux 8 for x86_64 - BaseOS RPMs 8
+                Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart 8.7
+                Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8.7
+        2. Sync all four repositories at the same time
+        3. Assert that the bulk sync succeeds
+
+    :customerscenario: true
+
+    :expectedresults: All repositories should sync with no errors
+
+    :BZ: 2224031
+    """
+    repo_names = ['rhel8_bos', 'rhel8_aps']
+    kickstart_names = ['rhel8_bos', 'rhel8_aps']
+    for name in repo_names:
+        rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
+            basearch=DEFAULT_ARCHITECTURE,
+            org_id=module_entitlement_manifest_org.id,
+            product=REPOS[name]['product'],
+            repo=REPOS[name]['name'],
+            reposet=REPOS[name]['reposet'],
+            releasever=REPOS[name]['releasever'],
+        )
+
+    for name in kickstart_names:
+        rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
+            basearch=constants.DEFAULT_ARCHITECTURE,
+            org_id=module_entitlement_manifest_org.id,
+            product=constants.REPOS['kickstart'][name]['product'],
+            repo=constants.REPOS['kickstart'][name]['name'],
+            reposet=constants.REPOS['kickstart'][name]['reposet'],
+            releasever=constants.REPOS['kickstart'][name]['version'],
+        )
+    rh_repos = entities.Repository(id=rh_repo_id).read()
+    rh_products = entities.Product(id=rh_repos.product.id).read()
+    assert len(rh_products.repository) == 4
+    res = module_target_sat.api.ProductBulkAction().sync(
+        data={'ids': [rh_products.id]}, timeout=2000
+    )
+    assert res['result'] == 'success'

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -256,12 +256,10 @@ def test_positive_sync_mulitple_large_repos(module_target_sat, module_entitlemen
         1. Enabled multiple large Repositories
                 Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs 8
                 Red Hat Enterprise Linux 8 for x86_64 - BaseOS RPMs 8
-                Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart 8.7
-                Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8.7
+                Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart 8
+                Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8
         2. Sync all four repositories at the same time
         3. Assert that the bulk sync succeeds
-
-    :customerscenario: true
 
     :expectedresults: All repositories should sync with no errors
 
@@ -288,8 +286,8 @@ def test_positive_sync_mulitple_large_repos(module_target_sat, module_entitlemen
             reposet=constants.REPOS['kickstart'][name]['reposet'],
             releasever=constants.REPOS['kickstart'][name]['version'],
         )
-    rh_repos = entities.Repository(id=rh_repo_id).read()
-    rh_products = entities.Product(id=rh_repos.product.id).read()
+    rh_repos = module_target_sat.api.Repository(id=rh_repo_id).read()
+    rh_products = module_target_sat.api.Product(id=rh_repos.product.id).read()
     assert len(rh_products.repository) == 4
     res = module_target_sat.api.ProductBulkAction().sync(
         data={'ids': [rh_products.id]}, timeout=2000

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -17,6 +17,9 @@
 :Upstream: No
 """
 import pytest
+import time
+from requests.exceptions import HTTPError
+
 
 
 @pytest.mark.rhel_ver_match('[^6]')
@@ -47,3 +50,43 @@ def test_positive_custom_products_disabled_by_default(
     assert rhel_contenthost.subscribed
     product_details = rhel_contenthost.run('subscription-manager repos --list')
     assert 'Enabled:   0' in product_details.stdout
+
+
+def test_negative_invalid_repo_fails_publish(
+    module_repository,
+    module_org,
+    target_sat,
+):
+    """Verify that an invalid repository fails when trying to publish in a content view
+
+    :id: 64e03f28-8213-467a-a229-44c8cbfaaef1
+
+    :steps:
+        1. Create custom product and upload repository
+        2. Run Katello commands to make repository invalid
+        3. Create content view and add repository 
+        4. Verify Publish fails 
+
+    :expectedresults: Publishing a content view with an invalid repository fails
+
+    :customerscenario: true
+
+    :BZ: 2032040
+    """
+    repo = module_repository
+    with target_sat.session.shell() as sh:
+            sh.send('foreman-rake console')
+            time.sleep(30)  # sleep to allow time for console to open
+            sh.send(f'root = ::Katello::RootRepository.last')
+            time.sleep(3)  # give enough time for the command to complete
+            sh.send(f'::Katello::Resources::Candlepin::Product.remove_content(root.product.organization.label, root.product.cp_id, root.content_id)')
+            time.sleep(3)
+            sh.send(f'::Katello::Resources::Candlepin::Content.destroy(root.product.organization.label, root.content_id)') 
+            time.sleep(3)  
+    cv = target_sat.api.ContentView(
+        organization=module_org.name,
+        repository=[repo.id],
+    ).create()
+    with pytest.raises(HTTPError) as context:
+        cv.publish()
+    assert 'Remove the invalid repository before publishing again' in context.value.response.text

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -17,9 +17,6 @@
 :Upstream: No
 """
 import pytest
-import time
-from requests.exceptions import HTTPError
-
 
 
 @pytest.mark.rhel_ver_match('[^6]')
@@ -50,43 +47,3 @@ def test_positive_custom_products_disabled_by_default(
     assert rhel_contenthost.subscribed
     product_details = rhel_contenthost.run('subscription-manager repos --list')
     assert 'Enabled:   0' in product_details.stdout
-
-
-def test_negative_invalid_repo_fails_publish(
-    module_repository,
-    module_org,
-    target_sat,
-):
-    """Verify that an invalid repository fails when trying to publish in a content view
-
-    :id: 64e03f28-8213-467a-a229-44c8cbfaaef1
-
-    :steps:
-        1. Create custom product and upload repository
-        2. Run Katello commands to make repository invalid
-        3. Create content view and add repository 
-        4. Verify Publish fails 
-
-    :expectedresults: Publishing a content view with an invalid repository fails
-
-    :customerscenario: true
-
-    :BZ: 2032040
-    """
-    repo = module_repository
-    with target_sat.session.shell() as sh:
-            sh.send('foreman-rake console')
-            time.sleep(30)  # sleep to allow time for console to open
-            sh.send(f'root = ::Katello::RootRepository.last')
-            time.sleep(3)  # give enough time for the command to complete
-            sh.send(f'::Katello::Resources::Candlepin::Product.remove_content(root.product.organization.label, root.product.cp_id, root.content_id)')
-            time.sleep(3)
-            sh.send(f'::Katello::Resources::Candlepin::Content.destroy(root.product.organization.label, root.content_id)') 
-            time.sleep(3)  
-    cv = target_sat.api.ContentView(
-        organization=module_org.name,
-        repository=[repo.id],
-    ).create()
-    with pytest.raises(HTTPError) as context:
-        cv.publish()
-    assert 'Remove the invalid repository before publishing again' in context.value.response.text


### PR DESCRIPTION
Test for syncing multiple large repositories

This is a part of the Repository Rewrite efforts. Also covers a custom case 2224031

Steps:

Enabling and syncing the following repos succeeds with no errors

Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs 8

Red Hat Enterprise Linux 8 for x86_64 - BaseOS RPMs 8

Red Hat Enterprise Linux 8 for x86_64 - AppStream Kickstart 8.7

Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8.7
