### PR TITLE
[6.14.z] Add coverage for 1964037 installer cert regeneration

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -120,6 +120,16 @@ class Base:
         return cls.execute(cls._construct_command(options))
 
     @classmethod
+    def ping(cls, options=None):
+        """
+        Display status of Satellite.
+        """
+
+        cls.command_sub = 'ping'
+
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
     def create(cls, options=None, timeout=None):
         """
         Creates a new record using the arguments passed via dictionary.
@@ -419,6 +429,6 @@ class Base:
                 if isinstance(val, list):
                     val = ','.join(str(el) for el in val)
                 tail += f' --{key}="{val}"'
-        cmd = f"{cls.command_base} {cls.command_sub or ''} {tail.strip()} {cls.command_end or ''}"
+        cmd = f"{cls.command_base or ''} {cls.command_sub or ''} {tail.strip()} {cls.command_end or ''}"
 
         return cmd


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12776

The changes to base.py are also in another one of my PR's (https://github.com/SatelliteQE/robottelo/pull/12756). Simple test here to make sure cert regeneration works when the change is made to the answers file. Also providing coverage for certs-regenerate since we don't have any tests for that.