### PR TITLE
[6.12.z] Set timeout as backup takes long time

### DIFF
--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -456,6 +456,7 @@ def test_positive_backup_restore(
         backup_dir=subdir,
         backup_type=backup_type,
         options={'assumeyes': True, 'plaintext': True, 'skip-pulp-content': skip_pulp},
+        timeout='30m',
     )
     assert result.status == 0
     assert 'FAIL' not in result.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12554

`tests.foreman.maintain.test_backup_restore.test_positive_backup_restore` fails with `ssh2.exceptions.Timeout` when running for `satellite` and `include-pulp` datapoints

Backing up a Satellite including pulp data takes long time.