### PR TITLE
[6.12.z] Switch import formatting to use Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,6 @@
 # configuration for pre-commit git hooks
 
 repos:
-- repo: https://github.com/asottile/reorder_python_imports
-  rev: v3.9.0
-  hooks:
-  - id: reorder-python-imports
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,22 @@ select = [
     # "C90", # mccabe
     "E",  # pycodestyle
     "F",  # flake8
+    "I", # isort
     # "Q",  # flake8-quotes
     "UP",  # pyupgrade
     "W",  # pycodestyle
 ]
 
-# Allow lines to be as long as 100 characters.
-line-length = 100
+ignore = [
+    "E501",  # line too long - handled by black
+]
+
+[tool.ruff.isort]
+force-sort-within-sections = true
+known-first-party = [
+    "robottelo",
+]
+combine-as-imports = true
 
 
 [tool.ruff.flake8-quotes]

--- a/pytest_fixtures/component/computeprofile.py
+++ b/pytest_fixtures/component/computeprofile.py
@@ -1,6 +1,6 @@
 # Compute Profile Fixtures
-import pytest
 from nailgun import entities
+import pytest
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/contentview.py
+++ b/pytest_fixtures/component/contentview.py
@@ -1,6 +1,6 @@
 # Content View Fixtures
-import pytest
 from nailgun.entity_mixins import call_entity_method_with_timeout
+import pytest
 
 from robottelo.constants import DEFAULT_CV
 

--- a/pytest_fixtures/component/domain.py
+++ b/pytest_fixtures/component/domain.py
@@ -1,6 +1,6 @@
 # Domain Fixtures
-import pytest
 from nailgun import entities
+import pytest
 
 
 @pytest.fixture(scope='session')

--- a/pytest_fixtures/component/host.py
+++ b/pytest_fixtures/component/host.py
@@ -1,14 +1,10 @@
 # Host Specific Fixtures
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.factory import setup_org_for_a_rh_repo
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import ENVIRONMENT
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import DEFAULT_CV, ENVIRONMENT, PRDS, REPOS, REPOSET
 
 
 @pytest.fixture

--- a/pytest_fixtures/component/hostgroup.py
+++ b/pytest_fixtures/component/hostgroup.py
@@ -1,6 +1,6 @@
 # Hostgroup Fixtures
-import pytest
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.logging import logger

--- a/pytest_fixtures/component/katello_agent.py
+++ b/pytest_fixtures/component/katello_agent.py
@@ -1,5 +1,5 @@
-import pytest
 from box import Box
+import pytest
 
 from robottelo.config import settings
 from robottelo.utils.installer import InstallerCommand

--- a/pytest_fixtures/component/katello_certs_check.py
+++ b/pytest_fixtures/component/katello_certs_check.py
@@ -1,8 +1,8 @@
 # katello_certs_check Fixtures
 from pathlib import Path
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.constants import CERT_DATA as cert_data
 from robottelo.hosts import Capsule

--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -6,9 +6,7 @@ import pytest
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.constants import SATELLITE_MAINTAIN_YML
-from robottelo.hosts import Capsule
-from robottelo.hosts import Satellite
-from robottelo.hosts import SatelliteHostError
+from robottelo.hosts import Capsule, Satellite, SatelliteHostError
 from robottelo.logging import logger
 
 synced_repos = pytest.StashKey[dict]

--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -1,6 +1,6 @@
 # Operating System Fixtures
-import pytest
 from nailgun import entities
+import pytest
 
 
 @pytest.fixture(scope='session')

--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -1,15 +1,12 @@
 from pathlib import PurePath
 
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.factory import make_scapcontent
-from robottelo.config import robottelo_tmp_dir
-from robottelo.config import settings
-from robottelo.constants import DataFile
-from robottelo.constants import OSCAP_PROFILE
-from robottelo.constants import OSCAP_TAILORING_FILE
+from robottelo.config import robottelo_tmp_dir, settings
+from robottelo.constants import OSCAP_PROFILE, OSCAP_TAILORING_FILE, DataFile
 
 
 @pytest.fixture(scope="session")

--- a/pytest_fixtures/component/provision_azure.py
+++ b/pytest_fixtures/component/provision_azure.py
@@ -1,15 +1,17 @@
 # Azure CR Fixtures
-import pytest
 from fauxfactory import gen_string
+import pytest
 from wrapanapi import AzureSystem
 
 from robottelo.config import settings
-from robottelo.constants import AZURERM_RHEL7_FT_BYOS_IMG_URN
-from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
-from robottelo.constants import AZURERM_RHEL7_FT_GALLERY_IMG_URN
-from robottelo.constants import AZURERM_RHEL7_FT_IMG_URN
-from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
-from robottelo.constants import DEFAULT_ARCHITECTURE
+from robottelo.constants import (
+    AZURERM_RHEL7_FT_BYOS_IMG_URN,
+    AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
+    AZURERM_RHEL7_FT_GALLERY_IMG_URN,
+    AZURERM_RHEL7_FT_IMG_URN,
+    AZURERM_RHEL7_UD_IMG_URN,
+    DEFAULT_ARCHITECTURE,
+)
 
 
 @pytest.fixture(scope='session')

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -2,16 +2,18 @@
 import json
 from tempfile import mkstemp
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 from wrapanapi.systems.google import GoogleCloudSystem
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import DEFAULT_PTABLE
-from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import GCE_RHEL_CLOUD_PROJECTS
-from robottelo.constants import GCE_TARGET_RHEL_IMAGE_NAME
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_PTABLE,
+    FOREMAN_PROVIDERS,
+    GCE_RHEL_CLOUD_PROJECTS,
+    GCE_TARGET_RHEL_IMAGE_NAME,
+)
 from robottelo.exceptions import GCECertNotFoundError
 
 

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -3,11 +3,11 @@ import os
 import re
 from tempfile import mkstemp
 
-import pytest
 from box import Box
 from broker import Broker
 from fauxfactory import gen_string
 from packaging.version import Version
+import pytest
 
 from robottelo import constants
 from robottelo.config import settings

--- a/pytest_fixtures/component/provisioning_template.py
+++ b/pytest_fixtures/component/provisioning_template.py
@@ -1,13 +1,11 @@
 # Provisioning Template Fixtures
-import pytest
 from box import Box
 from nailgun import entities
 from packaging.version import Version
+import pytest
 
 from robottelo import constants
-from robottelo.constants import DEFAULT_PTABLE
-from robottelo.constants import DEFAULT_PXE_TEMPLATE
-from robottelo.constants import DEFAULT_TEMPLATE
+from robottelo.constants import DEFAULT_PTABLE, DEFAULT_PXE_TEMPLATE, DEFAULT_TEMPLATE
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -1,13 +1,10 @@
 # Repository Fixtures
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
+import pytest
 
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import DEFAULT_ARCHITECTURE, PRDS, REPOS, REPOSET
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -1,5 +1,5 @@
-import pytest
 from broker import Broker
+import pytest
 
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
 

--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -1,20 +1,21 @@
 import copy
 import socket
 
-import pytest
 from box import Box
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import AUDIENCE_MAPPER
-from robottelo.constants import CERT_PATH
-from robottelo.constants import GROUP_MEMBERSHIP_MAPPER
-from robottelo.constants import HAMMER_CONFIG
-from robottelo.constants import HAMMER_SESSIONS
-from robottelo.constants import LDAP_ATTR
-from robottelo.constants import LDAP_SERVER_TYPE
-from robottelo.hosts import IPAHost
-from robottelo.hosts import SSOHost
+from robottelo.constants import (
+    AUDIENCE_MAPPER,
+    CERT_PATH,
+    GROUP_MEMBERSHIP_MAPPER,
+    HAMMER_CONFIG,
+    HAMMER_SESSIONS,
+    LDAP_ATTR,
+    LDAP_SERVER_TYPE,
+)
+from robottelo.hosts import IPAHost, SSOHost
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.issue_handlers import is_open
 

--- a/pytest_fixtures/component/subnet.py
+++ b/pytest_fixtures/component/subnet.py
@@ -1,6 +1,6 @@
 # Subnet Fixtures
-import pytest
 from nailgun import entities
+import pytest
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -1,10 +1,9 @@
 # Content Component fixtures
-import pytest
 from manifester import Manifester
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC
-from robottelo.constants import DEFAULT_ORG
+from robottelo.constants import DEFAULT_LOC, DEFAULT_ORG
 from robottelo.utils.manifest import clone
 
 

--- a/pytest_fixtures/component/templatesync.py
+++ b/pytest_fixtures/component/templatesync.py
@@ -1,6 +1,6 @@
+from fauxfactory import gen_string
 import pytest
 import requests
-from fauxfactory import gen_string
 
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_TEMPLATE_ROOT_DIR

--- a/pytest_fixtures/component/user_role.py
+++ b/pytest_fixtures/component/user_role.py
@@ -1,7 +1,6 @@
-import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_string
+from fauxfactory import gen_alphanumeric, gen_string
 from nailgun import entities
+import pytest
 
 
 @pytest.fixture(scope='class')

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -1,13 +1,11 @@
 from contextlib import contextmanager
 
-import pytest
 from box import Box
 from broker import Broker
+import pytest
 
 from robottelo.config import settings
-from robottelo.hosts import ContentHostError
-from robottelo.hosts import lru_sat_ready_rhel
-from robottelo.hosts import Satellite
+from robottelo.hosts import ContentHostError, Satellite, lru_sat_ready_rhel
 
 
 @pytest.fixture(scope='session')

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -4,8 +4,8 @@ This module is to define pytest functions for content hosts
 The functions in this module are read in the pytest_plugins/fixture_markers.py module
 All functions in this module will be treated as fixtures that apply the contenthost mark
 """
-import pytest
 from broker import Broker
+import pytest
 
 from robottelo import constants
 from robottelo.config import settings

--- a/pytest_fixtures/core/reporting.py
+++ b/pytest_fixtures/core/reporting.py
@@ -1,12 +1,10 @@
 import datetime
 
-import pytest
 from _pytest.junitxml import xml_key
+import pytest
 from xdist import get_xdist_worker_id
 
-from robottelo.config import setting_is_set
-from robottelo.config import settings
-
+from robottelo.config import setting_is_set, settings
 
 FMT_XUNIT_TIME = '%Y-%m-%dT%H:%M:%S'
 

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -1,17 +1,17 @@
 from contextlib import contextmanager
 
-import pytest
 from broker import Broker
+import pytest
 from wait_for import wait_for
 
-from robottelo.config import configure_airgun
-from robottelo.config import configure_nailgun
-from robottelo.config import settings
-from robottelo.hosts import Capsule
-from robottelo.hosts import get_sat_rhel_version
-from robottelo.hosts import IPAHost
-from robottelo.hosts import lru_sat_ready_rhel
-from robottelo.hosts import Satellite
+from robottelo.config import configure_airgun, configure_nailgun, settings
+from robottelo.hosts import (
+    Capsule,
+    IPAHost,
+    Satellite,
+    get_sat_rhel_version,
+    lru_sat_ready_rhel,
+)
 from robottelo.logging import logger
 from robottelo.utils.installer import InstallerCommand
 

--- a/pytest_fixtures/core/ui.py
+++ b/pytest_fixtures/core/ui.py
@@ -1,5 +1,5 @@
-import pytest
 from fauxfactory import gen_string
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.logging import logger

--- a/pytest_fixtures/core/upgrade.py
+++ b/pytest_fixtures/core/upgrade.py
@@ -1,5 +1,5 @@
-import pytest
 from broker import Broker
+import pytest
 
 from robottelo.hosts import Capsule
 from robottelo.logging import logger

--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -1,12 +1,10 @@
 """Fixtures specific to or relating to pytest's xdist plugin"""
 import random
 
-import pytest
 from broker import Broker
+import pytest
 
-from robottelo.config import configure_airgun
-from robottelo.config import configure_nailgun
-from robottelo.config import settings
+from robottelo.config import configure_airgun, configure_nailgun, settings
 from robottelo.hosts import Satellite
 from robottelo.logging import logger
 

--- a/pytest_plugins/factory_collection.py
+++ b/pytest_plugins/factory_collection.py
@@ -1,5 +1,4 @@
-from inspect import getmembers
-from inspect import isfunction
+from inspect import getmembers, isfunction
 
 
 def pytest_configure(config):

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -1,9 +1,7 @@
+from inspect import getmembers, isfunction
 import re
-from inspect import getmembers
-from inspect import isfunction
 
 from robottelo.config import settings
-
 
 TARGET_FIXTURES = [
     'rhel_contenthost',

--- a/pytest_plugins/issue_handlers.py
+++ b/pytest_plugins/issue_handlers.py
@@ -1,20 +1,21 @@
+from collections import defaultdict
+from datetime import datetime
 import inspect
 import json
 import re
-from collections import defaultdict
-from datetime import datetime
 
 import pytest
 
 from robottelo.config import settings
 from robottelo.logging import collection_logger as logger
 from robottelo.utils import slugify_component
-from robottelo.utils.issue_handlers import add_workaround
-from robottelo.utils.issue_handlers import bugzilla
-from robottelo.utils.issue_handlers import is_open
-from robottelo.utils.issue_handlers import should_deselect
-from robottelo.utils.version import search_version_key
-from robottelo.utils.version import VersionEncoder
+from robottelo.utils.issue_handlers import (
+    add_workaround,
+    bugzilla,
+    is_open,
+    should_deselect,
+)
+from robottelo.utils.version import VersionEncoder, search_version_key
 
 DEFAULT_BZ_CACHE_FILE = 'bz_cache.json'
 

--- a/pytest_plugins/logging_hooks.py
+++ b/pytest_plugins/logging_hooks.py
@@ -4,16 +4,17 @@ import logzero
 import pytest
 from xdist import is_xdist_worker
 
-from robottelo.logging import broker_log_setup
-from robottelo.logging import DEFAULT_DATE_FORMAT
-from robottelo.logging import logger
-from robottelo.logging import logging_yaml
-from robottelo.logging import robottelo_log_dir
-from robottelo.logging import robottelo_log_file
+from robottelo.logging import (
+    DEFAULT_DATE_FORMAT,
+    broker_log_setup,
+    logger,
+    logging_yaml,
+    robottelo_log_dir,
+    robottelo_log_file,
+)
 
 try:
-    from pytest_reportportal import RPLogger
-    from pytest_reportportal import RPLogHandler
+    from pytest_reportportal import RPLogger, RPLogHandler
 except ImportError:
     pass
 

--- a/pytest_plugins/marker_deselection.py
+++ b/pytest_plugins/marker_deselection.py
@@ -2,7 +2,6 @@ import pytest
 
 from robottelo.logging import collection_logger as logger
 
-
 non_satCI_components = ['Virt-whoConfigurePlugin']
 
 

--- a/pytest_plugins/requirements/req_updater.py
+++ b/pytest_plugins/requirements/req_updater.py
@@ -1,5 +1,5 @@
-import subprocess
 from functools import cached_property
+import subprocess
 
 
 class ReqUpdater:

--- a/pytest_plugins/settings_skip.py
+++ b/pytest_plugins/settings_skip.py
@@ -1,7 +1,6 @@
 import pytest
 
-from robottelo.config import setting_is_set
-from robottelo.config import settings
+from robottelo.config import setting_is_set, settings
 
 
 def pytest_configure(config):

--- a/pytest_plugins/upgrade/scenario_workers.py
+++ b/pytest_plugins/upgrade/scenario_workers.py
@@ -3,10 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from robottelo.config import configure_airgun
-from robottelo.config import configure_nailgun
-from robottelo.config import settings
-
+from robottelo.config import configure_airgun, configure_nailgun, settings
 
 _json_file = 'upgrade_workers.json'
 json_file = Path(_json_file)

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -34,8 +34,7 @@ Options::
     -h, --help                    print help
 """
 from robottelo.cli import hammer
-from robottelo.cli.base import Base
-from robottelo.cli.base import CLIError
+from robottelo.cli.base import Base, CLIError
 
 
 class ContentViewFilterRule(Base):

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -3,20 +3,22 @@ Factory object creation for all CLI methods
 """
 import datetime
 import os
+from os import chmod
 import pprint
 import random
-from os import chmod
 from tempfile import mkstemp
 from time import sleep
 
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_mac
-from fauxfactory import gen_netmask
-from fauxfactory import gen_string
-from fauxfactory import gen_url
+from fauxfactory import (
+    gen_alphanumeric,
+    gen_choice,
+    gen_integer,
+    gen_ipaddr,
+    gen_mac,
+    gen_netmask,
+    gen_string,
+    gen_url,
+)
 
 from robottelo import constants
 from robottelo.cli.activationkey import ActivationKey
@@ -24,9 +26,11 @@ from robottelo.cli.architecture import Architecture
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.content_credentials import ContentCredential
-from robottelo.cli.contentview import ContentView
-from robottelo.cli.contentview import ContentViewFilter
-from robottelo.cli.contentview import ContentViewFilterRule
+from robottelo.cli.contentview import (
+    ContentView,
+    ContentViewFilter,
+    ContentViewFilterRule,
+)
 from robottelo.cli.discoveryrule import DiscoveryRule
 from robottelo.cli.domain import Domain
 from robottelo.cli.environment import Environment
@@ -60,8 +64,7 @@ from robottelo.cli.syncplan import SyncPlan
 from robottelo.cli.template import Template
 from robottelo.cli.template_input import TemplateInput
 from robottelo.cli.user import User
-from robottelo.cli.usergroup import UserGroup
-from robottelo.cli.usergroup import UserGroupExternal
+from robottelo.cli.usergroup import UserGroup, UserGroupExternal
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.logging import logger
@@ -69,7 +72,6 @@ from robottelo.utils import ssh
 from robottelo.utils.datafactory import valid_cron_expressions
 from robottelo.utils.decorators import cacheable
 from robottelo.utils.manifest import clone
-
 
 ORG_KEYS = ['organization', 'organization-id', 'organization-label']
 CONTENT_VIEW_KEYS = ['content-view', 'content-view-id']

--- a/robottelo/cli/report_template.py
+++ b/robottelo/cli/report_template.py
@@ -25,10 +25,8 @@ from os import chmod
 from tempfile import mkstemp
 
 from robottelo import ssh
-from robottelo.cli.base import Base
-from robottelo.cli.base import CLIError
-from robottelo.constants import DataFile
-from robottelo.constants import REPORT_TEMPLATE_FILE
+from robottelo.cli.base import Base, CLIError
+from robottelo.constants import REPORT_TEMPLATE_FILE, DataFile
 
 
 class ReportTemplate(Base):

--- a/robottelo/cli/template_input.py
+++ b/robottelo/cli/template_input.py
@@ -15,8 +15,7 @@ Subcommands::
     info                          Show template input details
     list                          List template inputs
 """
-from robottelo.cli.base import Base
-from robottelo.cli.base import CLIError
+from robottelo.cli.base import Base, CLIError
 
 
 class TemplateInput(Base):

--- a/robottelo/cli/webhook.py
+++ b/robottelo/cli/webhook.py
@@ -13,10 +13,8 @@ Subcommands:
 Options:
  -h, --help                    Print help
 """
-from robottelo.cli.base import Base
-from robottelo.cli.base import CLIError
-from robottelo.constants import WEBHOOK_EVENTS
-from robottelo.constants import WEBHOOK_METHODS
+from robottelo.cli.base import Base, CLIError
+from robottelo.constants import WEBHOOK_EVENTS, WEBHOOK_METHODS
 
 
 class Webhook(Base):

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -9,8 +9,7 @@ from dynaconf.validator import ValidationError
 from nailgun.config import ServerConfig
 
 from robottelo.config.validators import VALIDATORS
-from robottelo.logging import logger
-from robottelo.logging import robottelo_root_dir
+from robottelo.logging import logger, robottelo_root_dir
 
 if not os.getenv('ROBOTTELO_DIR'):
     # dynaconf robottelo file uses ROBOTELLO_DIR for screenshots
@@ -150,8 +149,7 @@ def configure_nailgun():
         of this.
     * Set a default value for ``nailgun.entities.GPGKey.content``.
     """
-    from nailgun import entities
-    from nailgun import entity_mixins
+    from nailgun import entities, entity_mixins
     from nailgun.config import ServerConfig
 
     entity_mixins.CREATE_MISSING = True

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -1,8 +1,6 @@
 from dynaconf import Validator
 
-from robottelo.constants import AZURERM_VALID_REGIONS
-from robottelo.constants import VALID_GCE_ZONES
-
+from robottelo.constants import AZURERM_VALID_REGIONS, VALID_GCE_ZONES
 
 VALIDATORS = dict(
     supportability=[

--- a/robottelo/host_helpers/__init__.py
+++ b/robottelo/host_helpers/__init__.py
@@ -1,13 +1,16 @@
-from robottelo.host_helpers.capsule_mixins import CapsuleInfo
-from robottelo.host_helpers.capsule_mixins import EnablePluginsCapsule
-from robottelo.host_helpers.contenthost_mixins import HostInfo
-from robottelo.host_helpers.contenthost_mixins import SystemFacts
-from robottelo.host_helpers.contenthost_mixins import VersionedContent
-from robottelo.host_helpers.satellite_mixins import ContentInfo
-from robottelo.host_helpers.satellite_mixins import EnablePluginsSatellite
-from robottelo.host_helpers.satellite_mixins import Factories
-from robottelo.host_helpers.satellite_mixins import ProvisioningSetup
-from robottelo.host_helpers.satellite_mixins import SystemInfo
+from robottelo.host_helpers.capsule_mixins import CapsuleInfo, EnablePluginsCapsule
+from robottelo.host_helpers.contenthost_mixins import (
+    HostInfo,
+    SystemFacts,
+    VersionedContent,
+)
+from robottelo.host_helpers.satellite_mixins import (
+    ContentInfo,
+    EnablePluginsSatellite,
+    Factories,
+    ProvisioningSetup,
+    SystemInfo,
+)
 
 
 class ContentHostMixins(HostInfo, SystemFacts, VersionedContent):

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -2,23 +2,23 @@
 It is not meant to be used directly, but as part of a robottelo.hosts.Satellite instance
 example: my_satellite.api_factory.api_method()
 """
-import time
 from contextlib import contextmanager
+import time
 
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_mac
-from fauxfactory import gen_string
+from fauxfactory import gen_ipaddr, gen_mac, gen_string
 from nailgun import entity_mixins
 from nailgun.client import request
 from nailgun.entity_mixins import call_entity_method_with_timeout
 from requests import HTTPError
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import DEFAULT_PTABLE
-from robottelo.constants import DEFAULT_PXE_TEMPLATE
-from robottelo.constants import DEFAULT_TEMPLATE
-from robottelo.constants import REPO_TYPE
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_PTABLE,
+    DEFAULT_PXE_TEMPLATE,
+    DEFAULT_TEMPLATE,
+    REPO_TYPE,
+)
 from robottelo.exceptions import ImproperlyConfigured
 
 

--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -1,8 +1,7 @@
-import time
 from datetime import datetime
+import time
 
-from robottelo.constants import PUPPET_CAPSULE_INSTALLER
-from robottelo.constants import PUPPET_COMMON_INSTALLER_OPTS
+from robottelo.constants import PUPPET_CAPSULE_INSTALLER, PUPPET_COMMON_INSTALLER_OPTS
 from robottelo.logging import logger
 from robottelo.utils.installer import InstallerCommand
 

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -4,25 +4,26 @@ It is not meant to be used directly, but as part of a robottelo.hosts.Satellite 
 example: my_satellite.cli_factory.make_org()
 """
 import datetime
+from functools import lru_cache, partial
 import inspect
 import os
+from os import chmod
 import pprint
 import random
-from functools import lru_cache
-from functools import partial
-from os import chmod
 from tempfile import mkstemp
 from time import sleep
 
 from box import Box
-from fauxfactory import gen_alpha
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_mac
-from fauxfactory import gen_netmask
-from fauxfactory import gen_url
+from fauxfactory import (
+    gen_alpha,
+    gen_alphanumeric,
+    gen_choice,
+    gen_integer,
+    gen_ipaddr,
+    gen_mac,
+    gen_netmask,
+    gen_url,
+)
 
 from robottelo import constants
 from robottelo.cli.base import CLIReturnCodeError

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -1,14 +1,12 @@
 """A collection of mixins for robottelo.hosts classes"""
-import json
 from functools import cached_property
+import json
 from tempfile import NamedTemporaryFile
 
 from robottelo import constants
-from robottelo.config import robottelo_tmp_dir
-from robottelo.config import settings
+from robottelo.config import robottelo_tmp_dir, settings
 from robottelo.logging import logger
-from robottelo.utils.ohsnap import dogfood_repofile_url
-from robottelo.utils.ohsnap import dogfood_repository
+from robottelo.utils.ohsnap import dogfood_repofile_url, dogfood_repository
 
 
 class VersionedContent:

--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -7,12 +7,14 @@ import sys
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.exceptions import DistroNotSupportedError
-from robottelo.exceptions import OnlyOneOSRepositoryAllowed
-from robottelo.exceptions import ReposContentSetupWasNotPerformed
-from robottelo.exceptions import RepositoryAlreadyCreated
-from robottelo.exceptions import RepositoryAlreadyDefinedError
-from robottelo.exceptions import RepositoryDataNotFound
+from robottelo.exceptions import (
+    DistroNotSupportedError,
+    OnlyOneOSRepositoryAllowed,
+    ReposContentSetupWasNotPerformed,
+    RepositoryAlreadyCreated,
+    RepositoryAlreadyDefinedError,
+    RepositoryDataNotFound,
+)
 
 
 def initiate_repo_helpers(satellite):

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -1,19 +1,21 @@
 import contextlib
+from functools import cache
 import io
 import os
 import random
 import re
-from functools import cache
 
 import requests
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.proxy import CapsuleTunnelError
 from robottelo.config import settings
-from robottelo.constants import PULP_EXPORT_DIR
-from robottelo.constants import PULP_IMPORT_DIR
-from robottelo.constants import PUPPET_COMMON_INSTALLER_OPTS
-from robottelo.constants import PUPPET_SATELLITE_INSTALLER
+from robottelo.constants import (
+    PULP_EXPORT_DIR,
+    PULP_IMPORT_DIR,
+    PUPPET_COMMON_INSTALLER_OPTS,
+    PUPPET_SATELLITE_INSTALLER,
+)
 from robottelo.host_helpers.api_factory import APIFactory
 from robottelo.host_helpers.cli_factory import CLIFactory
 from robottelo.host_helpers.ui_factory import UIFactory

--- a/robottelo/host_helpers/ui_factory.py
+++ b/robottelo/host_helpers/ui_factory.py
@@ -5,8 +5,7 @@ example: my_satellite.ui_factory(session).ui_method()
 """
 from fauxfactory import gen_string
 
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import ENVIRONMENT
+from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 
 
 class UIFactory:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1,63 +1,57 @@
+from configparser import ConfigParser
 import contextlib
+from contextlib import contextmanager
+from functools import cached_property, lru_cache
 import importlib
 import io
 import json
+from pathlib import Path, PurePath
 import random
 import re
-import time
-from configparser import ConfigParser
-from contextlib import contextmanager
-from functools import cached_property
-from functools import lru_cache
-from pathlib import Path
-from pathlib import PurePath
 from tempfile import NamedTemporaryFile
-from urllib.parse import urljoin
-from urllib.parse import urlparse
-from urllib.parse import urlunsplit
+import time
+from urllib.parse import urljoin, urlparse, urlunsplit
 
-import requests
-import yaml
 from box import Box
 from broker import Broker
 from broker.hosts import Host
 from dynaconf.vendor.box.exceptions import BoxKeyError
-from fauxfactory import gen_alpha
-from fauxfactory import gen_string
+from fauxfactory import gen_alpha, gen_string
 from nailgun import entities
 from packaging.version import Version
+import requests
 from ssh2.exceptions import AuthenticationError
-from wait_for import TimedOutError
-from wait_for import wait_for
+from wait_for import TimedOutError, wait_for
 from wrapanapi.entities.vm import VmState
+import yaml
 
 from robottelo import constants
 from robottelo.cli.base import Base
 from robottelo.cli.factory import CLIFactoryError
-from robottelo.config import configure_airgun
-from robottelo.config import configure_nailgun
-from robottelo.config import robottelo_tmp_dir
-from robottelo.config import settings
-from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS
-from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS_PATH
-from robottelo.constants import CUSTOM_PUPPET_MODULE_REPOS_VERSION
-from robottelo.constants import HAMMER_CONFIG
-from robottelo.constants import KEY_CLOAK_CLI
-from robottelo.constants import RHSSO_NEW_GROUP
-from robottelo.constants import RHSSO_NEW_USER
-from robottelo.constants import RHSSO_RESET_PASSWORD
-from robottelo.constants import RHSSO_USER_UPDATE
-from robottelo.constants import SATELLITE_VERSION
-from robottelo.exceptions import DownloadFileError
-from robottelo.exceptions import HostPingFailed
-from robottelo.host_helpers import CapsuleMixins
-from robottelo.host_helpers import ContentHostMixins
-from robottelo.host_helpers import SatelliteMixins
+from robottelo.config import (
+    configure_airgun,
+    configure_nailgun,
+    robottelo_tmp_dir,
+    settings,
+)
+from robottelo.constants import (
+    CUSTOM_PUPPET_MODULE_REPOS,
+    CUSTOM_PUPPET_MODULE_REPOS_PATH,
+    CUSTOM_PUPPET_MODULE_REPOS_VERSION,
+    HAMMER_CONFIG,
+    KEY_CLOAK_CLI,
+    RHSSO_NEW_GROUP,
+    RHSSO_NEW_USER,
+    RHSSO_RESET_PASSWORD,
+    RHSSO_USER_UPDATE,
+    SATELLITE_VERSION,
+)
+from robottelo.exceptions import DownloadFileError, HostPingFailed
+from robottelo.host_helpers import CapsuleMixins, ContentHostMixins, SatelliteMixins
 from robottelo.logging import logger
 from robottelo.utils import validate_ssh_pub_key
 from robottelo.utils.datafactory import valid_emails_list
 from robottelo.utils.installer import InstallerCommand
-
 
 POWER_OPERATIONS = {
     VmState.RUNNING: 'running',
@@ -1222,9 +1216,9 @@ class ContentHost(Host, ContentHostMixins):
         :param bool upload_manifest: whether to upload the organization manifest
         :param list extra_repos: (Optional) repositories dict options to setup additionally.
         """
-        from robottelo.cli.org import Org
         from robottelo.cli import factory as cli_factory
         from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
+        from robottelo.cli.org import Org
         from robottelo.cli.subscription import Subscription
         from robottelo.cli.virt_who_config import VirtWhoConfig
 

--- a/robottelo/logging.py
+++ b/robottelo/logging.py
@@ -2,12 +2,11 @@ import logging
 import os
 from pathlib import Path
 
-import logzero
-import yaml
 from box import Box
 from broker.logger import setup_logzero as broker_log_setup
+import logzero
 from manifester.logger import setup_logzero as manifester_log_setup
-
+import yaml
 
 robottelo_root_dir = Path(os.environ.get('ROBOTTELO_DIR', Path(__file__).resolve().parent.parent))
 robottelo_log_dir = robottelo_root_dir.joinpath('logs')

--- a/robottelo/utils/__init__.py
+++ b/robottelo/utils/__init__.py
@@ -2,8 +2,8 @@
 # Independent utility functions that doesnt need separate module
 import base64
 import os
-import re
 from pathlib import Path
+import re
 
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
 from cryptography.hazmat.primitives import serialization as crypto_serialization

--- a/robottelo/utils/datafactory.py
+++ b/robottelo/utils/datafactory.py
@@ -1,18 +1,13 @@
 """Data Factory for all entities"""
+from functools import wraps
 import random
 import string
-from functools import wraps
 from urllib.parse import quote_plus
 
-from fauxfactory import gen_alpha
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from fauxfactory import gen_url
-from fauxfactory import gen_utf8
+from fauxfactory import gen_alpha, gen_integer, gen_string, gen_url, gen_utf8
 
 from robottelo.config import settings
-from robottelo.constants import DOMAIN
-from robottelo.constants import STRING_TYPES
+from robottelo.constants import DOMAIN, STRING_TYPES
 
 
 class InvalidArgumentError(Exception):

--- a/robottelo/utils/decorators/__init__.py
+++ b/robottelo/utils/decorators/__init__.py
@@ -1,7 +1,6 @@
 """Implements various decorators"""
 from functools import wraps
 
-
 OBJECT_CACHE = {}
 
 

--- a/robottelo/utils/decorators/func_locker.py
+++ b/robottelo/utils/decorators/func_locker.py
@@ -39,11 +39,11 @@ Usage::
             with locking_function(self.test_to_lock):
                 # do some operations that conflict with test_to_lock
 """
+from contextlib import contextmanager
 import functools
 import inspect
 import os
 import tempfile
-from contextlib import contextmanager
 
 from pytest_services.locks import file_lock
 

--- a/robottelo/utils/decorators/func_shared/shared.py
+++ b/robottelo/utils/decorators/func_shared/shared.py
@@ -87,23 +87,20 @@ Usage::
 import datetime
 import functools
 import hashlib
+from importlib import import_module
 import inspect
 import os
 import sys
 import traceback
 import uuid
-from importlib import import_module
 
 from nailgun.entities import Entity
 
-from robottelo.config import setting_is_set
-from robottelo.config import settings
+from robottelo.config import setting_is_set, settings
 from robottelo.logging import logger
-from robottelo.utils.decorators.func_shared import file_storage
-from robottelo.utils.decorators.func_shared import redis_storage
+from robottelo.utils.decorators.func_shared import file_storage, redis_storage
 from robottelo.utils.decorators.func_shared.file_storage import FileStorageHandler
 from robottelo.utils.decorators.func_shared.redis_storage import RedisStorageHandler
-
 
 _storage_handlers = {'file': FileStorageHandler, 'redis': RedisStorageHandler}
 

--- a/robottelo/utils/io/__init__.py
+++ b/robottelo/utils/io/__init__.py
@@ -1,8 +1,8 @@
 # Helper methods for tests requiring I/0
 import hashlib
 import json
-import tarfile
 from pathlib import Path
+import tarfile
 
 
 def get_local_file_data(path):

--- a/robottelo/utils/issue_handlers/__init__.py
+++ b/robottelo/utils/issue_handlers/__init__.py
@@ -1,7 +1,6 @@
 # Methods related to issue handlers in general
 from robottelo.utils.issue_handlers import bugzilla
 
-
 handler_methods = {'BZ': bugzilla.is_open_bz}
 SUPPORTED_HANDLERS = tuple(f"{handler}:" for handler in handler_methods.keys())
 

--- a/robottelo/utils/issue_handlers/bugzilla.py
+++ b/robottelo/utils/issue_handlers/bugzilla.py
@@ -1,20 +1,15 @@
-import re
 from collections import defaultdict
+import re
 
+from packaging.version import Version
 import pytest
 import requests
-from packaging.version import Version
-from tenacity import retry
-from tenacity import stop_after_attempt
-from tenacity import wait_fixed
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from robottelo.config import settings
-from robottelo.constants import CLOSED_STATUSES
-from robottelo.constants import OPEN_STATUSES
-from robottelo.constants import WONTFIX_RESOLUTIONS
+from robottelo.constants import CLOSED_STATUSES, OPEN_STATUSES, WONTFIX_RESOLUTIONS
 from robottelo.hosts import get_sat_version
 from robottelo.logging import logger
-
 
 # match any version as in `sat-6.2.x` or `sat-6.2.0` or `6.2.9`
 # The .version group being a `d.d` string that can be casted to Version()

--- a/robottelo/utils/manifest.py
+++ b/robottelo/utils/manifest.py
@@ -4,11 +4,10 @@ import time
 import uuid
 import zipfile
 
-import requests
 from cryptography.hazmat.backends import default_backend as crypto_default_backend
-from cryptography.hazmat.primitives import hashes
-from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives import hashes, serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import padding
+import requests
 
 from robottelo.config import settings
 

--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -1,12 +1,11 @@
 """Utility module to communicate with Ohsnap API"""
-import requests
 from box import Box
 from packaging.version import Version
+import requests
 from wait_for import wait_for
 
 from robottelo import constants
-from robottelo.exceptions import InvalidArgumentError
-from robottelo.exceptions import RepositoryDataNotFound
+from robottelo.exceptions import InvalidArgumentError, RepositoryDataNotFound
 from robottelo.logging import logger
 
 

--- a/robottelo/utils/report_portal/portal.py
+++ b/robottelo/utils/report_portal/portal.py
@@ -1,7 +1,5 @@
 import requests
-from tenacity import retry
-from tenacity import stop_after_attempt
-from tenacity import wait_fixed
+from tenacity import retry, stop_after_attempt, wait_fixed
 
 from robottelo.config import settings
 from robottelo.logging import logger

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -3,11 +3,9 @@ import json
 import re
 import uuid
 
-import requests
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from fauxfactory import gen_url
+from fauxfactory import gen_integer, gen_string, gen_url
 from nailgun import entities
+import requests
 from wait_for import wait_for
 
 from robottelo import ssh

--- a/scripts/config_helpers.py
+++ b/scripts/config_helpers.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 import click
 import deepdiff
-import yaml
 from logzero import logger
+import yaml
 
 
 def merge_nested_dictionaries(original, new, overwrite=False):

--- a/scripts/graph_entities.py
+++ b/scripts/graph_entities.py
@@ -9,8 +9,7 @@ command provided by the make file in the parent directory.
 """
 import inspect
 
-from nailgun import entities
-from nailgun import entity_mixins
+from nailgun import entities, entity_mixins
 
 
 def graph():

--- a/scripts/tokenize_customer_scenario.py
+++ b/scripts/tokenize_customer_scenario.py
@@ -14,11 +14,8 @@ On robottelo root dir run:
 $ python scripts/tokenize_customer_scenario.py
 """
 import codemod
-from codemod import Query
-from codemod import regex_suggestor
-from codemod import run_interactive
+from codemod import Query, regex_suggestor, run_interactive
 from codemod.helpers import path_filter
-
 
 codemod.base.yes_to_all = True
 

--- a/scripts/vault_login.py
+++ b/scripts/vault_login.py
@@ -2,14 +2,13 @@
 # This Enables and Disables individuals OIDC token to access secrets from vault
 import json
 import os
+from pathlib import Path
 import re
 import subprocess
 import sys
-from pathlib import Path
 
 from robottelo.constants import Colored
 from robottelo.utils import export_vault_env_vars
-
 
 HELP_TEXT = (
     "Vault CLI in not installed in your system, "

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import find_packages, setup
 
 with open('README.rst') as f:
     README = f.read()

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -18,22 +18,19 @@
 """
 import http
 
+from fauxfactory import gen_integer, gen_string
+from nailgun import client, entities
 import pytest
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from nailgun import client
-from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.config import get_credentials
-from robottelo.config import user_nailgun_config
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.config import get_credentials, user_nailgun_config
+from robottelo.constants import PRDS, REPOS, REPOSET
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_names_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -16,14 +16,16 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_choice
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_names_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @pytest.mark.tier1

--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo.utils.datafactory import gen_string
 

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -18,15 +18,13 @@
 """
 import random
 
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.constants import BOOKMARK_ENTITIES
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import valid_data_list
-
+from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 # List of unique bookmark controller values, preserving order
 CONTROLLERS = list(dict.fromkeys(entity['controller'] for entity in BOOKMARK_ENTITIES))

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -20,18 +20,19 @@ interactions and use capsule.
 import re
 from time import sleep
 
-import pytest
-from nailgun import client
-from nailgun import entities
+from nailgun import client, entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
+import pytest
 
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.constants import DataFile
 from robottelo.constants.repos import ANSIBLE_GALAXY
-from robottelo.content_info import get_repo_files_by_url
-from robottelo.content_info import get_repomd
-from robottelo.content_info import get_repomd_revision
+from robottelo.content_info import (
+    get_repo_files_by_url,
+    get_repomd,
+    get_repomd_revision,
+)
 
 
 @pytest.mark.run_in_one_thread

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -19,15 +19,12 @@
 import json
 from random import choice
 
+from fauxfactory import gen_boolean, gen_integer, gen_string
 import pytest
-from fauxfactory import gen_boolean
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
 from requests import HTTPError
 
 from robottelo.config import settings
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import parametrized
+from robottelo.utils.datafactory import filtered_datapoint, parametrized
 
 
 @filtered_datapoint

--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -16,13 +16,15 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -16,16 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import AZURERM_FILE_URI
-from robottelo.constants import AZURERM_PLATFORM_DEFAULT
-from robottelo.constants import AZURERM_PREMIUM_OS_Disk
-from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
-from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
-from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
+from robottelo.constants import (
+    AZURERM_FILE_URI,
+    AZURERM_PLATFORM_DEFAULT,
+    AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
+    AZURERM_RHEL7_UD_IMG_URN,
+    AZURERM_VM_SIZE_DEFAULT,
+    AZURERM_PREMIUM_OS_Disk,
+)
 
 
 class TestAzureRMComputeResourceTestCase:

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -21,12 +21,11 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 """
 import random
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import GCE_RHEL_CLOUD_PROJECTS
-from robottelo.constants import VALID_GCE_ZONES
+from robottelo.constants import GCE_RHEL_CLOUD_PROJECTS, VALID_GCE_ZONES
 
 
 @pytest.mark.skip_if_not_set('gce')

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -20,16 +20,17 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
-from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import LIBVIRT_RESOURCE_URL
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 pytestmark = [pytest.mark.skip_if_not_set('libvirt')]
 

--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 from requests import HTTPError
 
 from robottelo.constants import DataFile
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 key_content = DataFile.VALID_GPG_KEY_FILE.read_text()
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -18,27 +18,27 @@
 """
 import random
 
-import pytest
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from fauxfactory import gen_utf8
+from fauxfactory import gen_integer, gen_string, gen_utf8
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.config import settings
-from robottelo.config import user_nailgun_config
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CUSTOM_RPM_SHA_512_FEED_COUNT
-from robottelo.constants import FILTER_ERRATA_TYPE
-from robottelo.constants import PERMISSIONS
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-from robottelo.constants.repos import CUSTOM_RPM_SHA_512
-from robottelo.constants.repos import FEDORA_OSTREE_REPO
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.config import settings, user_nailgun_config
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CUSTOM_RPM_SHA_512_FEED_COUNT,
+    FILTER_ERRATA_TYPE,
+    PERMISSIONS,
+    PRDS,
+    REPOS,
+    REPOSET,
+)
+from robottelo.constants.repos import CUSTOM_RPM_SHA_512, FEDORA_OSTREE_REPO
+from robottelo.utils.datafactory import (
+    invalid_names_list,
+    parametrized,
+    valid_data_list,
+)
 
 # Some tests repeatedly publish content views or promote content view versions.
 # How many times should that be done? A higher number means a more interesting

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -23,19 +23,18 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 import http
 from random import randint
 
+from fauxfactory import gen_integer, gen_string
+from nailgun import client, entities
 import pytest
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from nailgun import client
-from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.config import get_credentials
-from robottelo.config import settings
+from robottelo.config import get_credentials, settings
 from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_names_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -16,16 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import DataFile
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import ENVIRONMENT
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    DEFAULT_CV,
+    ENVIRONMENT,
+    DataFile,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -18,9 +18,7 @@ import pytest
 import requests
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import REPOS
+from robottelo.constants import DEFAULT_ARCHITECTURE, DEFAULT_SUBSCRIPTION_NAME, REPOS
 
 
 def create_repo(sat, org, repo_url, ssl_cert=None):

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -16,14 +16,10 @@
 """
 import re
 
-import pytest
-from fauxfactory import gen_choice
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_mac
-from fauxfactory import gen_string
+from fauxfactory import gen_choice, gen_ipaddr, gen_mac, gen_string
 from nailgun import entity_mixins
-from wait_for import TimedOutError
-from wait_for import wait_for
+import pytest
+from wait_for import TimedOutError, wait_for
 
 from robottelo.logging import logger
 from robottelo.utils.datafactory import valid_data_list

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -16,11 +16,9 @@
 
 :Upstream: No
 """
-import pytest
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
+from fauxfactory import gen_choice, gen_integer, gen_string
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.utils.datafactory import valid_data_list

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -12,23 +12,21 @@
 
 :Upstream: No
 """
-from random import choice
-from random import randint
-from random import shuffle
+from random import choice, randint, shuffle
 
-import pytest
-from fauxfactory import gen_string
-from fauxfactory import gen_url
+from fauxfactory import gen_string, gen_url
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import invalid_docker_upstream_names
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_docker_repository_names
-from robottelo.utils.datafactory import valid_docker_upstream_names
+from robottelo.constants import CONTAINER_REGISTRY_HUB, CONTAINER_UPSTREAM_NAME
+from robottelo.utils.datafactory import (
+    generate_strings_list,
+    invalid_docker_upstream_names,
+    parametrized,
+    valid_docker_repository_names,
+    valid_docker_upstream_names,
+)
 
 DOCKER_PROVIDER = 'Docker'
 

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -20,14 +20,16 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.utils.datafactory import invalid_environments_list
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_environments_list
+from robottelo.utils.datafactory import (
+    invalid_environments_list,
+    invalid_names_list,
+    parametrized,
+    valid_environments_list,
+)
 
 
 @pytest.mark.tier1

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -19,12 +19,11 @@
 # For ease of use hc refers to host-collection throughout this document
 from time import sleep
 
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo import constants
-from robottelo.cli.factory import setup_org_for_a_custom_repo
-from robottelo.cli.factory import setup_org_for_a_rh_repo
+from robottelo.cli.factory import setup_org_for_a_custom_repo, setup_org_for_a_rh_repo
 from robottelo.cli.host import Host
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -20,8 +20,8 @@ http://theforeman.org/api/apidoc/v2/filters.html
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -22,19 +22,13 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 """
 import http
 
+from fauxfactory import gen_choice, gen_integer, gen_ipaddr, gen_mac, gen_string
+from nailgun import client, entities
 import pytest
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_mac
-from fauxfactory import gen_string
-from nailgun import client
-from nailgun import entities
 from requests.exceptions import HTTPError
 
 from robottelo.config import get_credentials
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import ENVIRONMENT
+from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 from robottelo.utils import datafactory
 
 

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -16,18 +16,19 @@
 
 :Upstream: No
 """
-from random import choice
-from random import randint
+from random import choice, randint
 
-import pytest
 from broker import Broker
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.hosts import ContentHost
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -18,17 +18,17 @@
 """
 from random import randint
 
-import pytest
 from fauxfactory import gen_string
-from nailgun import client
-from nailgun import entities
-from nailgun import entity_fields
+from nailgun import client, entities, entity_fields
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import get_credentials
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_hostgroups_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_hostgroups_list,
+)
 
 
 @pytest.fixture

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -16,9 +16,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo import constants
 from robottelo.config import settings

--- a/tests/foreman/api/test_ldapauthsource.py
+++ b/tests/foreman/api/test_ldapauthsource.py
@@ -16,12 +16,11 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.constants import LDAP_ATTR
-from robottelo.constants import LDAP_SERVER_TYPE
+from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.utils.datafactory import generate_strings_list
 
 

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -20,15 +20,17 @@ http://www.katello.org/docs/api/apidoc/lifecycle_environments.html
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.constants import ENVIRONMENT
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_names_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -21,15 +21,16 @@ http://theforeman.org/api/apidoc/v2/locations.html
 """
 from random import randint
 
+from fauxfactory import gen_integer, gen_string
 import pytest
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
 from requests.exceptions import HTTPError
 
 from robottelo.constants import DEFAULT_LOC
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_values_list,
+    parametrized,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -18,16 +18,17 @@
 """
 import random
 
-import pytest
-from fauxfactory import gen_string
-from fauxfactory import gen_url
+from fauxfactory import gen_string, gen_url
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.constants import OPERATING_SYSTEMS
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 class TestMedia:

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -18,16 +18,12 @@
 """
 import http
 
+from nailgun import client, entities, entity_fields
 import pytest
-from nailgun import client
-from nailgun import entities
-from nailgun import entity_fields
 
-from robottelo.config import get_credentials
-from robottelo.config import user_nailgun_config
+from robottelo.config import get_credentials, user_nailgun_config
 from robottelo.logging import logger
 from robottelo.utils.datafactory import parametrized
-
 
 VALID_ENTITIES = {
     entities.ActivationKey,

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -16,17 +16,19 @@
 
 :Upstream: No
 """
-import random
 from http.client import NOT_FOUND
+import random
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.constants import OPERATING_SYSTEMS
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 class TestOperatingSystemParameter:

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -23,17 +23,18 @@ import http
 import json
 from random import randint
 
-import pytest
 from fauxfactory import gen_string
-from nailgun import client
-from nailgun import entities
+from nailgun import client, entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import get_credentials
 from robottelo.constants import DEFAULT_ORG
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_values_list,
+    parametrized,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo.utils.datafactory import gen_string
 

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -16,9 +16,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 
 class TestOscapPolicy:

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -22,16 +22,17 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 """
 import random
 
+from fauxfactory import gen_integer, gen_string
 import pytest
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
 from requests.exceptions import HTTPError
 
 from robottelo.constants import OPERATING_SYSTEMS
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    generate_strings_list,
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 class TestPartitionTable:

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -20,14 +20,14 @@ http://<satellite-host>/apidoc/v2/permissions.html
 
 :Upstream: No
 """
+from itertools import chain
 import json
 import re
-from itertools import chain
 
-import pytest
 from fauxfactory import gen_alphanumeric
 from nailgun import entities
 from nailgun.entity_fields import OneToManyField
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import user_nailgun_config

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -19,19 +19,23 @@ http://<sat6>/apidoc/v2/products.html
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.constants import DataFile
-from robottelo.constants import REPO_TYPE
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_UPSTREAM_NAME,
+    REPO_TYPE,
+    DataFile,
+)
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @pytest.mark.tier1

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -16,9 +16,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from packaging.version import Version
+import pytest
 from wait_for import wait_for
 
 

--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -21,18 +21,13 @@ http://theforeman.org/api/apidoc/v2/provisioning_templates.html
 """
 from random import choice
 
-import pytest
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_mac
-from fauxfactory import gen_string
+from fauxfactory import gen_choice, gen_integer, gen_mac, gen_string
 from nailgun import client
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.config import settings
-from robottelo.config import user_nailgun_config
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.config import settings, user_nailgun_config
+from robottelo.utils.datafactory import invalid_names_list, valid_data_list
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/api/test_puppetbootstrap.py
+++ b/tests/foreman/api/test_puppetbootstrap.py
@@ -16,9 +16,9 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string
 import pytest
 import requests
-from fauxfactory import gen_string
 
 
 @pytest.mark.e2e

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -20,8 +20,7 @@ import uuid
 
 import pytest
 
-from robottelo.constants import CLIENT_PORT
-from robottelo.constants import ENVIRONMENT
+from robottelo.constants import CLIENT_PORT, ENVIRONMENT
 from robottelo.utils.issue_handlers import is_open
 
 pytestmark = pytest.mark.tier1

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -16,20 +16,16 @@
 
 :Upstream: No
 """
-import pytest
 from broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 from requests import HTTPError
 from wait_for import wait_for
 
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME, PRDS, REPOS, REPOSET
 from robottelo.hosts import ContentHost
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import parametrized, valid_data_list
 from robottelo.utils.issue_handlers import is_open
 
 

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -16,10 +16,10 @@
 
 :Upstream: No
 """
-import pytest
 from manifester import Manifester
 from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo import constants

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -17,25 +17,20 @@
 :Upstream: No
 """
 import re
+from string import punctuation
 import tempfile
 import time
-from string import punctuation
-from urllib.parse import urljoin
-from urllib.parse import urlparse
-from urllib.parse import urlunparse
+from urllib.parse import urljoin, urlparse, urlunparse
 
-import pytest
 from fauxfactory import gen_string
-from nailgun import client
-from nailgun import entities
-from nailgun.entity_mixins import call_entity_method_with_timeout
-from nailgun.entity_mixins import TaskFailedError
+from nailgun import client, entities
+from nailgun.entity_mixins import TaskFailedError, call_entity_method_with_timeout
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import DataFile
-from robottelo.constants import repos as repo_constants
+from robottelo.constants import DataFile, repos as repo_constants
 from robottelo.content_info import get_repo_files_by_url
 from robottelo.logging import logger
 from robottelo.utils import datafactory

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -19,11 +19,10 @@ https://theforeman.org/plugins/katello/3.16/api/apidoc/v2/repository_sets.html
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 
-from robottelo.constants import PRDS
-from robottelo.constants import REPOSET
+from robottelo.constants import PRDS, REPOSET
 
 pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.tier1]
 

--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.utils.issue_handlers import is_open
 

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -18,15 +18,12 @@
 """
 from datetime import datetime
 
+from fauxfactory import gen_alphanumeric, gen_string
 import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_string
 from wait_for import wait_for
 
 from robottelo.config import robottelo_tmp_dir
-from robottelo.utils.io import get_local_file_data
-from robottelo.utils.io import get_report_data
-from robottelo.utils.io import get_report_metadata
+from robottelo.utils.io import get_local_file_data, get_report_data, get_report_metadata
 
 generate_report_task = 'ForemanInventoryUpload::Async::UploadReportJob'
 

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -22,11 +22,10 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 """
 import http
 
-import pytest
 from nailgun import client
+import pytest
 
-from robottelo.config import get_credentials
-from robottelo.config import get_url
+from robottelo.config import get_credentials, get_url
 
 
 @pytest.mark.tier1

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -20,17 +20,14 @@ http://theforeman.org/api/apidoc/v2/roles.html
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
 from nailgun.config import ServerConfig
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.cli.ldapauthsource import LDAPAuthSource
-from robottelo.constants import LDAP_ATTR
-from robottelo.constants import LDAP_SERVER_TYPE
-from robottelo.utils.datafactory import gen_string
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
+from robottelo.utils.datafactory import gen_string, generate_strings_list, parametrized
 from robottelo.utils.issue_handlers import is_open
 
 

--- a/tests/foreman/api/test_settings.py
+++ b/tests/foreman/api/test_settings.py
@@ -18,14 +18,16 @@
 """
 import random
 
-import pytest
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    generate_strings_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/api/test_smartproxy.py
+++ b/tests/foreman/api/test_smartproxy.py
@@ -16,15 +16,12 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string, gen_url
 import pytest
-from fauxfactory import gen_string
-from fauxfactory import gen_url
 from requests import HTTPError
 
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import parametrized, valid_data_list
 from robottelo.utils.issue_handlers import is_open
-
 
 pytestmark = [pytest.mark.run_in_one_thread]
 

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -23,14 +23,16 @@ http://theforeman.org/api/apidoc/v2/1.15.html
 """
 import re
 
-import pytest
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.utils.datafactory import gen_string
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.utils.datafactory import (
+    gen_string,
+    generate_strings_list,
+    invalid_values_list,
+    parametrized,
+)
 
 
 @pytest.mark.tier1

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -20,19 +20,15 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
 from nailgun.config import ServerConfig
 from nailgun.entity_mixins import TaskFailedError
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.cli.subscription import Subscription
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME, PRDS, REPOS, REPOSET
 
 pytestmark = [pytest.mark.run_in_one_thread]
 

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -20,30 +20,24 @@ API reference for sync plans can be found on your Satellite:
 
 :Upstream: No
 """
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from time import sleep
 
+from fauxfactory import gen_choice, gen_string
+from nailgun import client, entities
 import pytest
-from fauxfactory import gen_choice
-from fauxfactory import gen_string
-from nailgun import client
-from nailgun import entities
 from requests.exceptions import HTTPError
 
-from robottelo.config import get_credentials
-from robottelo.config import get_url
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-from robottelo.constants import SYNC_INTERVAL
+from robottelo.config import get_credentials, get_url
+from robottelo.constants import PRDS, REPOS, REPOSET, SYNC_INTERVAL
 from robottelo.logging import logger
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_cron_expressions
-from robottelo.utils.datafactory import valid_data_list
-
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_values_list,
+    parametrized,
+    valid_cron_expressions,
+    valid_data_list,
+)
 
 sync_date_deltas = {
     # Today

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -18,18 +18,19 @@ import base64
 import json
 import time
 
-import pytest
-import requests
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
+import requests
 
 from robottelo.config import settings
-from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_API_URL
-from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL
-from robottelo.constants import FOREMAN_TEMPLATE_ROOT_DIR
-from robottelo.constants import FOREMAN_TEMPLATE_TEST_TEMPLATE
+from robottelo.constants import (
+    FOREMAN_TEMPLATE_IMPORT_API_URL,
+    FOREMAN_TEMPLATE_IMPORT_URL,
+    FOREMAN_TEMPLATE_ROOT_DIR,
+    FOREMAN_TEMPLATE_TEST_TEMPLATE,
+)
 from robottelo.logging import logger
-
 
 git = settings.git
 

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -23,25 +23,25 @@ http://<satellite-host>/apidoc/v2/users.html
 import json
 import re
 
-import pytest
 from nailgun import entities
 from nailgun.config import ServerConfig
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
-from robottelo.constants import DataFile
-from robottelo.constants import LDAP_ATTR
-from robottelo.constants import LDAP_SERVER_TYPE
+from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE, DataFile
 from robottelo.utils import gen_ssh_keypairs
-from robottelo.utils.datafactory import gen_string
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import invalid_emails_list
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import invalid_usernames_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
-from robottelo.utils.datafactory import valid_emails_list
-from robottelo.utils.datafactory import valid_usernames_list
+from robottelo.utils.datafactory import (
+    gen_string,
+    generate_strings_list,
+    invalid_emails_list,
+    invalid_names_list,
+    invalid_usernames_list,
+    parametrized,
+    valid_data_list,
+    valid_emails_list,
+    valid_usernames_list,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/api/test_usergroup.py
+++ b/tests/foreman/api/test_usergroup.py
@@ -21,15 +21,17 @@ https://theforeman.org/api/2.0/apidoc/v2/usergroups.html
 """
 from random import randint
 
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
-from robottelo.utils.datafactory import valid_usernames_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+    valid_usernames_list,
+)
 
 
 class TestUserGroup:

--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -18,15 +18,13 @@
 """
 import re
 
-import pytest
 from nailgun import entities
+import pytest
 from requests.exceptions import HTTPError
-from wait_for import TimedOutError
-from wait_for import wait_for
+from wait_for import TimedOutError, wait_for
 
 from robottelo.config import settings
-from robottelo.constants import WEBHOOK_EVENTS
-from robottelo.constants import WEBHOOK_METHODS
+from robottelo.constants import WEBHOOK_EVENTS, WEBHOOK_METHODS
 from robottelo.logging import logger
 from robottelo.utils.datafactory import parametrized
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -16,40 +16,41 @@
 
 :Upstream: No
 """
-import re
 from random import choice
+import re
 
-import pytest
 from broker import Broker
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_string
+from fauxfactory import gen_alphanumeric, gen_string
+import pytest
 
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.defaults import Defaults
-from robottelo.cli.factory import add_role_permissions
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_activation_key
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_host_collection
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_user
-from robottelo.cli.factory import setup_org_for_a_custom_repo
-from robottelo.cli.factory import setup_org_for_a_rh_repo
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    add_role_permissions,
+    make_activation_key,
+    make_content_view,
+    make_host_collection,
+    make_lifecycle_environment,
+    make_role,
+    make_user,
+    setup_org_for_a_custom_repo,
+    setup_org_for_a_rh_repo,
+)
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.repository import Repository
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import PRDS, REPOS, REPOSET
 from robottelo.hosts import ContentHost
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 from robottelo.utils.issue_handlers import is_open
 
 

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -16,16 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_choice
+import pytest
 
 from robottelo.cli.architecture import Architecture
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_architecture
-from robottelo.utils.datafactory import invalid_id_list
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_id_list,
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 class TestArchitecture:

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -18,11 +18,10 @@
 """
 from time import sleep
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
-from robottelo.cli.auth import Auth
-from robottelo.cli.auth import AuthLogin
+from robottelo.cli.auth import Auth, AuthLogin
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_user
 from robottelo.cli.org import Org

--- a/tests/foreman/cli/test_bootdisk.py
+++ b/tests/foreman/cli/test_bootdisk.py
@@ -16,9 +16,8 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_mac, gen_string
 import pytest
-from fauxfactory import gen_mac
-from fauxfactory import gen_string
 
 from robottelo.config import settings
 from robottelo.constants import HTTPS_MEDIUM_URL

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -16,17 +16,14 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_alphanumeric, gen_string
 import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.proxy import Proxy
 from robottelo.host_helpers.cli_factory import CLIFactoryError
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import parametrized, valid_data_list
 from robottelo.utils.issue_handlers import is_open
-
 
 pytestmark = [pytest.mark.run_in_one_thread]
 

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -16,18 +16,20 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.host import Host
 from robottelo.config import settings
-from robottelo.constants import AZURERM_FILE_URI
-from robottelo.constants import AZURERM_PLATFORM_DEFAULT
-from robottelo.constants import AZURERM_PREMIUM_OS_Disk
-from robottelo.constants import AZURERM_RHEL7_FT_CUSTOM_IMG_URN
-from robottelo.constants import AZURERM_RHEL7_UD_IMG_URN
-from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
+from robottelo.constants import (
+    AZURERM_FILE_URI,
+    AZURERM_PLATFORM_DEFAULT,
+    AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
+    AZURERM_RHEL7_UD_IMG_URN,
+    AZURERM_VM_SIZE_DEFAULT,
+    AZURERM_PREMIUM_OS_Disk,
+)
 
 
 @pytest.fixture(scope='class')

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -13,16 +13,13 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
-from robottelo.cli.factory import make_compute_resource
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_org
+from robottelo.cli.factory import make_compute_resource, make_location, make_org
 from robottelo.cli.org import Org
 from robottelo.config import settings
-from robottelo.constants import EC2_REGION_CA_CENTRAL_1
-from robottelo.constants import FOREMAN_PROVIDERS
+from robottelo.constants import EC2_REGION_CA_CENTRAL_1, FOREMAN_PROVIDERS
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -35,18 +35,15 @@ Subcommands::
 """
 import random
 
+from fauxfactory import gen_string, gen_url
 import pytest
-from fauxfactory import gen_string
-from fauxfactory import gen_url
 from wait_for import wait_for
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
-from robottelo.cli.factory import make_compute_resource
-from robottelo.cli.factory import make_location
+from robottelo.cli.factory import make_compute_resource, make_location
 from robottelo.config import settings
-from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import LIBVIRT_RESOURCE_URL
+from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
 from robottelo.utils.datafactory import parametrized
 
 LIBVIRT_URL = LIBVIRT_RESOURCE_URL % settings.libvirt.libvirt_hostname

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -15,9 +15,9 @@
 
 :Upstream: No
 """
-import pytest
 from box import Box
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.factory import CLIReturnCodeError
 from robottelo.config import settings

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -15,15 +15,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 from wait_for import wait_for
 from wrapanapi import RHEVMSystem
 
 from robottelo.cli.computeresource import ComputeResource
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import CLIReturnCodeError
-from robottelo.cli.factory import make_compute_resource
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    CLIReturnCodeError,
+    make_compute_resource,
+)
 from robottelo.cli.host import Host
 from robottelo.config import settings
 

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -13,8 +13,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.factory import make_compute_resource
 from robottelo.cli.org import Org

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -12,21 +12,25 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 from wait_for import wait_for
 
-from robottelo.cli.factory import ContentView
-from robottelo.cli.factory import LifecycleEnvironment
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_product_wait
-from robottelo.cli.factory import make_repository
-from robottelo.cli.factory import Repository
+from robottelo.cli.factory import (
+    ContentView,
+    LifecycleEnvironment,
+    Repository,
+    make_content_view,
+    make_lifecycle_environment,
+    make_product_wait,
+    make_repository,
+)
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.constants import REPO_TYPE
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_UPSTREAM_NAME,
+    REPO_TYPE,
+)
 from robottelo.logging import logger
 
 

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -16,16 +16,18 @@
 """
 import time
 
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo.cli.host import Host
 from robottelo.cli.package import Package
 from robottelo.config import settings
-from robottelo.constants import REAL_0_ERRATA_ID
-from robottelo.constants import REAL_RHEL7_0_2_PACKAGE_FILENAME
-from robottelo.constants import REAL_RHEL7_0_2_PACKAGE_NAME
-from robottelo.constants import REPOS
+from robottelo.constants import (
+    REAL_0_ERRATA_ID,
+    REAL_RHEL7_0_2_PACKAGE_FILENAME,
+    REAL_RHEL7_0_2_PACKAGE_NAME,
+    REPOS,
+)
 
 pytestmark = [
     pytest.mark.skipif(

--- a/tests/foreman/cli/test_contentcredentials.py
+++ b/tests/foreman/cli/test_contentcredentials.py
@@ -20,26 +20,26 @@ Satellite 6.8
 """
 from tempfile import mkstemp
 
+from fauxfactory import gen_alphanumeric, gen_choice, gen_integer, gen_string
 import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.content_credentials import ContentCredential
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_content_credential
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_repository
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_content_credential,
+    make_product,
+    make_repository,
+)
 from robottelo.cli.org import Org
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
-from robottelo.constants import DataFile
-from robottelo.constants import DEFAULT_ORG
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.constants import DEFAULT_ORG, DataFile
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 VALID_GPG_KEY_FILE_PATH = DataFile.VALID_GPG_KEY_FILE
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -18,10 +18,9 @@
 """
 import random
 
-import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_string
+from fauxfactory import gen_alphanumeric, gen_string
 from nailgun import entities
+import pytest
 from wrapanapi.entities.vm import VmState
 
 from robottelo import constants
@@ -42,13 +41,17 @@ from robottelo.cli.repository import Repository
 from robottelo.cli.role import Role
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import DataFile
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE_NAME
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_names_list
+from robottelo.constants import (
+    FAKE_2_CUSTOM_PACKAGE,
+    FAKE_2_CUSTOM_PACKAGE_NAME,
+    DataFile,
+)
+from robottelo.utils.datafactory import (
+    generate_strings_list,
+    invalid_names_list,
+    parametrized,
+    valid_names_list,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -16,19 +16,20 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.defaults import Defaults
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_repository
+from robottelo.cli.factory import make_content_view, make_repository
 from robottelo.cli.repository import Repository
 from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -16,30 +16,31 @@
 
 :Upstream: No
 """
-import random
 from functools import partial
+import random
 
-import pytest
 from box import Box
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from nailgun.entities import Role as RoleEntity
-from nailgun.entities import User as UserEntity
+from fauxfactory import gen_choice, gen_integer, gen_string
+from nailgun.entities import Role as RoleEntity, User as UserEntity
+import pytest
 from requests import HTTPError
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.discoveryrule import DiscoveryRule
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_discoveryrule
-from robottelo.cli.factory import make_hostgroup
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_org
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_discoveryrule,
+    make_hostgroup,
+    make_location,
+    make_org,
+)
 from robottelo.logging import logger
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -12,34 +12,38 @@
 
 :Upstream: No
 """
-from random import choice
-from random import randint
+from random import choice, randint
 
+from fauxfactory import gen_string, gen_url
 import pytest
-from fauxfactory import gen_string
-from fauxfactory import gen_url
 
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
 from robottelo.cli.docker import Docker
-from robottelo.cli.factory import make_activation_key
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_product_wait
-from robottelo.cli.factory import make_repository
+from robottelo.cli.factory import (
+    make_activation_key,
+    make_content_view,
+    make_lifecycle_environment,
+    make_product_wait,
+    make_repository,
+)
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_RH_REGISTRY_UPSTREAM_NAME
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.constants import REPO_TYPE
-from robottelo.utils.datafactory import invalid_docker_upstream_names
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_docker_repository_names
-from robottelo.utils.datafactory import valid_docker_upstream_names
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_RH_REGISTRY_UPSTREAM_NAME,
+    CONTAINER_UPSTREAM_NAME,
+    REPO_TYPE,
+)
+from robottelo.utils.datafactory import (
+    invalid_docker_upstream_names,
+    parametrized,
+    valid_docker_repository_names,
+    valid_docker_upstream_names,
+)
 
 
 def _repo(product_id, name=None, upstream_name=None, url=None):

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -16,18 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.domain import Domain
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_domain
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_org
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_id_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.cli.factory import CLIFactoryError, make_domain, make_location, make_org
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_id_list,
+    parametrized,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -18,15 +18,16 @@
 """
 from random import choice
 
+from fauxfactory import gen_alphanumeric, gen_string
 import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
-from robottelo.utils.datafactory import invalid_id_list
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.utils.datafactory import (
+    invalid_id_list,
+    invalid_values_list,
+    parametrized,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -16,30 +16,29 @@
 
 :Upstream: No
 """
-from datetime import date
-from datetime import datetime
-from datetime import timedelta
+from datetime import date, datetime, timedelta
 from operator import itemgetter
 
-import pytest
 from broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.contentview import ContentView
-from robottelo.cli.contentview import ContentViewFilter
+from robottelo.cli.contentview import ContentView, ContentViewFilter
 from robottelo.cli.erratum import Erratum
-from robottelo.cli.factory import make_content_view_filter
-from robottelo.cli.factory import make_content_view_filter_rule
-from robottelo.cli.factory import make_filter
-from robottelo.cli.factory import make_host_collection
-from robottelo.cli.factory import make_repository
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_user
-from robottelo.cli.factory import setup_org_for_a_custom_repo
-from robottelo.cli.factory import setup_org_for_a_rh_repo
+from robottelo.cli.factory import (
+    make_content_view_filter,
+    make_content_view_filter_rule,
+    make_filter,
+    make_host_collection,
+    make_repository,
+    make_role,
+    make_user,
+    setup_org_for_a_custom_repo,
+    setup_org_for_a_rh_repo,
+)
 from robottelo.cli.filter import Filter
 from robottelo.cli.host import Host
 from robottelo.cli.hostcollection import HostCollection
@@ -50,21 +49,23 @@ from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_5_CUSTOM_PACKAGE
-from robottelo.constants import PRDS
-from robottelo.constants import REAL_0_ERRATA_ID
-from robottelo.constants import REAL_4_ERRATA_CVES
-from robottelo.constants import REAL_4_ERRATA_ID
-from robottelo.constants import REAL_RHEL7_0_2_PACKAGE_NAME
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_SUBSCRIPTION_NAME,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_2_CUSTOM_PACKAGE,
+    FAKE_2_CUSTOM_PACKAGE_NAME,
+    FAKE_4_CUSTOM_PACKAGE,
+    FAKE_4_CUSTOM_PACKAGE_NAME,
+    FAKE_5_CUSTOM_PACKAGE,
+    PRDS,
+    REAL_0_ERRATA_ID,
+    REAL_4_ERRATA_CVES,
+    REAL_4_ERRATA_ID,
+    REAL_RHEL7_0_2_PACKAGE_NAME,
+    REPOS,
+    REPOSET,
+)
 from robottelo.hosts import ContentHost
 
 PER_PAGE = 10

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -16,11 +16,10 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.fact import Fact
-
 
 pytestmark = [pytest.mark.tier1]
 

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -19,10 +19,7 @@
 import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_filter
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_role
+from robottelo.cli.factory import make_filter, make_location, make_org, make_role
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
 

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -18,11 +18,10 @@
 """
 from functools import partial
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.globalparam import GlobalParameter
-
 
 pytestmark = [pytest.mark.tier1]
 

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -27,7 +27,6 @@ from robottelo.cli import hammer
 from robottelo.constants import DataFile
 from robottelo.logging import logger
 
-
 HAMMER_COMMANDS = json.loads(DataFile.HAMMER_COMMANDS_JSON.read_text())
 
 pytestmark = [pytest.mark.tier1, pytest.mark.upgrade, pytest.mark.e2e]

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -16,49 +16,48 @@
 
 :Upstream: No
 """
-import re
 from random import choice
+import re
 
+from fauxfactory import gen_choice, gen_integer, gen_ipaddr, gen_mac, gen_string
 import pytest
+from wait_for import TimedOutError, wait_for
 import yaml
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_mac
-from fauxfactory import gen_string
-from wait_for import TimedOutError
-from wait_for import wait_for
 
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import add_role_permissions
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_fake_host
-from robottelo.cli.factory import make_host
-from robottelo.cli.factory import setup_org_for_a_rh_repo
-from robottelo.cli.host import Host
-from robottelo.cli.host import HostInterface
-from robottelo.cli.host import HostTraces
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    add_role_permissions,
+    make_fake_host,
+    make_host,
+    setup_org_for_a_rh_repo,
+)
+from robottelo.cli.host import Host, HostInterface, HostTraces
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.package import Package
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_7_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_8_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_8_CUSTOM_PACKAGE_NAME
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-from robottelo.constants import SM_OVERALL_STATUS
+from robottelo.constants import (
+    DEFAULT_SUBSCRIPTION_NAME,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_1_CUSTOM_PACKAGE_NAME,
+    FAKE_2_CUSTOM_PACKAGE,
+    FAKE_7_CUSTOM_PACKAGE,
+    FAKE_8_CUSTOM_PACKAGE,
+    FAKE_8_CUSTOM_PACKAGE_NAME,
+    PRDS,
+    REPOS,
+    REPOSET,
+    SM_OVERALL_STATUS,
+)
 from robottelo.hosts import ContentHostError
 from robottelo.logging import logger
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import valid_data_list
-from robottelo.utils.datafactory import valid_hosts_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    valid_data_list,
+    valid_hosts_list,
+)
 from robottelo.utils.issue_handlers import is_open
 
 

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -16,26 +16,29 @@
 
 :Upstream: No
 """
-import pytest
 from broker import Broker
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.activationkey import ActivationKey
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_fake_host
-from robottelo.cli.factory import make_host_collection
-from robottelo.cli.factory import make_org
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_fake_host,
+    make_host_collection,
+    make_org,
+)
 from robottelo.cli.host import Host
 from robottelo.cli.hostcollection import HostCollection
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import ENVIRONMENT
+from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 from robottelo.hosts import ContentHost
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 def _make_fake_host_helper(module_org):

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -16,31 +16,35 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_integer
 from nailgun import entities
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_architecture
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_domain
-from robottelo.cli.factory import make_environment
-from robottelo.cli.factory import make_hostgroup
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_medium
-from robottelo.cli.factory import make_os
-from robottelo.cli.factory import make_partition_table
-from robottelo.cli.factory import make_subnet
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_architecture,
+    make_content_view,
+    make_domain,
+    make_environment,
+    make_hostgroup,
+    make_lifecycle_environment,
+    make_location,
+    make_medium,
+    make_os,
+    make_partition_table,
+    make_subnet,
+)
 from robottelo.cli.hostgroup import HostGroup
 from robottelo.cli.proxy import Proxy
 from robottelo.config import settings
-from robottelo.utils.datafactory import invalid_id_list
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_hostgroups_list
+from robottelo.utils.datafactory import (
+    invalid_id_list,
+    invalid_values_list,
+    parametrized,
+    valid_hostgroups_list,
+)
 
 pytestmark = [
     pytest.mark.skipif(

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -16,14 +16,11 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_integer, gen_string, gen_url
 import pytest
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from fauxfactory import gen_url
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_repository
+from robottelo.cli.factory import make_product, make_repository
 from robottelo.cli.http_proxy import HttpProxy
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository

--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -16,16 +16,14 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo import ssh
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_job_template
+from robottelo.cli.factory import CLIFactoryError, make_job_template
 from robottelo.cli.job_template import JobTemplate
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.utils.datafactory import invalid_values_list, parametrized
 
 TEMPLATE_FILE = 'template_file.txt'
 TEMPLATE_FILE_EMPTY = 'template_file_empty.txt'

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -16,23 +16,22 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.auth import Auth
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_ldap_auth_source
-from robottelo.cli.factory import make_usergroup
-from robottelo.cli.factory import make_usergroup_external
+from robottelo.cli.factory import (
+    make_ldap_auth_source,
+    make_usergroup,
+    make_usergroup_external,
+)
 from robottelo.cli.ldapauthsource import LDAPAuthSource
 from robottelo.cli.role import Role
-from robottelo.cli.usergroup import UserGroup
-from robottelo.cli.usergroup import UserGroupExternal
-from robottelo.constants import LDAP_ATTR
-from robottelo.constants import LDAP_SERVER_TYPE
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.cli.usergroup import UserGroup, UserGroupExternal
+from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
+from robottelo.utils.datafactory import generate_strings_list, parametrized
 
 
 @pytest.fixture()

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from broker import Broker
+import pytest
 
 from robottelo.config import settings
 from robottelo.constants import PRDS

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -18,12 +18,11 @@
 """
 from math import ceil
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_org
+from robottelo.cli.factory import make_lifecycle_environment, make_org
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.constants import ENVIRONMENT
 

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -16,23 +16,25 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.computeresource import ComputeResource
 from robottelo.cli.domain import Domain
 from robottelo.cli.environment import Environment
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_compute_resource
-from robottelo.cli.factory import make_domain
-from robottelo.cli.factory import make_environment
-from robottelo.cli.factory import make_hostgroup
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_medium
-from robottelo.cli.factory import make_subnet
-from robottelo.cli.factory import make_template
-from robottelo.cli.factory import make_user
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_compute_resource,
+    make_domain,
+    make_environment,
+    make_hostgroup,
+    make_location,
+    make_medium,
+    make_subnet,
+    make_template,
+    make_user,
+)
 from robottelo.cli.hostgroup import HostGroup
 from robottelo.cli.location import Location
 from robottelo.cli.medium import Medium

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -18,12 +18,11 @@
 """
 import re
 
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_repository
+from robottelo.cli.factory import make_product, make_repository
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.config import settings

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -16,17 +16,13 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_alphanumeric
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_medium
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_os
+from robottelo.cli.factory import make_location, make_medium, make_org, make_os
 from robottelo.cli.medium import Medium
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import parametrized, valid_data_list
 
 URL = "http://mirror.fakeos.org/%s/$major.$minor/os/$arch"
 OSES = ['Archlinux', 'Debian', 'Gentoo', 'Redhat', 'Solaris', 'Suse', 'Windows']

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -16,16 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.factory import make_model
 from robottelo.cli.model import Model
-from robottelo.utils.datafactory import invalid_id_list
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    invalid_id_list,
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 class TestModel:

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -16,20 +16,23 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_alphanumeric, gen_string
 import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_string
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_architecture
-from robottelo.cli.factory import make_medium
-from robottelo.cli.factory import make_partition_table
-from robottelo.cli.factory import make_template
+from robottelo.cli.factory import (
+    make_architecture,
+    make_medium,
+    make_partition_table,
+    make_template,
+)
 from robottelo.constants import DEFAULT_ORG
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -16,31 +16,35 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_compute_resource
-from robottelo.cli.factory import make_domain
-from robottelo.cli.factory import make_hostgroup
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_medium
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_subnet
-from robottelo.cli.factory import make_template
-from robottelo.cli.factory import make_user
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_compute_resource,
+    make_domain,
+    make_hostgroup,
+    make_lifecycle_environment,
+    make_location,
+    make_medium,
+    make_org,
+    make_subnet,
+    make_template,
+    make_user,
+)
 from robottelo.cli.lifecycleenvironment import LifecycleEnvironment
 from robottelo.cli.org import Org
 from robottelo.cli.user import User
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
-from robottelo.utils.datafactory import valid_org_names_list
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+    valid_org_names_list,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -16,26 +16,28 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_hostgroup
-from robottelo.cli.factory import make_scap_policy
-from robottelo.cli.factory import make_scapcontent
-from robottelo.cli.factory import make_tailoringfile
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_hostgroup,
+    make_scap_policy,
+    make_scapcontent,
+    make_tailoringfile,
+)
 from robottelo.cli.host import Host
 from robottelo.cli.scap_policy import Scappolicy
 from robottelo.cli.scapcontent import Scapcontent
 from robottelo.config import settings
-from robottelo.constants import OSCAP_DEFAULT_CONTENT
-from robottelo.constants import OSCAP_PERIOD
-from robottelo.constants import OSCAP_WEEKDAY
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.constants import OSCAP_DEFAULT_CONTENT, OSCAP_PERIOD, OSCAP_WEEKDAY
+from robottelo.utils.datafactory import (
+    invalid_names_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 class TestOpenScap:

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -16,18 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_tailoringfile
+from robottelo.cli.factory import CLIFactoryError, make_tailoringfile
 from robottelo.cli.scap_tailoring_files import TailoringFiles
-from robottelo.constants import DataFile
-from robottelo.constants import SNIPPET_DATA_FILE
-from robottelo.utils.datafactory import invalid_names_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.constants import SNIPPET_DATA_FILE, DataFile
+from robottelo.utils.datafactory import (
+    invalid_names_list,
+    parametrized,
+    valid_data_list,
+)
 
 
 class TestTailoringFiles:

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -18,14 +18,16 @@
 """
 import random
 
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo.cli.contentview import ContentView
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_org_with_credentials
-from robottelo.cli.factory import make_product_with_credentials
-from robottelo.cli.factory import make_repository_with_credentials
+from robottelo.cli.factory import (
+    make_content_view,
+    make_org_with_credentials,
+    make_product_with_credentials,
+    make_repository_with_credentials,
+)
 from robottelo.cli.ostreebranch import OstreeBranch
 from robottelo.cli.repository import Repository
 from robottelo.config import settings

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -18,15 +18,13 @@
 """
 from random import randint
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_os
-from robottelo.cli.factory import make_partition_table
+from robottelo.cli.factory import make_os, make_partition_table
 from robottelo.cli.partitiontable import PartitionTable
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.utils.datafactory import generate_strings_list, parametrized
 
 
 class TestPartitionTable:

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -16,29 +16,30 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_alphanumeric, gen_integer, gen_string, gen_url
 import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from fauxfactory import gen_url
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.defaults import Defaults
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_content_credential
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_repository
-from robottelo.cli.factory import make_sync_plan
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_content_credential,
+    make_org,
+    make_product,
+    make_repository,
+    make_sync_plan,
+)
 from robottelo.cli.package import Package
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.config import settings
 from robottelo.constants import FAKE_0_YUM_REPO_PACKAGES_COUNT
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
-from robottelo.utils.datafactory import valid_labels_list
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+    valid_labels_list,
+)
 
 
 @pytest.mark.tier1

--- a/tests/foreman/cli/test_provisioningtemplate.py
+++ b/tests/foreman/cli/test_provisioningtemplate.py
@@ -19,8 +19,8 @@
 import random
 from random import randint
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo import constants
 from robottelo.cli.base import CLIReturnCodeError

--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -18,12 +18,11 @@
 """
 import random
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_realm
+from robottelo.cli.factory import CLIFactoryError, make_realm
 from robottelo.cli.realm import Realm
 
 

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -16,21 +16,22 @@
 
 :Upstream: No
 """
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from time import sleep
 
-import pytest
 from broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
-from robottelo.cli.factory import make_filter
-from robottelo.cli.factory import make_job_invocation
-from robottelo.cli.factory import make_job_invocation_with_credentials
-from robottelo.cli.factory import make_job_template
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_user
+from robottelo.cli.factory import (
+    make_filter,
+    make_job_invocation,
+    make_job_invocation_with_credentials,
+    make_job_template,
+    make_role,
+    make_user,
+)
 from robottelo.cli.filter import Filter
 from robottelo.cli.globalparam import GlobalParameter
 from robottelo.cli.host import Host
@@ -41,9 +42,7 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.task import Task
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import PRDS, REPOS, REPOSET
 from robottelo.hosts import ContentHost
 from robottelo.utils import ohsnap
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -15,32 +15,33 @@
 
 :Upstream: No
 """
-import pytest
 from broker import Broker
 from fauxfactory import gen_alpha
+import pytest
 
 from robottelo.cli.activationkey import ActivationKey
-from robottelo.cli.base import Base
-from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.base import Base, CLIReturnCodeError
 from robottelo.cli.contentview import ContentView
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_activation_key
-from robottelo.cli.factory import make_architecture
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_fake_host
-from robottelo.cli.factory import make_filter
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_medium
-from robottelo.cli.factory import make_os
-from robottelo.cli.factory import make_partition_table
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_report_template
-from robottelo.cli.factory import make_repository
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_template_input
-from robottelo.cli.factory import make_user
-from robottelo.cli.factory import setup_org_for_a_custom_repo
-from robottelo.cli.factory import setup_org_for_a_rh_repo
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_activation_key,
+    make_architecture,
+    make_content_view,
+    make_fake_host,
+    make_filter,
+    make_lifecycle_environment,
+    make_medium,
+    make_os,
+    make_partition_table,
+    make_product,
+    make_report_template,
+    make_repository,
+    make_role,
+    make_template_input,
+    make_user,
+    setup_org_for_a_custom_repo,
+    setup_org_for_a_rh_repo,
+)
 from robottelo.cli.filter import Filter
 from robottelo.cli.host import Host
 from robottelo.cli.location import Location
@@ -51,17 +52,19 @@ from robottelo.cli.settings import Settings
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC
-from robottelo.constants import DEFAULT_ORG
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import PRDS
-from robottelo.constants import REPORT_TEMPLATE_FILE
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import (
+    DEFAULT_LOC,
+    DEFAULT_ORG,
+    DEFAULT_SUBSCRIPTION_NAME,
+    FAKE_0_CUSTOM_PACKAGE_NAME,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_1_CUSTOM_PACKAGE_NAME,
+    FAKE_2_CUSTOM_PACKAGE,
+    PRDS,
+    REPORT_TEMPLATE_FILE,
+    REPOS,
+    REPOSET,
+)
 from robottelo.hosts import ContentHost
 
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -19,30 +19,29 @@
 from random import choice
 from string import punctuation
 
+from fauxfactory import gen_alphanumeric, gen_integer, gen_string, gen_url
+from nailgun import entities
 import pytest
 import requests
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from fauxfactory import gen_url
-from nailgun import entities
 from wait_for import wait_for
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.content_export import ContentExport
 from robottelo.cli.content_import import ContentImport
 from robottelo.cli.contentview import ContentView
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_content_credential
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_filter
-from robottelo.cli.factory import make_lifecycle_environment
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_repository
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_user
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_content_credential,
+    make_content_view,
+    make_filter,
+    make_lifecycle_environment,
+    make_location,
+    make_org,
+    make_product,
+    make_repository,
+    make_role,
+    make_user,
+)
 from robottelo.cli.file import File
 from robottelo.cli.filter import Filter
 from robottelo.cli.module_stream import ModuleStream
@@ -57,31 +56,37 @@ from robottelo.cli.srpm import Srpm
 from robottelo.cli.task import Task
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.constants import CUSTOM_FILE_REPO_FILES_COUNT
-from robottelo.constants import CUSTOM_LOCAL_FOLDER
-from robottelo.constants import DataFile
-from robottelo.constants import DOWNLOAD_POLICIES
-from robottelo.constants import MIRRORING_POLICIES
-from robottelo.constants import OS_TEMPLATE_DATA_FILE
-from robottelo.constants import REPO_TYPE
-from robottelo.constants import RPM_TO_UPLOAD
-from robottelo.constants import SRPM_TO_UPLOAD
-from robottelo.constants.repos import ANSIBLE_GALAXY
-from robottelo.constants.repos import CUSTOM_3RD_PARTY_REPO
-from robottelo.constants.repos import CUSTOM_FILE_REPO
-from robottelo.constants.repos import CUSTOM_RPM_SHA
-from robottelo.constants.repos import FAKE_5_YUM_REPO
-from robottelo.constants.repos import FAKE_YUM_DRPM_REPO
-from robottelo.constants.repos import FAKE_YUM_MD5_REPO
-from robottelo.constants.repos import FAKE_YUM_SRPM_REPO
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_UPSTREAM_NAME,
+    CUSTOM_FILE_REPO_FILES_COUNT,
+    CUSTOM_LOCAL_FOLDER,
+    DOWNLOAD_POLICIES,
+    MIRRORING_POLICIES,
+    OS_TEMPLATE_DATA_FILE,
+    REPO_TYPE,
+    RPM_TO_UPLOAD,
+    SRPM_TO_UPLOAD,
+    DataFile,
+)
+from robottelo.constants.repos import (
+    ANSIBLE_GALAXY,
+    CUSTOM_3RD_PARTY_REPO,
+    CUSTOM_FILE_REPO,
+    CUSTOM_RPM_SHA,
+    FAKE_5_YUM_REPO,
+    FAKE_YUM_DRPM_REPO,
+    FAKE_YUM_MD5_REPO,
+    FAKE_YUM_SRPM_REPO,
+)
 from robottelo.logging import logger
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
-from robottelo.utils.datafactory import valid_docker_repository_names
-from robottelo.utils.datafactory import valid_http_credentials
+from robottelo.utils.datafactory import (
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+    valid_docker_repository_names,
+    valid_http_credentials,
+)
 
 # from robottelo.constants.repos import FEDORA_OSTREE_REPO
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -20,8 +20,7 @@ import pytest
 
 from robottelo.cli.product import Product
 from robottelo.cli.repository_set import RepositorySet
-from robottelo.constants import PRDS
-from robottelo.constants import REPOSET
+from robottelo.constants import PRDS, REPOSET
 
 pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.tier1]
 

--- a/tests/foreman/cli/test_rhcloud_insights.py
+++ b/tests/foreman/cli/test_rhcloud_insights.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from broker import Broker
+import pytest
 
 from robottelo.hosts import ContentHost
 

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -16,15 +16,14 @@
 
 :Upstream: No
 """
-import time
 from datetime import datetime
+import time
 
 import pytest
 from wait_for import wait_for
 
 from robottelo.config import robottelo_tmp_dir
-from robottelo.utils.io import get_local_file_data
-from robottelo.utils.io import get_remote_report_checksum
+from robottelo.utils.io import get_local_file_data, get_remote_report_checksum
 
 inventory_sync_task = 'InventorySync::Async::InventoryFullSync'
 generate_report_jobs = 'ForemanInventoryUpload::Async::GenerateAllReportsJob'

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -16,28 +16,27 @@
 
 :Upstream: No
 """
-import re
 from math import ceil
 from random import choice
+import re
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
-from robottelo.cli.base import CLIDataBaseError
-from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_filter
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_user
+from robottelo.cli.base import CLIDataBaseError, CLIReturnCodeError
+from robottelo.cli.factory import (
+    make_filter,
+    make_location,
+    make_org,
+    make_role,
+    make_user,
+)
 from robottelo.cli.filter import Filter
 from robottelo.cli.role import Role
 from robottelo.cli.settings import Settings
 from robottelo.cli.user import User
-from robottelo.constants import PERMISSIONS
-from robottelo.constants import ROLES
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import parametrized
+from robottelo.constants import PERMISSIONS, ROLES
+from robottelo.utils.datafactory import generate_strings_list, parametrized
 
 
 class TestRole:

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -16,31 +16,35 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from manifester import Manifester
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.content_export import ContentExport
 from robottelo.cli.content_import import ContentImport
 from robottelo.cli.contentview import ContentView
-from robottelo.cli.factory import make_content_view
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_repository
+from robottelo.cli.factory import (
+    make_content_view,
+    make_org,
+    make_product,
+    make_repository,
+)
 from robottelo.cli.package import Package
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.cli.settings import Settings
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import EXPORT_LIBRARY_NAME
-from robottelo.constants import PULP_EXPORT_DIR
-from robottelo.constants import PULP_IMPORT_DIR
-from robottelo.constants import REPO_TYPE
-from robottelo.constants import REPOS
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_CV,
+    EXPORT_LIBRARY_NAME,
+    PULP_EXPORT_DIR,
+    PULP_IMPORT_DIR,
+    REPO_TYPE,
+    REPOS,
+)
 from robottelo.constants.repos import ANSIBLE_GALAXY
 
 

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -24,14 +24,16 @@ import pytest
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.settings import Settings
 from robottelo.config import settings
-from robottelo.utils.datafactory import gen_string
-from robottelo.utils.datafactory import generate_strings_list
-from robottelo.utils.datafactory import invalid_boolean_strings
-from robottelo.utils.datafactory import invalid_emails_list
-from robottelo.utils.datafactory import valid_data_list
-from robottelo.utils.datafactory import valid_emails_list
-from robottelo.utils.datafactory import valid_url_list
-from robottelo.utils.datafactory import xdist_adapter
+from robottelo.utils.datafactory import (
+    gen_string,
+    generate_strings_list,
+    invalid_boolean_strings,
+    invalid_emails_list,
+    valid_data_list,
+    valid_emails_list,
+    valid_url_list,
+    xdist_adapter,
+)
 
 
 @pytest.mark.stubbed

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -19,20 +19,18 @@
 import random
 import re
 
+from fauxfactory import gen_choice, gen_integer, gen_ipaddr
 import pytest
-from fauxfactory import gen_choice
-from fauxfactory import gen_integer
-from fauxfactory import gen_ipaddr
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_domain
-from robottelo.cli.factory import make_subnet
+from robottelo.cli.factory import CLIFactoryError, make_domain, make_subnet
 from robottelo.cli.subnet import Subnet
 from robottelo.constants import SUBNET_IPAM_TYPES
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    parametrized,
+    valid_data_list,
+)
 
 
 @filtered_datapoint

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -16,21 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_activation_key
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_repository
+from robottelo.cli.factory import make_activation_key, make_product, make_repository
 from robottelo.cli.host import Host
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subscription import Subscription
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import PRDS, REPOS, REPOSET
 
 pytestmark = [pytest.mark.run_in_one_thread]
 

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -16,31 +16,32 @@
 
 :Upstream: No
 """
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 from time import sleep
 
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_product
-from robottelo.cli.factory import make_repository
-from robottelo.cli.factory import make_sync_plan
+from robottelo.cli.factory import (
+    CLIFactoryError,
+    make_product,
+    make_repository,
+    make_sync_plan,
+)
 from robottelo.cli.product import Product
 from robottelo.cli.repository import Repository
 from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.syncplan import SyncPlan
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import PRDS, REPOS, REPOSET
 from robottelo.logging import logger
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import invalid_values_list
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import (
+    filtered_datapoint,
+    invalid_values_list,
+    parametrized,
+    valid_data_list,
+)
 
 SYNC_DATE_FMT = '%Y-%m-%d %H:%M:%S UTC'
 

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -16,17 +16,18 @@
 """
 import base64
 
-import pytest
-import requests
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
+import requests
 
 from robottelo.cli.template import Template
 from robottelo.cli.template_sync import TemplateSync
 from robottelo.config import settings
-from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL
-from robottelo.constants import FOREMAN_TEMPLATE_TEST_TEMPLATE
-
+from robottelo.constants import (
+    FOREMAN_TEMPLATE_IMPORT_URL,
+    FOREMAN_TEMPLATE_TEST_TEMPLATE,
+)
 
 git = settings.git
 

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -26,27 +26,30 @@ import datetime
 import random
 from time import sleep
 
-import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_string
+from fauxfactory import gen_alphanumeric, gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_filter
-from robottelo.cli.factory import make_location
-from robottelo.cli.factory import make_org
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_user
+from robottelo.cli.factory import (
+    make_filter,
+    make_location,
+    make_org,
+    make_role,
+    make_user,
+)
 from robottelo.cli.filter import Filter
 from robottelo.cli.org import Org
 from robottelo.cli.user import User
 from robottelo.config import settings
 from robottelo.constants import LOCALES
 from robottelo.utils import gen_ssh_keypairs
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
-from robottelo.utils.datafactory import valid_emails_list
-from robottelo.utils.datafactory import valid_usernames_list
+from robottelo.utils.datafactory import (
+    parametrized,
+    valid_data_list,
+    valid_emails_list,
+    valid_usernames_list,
+)
 
 
 class TestUser:

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -21,15 +21,16 @@ import random
 import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.factory import make_role
-from robottelo.cli.factory import make_user
-from robottelo.cli.factory import make_usergroup
-from robottelo.cli.factory import make_usergroup_external
+from robottelo.cli.factory import (
+    make_role,
+    make_user,
+    make_usergroup,
+    make_usergroup_external,
+)
 from robottelo.cli.ldapauthsource import LDAPAuthSource
 from robottelo.cli.task import Task
 from robottelo.cli.user import User
-from robottelo.cli.usergroup import UserGroup
-from robottelo.cli.usergroup import UserGroupExternal
+from robottelo.cli.usergroup import UserGroup, UserGroupExternal
 from robottelo.utils.datafactory import valid_usernames_list
 
 

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from broker import Broker
+import pytest
 
 from robottelo.cli.factory import make_lifecycle_environment
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.constants import DISTROS_SUPPORTED
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_UPSTREAM_NAME,
+    DISTROS_SUPPORTED,
+    FAKE_0_CUSTOM_PACKAGE,
+)
 from robottelo.hosts import ContentHost
 
 

--- a/tests/foreman/cli/test_webhook.py
+++ b/tests/foreman/cli/test_webhook.py
@@ -19,14 +19,13 @@
 from functools import partial
 from random import choice
 
-import pytest
 from box import Box
 from fauxfactory import gen_alphanumeric
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.cli.webhook import Webhook
-from robottelo.constants import WEBHOOK_EVENTS
-from robottelo.constants import WEBHOOK_METHODS
+from robottelo.constants import WEBHOOK_EVENTS, WEBHOOK_METHODS
 
 
 @pytest.fixture(scope='function')

--- a/tests/foreman/destructive/test_auth.py
+++ b/tests/foreman/destructive/test_auth.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
 from robottelo.constants import HAMMER_CONFIG

--- a/tests/foreman/destructive/test_capsule.py
+++ b/tests/foreman/destructive/test_capsule.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.hosts import Capsule
 from robottelo.utils.installer import InstallerCommand

--- a/tests/foreman/destructive/test_capsulecontent.py
+++ b/tests/foreman/destructive/test_capsulecontent.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_alpha
+import pytest
 
 from robottelo import constants
 

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -19,8 +19,7 @@
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
+from robottelo.constants import FAKE_0_CUSTOM_PACKAGE, FAKE_1_CUSTOM_PACKAGE
 
 pytestmark = pytest.mark.destructive
 

--- a/tests/foreman/destructive/test_contentview.py
+++ b/tests/foreman/destructive/test_contentview.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun.entity_mixins import TaskFailedError
+import pytest
 
 from robottelo import constants
 

--- a/tests/foreman/destructive/test_discoveredhost.py
+++ b/tests/foreman/destructive/test_discoveredhost.py
@@ -14,13 +14,12 @@
 
 :Upstream: No
 """
-import re
 from copy import copy
+import re
 
-import pytest
 from nailgun import entity_mixins
-from wait_for import TimedOutError
-from wait_for import wait_for
+import pytest
+from wait_for import TimedOutError, wait_for
 
 from robottelo.logging import logger
 

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from airgun.exceptions import NoSuchElementException
+import pytest
 
 
 class TestHostCockpit:

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -14,10 +14,9 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_mac, gen_string
 import pytest
 import requests
-from fauxfactory import gen_mac
-from fauxfactory import gen_string
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -19,15 +19,13 @@
 import os
 from time import sleep
 
+from navmazing import NavigationTriesExceeded
 import pyotp
 import pytest
-from navmazing import NavigationTriesExceeded
 
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
-from robottelo.constants import CERT_PATH
-from robottelo.constants import HAMMER_SESSIONS
-from robottelo.constants import LDAP_ATTR
+from robottelo.constants import CERT_PATH, HAMMER_SESSIONS, LDAP_ATTR
 from robottelo.utils.datafactory import gen_string
 
 pytestmark = [pytest.mark.destructive, pytest.mark.run_in_one_thread]

--- a/tests/foreman/destructive/test_ldapauthsource.py
+++ b/tests/foreman/destructive/test_ldapauthsource.py
@@ -24,7 +24,6 @@ from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
 from robottelo.constants import HAMMER_CONFIG
 
-
 pytestmark = [pytest.mark.destructive]
 
 

--- a/tests/foreman/destructive/test_leapp_satellite.py
+++ b/tests/foreman/destructive/test_leapp_satellite.py
@@ -14,11 +14,10 @@
 
 :Upstream: No
 """
-import pytest
 from broker import Broker
+import pytest
 
-from robottelo.hosts import get_sat_rhel_version
-from robottelo.hosts import get_sat_version
+from robottelo.hosts import get_sat_rhel_version, get_sat_version
 
 
 @pytest.mark.e2e

--- a/tests/foreman/destructive/test_puppetplugin.py
+++ b/tests/foreman/destructive/test_puppetplugin.py
@@ -18,8 +18,7 @@
 """
 import pytest
 
-from robottelo.constants import PUPPET_CAPSULE_INSTALLER
-from robottelo.constants import PUPPET_COMMON_INSTALLER_OPTS
+from robottelo.constants import PUPPET_CAPSULE_INSTALLER, PUPPET_COMMON_INSTALLER_OPTS
 from robottelo.hosts import Satellite
 from robottelo.utils.installer import InstallerCommand
 

--- a/tests/foreman/destructive/test_realm.py
+++ b/tests/foreman/destructive/test_realm.py
@@ -18,11 +18,10 @@
 """
 import random
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.base import CLIReturnCodeError
-
 
 pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.destructive]
 

--- a/tests/foreman/destructive/test_remoteexecution.py
+++ b/tests/foreman/destructive/test_remoteexecution.py
@@ -16,10 +16,10 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun.entity_mixins import TaskFailedError
+import pytest
 
 from robottelo.config import get_credentials
 from robottelo.hosts import get_sat_version

--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -17,8 +17,8 @@
 :Upstream: No
 
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli import hammer
 from robottelo.config import settings

--- a/tests/foreman/destructive/test_repository.py
+++ b/tests/foreman/destructive/test_repository.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun.entity_mixins import TaskFailedError
+import pytest
 
 from robottelo import constants
 

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -16,25 +16,25 @@
 
 :Upstream: No
 """
-import http
 from collections import defaultdict
+import http
 from pprint import pformat
 
-import pytest
 from deepdiff import DeepDiff
 from fauxfactory import gen_string
-from nailgun import client
-from nailgun import entities
+from nailgun import client, entities
+import pytest
 
 from robottelo import constants
-from robottelo.config import get_credentials
-from robottelo.config import get_url
-from robottelo.config import setting_is_set
-from robottelo.config import settings
-from robottelo.config import user_nailgun_config
+from robottelo.config import (
+    get_credentials,
+    get_url,
+    setting_is_set,
+    settings,
+    user_nailgun_config,
+)
 from robottelo.constants.repos import CUSTOM_RPM_REPO
 from robottelo.utils.issue_handlers import is_open
-
 
 API_PATHS = {
     # flake8:noqa (line-too-long)

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -16,9 +16,8 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_alphanumeric, gen_ipaddr
 import pytest
-from fauxfactory import gen_alphanumeric
-from fauxfactory import gen_ipaddr
 
 from robottelo import constants
 from robottelo.cli.activationkey import ActivationKey
@@ -37,8 +36,7 @@ from robottelo.cli.repository_set import RepositorySet
 from robottelo.cli.subnet import Subnet
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.user import User
-from robottelo.config import setting_is_set
-from robottelo.config import settings
+from robottelo.config import setting_is_set, settings
 from robottelo.constants.repos import CUSTOM_RPM_REPO
 
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -16,20 +16,21 @@
 
 :Upstream: No
 """
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import ENVIRONMENT
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_SUBSCRIPTION_NAME,
+    ENVIRONMENT,
+    FAKE_4_CUSTOM_PACKAGE,
+    PRDS,
+    REPOS,
+    REPOSET,
+)
 
 pytestmark = [pytest.mark.run_in_one_thread]
 

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -16,29 +16,29 @@
 
 :Upstream: No
 """
-import pytest
 from broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.ansible import Ansible
 from robottelo.cli.arfreport import Arfreport
-from robottelo.cli.factory import make_hostgroup
-from robottelo.cli.factory import make_scap_policy
+from robottelo.cli.factory import make_hostgroup, make_scap_policy
 from robottelo.cli.host import Host
 from robottelo.cli.job_invocation import JobInvocation
 from robottelo.cli.proxy import Proxy
 from robottelo.cli.scapcontent import Scapcontent
 from robottelo.config import settings
-from robottelo.constants import OSCAP_DEFAULT_CONTENT
-from robottelo.constants import OSCAP_PERIOD
-from robottelo.constants import OSCAP_PROFILE
-from robottelo.constants import OSCAP_TARGET_CORES
-from robottelo.constants import OSCAP_TARGET_MEMORY
-from robottelo.constants import OSCAP_WEEKDAY
+from robottelo.constants import (
+    OSCAP_DEFAULT_CONTENT,
+    OSCAP_PERIOD,
+    OSCAP_PROFILE,
+    OSCAP_TARGET_CORES,
+    OSCAP_TARGET_MEMORY,
+    OSCAP_WEEKDAY,
+)
 from robottelo.exceptions import ProxyError
 from robottelo.hosts import ContentHost
-
 
 rhel6_content = OSCAP_DEFAULT_CONTENT['rhel6_content']
 rhel7_content = OSCAP_DEFAULT_CONTENT['rhel7_content']

--- a/tests/foreman/longrun/test_provisioning_computeresource.py
+++ b/tests/foreman/longrun/test_provisioning_computeresource.py
@@ -11,16 +11,14 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 from wrapanapi import VMWareSystem
 
-from robottelo.cli.factory import make_compute_resource
-from robottelo.cli.factory import make_host
+from robottelo.cli.factory import make_compute_resource, make_host
 from robottelo.cli.host import Host
 from robottelo.config import settings
-from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import VMWARE_CONSTANTS
+from robottelo.constants import FOREMAN_PROVIDERS, VMWARE_CONSTANTS
 
 
 @pytest.fixture(scope="module")

--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -19,12 +19,9 @@
 import pytest
 import yaml
 
-from robottelo.config import robottelo_tmp_dir
-from robottelo.config import settings
-from robottelo.constants import MAINTAIN_HAMMER_YML
-from robottelo.constants import SAT_NON_GA_VERSIONS
-from robottelo.hosts import get_sat_rhel_version
-from robottelo.hosts import get_sat_version
+from robottelo.config import robottelo_tmp_dir, settings
+from robottelo.constants import MAINTAIN_HAMMER_YML, SAT_NON_GA_VERSIONS
+from robottelo.hosts import get_sat_rhel_version, get_sat_version
 
 sat_x_y_release = f'{get_sat_version().major}.{get_sat_version().minor}'
 

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -18,8 +18,8 @@
 """
 import re
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo import constants
 from robottelo.config import settings

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -18,11 +18,10 @@
 """
 import time
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-
 
 upstream_url = {
     'foreman_repo': 'https://yum.theforeman.org/releases/nightly/el8/x86_64/',

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -16,13 +16,15 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import HAMMER_CONFIG
-from robottelo.constants import MAINTAIN_HAMMER_YML
-from robottelo.constants import SATELLITE_ANSWER_FILE
+from robottelo.constants import (
+    HAMMER_CONFIG,
+    MAINTAIN_HAMMER_YML,
+    SATELLITE_ANSWER_FILE,
+)
 from robottelo.hosts import Satellite
 from robottelo.utils.issue_handlers import is_open
 

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -18,9 +18,7 @@
 """
 import pytest
 
-from robottelo.constants import FAM_MODULE_PATH
-from robottelo.constants import FOREMAN_ANSIBLE_MODULES
-from robottelo.constants import RH_SAT_ROLES
+from robottelo.constants import FAM_MODULE_PATH, FOREMAN_ANSIBLE_MODULES, RH_SAT_ROLES
 
 
 @pytest.fixture

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import json
 from datetime import datetime
+import json
 
 import pytest
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -18,18 +18,17 @@
 """
 import random
 
-import pytest
 from airgun.session import Session
 from broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo import constants
 from robottelo.cli.factory import setup_org_for_a_custom_repo
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.utils.datafactory import parametrized, valid_data_list
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -16,13 +16,12 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string
 import pytest
 import yaml
-from fauxfactory import gen_string
 
 from robottelo import constants
-from robottelo.config import robottelo_tmp_dir
-from robottelo.config import settings
+from robottelo.config import robottelo_tmp_dir, settings
 
 
 def test_positive_create_and_delete_variable(target_sat):

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -16,9 +16,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -14,9 +14,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.constants import ENVIRONMENT
 

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -16,11 +16,11 @@
 
 :Upstream: No
 """
-import pytest
 from airgun.exceptions import NoSuchElementException
 from airgun.session import Session
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.config import user_nailgun_config
 from robottelo.constants import BOOKMARK_ENTITIES

--- a/tests/foreman/ui/test_branding.py
+++ b/tests/foreman/ui/test_branding.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from airgun.session import Session
+import pytest
 
 
 @pytest.mark.e2e

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -16,9 +16,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -16,17 +16,13 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 from wait_for import wait_for
 
-from robottelo.config import setting_is_set
-from robottelo.config import settings
-from robottelo.constants import COMPUTE_PROFILE_LARGE
-from robottelo.constants import DEFAULT_LOC
-from robottelo.constants import FOREMAN_PROVIDERS
+from robottelo.config import setting_is_set, settings
+from robottelo.constants import COMPUTE_PROFILE_LARGE, DEFAULT_LOC, FOREMAN_PROVIDERS
 from robottelo.utils.datafactory import gen_string
-
 
 # TODO mark this on the module with a lambda for skip condition
 # so that this is executed during the session at run loop, instead of at module import

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -16,14 +16,16 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import AZURERM_FILE_URI
-from robottelo.constants import AZURERM_PLATFORM_DEFAULT
-from robottelo.constants import AZURERM_VM_SIZE_DEFAULT
-from robottelo.constants import COMPUTE_PROFILE_SMALL
+from robottelo.constants import (
+    AZURERM_FILE_URI,
+    AZURERM_PLATFORM_DEFAULT,
+    AZURERM_VM_SIZE_DEFAULT,
+    COMPUTE_PROFILE_SMALL,
+)
 
 pytestmark = [pytest.mark.skip_if_not_set('azurerm')]
 

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import AWS_EC2_FLAVOR_T2_MICRO
-from robottelo.constants import COMPUTE_PROFILE_LARGE
-from robottelo.constants import EC2_REGION_CA_CENTRAL_1
-from robottelo.constants import FOREMAN_PROVIDERS
+from robottelo.constants import (
+    AWS_EC2_FLAVOR_T2_MICRO,
+    COMPUTE_PROFILE_LARGE,
+    EC2_REGION_CA_CENTRAL_1,
+    FOREMAN_PROVIDERS,
+)
 
 pytestmark = [pytest.mark.skip_if_not_set('ec2')]
 

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -19,16 +19,18 @@
 import json
 import random
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.constants import COMPUTE_PROFILE_SMALL
-from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import GCE_EXTERNAL_IP_DEFAULT
-from robottelo.constants import GCE_MACHINE_TYPE_DEFAULT
-from robottelo.constants import GCE_NETWORK_DEFAULT
+from robottelo.constants import (
+    COMPUTE_PROFILE_SMALL,
+    FOREMAN_PROVIDERS,
+    GCE_EXTERNAL_IP_DEFAULT,
+    GCE_MACHINE_TYPE_DEFAULT,
+    GCE_NETWORK_DEFAULT,
+)
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -18,14 +18,16 @@
 """
 from random import choice
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings
-from robottelo.constants import COMPUTE_PROFILE_SMALL
-from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import LIBVIRT_RESOURCE_URL
+from robottelo.constants import (
+    COMPUTE_PROFILE_SMALL,
+    FOREMAN_PROVIDERS,
+    LIBVIRT_RESOURCE_URL,
+)
 
 pytestmark = [pytest.mark.skip_if_not_set('libvirt')]
 

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -16,21 +16,20 @@
 
 :Upstream: No
 """
-from math import floor
-from math import log10
+from math import floor, log10
 from random import choice
 
-import pytest
 from nailgun import entities
-from wait_for import TimedOutError
-from wait_for import wait_for
-from wrapanapi.systems.virtualcenter import vim
-from wrapanapi.systems.virtualcenter import VMWareSystem
+import pytest
+from wait_for import TimedOutError, wait_for
+from wrapanapi.systems.virtualcenter import VMWareSystem, vim
 
 from robottelo.config import settings
-from robottelo.constants import COMPUTE_PROFILE_LARGE
-from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import VMWARE_CONSTANTS
+from robottelo.constants import (
+    COMPUTE_PROFILE_LARGE,
+    FOREMAN_PROVIDERS,
+    VMWARE_CONSTANTS,
+)
 from robottelo.utils.datafactory import gen_string
 
 pytestmark = [pytest.mark.skip_if_not_set('vmware')]

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -16,13 +16,15 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.constants import ENVIRONMENT
-from robottelo.constants import REPO_TYPE
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_UPSTREAM_NAME,
+    ENVIRONMENT,
+    REPO_TYPE,
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/foreman/ui/test_contentcredentials.py
+++ b/tests/foreman/ui/test_contentcredentials.py
@@ -16,12 +16,11 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import CONTENT_CREDENTIALS_TYPES
-from robottelo.constants import DataFile
+from robottelo.constants import CONTENT_CREDENTIALS_TYPES, DataFile
 from robottelo.utils.datafactory import gen_string
 
 empty_message = "You currently don't have any Products associated with this Content Credential."

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -16,34 +16,31 @@
 
 :Upstream: No
 """
+from datetime import datetime, timedelta
 import re
-from datetime import datetime
-from datetime import timedelta
 from urllib.parse import urlparse
 
-import pytest
 from airgun.session import Session
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
+from fauxfactory import gen_integer, gen_string
 from nailgun import entities
+import pytest
 
-from robottelo.cli.factory import CLIFactoryError
-from robottelo.cli.factory import make_fake_host
-from robottelo.cli.factory import make_virt_who_config
-from robottelo.config import setting_is_set
-from robottelo.config import settings
-from robottelo.constants import DEFAULT_SYSPURPOSE_ATTRIBUTES
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_GROUP
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_GROUP_NAME
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_1_ERRATA_ID
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE_NAME
-from robottelo.constants import VDC_SUBSCRIPTION_NAME
-from robottelo.constants import VIRT_WHO_HYPERVISOR_TYPES
+from robottelo.cli.factory import CLIFactoryError, make_fake_host, make_virt_who_config
+from robottelo.config import setting_is_set, settings
+from robottelo.constants import (
+    DEFAULT_SYSPURPOSE_ATTRIBUTES,
+    FAKE_0_CUSTOM_PACKAGE,
+    FAKE_0_CUSTOM_PACKAGE_GROUP,
+    FAKE_0_CUSTOM_PACKAGE_GROUP_NAME,
+    FAKE_0_CUSTOM_PACKAGE_NAME,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_1_CUSTOM_PACKAGE_NAME,
+    FAKE_1_ERRATA_ID,
+    FAKE_2_CUSTOM_PACKAGE,
+    FAKE_2_CUSTOM_PACKAGE_NAME,
+    VDC_SUBSCRIPTION_NAME,
+    VIRT_WHO_HYPERVISOR_TYPES,
+)
 from robottelo.utils.issue_handlers import is_open
 from robottelo.utils.virtwho import create_fake_hypervisor_content
 

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -22,36 +22,37 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 import datetime
 from random import randint
 
-import pytest
-from airgun.exceptions import InvalidElementStateException
-from airgun.exceptions import NoSuchElementException
+from airgun.exceptions import InvalidElementStateException, NoSuchElementException
 from airgun.session import Session
 from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
 from navmazing import NavigationTriesExceeded
 from productmd.common import parse_nvra
+import pytest
 
 from robottelo import constants
 from robottelo.cli.contentview import ContentView
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import DEFAULT_PTABLE
-from robottelo.constants import ENVIRONMENT
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_9_YUM_SECURITY_ERRATUM_COUNT
-from robottelo.constants import FILTER_CONTENT_TYPE
-from robottelo.constants import FILTER_ERRATA_TYPE
-from robottelo.constants import FILTER_TYPE
-from robottelo.constants import PERMISSIONS
-from robottelo.constants import PRDS
-from robottelo.constants import REPO_TYPE
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_UPSTREAM_NAME,
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_CV,
+    DEFAULT_PTABLE,
+    ENVIRONMENT,
+    FAKE_0_CUSTOM_PACKAGE,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_2_CUSTOM_PACKAGE,
+    FAKE_9_YUM_SECURITY_ERRATUM_COUNT,
+    FILTER_CONTENT_TYPE,
+    FILTER_ERRATA_TYPE,
+    FILTER_TYPE,
+    PERMISSIONS,
+    PRDS,
+    REPO_TYPE,
+    REPOS,
+    REPOSET,
+)
 from robottelo.utils.datafactory import gen_string
 
 VERSION = 'Version 1.0'

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -16,10 +16,10 @@
 
 :Upstream: No
 """
-import pytest
 from airgun.session import Session
 from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
+import pytest
 
 from robottelo.config import settings
 from robottelo.constants import FAKE_1_CUSTOM_PACKAGE

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -14,10 +14,9 @@
 
 :Upstream: No
 """
-import pytest
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_string
+from fauxfactory import gen_ipaddr, gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.utils import ssh
 

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -16,12 +16,10 @@
 
 :Upstream: No
 """
-import pytest
 from airgun.session import Session
-from fauxfactory import gen_integer
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_string
+from fauxfactory import gen_integer, gen_ipaddr, gen_string
 from nailgun import entities
+import pytest
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -16,9 +16,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.utils.datafactory import valid_domain_names
 

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -16,33 +16,34 @@
 
 :Upstream: No
 """
-import pytest
 from airgun.session import Session
 from broker import Broker
 from fauxfactory import gen_string
 from manifester import Manifester
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC
-from robottelo.constants import FAKE_10_YUM_BUGFIX_ERRATUM
-from robottelo.constants import FAKE_10_YUM_BUGFIX_ERRATUM_COUNT
-from robottelo.constants import FAKE_11_YUM_ENHANCEMENT_ERRATUM
-from robottelo.constants import FAKE_11_YUM_ENHANCEMENT_ERRATUM_COUNT
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_3_YUM_OUTDATED_PACKAGES
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_5_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_9_YUM_OUTDATED_PACKAGES
-from robottelo.constants import FAKE_9_YUM_SECURITY_ERRATUM
-from robottelo.constants import FAKE_9_YUM_SECURITY_ERRATUM_COUNT
-from robottelo.constants import PRDS
-from robottelo.constants import REAL_0_RH_PACKAGE
-from robottelo.constants import REAL_4_ERRATA_CVES
-from robottelo.constants import REAL_4_ERRATA_ID
+from robottelo.constants import (
+    DEFAULT_LOC,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_2_CUSTOM_PACKAGE,
+    FAKE_3_YUM_OUTDATED_PACKAGES,
+    FAKE_4_CUSTOM_PACKAGE,
+    FAKE_5_CUSTOM_PACKAGE,
+    FAKE_9_YUM_OUTDATED_PACKAGES,
+    FAKE_9_YUM_SECURITY_ERRATUM,
+    FAKE_9_YUM_SECURITY_ERRATUM_COUNT,
+    FAKE_10_YUM_BUGFIX_ERRATUM,
+    FAKE_10_YUM_BUGFIX_ERRATUM_COUNT,
+    FAKE_11_YUM_ENHANCEMENT_ERRATUM,
+    FAKE_11_YUM_ENHANCEMENT_ERRATUM_COUNT,
+    PRDS,
+    REAL_0_RH_PACKAGE,
+    REAL_4_ERRATA_CVES,
+    REAL_4_ERRATA_ID,
+)
 from robottelo.hosts import ContentHost
-
 
 CUSTOM_REPO_URL = settings.repos.yum_9.url
 CUSTOM_REPO_ERRATA_ID = settings.repos.yum_9.errata[0]

--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -14,9 +14,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -18,34 +18,35 @@
 """
 import copy
 import csv
+from datetime import datetime
 import os
 import random
 import re
-from datetime import datetime
 
-import pytest
-import yaml
-from airgun.exceptions import DisabledWidgetError
-from airgun.exceptions import NoSuchElementException
+from airgun.exceptions import DisabledWidgetError, NoSuchElementException
 from airgun.session import Session
+import pytest
 from wait_for import wait_for
+import yaml
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import ANY_CONTEXT
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import DEFAULT_LOC
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import ENVIRONMENT
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_7_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_8_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_8_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FOREMAN_PROVIDERS
-from robottelo.constants import OSCAP_PERIOD
-from robottelo.constants import OSCAP_WEEKDAY
-from robottelo.constants import PERMISSIONS
-from robottelo.constants import REPO_TYPE
+from robottelo.constants import (
+    ANY_CONTEXT,
+    DEFAULT_CV,
+    DEFAULT_LOC,
+    DEFAULT_SUBSCRIPTION_NAME,
+    ENVIRONMENT,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_7_CUSTOM_PACKAGE,
+    FAKE_8_CUSTOM_PACKAGE,
+    FAKE_8_CUSTOM_PACKAGE_NAME,
+    FOREMAN_PROVIDERS,
+    OSCAP_PERIOD,
+    OSCAP_WEEKDAY,
+    PERMISSIONS,
+    REPO_TYPE,
+)
 from robottelo.utils.datafactory import gen_string
 from robottelo.utils.issue_handlers import is_open
 

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -18,9 +18,9 @@
 """
 import time
 
-import pytest
 from broker import Broker
 from manifester import Manifester
+import pytest
 
 from robottelo import constants
 from robottelo.config import settings

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -16,13 +16,12 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import ENVIRONMENT
+from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -16,14 +16,11 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_integer, gen_string, gen_url
 import pytest
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
-from fauxfactory import gen_url
 
 from robottelo.config import settings
-from robottelo.constants import DOCKER_REPO_UPSTREAM_NAME
-from robottelo.constants import REPO_TYPE
+from robottelo.constants import DOCKER_REPO_UPSTREAM_NAME, REPO_TYPE
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from inflection import camelize
+import pytest
 
 from robottelo.utils.datafactory import gen_string
 

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -18,19 +18,16 @@
 """
 import os
 
-import pyotp
-import pytest
 from airgun.session import Session
 from fauxfactory import gen_url
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
+import pyotp
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import CERT_PATH
-from robottelo.constants import LDAP_ATTR
-from robottelo.constants import PERMISSIONS
+from robottelo.constants import CERT_PATH, LDAP_ATTR, PERMISSIONS
 from robottelo.utils.datafactory import gen_string
-
 
 pytestmark = [pytest.mark.run_in_one_thread]
 

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -16,18 +16,20 @@
 
 :Upstream: No
 """
-import pytest
 from airgun.session import Session
 from navmazing import NavigationTriesExceeded
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import ENVIRONMENT
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_1_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_2_CUSTOM_PACKAGE
-from robottelo.constants import FAKE_3_CUSTOM_PACKAGE_NAME
+from robottelo.constants import (
+    ENVIRONMENT,
+    FAKE_0_CUSTOM_PACKAGE,
+    FAKE_0_CUSTOM_PACKAGE_NAME,
+    FAKE_1_CUSTOM_PACKAGE,
+    FAKE_1_CUSTOM_PACKAGE_NAME,
+    FAKE_2_CUSTOM_PACKAGE,
+    FAKE_3_CUSTOM_PACKAGE_NAME,
+)
 from robottelo.utils.datafactory import gen_string
 
 

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -16,15 +16,12 @@
 
 :Upstream: No
 """
-import pytest
-from fauxfactory import gen_ipaddr
-from fauxfactory import gen_string
+from fauxfactory import gen_ipaddr, gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import ANY_CONTEXT
-from robottelo.constants import INSTALL_MEDIUM_URL
-from robottelo.constants import LIBVIRT_RESOURCE_URL
+from robottelo.constants import ANY_CONTEXT, INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_media.py
+++ b/tests/foreman/ui/test_media.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.constants import INSTALL_MEDIUM_URL
 

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -16,9 +16,9 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
 

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -16,14 +16,12 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG
-from robottelo.constants import INSTALL_MEDIUM_URL
-from robottelo.constants import LIBVIRT_RESOURCE_URL
+from robottelo.constants import DEFAULT_ORG, INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
 from robottelo.logging import logger
 
 CUSTOM_REPO_ERRATA_ID = settings.repos.yum_0.errata[0]

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -20,8 +20,7 @@ import os
 
 import pytest
 
-from robottelo.config import robottelo_tmp_dir
-from robottelo.config import settings
+from robottelo.config import robottelo_tmp_dir, settings
 from robottelo.constants import DataFile
 from robottelo.utils.datafactory import gen_string
 

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo.constants import OSCAP_PROFILE
 from robottelo.utils.datafactory import gen_string

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from nailgun import entities
+import pytest
 
 from robottelo.utils.datafactory import gen_string
 

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -16,13 +16,12 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DataFile
-from robottelo.constants import RPM_TO_UPLOAD
+from robottelo.constants import RPM_TO_UPLOAD, DataFile
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.constants import DataFile
 

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -18,18 +18,18 @@
 """
 from datetime import timedelta
 
-import pytest
 from fauxfactory import gen_choice
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DataFile
-from robottelo.constants import REPO_TYPE
-from robottelo.constants import SYNC_INTERVAL
-from robottelo.utils.datafactory import gen_string
-from robottelo.utils.datafactory import parametrized
-from robottelo.utils.datafactory import valid_cron_expressions
-from robottelo.utils.datafactory import valid_data_list
+from robottelo.constants import REPO_TYPE, SYNC_INTERVAL, DataFile
+from robottelo.utils.datafactory import (
+    gen_string,
+    parametrized,
+    valid_cron_expressions,
+    valid_data_list,
+)
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -18,8 +18,7 @@
 """
 import pytest
 
-from robottelo.constants import DEFAULT_CV
-from robottelo.constants import ENVIRONMENT
+from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 from robottelo.utils.datafactory import gen_string
 
 

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -19,8 +19,8 @@
 import datetime
 import time
 
-import pytest
 from broker import Broker
+import pytest
 from wait_for import wait_for
 
 from robottelo.hosts import ContentHost

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -19,19 +19,15 @@
 import csv
 import json
 import os
-from pathlib import Path
-from pathlib import PurePath
+from pathlib import Path, PurePath
 
-import pytest
-import yaml
 from lxml import etree
 from nailgun import entities
+import pytest
+import yaml
 
 from robottelo.config import robottelo_tmp_dir
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME, PRDS, REPOS, REPOSET
 from robottelo.utils.datafactory import gen_string
 
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -16,29 +16,31 @@
 
 :Upstream: No
 """
-from datetime import datetime
-from datetime import timedelta
-from random import randint
-from random import shuffle
+from datetime import datetime, timedelta
+from random import randint, shuffle
 
-import pytest
 from airgun.session import Session
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
+import pytest
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import DataFile
-from robottelo.constants import DOWNLOAD_POLICIES
-from robottelo.constants import INVALID_URL
-from robottelo.constants import PRDS
-from robottelo.constants import REPO_TYPE
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-from robottelo.constants.repos import ANSIBLE_GALAXY
-from robottelo.constants.repos import CUSTOM_3RD_PARTY_REPO
-from robottelo.constants.repos import CUSTOM_RPM_SHA
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    DOWNLOAD_POLICIES,
+    INVALID_URL,
+    PRDS,
+    REPO_TYPE,
+    REPOS,
+    REPOSET,
+    DataFile,
+)
+from robottelo.constants.repos import (
+    ANSIBLE_GALAXY,
+    CUSTOM_3RD_PARTY_REPO,
+    CUSTOM_RPM_SHA,
+)
 from robottelo.hosts import get_sat_version
 from robottelo.utils.datafactory import gen_string
 

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 from wait_for import wait_for
 
 from robottelo import constants

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -18,8 +18,8 @@
 """
 from datetime import datetime
 
-import pytest
 from airgun.session import Session
+import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -16,17 +16,18 @@
 
 :Upstream: No
 """
-from datetime import datetime
-from datetime import timedelta
+from datetime import datetime, timedelta
 
-import pytest
 from airgun.session import Session
+import pytest
 from wait_for import wait_for
 
 from robottelo.constants import DEFAULT_LOC
-from robottelo.utils.io import get_local_file_data
-from robottelo.utils.io import get_remote_report_checksum
-from robottelo.utils.io import get_report_data
+from robottelo.utils.io import (
+    get_local_file_data,
+    get_remote_report_checksum,
+    get_report_data,
+)
 
 
 def common_assertion(report_path, inventory_data, org, satellite):

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -18,13 +18,12 @@
 """
 import random
 
-import pytest
 from airgun.session import Session
 from nailgun import entities
 from navmazing import NavigationTriesExceeded
+import pytest
 
-from robottelo.constants import PERMISSIONS_UI
-from robottelo.constants import ROLES
+from robottelo.constants import PERMISSIONS_UI, ROLES
 from robottelo.utils.datafactory import gen_string
 
 

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -18,15 +18,14 @@
 """
 import math
 
-import pytest
 from airgun.session import Session
 from fauxfactory import gen_url
 from nailgun import entities
+import pytest
 
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.utils.datafactory import filtered_datapoint
-from robottelo.utils.datafactory import gen_string
+from robottelo.utils.datafactory import filtered_datapoint, gen_string
 
 
 @filtered_datapoint

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -16,8 +16,7 @@
 
 :Upstream: No
 """
-from random import choice
-from random import uniform
+from random import choice, uniform
 
 import pytest
 import yaml

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_ipaddr
+import pytest
 
 from robottelo.utils.datafactory import gen_string
 

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -16,22 +16,24 @@
 
 :Upstream: No
 """
-import time
 from tempfile import mkstemp
+import time
 
-import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.cli.factory import make_virt_who_config
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME
-from robottelo.constants import PRDS
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
-from robottelo.constants import VDC_SUBSCRIPTION_NAME
-from robottelo.constants import VIRT_WHO_HYPERVISOR_TYPES
+from robottelo.constants import (
+    DEFAULT_SUBSCRIPTION_NAME,
+    PRDS,
+    REPOS,
+    REPOSET,
+    VDC_SUBSCRIPTION_NAME,
+    VIRT_WHO_HYPERVISOR_TYPES,
+)
 from robottelo.utils.manifest import clone
 
 pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.skip_if_not_set('fake_manifest')]

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -16,17 +16,19 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
-from robottelo.constants import CONTAINER_UPSTREAM_NAME
-from robottelo.constants import PRDS
-from robottelo.constants import REPO_TYPE
-from robottelo.constants import REPOS
-from robottelo.constants import REPOSET
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_UPSTREAM_NAME,
+    PRDS,
+    REPO_TYPE,
+    REPOS,
+    REPOSET,
+)
 from robottelo.constants.repos import FEDORA_OSTREE_REPO
 
 

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -16,17 +16,15 @@
 
 :Upstream: No
 """
+from datetime import datetime, timedelta
 import time
-from datetime import datetime
-from datetime import timedelta
 
-import pytest
 from fauxfactory import gen_choice
 from nailgun import entities
+import pytest
 
 from robottelo.constants import SYNC_INTERVAL
-from robottelo.utils.datafactory import gen_string
-from robottelo.utils.datafactory import valid_cron_expressions
+from robottelo.utils.datafactory import gen_string, valid_cron_expressions
 
 
 def validate_task_status(sat, repo_id, org_id, max_tries=10):

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -14,14 +14,13 @@
 
 :Upstream: No
 """
-import pytest
-import requests
 from fauxfactory import gen_string
 from nailgun import entities
+import pytest
+import requests
 
 from robottelo.config import settings
-from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL
-from robottelo.constants import FOREMAN_TEMPLATE_ROOT_DIR
+from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL, FOREMAN_TEMPLATE_ROOT_DIR
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -18,14 +18,11 @@
 """
 import random
 
-import pytest
 from airgun.session import Session
-from fauxfactory import gen_email
-from fauxfactory import gen_string
+from fauxfactory import gen_email, gen_string
+import pytest
 
-from robottelo.constants import DEFAULT_ORG
-from robottelo.constants import PERMISSIONS
-from robottelo.constants import ROLES
+from robottelo.constants import DEFAULT_ORG, PERMISSIONS, ROLES
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -16,10 +16,9 @@
 
 :Upstream: No
 """
-import pytest
-from fauxfactory import gen_string
-from fauxfactory import gen_utf8
+from fauxfactory import gen_string, gen_utf8
 from nailgun import entities
+import pytest
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_webhook.py
+++ b/tests/foreman/ui/test_webhook.py
@@ -16,9 +16,8 @@
 
 :Upstream: No
 """
+from fauxfactory import gen_string, gen_url
 import pytest
-from fauxfactory import gen_string
-from fauxfactory import gen_url
 
 
 @pytest.mark.tier1

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -16,18 +16,20 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import create_http_proxy
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_command_check
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import ETC_VIRTWHO_CONFIG
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    ETC_VIRTWHO_CONFIG,
+    create_http_proxy,
+    deploy_configure_by_command,
+    deploy_configure_by_command_check,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -18,22 +18,24 @@
 """
 import re
 
+from fauxfactory import gen_string
 import pytest
 import requests
-from fauxfactory import gen_string
 
 from robottelo.cli.user import User
 from robottelo.config import settings
-from robottelo.utils.virtwho import create_http_proxy
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_command_check
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import ETC_VIRTWHO_CONFIG
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
-from robottelo.utils.virtwho import hypervisor_json_create
-from robottelo.utils.virtwho import virtwho_package_locked
+from robottelo.utils.virtwho import (
+    ETC_VIRTWHO_CONFIG,
+    create_http_proxy,
+    deploy_configure_by_command,
+    deploy_configure_by_command_check,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+    hypervisor_json_create,
+    virtwho_package_locked,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -16,15 +16,17 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -1,6 +1,6 @@
-import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
+import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.logging import logger

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -18,27 +18,29 @@
 """
 from datetime import datetime
 
-import pytest
 from airgun.session import Session
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
 from robottelo.utils.datafactory import valid_emails_list
-from robottelo.utils.virtwho import add_configure_option
-from robottelo.utils.virtwho import create_http_proxy
-from robottelo.utils.virtwho import delete_configure_option
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_command_check
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import ETC_VIRTWHO_CONFIG
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_id
-from robottelo.utils.virtwho import get_configure_option
-from robottelo.utils.virtwho import get_guest_info
-from robottelo.utils.virtwho import get_virtwho_status
-from robottelo.utils.virtwho import restart_virtwho_service
-from robottelo.utils.virtwho import update_configure_option
+from robottelo.utils.virtwho import (
+    ETC_VIRTWHO_CONFIG,
+    add_configure_option,
+    create_http_proxy,
+    delete_configure_option,
+    deploy_configure_by_command,
+    deploy_configure_by_command_check,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_id,
+    get_configure_option,
+    get_guest_info,
+    get_virtwho_status,
+    restart_virtwho_service,
+    update_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -16,16 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_id
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_id,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -16,16 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_id
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_id,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -16,16 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_id
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_id,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -16,16 +16,18 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.config import settings
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import deploy_configure_by_script
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_id
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_configure_file,
+    get_configure_id,
+    get_configure_option,
+)
 
 
 @pytest.fixture()

--- a/tests/robottelo/conftest.py
+++ b/tests/robottelo/conftest.py
@@ -3,8 +3,8 @@ import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -1,14 +1,16 @@
-import unittest
 from functools import partial
+import unittest
 from unittest import mock
 
 import pytest
 
-from robottelo.cli.base import Base
-from robottelo.cli.base import CLIBaseError
-from robottelo.cli.base import CLIDataBaseError
-from robottelo.cli.base import CLIError
-from robottelo.cli.base import CLIReturnCodeError
+from robottelo.cli.base import (
+    Base,
+    CLIBaseError,
+    CLIDataBaseError,
+    CLIError,
+    CLIReturnCodeError,
+)
 
 
 class CLIClass(Base):

--- a/tests/robottelo/test_dependencies.py
+++ b/tests/robottelo/test_dependencies.py
@@ -3,10 +3,8 @@
 
 def test_cryptography():
     from cryptography.hazmat.backends import default_backend
-    from cryptography.hazmat.primitives import hashes
-    from cryptography.hazmat.primitives import serialization
-    from cryptography.hazmat.primitives.asymmetric import padding
-    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
     fake_key = rsa.generate_private_key(
         public_exponent=65537, key_size=2048, backend=default_backend()
@@ -111,9 +109,7 @@ def test_requests():
 
 
 def test_tenacity():
-    from tenacity import retry
-    from tenacity import stop_after_attempt
-    from tenacity import wait_fixed
+    from tenacity import retry, stop_after_attempt, wait_fixed
 
     @retry(stop=stop_after_attempt(3), wait=wait_fixed(1))
     def test():

--- a/tests/robottelo/test_func_locker.py
+++ b/tests/robottelo/test_func_locker.py
@@ -1,8 +1,8 @@
 import multiprocessing
 import os
+from pathlib import Path
 import tempfile
 import time
-from pathlib import Path
 
 import pytest
 

--- a/tests/robottelo/test_func_shared.py
+++ b/tests/robottelo/test_func_shared.py
@@ -2,19 +2,22 @@ import multiprocessing
 import os
 import time
 
+from fauxfactory import gen_integer, gen_string
 import pytest
-from fauxfactory import gen_integer
-from fauxfactory import gen_string
 
-from robottelo.utils.decorators.func_shared.file_storage import get_temp_dir
-from robottelo.utils.decorators.func_shared.file_storage import TEMP_FUNC_SHARED_DIR
-from robottelo.utils.decorators.func_shared.file_storage import TEMP_ROOT_DIR
-from robottelo.utils.decorators.func_shared.shared import _NAMESPACE_SCOPE_KEY_TYPE
-from robottelo.utils.decorators.func_shared.shared import _set_configured
-from robottelo.utils.decorators.func_shared.shared import enable_shared_function
-from robottelo.utils.decorators.func_shared.shared import set_default_scope
-from robottelo.utils.decorators.func_shared.shared import shared
-from robottelo.utils.decorators.func_shared.shared import SharedFunctionException
+from robottelo.utils.decorators.func_shared.file_storage import (
+    TEMP_FUNC_SHARED_DIR,
+    TEMP_ROOT_DIR,
+    get_temp_dir,
+)
+from robottelo.utils.decorators.func_shared.shared import (
+    _NAMESPACE_SCOPE_KEY_TYPE,
+    SharedFunctionException,
+    _set_configured,
+    enable_shared_function,
+    set_default_scope,
+    shared,
+)
 
 DEFAULT_POOL_SIZE = 8
 SIMPLE_TIMEOUT_VALUE = 3

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -1,8 +1,7 @@
 """Tests for module ``robottelo.helpers``."""
 import pytest
 
-from robottelo.utils import slugify_component
-from robottelo.utils import validate_ssh_pub_key
+from robottelo.utils import slugify_component, validate_ssh_pub_key
 
 
 class FakeSSHResult:

--- a/tests/robottelo/test_issue_handlers.py
+++ b/tests/robottelo/test_issue_handlers.py
@@ -1,18 +1,14 @@
+from collections import defaultdict
 import os
 import subprocess
 import sys
-from collections import defaultdict
 
-import pytest
 from packaging.version import Version
+import pytest
 
 from pytest_plugins.issue_handlers import DEFAULT_BZ_CACHE_FILE
-from robottelo.constants import CLOSED_STATUSES
-from robottelo.constants import OPEN_STATUSES
-from robottelo.constants import WONTFIX_RESOLUTIONS
-from robottelo.utils.issue_handlers import add_workaround
-from robottelo.utils.issue_handlers import is_open
-from robottelo.utils.issue_handlers import should_deselect
+from robottelo.constants import CLOSED_STATUSES, OPEN_STATUSES, WONTFIX_RESOLUTIONS
+from robottelo.utils.issue_handlers import add_workaround, is_open, should_deselect
 
 
 class TestBugzillaIssueHandler:

--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -86,8 +86,8 @@ import functools
 import json
 import os
 
-import pytest
 from box import Box
+import pytest
 
 from robottelo.logging import logger
 from robottelo.utils.decorators.func_locker import lock_function

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -21,8 +21,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 """
 import pytest
 
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
+from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME, FAKE_4_CUSTOM_PACKAGE_NAME
 from robottelo.hosts import ContentHost
 
 

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -16,12 +16,11 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_alpha
+import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DataFile
-from robottelo.constants import RPM_TO_UPLOAD
+from robottelo.constants import RPM_TO_UPLOAD, DataFile
 
 
 class TestContentView:

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 
 class TestScenarioPositiveGCEHostComputeResource:

--- a/tests/upgrades/test_hostgroup.py
+++ b/tests/upgrades/test_hostgroup.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 
 class TestHostgroup:

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -19,8 +19,7 @@
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME
-from robottelo.constants import FAKE_4_CUSTOM_PACKAGE_NAME
+from robottelo.constants import FAKE_0_CUSTOM_PACKAGE_NAME, FAKE_4_CUSTOM_PACKAGE_NAME
 from robottelo.hosts import ContentHost
 
 UPSTREAM_USERNAME = 'rTtest123'

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from manifester import Manifester
+import pytest
 
 from robottelo import constants
 from robottelo.config import settings

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -16,8 +16,8 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_choice
+import pytest
 
 from robottelo.constants import SYNC_INTERVAL
 from robottelo.utils.datafactory import valid_cron_expressions

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -16,11 +16,10 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
-from robottelo.constants import LDAP_ATTR
-from robottelo.constants import LDAP_SERVER_TYPE
+from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 
 
 class TestUserGroupMembership:

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -16,18 +16,20 @@
 
 :Upstream: No
 """
-import pytest
 from fauxfactory import gen_string
+import pytest
 
 from robottelo.cli.host import Host
 from robottelo.cli.subscription import Subscription
 from robottelo.cli.virt_who_config import VirtWhoConfig
 from robottelo.config import settings
 from robottelo.utils.issue_handlers import is_open
-from robottelo.utils.virtwho import deploy_configure_by_command
-from robottelo.utils.virtwho import get_configure_command
-from robottelo.utils.virtwho import get_configure_file
-from robottelo.utils.virtwho import get_configure_option
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    get_configure_command,
+    get_configure_file,
+    get_configure_option,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
This now drops the old standard of one import per line in favor of a less noisy standard (sort).

fixes #12700 