### PR TITLE
[6.13.z] Fix : ZStream Dependency Auto Merging

### DIFF
--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -1,16 +1,15 @@
-name: Dependabot Auto Merge
-on: pull_request
-
-permissions:
-  pull-requests: write
+name: Dependabot Auto Merge - ZStream
+on:
+  pull_request:
+    branches-ignore:
+      - master
 
 jobs:
   dependabot:
     name: dependabot-auto-merge
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.user.login == 'Satellite-QE' &&
-      contains( github.event.pull_request.labels.*.name, 'dependencies')
+      contains(github.event.pull_request.labels.*.name, 'dependencies')
 
     steps:
       - id: find-prt-comment


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12483

Fixing the AutoMerge of Dependabot AutoCherrypicked PRs are not running.

Attempt to change:
- The `pull_request_target` event
- The Author check for PR now removed and just checking for `dependency` label
- Separate GHA for zStream than master as the things varies for zStream for dependecy PRs auto-merge

Good if this is merged along with https://github.com/SatelliteQE/robottelo/pull/12682 that copies dependencies label to zStream cherrypicked PRs !