### PR TITLE
[6.14.z] Discovery coverage for rule priority/limit/provisioning

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -238,6 +238,33 @@ def provisioning_host(module_ssh_key_file, pxe_loader):
 
 
 @pytest.fixture
+def provision_multiple_hosts(module_ssh_key_file, pxe_loader, request):
+    """Fixture to check out two blank VMs"""
+    vlan_id = settings.provisioning.vlan_id
+    cd_iso = (
+        ""  # TODO: Make this an optional fixture parameter (update vm_firmware when adding this)
+    )
+    # Keeping the default value to 2
+    count = request.param if request.param is not None else 2
+
+    with Broker(
+        workflow="deploy-configure-pxe-provisioning-host-rhv",
+        host_class=ContentHost,
+        _count=count,
+        target_vlan_id=vlan_id,
+        target_vm_firmware=pxe_loader.vm_firmware,
+        target_vm_cd_iso=cd_iso,
+        blank=True,
+        target_memory='6GiB',
+        auth=module_ssh_key_file,
+    ) as hosts:
+        yield hosts
+
+        for prov_host in hosts:
+            prov_host.blank = getattr(prov_host, 'blank', False)
+
+
+@pytest.fixture
 def provisioning_hostgroup(
     module_provisioning_sat,
     module_sca_manifest_org,

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -16,36 +16,16 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_choice, gen_integer, gen_string
-from nailgun import entities
+from fauxfactory import gen_choice, gen_integer
 import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.utils.datafactory import valid_data_list
 
 
-@pytest.fixture(scope="module")
-def module_hostgroup(module_org):
-    module_hostgroup = entities.HostGroup(organization=[module_org]).create()
-    yield module_hostgroup
-    module_hostgroup.delete()
-
-
-@pytest.fixture(scope="module")
-def module_location(module_location):
-    yield module_location
-    module_location.delete()
-
-
-@pytest.fixture(scope="module")
-def module_org(module_org):
-    yield module_org
-    module_org.delete()
-
-
 @pytest.mark.tier1
 @pytest.mark.e2e
-def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup):
+def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup, target_sat):
     """Create a new discovery rule with several attributes, update them
     and delete the rule itself.
 
@@ -67,7 +47,7 @@ def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup)
     name = gen_choice(list(valid_data_list().values()))
     search = gen_choice(searches)
     hostname = 'myhost-<%= rand(99999) %>'
-    discovery_rule = entities.DiscoveryRule(
+    discovery_rule = target_sat.api.DiscoveryRule(
         name=name,
         search_=search,
         hostname=hostname,
@@ -103,23 +83,10 @@ def test_positive_end_to_end_crud(module_org, module_location, module_hostgroup)
         discovery_rule.read()
 
 
-@pytest.mark.tier1
-def test_negative_create_with_invalid_host_limit_and_priority():
-    """Create a discovery rule with invalid host limit and priority
-
-    :id: e3c7acb1-ac56-496b-ac04-2a83f66ec290
-
-    :expectedresults: Validation error should be raised
-    """
-    with pytest.raises(HTTPError):
-        entities.DiscoveryRule(max_count=gen_string('alpha')).create()
-    with pytest.raises(HTTPError):
-        entities.DiscoveryRule(priority=gen_string('alpha')).create()
-
-
-@pytest.mark.stubbed
 @pytest.mark.tier3
-def test_positive_provision_with_rule_priority():
+def test_positive_update_and_provision_with_rule_priority(
+    module_target_sat, module_discovery_hostgroup, discovery_location, discovery_org
+):
     """Create multiple discovery rules with different priority and check
     rule with highest priority executed first
 
@@ -130,44 +97,67 @@ def test_positive_provision_with_rule_priority():
     :expectedresults: Host with lower count have higher priority and that
         rule should be executed first
 
-    :CaseAutomation: NotAutomated
-
     :CaseImportance: High
     """
+    discovered_host = module_target_sat.api_factory.create_discovered_host()
+
+    prio_rule = module_target_sat.api.DiscoveryRule(
+        max_count=5,
+        hostgroup=module_discovery_hostgroup,
+        search_=f'name = {discovered_host["name"]}',
+        location=[discovery_location],
+        organization=[discovery_org],
+        priority=1,
+    ).create()
+
+    rule = module_target_sat.api.DiscoveryRule(
+        max_count=5,
+        hostgroup=module_discovery_hostgroup,
+        search_=f'name = {discovered_host["name"]}',
+        location=[discovery_location],
+        organization=[discovery_org],
+        priority=10,
+    ).create()
+
+    result = module_target_sat.api.DiscoveredHost(id=discovered_host['id']).auto_provision()
+    assert f'provisioned with rule {prio_rule.name}' in result['message']
+
+    # Delete discovery rule
+    for _ in rule, prio_rule:
+        _.delete()
+        with pytest.raises(HTTPError):
+            _.read()
 
 
-@pytest.mark.stubbed
 @pytest.mark.tier3
-def test_positive_multi_provision_with_rule_limit():
-    """Create a discovery rule (CPU_COUNT = 2) with host limit 1 and
-    provision more than 2 hosts with same rule
+def test_positive_multi_provision_with_rule_limit(
+    module_target_sat, module_discovery_hostgroup, discovery_location, discovery_org
+):
+    """Create a discovery rule with certain host limit and try to provision more than the passed limit
 
     :id: 553c8ebf-d1c1-4ac2-7948-d3664a5b450b
 
-    :Setup: Hosts with two CPUs should already be discovered
+    :Setup: Hosts should already be discovered
 
-    :expectedresults: Rule should only be applied to 2 discovered hosts
-        and the rule should already be skipped for the 3rd one.
-
-    :CaseAutomation: NotAutomated
+    :expectedresults: Rule should only be applied to the number of the hosts passed as limit in the rule
 
     :CaseImportance: High
     """
+    for _ in range(2):
+        discovered_host = module_target_sat.api_factory.create_discovered_host()
 
+    rule = module_target_sat.api.DiscoveryRule(
+        max_count=1,
+        hostgroup=module_discovery_hostgroup,
+        search_=f'name = {discovered_host["name"]}',
+        location=[discovery_location],
+        organization=[discovery_org],
+        priority=1000,
+    ).create()
+    result = module_target_sat.api.DiscoveredHost().auto_provision_all()
+    assert '1 discovered hosts were provisioned' in result['message']
 
-@pytest.mark.stubbed
-@pytest.mark.tier3
-def test_positive_provision_with_updated_discovery_rule():
-    """Update an existing rule and provision a host with it.
-
-    :id: 3fb20f0f-02e9-4158-9744-f583308c4e89
-
-    :Setup: Host should already be discovered
-
-    :expectedresults: User should be able to update the rule and it should
-        be applied on discovered host
-
-    :CaseAutomation: NotAutomated
-
-    :CaseImportance: High
-    """
+    # Delete discovery rule
+    rule.delete()
+    with pytest.raises(HTTPError):
+        rule.read()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12962

Coverage for :
```
test_positive_reboot_all_pxe_hosts
test_positive_end_to_end_crud
test_positive_provision_with_rule_priority
test_positive_multi_provision_with_rule_limit
```
The `reboot_all `scenario is expected to be breaking due to a known issue which will be worked on.