### PR TITLE
[6.15 RFE] Prepare for SCA only deprecation

### DIFF
--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -362,3 +362,24 @@ def test_positive_product_view_organization_switch(session, module_org, module_p
         assert session.product.search(module_product.name)
         session.organization.select(org_name="Default Organization")
         assert not session.product.search(module_product.name) == module_product.name
+
+
+def test_positive_prepare_for_sca_only_deprecation(target_sat):
+    """Verify that Simple Content Access endpoints are depreacated and will be required
+        for all organizations in Satellite 6.16
+
+    :id: 08539596-1bd3-4363-9737-e45f32ee5cbb
+
+    :expectedresults: Attepting to create an Organization with sca set to False, will throw
+        deprecation endpoint message
+    """
+    with target_sat.ui_session() as session:
+        session.organization.create(
+            {
+                'name': gen_string('alpha'),
+                'label': gen_string('alpha'),
+                'simple_content_access': False,
+            }
+        )
+        results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout
+    assert 'Simple Content Access will be required for all organizations in Katello 4.12' in results

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -382,4 +382,6 @@ def test_positive_prepare_for_sca_only_deprecation(target_sat):
             }
         )
         results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout
-    assert 'Simple Content Access will be required for all organizations in Satellite 6.16' in results
+    assert (
+        'Simple Content Access will be required for all organizations in Satellite 6.16' in results
+    )

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -378,7 +378,7 @@ def test_positive_prepare_for_sca_only_deprecation(target_sat):
             {
                 'name': gen_string('alpha'),
                 'label': gen_string('alpha'),
-                'simple_content_access': False,
+                'sca': False,
             }
         )
         results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -382,4 +382,4 @@ def test_positive_prepare_for_sca_only_deprecation(target_sat):
             }
         )
         results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout
-    assert 'Simple Content Access will be required for all organizations in Katello 4.12' in results
+    assert 'Simple Content Access will be required for all organizations in Satellite 6.16' in results


### PR DESCRIPTION
6.15 Feature automation: SAT-20201

This test is verifying that that Simple Content Access endpoints are deprecated and will be required
        for all organizations in Satellite 6.16

As of now, Stream Satellite is showing Katello 4.12 instead of Satellite 6.16. Keeping in Draft state until changes are made