### PR TITLE
[6.13.z] Adding the image config details in the docker config

### DIFF
--- a/conf/docker.yaml.template
+++ b/conf/docker.yaml.template
@@ -9,3 +9,23 @@ DOCKER:
   PRIVATE_REGISTRY_USERNAME:
   # Private docker registry password
   PRIVATE_REGISTRY_PASSWORD:
+  # Image Pass Registry
+  IMAGE_REGISTRY:
+    # image repository URL
+    URL:
+    # Pull a non-namespace image using the image pass registry proxy
+    NON_NAMESPACE:
+      # Proxy for the non-namespace image
+      PROXY:
+      # Username for the non-namespace image pass registry proxy
+      USERNAME:
+      # Password for the non-namespace image pass registry proxy
+      PASSWORD:
+    # Pull a namespace image using the image pass registry proxy
+    NAMESPACE:
+      # proxy for the namespace image
+      PROXY:
+      # Username for the namespace image pass registry proxy
+      USERNAME:
+      # Password for the namespace image pass registry proxy
+      PASSWORD:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12958

Updating the image registry configuration details in the docker config template. These details will be necessary for communicating with hub using the image registry proxy. In the CI, we have raised the `MR-1140` that contains all the required information.
 