### PR TITLE
[6.14.z] Refactor tests/foreman/ui/test_rhcloud_inventory.py

### DIFF
--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -157,34 +157,6 @@ def test_rhcloud_inventory_api_hosts_synchronization(
     # To Do: Add support in Nailgun to get Insights and Inventory host properties.
 
 
-@pytest.mark.stubbed
-def test_rhcloud_inventory_mtu_field():
-    """Verify that the hosts having mtu field value as string in foreman's Nic object
-    is present in the inventory report.
-
-    :id: df6d5f4f-5ee1-4f34-bf24-b93fbd089322
-
-    :customerscenario: true
-
-    :Steps:
-        1. Register a content host.
-        2. If value of mtu field is not a string then use foreman-rake to change it.
-        3. Generate inventory report.
-        4. Assert that host is listed in the inventory report.
-        5. Assert that value of mtu field in generated report is a number.
-
-    :CaseImportance: Medium
-
-    :expectedresults:
-        1. Host having string mtu field value is present in the inventory report.
-        2. Value of mtu field in generated inventory report is a number.
-
-    :BZ: 1893439
-
-    :CaseAutomation: ManualOnly
-    """
-
-
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 def test_system_purpose_sla_field(

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -78,7 +78,7 @@ def test_rhcloud_inventory_e2e(
         5. JSON files inside report can be parsed
         6. metadata.json lists all and only slice JSON files in tar
         7. Host counts in metadata matches host counts in slices
-        8. Assert Hostnames, IP addresses, and installed packages are present in report.
+        8. Assert Hostnames, IP addresses, and installed packages are present in the report.
 
     :CaseImportance: Critical
 
@@ -91,6 +91,7 @@ def test_rhcloud_inventory_e2e(
         session.location.select(loc_name=DEFAULT_LOC)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
+        # wait_for_tasks report generation task to finish.
         wait_for(
             lambda: module_target_sat.api.ForemanTask()
             .search(
@@ -108,12 +109,15 @@ def test_rhcloud_inventory_e2e(
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
-
+    # Verify that generated archive is valid.
     common_assertion(report_path, inventory_data, org, module_target_sat)
+    # Get report data for assertion
     json_data = get_report_data(report_path)
+    # Verify that hostnames are present in the report.
     hostnames = [host['fqdn'] for host in json_data['hosts']]
     assert virtual_host.hostname in hostnames
     assert baremetal_host.hostname in hostnames
+    # Verify that ip_addresses are present report.
     ip_addresses = [
         host['system_profile']['network_interfaces'][0]['ipv4_addresses'][0]
         for host in json_data['hosts']
@@ -123,6 +127,7 @@ def test_rhcloud_inventory_e2e(
     assert baremetal_host.ip_addr in ip_addresses
     assert virtual_host.ip_addr in ipv4_addresses
     assert baremetal_host.ip_addr in ipv4_addresses
+    # Verify that packages are included in report
     all_host_profiles = [host['system_profile'] for host in json_data['hosts']]
     for host_profiles in all_host_profiles:
         assert 'installed_packages' in host_profiles
@@ -131,29 +136,45 @@ def test_rhcloud_inventory_e2e(
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_obfuscate_host_names(
+def test_rh_cloud_inventory_settings(
     module_target_sat,
     inventory_settings,
     rhcloud_manifest_org,
     rhcloud_registered_hosts,
 ):
-    """Test whether `Obfuscate host names` setting works as expected.
+    """Test whether `Obfuscate host names`, `Obfuscate host ipv4 addresses`
+        and `Exclude Packages` setting works as expected.
 
     :id: 3c3a36b6-6566-446b-b803-3f8f9aab2511
+
+    :customerscenario: true
 
     :Steps:
 
         1. Prepare machine and upload its data to Insights.
         2. Go to Configure > Inventory upload > enable “Obfuscate host names” setting.
-        3. Generate report after enabling the setting.
-        4. Check if host names are obfuscated in generated reports.
-        5. Disable previous setting.
-        6. Go to Administer > Settings > RH Cloud and enable "Obfuscate host names" setting.
-        7. Generate report after enabling the setting.
-        8. Check if host names are obfuscated in generated reports.
+        3. Go to Configure > Inventory upload > enable “Obfuscate host ipv4 addresses” setting.
+        4. Go to Configure > Inventory upload > enable “Exclude Packages” setting.
+        5. Generate report after enabling the settings.
+        6. Check if host names are obfuscated in generated reports.
+        7. Check if hosts ipv4 addresses are obfuscated in generated reports.
+        8. Check if packages are excluded from generated reports.
+        9. Disable previous setting.
+        10. Go to Administer > Settings > RH Cloud and enable "Obfuscate host names" setting.
+        11. Go to Administer > Settings > RH Cloud and enable "Obfuscate IPs" setting.
+        12. Go to Administer > Settings > RH Cloud and enable
+            "Don't upload installed packages" setting.
+        13. Generate report after enabling the setting.
+        14. Check if host names are obfuscated in generated reports.
+        15. Check if hosts ipv4 addresses are obfuscated in generated reports.
+        16. Check if packages are excluded from generated reports.
 
     :expectedresults:
         1. Obfuscated host names in reports generated.
+        2. Obfuscated host ipv4 addresses in generated reports.
+        3. Packages are excluded from reports generated.
+
+    :BZ: 1852594, 1889690, 1852594
 
     :CaseAutomation: Automated
     """
@@ -162,241 +183,13 @@ def test_obfuscate_host_names(
     with module_target_sat.ui_session() as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
-        # Enable obfuscate_hostnames setting on inventory page.
+        # Enable settings on inventory page.
         session.cloudinventory.update({'obfuscate_hostnames': True})
-        timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
-        session.cloudinventory.generate_report(org.name)
-        # wait_for_tasks report generation task to finish.
-        wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
-            timeout=400,
-            delay=15,
-            silent_failure=True,
-            handle_exception=True,
-        )
-        report_path = session.cloudinventory.download_report(org.name)
-        inventory_data = session.cloudinventory.read(org.name)
-
-        # Assert that obfuscate_hostnames is enabled.
-        assert inventory_data['obfuscate_hostnames'] is True
-        # Assert that generated archive is valid.
-        common_assertion(report_path, inventory_data, org, module_target_sat)
-        # Get report data for assertion
-        json_data = get_report_data(report_path)
-        hostnames = [host['fqdn'] for host in json_data['hosts']]
-        assert virtual_host.hostname not in hostnames
-        assert baremetal_host.hostname not in hostnames
-        # Assert that host ip_addresses are present in the report.
-        ipv4_addresses = [host['ip_addresses'][0] for host in json_data['hosts']]
-        assert virtual_host.ip_addr in ipv4_addresses
-        assert baremetal_host.ip_addr in ipv4_addresses
-        # Disable obfuscate_hostnames setting on inventory page.
-        session.cloudinventory.update({'obfuscate_hostnames': False})
-
-        # Enable obfuscate_hostnames setting.
-        module_target_sat.update_setting('obfuscate_inventory_hostnames', True)
-        timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
-        session.cloudinventory.generate_report(org.name)
-        # wait_for_tasks report generation task to finish.
-        wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
-            timeout=400,
-            delay=15,
-            silent_failure=True,
-            handle_exception=True,
-        )
-        report_path = session.cloudinventory.download_report(org.name)
-        inventory_data = session.cloudinventory.read(org.name)
-
-        assert inventory_data['obfuscate_hostnames'] is True
-        json_data = get_report_data(report_path)
-        hostnames = [host['fqdn'] for host in json_data['hosts']]
-        assert virtual_host.hostname not in hostnames
-        assert baremetal_host.hostname not in hostnames
-        ipv4_addresses = [host['ip_addresses'][0] for host in json_data['hosts']]
-        assert virtual_host.ip_addr in ipv4_addresses
-        assert baremetal_host.ip_addr in ipv4_addresses
-
-
-@pytest.mark.run_in_one_thread
-@pytest.mark.tier3
-def test_obfuscate_host_ipv4_addresses(
-    module_target_sat,
-    inventory_settings,
-    rhcloud_manifest_org,
-    rhcloud_registered_hosts,
-):
-    """Test whether `Obfuscate host ipv4 addresses` setting works as expected.
-
-    :id: c0fc4ee9-a6a1-42c0-83f0-0f131ca9ab41
-
-    :customerscenario: true
-
-    :Steps:
-
-        1. Prepare machine and upload its data to Insights.
-        2. Go to Configure > Inventory upload > enable “Obfuscate host ipv4 addresses” setting.
-        3. Generate report after enabling the setting.
-        4. Check if hosts ipv4 addresses are obfuscated in generated reports.
-        5. Disable previous setting.
-        6. Go to Administer > Settings > RH Cloud and enable "Obfuscate IPs" setting.
-        7. Generate report after enabling the setting.
-        8. Check if hosts ipv4 addresses are obfuscated in generated reports.
-
-    :expectedresults:
-        1. Obfuscated host ipv4 addresses in generated reports.
-
-    :BZ: 1852594, 1889690
-
-    :CaseAutomation: Automated
-    """
-    org = rhcloud_manifest_org
-    virtual_host, baremetal_host = rhcloud_registered_hosts
-    with module_target_sat.ui_session() as session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=DEFAULT_LOC)
-        # Enable obfuscate_ips setting on inventory page.
         session.cloudinventory.update({'obfuscate_ips': True})
-        timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
-        session.cloudinventory.generate_report(org.name)
-        # wait_for_tasks report generation task to finish.
-        wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
-            timeout=400,
-            delay=15,
-            silent_failure=True,
-            handle_exception=True,
-        )
-        report_path = session.cloudinventory.download_report(org.name)
-        inventory_data = session.cloudinventory.read(org.name)
-        # Assert that obfuscate_ips is enabled.
-        assert inventory_data['obfuscate_ips'] is True
-        # Assert that generated archive is valid.
-        common_assertion(report_path, inventory_data, org, module_target_sat)
-        # Get report data for assertion
-        json_data = get_report_data(report_path)
-        hostnames = [host['fqdn'] for host in json_data['hosts']]
-        assert virtual_host.hostname in hostnames
-        assert baremetal_host.hostname in hostnames
-        # Assert that ip_addresses are obfuscated from report.
-        ip_addresses = [
-            host['system_profile']['network_interfaces'][0]['ipv4_addresses'][0]
-            for host in json_data['hosts']
-        ]
-        ipv4_addresses = [host['ip_addresses'][0] for host in json_data['hosts']]
-        assert virtual_host.ip_addr not in ip_addresses
-        assert baremetal_host.ip_addr not in ip_addresses
-        assert virtual_host.ip_addr not in ipv4_addresses
-        assert baremetal_host.ip_addr not in ipv4_addresses
-        # Disable obfuscate_ips setting on inventory page.
-        session.cloudinventory.update({'obfuscate_ips': False})
-
-        # Enable obfuscate_inventory_ips setting.
-        module_target_sat.update_setting('obfuscate_inventory_ips', True)
-        timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
-        session.cloudinventory.generate_report(org.name)
-        # wait_for_tasks report generation task to finish.
-        wait_for(
-            lambda: module_target_sat.api.ForemanTask()
-            .search(
-                query={
-                    'search': f'label = ForemanInventoryUpload::Async::GenerateReportJob '
-                    f'and started_at >= "{timestamp}"'
-                }
-            )[0]
-            .result
-            == 'success',
-            timeout=400,
-            delay=15,
-            silent_failure=True,
-            handle_exception=True,
-        )
-        report_path = session.cloudinventory.download_report(org.name)
-        inventory_data = session.cloudinventory.read(org.name)
-
-        assert inventory_data['obfuscate_ips'] is True
-        # Get report data for assertion
-        json_data = get_report_data(report_path)
-        hostnames = [host['fqdn'] for host in json_data['hosts']]
-        assert virtual_host.hostname in hostnames
-        assert baremetal_host.hostname in hostnames
-        ip_addresses = [
-            host['system_profile']['network_interfaces'][0]['ipv4_addresses'][0]
-            for host in json_data['hosts']
-        ]
-        ipv4_addresses = [host['ip_addresses'][0] for host in json_data['hosts']]
-        assert virtual_host.ip_addr not in ip_addresses
-        assert baremetal_host.ip_addr not in ip_addresses
-        assert virtual_host.ip_addr not in ipv4_addresses
-        assert baremetal_host.ip_addr not in ipv4_addresses
-
-
-@pytest.mark.run_in_one_thread
-@pytest.mark.tier3
-def test_exclude_packages_setting(
-    module_target_sat,
-    inventory_settings,
-    rhcloud_manifest_org,
-    rhcloud_registered_hosts,
-):
-    """Test whether `Exclude Packages` setting works as expected.
-
-    :id: 646093fa-fdd6-4f70-82aa-725e31fa3f12
-
-    :customerscenario: true
-
-    :Steps:
-
-        1. Prepare machine and upload its data to Insights
-        2. Go to Configure > Inventory upload > enable “Exclude Packages” setting.
-        3. Generate report after enabling the setting.
-        4. Check if packages are excluded from generated reports.
-        5. Disable previous setting.
-        6. Go to Administer > Settings > RH Cloud and enable
-            "Don't upload installed packages" setting.
-        7. Generate report after enabling the setting.
-        8. Check if packages are excluded from generated reports.
-
-    :expectedresults:
-        1. Packages are excluded from reports generated.
-
-    :BZ: 1852594
-
-    :CaseAutomation: Automated
-    """
-    org = rhcloud_manifest_org
-    virtual_host, baremetal_host = rhcloud_registered_hosts
-    with module_target_sat.ui_session() as session:
-        session.organization.select(org_name=org.name)
-        session.location.select(loc_name=DEFAULT_LOC)
-        # Enable exclude_packages setting on inventory page.
         session.cloudinventory.update({'exclude_packages': True})
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
+        # wait_for_tasks report generation task to finish.
         wait_for(
             lambda: module_target_sat.api.ForemanTask()
             .search(
@@ -414,26 +207,43 @@ def test_exclude_packages_setting(
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
+        # Verify settings are enabled.
+        assert inventory_data['obfuscate_hostnames'] is True
+        assert inventory_data['obfuscate_ips'] is True
         assert inventory_data['exclude_packages'] is True
-        # Disable exclude_packages setting on inventory page.
-        session.cloudinventory.update({'exclude_packages': False})
-        # Assert that generated archive is valid.
+        # Verify that generated archive is valid.
         common_assertion(report_path, inventory_data, org, module_target_sat)
         # Get report data for assertion
         json_data = get_report_data(report_path)
-        # Assert that right hosts are present in report.
+        # Verify that hostnames are obfuscated from the report.
         hostnames = [host['fqdn'] for host in json_data['hosts']]
-        assert virtual_host.hostname in hostnames
-        assert baremetal_host.hostname in hostnames
-        # Assert that packages are excluded from report
+        assert virtual_host.hostname not in hostnames
+        assert baremetal_host.hostname not in hostnames
+        # Verify that ip_addresses are obfuscated from the report.
+        ip_addresses = [
+            host['system_profile']['network_interfaces'][0]['ipv4_addresses'][0]
+            for host in json_data['hosts']
+        ]
+        ipv4_addresses = [host['ip_addresses'][0] for host in json_data['hosts']]
+        assert virtual_host.ip_addr not in ip_addresses
+        assert baremetal_host.ip_addr not in ip_addresses
+        assert virtual_host.ip_addr not in ipv4_addresses
+        assert baremetal_host.ip_addr not in ipv4_addresses
+        # Verify that packages are excluded from report
         all_host_profiles = [host['system_profile'] for host in json_data['hosts']]
         for host_profiles in all_host_profiles:
             assert 'installed_packages' not in host_profiles
-
-        # Enable exclude_installed_packages setting.
+        # Disable settings on inventory page.
+        session.cloudinventory.update({'obfuscate_hostnames': False})
+        session.cloudinventory.update({'obfuscate_ips': False})
+        session.cloudinventory.update({'exclude_packages': False})
+        # Enable settings, the one on the main settings page.
+        module_target_sat.update_setting('obfuscate_inventory_hostnames', True)
+        module_target_sat.update_setting('obfuscate_inventory_ips', True)
         module_target_sat.update_setting('exclude_installed_packages', True)
         timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
+        # wait_for_tasks report generation task to finish.
         wait_for(
             lambda: module_target_sat.api.ForemanTask()
             .search(
@@ -451,11 +261,27 @@ def test_exclude_packages_setting(
         )
         report_path = session.cloudinventory.download_report(org.name)
         inventory_data = session.cloudinventory.read(org.name)
+        # Verify settings are enabled.
+        assert inventory_data['obfuscate_hostnames'] is True
+        assert inventory_data['obfuscate_ips'] is True
         assert inventory_data['exclude_packages'] is True
+        # Get report data for assertion
         json_data = get_report_data(report_path)
+        # Verify that hostnames are obfuscated from the report.
         hostnames = [host['fqdn'] for host in json_data['hosts']]
-        assert virtual_host.hostname in hostnames
-        assert baremetal_host.hostname in hostnames
+        assert virtual_host.hostname not in hostnames
+        assert baremetal_host.hostname not in hostnames
+        # Verify that ip_addresses are obfuscated from the report.
+        ip_addresses = [
+            host['system_profile']['network_interfaces'][0]['ipv4_addresses'][0]
+            for host in json_data['hosts']
+        ]
+        ipv4_addresses = [host['ip_addresses'][0] for host in json_data['hosts']]
+        assert virtual_host.ip_addr not in ip_addresses
+        assert baremetal_host.ip_addr not in ip_addresses
+        assert virtual_host.ip_addr not in ipv4_addresses
+        assert baremetal_host.ip_addr not in ipv4_addresses
+        # Verify that packages are excluded from report
         all_host_profiles = [host['system_profile'] for host in json_data['hosts']]
         for host_profiles in all_host_profiles:
             assert 'installed_packages' not in host_profiles
@@ -529,54 +355,3 @@ def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
         f'Skipping organization {module_org.name}, no candlepin certificate defined.'
         in inventory_data['uploading']['terminal']
     )
-
-
-@pytest.mark.stubbed
-def test_automatic_inventory_upload_enabled_setting():
-    """Test "Automatic inventory upload" setting.
-
-    :id: e84790c6-1700-46c4-9bf8-d8f1e63a7f1f
-
-    :Steps:
-        1. Register satellite content host with insights.
-        2. Sync inventory status.
-        3. Wait for "Inventory scheduled sync" task to execute.
-            (Change wait time to 1 minute for testing.)
-        4. Check whether the satellite shows successful inventory upload for the host.
-        5. Disable "Automatic inventory upload" setting.
-        6. Unregister host from insights OR Delete host from cloud.
-        7. Wait for "Inventory scheduled sync" task to execute.
-
-    :expectedresults:
-        1. When "Automatic inventory upload" setting is disabled then
-            "Inventory scheduled sync" task doesn't sync the inventory status.
-
-    :CaseImportance: Medium
-
-    :BZ: 1965239
-
-    :CaseAutomation: ManualOnly
-    """
-
-
-@pytest.mark.stubbed
-def test_automatic_inventory_upload_disabled_setting():
-    """Test "Automatic inventory upload" setting.
-
-    :id: 2c830833-3f92-497c-bbb9-f485a1d8eb47
-
-    :Steps:
-        1. Register few hosts with satellite.
-        2. Enable "Automatic inventory upload" setting.
-        3. Wait for "Inventory scheduled sync" recurring logic to run.
-
-    :expectedresults:
-        1. Satellite has "Inventory scheduled sync" recurring logic, which syncs
-            inventory status automatically if "Automatic inventory upload" setting is enabled.
-
-    :CaseImportance: Medium
-
-    :BZ: 1962695
-
-    :CaseAutomation: ManualOnly
-    """


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12511

Refactor tests present in tests/foreman/ui/test_rhcloud_inventory.py based on feedback received on Components evaluation sheet.

This PR:

- removes `test_rhcloud_inventory_mtu_field` as it's covered in foreman unit tests.
- removes `test_obfuscate_host_ipv4_addresses`, `test_exclude_packages_setting` and `test_obfuscate_host_names` and covers them in `test_rh_cloud_inventory_settings`
- removes `test_automatic_inventory_upload_enabled_setting` and `test_automatic_inventory_upload_disabled_setting` as it's covered in `test_rhcloud_inventory_auto_upload_setting`.