### PR TITLE
[6.13.z] Move SCAPPlugin Component to Endeavour Team

### DIFF
--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SCAPPlugin
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SCAPPlugin
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: SCAPPlugin
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: SCAPPlugin
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SCAPPlugin
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SCAPPlugin
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SCAPPlugin
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: SCAPPlugin
 
-:Team: Rocket
+:Team: Endeavour
 
 :TestType: Functional
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12520

This PR is to move all SCAP related tests and modules to Endeavour Team since the component moved to that team.