### PR TITLE
[6.14.z] Log end of test phases and broker host setup and teardown

### DIFF
--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -73,5 +73,7 @@ def pytest_runtest_logstart(nodeid, location):
     logger.info(f'Started Test: {nodeid}')
 
 
-def pytest_runtest_logfinish(nodeid, location):
-    logger.info(f'Finished Test: {nodeid}')
+def pytest_runtest_logreport(report):
+    """Process the TestReport produced for each of the setup,
+    call and teardown runtest phases of an item."""
+    logger.info('Finished %s for test: %s, result: %s', report.when, report.nodeid, report.outcome)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -372,14 +372,20 @@ class ContentHost(Host, ContentHostMixins):
                 del self.__dict__[name]
 
     def setup(self):
+        logger.debug('START: setting up host %s', self)
         if not self.blank:
             self.remove_katello_ca()
 
+        logger.debug('END: setting up host %s', self)
+
     def teardown(self):
+        logger.debug('START: tearing down host %s', self)
         if not self.blank and not getattr(self, '_skip_context_checkin', False):
             self.unregister()
             if type(self) is not Satellite and self.nailgun_host:
                 self.nailgun_host.delete()
+
+        logger.debug('END: tearing down host %s', self)
 
     def power_control(self, state=VmState.RUNNING, ensure=True):
         """Lookup the host workflow for power on and execute


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12472

## Problem statement
* There is no way to distinguish between the start and end of individual test phases (setup, call, teardown) in our logs
* There is no feasible way to tell which test failed if the test suite is still running
* There is no contextual message informing the log reader about broker host `setup` and `teardown` being executed

## Solution
* Use the `pytest_runtest_logreport` hook to log the result of each phase.
* Add logging to setup and teardown to improve context awareness of our logs - fixes #12438.

## RoI
This functionality increases context awareness for those who read logs.


## Notes
* pytest documentation: https://docs.pytest.org/en/latest/reference/reference.html#pytest.hookspec.pytest_runtest_logreport