### PR TITLE
[6.14.z] fixture support for virt-who config api : data_form deploy_type virtwho_config 

### DIFF
--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -16,7 +16,6 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
@@ -25,54 +24,18 @@ from robottelo.utils.virtwho import (
     create_http_proxy,
     deploy_configure_by_command,
     deploy_configure_by_command_check,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
-    get_guest_info,
 )
 
 
-@pytest.fixture()
-def form_data(default_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.esx.hypervisor_type,
-        'hypervisor_server': settings.virtwho.esx.hypervisor_server,
-        'organization_id': default_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.esx.hypervisor_username,
-        'hypervisor_password': settings.virtwho.esx.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
-@pytest.fixture(autouse=True)
-def delete_host(form_data, target_sat):
-    guest_name, _ = get_guest_info(form_data['hypervisor_type'])
-    results = target_sat.api.Host().search(query={'search': guest_name})
-    if results:
-        target_sat.api.Host(id=results[0].read_json()['id']).delete()
-
-
-@pytest.mark.usefixtures('delete_host')
+@pytest.mark.delete_host
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, target_sat, virtwho_config_api, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -84,23 +47,11 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=default_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
+        hypervisor_name, guest_name = deploy_type_api
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
@@ -132,7 +83,9 @@ class TestVirtWhoConfigforEsx:
             assert result['subscription_status_label'] == 'Fully entitled'
 
     @pytest.mark.tier2
-    def test_positive_debug_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_debug_option(
+        self, default_org, form_data_api, virtwho_config_api, target_sat
+    ):
         """Verify debug option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -147,16 +100,18 @@ class TestVirtWhoConfigforEsx:
         """
         options = {'true': '1', 'false': '0', '1': '1', '0': '0'}
         for key, value in sorted(options.items(), key=lambda item: item[0]):
-            virtwho_config.debug = key
-            virtwho_config.update(['debug'])
-            command = get_configure_command(virtwho_config.id, default_org.name)
+            virtwho_config_api.debug = key
+            virtwho_config_api.update(['debug'])
+            command = get_configure_command(virtwho_config_api.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_api['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
 
     @pytest.mark.tier2
-    def test_positive_interval_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_interval_option(
+        self, default_org, form_data_api, virtwho_config_api, target_sat
+    ):
         """Verify interval option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -180,17 +135,17 @@ class TestVirtWhoConfigforEsx:
             '4320': '259200',
         }
         for key, value in sorted(options.items(), key=lambda item: int(item[0])):
-            virtwho_config.interval = key
-            virtwho_config.update(['interval'])
-            command = get_configure_command(virtwho_config.id, default_org.name)
+            virtwho_config_api.interval = key
+            virtwho_config_api.update(['interval'])
+            command = get_configure_command(virtwho_config_api.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_api['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -207,17 +162,19 @@ class TestVirtWhoConfigforEsx:
         # esx and rhevm support hwuuid option
         values = ['uuid', 'hostname', 'hwuuid']
         for value in values:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, default_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_api['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
-    def test_positive_filter_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_filter_option(
+        self, default_org, form_data_api, virtwho_config_api, target_sat
+    ):
         """Verify filter option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id"
@@ -236,26 +193,30 @@ class TestVirtWhoConfigforEsx:
         whitelist['filter_host_parents'] = '.*redhat.com'
         blacklist['exclude_host_parents'] = '.*redhat.com'
         # Update Whitelist and check the result
-        virtwho_config.filtering_mode = whitelist['filtering_mode']
-        virtwho_config.whitelist = whitelist['whitelist']
-        virtwho_config.filter_host_parents = whitelist['filter_host_parents']
-        virtwho_config.update(whitelist.keys())
-        config_file = get_configure_file(virtwho_config.id)
-        command = get_configure_command(virtwho_config.id, default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
+        virtwho_config_api.filtering_mode = whitelist['filtering_mode']
+        virtwho_config_api.whitelist = whitelist['whitelist']
+        virtwho_config_api.filter_host_parents = whitelist['filter_host_parents']
+        virtwho_config_api.update(whitelist.keys())
+        config_file = get_configure_file(virtwho_config_api.id)
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
+        deploy_configure_by_command(
+            command, form_data_api['hypervisor_type'], org=default_org.label
+        )
         assert get_configure_option('filter_hosts', config_file) == whitelist['whitelist']
         assert (
             get_configure_option('filter_host_parents', config_file)
             == whitelist['filter_host_parents']
         )
         # Update Blacklist and check the result
-        virtwho_config.filtering_mode = blacklist['filtering_mode']
-        virtwho_config.blacklist = blacklist['blacklist']
-        virtwho_config.exclude_host_parents = blacklist['exclude_host_parents']
-        virtwho_config.update(blacklist.keys())
-        config_file = get_configure_file(virtwho_config.id)
-        command = get_configure_command(virtwho_config.id, default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
+        virtwho_config_api.filtering_mode = blacklist['filtering_mode']
+        virtwho_config_api.blacklist = blacklist['blacklist']
+        virtwho_config_api.exclude_host_parents = blacklist['exclude_host_parents']
+        virtwho_config_api.update(blacklist.keys())
+        config_file = get_configure_file(virtwho_config_api.id)
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
+        deploy_configure_by_command(
+            command, form_data_api['hypervisor_type'], org=default_org.label
+        )
         assert get_configure_option('exclude_hosts', config_file) == blacklist['blacklist']
         assert (
             get_configure_option('exclude_host_parents', config_file)
@@ -263,7 +224,9 @@ class TestVirtWhoConfigforEsx:
         )
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_proxy_option(
+        self, default_org, form_data_api, virtwho_config_api, target_sat
+    ):
         """Verify http_proxy option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id""
@@ -278,8 +241,10 @@ class TestVirtWhoConfigforEsx:
 
         :BZ: 1902199
         """
-        command = get_configure_command(virtwho_config.id, default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
+        deploy_configure_by_command(
+            command, form_data_api['hypervisor_type'], org=default_org.label
+        )
         # Check default NO_PROXY option
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == '*'
         # Check HTTTP Proxy and No_PROXY option
@@ -287,23 +252,27 @@ class TestVirtWhoConfigforEsx:
             http_type='http', org=default_org
         )
         no_proxy = 'test.satellite.com'
-        virtwho_config.http_proxy_id = http_proxy_id
-        virtwho_config.no_proxy = no_proxy
-        virtwho_config.update(['http_proxy_id', 'no_proxy'])
-        command = get_configure_command(virtwho_config.id, default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
+        virtwho_config_api.http_proxy_id = http_proxy_id
+        virtwho_config_api.no_proxy = no_proxy
+        virtwho_config_api.update(['http_proxy_id', 'no_proxy'])
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
+        deploy_configure_by_command(
+            command, form_data_api['hypervisor_type'], org=default_org.label
+        )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
         # Check HTTTPs Proxy option
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(org=default_org)
-        virtwho_config.http_proxy_id = https_proxy_id
-        virtwho_config.update(['http_proxy_id'])
-        deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
+        virtwho_config_api.http_proxy_id = https_proxy_id
+        virtwho_config_api.update(['http_proxy_id'])
+        deploy_configure_by_command(
+            command, form_data_api['hypervisor_type'], org=default_org.label
+        )
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
 
     @pytest.mark.tier2
     def test_positive_configure_organization_list(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify "GET /foreman_virt_who_configure/
 
@@ -317,14 +286,16 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        command = get_configure_command(virtwho_config.id, default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor_type'], org=default_org.label)
-        search_result = virtwho_config.get_organization_configs(data={'per_page': '1000'})
-        assert [item for item in search_result['results'] if item['name'] == form_data['name']]
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
+        deploy_configure_by_command(
+            command, form_data_api['hypervisor_type'], org=default_org.label
+        )
+        search_result = virtwho_config_api.get_organization_configs(data={'per_page': '1000'})
+        assert [item for item in search_result['results'] if item['name'] == form_data_api['name']]
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_hypervisor_password_with_special_characters(
-        self, default_org, form_data, target_sat
+        self, default_org, form_data_api, target_sat
     ):
         """Verify " hammer virt-who-config deploy hypervisor with special characters"
 
@@ -341,25 +312,25 @@ class TestVirtWhoConfigforEsx:
         :customerscenario: true
         """
         # check the hypervisor password contains single quotes
-        form_data['hypervisor_password'] = "Tes't"
-        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-        assert virtwho_config.status == 'unknown'
-        command = get_configure_command(virtwho_config.id, default_org.name)
+        form_data_api['hypervisor_password'] = "Tes't"
+        virtwho_config_api = target_sat.api.VirtWhoConfig(**form_data_api).create()
+        assert virtwho_config_api.status == 'unknown'
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
         deploy_status = deploy_configure_by_command_check(command)
         assert deploy_status == 'Finished successfully'
-        config_file = get_configure_file(virtwho_config.id)
+        config_file = get_configure_file(virtwho_config_api.id)
         assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
         assert (
             get_configure_option('username', config_file)
             == settings.virtwho.esx.hypervisor_username
         )
-        virtwho_config.delete()
+        virtwho_config_api.delete()
         assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
+            query={'search': f"name={form_data_api['name']}"}
         )
         # check the hypervisor password contains backtick
-        form_data['hypervisor_password'] = "my`password"
-        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+        form_data_api['hypervisor_password'] = "my`password"
+        virtwho_config = target_sat.api.VirtWhoConfig(**form_data_api).create()
         assert virtwho_config.status == 'unknown'
         command = get_configure_command(virtwho_config.id, default_org.name)
         deploy_status = deploy_configure_by_command_check(command)
@@ -372,11 +343,13 @@ class TestVirtWhoConfigforEsx:
         )
         virtwho_config.delete()
         assert not target_sat.api.VirtWhoConfig().search(
-            query={'search': f"name={form_data['name']}"}
+            query={'search': f"name={form_data_api['name']}"}
         )
 
     @pytest.mark.tier2
-    def test_positive_remove_env_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_remove_env_option(
+        self, default_org, form_data_api, virtwho_config_api, target_sat
+    ):
         """remove option 'env=' from the virt-who configuration file and without any error
 
         :id: 981b6828-a7ed-46d9-9c6c-9fb22af4011e
@@ -394,19 +367,19 @@ class TestVirtWhoConfigforEsx:
         :BZ: 1834897
 
         """
-        command = get_configure_command(virtwho_config.id, default_org.name)
+        command = get_configure_command(virtwho_config_api.id, default_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=default_org.label
+            command, form_data_api['hypervisor_type'], debug=True, org=default_org.label
         )
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
         option = "env"
-        config_file = get_configure_file(virtwho_config.id)
+        config_file = get_configure_file(virtwho_config_api.id)
         env_error = (
             f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
         )

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -16,50 +16,22 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data(default_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
-        'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
-        'organization_id': default_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
-        'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -71,23 +43,11 @@ class TestVirtWhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=default_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
+        hypervisor_name, guest_name = deploy_type_api
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
@@ -120,7 +80,7 @@ class TestVirtWhoConfigforHyperv:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -136,11 +96,11 @@ class TestVirtWhoConfigforHyperv:
         """
         values = ['uuid', 'hostname']
         for value in values:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, default_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_api['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -16,50 +16,21 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
-        'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
-        'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -71,30 +42,17 @@ class TestVirtWhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -109,11 +67,11 @@ class TestVirtWhoConfigforHyperv:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -16,58 +16,23 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
-    get_guest_info,
 )
 
 
-@pytest.fixture()
-def form_data(default_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization_id': default_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'kubeconfig_path': settings.virtwho.kubevirt.hypervisor_config_file,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
-@pytest.fixture(autouse=True)
-def delete_host(form_data, target_sat):
-    guest_name, _ = get_guest_info(form_data['hypervisor_type'])
-    results = target_sat.api.Host().search(query={'search': guest_name})
-    if results:
-        target_sat.api.Host(id=results[0].read_json()['id']).delete()
-
-
-@pytest.mark.usefixtures('delete_host')
+@pytest.mark.delete_host
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -79,80 +44,11 @@ class TestVirtWhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=default_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
+        hypervisor_name, guest_name = deploy_type_api
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
-            .status
-        )
-        assert virt_who_instance == 'ok'
-        hosts = [
-            (
-                hypervisor_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL',
-            ),
-            (
-                guest_name,
-                f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED',
-            ),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization': default_org.name, 'search': sku}
-            )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
-            )
-            result = target_sat.api.Host().search(query={'search': hostname})[0].read_json()
-            assert result['subscription_status_label'] == 'Fully entitled'
-
-    @pytest.mark.tier2
-    def test_positive_deploy_configure_by_script(
-        self, default_org, form_data, virtwho_config, target_sat
-    ):
-        """Verify "GET /foreman_virt_who_configure/api/
-
-        v2/configs/:id/deploy_script"
-
-        :id: 77100dc7-644a-44a4-802a-2da562246cba
-
-        :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
-
-        :CaseImportance: High
-        """
-        assert virtwho_config.status == 'unknown'
-        script = virtwho_config.deploy_script()
-        hypervisor_name, guest_name = deploy_configure_by_script(
-            script['virt_who_config_script'],
-            form_data['hypervisor_type'],
-            debug=True,
-            org=default_org.label,
-        )
-        virt_who_instance = (
-            target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
@@ -185,7 +81,7 @@ class TestVirtWhoConfigforKubevirt:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -201,11 +97,11 @@ class TestVirtWhoConfigforKubevirt:
         """
         values = ['uuid', 'hostname']
         for value in values:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, default_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=default_org.label
+                command, form_data_api['hypervisor_type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -14,48 +14,21 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'kubeconfig_path': settings.virtwho.kubevirt.hypervisor_config_file,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -67,30 +40,17 @@ class TestVirtWhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -105,11 +65,11 @@ class TestVirtWhoConfigforKubevirt:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -14,49 +14,21 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.libvirt.hypervisor_type,
-        'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -68,30 +40,17 @@ class TestVirtWhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT /foreman_virt_who_configure/api/v2/configs/:id"
 
@@ -104,11 +63,11 @@ class TestVirtWhoConfigforLibvirt:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -16,10 +16,8 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
     deploy_configure_by_script,
@@ -29,38 +27,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
-def form_data(module_sca_manifest_org, target_sat):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor_id': 'hostname',
-        'hypervisor_type': settings.virtwho.ahv.hypervisor_type,
-        'hypervisor_server': settings.virtwho.ahv.hypervisor_server,
-        'organization_id': module_sca_manifest_org.id,
-        'filtering_mode': 'none',
-        'satellite_url': target_sat.hostname,
-        'hypervisor_username': settings.virtwho.ahv.hypervisor_username,
-        'hypervisor_password': settings.virtwho.ahv.hypervisor_password,
-        'prism_flavor': settings.virtwho.ahv.prism_flavor,
-    }
-    return form
-
-
-@pytest.fixture()
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
-    yield virtwho_config
-    virtwho_config.delete()
-    assert not target_sat.api.VirtWhoConfig().search(query={'search': f"name={form_data['name']}"})
-
-
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_api, target_sat, deploy_type_api
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs"
 
@@ -72,30 +43,17 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        assert virtwho_config.status == 'unknown'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = virtwho_config.deploy_script()
-            deploy_configure_by_script(
-                script['virt_who_config_script'],
-                form_data['hypervisor_type'],
-                debug=True,
-                org=module_sca_manifest_org.label,
-            )
+        assert virtwho_config_api.status == 'unknown'
         virt_who_instance = (
             target_sat.api.VirtWhoConfig()
-            .search(query={'search': f'name={virtwho_config.name}'})[0]
+            .search(query={'search': f'name={virtwho_config_api.name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify hypervisor_id option by "PUT
 
@@ -110,19 +68,19 @@ class TestVirtWhoConfigforNutanix:
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
-            virtwho_config.hypervisor_id = value
-            virtwho_config.update(['hypervisor_id'])
-            config_file = get_configure_file(virtwho_config.id)
-            command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+            virtwho_config_api.hypervisor_id = value
+            virtwho_config_api.update(['hypervisor_id'])
+            config_file = get_configure_file(virtwho_config_api.id)
+            command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+                command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, target_sat, deploy_type
+        self, module_sca_manifest_org, form_data_api, target_sat, deploy_type
     ):
         """Verify "POST /foreman_virt_who_configure/api/v2/configs" on nutanix prism central mode
 
@@ -136,19 +94,22 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        form_data['prism_flavor'] = "central"
-        virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
+        form_data_api['prism_flavor'] = "central"
+        virtwho_config = target_sat.api.VirtWhoConfig(**form_data_api).create()
         assert virtwho_config.status == 'unknown'
         if deploy_type == "id":
             command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
+                command,
+                form_data_api['hypervisor_type'],
+                debug=True,
+                org=module_sca_manifest_org.label,
             )
         elif deploy_type == "script":
             script = virtwho_config.deploy_script()
             deploy_configure_by_script(
                 script['virt_who_config_script'],
-                form_data['hypervisor_type'],
+                form_data_api['hypervisor_type'],
                 debug=True,
                 org=module_sca_manifest_org.label,
             )
@@ -164,7 +125,7 @@ class TestVirtWhoConfigforNutanix:
 
     @pytest.mark.tier2
     def test_positive_prism_central_prism_central_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify prism_flavor option by "PUT
 
@@ -179,11 +140,11 @@ class TestVirtWhoConfigforNutanix:
         :CaseImportance: Medium
         """
         value = 'central'
-        virtwho_config.prism_flavor = value
-        virtwho_config.update(['prism_flavor'])
-        config_file = get_configure_file(virtwho_config.id)
-        command = get_configure_command(virtwho_config.id, module_sca_manifest_org.name)
+        virtwho_config_api.prism_flavor = value
+        virtwho_config_api.update(['prism_flavor'])
+        config_file = get_configure_file(virtwho_config_api.id)
+        command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor_type'], org=module_sca_manifest_org.label
+            command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
         )
         assert get_configure_option("prism_central", config_file) == 'true'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12620

Tasks:

fixture support for virt-who config api : data_form deploy_type virtwho_config
depend on #12619 remove content for manifest
Cases PASS:
```
(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx**.py
                                                                                                           

tests/foreman/virtwho/api/test_esx.py ..........                                                                                                                                                            [ 43%]
tests/foreman/virtwho/api/test_esx_sca.py .............                                                                                                                                                     [100%]

=====================================================================23 passed, 23 deselected, 138 warnings in 1878.02s (0:31:18) ======================================================================
(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ 

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_hyperv**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 35 warnings in 1099.90s (0:18:19)
(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_kubevirt**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 37 warnings in 906.93s (0:15:06)

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_libvirt**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 35 warnings in 565.59s (0:09:25)

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix**.py --disable-pytest-warnings -q
.............                                                                                                                                                                                               [100%]
13 passed, 13 deselected, 90 warnings in 1388.06s (0:23:08)
```