### PR TITLE
Add coverage for 2055790 to service enable disable

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -120,6 +120,16 @@ class Base:
         return cls.execute(cls._construct_command(options))
 
     @classmethod
+    def ping(cls, options=None):
+        """
+        Display status of Satellite.
+        """
+
+        cls.command_sub = 'ping'
+
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def create(cls, options=None, timeout=None):
         """
         Creates a new record using the arguments passed via dictionary.
@@ -419,6 +429,6 @@ class Base:
                 if isinstance(val, list):
                     val = ','.join(str(el) for el in val)
                 tail += f' --{key}="{val}"'
-        cmd = f"{cls.command_base} {cls.command_sub or ''} {tail.strip()} {cls.command_end or ''}"
+        cmd = f"{cls.command_base or ''} {cls.command_sub or ''} {tail.strip()} {cls.command_end or ''}"
 
         return cmd

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -25,9 +25,7 @@ from requests.exceptions import HTTPError
 from robottelo import constants
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import MIRRORING_POLICIES
-from robottelo.constants import REPOS
+from robottelo.constants import DEFAULT_ARCHITECTURE, MIRRORING_POLICIES, REPOS
 from robottelo.utils.datafactory import parametrized
 
 

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -25,6 +25,7 @@ from robottelo.constants import (
     MAINTAIN_HAMMER_YML,
     SATELLITE_ANSWER_FILE,
 )
+from wait_for import wait_for
 from robottelo.hosts import Satellite
 
 SATELLITE_SERVICES = [
@@ -181,6 +182,27 @@ def test_positive_service_enable_disable(sat_maintain):
     assert 'FAIL' not in result.stdout
     assert result.status == 0
     result = sat_maintain.cli.Service.enable()
+    assert 'FAIL' not in result.stdout
+    assert result.status == 0
+    sat_maintain.power_control(state='reboot')
+    if type(sat_maintain) is Satellite:
+        result, _ = wait_for(
+            sat_maintain.cli.Service.status,
+            func_kwargs={'options': {'brief': True, 'only': 'foreman.service'}},
+            fail_condition=lambda res: "FAIL" in res.stdout,
+            handle_exception=True,
+            delay=30,
+            timeout=300,
+        )
+    else:
+        result, _ = wait_for(
+            sat_maintain.cli.Service.status,
+            func_kwargs={'options': {'brief': True}},
+            fail_condition=lambda res: "FAIL" in res.stdout,
+            handle_exception=True,
+            delay=30,
+            timeout=300,
+        )
     assert 'FAIL' not in result.stdout
     assert result.status == 0
 

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -18,6 +18,7 @@
 """
 from fauxfactory import gen_string
 import pytest
+from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (
@@ -25,7 +26,6 @@ from robottelo.constants import (
     MAINTAIN_HAMMER_YML,
     SATELLITE_ANSWER_FILE,
 )
-from wait_for import wait_for
 from robottelo.hosts import Satellite
 
 SATELLITE_SERVICES = [
@@ -174,6 +174,10 @@ def test_positive_service_enable_disable(sat_maintain):
         2. Run satellite-maintain service enable
 
     :expectedresults: Services should enable/disable
+
+    :BZ: 1995783, 2055790
+
+    :customerscenario: true
     """
     result = sat_maintain.cli.Service.stop()
     assert 'FAIL' not in result.stdout
@@ -185,7 +189,7 @@ def test_positive_service_enable_disable(sat_maintain):
     assert 'FAIL' not in result.stdout
     assert result.status == 0
     sat_maintain.power_control(state='reboot')
-    if type(sat_maintain) is Satellite:
+    if isinstance(sat_maintain, Satellite):
         result, _ = wait_for(
             sat_maintain.cli.Service.status,
             func_kwargs={'options': {'brief': True, 'only': 'foreman.service'}},
@@ -194,6 +198,7 @@ def test_positive_service_enable_disable(sat_maintain):
             delay=30,
             timeout=300,
         )
+        assert 'FAIL' not in sat_maintain.cli.Base.ping()
     else:
         result, _ = wait_for(
             sat_maintain.cli.Service.status,


### PR DESCRIPTION
The first commit here is a cherry-pick of an old PR that I accidentally removed in one of my Foreman Maintain audits. I must not have had the latest changes on that branch. I'm adding that back in and also adding coverage for 2055790.