### PR TITLE
Set timeout as backup takes long time

### DIFF
--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -523,6 +523,7 @@ def test_positive_backup_restore(
         backup_dir=subdir,
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True, 'skip-pulp-content': skip_pulp},
+        timeout='30m',
     )
     assert result.status == 0
     assert 'FAIL' not in result.stdout


### PR DESCRIPTION
`tests.foreman.maintain.test_backup_restore.test_positive_backup_restore` fails with `ssh2.exceptions.Timeout` when running for `satellite` and `include-pulp` datapoints

Backing up a Satellite including pulp data takes long time.