### PR TITLE
[6.13.z] Change read to read_legacy_ui

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -78,7 +78,12 @@ def test_positive_end_to_end_crud(session, module_org):
     indirect=True,
 )
 def test_positive_end_to_end_register(
-    session, function_entitlement_manifest_org, repos_collection, rhel7_contenthost, target_sat
+    session,
+    function_entitlement_manifest_org,
+    default_location,
+    repos_collection,
+    rhel7_contenthost,
+    target_sat,
 ):
     """Create activation key and use it during content host registering
 
@@ -98,10 +103,13 @@ def test_positive_end_to_end_register(
     repos_collection.setup_content(org.id, lce.id, upload_manifest=False)
     ak_name = repos_collection.setup_content_data['activation_key']['name']
 
-    repos_collection.setup_virtual_machine(rhel7_contenthost)
+    repos_collection.setup_virtual_machine(rhel7_contenthost, install_katello_agent=False)
     with session:
         session.organization.select(org.name)
-        chost = session.contenthost.read(rhel7_contenthost.hostname, widget_names='details')
+        session.location.select(default_location.name)
+        chost = session.contenthost.read_legacy_ui(
+            rhel7_contenthost.hostname, widget_names='details'
+        )
         assert chost['details']['registered_by'] == f'Activation Key {ak_name}'
         ak_values = session.activationkey.read(ak_name, widget_names='content_hosts')
         assert len(ak_values['content_hosts']['table']) == 1


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12844

Changes a few things here to unblock this test:

- sets `install_katello_agent` to false
- selects the default location, where hosts are being registered
- uses the read_legacy_ui, instead of read, since the test is referencing the old UI