### PR TITLE
Initial commit to test updated sat util url

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -47,6 +47,8 @@ from robottelo.utils.virtwho import create_fake_hypervisor_content
 if not setting_is_set('clients') or not setting_is_set('fake_manifest'):
     pytest.skip('skipping tests due to missing settings', allow_module_level=True)
 
+pytestmark = [pytest.mark.no_containers]
+
 
 @pytest.fixture(scope='module', autouse=True)
 def host_ui_default():
@@ -82,7 +84,9 @@ def vm(module_repos_collection_with_manifest, rhel7_contenthost, target_sat):
 @pytest.fixture
 def vm_module_streams(module_repos_collection_with_manifest, rhel8_contenthost, target_sat):
     """Virtual machine registered in satellite"""
-    module_repos_collection_with_manifest.setup_virtual_machine(rhel8_contenthost)
+    module_repos_collection_with_manifest.setup_virtual_machine(
+        rhel8_contenthost, enable_custom_repos=True
+    )
     rhel8_contenthost.add_rex_key(satellite=target_sat)
     yield rhel8_contenthost
 


### PR DESCRIPTION
- 11 tests from `foreman.ui.test_contenthost` was failing due to the formation of wrong Satellite Util repository URL, ultimately was failing to sync repo and ended up with **CLIReturnCodeError**
- Because of that expected module - stream didn't found for further operation on content host stream tab
- These changes will resolve the problem mentioned above.

**Note:** 
1. Below 9 tests from `test_contenthost.py` will be part of this PR
```
test_install_modular_errata
test_module_status_update_from_content_host_to_satellite
test_module_status_update_without_force_upload_package_profile
test_module_stream_update_from_satellite
test_set_syspurpose_attributes_cli
test_syspurpose_attributes_empty
test_syspurpose_matched
test_syspurpose_mismatched
test_unset_syspurpose_attributes_cli
```
2. Still 2 tests are failing will be addressed in another PR
```
test_module_stream_actions_on_content_host
test_module_streams_customize_action
```