### PR TITLE
[6.13.z] Audit - Adding coverage for Discovery provisioning via CLI

### DIFF
--- a/robottelo/cli/discoveredhost.py
+++ b/robottelo/cli/discoveredhost.py
@@ -31,10 +31,28 @@ class DiscoveredHost(Base):
     def provision(cls, options=None):
         """Manually provision discovered host"""
         cls.command_sub = 'provision'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
     def facts(cls, options=None):
         """Get all the facts associated with discovered host"""
         cls.command_sub = 'facts'
-        return cls.execute(cls._construct_command(options))
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def auto_provision(cls, options=None):
+        """Auto provision discovered host"""
+        cls.command_sub = 'auto-provision'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def reboot(cls, options=None):
+        """Reboot discovered host"""
+        cls.command_sub = 'reboot'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def refresh_facts(cls, options=None):
+        """Refresh facts associated with discovered host"""
+        cls.command_sub = 'refresh-facts'
+        return cls.execute(cls._construct_command(options), output_format='csv')

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -14,50 +14,145 @@
 
 :Upstream: No
 """
-from time import sleep
-
 import pytest
-
-from robottelo.cli.base import CLIReturnCodeError
-from robottelo.cli.discoveredhost import DiscoveredHost
+from wait_for import wait_for
 
 pytestmark = [pytest.mark.run_in_one_thread]
 
 
-def _assertdiscoveredhost(hostname):
-    """Check if host is discovered and information about it can be
-    retrieved back
+@pytest.mark.e2e
+@pytest.mark.on_premises_provisioning
+@pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
+@pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
+@pytest.mark.rhel_ver_match('8')
+def test_rhel_pxe_discovery_provisioning(
+    module_provisioning_rhel_content,
+    module_discovery_sat,
+    provisioning_host,
+    provisioning_hostgroup,
+    request,
+):
+    """Provision a PXE-based discovered host
 
-    Introduced a delay of 300secs by polling every 10 secs to get expected
-    host
-    """
-    for _ in range(30):
-        try:
-            discovered_host = DiscoveredHost.info({'name': hostname})
-        except CLIReturnCodeError:
-            sleep(10)
-            continue
-        return discovered_host
+    :id: b32a3b05-86bc-4ba6-ab6c-22b2f81e4315
 
+    :parametrized: yes
 
-@pytest.mark.stubbed
-@pytest.mark.tier3
-def test_positive_pxe_based_discovery():
-    """Discover a host via PXE boot by setting "proxy.type=proxy" in
-    PXE default
+    :Setup: Satellite with Provisioning and Discovery features configured
 
-    :id: 25e935fe-18f4-477e-b791-7ea5a395b4f6
+    :Steps:
 
-    :Setup: Provisioning should be configured
+        1. Boot up the host to discover
+        2. Provision the host
 
-    :Steps: PXE boot a host/VM
-
-    :expectedresults: Host should be successfully discovered
+    :expectedresults: Host should be successfully discovered and provisioned
 
     :CaseImportance: Critical
 
     :BZ: 1731112
     """
+    sat = module_discovery_sat.sat
+    provisioning_host.power_control(ensure=False)
+    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+
+    wait_for(
+        lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
+        timeout=240,
+        delay=20,
+    )
+    discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
+    discovered_host.hostgroup = provisioning_hostgroup
+    discovered_host.location = provisioning_hostgroup.location[0]
+    discovered_host.organization = provisioning_hostgroup.organization[0]
+    discovered_host.build = True
+    result = sat.cli.DiscoveredHost.provision(
+        {
+            'id': discovered_host.id,
+            'hostgroup-id': discovered_host.hostgroup.id,
+            'organization-id': discovered_host.organization.id,
+            'location-id': discovered_host.location.id,
+        }
+    )
+    # teardown
+    @request.addfinalizer
+    def _finalize():
+        host.delete()
+        assert not sat.api.Host().search(query={"search": f'name={host.name}'})
+
+    assert 'Host created' in result[0]['message']
+    host = sat.api.Host().search(query={"search": f'id={discovered_host.id}'})[0]
+    assert host
+    wait_for(
+        lambda: host.read().build_status_label != 'Pending installation',
+        timeout=1500,
+        delay=10,
+    )
+    assert host.read().build_status_label == 'Installed'
+    assert not sat.api.DiscoveredHost().search(query={'mac': mac})
+
+
+@pytest.mark.e2e
+@pytest.mark.on_premises_provisioning
+@pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
+@pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
+@pytest.mark.rhel_ver_match('8')
+def test_rhel_pxeless_discovery_provisioning(
+    module_discovery_sat,
+    pxeless_discovery_host,
+    module_provisioning_rhel_content,
+    provisioning_hostgroup,
+    request,
+):
+    """Provision a PXE-less discovered host
+
+    :id: e75ee13a-9edc-4182-b02a-6b106a459751
+
+    :Setup: Provisioning should be configured and a host should be
+        discovered via cli
+
+    :expectedresults: Host should be provisioned successfully
+
+    :CaseImportance: Critical
+    """
+    sat = module_discovery_sat.sat
+    pxeless_discovery_host.power_control(ensure=False)
+    mac = pxeless_discovery_host._broker_args['provisioning_nic_mac_addr']
+
+    wait_for(
+        lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
+        timeout=240,
+        delay=20,
+    )
+    discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
+    discovered_host.hostgroup = provisioning_hostgroup
+    discovered_host.location = provisioning_hostgroup.location[0]
+    discovered_host.organization = provisioning_hostgroup.organization[0]
+    discovered_host.build = True
+    result = sat.cli.DiscoveredHost.provision(
+        {
+            'id': discovered_host.id,
+            'hostgroup-id': discovered_host.hostgroup.id,
+            'organization-id': discovered_host.organization.id,
+            'location-id': discovered_host.location.id,
+        }
+    )
+
+    # teardown
+    @request.addfinalizer
+    def _finalize():
+        host.delete()
+        assert not sat.api.Host().search(query={"search": f'name={host.name}'})
+
+    assert 'Host created' in result[0]['message']
+    host = sat.api.Host().search(query={"search": f'id={discovered_host.id}'})[0]
+    assert host
+    wait_for(
+        lambda: host.read().build_status_label != 'Pending installation',
+        timeout=1500,
+        delay=10,
+    )
+    assert host.read().build_status_label == 'Installed'
+    assert not sat.api.DiscoveredHost().search(query={'mac': mac})
 
 
 @pytest.mark.stubbed
@@ -146,57 +241,6 @@ def test_positive_provision_pxe_host_with_bios_syslinux():
     :CaseImportance: High
 
     :BZ: 1731112
-    """
-
-
-@pytest.mark.stubbed
-@pytest.mark.tier3
-def test_positive_provision_pxe_host_with_uefi_grub2():
-    """Provision the pxe-based UEFI discovered host from cli using PXEGRUB2
-    loader
-
-    :id: 0002af1b-6f4b-40e2-8f2f-343387be6f72
-
-    :Setup:
-        1. Create an UEFI VM and set it to boot from a network
-        2. Synchronize RHEL7 kickstart repo (rhel6 kernel too old for GRUB)
-        3. for getting more detailed info from FDI, remaster the image to
-            have ssh enabled
-
-    :steps:
-        1. Build a default PXE template
-        2. Run assertion step #1
-        3. Boot the VM (from NW)
-        4. Run assertion steps #2-4
-        5. Provision the discovered host
-        6. Run assertion steps #5-9
-
-    :expectedresults: Host should be provisioned successfully
-        1. Ensure the tftpboot files are updated
-
-            1.1 Ensure fdi-image files have been placed under tftpboot/boot/
-            1.2 Ensure the 'default' pxelinux config has been placed under
-            tftpboot/pxelinux.cfg/
-            1.3 Ensure the discovery section exists inside pxelinux config,
-            it leads to the FDI kernel and the ONTIMEOUT is set to discovery
-
-        2. Ensure PXE handoff goes as expected (tcpdump -p tftp)
-        3. Ensure FDI loaded and successfully sent out facts
-
-            3.1 ping vm
-            3.2 ssh to the VM and read the logs (if ssh enabled)
-            3.3 optionally sniff the HTTP traffic coming from the host
-
-        4. Ensure host appeared in Discovered Hosts on satellite
-        5. Ensure the tftpboot files are updated for the hosts mac
-        6. Ensure PXE handoff goes as expected (tcpdump -p tftp)
-        7. Optionally ensure anaconda loaded and the installation finished
-        8. Ensure the host is provisioned with correct attributes
-        9. Ensure the entry from discovered host list disappeared
-
-    :CaseAutomation: NotAutomated
-
-    :CaseImportance: High
     """
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12467

PR aims to add coverage for Pxe and Pxeless Discovery host provisioning via hammer(CLI).