### PR TITLE
Stream fix errata:UI (test_end_to_end)

### DIFF
--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1692,9 +1692,10 @@ def setup_org_for_a_custom_repo(options=None):
         raise CLIFactoryError(f'Failed to publish new version of content view\n{err.msg}')
     # Get the content view info
     cv_info = ContentView.info({'id': cv_id})
-    lce_promoted = cv_info['lifecycle-environments']
     assert len(cv_info['versions']) > 0
-    cvv = sorted(cvv['id'] for cvv in cv_info['versions'])[-1]
+    cv_info['versions'].sort(key=lambda version: version['id'])
+    cvv = cv_info['versions'][-1]
+    lce_promoted = cv_info['lifecycle-environments']
     # Promote version to next env
     try:
         if env_id not in [int(lce['id']) for lce in lce_promoted]:

--- a/robottelo/cli/factory.py
+++ b/robottelo/cli/factory.py
@@ -1693,12 +1693,17 @@ def setup_org_for_a_custom_repo(options=None):
     # Get the content view info
     cv_info = ContentView.info({'id': cv_id})
     lce_promoted = cv_info['lifecycle-environments']
-    cvv = cv_info['versions'][-1]
+    assert len(cv_info['versions']) > 0
+    cvv = sorted(cvv['id'] for cvv in cv_info['versions'])[-1]
     # Promote version to next env
     try:
         if env_id not in [int(lce['id']) for lce in lce_promoted]:
             ContentView.version_promote(
-                {'id': cvv['id'], 'organization-id': org_id, 'to-lifecycle-environment-id': env_id}
+                {
+                    'id': cvv['id'],
+                    'organization-id': org_id,
+                    'to-lifecycle-environment-id': env_id,
+                }
             )
     except CLIReturnCodeError as err:
         raise CLIFactoryError(f'Failed to promote version to next environment\n{err.msg}')

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -630,14 +630,15 @@ class CLIFactory:
             raise CLIFactoryError(f'Failed to publish new version of content view\n{err.msg}')
         # Get the version id
         cv_info = self._satellite.cli.ContentView.info({'id': cv_id})
+        assert len(cv_info['versions']) > 0
+        cvv_id = sorted(cvv['id'] for cvv in cv_info['versions'])[-1]
         lce_promoted = cv_info['lifecycle-environments']
-        cvv = cv_info['versions'][-1]
         # Promote version to next env
         try:
             if env_id not in [int(lce['id']) for lce in lce_promoted]:
                 self._satellite.cli.ContentView.version_promote(
                     {
-                        'id': cvv['id'],
+                        'id': cvv_id,
                         'organization-id': org_id,
                         'to-lifecycle-environment-id': env_id,
                     }

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -631,14 +631,15 @@ class CLIFactory:
         # Get the version id
         cv_info = self._satellite.cli.ContentView.info({'id': cv_id})
         assert len(cv_info['versions']) > 0
-        cvv_id = sorted(cvv['id'] for cvv in cv_info['versions'])[-1]
+        cv_info['versions'].sort(key=lambda version: version['id'])
+        cvv = cv_info['versions'][-1]
         lce_promoted = cv_info['lifecycle-environments']
         # Promote version to next env
         try:
             if env_id not in [int(lce['id']) for lce in lce_promoted]:
                 self._satellite.cli.ContentView.version_promote(
                     {
-                        'id': cvv_id,
+                        'id': cvv['id'],
                         'organization-id': org_id,
                         'to-lifecycle-environment-id': env_id,
                     }


### PR DESCRIPTION
Refactor errata e2e with updated standards, contenthost through Global Registration, enable repositories with subscription manager. 

Remove `setting_update` of remote_execution_by_default:True ([BZ 2029192](https://bugzilla.redhat.com/show_bug.cgi?id=2029192)), this user setting has 
been removed for 6.15.0, and by default is set to True.

Used `request.addfinalizer` for cleanup of entities modified in the new fixture `registered_contenthost`, to prevent conflicts between parameterized runs.
~Depends on navigation fix in [airgun 1018](https://github.com/SatelliteQE/airgun/pull/1018).~ Merged