### PR TITLE
[6.13.z] Nailgun ssl cert verification

### DIFF
--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -48,6 +48,10 @@ SERVER:
   ADMIN_USERNAME: admin
   # Admin password when accessing API and UI
   ADMIN_PASSWORD: changeme
+  # Set to true to verify against the certificate given in REQUESTS_CA_BUNDLE
+  # Or specify path to certificate path or directory
+  # see: https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification
+  VERIFY_CA: false
 
   SSH_CLIENT:
     # Specify port number for ssh client, Default: 22

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -110,7 +110,7 @@ def user_nailgun_config(username=None, password=None):
 
     """
     creds = (username, password)
-    return ServerConfig(get_url(), creds, verify=False)
+    return ServerConfig(get_url(), creds, verify=settings.server.verify_ca)
 
 
 def setting_is_set(option):
@@ -153,7 +153,9 @@ def configure_nailgun():
     from nailgun.config import ServerConfig
 
     entity_mixins.CREATE_MISSING = True
-    entity_mixins.DEFAULT_SERVER_CONFIG = ServerConfig(get_url(), get_credentials(), verify=False)
+    entity_mixins.DEFAULT_SERVER_CONFIG = ServerConfig(
+        get_url(), get_credentials(), verify=settings.server.verify_ca
+    )
     gpgkey_init = entities.GPGKey.__init__
 
     def patched_gpgkey_init(self, server_config=None, **kwargs):

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -29,6 +29,7 @@ VALIDATORS = dict(
         Validator('server.port', default=443),
         Validator('server.ssh_username', default='root'),
         Validator('server.ssh_password', default=None),
+        Validator('server.verify_ca', default=False),
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1722,7 +1722,7 @@ class Satellite(Capsule, SatelliteMixins):
         self.nailgun_cfg = ServerConfig(
             auth=(settings.server.admin_username, settings.server.admin_password),
             url=f'{self.url}',
-            verify=False,
+            verify=settings.server.verify_ca,
         )
         # add each nailgun entity to self.api, injecting our server config
         for name, obj in entities.__dict__.items():

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -26,6 +26,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.cli.ldapauthsource import LDAPAuthSource
+from robottelo.config import settings
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.utils.datafactory import gen_string, generate_strings_list, parametrized
 from robottelo.utils.issue_handlers import is_open
@@ -154,7 +155,9 @@ class TestCannedRole:
         :param user: The nailgun.entities.User object of an user with passwd
             parameter
         """
-        return ServerConfig(auth=(user.login, user.passwd), url=satellite.url, verify=False)
+        return ServerConfig(
+            auth=(user.login, user.passwd), url=satellite.url, verify=settings.server.verify_ca
+        )
 
     @pytest.fixture
     def role_taxonomies(self):
@@ -991,7 +994,9 @@ class TestCannedRole:
             location=[role_taxonomies['loc'].id],
         ).create()
         for login, password in ((userone_login, userone_pass), (usertwo_login, usertwo_pass)):
-            sc = ServerConfig(auth=(login, password), url=target_sat.url, verify=False)
+            sc = ServerConfig(
+                auth=(login, password), url=target_sat.url, verify=settings.server.verify_ca
+            )
             try:
                 entities.Domain(sc).search(
                     query={
@@ -1120,7 +1125,9 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
+        sc = ServerConfig(
+            auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
+        )
         # Getting the domain from user1
         dom = entities.Domain(sc, id=dom.id).read()
         dom.organization = [filter_taxonomies['org']]
@@ -1279,7 +1286,9 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
+        sc = ServerConfig(
+            auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
+        )
         role_name = gen_string('alpha')
         with pytest.raises(HTTPError):
             entities.Role(
@@ -1344,7 +1353,9 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
+        sc = ServerConfig(
+            auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
+        )
         with pytest.raises(HTTPError):
             entities.User(sc, id=1).read()
 
@@ -1389,7 +1400,9 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc_user = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
+        sc_user = ServerConfig(
+            auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
+        )
         user_login = gen_string('alpha')
         user_pass = gen_string('alphanumeric')
         user = entities.User(
@@ -1470,7 +1483,9 @@ class TestCannedRole:
         )
         user.role = [org_admin]
         user = user.update(['role'])
-        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
+        sc = ServerConfig(
+            auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
+        )
         name = gen_string('alphanumeric')
         location = entities.Location(sc, name=name, parent=role_taxonomies['loc'].id).create()
         assert location.name == name
@@ -1534,7 +1549,9 @@ class TestCannedRole:
             location=[role_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
+        sc = ServerConfig(
+            auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
+        )
         with pytest.raises(HTTPError):
             entities.Organization(sc, name=gen_string('alpha')).create()
         if not is_open("BZ:1825698"):
@@ -1578,7 +1595,9 @@ class TestCannedRole:
             location=[role_taxonomies['loc'], filter_taxonomies['loc']],
         ).create()
         assert user_login == user.login
-        sc = ServerConfig(auth=(user_login, user_pass), url=target_sat.url, verify=False)
+        sc = ServerConfig(
+            auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
+        )
         try:
             for entity in [
                 entities.Architecture,
@@ -1627,7 +1646,7 @@ class TestCannedRole:
         sc = ServerConfig(
             auth=(create_ldap['ldap_user_name'], create_ldap['ldap_user_passwd']),
             url=create_ldap['sat_url'],
-            verify=False,
+            verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
@@ -1670,7 +1689,7 @@ class TestCannedRole:
         sc = ServerConfig(
             auth=(create_ldap['ldap_user_name'], create_ldap['ldap_user_passwd']),
             url=create_ldap['sat_url'],
-            verify=False,
+            verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
@@ -1734,7 +1753,7 @@ class TestCannedRole:
             sc = ServerConfig(
                 auth=(user.login, password),
                 url=create_ldap['sat_url'],
-                verify=False,
+                verify=settings.server.verify_ca,
             )
             # Accessing the Domain resource
             entities.Domain(sc, id=domain.id).read()
@@ -1790,7 +1809,7 @@ class TestCannedRole:
             sc = ServerConfig(
                 auth=(user.login, password),
                 url=create_ldap['sat_url'],
-                verify=False,
+                verify=settings.server.verify_ca,
             )
             # Trying to access the Domain resource
             with pytest.raises(HTTPError):

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -28,6 +28,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.cli.subscription import Subscription
+from robottelo.config import settings
 from robottelo.constants import DEFAULT_SUBSCRIPTION_NAME, PRDS, REPOS, REPOSET
 
 pytestmark = [pytest.mark.run_in_one_thread]
@@ -191,7 +192,7 @@ def test_positive_delete_manifest_as_another_user(
     sc1 = ServerConfig(
         auth=(user1.login, user1_password),
         url=target_sat.url,
-        verify=False,
+        verify=settings.server.verify_ca,
     )
     user2_password = gen_string('alphanumeric')
     user2 = target_sat.api.User(
@@ -203,7 +204,7 @@ def test_positive_delete_manifest_as_another_user(
     sc2 = ServerConfig(
         auth=(user2.login, user2_password),
         url=target_sat.url,
-        verify=False,
+        verify=settings.server.verify_ca,
     )
     # use the first admin to upload a manifest
     with function_entitlement_manifest as manifest:

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -418,7 +418,9 @@ class TestUser:
         user = entities.User(role=existing_roles, password=password).create()
         name = "hosts"
         columns = ["power_status", "name", "comment"]
-        sc = ServerConfig(auth=(user.login, password), url=module_target_sat.url, verify=False)
+        sc = ServerConfig(
+            auth=(user.login, password), url=module_target_sat.url, verify=settings.server.verify_ca
+        )
         entities.TablePreferences(sc, user=user, name=name, columns=columns).create()
         table_preferences = entities.TablePreferences(sc, user=user).search()
         assert len(table_preferences) == 1
@@ -726,7 +728,7 @@ class TestActiveDirectoryUser:
         sc = ServerConfig(
             auth=(create_ldap['ldap_user_name'], create_ldap['ldap_user_passwd']),
             url=create_ldap['sat_url'],
-            verify=False,
+            verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
@@ -775,7 +777,7 @@ class TestActiveDirectoryUser:
         sc = ServerConfig(
             auth=(create_ldap['ldap_user_name'], create_ldap['ldap_user_passwd']),
             url=create_ldap['sat_url'],
-            verify=False,
+            verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
@@ -857,7 +859,7 @@ class TestFreeIPAUser:
         sc = ServerConfig(
             auth=(create_ldap['username'], create_ldap['ldap_user_passwd']),
             url=create_ldap['sat_url'],
-            verify=False,
+            verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()
@@ -896,7 +898,7 @@ class TestFreeIPAUser:
         sc = ServerConfig(
             auth=(create_ldap['username'], create_ldap['ldap_user_passwd']),
             url=create_ldap['sat_url'],
-            verify=False,
+            verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
             entities.Architecture(sc).search()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12813

This PR adds the possibility to overwrite the `verify` settings of nailgun's [ServerConfig ](https://github.com/SatelliteQE/nailgun/blob/master/nailgun/config.py#L219) 

According to the setttings given by [requests](https://requests.readthedocs.io/en/latest/user/advanced/#ssl-cert-verification)

Backwards compatibility is kept by defaulting to `False` if the new settings option is not available.


