### PR TITLE
[6.12.z] Replace flake8 with Ruff

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,22 +10,17 @@ repos:
   hooks:
   - id: trailing-whitespace
     exclude: tests/foreman/data/
-  - id: end-of-file-fixer
   - id: check-yaml
   - id: debug-statements
-- repo: https://github.com/asottile/pyupgrade
-  rev: v3.3.0
-  hooks:
-  - id: pyupgrade
-    args: [--py38-plus]
 - repo: https://github.com/psf/black
   rev: 22.10.0
   hooks:
   - id: black
-- repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.0.277
   hooks:
-  - id: flake8
+    - id: ruff
+      args: [--fix, --exit-non-zero-on-fix]
 - repo: local
   hooks:
     - id: fix-uuids

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,29 @@ exclude = '''
 )/
 '''
 
+[tool.ruff]
+target-version = "py311"
+fixable = ["ALL"]
+
+select = [
+    # "C90", # mccabe
+    "E",  # pycodestyle
+    "F",  # flake8
+    # "Q",  # flake8-quotes
+    "UP",  # pyupgrade
+    "W",  # pycodestyle
+]
+
+# Allow lines to be as long as 100 characters.
+line-length = 100
+
+
+[tool.ruff.flake8-quotes]
+inline-quotes = "single"
+
+[tool.ruff.mccabe]
+max-complexity = 20
+
 [tool.pytest.ini_options]
 junit_logging = 'all'
 addopts = '--show-capture=no'

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -315,7 +315,6 @@ REPOSET = {
     'rhel7_extra': 'Red Hat Enterprise Linux 7 Server - Extras (RPMs)',
     'rhel7_optional': 'Red Hat Enterprise Linux 7 Server - Optional (RPMs)',
     'rhel7_sup': 'Red Hat Enterprise Linux 7 Server - Supplementary (RPMs)',
-    'rhst7_610': 'Red Hat Satellite Tools 6.10 (for RHEL 7 Server) (RPMs)',
 }
 
 SM_OVERALL_STATUS = {

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -142,7 +142,7 @@ class ContentInfo:
         :returns: the manifest upload result
 
         """
-        if not isinstance(manifest, (bytes, io.BytesIO)):
+        if not isinstance(manifest, bytes | io.BytesIO):
             if manifest.content is None:
                 manifest = clone()
         if timeout is None:
@@ -160,7 +160,7 @@ class ContentInfo:
                     {'file': manifest.filename, 'organization-id': org_id}, timeout=timeout
                 )
         else:
-            if not isinstance(manifest, (bytes, io.BytesIO)):
+            if not isinstance(manifest, bytes | io.BytesIO):
                 manifest = manifest.content
             result = self.api.Subscription().upload(
                 data={'organization_id': org_id}, files={'content': manifest}

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -92,7 +92,7 @@ def _get_readable_attributes(entity):
     for field_name in list(attributes.keys()):
         if isinstance(
             entity.get_fields()[field_name],
-            (entity_fields.OneToOneField, entity_fields.OneToManyField),
+            entity_fields.OneToOneField | entity_fields.OneToManyField,
         ):
             del attributes[field_name]
 

--- a/tests/foreman/cli/test_webhook.py
+++ b/tests/foreman/cli/test_webhook.py
@@ -57,7 +57,7 @@ def webhook_factory(request, class_org, class_location):
 
 def assert_created(options, hook):
     for option in options.items():
-        if not option[0] in ['event', 'organization-id', 'location-id']:
+        if option[0] not in ['event', 'organization-id', 'location-id']:
             assert hook[option[0]] == option[1]
 
 

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -17,7 +17,6 @@
 :Upstream: No
 """
 import http
-import random
 from collections import defaultdict
 from pprint import pformat
 
@@ -35,7 +34,6 @@ from robottelo.config import settings
 from robottelo.config import user_nailgun_config
 from robottelo.constants.repos import CUSTOM_RPM_REPO
 from robottelo.utils.issue_handlers import is_open
-from robottelo.utils.manifest import clone
 
 
 API_PATHS = {

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -42,7 +42,7 @@ def ui_entity(module_org, module_location, request):
         # Skip the entities, which can't be tested ATM (not implemented in
         # airgun or have open BZs)
         skip = entity.get('skip_for_ui')
-        if isinstance(skip, (tuple, list)):
+        if isinstance(skip, tuple | list):
             open_issues = {issue for issue in skip if is_open(issue)}
             pytest.skip(f'There is/are an open issue(s) {open_issues} with entity {entity_name}')
         # entities with 1 organization and location

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -127,7 +127,7 @@ class TestReturnTypes:
         ):
             assert isinstance(item, str)
         for item in datafactory.invalid_id_list():
-            if not (isinstance(item, (str, int)) or item is None):
+            if not (isinstance(item, str | int) or item is None):
                 pytest.fail('Unexpected data type')
 
 

--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -230,7 +230,7 @@ def pre_upgrade_data(request):
     dependant_on_functions = []
     for marker in request.node.iter_markers(POST_UPGRADE_MARK):
         depend_on = marker.kwargs.get('depend_on')
-        if isinstance(depend_on, (list, tuple)):
+        if isinstance(depend_on, list | tuple):
             dependant_on_functions.extend(depend_on)
         elif depend_on is not None:
             dependant_on_functions.append(depend_on)
@@ -373,7 +373,7 @@ def pytest_collection_modifyitems(items, config):
             dependant_on_functions = []
             for marker in item.iter_markers(POST_UPGRADE_MARK):
                 depend_on = marker.kwargs.get('depend_on')
-                if isinstance(depend_on, (list, tuple)):
+                if isinstance(depend_on, list | tuple):
                     dependant_on_functions.extend(depend_on)
                 elif depend_on is not None:
                     dependant_on_functions.append(depend_on)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12621

This patch replaces flake8 with Ruff that is 10-100x faster than flake8. It enables only a few rule sets that were enabled by pyflakes already.

Other rules will be added in future PRs.

