### PR TITLE
[6.14.z] Add customer coverage to health check

### DIFF
--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -96,11 +96,17 @@ def test_positive_health_check(sat_maintain):
         1. Run satellite-maintain health check
 
     :expectedresults: Health check should pass.
+
+    :BZ: 1956210
+
+    :customerscenario: true
     """
     result = sat_maintain.cli.Health.check(options={'assumeyes': True})
     assert result.status == 0
     if 'paused tasks in the system' not in result.stdout:
         assert 'FAIL' not in result.stdout
+    result = sat_maintain.execute('tail /var/log/foreman-proxy/proxy.log')
+    assert 'sslv3 alert bad certificate' not in result.stdout
 
 
 @pytest.mark.include_capsule


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12745

Adding coverage for BZ1956210. Just need to assert that health check doesn't cause an SSL error.