### PR TITLE
[6.13.z] Coverage for autoprovision and reboot of discovered host

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -38,6 +38,7 @@ pytest_plugins = [
     'pytest_fixtures.component.computeprofile',
     'pytest_fixtures.component.contentview',
     'pytest_fixtures.component.domain',
+    'pytest_fixtures.component.discovery',
     'pytest_fixtures.component.host',
     'pytest_fixtures.component.hostgroup',
     'pytest_fixtures.component.http_proxy',

--- a/pytest_fixtures/component/discovery.py
+++ b/pytest_fixtures/component/discovery.py
@@ -1,0 +1,31 @@
+from fauxfactory import gen_string
+import pytest
+
+
+@pytest.fixture(scope='module')
+def module_discovery_hostgroup(module_org, module_location, module_target_sat):
+    host = module_target_sat.api.Host(organization=module_org, location=module_location).create()
+    return module_target_sat.api.HostGroup(
+        organization=[module_org],
+        location=[module_location],
+        medium=host.medium,
+        root_pass=gen_string('alpha'),
+        operatingsystem=host.operatingsystem,
+        ptable=host.ptable,
+        domain=host.domain,
+        architecture=host.architecture,
+    ).create()
+
+
+@pytest.fixture(scope='module')
+def discovery_org(module_org, module_target_sat):
+    discovery_org = module_target_sat.update_setting('discovery_organization', module_org.name)
+    yield module_org
+    module_target_sat.update_setting('discovery_organization', discovery_org)
+
+
+@pytest.fixture(scope='module')
+def discovery_location(module_location, module_target_sat):
+    discovery_loc = module_target_sat.update_setting('discovery_location', module_location.name)
+    yield module_location
+    module_target_sat.update_setting('discovery_location', discovery_loc)

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -247,8 +247,6 @@ class TestDiscoveredHost:
 
         :expectedresults: Host should be provisioned successfully
 
-        :CaseAutomation: NotAutomated
-
         :CaseImportance: Critical
         """
         sat = module_discovery_sat.sat
@@ -274,9 +272,10 @@ class TestDiscoveredHost:
             assert not sat.api.Host().search(query={"search": f'name={host.name}'})
         pxeless_discovery_host.blank = True
 
-    @pytest.mark.stubbed
     @pytest.mark.tier3
-    def test_positive_auto_provision_pxe_host(self):
+    def test_positive_auto_provision_pxe_host(
+        self, module_discovery_hostgroup, module_target_sat, discovery_org, discovery_location
+    ):
         """Auto provision a pxe-based host by executing discovery rules
 
         :id: c93fd7c9-41ef-4eb5-8042-f72e87e67e10
@@ -290,14 +289,24 @@ class TestDiscoveredHost:
 
         :expectedresults: Selected Host should be auto-provisioned successfully
 
-        :CaseAutomation: Automated
-
         :CaseImportance: Critical
         """
+        discovered_host = module_target_sat.api_factory.create_discovered_host()
 
-    @pytest.mark.stubbed
+        rule = module_target_sat.api.DiscoveryRule(
+            max_count=1,
+            hostgroup=module_discovery_hostgroup,
+            search_=f'name = {discovered_host["name"]}',
+            location=[discovery_location],
+            organization=[discovery_org],
+        ).create()
+        result = module_target_sat.api.DiscoveredHost(id=discovered_host['id']).auto_provision()
+        assert f'provisioned with rule {rule.name}' in result['message']
+
     @pytest.mark.tier3
-    def test_positive_auto_provision_all(self):
+    def test_positive_auto_provision_all(
+        self, module_discovery_hostgroup, module_target_sat, discovery_org, discovery_location
+    ):
         """Auto provision all host by executing discovery rules
 
         :id: 954d3688-62d9-47f7-9106-a4fff8825ffa
@@ -314,6 +323,19 @@ class TestDiscoveredHost:
 
         :CaseImportance: High
         """
+        module_target_sat.api.DiscoveryRule(
+            max_count=25,
+            hostgroup=module_discovery_hostgroup,
+            search_=f'location = "{discovery_location.name}"',
+            location=[discovery_location],
+            organization=[discovery_org],
+        ).create()
+
+        for _ in range(2):
+            module_target_sat.api_factory.create_discovered_host()
+
+        result = module_target_sat.api.DiscoveredHost().auto_provision_all()
+        assert '2 discovered hosts were provisioned' in result['message']
 
     @pytest.mark.stubbed
     @pytest.mark.tier3
@@ -337,9 +359,19 @@ class TestDiscoveredHost:
         :CaseImportance: High
         """
 
-    @pytest.mark.stubbed
+    @pytest.mark.on_premises_provisioning
+    @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
+    @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
+    @pytest.mark.rhel_ver_match('9')
     @pytest.mark.tier3
-    def test_positive_reboot_pxe_host(self):
+    def test_positive_reboot_pxe_host(
+        self,
+        module_provisioning_rhel_content,
+        module_discovery_sat,
+        provisioning_host,
+        provisioning_hostgroup,
+        pxe_loader,
+    ):
         """Rebooting a pxe based discovered host
 
         :id: 69c807f8-5646-4aa6-8b3c-5ecab69560fc
@@ -352,10 +384,23 @@ class TestDiscoveredHost:
 
         :expectedresults: Selected host should be rebooted successfully
 
-        :CaseAutomation: Automated
-
         :CaseImportance: Medium
         """
+        sat = module_discovery_sat.sat
+        provisioning_host.power_control(ensure=False)
+        mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+        wait_for(
+            lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
+            timeout=240,
+            delay=20,
+        )
+        discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]
+        discovered_host.hostgroup = provisioning_hostgroup
+        discovered_host.location = provisioning_hostgroup.location[0]
+        discovered_host.organization = provisioning_hostgroup.organization[0]
+        discovered_host.build = True
+        result = sat.api.DiscoveredHost(id=discovered_host.id).reboot()
+        assert 'Unable to perform reboot' not in result
 
     @pytest.mark.stubbed
     @pytest.mark.tier3
@@ -380,8 +425,6 @@ class TestDiscoveredHost:
 
 class TestFakeDiscoveryTests:
     """Tests that use fake discovered host.
-
-    :CaseAutomation: Automated
 
     :CaseImportance: High
     """


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12815

1. Adding coverage for the auto-provision and reboot API endpoints for a single host.
2. Adding coverage for the auto-provision of multiple discovered hosts.
