### PR TITLE
fixing the memory issue in auto-cherry-pick GHA

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -40,6 +40,12 @@ jobs:
         label: ${{ github.event.pull_request.labels.*.name }}
 
     steps:
+      # Needed to avoid out-of-memory error
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
       ## Robottelo Repo Checkout
       - uses: actions/checkout@v4
         if: ${{ startsWith(matrix.label, '6.') && matrix.label != github.base_ref }}


### PR DESCRIPTION
**PR Description**

## Summary
This PR addresses an issue related to out-of-memory errors during the execution of GitHub Actions workflows. To mitigate this problem, we're introducing a step to set up swap space.

## Changes Made
- Added a new step to the workflow that sets up swap space with a size of 10GB.

## Context
In certain resource-intensive workflows, such as those involving large builds or data processing tasks, GitHub Actions runners may encounter out-of-memory errors. These errors can disrupt the workflow and cause it to fail.

To avoid such errors and ensure the smooth execution of workflows, we have introduced a step that configures a swap space of 10GB. Swap space provides additional virtual memory, which can be used when the physical memory is exhausted, thereby preventing out-of-memory errors.

