### PR TITLE
[6.14.z] Update `test_positive_all_packages_update`

### DIFF
--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -16,11 +16,14 @@
 
 :Upstream: No
 """
+import re
+
 import pytest
 
 pytestmark = pytest.mark.destructive
 
 
+@pytest.mark.include_capsule
 def test_positive_all_packages_update(target_sat):
     """Verify update and check-update work as expected.
 
@@ -48,5 +51,10 @@ def test_positive_all_packages_update(target_sat):
         target_sat.power_control(state='reboot')
     # Run check-update again to verify there are no more packages available to update
     result = target_sat.cli.Packages.check_update()
+    # Regex to match if there are packages available to update
+    # Matches lines like '\n\nwalrus.noarch        5.21-1        custom_repo\n'
+    pattern = '(\\n){1,2}(\\S+)(\\s+)(\\S+)(\\s+)(\\S+)(\\n)'
+    matches = re.search(pattern, result.stdout)
+    assert matches is None  # No packages available to update
     assert 'FAIL' not in result.stdout
     assert result.status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12342

Automate [BZ 2073535](https://bugzilla.redhat.com/show_bug.cgi?id=2073535) (`satellite-maintain packages check-update fails when there are no packages to be updated`).