### PR TITLE
Remove stubbed FM case that is no longer needed

### DIFF
--- a/tests/foreman/maintain/test_packages.py
+++ b/tests/foreman/maintain/test_packages.py
@@ -273,22 +273,3 @@ def test_positive_fm_packages_update(request, sat_maintain):
     def _finalize():
         assert sat_maintain.execute('dnf remove -y walrus').status == 0
         sat_maintain.execute('rm -rf /etc/yum.repos.d/custom_repo.repo')
-
-
-@pytest.mark.stubbed
-def test_positive_fm_packages_sat_installer(sat_maintain):
-    """Verify satellite-installer is not executed after install/update
-    of satellite-maintain/rubygem-foreman_maintain package
-
-    :id: d73971a1-68b4-4ab2-a87c-76cc5ff80a39
-
-    :steps:
-        1. satellite-maintain packages install/update satellite-maintain/rubygem-foreman_maintain
-
-    :BZ: 1825841
-
-    :expectedresults: satellite-installer shouldn't be executed after install/update
-        of satellite-maintain/rubygem-foreman_maintain package
-
-    :CaseAutomation: ManualOnly
-    """


### PR DESCRIPTION
I'm removing this stubbed case because the steps for updating satellite-maintain here are outdated. We now rely on satellite-maintain's ability to self-upgrade either by running a command like `satellite-maintain upgrade list-versions` which is being tested in https://github.com/SatelliteQE/robottelo/pull/12647 or by using `satellite-maintain self-upgrade`. Dev is planning to make some changes to these commands as well which will get there own automation when it's ready. For now we can just remove this outdated stubbed case.