### PR TITLE
Capsule N-Minus testing

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -1,4 +1,6 @@
 CAPSULE:
+  # Capsule hostname for N-minus testing
+  HOSTNAME:
   VERSION:
     # The full release version (6.9.2)
     RELEASE:  # populate with capsule version

--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -85,9 +85,9 @@ def get_ohsnap_repos(settings):
         settings,
         repo='capsule',
         product='capsule',
-        release=settings.server.version.release,
-        os_release=settings.server.version.rhel_version,
-        snap=settings.server.version.snap,
+        release=settings.capsule.version.release,
+        os_release=settings.capsule.version.rhel_version,
+        snap=settings.capsule.version.snap,
     )
 
     data['SATELLITE_REPO'] = get_ohsnap_repo_url(

--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,7 @@ pytest_plugins = [
     'pytest_plugins.requirements.update_requirements',
     'pytest_plugins.sanity_plugin',
     'pytest_plugins.video_cleanup',
+    'pytest_plugins.capsule_n-minus',
     # Fixtures
     'pytest_fixtures.core.broker',
     'pytest_fixtures.core.sat_cap_factory',

--- a/pytest_plugins/capsule_n-minus.py
+++ b/pytest_plugins/capsule_n-minus.py
@@ -1,0 +1,55 @@
+# Collection of Capsule Factory fixture tests
+# No destructive tests
+# Adjust capsule host and capsule_configured host behavior for n_minus testing
+# Calculate capsule hostname from inventory just as we do in xDist.py
+from robottelo.config import settings
+from robottelo.hosts import Capsule
+
+
+def pytest_addoption(parser):
+    """Add options for pytest to collect tests based on fixtures its using"""
+    help_text = '''
+        Collects tests based on capsule fixtures used by tests and uncollect destructive tests
+
+        Usage: --n-minus
+
+        example: pytest --n-minus tests/foreman
+    '''
+    parser.addoption("--n-minus", action='store_true', default=False, help=help_text)
+
+
+def pytest_collection_modifyitems(items, config):
+
+    if not config.getoption('n_minus', False):
+        return
+
+    selected = []
+    deselected = []
+
+    for item in items:
+        is_destructive = item.get_closest_marker('destructive')
+        # Deselect Destructive tests and tests without capsule_factory fixture
+        if 'capsule_factory' not in item.fixturenames or is_destructive:
+            deselected.append(item)
+            continue
+        # Ignoring all puppet tests as they are destructive in nature
+        # and needs its own satellite for verification
+        if 'session_puppet_enabled_sat' in item.fixturenames:
+            deselected.append(item)
+            continue
+        # Ignoring all satellite maintain tests as they are destructive in nature
+        # Also dont need them in nminus testing as its not integration testing
+        if 'sat_maintain' in item.fixturenames and 'satellite' in item.callspec.params.values():
+            deselected.append(item)
+            continue
+        selected.append(item)
+
+    config.hook.pytest_deselected(items=deselected)
+    items[:] = selected
+
+
+def pytest_sessionfinish(session, exitstatus):
+    # Unregister the capsule from CDN after all tests
+    if session.config.option.n_minus and not session.config.option.collectonly:
+        caps = Capsule.get_host_by_hostname(hostname=settings.capsule.hostname)
+        caps.unregister()

--- a/robottelo/exceptions.py
+++ b/robottelo/exceptions.py
@@ -75,6 +75,12 @@ class CLIError(Exception):
     """Indicates that a CLI command could not be run."""
 
 
+class CapsuleHostError(Exception):
+    """Indicates error in capsule configuration etc"""
+
+    pass
+
+
 class CLIBaseError(Exception):
     """Indicates that a CLI command has finished with return code different
     from zero.

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1600,6 +1600,21 @@ class Capsule(ContentHost, CapsuleMixins):
         """Get capsule features"""
         return requests.get(f'https://{self.hostname}:9090/features', verify=False).text
 
+    def enable_capsule_downstream_repos(self):
+        """Enable CDN repos and capsule downstream repos on Capsule Host"""
+        # CDN Repos
+        self.register_to_cdn()
+        for repo in getattr(constants, f"OHSNAP_RHEL{self.os_version.major}_REPOS"):
+            result = self.enable_repo(repo, force=True)
+            if result.status:
+                raise CapsuleHostError(f'Repo enable at capsule host failed\n{result.stdout}')
+        # Downstream Capsule specific Repos
+        self.download_repofile(
+            product='capsule',
+            release=settings.capsule.version.release,
+            snap=settings.capsule.version.snap,
+        )
+
     def capsule_setup(self, sat_host=None, capsule_cert_opts=None, **installer_kwargs):
         """Prepare the host and run the capsule installer"""
         self._satellite = sat_host or Satellite()
@@ -1687,7 +1702,10 @@ class Capsule(ContentHost, CapsuleMixins):
             timeout=timeout,
         )
         if result.status != 0:
-            raise SatelliteHostError(f'Failed to execute with argument: {result.stderr}')
+            raise SatelliteHostError(
+                f'Failed to execute with arguments: {installer_args} and,'
+                f' the stderr is {result.stderr}'
+            )
 
     def set_mqtt_resend_interval(self, value):
         """Set the time interval in seconds at which the notification should be

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1263,6 +1263,7 @@ class TestCapsuleContentManagement:
     def test_positive_remove_capsule_orphans(
         self,
         target_sat,
+        pytestconfig,
         capsule_configured,
         function_entitlement_manifest_org,
         function_lce_library,
@@ -1292,6 +1293,8 @@ class TestCapsuleContentManagement:
         :BZ: 22043089, 2211962
 
         """
+        if not pytestconfig.option.n_minus:
+            pytest.skip('Test cannot be run on n-minus setups session-scoped capsule')
         # Enable RHST repo and sync it to the Library LCE.
         repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -14,6 +14,8 @@ import pytest
 
 from robottelo.config import settings
 
+pytestmark = pytest.mark.destructive
+
 
 @pytest.mark.tier3
 @pytest.mark.no_containers


### PR DESCRIPTION
Changes include:
- A new pytest plugin for Capsule N-minus testing that would smart collect all capsule specific tests excluding few.
  - New option of `--n-minus` for collecting only capsule specific tests
  - tests using the caspule_factory are collected
  - destructive, maintain and puppet tests are excluded since they need a separate satellite
- Introduces new setting `hostname` in capsule conf to take capsule hostname given from CI.
- **_target_capsule_host context manager now returns the cached capsule taken from CI instead of spinning of new capsule for everytime**. 
- The CI capsule is registered once/cached to CDN for RHEL contents needed by some tests at the start of the n-minus testing and would be unregistered at the end of test session.
- Since we are using single capsule already integrated with satellite in CI, we are escaping the capsule setup from fixtures for n-minus testing
- Some test amendments for nminus testing.