### PR TITLE
change in import/export directory context

### DIFF
--- a/pytest_fixtures/component/templatesync.py
+++ b/pytest_fixtures/component/templatesync.py
@@ -24,7 +24,7 @@ def create_import_export_local_dir(target_sat):
         f'mkdir -p {dir_path} && '
         f'chown foreman -R {root_dir} && '
         f'restorecon -R -v {root_dir} && '
-        f'chcon -t httpd_sys_rw_content_t {dir_path} -R'
+        f'chcon -t foreman_lib_t {dir_path} -R'
     )
     if result.status != 0:
         logger.debug(result.stdout)


### PR DESCRIPTION
Updating the fixture as BZ#2232162 evolved into documentation fixture. The new recommended way is to either use a pre-defined export dir or use a different context if custom one is needed. I chose the second option as the first one is already tested in bats tests.