### PR TITLE
bump python version for weekly action

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v4


### PR DESCRIPTION
weekly check (that looks if customerscenario tags are not missing) was not checking for a while, the failure was on dependency install, bumping python version to get over it