### PR TITLE
[6.13.z] Missing content ID test

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1498,6 +1498,40 @@ class TestRepositorySync:
         )
         assert len(os)
 
+    @pytest.mark.tier2
+    @pytest.mark.parametrize(
+        'repo_options',
+        **datafactory.parametrized(
+            {'yum': {'content_type': 'yum', 'unprotected': True, 'url': 'http://example.com'}}
+        ),
+        indirect=True,
+    )
+    def test_missing_content_id(self, repo):
+        """Handle several cases of missing content ID correctly
+
+        :id: f507790a-933b-4b3f-ac93-cade6967fbd2
+
+        :parametrized: yes
+
+        :expectedresults: Repository URL can be set to something new and the repo can be deleted
+
+        :BZ:2032040
+        """
+        # Wait for async metadata generate task to finish
+        time.sleep(5)
+        # Get rid of the URL
+        repo.url = ''
+        repo = repo.update(['url'])
+        assert repo.url is None
+        # Now change the URL back
+        repo.url = 'http://example.com'
+        repo = repo.update(['url'])
+        assert repo.url == 'http://example.com'
+        # Now delete the Repo
+        repo.delete()
+        with pytest.raises(HTTPError):
+            repo.read()
+
 
 class TestDockerRepository:
     """Tests specific to using ``Docker`` repositories."""


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12764

Simple test for a pretty complicated BZ. Basically, this creates a repository and then deletes the Upstream URL, which in the BZ case triggered the missing content ID issues. It then goes on to make sure you can both update the URL, and delete the repo, cases which were impacted in the BZ. 

The sleep at the beginning is a simple solution to a bit of a weird problem, where when creating a repo, an asynchronous task to generate the metadata is kicked off. If we adjust the URL before that's done, it will collide with that task and error out. Sleeping for 5s gets around this case. 