### PR TITLE
[6.14.z] Fixed test_positive_assign_http_proxy_to_products_repositories failure

### DIFF
--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -110,6 +110,8 @@ def test_positive_assign_http_proxy_to_products_repositories(
     # Create repositories from UI.
     with target_sat.ui_session() as session:
         repo_a1_name = gen_string('alpha')
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
         session.repository.create(
             product_a.name,
             {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12850

This test was failing in stream due to not having an org and location selected. 

