### PR TITLE
Remove stream specific code from upgrade_list test

### DIFF
--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -16,8 +16,6 @@
 
 :Upstream: No
 """
-import re
-
 import pytest
 
 from robottelo.config import settings
@@ -66,12 +64,8 @@ def test_positive_satellite_maintain_upgrade_list(sat_maintain):
     result = sat_maintain.cli.Upgrade.list_versions()
     assert result.status == 0
     assert 'FAIL' not in result.stdout
-    # If on stream, check there is no version listed
-    if sat_maintain.is_stream:
-        assert not bool(re.search(r'\d', result.stdout))
-    else:
-        for ver in versions:
-            assert ver in result.stdout
+    for ver in versions:
+        assert ver in result.stdout
 
 
 @pytest.mark.include_capsule


### PR DESCRIPTION
Reverting this change to how it was before. This test wasn't passing before we had the 6.15.z upgrade path in stream, but now that it's been added we can assert for 6.15 in the output.

Going forward we will need a way to turn on and off the upgrade tests for stream depending on if the upgrade path is in stream yet.