### PR TITLE
Removing 6.11.z branch for dependabot to not to auto cherrypick

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       - "6.14.z"
       - "6.13.z"
       - "6.12.z"
-      - "6.11.z"
 
   # Maintain dependencies for our GitHub Actions
   - package-ecosystem: "github-actions"
@@ -28,4 +27,3 @@ updates:
       - "6.14.z"
       - "6.13.z"
       - "6.12.z"
-      - "6.11.z"


### PR DESCRIPTION
Removing 6.11.z label from dependabot for not to autocherrypick by ACP GHA.