### PR TITLE
[6.15 RFE] Prepare for SCA Only Update Web UI

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1229,3 +1229,22 @@ def test_positive_ak_with_custom_product_on_rhel6(session, rhel6_contenthost, ta
         ak = session.activationkey.read(ak.name, widget_names='content_hosts')
         assert len(ak['content_hosts']['table']) == 1
         assert ak['content_hosts']['table'][0]['Name'] == rhel6_contenthost.hostname
+
+
+def test_positive_prepare_for_sca_only_ak(target_sat, function_entitlement_manifest_org):
+    """Verify that the ActivationKey details page notifies users that Simple Content Access
+        will be required for all organizations in Satellite 6.16
+
+    :id: 417a8331-3c66-473f-938c-bbf01deb6031
+
+    :expectedresults: The ActivationKey page notifies users that Simple Content Access will
+        be required for all organizations in Satellite 6.16
+    """
+    ak = target_sat.api.ActivationKey(organization=function_entitlement_manifest_org).create()
+    with target_sat.ui_session() as session:
+        session.organization.select(function_entitlement_manifest_org.name)
+        ak = session.activationkey.read(ak.name)
+        assert (
+            'This organization is not using Simple Content Access. Entitlement-based subscription management is deprecated and will be removed in Katello 4.12.'
+            in ak['sca_alert']
+        )

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1245,6 +1245,6 @@ def test_positive_prepare_for_sca_only_ak(target_sat, function_entitlement_manif
         session.organization.select(function_entitlement_manifest_org.name)
         ak = session.activationkey.read(ak.name)
         assert (
-            'This organization is not using Simple Content Access. Entitlement-based subscription management is deprecated and will be removed in Katello 4.12.'
-            in ak['sca_alert']
+            'This organization is not using Simple Content Access. Entitlement-based subscription '
+            'management is deprecated and will be removed in Satellite 6.16.' in ak['sca_alert']
         )

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -1851,6 +1851,7 @@ def test_positive_prepare_for_sca_only_content_host(
         session.location.select(default_location.name)
         host_details = session.contenthost.read(rhel_contenthost.hostname, widget_names='details')
         assert (
-            'This organization is not using Simple Content Access. Entitlement-based subscription management is deprecated and will be removed in Katello 4.12.'
+            'This organization is not using Simple Content Access. Entitlement-based subscription '
+            'management is deprecated and will be removed in Satellite 6.16.'
             in host_details['details']['sca_alert']
         )

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -382,3 +382,24 @@ def test_positive_prepare_for_sca_only_organization(target_sat, function_entitle
             'Simple Content Access will be required for all organizations in Katello 4.12.'
             in sca_alert['primary']['sca_alert']
         )
+
+
+def test_positive_prepare_for_sca_only_deprecation(target_sat):
+    """Verify that Simple Content Access endpoints are depreacated and will be required
+        for all organizations in Satellite 6.16
+
+    :id: 08539596-1bd3-4363-9737-e45f32ee5cbb
+
+    :expectedresults: Attepting to create an Organization with sca set to False, will throw
+        deprecation endpoint message
+    """
+    with target_sat.ui_session() as session:
+        session.organization.create(
+            {
+                'name': gen_string('alpha'),
+                'label': gen_string('alpha'),
+                'simple_content_access': False,
+            }
+        )
+        results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout
+    assert 'Simple Content Access will be required for all organizations in Katello 4.12' in results

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -362,3 +362,23 @@ def test_positive_product_view_organization_switch(session, module_org, module_p
         assert session.product.search(module_product.name)
         session.organization.select(org_name="Default Organization")
         assert not session.product.search(module_product.name) == module_product.name
+
+
+def test_positive_prepare_for_sca_only_organization(target_sat, function_entitlement_manifest_org):
+    """Verify that the organization details page notifies users that Simple Content Access
+        will be required for all organizations in Satellite 6.16
+
+    :id: 3a6a848b-3c16-4dbb-8f52-5ea57a9a97ef
+
+    :expectedresults: The Organization details page notifies users that Simple Content Access will
+        be required for all organizations in Satellite 6.16
+    """
+    with target_sat.ui_session() as session:
+        session.organization.select(function_entitlement_manifest_org.name)
+        sca_alert = session.organization.read(
+            function_entitlement_manifest_org.name, widget_names='primary'
+        )
+        assert (
+            'Simple Content Access will be required for all organizations in Katello 4.12.'
+            in sca_alert['primary']['sca_alert']
+        )

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -379,27 +379,6 @@ def test_positive_prepare_for_sca_only_organization(target_sat, function_entitle
             function_entitlement_manifest_org.name, widget_names='primary'
         )
         assert (
-            'Simple Content Access will be required for all organizations in Katello 4.12.'
+            'Simple Content Access will be required for all organizations in Satellite 6.16.'
             in sca_alert['primary']['sca_alert']
         )
-
-
-def test_positive_prepare_for_sca_only_deprecation(target_sat):
-    """Verify that Simple Content Access endpoints are depreacated and will be required
-        for all organizations in Satellite 6.16
-
-    :id: 08539596-1bd3-4363-9737-e45f32ee5cbb
-
-    :expectedresults: Attepting to create an Organization with sca set to False, will throw
-        deprecation endpoint message
-    """
-    with target_sat.ui_session() as session:
-        session.organization.create(
-            {
-                'name': gen_string('alpha'),
-                'label': gen_string('alpha'),
-                'simple_content_access': False,
-            }
-        )
-        results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout
-    assert 'Simple Content Access will be required for all organizations in Katello 4.12' in results

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -552,3 +552,21 @@ def test_positive_candlepin_events_processed_by_STOMP(
         response = entities.Ping().search_json()['services']['candlepin_events']
         assert response['status'] == 'ok'
         assert '0 Failed' in response['message']
+
+
+def test_positive_prepare_for_sca_only_subscription(target_sat, function_entitlement_manifest_org):
+    """Verify that the Subcsription page notifies users that Simple Content Access
+        will be required for all organizations in Satellite 6.16
+
+    :id: cb6fdfdd-04ee-4acb-9460-c78556cef11e
+
+    :expectedresults: The Subscription page notifies users that Simple Content Access will
+        be required for all organizations in Satellite 6.16
+    """
+    with target_sat.ui_session() as session:
+        session.organization.select(function_entitlement_manifest_org.name)
+        sca_alert = session.subscription.sca_alert()
+        assert (
+            'This organization is not using Simple Content Access. Entitlement-based subscription management is deprecated and will be removed in Katello 4.12.'
+            in sca_alert
+        )

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -567,6 +567,6 @@ def test_positive_prepare_for_sca_only_subscription(target_sat, function_entitle
         session.organization.select(function_entitlement_manifest_org.name)
         sca_alert = session.subscription.sca_alert()
         assert (
-            'This organization is not using Simple Content Access. Entitlement-based subscription management is deprecated and will be removed in Katello 4.12.'
-            in sca_alert
+            'This organization is not using Simple Content Access. Entitlement-based subscription '
+            'management is deprecated and will be removed in Satellite 6.16.' in sca_alert
         )


### PR DESCRIPTION
6.15 Feature automation: SAT-20200

This test is verifying that the Web UI notifies users that Simple Content Access will be required for all organizations in Satellite 6.16

As of now, Stream Satellite is showing Katello 4.12 instead of Satellite 6.16. Keeping in Draft state until changes are made