### PR TITLE
[6.12.z] Fix maintain CLI caching class attributes

### DIFF
--- a/robottelo/cli/sm_packages.py
+++ b/robottelo/cli/sm_packages.py
@@ -30,6 +30,7 @@ class Packages(Base):
     def lock(cls, options=None):
         """Build satellite-maintain packages lock"""
         cls.command_sub = 'lock'
+        cls.command_end = None
         options = options or {}
         return cls.sm_execute(cls._construct_command(options))
 
@@ -37,6 +38,7 @@ class Packages(Base):
     def unlock(cls, options=None):
         """Build satellite-maintain packages unlock"""
         cls.command_sub = 'unlock'
+        cls.command_end = None
         options = options or {}
         return cls.sm_execute(cls._construct_command(options))
 
@@ -44,6 +46,7 @@ class Packages(Base):
     def is_locked(cls, options=None):
         """Build satellite-maintain packages is-locked"""
         cls.command_sub = 'is-locked'
+        cls.command_end = None
         options = options or {}
         return cls.sm_execute(cls._construct_command(options))
 
@@ -75,5 +78,6 @@ class Packages(Base):
     def check_update(cls, options=None):
         """Build satellite-maintain packages check-update"""
         cls.command_sub = 'check-update'
+        cls.command_end = None
         options = options or {}
         return cls.sm_execute(cls._construct_command(options))


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12918

Jake's #12765 added caching mechanism to the Satellite's API and CLI property.

This means that any such class property is now persistent as it is being cached now.

Fixes this pattern in ` tests.foreman.maintain.test_packages.test_positive_fm_packages_install[satellite] `:
```
sat_maintain.cli.Packages.install(packages='zsh', options={'assumeyes': True})
sat_maintain.cli.Packages.status()
```
And **cli.Packages.status()** is failing with 
```
ERROR: too many arguments

See: 'satellite-maintain packages status --help'
```

The two CLI calls run these two commands:
```
executing command:  satellite-maintain packages install --assumeyes zsh
executing command:  satellite-maintain packages status  zsh
```

Note wrongly apended **zsh** ! All successive commands have now `zsh`  being appended - caching works indeed

This issue was already handled by #12845 but no fully - it still leaves possible issues with other packages subcommands 
