### PR TITLE
Markers as test property in reports

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -116,8 +116,18 @@ def pytest_collection_modifyitems(items, config):
 
         # add markers as user_properties so they are recorded in XML properties of the report
         # pytest-ibutsu will include user_properties dict in testresult metadata
+        markers_prop_data = []
+        exclude_markers = ['parametrize', 'skipif', 'usefixtures', 'skip_if_not_set']
         for marker in item.iter_markers():
-            item.user_properties.append((marker.name, next(iter(marker.args), None)))
+            prop = marker.name
+            if prop in exclude_markers:
+                continue
+            if marker_val := next(iter(marker.args), None):
+                prop = '='.join([prop, str(marker_val)])
+            markers_prop_data.append(prop)
+        item.user_properties.append(("markers", ", ".join(markers_prop_data)))
+
+        # Version specific user properties
         item.user_properties.append(("BaseOS", rhel_version))
         item.user_properties.append(("SatelliteVersion", sat_version))
         item.user_properties.append(("SnapVersion", snap_version))

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -8,7 +8,7 @@
 
 :CaseComponent: Virt-whoConfigurePlugin
 
-:Team: Phoenix
+:Team: Phoenix-subscriptions
 
 :TestType: Functional
 


### PR DESCRIPTION
Test Markers as test metadata in Polarion, RP and Ibutsu reporting tools.

These markers would be used in RP and ibutsu to filter the results based on markers !