### PR TITLE
[6.12.z] Passing more correct metadata sat version for ibutsu

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -6,7 +6,6 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.hosts import get_sat_rhel_version
-from robottelo.hosts import get_sat_version
 from robottelo.logging import collection_logger as logger
 
 FMT_XUNIT_TIME = '%Y-%m-%dT%H:%M:%S'
@@ -59,7 +58,7 @@ team_regex = re.compile(
 
 
 @pytest.hookimpl(tryfirst=True)
-def pytest_collection_modifyitems(session, items, config):
+def pytest_collection_modifyitems(items, config):
     """Add markers and user_properties for testimony token metadata
 
     user_properties is used by the junit plugin, and thus by many test report systems
@@ -74,7 +73,7 @@ def pytest_collection_modifyitems(session, items, config):
     """
     # get RHEL version of the satellite
     rhel_version = get_sat_rhel_version().base_version
-    sat_version = get_sat_version().base_version
+    sat_version = settings.server.version.get('release')
     snap_version = settings.server.version.get('snap', '')
 
     # split the option string and handle no option, single option, multiple


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12488

Currently, when I see ibutsu report I see only 6.15, 6.14.. and never seen x.y.z format. Even we are testing on Satellite 6.13.4 it is showing as 6.13. This will fix that.    

![image](https://github.com/SatelliteQE/robottelo/assets/3190629/3e0c8404-2ec2-4e40-9498-eedd205d1327)
 