### PR TITLE
Fixture collection splitting restructured

### DIFF
--- a/pytest_plugins/fixture_collection.py
+++ b/pytest_plugins/fixture_collection.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
 
         example: pytest tests/foreman --uses-fixtures target_sat module_target_sat
     '''
-    parser.addoption("--uses-fixtures", nargs='+', help=help_text)
+    parser.addoption("--uses-fixtures", nargs='?', help=help_text)
 
 
 def pytest_collection_modifyitems(items, config):
@@ -22,17 +22,18 @@ def pytest_collection_modifyitems(items, config):
         return
 
     filter_fixtures = config.getvalue('uses_fixtures')
+    fixtures_list = filter_fixtures.split(',') if ',' in filter_fixtures else [filter_fixtures]
     selected = []
     deselected = []
 
     for item in items:
-        if set(item.fixturenames).intersection(set(filter_fixtures)):
+        if set(item.fixturenames).intersection(set(fixtures_list)):
             selected.append(item)
         else:
             deselected.append(item)
     logger.debug(
         f'Selected {len(selected)} and deselected {len(deselected)} '
-        f'tests based on given fixtures {filter_fixtures} used by tests'
+        f'tests based on given fixtures {fixtures_list} used by tests'
     )
     config.hook.pytest_deselected(items=deselected)
     items[:] = selected


### PR DESCRIPTION
The processing of the list of fixtures in the command line for in Pytest Plugin `Fixture Collection` is restructured.

Earlier:
```
# pytest --uses-fixtures fix1 fix2 fix3 tests/foreman
```

Now:
```
# pytest --uses-fixtures fix1,fix2,fix3 tests/foreman
```


Issue and Fix:
---------------
Earlier pytest is used to process all the non specific arguments after `--uses-fixtures` option , e.g in example above it used to consider `tests/foreman` as fixture as well :)

Now, it process only a string after an option and splits string by comma to obtain the list of fixtures to collect the tests for all those fixtures.