### PR TITLE
[6.14.z] update case component with correct name

### DIFF
--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Host-Content
+:CaseComponent: Hosts-Content
 
 :Team: Phoenix-subscriptions
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12859

- `CaseComponent`  name need to update in `robottelo/tests/upgrades/test_hostcontent.py`
- Branch - 6.11.z, 6.12.z, 6.13.z, 6.14.z, Stream