### PR TITLE
[6.12.z] Check if VAULT_ADDR env var exists before deleting it

### DIFF
--- a/robottelo/utils/vault.py
+++ b/robottelo/utils/vault.py
@@ -31,7 +31,8 @@ class Vault:
             self.export_vault_addr()
 
     def teardown(self):
-        del os.environ['VAULT_ADDR']
+        if os.environ.get('VAULT_ADDR') is not None:
+            del os.environ['VAULT_ADDR']
 
     def export_vault_addr(self):
         vaulturl = re.findall('VAULT_URL_FOR_DYNACONF=(.*)', self.envdata)[0]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13016

Currently this throws an error in teardown if `VAULT_ADDR` is not set.