### PR TITLE
[6.13.z] Update tests to use snap version when getting ohsnap repo urls (#12528)

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -294,7 +294,11 @@ def installer_satellite(request):
     sat.setup_firewall()
     # # Register for RHEL8 repos, get Ohsnap repofile, and enable and download satellite
     sat.register_to_cdn()
-    sat.download_repofile(product='satellite', release=settings.server.version.release)
+    sat.download_repofile(
+        product='satellite',
+        release=settings.server.version.release,
+        snap=settings.server.version.snap,
+    )
     sat.execute('dnf -y module enable satellite:el8 && dnf -y install satellite')
     installed_version = sat.execute('rpm --query satellite').stdout
     assert sat_version in installed_version

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -94,7 +94,9 @@ def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pul
     # Disabling repositories
     assert sat_ready_rhel.execute('subscription-manager repos --disable=*').status == 0
     # Getting satellite maintenace repo
-    sat_ready_rhel.download_repofile(product='satellite', release=sat_version)
+    sat_ready_rhel.download_repofile(
+        product='satellite', release=sat_version, snap=settings.server.version.snap
+    )
     # Enabling repositories
     for repo in getattr(constants, f"OHSNAP_RHEL{rhel_version}_REPOS"):
         sat_ready_rhel.enable_repo(repo, force=True)

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -142,7 +142,9 @@ def test_negative_pre_upgrade_tuning_profile_check(request, custom_host):
         timeout='30m',
     )
     # Get current Satellite version's repofile
-    custom_host.download_repofile(product='satellite', release=sat_version)
+    custom_host.download_repofile(
+        product='satellite', release=sat_version, snap=settings.server.version.snap
+    )
     # Run satellite-maintain to have it self update to the newest version,
     # however, this will not actually execute the command after updating
     custom_host.execute('satellite-maintain upgrade list-versions')

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -43,7 +43,11 @@ def test_positive_install_sat_with_katello_certs(certs_data, sat_ready_rhel):
 
     :CaseAutomation: Automated
     """
-    sat_ready_rhel.download_repofile(product='satellite', release=settings.server.version.release)
+    sat_ready_rhel.download_repofile(
+        product='satellite',
+        release=settings.server.version.release,
+        snap=settings.server.version.snap,
+    )
     sat_ready_rhel.register_to_cdn()
     sat_ready_rhel.execute('dnf -y update')
     result = sat_ready_rhel.execute(


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/issues/12548

Cherry-pick of https://github.com/SatelliteQE/robottelo/pull/12528