### PR TITLE
fixture support for virt-who config api : data_form deploy_type virtwho_config 

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -17,6 +17,7 @@
 :Upstream: No
 """
 import pytest
+
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     ETC_VIRTWHO_CONFIG,
@@ -26,7 +27,6 @@ from robottelo.utils.virtwho import (
     get_configure_command,
     get_configure_file,
     get_configure_option,
-    get_guest_info,
 )
 
 

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -16,50 +16,22 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data(default_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
-        'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
-        'organization_id': default_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
-        'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -71,23 +43,11 @@ class TestVirtWhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=default_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
+        hypervisor_name, guest_name = deploy_type_api
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
@@ -120,7 +80,7 @@ class TestVirtWhoConfigforHyperv:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -136,11 +96,11 @@ class TestVirtWhoConfigforHyperv:
         """
         values = ['uuid', 'hostname']
         for value in values:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, default_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_api['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -16,50 +16,22 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
-        'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
-        'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -71,30 +43,17 @@ class TestVirtWhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -109,11 +68,11 @@ class TestVirtWhoConfigforHyperv:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -18,7 +18,6 @@
 """
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
     get_configure_command,

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -16,13 +16,11 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
@@ -30,44 +28,12 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data(default_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization_id': default_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'kubeconfig_path': settings.virtwho.kubevirt.hypervisor_config_file,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
-@pytest.fixture(autouse=True)
-def delete_host(form_data, target_sat):
-    guest_name, _ = get_guest_info(form_data['hypervisor_type'])
-    results = target_sat.api.Host().search(query={'search': guest_name})
-    if results:
-        target_sat.api.Host(id=results[0].read_json()['id']).delete()
-
-
-@pytest.mark.usefixtures('delete_host')
+@pytest.mark.delete_host
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -79,80 +45,11 @@ class TestVirtWhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=default_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
+        hypervisor_name, guest_name = deploy_type_api
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
-            .status
-        )
-        assert virt_who_instance == 'ok'
-        hosts = [
-            (
-                hypervisor_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
-            ),
-            (
-                guest_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
-            ),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
-            )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
-            )
-            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
-            assert result['subscription_status_label'] == 'Fully entitled'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, form_data, virtwho_config, target_sat
-    ):
-        """Verify "GET /foreman_virt_who_configure/api/
-
-        v2/configs/:id/deploy_script"
-
-        :id: 77100dc7-644a-44a4-802a-2da562246cba
-
-        :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        assert virtwho_config.status == 'unknown'
-        script = virtwho_config.deploy_script()
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script['virt_who_config_script'],
-            form_data['hypervisor_type'],
-            debug=True,
-            org=default_org.label,
-        )
-        virt_who_instance = (
-            target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
@@ -185,7 +82,7 @@ class TestVirtWhoConfigforKubevirt:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -201,11 +98,11 @@ class TestVirtWhoConfigforKubevirt:
         """
         values = ['uuid', 'hostname']
         for value in values:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, default_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_api['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -24,7 +24,6 @@ from robottelo.utils.virtwho import (
     get_configure_command,
     get_configure_file,
     get_configure_option,
-    get_guest_info,
 )
 
 

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -16,7 +16,6 @@
 """
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
     get_configure_command,

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -14,48 +14,22 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'kubeconfig_path': settings.virtwho.kubevirt.hypervisor_config_file,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -67,30 +41,17 @@ class TestVirtWhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -105,11 +66,11 @@ class TestVirtWhoConfigforKubevirt:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -14,49 +14,22 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.libvirt.hypervisor_type,
-        'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -68,30 +41,17 @@ class TestVirtWhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT /foreman_virt_who_configure/api/v2/configs/:id"
 
@@ -104,11 +64,11 @@ class TestVirtWhoConfigforLibvirt:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -16,7 +16,6 @@
 """
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
     get_configure_command,

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -26,7 +26,6 @@ from robottelo.utils.virtwho import (
     get_configure_command,
     get_configure_file,
     get_configure_option,
-    get_guest_info,
     get_hypervisor_ahv_mapping,
 )
 

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -16,7 +16,6 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
@@ -32,48 +31,12 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data(default_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.ahv.hypervisor_type,
-        'hypervisor_server': settings.virtwho.ahv.hypervisor_server,
-        'organization_id': default_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.ahv.hypervisor_username,
-        'hypervisor_password': settings.virtwho.ahv.hypervisor_password,
-        'prism_flavor': settings.virtwho.ahv.prism_flavor,
-        'ahv_internal_debug': 'false',
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
-@pytest.fixture(autouse=True)
-def delete_host(form_data, target_sat):
-    guest_name, _ = get_guest_info(form_data['hypervisor_type'])
-    results = target_sat.api.Host().search(query={'search': guest_name})
-    if results:
-        target_sat.api.Host(id=results[0].read_json()['id']).delete()
-
-
-@pytest.mark.usefixtures('delete_host')
+@pytest.mark.delete_host
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -85,23 +48,11 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=default_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
+        hypervisor_name, guest_name = deploy_type_api
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
@@ -138,7 +89,7 @@ class TestVirtWhoConfigforNutanix:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -154,19 +105,19 @@ class TestVirtWhoConfigforNutanix:
         """
         values = ['uuid', 'hostname']
         for value in values:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, default_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_api['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
-        self, default_org, form_data, target_sat, deploy_type
+        self, default_org, form_data_api, target_sat, deploy_type
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs" on nutanix prism central mode
 
@@ -180,19 +131,19 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        form_data['prism_flavor'] = "central"
-        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+        form_data_api['prism_flavor'] = "central"
+        virtwho_config = target_sat.api.VirtWhoConfig(**form_data_api).create()
         assert virtwho_config.status == 'unknown'
         if deploy_type == "id":
             command = get_configure_command(virtwho_config.id, default_org.name)
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
+                command, form_data_api['hypervisor_type'], debug=True, org=default_org.label
             )
         elif deploy_type == "script":
             script = virtwho_config.deploy_script()
             hypervisor_name, guest_name = deploy_configure_by_script(
                 script['virt_who_config_script'],
-                form_data['hypervisor_type'],
+                form_data_api['hypervisor_type'],
                 debug=True,
                 org=default_org.label,
             )
@@ -238,7 +189,7 @@ class TestVirtWhoConfigforNutanix:
 
     @pytest.mark.tier2
     def test_positive_prism_central_prism_central_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify prism_flavor option by "PUT
 
@@ -253,16 +204,18 @@ class TestVirtWhoConfigforNutanix:
         :CaseImportance: Medium
         """
         value = 'central'
-        virtwho_config.prism_flavor = value
-        virtwho_config.update(['prism_flavor'])
-        config_file = get_configure_file(virtwho_config.id)
-        command = get_configure_command(virtwho_config.id, default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
+        virtwho_config_api.prism_flavor = value
+        virtwho_config_api.update(['prism_flavor'])
+        config_file = get_configure_file(virtwho_config_api.id)
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
+        deploy_configure_by_command(
+            command, form_data_api['hypervisor_type'], org=default_org.label
+        )
         assert get_configure_option("prism_central", config_file) == 'true'
 
     @pytest.mark.tier2
     def test_positive_ahv_internal_debug_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify ahv_internal_debug option by hammer virt-who-config"
 
@@ -284,18 +237,18 @@ class TestVirtWhoConfigforNutanix:
 
         :customerscenario: true
         """
-        command = get_configure_command(virtwho_config.id, default_org.name)
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            command, form_data_api['hypervisor_type'], debug=True, org=default_org.label
         )
         result = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .ahv_internal_debug
         )
         assert str(result) == 'False'
         # ahv_internal_debug does not set in virt-who-config-X.conf
-        config_file = get_configure_file(virtwho_config.id)
+        config_file = get_configure_file(virtwho_config_api.id)
         option = 'ahv_internal_debug'
         env_error = f"option {option} is not exist or not be enabled in {config_file}"
         try:
@@ -308,21 +261,23 @@ class TestVirtWhoConfigforNutanix:
 
         # Update ahv_internal_debug option to true
         value = 'true'
-        virtwho_config.ahv_internal_debug = value
-        virtwho_config.update(['ahv_internal_debug'])
-        command = get_configure_command(virtwho_config.id, default_org.name)
+        virtwho_config_api.ahv_internal_debug = value
+        virtwho_config_api.update(['ahv_internal_debug'])
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            command, form_data_api['hypervisor_type'], debug=True, org=default_org.label
         )
-        assert get_hypervisor_ahv_mapping(form_data['hypervisor_type']) == 'Host UUID found for VM'
+        assert (
+            get_hypervisor_ahv_mapping(form_data_api['hypervisor_type']) == 'Host UUID found for VM'
+        )
         result = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .ahv_internal_debug
         )
         assert str(result) == 'True'
         # ahv_internal_debug bas been set to true in virt-who-config-X.conf
-        config_file = get_configure_file(virtwho_config.id)
+        config_file = get_configure_file(virtwho_config_api.id)
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -16,7 +16,6 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
@@ -29,38 +28,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.ahv.hypervisor_type,
-        'hypervisor_server': settings.virtwho.ahv.hypervisor_server,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.ahv.hypervisor_username,
-        'hypervisor_password': settings.virtwho.ahv.hypervisor_password,
-        'prism_flavor': settings.virtwho.ahv.prism_flavor,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -72,30 +44,17 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -110,19 +69,19 @@ class TestVirtWhoConfigforNutanix:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, target_sat, deploy_type
+        self, module_sca_manifest_org, form_data_api, target_sat, deploy_type
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs" on nutanix prism central mode
 
@@ -136,19 +95,22 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        form_data['prism_flavor'] = "central"
-        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+        form_data_api['prism_flavor'] = "central"
+        virtwho_config = target_sat.api.VirtWhoConfig(**form_data_api).create()
         assert virtwho_config.status == 'unknown'
         if deploy_type == "id":
             command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                debug=True,
+                org=module_sca_manifest_org.label,
             )
         elif deploy_type == "script":
             script = virtwho_config.deploy_script()
             deploy_configure_by_script(
                 script['virt_who_config_script'],
-                form_data['hypervisor_type'],
+                form_data_api['hypervisor_type'],
                 debug=True,
                 org=module_sca_manifest_org.label,
             )
@@ -164,7 +126,7 @@ class TestVirtWhoConfigforNutanix:
 
     @pytest.mark.tier2
     def test_positive_prism_central_prism_central_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify prism_flavor option by "PUT
 
@@ -179,11 +141,11 @@ class TestVirtWhoConfigforNutanix:
         :CaseImportance: Medium
         """
         value = 'central'
-        virtwho_config.prism_flavor = value
-        virtwho_config.update(['prism_flavor'])
-        config_file = get_configure_file(virtwho_config.id)
-        command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+        virtwho_config_api.prism_flavor = value
+        virtwho_config_api.update(['prism_flavor'])
+        config_file = get_configure_file(virtwho_config_api.id)
+        command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+            command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
         )
         assert get_configure_option("prism_central", config_file) == 'true'

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -18,7 +18,6 @@
 """
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
     deploy_configure_by_script,


### PR DESCRIPTION
Tasks:

fixture support for virt-who config api : data_form deploy_type virtwho_config
depend on #12619 remove content for manifest
Cases PASS:
```
(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx**.py
                                                                                                           

tests/foreman/virtwho/api/test_esx.py ..........                                                                                                                                                            [ 43%]
tests/foreman/virtwho/api/test_esx_sca.py .............                                                                                                                                                     [100%]

=====================================================================23 passed, 23 deselected, 138 warnings in 1878.02s (0:31:18) ======================================================================
(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ 

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_hyperv**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 35 warnings in 1099.90s (0:18:19)
(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_kubevirt**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 37 warnings in 906.93s (0:15:06)

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_libvirt**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 35 warnings in 565.59s (0:09:25)

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix**.py --disable-pytest-warnings -q
.............                                                                                                                                                                                               [100%]
13 passed, 13 deselected, 90 warnings in 1388.06s (0:23:08)
```