### PR TITLE
[6.14.z] Optional pytest Vault login and code nitpicking

### DIFF
--- a/robottelo/utils/vault.py
+++ b/robottelo/utils/vault.py
@@ -19,25 +19,31 @@ class Vault:
 
     def __init__(self, env_file='.env'):
         self.env_path = robottelo_root_dir.joinpath(env_file)
+        self.envdata = None
+        self.vault_enabled = None
 
     def setup(self):
-        self.export_vault_addr()
+        if self.env_path.exists():
+            self.envdata = self.env_path.read_text()
+            is_enabled = re.findall('\nVAULT_ENABLED_FOR_DYNACONF=(.*)', self.envdata)
+            if is_enabled:
+                self.vault_enabled = is_enabled[0]
+            self.export_vault_addr()
 
     def teardown(self):
         del os.environ['VAULT_ADDR']
 
     def export_vault_addr(self):
-        envdata = self.env_path.read_text()
-        vaulturl = re.findall('VAULT_URL_FOR_DYNACONF=(.*)', envdata)[0]
+        vaulturl = re.findall('VAULT_URL_FOR_DYNACONF=(.*)', self.envdata)[0]
 
         # Set Vault CLI Env Var
         os.environ['VAULT_ADDR'] = vaulturl
 
         # Dynaconf Vault Env Vars
-        if re.findall('VAULT_ENABLED_FOR_DYNACONF=(.*)', envdata)[0] == 'true':
+        if self.vault_enabled and self.vault_enabled in ['True', 'true']:
             if 'localhost:8200' in vaulturl:
                 raise InvalidVaultURLForOIDC(
-                    f"{vaulturl} doesnt supports OIDC login,"
+                    f"{vaulturl} doesn't support OIDC login,"
                     "please change url to corp vault in env file!"
                 )
 
@@ -63,7 +69,11 @@ class Vault:
         return vcommand
 
     def login(self, **kwargs):
-        if 'VAULT_SECRET_ID_FOR_DYNACONF' not in os.environ:
+        if (
+            self.vault_enabled
+            and self.vault_enabled in ['True', 'true']
+            and 'VAULT_SECRET_ID_FOR_DYNACONF' not in os.environ
+        ):
             if self.status(**kwargs).returncode != 0:
                 logger.warning(
                     "Warning! The browser is about to open for vault OIDC login, "
@@ -81,22 +91,22 @@ class Vault:
                 ).stdout
                 token = json.loads(str(token.decode('UTF-8')))['data']['id']
                 # Setting new token in env file
-                envdata = self.env_path.read_text()
-                envdata = re.sub(
-                    '.*VAULT_TOKEN_FOR_DYNACONF=.*', f"VAULT_TOKEN_FOR_DYNACONF={token}", envdata
+                _envdata = re.sub(
+                    '.*VAULT_TOKEN_FOR_DYNACONF=.*',
+                    f"VAULT_TOKEN_FOR_DYNACONF={token}",
+                    self.envdata,
                 )
-                self.env_path.write_text(envdata)
+                self.env_path.write_text(_envdata)
                 logger.info(
                     "Success! New OIDC token added to .env file to access secrets from vault!"
                 )
 
     def logout(self):
         # Teardown - Setting dymmy token in env file
-        envdata = self.env_path.read_text()
-        envdata = re.sub(
-            '.*VAULT_TOKEN_FOR_DYNACONF=.*', "# VAULT_TOKEN_FOR_DYNACONF=myroot", envdata
+        _envdata = re.sub(
+            '.*VAULT_TOKEN_FOR_DYNACONF=.*', "# VAULT_TOKEN_FOR_DYNACONF=myroot", self.envdata
         )
-        self.env_path.write_text(envdata)
+        self.env_path.write_text(_envdata)
         self.exec_vault_command('vault token revoke -self')
         logger.info("Success! OIDC token removed from Env file successfully!")
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12822

This PR brings optional logging to the vault from pytest session requested by the community. 

- Multiple options to bypass vault login,  where pytest session won't insist on logging into Vault. :
  - No `.env` file
  - `VAULT_ENABLED_FOR_DYNACONF` option is set to `False` in `.env` file
  - Commented out VAULT_ENABLED_FOR_DYNACONF` option in `.env` file
  - No `VAULT_ENABLED_FOR_DYNACONF` option in `.env` file
- Also made some code nitpicking changes !