### PR TITLE
improved webhook event trigger test

### DIFF
--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -167,7 +167,7 @@ class TestWebhook:
         repo = target_sat.api.Repository(
             organization=module_org, content_type='yum', url=settings.repos.yum_0.url
         ).create()
-        with target_sat.api.session.shell() as shell:
+        with target_sat.session.shell() as shell:
             shell.send('foreman-tail')
             repo.sync()
             assert_event_triggered(shell, hook.event)


### PR DESCRIPTION
### Problem Statement

Webhook trigger is blocked by the safemode setting enabled, which is expected as the safemode prevents template rendering which is prerequisite for webhook trigger. 

The existing test didn't see this as it was looking just for one specific line in logs, so it passed even though no action was triggered.

### Solution

This PR disables the safemode setting for the test so that the task is actually triggers. Also it adds a check for the successful completion of the triggered task. 

