### PR TITLE
[6.14.z] Fix lce id option in host registration

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -769,7 +769,7 @@ class ContentHost(Host, ContentHostMixins):
             raise ValueError('Global registration method can be used with Satellite/Capsule only')
 
         if lifecycle_environment is not None:
-            options['lifecycle_environment_id'] = lifecycle_environment.id
+            options['lifecycle-environment-id'] = lifecycle_environment.id
         if operating_system is not None:
             options['operatingsystem-id'] = operating_system.id
         if hostgroup is not None:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12849

Registering host using the LCE id fails with `Failed to generate registration command:  Error: Unrecognised option '--lifecycle_environment_id'. See: 'hammer host-registration generate-command --help'` because the dashes are used for hammer CLI options.

```
# hammer host-registration generate-command --help
Usage:
    hammer host-registration generate-command [OPTIONS]

Options:
...
 --lifecycle-environment[-id] VALUE/NUMBER Lifecycle environment for the host.
```