### PR TITLE
fixture support for virt-who config ui : data_form deploy_type virtwho_config

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -31,57 +31,22 @@ from robottelo.utils.virtwho import (
     delete_configure_option,
     deploy_configure_by_command,
     deploy_configure_by_command_check,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_id,
     get_configure_option,
-    get_guest_info,
     get_virtwho_status,
     restart_virtwho_service,
     update_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data():
-    form = {
-        'debug': True,
-        'interval': 'Every hour',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.esx.hypervisor_type,
-        'hypervisor_content.server': settings.virtwho.esx.hypervisor_server,
-        'hypervisor_content.username': settings.virtwho.esx.hypervisor_username,
-        'hypervisor_content.password': settings.virtwho.esx.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat, session):
-    name = gen_string('alpha')
-    form_data['name'] = name
-    with session:
-        session.virtwho_configure.create(form_data)
-        yield virtwho_config
-        session.virtwho_configure.delete(name)
-        assert not session.virtwho_configure.search(name)
-
-
-@pytest.fixture(autouse=True)
-def delete_host(form_data, target_sat):
-    guest_name, _ = get_guest_info(form_data['hypervisor_type'])
-    results = target_sat.api.Host().search(query={'search': guest_name})
-    if results:
-        target_sat.api.Host(id=results[0].read_json()['id']).delete()
-
-
-@pytest.mark.usefixtures('delete_host')
+@pytest.mark.delete_host
 class TestVirtwhoConfigforEsx:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, virtwho_config, session, form_data, deploy_type
+        self, default_org, org_session, form_data_ui, deploy_type_ui
     ):
         """Verify configure created and deployed with id|script.
 
@@ -98,37 +63,28 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: High
         """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        if deploy_type == "id":
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisor_name, guest_name = deploy_type_ui
+        assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         assert (
-            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions'][
+                'status'
+            ]
             == 'Unsubscribed hypervisor'
         )
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert org_session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
         assert (
-            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
             == 'Unentitled'
         )
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert org_session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_debug_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_debug_option(self, default_org, virtwho_config_ui, org_session, form_data_ui):
         """Verify debug checkbox and the value changes of VIRTWHO_DEBUG
 
         :id: adb435c4-d02b-47b6-89f5-dce9a4ff7939
@@ -141,23 +97,25 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         deploy_configure_by_command(
-            config_command, form_data['hypervisor_type'], org=default_org.label
+            config_command, form_data_ui['hypervisor_type'], org=default_org.label
         )
         assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '1'
-        session.virtwho_configure.edit(name, {'debug': False})
-        results = session.virtwho_configure.read(name)
+        org_session.virtwho_configure.edit(name, {'debug': False})
+        results = org_session.virtwho_configure.read(name)
         assert results['overview']['debug'] is False
         deploy_configure_by_command(
-            config_command, form_data['hypervisor_type'], org=default_org.label
+            config_command, form_data_ui['hypervisor_type'], org=default_org.label
         )
         assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == '0'
 
     @pytest.mark.tier2
-    def test_positive_interval_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_interval_option(
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
+    ):
         """Verify interval dropdown options and the value changes of VIRTWHO_INTERVAL.
 
         :id: 731f8361-38d4-40b9-9530-8d785d61eaab
@@ -170,7 +128,7 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         intervals = {
@@ -184,16 +142,18 @@ class TestVirtwhoConfigforEsx:
             'Every 3 days': '259200',
         }
         for option, value in sorted(intervals.items(), key=lambda item: int(item[1])):
-            session.virtwho_configure.edit(name, {'interval': option})
-            results = session.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, {'interval': option})
+            results = org_session.virtwho_configure.read(name)
             assert results['overview']['interval'] == option
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
+                config_command, form_data_ui['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_hypervisor_id_option(
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
+    ):
         """Verify Hypervisor ID dropdown options.
 
         :id: cc494bd9-51d9-452a-bfa9-5cdcafef5197
@@ -206,23 +166,25 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         config_file = get_configure_file(config_id)
         # esx and rhevm support hwuuid option
         values = ['uuid', 'hostname', 'hwuuid']
         for value in values:
-            session.virtwho_configure.edit(name, {'hypervisor_id': value})
-            results = session.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
+                config_command, form_data_ui['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
-    def test_positive_filtering_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_filtering_option(
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
+    ):
         """Verify Filtering dropdown options.
 
         :id: e17dda14-79cd-4cd2-8f29-60970b24a905
@@ -237,7 +199,7 @@ class TestVirtwhoConfigforEsx:
 
         :BZ: 1735670
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         config_file = get_configure_file(config_id)
@@ -248,28 +210,28 @@ class TestVirtwhoConfigforEsx:
         whitelist['filtering_content.filter_host_parents'] = regex
         blacklist['filtering_content.exclude_host_parents'] = regex
         # Update Whitelist and check the result
-        session.virtwho_configure.edit(name, whitelist)
-        results = session.virtwho_configure.read(name)
+        org_session.virtwho_configure.edit(name, whitelist)
+        results = org_session.virtwho_configure.read(name)
         assert results['overview']['filter_hosts'] == regex
         assert results['overview']['filter_host_parents'] == regex
         deploy_configure_by_command(
-            config_command, form_data['hypervisor_type'], org=default_org.label
+            config_command, form_data_ui['hypervisor_type'], org=default_org.label
         )
         assert regex == get_configure_option('filter_hosts', config_file)
         assert regex == get_configure_option('filter_host_parents', config_file)
         # Update Blacklist and check the result
-        session.virtwho_configure.edit(name, blacklist)
-        results = session.virtwho_configure.read(name)
+        org_session.virtwho_configure.edit(name, blacklist)
+        results = org_session.virtwho_configure.read(name)
         assert results['overview']['exclude_hosts'] == regex
         assert results['overview']['exclude_host_parents'] == regex
         deploy_configure_by_command(
-            config_command, form_data['hypervisor_type'], org=default_org.label
+            config_command, form_data_ui['hypervisor_type'], org=default_org.label
         )
         assert regex == get_configure_option('exclude_hosts', config_file)
         assert regex == get_configure_option('exclude_host_parents', config_file)
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_proxy_option(self, default_org, virtwho_config_ui, org_session, form_data_ui):
         """Verify 'HTTP Proxy' and 'Ignore Proxy' options.
 
         :id: 6659d577-0135-4bf0-81af-14b930011536
@@ -285,31 +247,31 @@ class TestVirtwhoConfigforEsx:
         http_proxy, http_proxy_name, http_proxy_id = create_http_proxy(
             http_type='http', org=default_org
         )
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         no_proxy = 'test.satellite.com'
         # Check the https proxy and No_PROXY settings
-        session.virtwho_configure.edit(name, {'proxy': https_proxy, 'no_proxy': no_proxy})
-        results = session.virtwho_configure.read(name)
+        org_session.virtwho_configure.edit(name, {'proxy': https_proxy, 'no_proxy': no_proxy})
+        results = org_session.virtwho_configure.read(name)
         assert results['overview']['proxy'] == https_proxy
         assert results['overview']['no_proxy'] == no_proxy
         deploy_configure_by_command(
-            config_command, form_data['hypervisor_type'], org=default_org.label
+            config_command, form_data_ui['hypervisor_type'], org=default_org.label
         )
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
         # Check the http proxy setting
-        session.virtwho_configure.edit(name, {'proxy': http_proxy})
-        results = session.virtwho_configure.read(name)
+        org_session.virtwho_configure.edit(name, {'proxy': http_proxy})
+        results = org_session.virtwho_configure.read(name)
         assert results['overview']['proxy'] == http_proxy
         deploy_configure_by_command(
-            config_command, form_data['hypervisor_type'], org=default_org.label
+            config_command, form_data_ui['hypervisor_type'], org=default_org.label
         )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy
 
     @pytest.mark.tier2
-    def test_positive_virtwho_roles(self, session):
+    def test_positive_virtwho_roles(self, org_session):
         """Verify the default roles for virtwho configure
 
         :id: cd6a5363-f9ba-4b52-892c-905634168fc5
@@ -337,14 +299,14 @@ class TestVirtwhoConfigforEsx:
             },
             'Virt-who Viewer': {'Satellite virt who configure/config': ['view_virt_who_config']},
         }
-        with session:
+        with org_session:
             for role_name, role_filters in roles.items():
-                assert session.role.search(role_name)[0]['Name'] == role_name
-                assigned_permissions = session.filter.read_permissions(role_name)
+                assert org_session.role.search(role_name)[0]['Name'] == role_name
+                assigned_permissions = org_session.filter.read_permissions(role_name)
                 assert sorted(assigned_permissions) == sorted(role_filters)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_configs_widget(self, default_org, session, form_data):
+    def test_positive_virtwho_configs_widget(self, default_org, org_session, form_data_ui):
         """Check if Virt-who Configurations Status Widget is working in the Dashboard UI
 
         :id: 5d61ce00-a640-4823-89d4-7b1d02b50ea6
@@ -363,38 +325,40 @@ class TestVirtwhoConfigforEsx:
         """
         org_name = gen_string('alpha')
         name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.organization.create({'name': org_name})
-            session.organization.select(org_name)
-            session.virtwho_configure.create(form_data)
+        form_data_ui['name'] = name
+        with org_session:
+            org_session.organization.create({'name': org_name})
+            org_session.organization.select(org_name)
+            org_session.virtwho_configure.create(form_data_ui)
             expected_values = [
                 {'Configuration Status': 'No Reports', 'Count': '1'},
                 {'Configuration Status': 'No Change', 'Count': '0'},
                 {'Configuration Status': 'OK', 'Count': '0'},
                 {'Configuration Status': 'Total Configurations', 'Count': '1'},
             ]
-            values = session.dashboard.read('VirtWhoConfigStatus')
+            values = org_session.dashboard.read('VirtWhoConfigStatus')
             assert values['config_status'] == expected_values
             assert values['latest_config'] == 'No configuration found'
             # Check the 'Status' changed after deployed the virt-who config
             config_id = get_configure_id(name)
             config_command = get_configure_command(config_id, org_name)
-            deploy_configure_by_command(config_command, form_data['hypervisor_type'], org=org_name)
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+            deploy_configure_by_command(
+                config_command, form_data_ui['hypervisor_type'], org=org_name
+            )
+            assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
             expected_values = [
                 {'Configuration Status': 'No Reports', 'Count': '0'},
                 {'Configuration Status': 'No Change', 'Count': '0'},
                 {'Configuration Status': 'OK', 'Count': '1'},
                 {'Configuration Status': 'Total Configurations', 'Count': '1'},
             ]
-            values = session.dashboard.read('VirtWhoConfigStatus')
+            values = org_session.dashboard.read('VirtWhoConfigStatus')
             assert values['config_status'] == expected_values
             assert values['latest_config'] == 'No configuration found'
-            session.organization.select("Default Organization")
+            org_session.organization.select("Default Organization")
 
     @pytest.mark.tier2
-    def test_positive_delete_configure(self, default_org, session, form_data):
+    def test_positive_delete_configure(self, default_org, org_session, form_data_ui):
         """Verify when a config is deleted the associated user is deleted.
 
         :id: 0e66dcf6-dc64-4fb2-b8a9-518f5adfa800
@@ -410,22 +374,24 @@ class TestVirtwhoConfigforEsx:
 
         """
         name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
-            session.virtwho_configure.create(form_data)
+        form_data_ui['name'] = name
+        with org_session:
+            org_session.virtwho_configure.create(form_data_ui)
             config_id = get_configure_id(name)
             config_command = get_configure_command(config_id, default_org.name)
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
+                config_command, form_data_ui['hypervisor_type'], org=default_org.label
             )
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+            assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+            org_session.virtwho_configure.delete(name)
+            assert not org_session.virtwho_configure.search(name)
             restart_virtwho_service()
             assert get_virtwho_status() == 'logerror'
 
     @pytest.mark.tier2
-    def test_positive_virtwho_reporter_role(self, default_org, session, test_name, form_data):
+    def test_positive_virtwho_reporter_role(
+        self, default_org, org_session, test_name, form_data_ui
+    ):
         """Verify the virt-who reporter role can TRULY work.
 
         :id: cd235ab0-d89c-464b-98d6-9d090ac40d8f
@@ -438,9 +404,9 @@ class TestVirtwhoConfigforEsx:
         username = gen_string('alpha')
         password = gen_string('alpha')
         config_name = gen_string('alpha')
-        with session:
+        with org_session:
             # Create an user
-            session.user.create(
+            org_session.user.create(
                 {
                     'user.login': username,
                     'user.mail': valid_emails_list()[0],
@@ -450,14 +416,14 @@ class TestVirtwhoConfigforEsx:
                 }
             )
             # Create a virt-who config plugin
-            form_data['name'] = config_name
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(config_name)
+            form_data_ui['name'] = config_name
+            org_session.virtwho_configure.create(form_data_ui)
+            values = org_session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_ui['hypervisor_type'], org=default_org.label
             )
-            assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
+            assert org_session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Update the virt-who config file
             config_id = get_configure_id(config_name)
             config_file = get_configure_file(config_id)
@@ -467,19 +433,19 @@ class TestVirtwhoConfigforEsx:
             restart_virtwho_service()
             assert get_virtwho_status() == 'logerror'
             # Check the permissioin of Virt-who Reporter
-            session.user.update(username, {'roles.resources.assigned': ['Virt-who Reporter']})
-            assert session.user.search(username)[0]['Username'] == username
-            user = session.user.read(username)
+            org_session.user.update(username, {'roles.resources.assigned': ['Virt-who Reporter']})
+            assert org_session.user.search(username)[0]['Username'] == username
+            user = org_session.user.read(username)
             assert user['roles']['resources']['assigned'] == ['Virt-who Reporter']
             restart_virtwho_service()
             assert get_virtwho_status() == 'running'
             with Session(test_name, username, password) as newsession:
                 assert not newsession.virtwho_configure.check_create_permission()['can_view']
-            session.user.delete(username)
-            assert not session.user.search(username)
+            org_session.user.delete(username)
+            assert not org_session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_viewer_role(self, default_org, session, test_name, form_data):
+    def test_positive_virtwho_viewer_role(self, default_org, org_session, test_name, form_data_ui):
         """Verify the virt-who viewer role can TRULY work.
 
         :id: bf3be2e4-3853-41cc-9b3e-c8677f0b8c5f
@@ -492,9 +458,9 @@ class TestVirtwhoConfigforEsx:
         username = gen_string('alpha')
         password = gen_string('alpha')
         config_name = gen_string('alpha')
-        with session:
+        with org_session:
             # Create an user
-            session.user.create(
+            org_session.user.create(
                 {
                     'user.login': username,
                     'user.mail': valid_emails_list()[0],
@@ -504,17 +470,17 @@ class TestVirtwhoConfigforEsx:
                 }
             )
             # Create a virt-who config plugin
-            form_data['name'] = config_name
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(config_name)
+            form_data_ui['name'] = config_name
+            org_session.virtwho_configure.create(form_data_ui)
+            values = org_session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_ui['hypervisor_type'], org=default_org.label
             )
-            assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
+            assert org_session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Check the permissioin of Virt-who Viewer
-            session.user.update(username, {'roles.resources.assigned': ['Virt-who Viewer']})
-            user = session.user.read(username)
+            org_session.user.update(username, {'roles.resources.assigned': ['Virt-who Viewer']})
+            user = org_session.user.read(username)
             assert user['roles']['resources']['assigned'] == ['Virt-who Viewer']
             # Update the virt-who config file
             config_id = get_configure_id(config_name)
@@ -535,11 +501,11 @@ class TestVirtwhoConfigforEsx:
                 assert not update_permission['can_edit']
                 newsession.virtwho_configure.read(config_name)
             # Delete the created user
-            session.user.delete(username)
-            assert not session.user.search(username)
+            org_session.user.delete(username)
+            assert not org_session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_manager_role(self, default_org, session, test_name, form_data):
+    def test_positive_virtwho_manager_role(self, default_org, org_session, test_name, form_data_ui):
         """Verify the virt-who manager role can TRULY work.
 
         :id: a72023fb-7b23-4582-9adc-c5227dc7859c
@@ -551,9 +517,9 @@ class TestVirtwhoConfigforEsx:
         username = gen_string('alpha')
         password = gen_string('alpha')
         config_name = gen_string('alpha')
-        with session:
+        with org_session:
             # Create an user
-            session.user.create(
+            org_session.user.create(
                 {
                     'user.login': username,
                     'user.mail': valid_emails_list()[0],
@@ -563,28 +529,28 @@ class TestVirtwhoConfigforEsx:
                 }
             )
             # Create a virt-who config plugin
-            form_data['name'] = config_name
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(config_name)
+            form_data_ui['name'] = config_name
+            org_session.virtwho_configure.create(form_data_ui)
+            values = org_session.virtwho_configure.read(config_name)
             command = values['deploy']['command']
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_ui['hypervisor_type'], org=default_org.label
             )
-            assert session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
+            assert org_session.virtwho_configure.search(config_name)[0]['Status'] == 'ok'
             # Check the permissioin of Virt-who Manager
-            session.user.update(username, {'roles.resources.assigned': ['Virt-who Manager']})
-            user = session.user.read(username)
+            org_session.user.update(username, {'roles.resources.assigned': ['Virt-who Manager']})
+            user = org_session.user.read(username)
             assert user['roles']['resources']['assigned'] == ['Virt-who Manager']
             with Session(test_name, username, password) as newsession:
                 # create_virt_who_config
                 new_virt_who_name = gen_string('alpha')
-                form_data['name'] = new_virt_who_name
-                newsession.virtwho_configure.create(form_data)
+                form_data_ui['name'] = new_virt_who_name
+                newsession.virtwho_configure.create(form_data_ui)
                 # view_virt_who_config
                 values = newsession.virtwho_configure.read(new_virt_who_name)
                 command = values['deploy']['command']
                 deploy_configure_by_command(
-                    command, form_data['hypervisor_type'], org=default_org.label
+                    command, form_data_ui['hypervisor_type'], org=default_org.label
                 )
                 assert newsession.virtwho_configure.search(new_virt_who_name)[0]['Status'] == 'ok'
                 # edit_virt_who_config
@@ -595,11 +561,11 @@ class TestVirtwhoConfigforEsx:
                 newsession.virtwho_configure.delete(modify_name)
                 assert not newsession.virtwho_configure.search(modify_name)
             # Delete the created user
-            session.user.delete(username)
-            assert not session.user.search(username)
+            org_session.user.delete(username)
+            assert not org_session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_overview_label_name(self, default_org, form_data, session):
+    def test_positive_overview_label_name(self, default_org, form_data_ui, org_session):
         """Verify the label name on virt-who config Overview Page.
 
         :id: 21df8175-bb41-422e-a263-8677bc3a9565
@@ -613,20 +579,20 @@ class TestVirtwhoConfigforEsx:
         :CaseImportance: Medium
         """
         name = gen_string('alpha')
-        form_data['name'] = name
-        hypervisor_type = form_data['hypervisor_type']
+        form_data_ui['name'] = name
+        hypervisor_type = form_data_ui['hypervisor_type']
         http_proxy_url, proxy_name, proxy_id = create_http_proxy(org=default_org)
-        form_data['proxy'] = http_proxy_url
-        form_data['no_proxy'] = 'test.satellite.com'
+        form_data_ui['proxy'] = http_proxy_url
+        form_data_ui['no_proxy'] = 'test.satellite.com'
         regex = '.*redhat.com'
         whitelist = {'filtering': 'Whitelist', 'filtering_content.filter_hosts': regex}
         blacklist = {'filtering': 'Blacklist', 'filtering_content.exclude_hosts': regex}
         if hypervisor_type == 'esx':
             whitelist['filtering_content.filter_host_parents'] = regex
             blacklist['filtering_content.exclude_host_parents'] = regex
-        form_data = dict(form_data, **whitelist)
-        with session:
-            session.virtwho_configure.create(form_data)
+        form_data = dict(form_data_ui, **whitelist)
+        with org_session:
+            org_session.virtwho_configure.create(form_data)
             fields = {
                 'status_label': 'Status',
                 'hypervisor_type_label': 'Hypervisor Type',
@@ -647,11 +613,11 @@ class TestVirtwhoConfigforEsx:
                 fields['kubeconfig_path_label'] = 'Kubeconfig Path'
             if hypervisor_type == 'esx':
                 fields['filter_host_parents_label'] = 'Filter Host Parents'
-            results = session.virtwho_configure.read(name)
+            results = org_session.virtwho_configure.read(name)
             for key, value in fields.items():
                 assert results['overview'][key] == value
-            session.virtwho_configure.edit(name, blacklist)
-            results = session.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, blacklist)
+            results = org_session.virtwho_configure.read(name)
             del fields['filter_hosts_label']
             if hypervisor_type == 'esx':
                 del fields['filter_host_parents_label']
@@ -661,7 +627,9 @@ class TestVirtwhoConfigforEsx:
                 assert results['overview'][key] == value
 
     @pytest.mark.tier2
-    def test_positive_last_checkin_status(self, default_org, virtwho_config, form_data, session):
+    def test_positive_last_checkin_status(
+        self, default_org, virtwho_config_ui, form_data_ui, org_session
+    ):
         """Verify the Last Checkin status on Content Hosts Page.
 
         :id: 7448d482-d05c-4727-8980-176586e9e4a7
@@ -676,15 +644,15 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name, widget_names='deploy.command')
+        name = form_data_ui['name']
+        values = org_session.virtwho_configure.read(name, widget_names='deploy.command')
         command = values['deploy']['command']
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            command, form_data_ui['hypervisor_type'], debug=True, org=default_org.label
         )
-        time_now = session.browser.get_client_datetime()
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        checkin_time = session.contenthost.search(hypervisor_name)[0]['Last Checkin']
+        time_now = org_session.browser.get_client_datetime()
+        assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        checkin_time = org_session.contenthost.search(hypervisor_name)[0]['Last Checkin']
         # 10 mins margin to check the Last Checkin time
         assert (
             abs(
@@ -698,7 +666,7 @@ class TestVirtwhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_hypervisor_password_with_special_characters(
-        self, default_org, form_data, target_sat, session
+        self, default_org, form_data_ui, target_sat, org_session
     ):
         """Verify " hammer virt-who-config deploy hypervisor with special characters"
 
@@ -715,12 +683,12 @@ class TestVirtwhoConfigforEsx:
         :customerscenario: true
         """
         name = gen_string('alpha')
-        form_data['name'] = name
-        with session:
+        form_data_ui['name'] = name
+        with org_session:
             # check the hypervisor password contains single quotes
-            form_data['hypervisor_content.password'] = "Tes't"
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
+            form_data_ui['hypervisor_content.password'] = "Tes't"
+            org_session.virtwho_configure.create(form_data_ui)
+            values = org_session.virtwho_configure.read(name)
             command = values['deploy']['command']
             config_id = get_configure_id(name)
             deploy_status = deploy_configure_by_command_check(command)
@@ -731,12 +699,12 @@ class TestVirtwhoConfigforEsx:
                 get_configure_option('username', config_file)
                 == settings.virtwho.esx.hypervisor_username
             )
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+            org_session.virtwho_configure.delete(name)
+            assert not org_session.virtwho_configure.search(name)
             # check the hypervisor password contains backtick
-            form_data['hypervisor_content.password'] = "my`password"
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
+            form_data_ui['hypervisor_content.password'] = "my`password"
+            org_session.virtwho_configure.create(form_data_ui)
+            values = org_session.virtwho_configure.read(name)
             command = values['deploy']['command']
             config_id = get_configure_id(name)
             deploy_status = deploy_configure_by_command_check(command)
@@ -747,12 +715,12 @@ class TestVirtwhoConfigforEsx:
                 get_configure_option('username', config_file)
                 == settings.virtwho.esx.hypervisor_username
             )
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+            org_session.virtwho_configure.delete(name)
+            assert not org_session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
     def test_positive_remove_env_option(
-        self, default_org, virtwho_config, form_data, target_sat, session
+        self, default_org, virtwho_config_ui, form_data_ui, target_sat, org_session
     ):
         """remove option 'env=' from the virt-who configuration file and without any error
 
@@ -770,13 +738,13 @@ class TestVirtwhoConfigforEsx:
 
         :customerscenario: true
         """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
+        name = form_data_ui['name']
+        values = org_session.virtwho_configure.read(name)
         command = values['deploy']['command']
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            command, form_data_ui['hypervisor_type'], debug=True, org=default_org.label
         )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
         option = "env"
         config_id = get_configure_id(name)

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -16,13 +16,11 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_id,
@@ -30,36 +28,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data():
-    form = {
-        'debug': True,
-        'interval': 'Every hour',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
-        'hypervisor_content.server': settings.virtwho.hyperv.hypervisor_server,
-        'hypervisor_content.username': settings.virtwho.hyperv.hypervisor_username,
-        'hypervisor_content.password': settings.virtwho.hyperv.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat, session):
-    name = gen_string('alpha')
-    form_data['name'] = name
-    with session:
-        session.virtwho_configure.create(form_data)
-        yield virtwho_config
-        session.virtwho_configure.delete(name)
-        assert not session.virtwho_configure.search(name)
-
-
 class TestVirtwhoConfigforHyperv:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, virtwho_config, session, form_data, deploy_type
+        self, default_org, org_session, form_data_ui, deploy_type_ui
     ):
         """Verify configure created and deployed with id.
 
@@ -76,37 +49,30 @@ class TestVirtwhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        if deploy_type == "id":
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisor_name, guest_name = deploy_type_ui
+        assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         assert (
-            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions'][
+                'status'
+            ]
             == 'Unsubscribed hypervisor'
         )
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert org_session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
         assert (
-            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
             == 'Unentitled'
         )
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert org_session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_hypervisor_id_option(
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
+    ):
         """Verify Hypervisor ID dropdown options.
 
         :id: f2efc018-d57e-4dc5-895e-53af320237de
@@ -119,16 +85,16 @@ class TestVirtwhoConfigforHyperv:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         config_file = get_configure_file(config_id)
         values = ['uuid', 'hostname']
         for value in values:
-            session.virtwho_configure.edit(name, {'hypervisor_id': value})
-            results = session.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
+                config_command, form_data_ui['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -14,13 +14,10 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_id,
@@ -28,36 +25,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data():
-    form = {
-        'debug': True,
-        'interval': 'Every hour',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
-        'hypervisor_content.server': settings.virtwho.hyperv.hypervisor_server,
-        'hypervisor_content.username': settings.virtwho.hyperv.hypervisor_username,
-        'hypervisor_content.password': settings.virtwho.hyperv.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat, session_sca):
-    name = gen_string('alpha')
-    form_data['name'] = name
-    with session_sca:
-        session_sca.virtwho_configure.create(form_data)
-        yield virtwho_config
-        session_sca.virtwho_configure.delete(name)
-        assert not session_sca.virtwho_configure.search(name)
-
-
 class TestVirtwhoConfigforHyperv:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, virtwho_config, session_sca, form_data, deploy_type
+        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui
     ):
         """Verify configure created and deployed with id.
 
@@ -74,29 +46,11 @@ class TestVirtwhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        name = form_data['name']
-        values = session_sca.virtwho_configure.read(name)
-        if deploy_type == "id":
-            command = values['deploy']['command']
-            deploy_configure_by_command(
-                command,
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
-        elif deploy_type == "script":
-            script = values['deploy']['script']
-            deploy_configure_by_script(
-                script,
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
-        assert session_sca.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, virtwho_config, session_sca, form_data
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):
         """Verify Hypervisor ID dropdown options.
 
@@ -110,16 +64,16 @@ class TestVirtwhoConfigforHyperv:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, module_sca_manifest_org.name)
         config_file = get_configure_file(config_id)
         values = ['uuid', 'hostname']
         for value in values:
-            session_sca.virtwho_configure.edit(name, {'hypervisor_id': value})
-            results = session_sca.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -16,13 +16,11 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_id,
@@ -30,34 +28,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data():
-    form = {
-        'debug': True,
-        'interval': 'Every hour',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
-        'hypervisor_content.kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat, session):
-    name = gen_string('alpha')
-    form_data['name'] = name
-    with session:
-        session.virtwho_configure.create(form_data)
-        yield virtwho_config
-        session.virtwho_configure.delete(name)
-        assert not session.virtwho_configure.search(name)
-
-
 class TestVirtwhoConfigforKubevirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, virtwho_config, session, form_data, deploy_type
+        self, default_org, org_session, form_data_ui, deploy_type_ui
     ):
         """Verify configure created and deployed with id.
 
@@ -74,37 +49,30 @@ class TestVirtwhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        if deploy_type == "id":
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisor_name, guest_name = deploy_type_ui
+        assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         assert (
-            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions'][
+                'status'
+            ]
             == 'Unsubscribed hypervisor'
         )
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert org_session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
         assert (
-            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
             == 'Unentitled'
         )
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert org_session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_hypervisor_id_option(
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
+    ):
         """Verify Hypervisor ID dropdown options.
 
         :id: 09826cc0-aa49-4355-8980-8097511eb7d7
@@ -117,16 +85,16 @@ class TestVirtwhoConfigforKubevirt:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         config_file = get_configure_file(config_id)
         values = ['uuid', 'hostname']
         for value in values:
-            session.virtwho_configure.edit(name, {'hypervisor_id': value})
-            results = session.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
+                config_command, form_data_ui['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -16,13 +16,11 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_id,
@@ -30,35 +28,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data():
-    form = {
-        'debug': True,
-        'interval': 'Every hour',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.libvirt.hypervisor_type,
-        'hypervisor_content.server': settings.virtwho.libvirt.hypervisor_server,
-        'hypervisor_content.username': settings.virtwho.libvirt.hypervisor_username,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat, session):
-    name = gen_string('alpha')
-    form_data['name'] = name
-    with session:
-        session.virtwho_configure.create(form_data)
-        yield virtwho_config
-        session.virtwho_configure.delete(name)
-        assert not session.virtwho_configure.search(name)
-
-
 class TestVirtwhoConfigforLibvirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, virtwho_config, session, form_data, deploy_type
+        self, default_org, org_session, form_data_ui, deploy_type_ui
     ):
         """Verify configure created and deployed with id.
 
@@ -75,37 +49,30 @@ class TestVirtwhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        if deploy_type == "id":
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisor_name, guest_name = deploy_type_ui
+        assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         assert (
-            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions'][
+                'status'
+            ]
             == 'Unsubscribed hypervisor'
         )
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert org_session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
         assert (
-            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
             == 'Unentitled'
         )
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert org_session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_hypervisor_id_option(
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
+    ):
         """Verify Hypervisor ID dropdown options.
 
         :id: b8b2b272-89f2-45d0-b922-6e988b20808b
@@ -118,16 +85,16 @@ class TestVirtwhoConfigforLibvirt:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         config_file = get_configure_file(config_id)
         values = ['uuid', 'hostname']
         for value in values:
-            session.virtwho_configure.edit(name, {'hypervisor_id': value})
-            results = session.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
+                config_command, form_data_ui['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -14,13 +14,10 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_id,
@@ -28,35 +25,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data():
-    form = {
-        'debug': True,
-        'interval': 'Every hour',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.libvirt.hypervisor_type,
-        'hypervisor_content.server': settings.virtwho.libvirt.hypervisor_server,
-        'hypervisor_content.username': settings.virtwho.libvirt.hypervisor_username,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat, session_sca):
-    name = gen_string('alpha')
-    form_data['name'] = name
-    with session_sca:
-        session_sca.virtwho_configure.create(form_data)
-        yield virtwho_config
-        session_sca.virtwho_configure.delete(name)
-        assert not session_sca.virtwho_configure.search(name)
-
-
 class TestVirtwhoConfigforLibvirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, virtwho_config, session_sca, form_data, deploy_type
+        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui
     ):
         """Verify configure created and deployed with id.
 
@@ -73,29 +46,11 @@ class TestVirtwhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        name = form_data['name']
-        values = session_sca.virtwho_configure.read(name)
-        if deploy_type == "id":
-            command = values['deploy']['command']
-            deploy_configure_by_command(
-                command,
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
-        elif deploy_type == "script":
-            script = values['deploy']['script']
-            deploy_configure_by_script(
-                script,
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
-        assert session_sca.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, virtwho_config, session_sca, form_data
+        self, module_sca_manifest_org, virtwho_config_ui, org_session, form_data_ui
     ):
         """Verify Hypervisor ID dropdown options.
 
@@ -109,16 +64,16 @@ class TestVirtwhoConfigforLibvirt:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, module_sca_manifest_org.name)
         config_file = get_configure_file(config_id)
         values = ['uuid', 'hostname']
         for value in values:
-            session_sca.virtwho_configure.edit(name, {'hypervisor_id': value})
-            results = session_sca.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                config_command, form_data_ui['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -32,38 +32,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data():
-    form = {
-        'debug': True,
-        'interval': 'Every hour',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.ahv.hypervisor_type,
-        'hypervisor_content.server': settings.virtwho.ahv.hypervisor_server,
-        'hypervisor_content.username': settings.virtwho.ahv.hypervisor_username,
-        'hypervisor_content.password': settings.virtwho.ahv.hypervisor_password,
-        'hypervisor_content.prism_flavor': "Prism Element",
-        'ahv_internal_debug': False,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat, session):
-    name = gen_string('alpha')
-    form_data['name'] = name
-    with session:
-        session.virtwho_configure.create(form_data)
-        yield virtwho_config
-        session.virtwho_configure.delete(name)
-        assert not session.virtwho_configure.search(name)
-
-
 class TestVirtwhoConfigforNutanix:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, virtwho_config, session, form_data, deploy_type
+        self, default_org, org_session, form_data_ui, deploy_type_ui
     ):
         """Verify configure created and deployed with id.
 
@@ -80,37 +53,30 @@ class TestVirtwhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
-        if deploy_type == "id":
-            command = values['deploy']['command']
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = values['deploy']['script']
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-        hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisor_name, guest_name = deploy_type_ui
+        assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
         vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
         vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
         assert (
-            session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions'][
+                'status'
+            ]
             == 'Unsubscribed hypervisor'
         )
-        session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-        assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
+        assert org_session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
         assert (
-            session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+            org_session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
             == 'Unentitled'
         )
-        session.contenthost.add_subscription(guest_name, vdc_virtual)
-        assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
+        org_session.contenthost.add_subscription(guest_name, vdc_virtual)
+        assert org_session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
 
     @pytest.mark.tier2
-    def test_positive_hypervisor_id_option(self, default_org, virtwho_config, session, form_data):
+    def test_positive_hypervisor_id_option(
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
+    ):
         """Verify Hypervisor ID dropdown options.
 
         :id: e076a305-88f4-42fb-8ef2-cb55e38eb912
@@ -123,25 +89,25 @@ class TestVirtwhoConfigforNutanix:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
-        values = session.virtwho_configure.read(name)
+        name = form_data_ui['name']
+        values = org_session.virtwho_configure.read(name)
         config_id = get_configure_id(name)
         config_command = values['deploy']['command']
         config_file = get_configure_file(config_id)
         values = ['uuid', 'hostname']
         for value in values:
-            session.virtwho_configure.edit(name, {'hypervisor_id': value})
-            results = session.virtwho_configure.read(name)
+            org_session.virtwho_configure.edit(name, {'hypervisor_id': value})
+            results = org_session.virtwho_configure.read(name)
             assert results['overview']['hypervisor_id'] == value
             deploy_configure_by_command(
-                config_command, form_data['hypervisor_type'], org=default_org.label
+                config_command, form_data_ui['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
-        self, default_org, session, form_data, deploy_type
+        self, default_org, org_session, form_data_ui, deploy_type
     ):
         """Verify configure created and deployed with id on nutanix prism central mode
 
@@ -160,49 +126,51 @@ class TestVirtwhoConfigforNutanix:
         :CaseImportance: High
         """
         name = gen_string('alpha')
-        form_data['name'] = name
-        form_data['hypervisor_content.prism_flavor'] = "Prism Central"
-        with session:
-            session.virtwho_configure.create(form_data)
-            values = session.virtwho_configure.read(name)
+        form_data_ui['name'] = name
+        form_data_ui['hypervisor_content.prism_flavor'] = "Prism Central"
+        with org_session:
+            org_session.virtwho_configure.create(form_data_ui)
+            values = org_session.virtwho_configure.read(name)
             if deploy_type == "id":
                 command = values['deploy']['command']
                 hypervisor_name, guest_name = deploy_configure_by_command(
-                    command, form_data['hypervisor_type'], debug=True, org=default_org.label
+                    command, form_data_ui['hypervisor_type'], debug=True, org=default_org.label
                 )
             elif deploy_type == "script":
                 script = values['deploy']['script']
                 hypervisor_name, guest_name = deploy_configure_by_script(
-                    script, form_data['hypervisor_type'], debug=True, org=default_org.label
+                    script, form_data_ui['hypervisor_type'], debug=True, org=default_org.label
                 )
             # Check the option "prism_central=true" should be set in etc/virt-who.d/virt-who.conf
             config_id = get_configure_id(name)
             config_file = get_configure_file(config_id)
             assert get_configure_option("prism_central", config_file) == 'true'
-            assert session.virtwho_configure.search(name)[0]['Status'] == 'ok'
-            hypervisor_display_name = session.contenthost.search(hypervisor_name)[0]['Name']
+            assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+            hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
             vdc_physical = f'product_id = {settings.virtwho.sku.vdc_physical} and type=NORMAL'
             vdc_virtual = f'product_id = {settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'
             assert (
-                session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions'][
+                org_session.contenthost.read_legacy_ui(hypervisor_display_name)['subscriptions'][
                     'status'
                 ]
                 == 'Unsubscribed hypervisor'
             )
-            session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
-            assert session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+            org_session.contenthost.add_subscription(hypervisor_display_name, vdc_physical)
             assert (
-                session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
+                org_session.contenthost.search(hypervisor_name)[0]['Subscription Status'] == 'green'
+            )
+            assert (
+                org_session.contenthost.read_legacy_ui(guest_name)['subscriptions']['status']
                 == 'Unentitled'
             )
-            session.contenthost.add_subscription(guest_name, vdc_virtual)
-            assert session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)
+            org_session.contenthost.add_subscription(guest_name, vdc_virtual)
+            assert org_session.contenthost.search(guest_name)[0]['Subscription Status'] == 'green'
+            org_session.virtwho_configure.delete(name)
+            assert not org_session.virtwho_configure.search(name)
 
     @pytest.mark.tier2
     def test_positive_prism_central_prism_flavor_option(
-        self, default_org, virtwho_config, session, form_data
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
     ):
         """Verify prism_flavor dropdown options.
 
@@ -216,23 +184,25 @@ class TestVirtwhoConfigforNutanix:
 
         :CaseImportance: Medium
         """
-        name = form_data['name']
-        results = session.virtwho_configure.read(name)
+        name = form_data_ui['name']
+        results = org_session.virtwho_configure.read(name)
         assert results['overview']['prism_flavor'] == "element"
         config_id = get_configure_id(name)
         config_command = get_configure_command(config_id, default_org.name)
         config_file = get_configure_file(config_id)
-        session.virtwho_configure.edit(name, {'hypervisor_content.prism_flavor': "Prism Central"})
-        results = session.virtwho_configure.read(name)
+        org_session.virtwho_configure.edit(
+            name, {'hypervisor_content.prism_flavor': "Prism Central"}
+        )
+        results = org_session.virtwho_configure.read(name)
         assert results['overview']['prism_flavor'] == "central"
         deploy_configure_by_command(
-            config_command, form_data['hypervisor_type'], org=default_org.label
+            config_command, form_data_ui['hypervisor_type'], org=default_org.label
         )
         assert get_configure_option('prism_central', config_file) == 'true'
 
     @pytest.mark.tier2
     def test_positive_ahv_internal_debug_option(
-        self, default_org, virtwho_config, session, form_data
+        self, default_org, virtwho_config_ui, org_session, form_data_ui
     ):
         """Verify ahv_internal_debug option by hammer virt-who-config"
 
@@ -253,15 +223,15 @@ class TestVirtwhoConfigforNutanix:
         :BZ: 2141719
         :customerscenario: true
         """
-        name = form_data['name']
+        name = form_data_ui['name']
         config_id = get_configure_id(name)
-        values = session.virtwho_configure.read(name)
+        values = org_session.virtwho_configure.read(name)
         command = values['deploy']['command']
         config_file = get_configure_file(config_id)
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            command, form_data_ui['hypervisor_type'], debug=True, org=default_org.label
         )
-        results = session.virtwho_configure.read(name)
+        results = org_session.virtwho_configure.read(name)
         assert str(results['overview']['ahv_internal_debug']) == 'False'
         # ahv_internal_debug does not set in virt-who-config-X.conf
         option = 'ahv_internal_debug'
@@ -275,14 +245,16 @@ class TestVirtwhoConfigforNutanix:
         assert check_message_in_rhsm_log(message) == message
 
         # Update ahv_internal_debug option to true
-        session.virtwho_configure.edit(name, {'ahv_internal_debug': True})
-        results = session.virtwho_configure.read(name)
+        org_session.virtwho_configure.edit(name, {'ahv_internal_debug': True})
+        results = org_session.virtwho_configure.read(name)
         command = results['deploy']['command']
         assert str(results['overview']['ahv_internal_debug']) == 'True'
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            command, form_data_ui['hypervisor_type'], debug=True, org=default_org.label
         )
-        assert get_hypervisor_ahv_mapping(form_data['hypervisor_type']) == 'Host UUID found for VM'
+        assert (
+            get_hypervisor_ahv_mapping(form_data_ui['hypervisor_type']) == 'Host UUID found for VM'
+        )
         # ahv_internal_debug bas been set to true in virt-who-config-X.conf
         config_file = get_configure_file(config_id)
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'


### PR DESCRIPTION
fixture support for virt-who config api : data_form deploy_type virtwho_config
depend on https://github.com/SatelliteQE/robottelo/pull/12619 remove content for manifest
Cases PASS:
```
(robottlo_vv311) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_hyperv**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 14 warnings in 2253.83s (0:37:33)


(robottlo_vv311) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx**.py --disable-pytest-warnings -q
..................................                                                                                                                                                                          [100%]

34 passed, 34 deselected, 22 warnings in 7530.92s (2:05:30)
(robottlo_vv311) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_libvirt**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 14 warnings in 1887.52s (0:31:27)


(robottlo_vv311) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_kubevirt**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 14 warnings in 1976.89s (0:32:56)
(robottlo_vv311) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_nutanix**.py --disable-pytest-warnings -q
..............E                                                                                                                                                                                             [100%]
14 passed, 14 deselected, 14 warnings, 1 error in 4094.89s (1:08:14)
```