### PR TITLE
Copy dependencies label for dependencies PRs

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -10,6 +10,7 @@ env:
   assignee: ${{ github.event.pull_request.assignee.login }}
   title: ${{ github.event.pull_request.title }}
   number: ${{ github.event.number }}
+  is_dependabot_pr: ''
 
 jobs:
 
@@ -52,6 +53,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      ## Set env var for dependencies label PR
+      - name: Set env var is_dependabot_pr to `dependencies` to set the label
+        if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+        run: |
+          echo "is_dependabot_pr=dependencies" >> $GITHUB_ENV
+
       ## CherryPicking and AutoMerging
       - name: Cherrypicking to zStream branch
         id: cherrypick
@@ -64,6 +71,7 @@ jobs:
             Auto_Cherry_Picked
             ${{ matrix.label }}
             No-CherryPick
+            ${{ env.is_dependabot_pr }}
           assignees: ${{ env.assignee }}
 
       - name: Add Parent PR's PRT comment to Auto_Cherry_Picked PR's


### PR DESCRIPTION
AutoCherryPick is currently missed adding `dependencies` label to the AutoCherrypicked Dependabot PRs and hence dependabot zStream cherrypicked PRs are not automerging as its missing the label for `dependencies`.

There is another reason its missing automerging the zStream PRs for which the PR is already raised : #12483 !


Verifed its working in my local testing repository:

- The GHA run finding and setting dependencies label: https://github.com/jyejare/test-acp/actions/runs/6260767022/job/16999485038?pr=17 
- The PR opened with dependencies label since parent PR has dependencies label: https://github.com/jyejare/test-acp/pull/18 