### PR TITLE
Coverage for autoprovision and reboot of discovered host

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -37,6 +37,7 @@ pytest_plugins = [
     'pytest_fixtures.component.computeprofile',
     'pytest_fixtures.component.contentview',
     'pytest_fixtures.component.domain',
+    'pytest_fixtures.component.discovery',
     'pytest_fixtures.component.host',
     'pytest_fixtures.component.hostgroup',
     'pytest_fixtures.component.http_proxy',

--- a/pytest_fixtures/component/discovery.py
+++ b/pytest_fixtures/component/discovery.py
@@ -1,0 +1,31 @@
+from fauxfactory import gen_string
+import pytest
+
+
+@pytest.fixture(scope='module')
+def module_discovery_hostgroup(module_org, module_location, module_target_sat):
+    host = module_target_sat.api.Host(organization=module_org, location=module_location).create()
+    return module_target_sat.api.HostGroup(
+        organization=[module_org],
+        location=[module_location],
+        medium=host.medium,
+        root_pass=gen_string('alpha'),
+        operatingsystem=host.operatingsystem,
+        ptable=host.ptable,
+        domain=host.domain,
+        architecture=host.architecture,
+    ).create()
+
+
+@pytest.fixture(scope='module')
+def discovery_org(module_org, module_target_sat):
+    discovery_org = module_target_sat.update_setting('discovery_organization', module_org.name)
+    yield module_org
+    module_target_sat.update_setting('discovery_organization', discovery_org)
+
+
+@pytest.fixture(scope='module')
+def discovery_location(module_location, module_target_sat):
+    discovery_loc = module_target_sat.update_setting('discovery_location', module_location.name)
+    yield module_location
+    module_target_sat.update_setting('discovery_location', discovery_loc)

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -320,7 +320,9 @@ class TestDiscoveredHost:
         assert f'provisioned with rule {rule.name}' in result['message']
 
     @pytest.mark.tier3
-    def test_positive_auto_provision_all(self):
+    def test_positive_auto_provision_all(
+        self, module_discovery_hostgroup, module_target_sat, default_org, default_location
+    ):
         """Auto provision all host by executing discovery rules
 
         :id: 954d3688-62d9-47f7-9106-a4fff8825ffa
@@ -337,6 +339,19 @@ class TestDiscoveredHost:
 
         :CaseImportance: High
         """
+        module_target_sat.api.DiscoveryRule(
+            max_count=25,
+            hostgroup=module_discovery_hostgroup,
+            search_='location = "Default Location"',
+            location=[default_location],
+            organization=[default_org],
+        ).create()
+
+        for _ in range(2):
+            module_target_sat.api_factory.create_discovered_host()
+
+        result = module_target_sat.api.DiscoveredHost().auto_provision_all()
+        assert '2 discovered hosts were provisioned' in result['message']
 
     @pytest.mark.stubbed
     @pytest.mark.tier3

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -25,9 +25,7 @@ from requests.exceptions import HTTPError
 from robottelo import constants
 from robottelo.cli.base import CLIReturnCodeError
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE
-from robottelo.constants import MIRRORING_POLICIES
-from robottelo.constants import REPOS
+from robottelo.constants import DEFAULT_ARCHITECTURE, MIRRORING_POLICIES, REPOS
 from robottelo.utils.datafactory import parametrized
 
 


### PR DESCRIPTION
1. Adding coverage for the auto-provision and reboot API endpoints for a single host.
2. Adding coverage for the auto-provision of multiple discovered hosts.
