### PR TITLE
Update to errata-stream fix, use up to date register method for rhel_contenthost

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -154,6 +154,7 @@ class HostInfo:
     @property
     def applicable_errata_count(self):
         """return the applicable errata count for a host"""
+        self.run('subscription-manager repos')
         return self.nailgun_host.read().content_facet_attributes['errata_counts']['total']
 
 

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -225,8 +225,7 @@ def test_positive_install_multiple_in_host(target_sat, rhel_contenthost, module_
             search_rate=20,
             max_tries=15,
         )
-        rhel_contenthost.run('subscription-manager repos')
-        sleep(10)
+        sleep(20)
         assert rhel_contenthost.applicable_errata_count == pre_errata_count - 1
 
 

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -17,7 +17,6 @@
 :Upstream: No
 """
 # For ease of use hc refers to host-collection throughout this document
-from copy import copy
 from time import sleep
 
 from nailgun import entities
@@ -159,12 +158,10 @@ def test_positive_install_in_hc(module_org, activation_key, custom_repo, target_
 
 
 @pytest.mark.tier3
-@pytest.mark.rhel_ver_match(r'^(?!6$)\d+$')
+@pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 @pytest.mark.e2e
-def test_positive_install_multiple_in_host(
-    target_sat, rhel_contenthost, function_org, function_lce
-):
+def test_positive_install_multiple_in_host(target_sat, rhel_contenthost, module_org, module_lce):
     """For a host with multiple applicable errata install one and ensure
     the rest of errata is still available
 
@@ -185,26 +182,22 @@ def test_positive_install_multiple_in_host(
     :CaseLevel: System
     """
     ak = target_sat.api.ActivationKey(
-        organization=function_org,
-        environment=function_lce,
+        organization=module_org,
+        environment=module_lce,
     ).create()
-    cv = target_sat.api.ContentView(organization=function_org).create()
-    # Associate custom repos with org, cv, lce, ak:
+    # Associate custom repos with org, lce, ak:
     target_sat.cli_factory.setup_org_for_a_custom_repo(
         {
             'url': settings.repos.yum_9.url,
-            'organization-id': function_org.id,
-            'content-view-id': cv.id,
-            'lifecycle-environment-id': function_lce.id,
+            'organization-id': module_org.id,
+            'lifecycle-environment-id': module_lce.id,
             'activationkey-id': ak.id,
         }
     )
     rhel_contenthost.register(
-        org=function_org,
         activation_keys=ak.name,
-        lifecycle_environment=function_lce,
         target=target_sat,
-        force=True,
+        org=module_org,
         loc=None,
     )
     assert rhel_contenthost.subscribed
@@ -213,11 +206,10 @@ def test_positive_install_multiple_in_host(
         rhel_contenthost.run(f'yum remove -y {str(package.split("-", 1)[0])}')
         assert rhel_contenthost.run(f'yum install -y {package}').status == 0
         assert rhel_contenthost.run(f'rpm -q {package}').status == 0
-    rhel_contenthost.add_rex_key(satellite=target_sat)
     # Each errata will be installed sequentially,
     # after each install, applicable-errata-count should drop by one.
     for errata in constants.FAKE_9_YUM_SECURITY_ERRATUM:
-        pre_errata_count = copy(rhel_contenthost.applicable_errata_count)
+        pre_errata_count = rhel_contenthost.applicable_errata_count
         assert pre_errata_count >= 1
         task_id = target_sat.api.JobInvocation().run(
             data={
@@ -225,7 +217,7 @@ def test_positive_install_multiple_in_host(
                 'inputs': {'errata': str(errata)},
                 'targeting_type': 'static_query',
                 'search_query': f'name = {rhel_contenthost.hostname}',
-                'organization_id': function_org.id,
+                'organization_id': module_org.id,
             },
         )['id']
         target_sat.wait_for_tasks(
@@ -233,7 +225,8 @@ def test_positive_install_multiple_in_host(
             search_rate=20,
             max_tries=15,
         )
-        sleep(20)
+        rhel_contenthost.run('subscription-manager repos')
+        sleep(10)
         assert rhel_contenthost.applicable_errata_count == pre_errata_count - 1
 
 


### PR DESCRIPTION
Previous pr was merged just a bit before I could get this in. The old method works and passes, 
but should use `.register()` going forward with the removal of katello-agent. 