### PR TITLE
Add gitleaks to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,33 @@
 # configuration for pre-commit git hooks
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-  - id: trailing-whitespace
-    exclude: tests/foreman/data/
-  - id: check-yaml
-  - id: debug-statements
-- repo: https://github.com/psf/black
-  rev: 22.10.0
-  hooks:
-  - id: black
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.277
-  hooks:
-    - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
-- repo: local
-  hooks:
-    - id: fix-uuids
-      name: Robottelo Custom Fix UUIDs script
-      description: This hook runs the scripts/fix_uuids.sh script
-      language: script
-      entry: scripts/fix_uuids.sh
-      verbose: true
-      types: [text]
-      require_serial: true
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: trailing-whitespace
+      exclude: tests/foreman/data/
+    - id: check-yaml
+    - id: debug-statements
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.277
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+  - repo: local
+    hooks:
+      - id: fix-uuids
+        name: Robottelo Custom Fix UUIDs script
+        description: This hook runs the scripts/fix_uuids.sh script
+        language: script
+        entry: scripts/fix_uuids.sh
+        verbose: true
+        types: [text]
+        require_serial: true
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
This will prevent secrets from being committed to the repository. Handling it in pre-commit because a check in actions is too late.