### PR TITLE
[6.14.z] Fix katello-agent

### DIFF
--- a/pytest_fixtures/component/katello_agent.py
+++ b/pytest_fixtures/component/katello_agent.py
@@ -48,7 +48,9 @@ def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
     org = sat_with_katello_agent.api.Organization().create()
     client_repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
     sat_with_katello_agent.register_host_custom_repo(
-        org, rhel_contenthost, [client_repo, settings.repos.yum_1.url]
+        org,
+        rhel_contenthost,
+        [client_repo, settings.repos.yum_1.url],
     )
     rhel_contenthost.install_katello_agent()
     host_info = sat_with_katello_agent.cli.Host.info({'name': rhel_contenthost.hostname})

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1991,7 +1991,7 @@ class Satellite(Capsule, SatelliteMixins):
         """Register content host to Satellite and sync repos
 
         :param module_org: Org where contenthost will be registered.
-        :param rhel_contenthost: contenthost to be register with Satellite.
+        :param rhel_contenthost: contenthost to be registered with Satellite.
         :param repo_urls: List of URLs to be synced and made available to contenthost
             via subscription-manager.
         :return: None
@@ -2050,6 +2050,9 @@ class Satellite(Capsule, SatelliteMixins):
             )
             # refresh repository metadata on the host
             rhel_contenthost.execute('subscription-manager repos --list')
+
+        # Override the repos to enabled
+        rhel_contenthost.execute(r'subscription-manager repos --enable \*')
 
     def enroll_ad_and_configure_external_auth(self, ad_data):
         """Enroll Satellite Server to an AD Server.

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -24,6 +24,7 @@ from robottelo.config import settings
 pytestmark = [
     pytest.mark.run_in_one_thread,
     pytest.mark.destructive,
+    pytest.mark.no_containers,
     pytest.mark.tier5,
     pytest.mark.upgrade,
 ]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12395

In this PR I propose two changes:
1. Since 6.14 the custom repos are disabled by default, we need to have them overridden to enabled.
2. Katello-agent fails in old (RHEL6 and 7) containers (IIRC goferd failed to start since it was missing some system service), but it pass on a regular VMs. In order to get this component tested for 6.14 RC properly I propose to set it run on the standard VMs. The price is 1.5 - 2 h of extra run time, which I find acceptable since the katello-agent gets removed from 6.15 anyway and these tests would be deleted in 18 months.

PRT results:
no_containers:
- 19 passed, 1 broker provider err (PRT#3689, 6:28:38) 
- all 20 passed (PRT#3790, 6:08:16)

with containers:
- 10 (RHEL6/7) failed, 10 (RHEL8/9) passed (PRT#3700, ~4:33:00)