### PR TITLE
Add in the caching mechanism to the Satellite's api property

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1735,6 +1735,7 @@ class Capsule(ContentHost, CapsuleMixins):
                     except AttributeError:
                         # not everything has an mro method, we don't care about them
                         pass
+        self._cli._configured = True
         return self._cli
 
 
@@ -1787,6 +1788,7 @@ class Satellite(Capsule, SatelliteMixins):
             except AttributeError:
                 # not everything has an mro method, we don't care about them
                 pass
+        self._api._configured = True
         return self._api
 
     @property
@@ -1816,6 +1818,7 @@ class Satellite(Capsule, SatelliteMixins):
                     except AttributeError:
                         # not everything has an mro method, we don't care about them
                         pass
+        self._cli._configured = True
         return self._cli
 
     @contextmanager


### PR DESCRIPTION
This should have always existed but was overlooked. It will dramatically decrease the amount of time it takes to access the api property since it doesn't need to be reconstructed each time the property is accessed.

Before
------
%timeit mysat.api.Host
3.62 ms ± 52.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

After
-----
%timeit mysat.api.Host
189 ns ± 0.943 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)