### PR TITLE
[6.12.z] Fix typo for organization field in global registration

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1354,7 +1354,7 @@ def test_global_registration_with_capsule_host(
         session.location.select(loc_name=module_location.name)
         cmd = session.host.get_register_command(
             {
-                'general.orgnization': module_org.name,
+                'general.organization': module_org.name,
                 'general.location': module_location.name,
                 'general.operating_system': default_os.title,
                 'general.capsule': capsule_configured.hostname,

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -535,7 +535,7 @@ def test_insights_registration_with_capsule(
         cmd = session.host.get_register_command(
             {
                 'general.operating_system': default_os.title,
-                'general.orgnization': org.name,
+                'general.organization': org.name,
                 'general.capsule': rhcloud_capsule.hostname,
                 'advanced.activation_keys': ak.name,
                 'general.insecure': True,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12902

Found this while discussing on https://github.com/SatelliteQE/robottelo/pull/12901#discussion_r1357977814