### PR TITLE
[6.12.z] Fix capsule test by CVV sort

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -302,6 +302,7 @@ class TestCapsuleContentManagement:
         cv = cv.read()
         assert len(cv.version) == 2
 
+        cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         cvv.promote(data={'environment_ids': function_lce.id})
         cvv = cvv.read()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12829

CVV sorting issue hits again