### PR TITLE
Fix convert2rhel tests by CVV sort and other fixes

### DIFF
--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -61,6 +61,7 @@ def update_cv(sat, cv, lce, repos):
     cv = sat.api.ContentView(id=cv.id, repository=repos).update(["repository"])
     cv.publish()
     cv = cv.read()
+    cv.version.sort(key=lambda version: version.id)
     cv.version[-1].promote(data={'environment_ids': lce.id, 'force': False})
     return cv
 


### PR DESCRIPTION
**Description:**
1. For fetching latest CVV from CV we use index -1, and CVV list isn't sorted every time, so in such case, it tries to promote the older CVV which is already promoted  and fails to promote again with below error.
```
2023-10-21 03:22:56 - nailgun.client - WARNING - Received HTTP 400 response: {"displayMessage":"Cannot promote environment out of sequence. Use force to bypass restriction.","errors":["Cannot promote environment out of sequence. Use force to bypass restriction."]}
```
2.  <del> Add workaround for CentOS 8 to fetch archived contents from new vault mirror, as its EOL in end of 2021 and existing mirror contents are now moved to vault mirror.</del>
3. <del>Use --releasever=8.4.2105 when updating packages using yum to avoid upgrading to latest CentOS 8.5, which causes C2R to fail later.</del>