### PR TITLE
[6.13.z] Fix regression from cloned manifest failover

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -140,8 +140,9 @@ class ContentInfo:
         :returns: the manifest upload result
 
         """
-        if manifest.content is None:
-            manifest = clone()
+        if not isinstance(manifest, (bytes, io.BytesIO)):
+            if manifest.content is None:
+                manifest = clone()
         if timeout is None:
             # Set the timeout to 1500 seconds to align with the API timeout.
             timeout = 1500000


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12605

This PR adds a check to resolve a regression in `upload_manifest` introduced by https://github.com/SatelliteQE/robottelo/pull/12515.