### PR TITLE
Remove katello-agent from helpers and mixins

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -69,6 +69,7 @@ def module_rhst_repo(module_target_sat, module_org_with_manifest, module_promote
     )
     cv.publish()
     cv = cv.read()
+    cv.version.sort(key=lambda version: version.id)
     cv.version[-1].promote(data={'environment_ids': module_lce.id})
     return REPOS['rhst7']['id']
 

--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -721,18 +721,16 @@ class RepositoryCollection:
         vm,
         location_title=None,
         patch_os_release=False,
-        install_katello_agent=True,
         enable_rh_repos=True,
         enable_custom_repos=False,
         configure_rhel_repo=False,
     ):
         """
         Setup The virtual machine basic task, eg: install katello ca,
-        register vm host, enable rh repos and install katello-agent
+        register vm host and enable rh repos
 
         :param robottelo.hosts.ContentHost vm: The Virtual machine to setup.
         :param bool patch_os_release: whether to patch the VM with os version.
-        :param bool install_katello_agent: whether to install katello-agent
         :param bool enable_rh_repos: whether to enable RH repositories
         :param bool enable_custom_repos: whether to enable custom repositories
         :param bool configure_rhel_repo: Whether to configure the distro Red Hat repository,
@@ -762,7 +760,6 @@ class RepositoryCollection:
             product_label=self.custom_product['label'] if self.custom_product else None,
             activation_key=self._setup_content_data['activation_key']['name'],
             patch_os_release_distro=patch_os_release_distro,
-            install_katello_agent=install_katello_agent,
         )
         if configure_rhel_repo:
             rhel_repo_option_name = f'rhel{constants.DISTROS_MAJOR_VERSION[self.distro]}_os'

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -65,7 +65,6 @@ CaseComponent:
     - Infrastructure
     - Installer
     - InterSatelliteSync
-    - katello-agent
     - katello-tracer
     - LDAP
     - Leappintegration

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -562,7 +562,6 @@ def test_positive_incremental_update_required(
     rhel7_contenthost.register_contenthost(module_org.label, activation_key.name)
     assert rhel7_contenthost.subscribed
     rhel7_contenthost.enable_repo(constants.REPOS['rhst7']['id'])
-    rhel7_contenthost.install_katello_agent()
     host = rhel7_contenthost.nailgun_host
     # install package to create demand for an Erratum
     assert rhel7_contenthost.run(f'yum install -y {constants.FAKE_1_CUSTOM_PACKAGE}').status == 0
@@ -670,9 +669,7 @@ def test_errata_installation_with_swidtags(
             'appstream': settings.repos.rhel8_os.appstream,
         }
     )
-    module_repos_collection_with_manifest.setup_virtual_machine(
-        rhel8_contenthost, install_katello_agent=False
-    )
+    module_repos_collection_with_manifest.setup_virtual_machine(rhel8_contenthost)
 
     # install older module stream
     rhel8_contenthost.add_rex_key(satellite=target_sat)

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1948,9 +1948,9 @@ def test_positive_attach(
         }
     )
     host_subscription_client.enable_repo(module_rhst_repo)
-    # ensure that katello agent can be installed
+    # ensure that katello-host-tools can be installed
     try:
-        host_subscription_client.install_katello_agent()
+        host_subscription_client.install_katello_host_tools()
     except ContentHostError:
         pytest.fail('ContentHostError raised unexpectedly!')
 
@@ -1995,9 +1995,9 @@ def test_positive_attach_with_lce(
         }
     )
     host_subscription_client.enable_repo(module_rhst_repo)
-    # ensure that katello agent can be installed
+    # ensure that katello-host-tools can be installed
     try:
-        host_subscription_client.install_katello_agent()
+        host_subscription_client.install_katello_host_tools()
     except ContentHostError:
         pytest.fail('ContentHostError raised unexpectedly!')
 
@@ -2209,9 +2209,9 @@ def test_positive_auto_attach(
     )
     Host.subscription_auto_attach({'host-id': host['id']})
     host_subscription_client.enable_repo(module_rhst_repo)
-    # ensure that katello agent can be installed
+    # ensure that katello-host-tools can be installed
     try:
-        host_subscription_client.install_katello_agent()
+        host_subscription_client.install_katello_host_tools()
     except ContentHostError:
         pytest.fail('ContentHostError raised unexpectedly!')
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -910,7 +910,6 @@ def test_positive_generate_hostpkgcompare(
             assert client.subscribed
             clients.append(client)
             client.enable_repo(REPOS['rhst7']['id'])
-            client.install_katello_agent()
         clients.sort(key=lambda client: client.hostname)
         hosts_info = [Host.info({'name': client.hostname}) for client in clients]
 

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -67,10 +67,8 @@ def test_vm_install_package(repos_collection, function_entitlement_manifest_org,
     # Create repos, content view, and activation key.
     repos_collection.setup_content(function_entitlement_manifest_org.id, lce['id'])
     with Broker(nick=distro, host_class=ContentHost) as host:
-        # install katello-agent
-        repos_collection.setup_virtual_machine(
-            host, enable_custom_repos=True, install_katello_agent=False
-        )
+        # enable custom repos
+        repos_collection.setup_virtual_machine(host, enable_custom_repos=True)
         # install a package from custom repo
         result = host.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE}')
         assert result.status == 0

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -53,7 +53,7 @@ def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
         ],
     )
     repos_collection.setup_content(org.id, lce.id, upload_manifest=False, override=True)
-    repos_collection.setup_virtual_machine(rhel7_contenthost, install_katello_agent=False)
+    repos_collection.setup_virtual_machine(rhel7_contenthost)
     result = rhel7_contenthost.execute(f'yum -y install {FAKE_1_CUSTOM_PACKAGE}')
     assert result.status == 0
     assert target_sat.cli.Service.stop(options={'only': 'foreman'}).status == 0

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -103,7 +103,7 @@ def test_positive_end_to_end_register(
     repos_collection.setup_content(org.id, lce.id, upload_manifest=False)
     ak_name = repos_collection.setup_content_data['activation_key']['name']
 
-    repos_collection.setup_virtual_machine(rhel7_contenthost, install_katello_agent=False)
+    repos_collection.setup_virtual_machine(rhel7_contenthost)
     with session:
         session.organization.select(org.name)
         session.location.select(default_location.name)

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -81,10 +81,8 @@ def vm(module_repos_collection_with_manifest, rhel7_contenthost, target_sat):
 
 @pytest.fixture
 def vm_module_streams(module_repos_collection_with_manifest, rhel8_contenthost, target_sat):
-    """Virtual machine registered in satellite without katello-agent installed"""
-    module_repos_collection_with_manifest.setup_virtual_machine(
-        rhel8_contenthost, install_katello_agent=False
-    )
+    """Virtual machine registered in satellite"""
+    module_repos_collection_with_manifest.setup_virtual_machine(rhel8_contenthost)
     rhel8_contenthost.add_rex_key(satellite=target_sat)
     yield rhel8_contenthost
 

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -261,7 +261,7 @@ def test_positive_user_access_with_host_filter(
         rhel_contenthost.add_rex_key(target_sat)
         repos_collection.setup_content(org.id, lce.id, upload_manifest=False)
         repos_collection.setup_virtual_machine(
-            rhel_contenthost, location_title=module_location.name, install_katello_agent=False
+            rhel_contenthost, location_title=module_location.name
         )
         rhel_contenthost.run('subscription-manager repos --enable "*"')
         result = rhel_contenthost.run(f'yum install -y {FAKE_7_CUSTOM_PACKAGE}')

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -484,9 +484,7 @@ def test_positive_apply_for_all_hosts(
         nick=module_repos_collection_with_setup.distro, host_class=ContentHost, _count=2
     ) as clients:
         for client in clients:
-            module_repos_collection_with_setup.setup_virtual_machine(
-                client, install_katello_agent=False
-            )
+            module_repos_collection_with_setup.setup_virtual_machine(client)
             client.add_rex_key(satellite=target_sat)
             assert _install_client_package(client, FAKE_1_CUSTOM_PACKAGE)
         with session:
@@ -582,9 +580,7 @@ def test_positive_filter_by_environment(
         nick=module_repos_collection_with_setup.distro, host_class=ContentHost, _count=2
     ) as clients:
         for client in clients:
-            module_repos_collection_with_setup.setup_virtual_machine(
-                client, install_katello_agent=False
-            )
+            module_repos_collection_with_setup.setup_virtual_machine(client)
             assert _install_client_package(client, FAKE_1_CUSTOM_PACKAGE, errata_applicability=True)
         # Promote the latest content view version to a new lifecycle environment
         content_view = entities.ContentView(

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1845,9 +1845,7 @@ def test_positive_update_delete_package(
     """
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(
-        client, target_sat, install_katello_agent=False
-    )
+    module_repos_collection_with_setup.setup_virtual_machine(client, target_sat)
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         if not is_open('BZ:2132680'):
@@ -1966,9 +1964,7 @@ def test_positive_apply_erratum(
     # install package
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(
-        client, target_sat, install_katello_agent=False
-    )
+    module_repos_collection_with_setup.setup_virtual_machine(client, target_sat)
     errata_id = settings.repos.yum_3.errata[25]
     client.run(f'yum install -y {FAKE_7_CUSTOM_PACKAGE}')
     result = client.run(f'rpm -q {FAKE_7_CUSTOM_PACKAGE}')
@@ -2049,9 +2045,7 @@ def test_positive_crud_module_streams(
     module_name = 'duck'
     client = rhel_contenthost
     client.add_rex_key(target_sat)
-    module_repos_collection_with_setup.setup_virtual_machine(
-        client, target_sat, install_katello_agent=False
-    )
+    module_repos_collection_with_setup.setup_virtual_machine(client, target_sat)
     with session:
         session.location.select(loc_name=DEFAULT_LOC)
         streams = session.host_new.get_module_streams(client.hostname, module_name)

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -74,7 +74,7 @@ def vm_content_hosts(smart_proxy_location, module_repos_collection, module_targe
     distro = module_repos_collection.distro
     with Broker(nick=distro, host_class=ContentHost, _count=2) as clients:
         for client in clients:
-            module_repos_collection.setup_virtual_machine(client, install_katello_agent=False)
+            module_repos_collection.setup_virtual_machine(client)
             client.add_rex_key(satellite=module_target_sat)
             module_target_sat.api_factory.update_vm_host_location(client, smart_proxy_location.id)
         yield clients
@@ -86,9 +86,7 @@ def vm_content_hosts_module_stream(
 ):
     with Broker(nick='rhel8', host_class=ContentHost, _count=2) as clients:
         for client in clients:
-            module_repos_collection_with_manifest.setup_virtual_machine(
-                client, install_katello_agent=False
-            )
+            module_repos_collection_with_manifest.setup_virtual_machine(client)
             client.add_rex_key(satellite=module_target_sat)
             module_target_sat.api_factory.update_vm_host_location(client, smart_proxy_location.id)
         yield clients
@@ -567,8 +565,7 @@ def test_positive_change_assigned_content(
     :steps:
         1. Setup activation key with content view that contain product
            repositories
-        2. Prepare hosts (minimum 2) and subscribe them to activation key,
-           katello agent must be also installed and running on each host
+        2. Prepare hosts (minimum 2) and subscribe them to activation key
         3. Create a host collection and add the hosts to it
         4. Run "subscription-manager repos" command on each host to notice
            the repos urls current values

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -315,7 +315,6 @@ def test_positive_view_vdc_subscription_products(
         target_sat,
         org.label,
         activation_key=repos_collection.setup_content_data['activation_key']['name'],
-        install_katello_agent=False,
     )
     with session:
         session.organization.select(org.name)


### PR DESCRIPTION
Katello agent was deprecated and is being removed from 6.15, the functionality will be replaced by REX.
This PR removes the references from helpers, mixins and tests from where they were used.
