### PR TITLE
[6.13.z] Add coverage for 1964037 installer cert regeneration

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -120,6 +120,16 @@ class Base:
         return cls.execute(cls._construct_command(options))
 
     @classmethod
+    def ping(cls, options=None):
+        """
+        Display status of Satellite.
+        """
+
+        cls.command_sub = 'ping'
+
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def create(cls, options=None, timeout=None):
         """
         Creates a new record using the arguments passed via dictionary.
@@ -419,6 +429,6 @@ class Base:
                 if isinstance(val, list):
                     val = ','.join(str(el) for el in val)
                 tail += f' --{key}="{val}"'
-        cmd = f"{cls.command_base} {cls.command_sub or ''} {tail.strip()} {cls.command_end or ''}"
+        cmd = f"{cls.command_base or ''} {cls.command_sub or ''} {tail.strip()} {cls.command_end or ''}"
 
         return cmd

--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -154,3 +154,34 @@ def test_positive_mismatched_satellite_fqdn(target_sat, set_random_fqdn):
     )
     installer_command_output = target_sat.execute('satellite-installer').stderr
     assert warning_message in str(installer_command_output)
+
+
+def test_positive_installer_certs_regenerate(target_sat):
+    """Ensure "satellite-installer --certs-regenerate true" command correctly generates
+    /etc/tomcat/cert-users.properties after editing answers file
+
+    :id: db6152c3-4459-425b-998d-4a7992ca1f72
+
+    :steps:
+        1. Update /etc/foreman-installer/scenarios.d/satellite-answers.yaml
+        2. Fill some empty strings in certs category for 'state'
+        3. Run satellite-installer --certs-regenerate true
+        4. hammer ping
+
+    :expectedresults: Correct generation of /etc/tomcat/cert-users.properties
+
+    :BZ: 1964037
+
+    :customerscenario: true
+    """
+    result = target_sat.install(
+        InstallerCommand(
+            'certs-update-all',
+            'certs-update-server',
+            'certs-update-server-ca',
+            certs_regenerate=['true'],
+            certs_state=['undef'],
+        )
+    )
+    assert result.status == 0
+    assert 'FAIL' not in target_sat.cli.Base.ping()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12776

The changes to base.py are also in another one of my PR's (https://github.com/SatelliteQE/robottelo/pull/12756). Simple test here to make sure cert regeneration works when the change is made to the answers file. Also providing coverage for certs-regenerate since we don't have any tests for that.