### PR TITLE
[6.14.z] Fix vault makescripts with capture output

### DIFF
--- a/pytest_plugins/auto_vault.py
+++ b/pytest_plugins/auto_vault.py
@@ -1,5 +1,4 @@
 """Plugin enables pytest to notify and update the requirements"""
-import subprocess
 
 from robottelo.utils.vault import Vault
 
@@ -7,4 +6,4 @@ from robottelo.utils.vault import Vault
 def pytest_addoption(parser):
     """Options to allow user to update the requirements"""
     with Vault() as vclient:
-        vclient.login(stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        vclient.login()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12909

Missing `Capture Output` made `make vault scripts` to break as it was trying to read and print STDOUT which was never returned due to `capture_output` was not set.

Fix:
- Set `capture_output` to True in subprocess running vault command.
- Alter logging of some events to appropriate level.

This also addresses the REGEX for Vault_enablement key in `.env` when its the first line in `.env` file.