### PR TITLE
[6.14.z] Add coverage for 2055790 to service enable disable

### DIFF
--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -18,6 +18,7 @@
 """
 from fauxfactory import gen_string
 import pytest
+from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (
@@ -173,6 +174,10 @@ def test_positive_service_enable_disable(sat_maintain):
         2. Run satellite-maintain service enable
 
     :expectedresults: Services should enable/disable
+
+    :BZ: 1995783, 2055790
+
+    :customerscenario: true
     """
     result = sat_maintain.cli.Service.stop()
     assert 'FAIL' not in result.stdout
@@ -181,6 +186,28 @@ def test_positive_service_enable_disable(sat_maintain):
     assert 'FAIL' not in result.stdout
     assert result.status == 0
     result = sat_maintain.cli.Service.enable()
+    assert 'FAIL' not in result.stdout
+    assert result.status == 0
+    sat_maintain.power_control(state='reboot')
+    if isinstance(sat_maintain, Satellite):
+        result, _ = wait_for(
+            sat_maintain.cli.Service.status,
+            func_kwargs={'options': {'brief': True, 'only': 'foreman.service'}},
+            fail_condition=lambda res: "FAIL" in res.stdout,
+            handle_exception=True,
+            delay=30,
+            timeout=300,
+        )
+        assert 'FAIL' not in sat_maintain.cli.Base.ping()
+    else:
+        result, _ = wait_for(
+            sat_maintain.cli.Service.status,
+            func_kwargs={'options': {'brief': True}},
+            fail_condition=lambda res: "FAIL" in res.stdout,
+            handle_exception=True,
+            delay=30,
+            timeout=300,
+        )
     assert 'FAIL' not in result.stdout
     assert result.status == 0
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12756

The first commit here is a cherry-pick of an old PR that I accidentally removed in one of my Foreman Maintain audits. I must not have had the latest changes on that branch. I'm adding that back in and also adding coverage for 2055790.