### PR TITLE
Fix ruff stylecheck

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -6,7 +6,7 @@ pre-commit==3.4.0
 
 # For generating documentation.
 sphinx==7.2.6
-sphinx-autoapi==2.1.1
+sphinx-autoapi==3.0.0
 
 # For 'manage' interactive shell
 manage==0.1.15

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -25,9 +25,7 @@ from requests.exceptions import HTTPError
 from robottelo import constants
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import MIRRORING_POLICIES
-from robottelo.constants import REPOS
+from robottelo.constants import DEFAULT_ARCHITECTURE, MIRRORING_POLICIES, REPOS
 from robottelo.utils.datafactory import parametrized
 
 


### PR DESCRIPTION
Broken by #12445
But not fault of his author nor reviewers.
PR just had been raised 26 days ago - before ruff

Yet `make docs` is now failing too:
```
Traceback (most recent call last):
  File "/home/lpramuk/.virtualenvs/r/lib/python3.11/site-packages/sphinx/events.py", line 97, in emit
    results.append(listener.handler(self.app, *args))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lpramuk/.virtualenvs/r/lib/python3.11/site-packages/autoapi/extension.py", line 153, in run_autoapi
    if sphinx_mapper_obj.load(
       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lpramuk/.virtualenvs/r/lib/python3.11/site-packages/autoapi/mappers/python/mapper.py", line 300, in load
    data = self.read_file(path=path, dir_root=dir_root)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lpramuk/.virtualenvs/r/lib/python3.11/site-packages/autoapi/mappers/python/mapper.py", line 318, in read_file
    parsed_data = Parser().parse_file(path)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/lpramuk/.virtualenvs/r/lib/python3.11/site-packages/autoapi/mappers/python/parser.py", line 41, in parse_file
    return self._parse_file(
           ^^^^^^^^^^^^^^^^^
  File "/home/lpramuk/.virtualenvs/r/lib/python3.11/site-packages/autoapi/mappers/python/parser.py", line 38, in _parse_file
    return self.parse(node)
           ^^^^^^^^^^^^^^^^
  File "/home/lpramuk/.virtualenvs/r/lib/python3.11/site-packages/autoapi/mappers/python/parser.py", line 265, in parse
    data = parse_func(node)
           ^^^^^^^^^^^^^^^^
  File "/home/lpramuk/.virtualenvs/r/lib/python3.11/site-packages/autoapi/mappers/python/parser.py", line 240, in parse_module
    "doc": _prepare_docstring(node.doc or ""),
                              ^^^^^^^^
AttributeError: 'Module' object has no attribute 'doc'
```
Bumping `sphinx-autoapi==3.0.0` to fix this