### PR TITLE
Debug failover to cloned manifests

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -141,13 +141,13 @@ class ContentInfo:
         :returns: the manifest upload result
 
         """
-        if manifest is None:
+        if manifest.content is None:
             manifest = clone()
         if timeout is None:
             # Set the timeout to 1500 seconds to align with the API timeout.
             timeout = 1500000
         if interface == 'CLI':
-            if isinstance(manifest.content, (bytes, io.BytesIO)):
+            if hasattr(manifest, 'path'):
                 self.put(f'{manifest.path}', f'{manifest.name}')
                 result = self.cli.Subscription.upload(
                     {'file': manifest.name, 'organization-id': org_id}, timeout=timeout

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -892,7 +892,7 @@ class ContentHost(Host, ContentHostMixins):
         If local_path is a manifest object, write its contents to a temporary file
         then continue with the upload.
         """
-        if 'utils.Manifest' in str(local_path):
+        if 'utils.manifest' in str(local_path):
             with NamedTemporaryFile(dir=robottelo_tmp_dir) as content_file:
                 content_file.write(local_path.content.read())
                 content_file.flush()


### PR DESCRIPTION
This PR, in combination with https://github.com/SatelliteQE/manifester/pull/21, addresses some of the errors that have been occurring in CI in cases where Manifester times out when exporting a manifest due to an upstream RHSM issue. These changes should enable Robottelo to successfully fail over to using cloned manifests in those cases.