### PR TITLE
[6.12.z] Add in the caching mechanism to the Satellite's api property

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1635,6 +1635,7 @@ class Capsule(ContentHost, CapsuleMixins):
                     except AttributeError:
                         # not everything has an mro method, we don't care about them
                         pass
+        self._cli._configured = True
         return self._cli
 
 
@@ -1683,6 +1684,7 @@ class Satellite(Capsule, SatelliteMixins):
             except AttributeError:
                 # not everything has an mro method, we don't care about them
                 pass
+        self._api._configured = True
         return self._api
 
     @property
@@ -1705,6 +1707,7 @@ class Satellite(Capsule, SatelliteMixins):
                     except AttributeError:
                         # not everything has an mro method, we don't care about them
                         pass
+        self._cli._configured = True
         return self._cli
 
     def ui_session(self, testname=None, user=None, password=None, url=None, login=True):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12765

This should have always existed but was overlooked. It will dramatically decrease the amount of time it takes to access the api property since it doesn't need to be reconstructed each time the property is accessed.

Before
------
%timeit mysat.api.Host
3.62 ms ± 52.4 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

After
-----
%timeit mysat.api.Host
189 ns ± 0.943 ns per loop (mean ± std. dev. of 7 runs, 10,000,000 loops each)