### PR TITLE
[6.13.z] Fix foreman-maintain tests failing because of automation issues

### DIFF
--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -8,6 +8,8 @@ from robottelo.config import settings
 from robottelo.constants import SATELLITE_MAINTAIN_YML
 from robottelo.hosts import Capsule
 from robottelo.hosts import Satellite
+from robottelo.hosts import SatelliteHostError
+from robottelo.logging import logger
 
 synced_repos = pytest.StashKey[dict]
 
@@ -21,14 +23,25 @@ def module_stash(request):
     yield request.node.stash
 
 
-@pytest.fixture(scope='session')
-def sat_maintain(request, session_target_sat, session_capsule_configured):
+@pytest.fixture(scope='module')
+def sat_maintain(request, module_target_sat, module_capsule_configured):
     if settings.remotedb.server:
         yield Satellite(settings.remotedb.server)
     else:
-        session_target_sat.register_to_cdn(pool_ids=settings.subscription.fm_rhn_poolid.split())
-        hosts = {'satellite': session_target_sat, 'capsule': session_capsule_configured}
+        module_target_sat.register_to_cdn(pool_ids=settings.subscription.fm_rhn_poolid.split())
+        hosts = {'satellite': module_target_sat, 'capsule': module_capsule_configured}
         yield hosts[request.param]
+
+
+@pytest.fixture
+def start_satellite_services(sat_maintain):
+    """Teardown for satellite-maintain tests to ensure that all Satellite services are started"""
+    yield
+    logger.info('Ensuring that all %s services are running', sat_maintain.__class__.__name__)
+    result = sat_maintain.cli.Service.start()
+    if result.status != 0:
+        logger.error('Unable to start all %s services', sat_maintain.__class__.__name__)
+        raise SatelliteHostError('Failed to start Satellite services')
 
 
 @pytest.fixture
@@ -42,9 +55,7 @@ def setup_backup_tests(request, sat_maintain):
 
 
 @pytest.fixture(scope='module')
-def module_synced_repos(
-    sat_maintain, session_capsule_configured, module_sca_manifest, module_stash
-):
+def module_synced_repos(sat_maintain, module_capsule_configured, module_sca_manifest, module_stash):
     if not module_stash[synced_repos]:
         org = sat_maintain.satellite.api.Organization().create()
         sat_maintain.satellite.upload_manifest(org.id, module_sca_manifest.content)
@@ -80,13 +91,13 @@ def module_synced_repos(
         lce = sat_maintain.satellite.api.LifecycleEnvironment(
             organization=module_stash[synced_repos]['org']
         ).search(query={'search': f'name={constants.ENVIRONMENT}'})[0]
-        session_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
+        module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
             data={'environment_id': lce.id}
         )
-        result = session_capsule_configured.nailgun_capsule.content_lifecycle_environments()
+        result = module_capsule_configured.nailgun_capsule.content_lifecycle_environments()
         assert lce.id in [capsule_lce['id'] for capsule_lce in result['results']]
         # sync the Capsule
-        sync_status = session_capsule_configured.nailgun_capsule.content_sync()
+        sync_status = module_capsule_configured.nailgun_capsule.content_sync()
         assert sync_status['result'] == 'success'
 
     yield {

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -18,6 +18,7 @@ class Colored(Box):
 # This should be updated after each version branch
 SATELLITE_VERSION = "6.13"
 SATELLITE_OS_VERSION = "8"
+SAT_NON_GA_VERSIONS = ['6.14', '6.15']
 
 # Default system ports
 HTTPS_PORT = '443'

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -65,7 +65,7 @@ class VersionedContent:
             'cbrhel': constants.OSCAP_PROFILE[f'cbrhel{self._v_major}'],
         }
 
-    def _dogfood_helper(self, product, release, snap, repo=None):
+    def _dogfood_helper(self, product, release, repo=None):
         """Function to return repository related attributes
         based on the input and the host object
         """
@@ -89,18 +89,17 @@ class VersionedContent:
                 'or the version of the Satellite object. '
                 f'settings: {settings_release}, parameter: {release}'
             )
-        snap = str(snap or settings.server.version.get("snap"))
-        return product, release, snap, v_major, repo
+        return product, release, v_major, repo
 
     def download_repofile(self, product=None, release=None, snap=''):
         """Downloads the tools/client, capsule, or satellite repos on the machine"""
-        product, release, snap, v_major, _ = self._dogfood_helper(product, release, snap)
+        product, release, v_major, _ = self._dogfood_helper(product, release)
         url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap)
         self.execute(f'curl -o /etc/yum.repos.d/dogfood.repo -L {url}')
 
     def dogfood_repository(self, repo=None, product=None, release=None, snap=''):
         """Returns a repository definition based on the arguments provided"""
-        product, release, snap, v_major, repo = self._dogfood_helper(product, release, snap, repo)
+        product, release, v_major, repo = self._dogfood_helper(product, release, repo)
         return dogfood_repository(settings.ohsnap, repo, product, release, v_major, snap, self.arch)
 
     def enable_tools_repo(self, organization_id):

--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -22,67 +22,26 @@ import yaml
 from robottelo.config import robottelo_tmp_dir
 from robottelo.config import settings
 from robottelo.constants import MAINTAIN_HAMMER_YML
+from robottelo.constants import SAT_NON_GA_VERSIONS
+from robottelo.hosts import get_sat_rhel_version
+from robottelo.hosts import get_sat_version
 
-pytestmark = pytest.mark.destructive
+
+sat_x_y_release = f'{get_sat_version().major}.{get_sat_version().minor}'
 
 
-# Common repositories for Satellite and Capsule
-common_repos = ['rhel-8-for-x86_64-baseos-rpms', 'rhel-8-for-x86_64-appstream-rpms']
-
-# Satellite repositories
-sat_611_repos = [
-    'satellite-6.11-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-6.11-for-rhel-8-x86_64-rpms',
-] + common_repos
-
-sat_612_repos = [
-    'satellite-6.12-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-6.12-for-rhel-8-x86_64-rpms',
-] + common_repos
-
-sat_613_repos = [
-    'satellite-6.13-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-6.13-for-rhel-8-x86_64-rpms',
-] + common_repos
-
-sat_614_repos = [
-    'satellite-6.14-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-6.14-for-rhel-8-x86_64-rpms',
-] + common_repos
-
-# Capsule repositories
-cap_611_repos = [
-    'satellite-capsule-6.11-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-6.11-for-rhel-8-x86_64-rpms',
-] + common_repos
-
-cap_612_repos = [
-    'satellite-capsule-6.12-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-6.12-for-rhel-8-x86_64-rpms',
-] + common_repos
-
-cap_613_repos = [
-    'satellite-capsule-6.13-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-6.13-for-rhel-8-x86_64-rpms',
-] + common_repos
-
-cap_614_repos = [
-    'satellite-capsule-6.14-for-rhel-8-x86_64-rpms',
-    'satellite-maintenance-6.14-for-rhel-8-x86_64-rpms',
-] + common_repos
-
-sat_repos = {
-    '6.11': sat_611_repos,
-    '6.12': sat_612_repos,
-    '6.13': sat_613_repos,
-    '6.14': sat_614_repos,
-}
-cap_repos = {
-    '6.11': cap_611_repos,
-    '6.12': cap_612_repos,
-    '6.13': cap_613_repos,
-    '6.14': cap_614_repos,
-}
+def get_satellite_capsule_repos(
+    x_y_release=sat_x_y_release, product='satellite', os_major_ver=get_sat_rhel_version().major
+):
+    if product == 'capsule':
+        product = 'satellite-capsule'
+    repos = [
+        f'{product}-{x_y_release}-for-rhel-{os_major_ver}-x86_64-rpms',
+        f'satellite-maintenance-{x_y_release}-for-rhel-{os_major_ver}-x86_64-rpms',
+        f'rhel-{os_major_ver}-for-x86_64-baseos-rpms',
+        f'rhel-{os_major_ver}-for-x86_64-appstream-rpms',
+    ]
+    return repos
 
 
 def test_positive_advanced_run_service_restart(sat_maintain):
@@ -299,7 +258,7 @@ def test_positive_sync_plan_with_hammer_defaults(request, sat_maintain, module_o
 
     :customerscenario: true
     """
-    sat_maintain.cli.Defaults.add({'param-name': 'organization_id', 'param-value': 1})
+    sat_maintain.cli.Defaults.add({'param-name': 'organization_id', 'param-value': module_org.id})
 
     sync_plans = []
     for name in ['plan1', 'plan2']:
@@ -321,6 +280,11 @@ def test_positive_sync_plan_with_hammer_defaults(request, sat_maintain, module_o
     def _finalize():
         sat_maintain.cli.Defaults.delete({'param-name': 'organization_id'})
         sync_plans[1].delete()
+        sync_plan = sat_maintain.api.SyncPlan(organization=module_org.id).search(
+            query={'search': f'name="{sync_plans[0]}"'}
+        )
+        if sync_plan:
+            sync_plans[0].delete()
 
 
 @pytest.mark.e2e
@@ -336,21 +300,21 @@ def test_positive_satellite_repositories_setup(sat_maintain):
 
     :expectedresults: Required Satellite repositories for install/upgrade should get enabled
     """
-    supported_versions = ['6.11', '6.12', '6.13']
-    for ver in supported_versions:
-        result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': ver})
+    sat_version = ".".join(sat_maintain.version.split('.')[0:2])
+    result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': sat_version})
+    if sat_version not in SAT_NON_GA_VERSIONS:
         assert result.status == 0
         assert 'FAIL' not in result.stdout
         result = sat_maintain.execute('yum repolist')
-        for repo in sat_repos[ver]:
+        for repo in get_satellite_capsule_repos(sat_version):
             assert repo in result.stdout
 
-    # 6.14 till not GA
-    result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': '6.14'})
-    assert result.status == 1
-    assert 'FAIL' in result.stdout
-    for repo in sat_repos['6.14']:
-        assert repo in result.stdout
+    # for non-ga versions
+    else:
+        assert result.status == 1
+        assert 'FAIL' in result.stdout
+        for repo in get_satellite_capsule_repos(sat_version):
+            assert repo in result.stdout
 
 
 @pytest.mark.e2e
@@ -369,36 +333,17 @@ def test_positive_capsule_repositories_setup(sat_maintain):
 
     :expectedresults: Required Capsule repositories should get enabled
     """
-    supported_versions = ['6.11', '6.12']
-    for ver in supported_versions:
-        result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': ver})
+    sat_version = ".".join(sat_maintain.version.split('.')[0:2])
+    result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': sat_version})
+    if sat_version not in SAT_NON_GA_VERSIONS:
         assert result.status == 0
         assert 'FAIL' not in result.stdout
         result = sat_maintain.execute('yum repolist')
-        for repo in cap_repos[ver]:
+        for repo in get_satellite_capsule_repos(sat_version, 'capsule'):
             assert repo in result.stdout
-
-    # 6.13 till not GA
-    result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': '6.13'})
-    assert result.status == 1
-    assert 'FAIL' in result.stdout
-    for repo in cap_repos['6.13']:
-        assert repo in result.stdout
-
-    # Verify that all required beta repositories gets enabled
-    # maintain beta repo is unavailable for EL8 https://bugzilla.redhat.com/show_bug.cgi?id=2106750
-    cap_beta_repo = common_repos
-    missing_beta_el8_repos = [
-        'satellite-capsule-6-beta-for-rhel-8-x86_64-rpms',
-        'satellite-maintenance-6-beta-for-rhel-8-x86_64-rpms',
-    ]
-    result = sat_maintain.cli.Advanced.run_repositories_setup(
-        options={'version': '6.12'}, env_var='FOREMAN_MAINTAIN_USE_BETA=1'
-    )
-    assert result.status != 0
-    assert 'FAIL' in result.stdout
-    for repo in missing_beta_el8_repos:
-        assert f"Error: '{repo}' does not match a valid repository ID" in result.stdout
-    result = sat_maintain.execute('yum repolist')
-    for repo in cap_beta_repo:
-        assert repo in result.stdout
+    # for non-ga versions
+    else:
+        assert result.status == 1
+        assert 'FAIL' in result.stdout
+        for repo in get_satellite_capsule_repos(sat_version, 'capsule'):
+            assert repo in result.stdout

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -165,7 +165,8 @@ def test_positive_health_check_server_ping(sat_maintain):
     assert 'FAIL' not in result.stdout
 
 
-def test_health_check_server_ping(sat_maintain, request):
+@pytest.mark.usefixtures('start_satellite_services')
+def test_health_check_server_ping(sat_maintain):
     """Verify health check server-ping
 
     :id: ecdc5bfb-2adf-49f6-948d-995dae34bcd3
@@ -184,10 +185,6 @@ def test_health_check_server_ping(sat_maintain, request):
     result = sat_maintain.cli.Health.check(options={'label': 'server-ping', 'assumeyes': True})
     assert result.status == 0
     assert 'FAIL' in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        assert sat_maintain.cli.Service.start().status == 0
 
 
 @pytest.mark.include_capsule
@@ -225,7 +222,6 @@ def test_negative_health_check_upstream_repository(sat_maintain, request):
         sat_maintain.execute('dnf clean all')
 
 
-@pytest.mark.include_capsule
 def test_positive_health_check_available_space(sat_maintain):
     """Verify available-space check
 

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -21,8 +21,6 @@ import yaml
 
 from robottelo.config import robottelo_tmp_dir
 
-pytestmark = pytest.mark.destructive
-
 
 @pytest.mark.e2e
 @pytest.mark.tier2

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -26,8 +26,6 @@ from robottelo.constants import SATELLITE_ANSWER_FILE
 from robottelo.hosts import Satellite
 from robottelo.utils.issue_handlers import is_open
 
-pytestmark = pytest.mark.destructive
-
 SATELLITE_SERVICES = [
     "dynflow-sidekiq@.service",
     "foreman-proxy.service",
@@ -95,6 +93,7 @@ def test_positive_service_list(sat_maintain):
 
 
 @pytest.mark.include_capsule
+@pytest.mark.usefixtures('start_satellite_services')
 def test_positive_service_stop_start(sat_maintain):
     """Start/Stop services using satellite-maintain service subcommand
 
@@ -125,6 +124,7 @@ def test_positive_service_stop_start(sat_maintain):
 
 
 @pytest.mark.include_capsule
+@pytest.mark.usefixtures('start_satellite_services')
 def test_positive_service_stop_restart(sat_maintain):
     """Disable services using satellite-maintain service
 
@@ -157,6 +157,7 @@ def test_positive_service_stop_restart(sat_maintain):
 
 
 @pytest.mark.include_capsule
+@pytest.mark.usefixtures('start_satellite_services')
 def test_positive_service_enable_disable(sat_maintain):
     """Enable/Disable services using satellite-maintain service subcommand
 
@@ -179,7 +180,8 @@ def test_positive_service_enable_disable(sat_maintain):
     assert result.status == 0
 
 
-def test_positive_foreman_service(request, sat_maintain):
+@pytest.mark.usefixtures('start_satellite_services')
+def test_positive_foreman_service(sat_maintain):
     """Validate httpd service should work as expected even stopping of the foreman service
 
     :id: 08a29ea2-2e49-11eb-a22b-d46d6dd3b5b2
@@ -200,10 +202,7 @@ def test_positive_foreman_service(request, sat_maintain):
     result = sat_maintain.cli.Health.check(options={'assumeyes': True})
     assert result.status == 0
     assert 'foreman' in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        assert sat_maintain.cli.Service.start(options={'only': 'foreman'}).status == 0
+    assert sat_maintain.cli.Service.start(options={'only': 'foreman'}).status == 0
 
 
 @pytest.mark.include_capsule

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -19,8 +19,7 @@
 import pytest
 
 from robottelo.config import settings
-
-pytestmark = pytest.mark.destructive
+from robottelo.constants import SATELLITE_VERSION
 
 
 def last_y_stream_version(release):
@@ -66,6 +65,10 @@ def test_positive_satellite_maintain_upgrade_list(sat_maintain):
 
 
 @pytest.mark.include_capsule
+@pytest.mark.skipif(
+    (settings.server.version.release == 'stream'),
+    reason='Upgrade path is not available for stream yet',
+)
 def test_positive_repositories_validate(sat_maintain):
     """Test repositories-validate pre-upgrade check is
      skipped when system is subscribed using custom activationkey.
@@ -106,6 +109,10 @@ def test_positive_repositories_validate(sat_maintain):
     ids=['default', 'medium'],
     indirect=True,
 )
+@pytest.mark.skipif(
+    (settings.server.version.release == 'stream'),
+    reason='Upgrade path is not available for stream yet',
+)
 def test_negative_pre_upgrade_tuning_profile_check(request, custom_host):
     """Negative test that verifies a satellite with less than
     tuning profile hardware requirements fails on pre-upgrade check.
@@ -124,7 +131,9 @@ def test_negative_pre_upgrade_tuning_profile_check(request, custom_host):
     # Register to CDN for RHEL8 repos, download and enable last y stream's ohsnap repos,
     # and enable the satellite module and install it on the host
     custom_host.register_to_cdn()
-    last_y_stream = last_y_stream_version(settings.server.version.release)
+    last_y_stream = last_y_stream_version(
+        SATELLITE_VERSION if sat_version == 'stream' else sat_version
+    )
     custom_host.download_repofile(product='satellite', release=last_y_stream)
     custom_host.execute('dnf -y module enable satellite:el8 && dnf -y install satellite')
     # Install without system checks to get around installer checks


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12440

This PR:

- removes destructive marker as it doesn't work as expected with tests using module or session scoped fixtures.
- converts`sat_maintain` to module scoped fixture.
- Adds `start_satellite_services` teardown fixture, which will be used by tests that stop/disable Satellite services.
- updates `test_positive_capsule_repositories_setup` to support 6.14 and stream.
- removes `include_capsule` marker from `test_positive_health_check_available_space` as capsule doesn't have `available-space-cp` check.
- fixes `test_positive_sync_plan_with_hammer_defaults`
- updates `test_positive_satellite_repositories_setup` and `test_positive_satellite_repositories_setup` to test only one sat version.
- fixes `test_negative_pre_upgrade_tuning_profile_check` for stream.
- Update `_dogfood_helper` to not assume snap number.
- adds `get_satellite_capsule_repos` and removes hardcoded sat/cap repos constants.