### PR TITLE
[Repository Rewrite] Upgrade test for large repo sync

### DIFF
--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -73,13 +73,22 @@ class TestActivationKey:
         org_subscriptions = target_sat.api.Subscription(
             organization=activation_key_setup['org']
         ).search()
-        for subscription in org_subscriptions:
-            ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
-        ak_subscriptions = ak.product_content()['results']
-        subscr_id = {subscr['product']['id'] for subscr in ak_subscriptions}
-        assert subscr_id == {activation_key_setup['custom_repo'].product.id}
-        ak.host_collection.append(target_sat.api.HostCollection().create())
-        ak.update(['host_collection'])
+        ak_repos = ak.product_content(data={'id': ak.id, 'content_access_mode_all': 1})['results']
+        ak.content_override(
+            data={
+                'content_overrides': [
+                    {'content_label': ak_repos[0]['content']['label'], 'value': '1'}
+                ]
+            }
+        )
+        ak_results = ak.product_content(data={'id': ak.id, 'content_access_mode_all': 1})['results']
+        assert ak_results[0]['overrides'][0]['name'] == 'enabled'
+        assert ak_results[0]['overrides'][0]['value'] is True
+        assert org_subscriptions[0].name == ak_results[0]['product']['name']
+        ak.host_collection.append(
+            target_sat.api.HostCollection(organization=activation_key_setup['org']).create()
+        )
+        ak.update(['host_collection', 'organization_id'])
         assert len(ak.host_collection) == 1
 
     @pytest.mark.post_upgrade(depend_on=test_pre_create_activation_key)
@@ -107,9 +116,9 @@ class TestActivationKey:
         )
         assert f'{pre_test_name}_ak' == ak[0].name
         assert f'{pre_test_name}_cv' == cv[0].name
-        ak[0].host_collection.append(target_sat.api.HostCollection().create())
-        ak[0].update(['host_collection'])
-        assert len(ak[0].host_collection) == 2
+        ak.host_collection.append(target_sat.api.HostCollection(organization=org).create())
+        ak.update(['host_collection', 'organization_id'])
+        assert len(ak.host_collection) == 2
         custom_repo2 = target_sat.api.Repository(
             product=target_sat.api.Product(organization=org[0]).create()
         ).create()
@@ -117,12 +126,19 @@ class TestActivationKey:
         cv2 = target_sat.api.ContentView(organization=org[0], repository=[custom_repo2.id]).create()
         cv2.publish()
         org_subscriptions = target_sat.api.Subscription(organization=org[0]).search()
-        for subscription in org_subscriptions:
-            provided_products_ids = [prod.id for prod in subscription.read().provided_product]
-            if custom_repo2.product.id in provided_products_ids:
-                ak[0].add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
-        ak_subscriptions = ak[0].product_content()['results']
-        assert custom_repo2.product.id in {subscr['product']['id'] for subscr in ak_subscriptions}
+
+        ak_repos = ak.product_content(data={'id': ak.id, 'content_access_mode_all': 1})['results']
+        ak.content_override(
+            data={
+                'content_overrides': [
+                    {'content_label': ak_repos[1]['content']['label'], 'value': '1'}
+                ]
+            }
+        )
+        ak_results = ak.product_content(data={'id': ak.id, 'content_access_mode_all': 1})['results']
+        assert ak_results[1]['overrides'][0]['name'] == 'enabled'
+        assert ak_results[1]['overrides'][0]['value'] is True
+        assert org_subscriptions[1].name == ak_results[1]['product']['name']
         ak[0].delete()
         with pytest.raises(HTTPError):
             target_sat.api.ActivationKey(id=ak[0].id).read()

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -318,6 +318,8 @@ class TestScenarioLargeRepoSyncCheck:
         4. Enable and sync a second large repository.
 
     BZ: 2043144
+
+    :customerscenario: true
     """
 
     @pytest.mark.pre_upgrade

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -365,7 +365,7 @@ class TestScenarioLargeRepoSyncCheck:
         org_id = pre_upgrade_data.get('org_id')
         rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=DEFAULT_ARCHITECTURE,
-            org_id=org_id.id,
+            org_id=org_id,
             product=REPOS['rhel8_aps']['product'],
             repo=REPOS['rhel8_aps']['name'],
             reposet=REPOS['rhel8_aps']['reposet'],

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -20,6 +20,8 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME, FAKE_4_CUSTOM_PACKAGE_NAME
+from robottelo.constants import DEFAULT_ARCHITECTURE
+from robottelo.constants import REPOS
 from robottelo.hosts import ContentHost
 
 UPSTREAM_USERNAME = 'rTtest123'
@@ -299,3 +301,62 @@ class TestScenarioCustomRepoOverrideCheck:
         result = rhel_client.execute('subscription-manager repo-override --list')
         assert 'enabled: 1' in result.stdout
         assert f'{org_name}_{product_name}_{repo_name}' in result.stdout
+
+    @pytest.mark.pre_upgrade
+    def test_pre_scenario_sync_large_repo(
+        self, target_sat, module_entitlement_manifest_org, save_test_data
+    ):
+        """This is a pre-upgrade scenario to verify that users can sync large repositories
+        before an upgrade
+
+        :id: afb957dc-c509-4009-ac85-4b71b64d3c74
+
+        :steps:
+            1. Enable a large redhat repository
+            2. Sync repository and assert sync succeeds
+
+        :expectedresults: Large Repositories should succeed when synced
+
+        :BZ: 2043144
+        """
+        rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
+            basearch=DEFAULT_ARCHITECTURE,
+            org_id=module_entitlement_manifest_org.id,
+            product=REPOS['rhel8_bos']['product'],
+            repo=REPOS['rhel8_bos']['name'],
+            reposet=REPOS['rhel8_bos']['reposet'],
+            releasever=REPOS['rhel8_bos']['releasever'],
+        )
+        repo = target_sat.api.Repository(id=rh_repo_id).read()
+        res = repo.sync(timeout=2000)
+        assert res['result'] == 'success'
+        save_test_data({'org_id': module_entitlement_manifest_org.id})
+
+    @pytest.mark.post_upgrade(depend_on=test_pre_scenario_sync_large_repo)
+    def test_post_scenario_sync_large_repo(self, target_sat, pre_upgrade_data):
+        """This is a post-upgrade scenario to verify that large repositories can be
+        synced after an upgrade
+
+        :id: 7bdbb2ac-7197-4e1a-8163-5852943eb49b
+
+        :steps:
+            1. Sync large repository
+            2. Upgrade satellite
+            3. Sync a second large repository in that same organization
+
+        :expectedresults: Large repositories should succeed after an upgrade
+
+        :BZ: 2043144
+        """
+        org_id = pre_upgrade_data.get('org_id')
+        rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
+            basearch=DEFAULT_ARCHITECTURE,
+            org_id=org_id.id,
+            product=REPOS['rhel8_aps']['product'],
+            repo=REPOS['rhel8_aps']['name'],
+            reposet=REPOS['rhel8_aps']['reposet'],
+            releasever=REPOS['rhel8_aps']['releasever'],
+        )
+        repo = target_sat.api.Repository(id=rh_repo_id).read()
+        res = repo.sync(timeout=4000)
+        assert res['result'] == 'success'

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -19,9 +19,12 @@
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME, FAKE_4_CUSTOM_PACKAGE_NAME
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import REPOS
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    FAKE_0_CUSTOM_PACKAGE_NAME,
+    FAKE_4_CUSTOM_PACKAGE_NAME,
+    REPOS,
+)
 from robottelo.hosts import ContentHost
 
 UPSTREAM_USERNAME = 'rTtest123'
@@ -302,6 +305,21 @@ class TestScenarioCustomRepoOverrideCheck:
         assert 'enabled: 1' in result.stdout
         assert f'{org_name}_{product_name}_{repo_name}' in result.stdout
 
+
+class TestScenarioLargeRepoSyncCheck:
+    """Scenario test to verify that large repositories can be synced without
+    failure after an upgrade.
+
+    Test Steps:
+
+        1. Before Satellite upgrade.
+        2. Enable and sync large RH repository.
+        3. Upgrade Satellite.
+        4. Enable and sync a second large repository.
+
+    BZ: 2043144
+    """
+
     @pytest.mark.pre_upgrade
     def test_pre_scenario_sync_large_repo(
         self, target_sat, module_entitlement_manifest_org, save_test_data
@@ -316,8 +334,6 @@ class TestScenarioCustomRepoOverrideCheck:
             2. Sync repository and assert sync succeeds
 
         :expectedresults: Large Repositories should succeed when synced
-
-        :BZ: 2043144
         """
         rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=DEFAULT_ARCHITECTURE,
@@ -345,8 +361,6 @@ class TestScenarioCustomRepoOverrideCheck:
             3. Sync a second large repository in that same organization
 
         :expectedresults: Large repositories should succeed after an upgrade
-
-        :BZ: 2043144
         """
         org_id = pre_upgrade_data.get('org_id')
         rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(


### PR DESCRIPTION
Scenario test to verify that large repositories can be synced without failure after an upgrade.

Test Steps:
        1. Before Satellite upgrade.
        2. Enable and sync large RH repository.
        3. Upgrade Satellite.
        4. Enable and sync a second large repository.