### PR TITLE
[6.14.z] Fix packages status

### DIFF
--- a/robottelo/cli/sm_packages.py
+++ b/robottelo/cli/sm_packages.py
@@ -51,6 +51,7 @@ class Packages(Base):
     def status(cls, options=None):
         """Build satellite-maintain packages status"""
         cls.command_sub = 'status'
+        cls.command_end = None
         options = options or {}
         return cls.sm_execute(cls._construct_command(options))
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12845

Previous package install commands are setting the command_end to the name of the package. This is causing a failure in one of our install tests. This makes sure that the status command does not pass along any package names even after an install.