### PR TITLE
[6.12.z] Add Ruff pytest standards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,15 @@ select = [
     "F",  # flake8
     "I", # isort
     # "Q",  # flake8-quotes
+    "PT",  # flake8-pytest
     "UP",  # pyupgrade
     "W",  # pycodestyle
 ]
 
 ignore = [
     "E501",  # line too long - handled by black
+    "PT004", # pytest underscrore prefix for non-return fixtures
+    "PT005", # pytest no underscrore prefix for return fixtures
 ]
 
 [tool.ruff.isort]
@@ -40,6 +43,9 @@ known-first-party = [
 ]
 combine-as-imports = true
 
+[tool.ruff.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
 
 [tool.ruff.flake8-quotes]
 inline-quotes = "single"

--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -3,7 +3,7 @@ import pytest
 from robottelo.config import settings
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def setup_http_proxy(request, module_manifest_org, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
     http_proxy = target_sat.api_factory.make_http_proxy(module_manifest_org, request.param)

--- a/pytest_fixtures/component/katello_agent.py
+++ b/pytest_fixtures/component/katello_agent.py
@@ -21,7 +21,7 @@ def sat_with_katello_agent(module_target_sat):
             InstallerCommand('foreman-proxy-content-enable-katello-agent true')
         )
         assert result.status == 0
-    yield module_target_sat
+    return module_target_sat
 
 
 @pytest.fixture
@@ -33,7 +33,7 @@ def katello_agent_client_for_upgrade(sat_with_katello_agent, sat_upgrade_chost, 
     )
     sat_upgrade_chost.install_katello_agent()
     host_info = sat_with_katello_agent.cli.Host.info({'name': sat_upgrade_chost.hostname})
-    yield Box(
+    return Box(
         {
             'client': sat_upgrade_chost,
             'host_info': host_info,
@@ -52,4 +52,4 @@ def katello_agent_client(sat_with_katello_agent, rhel_contenthost):
     )
     rhel_contenthost.install_katello_agent()
     host_info = sat_with_katello_agent.cli.Host.info({'name': rhel_contenthost.hostname})
-    yield Box({'client': rhel_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent})
+    return Box({'client': rhel_contenthost, 'host_info': host_info, 'sat': sat_with_katello_agent})

--- a/pytest_fixtures/component/katello_certs_check.py
+++ b/pytest_fixtures/component/katello_certs_check.py
@@ -13,7 +13,7 @@ def certs_data(sat_ready_rhel):
     cert_data['key_file_name'] = f'{sat_ready_rhel.hostname}/{sat_ready_rhel.hostname}.key'
     cert_data['cert_file_name'] = f'{sat_ready_rhel.hostname}/{sat_ready_rhel.hostname}.crt'
     sat_ready_rhel.custom_cert_generate(cert_data['capsule_hostname'])
-    yield cert_data
+    return cert_data
 
 
 @pytest.fixture

--- a/pytest_fixtures/component/lce.py
+++ b/pytest_fixtures/component/lce.py
@@ -16,7 +16,7 @@ def module_lce(module_org, module_target_sat):
     return module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_lce(function_org, target_sat):
     return target_sat.api.LifecycleEnvironment(organization=function_org).create()
 
@@ -31,7 +31,7 @@ def module_lce_library(module_org, module_target_sat):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_lce_library(function_org, target_sat):
     """Returns the Library lifecycle environment from chosen organization"""
     return (

--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -18,7 +18,7 @@ def module_stash(request):
     # Please refer the documentation for more details on stash
     # https://docs.pytest.org/en/latest/reference/reference.html#stash
     request.node.stash[synced_repos] = {}
-    yield request.node.stash
+    return request.node.stash
 
 
 @pytest.fixture(scope='module')
@@ -98,7 +98,7 @@ def module_synced_repos(sat_maintain, module_capsule_configured, module_sca_mani
         sync_status = module_capsule_configured.nailgun_capsule.content_sync()
         assert sync_status['result'] == 'success'
 
-    yield {
+    return {
         'custom': module_stash[synced_repos]['cust_repo'],
         'rh': module_stash[synced_repos]['rh_repo'],
     }

--- a/pytest_fixtures/component/provision_azure.py
+++ b/pytest_fixtures/component/provision_azure.py
@@ -17,22 +17,22 @@ from robottelo.constants import (
 @pytest.fixture(scope='session')
 def sat_azure(request, session_puppet_enabled_sat, session_target_sat):
     hosts = {'sat': session_target_sat, 'puppet_sat': session_puppet_enabled_sat}
-    yield hosts[request.param]
+    return hosts[request.param]
 
 
 @pytest.fixture(scope='module')
 def sat_azure_org(sat_azure):
-    yield sat_azure.api.Organization().create()
+    return sat_azure.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
 def sat_azure_loc(sat_azure):
-    yield sat_azure.api.Location().create()
+    return sat_azure.api.Location().create()
 
 
 @pytest.fixture(scope='module')
 def sat_azure_domain(sat_azure, sat_azure_loc, sat_azure_org):
-    yield sat_azure.api.Domain(location=[sat_azure_loc], organization=[sat_azure_org]).create()
+    return sat_azure.api.Domain(location=[sat_azure_loc], organization=[sat_azure_org]).create()
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -20,22 +20,22 @@ from robottelo.exceptions import GCECertNotFoundError
 @pytest.fixture(scope='session')
 def sat_gce(request, session_puppet_enabled_sat, session_target_sat):
     hosts = {'sat': session_target_sat, 'puppet_sat': session_puppet_enabled_sat}
-    yield hosts[getattr(request, 'param', 'sat')]
+    return hosts[getattr(request, 'param', 'sat')]
 
 
 @pytest.fixture(scope='module')
 def sat_gce_org(sat_gce):
-    yield sat_gce.api.Organization().create()
+    return sat_gce.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
 def sat_gce_loc(sat_gce):
-    yield sat_gce.api.Location().create()
+    return sat_gce.api.Location().create()
 
 
 @pytest.fixture(scope='module')
 def sat_gce_domain(sat_gce, sat_gce_loc, sat_gce_org):
-    yield sat_gce.api.Domain(location=[sat_gce_loc], organization=[sat_gce_org]).create()
+    return sat_gce.api.Domain(location=[sat_gce_loc], organization=[sat_gce_org]).create()
 
 
 @pytest.fixture(scope='module')
@@ -284,7 +284,7 @@ def module_gce_finishimg(
     return finish_image
 
 
-@pytest.fixture()
+@pytest.fixture
 def gce_setting_update(sat_gce):
     sat_gce.update_setting('destroy_vm_on_host_delete', True)
     yield

--- a/pytest_fixtures/component/provision_libvirt.py
+++ b/pytest_fixtures/component/provision_libvirt.py
@@ -18,4 +18,4 @@ def module_libvirt_image(module_target_sat, module_cr_libvirt):
 def module_libvirt_provisioning_sat(module_provisioning_sat):
     # Configure Libvirt CR for provisioning
     module_provisioning_sat.sat.configure_libvirt_cr()
-    yield module_provisioning_sat
+    return module_provisioning_sat

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -18,22 +18,22 @@ def session_puppet_enabled_sat(session_satellite_host):
 def session_puppet_enabled_capsule(session_capsule_host, session_puppet_enabled_sat):
     """Capsule with enabled puppet plugin"""
     session_capsule_host.capsule_setup(sat_host=session_puppet_enabled_sat)
-    yield session_capsule_host.enable_puppet_capsule(satellite=session_puppet_enabled_sat)
+    return session_capsule_host.enable_puppet_capsule(satellite=session_puppet_enabled_sat)
 
 
 @pytest.fixture(scope='module')
 def module_puppet_org(session_puppet_enabled_sat):
-    yield session_puppet_enabled_sat.api.Organization().create()
+    return session_puppet_enabled_sat.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
 def module_puppet_loc(session_puppet_enabled_sat):
-    yield session_puppet_enabled_sat.api.Location().create()
+    return session_puppet_enabled_sat.api.Location().create()
 
 
 @pytest.fixture(scope='module')
 def module_puppet_domain(session_puppet_enabled_sat, module_puppet_loc, module_puppet_org):
-    yield session_puppet_enabled_sat.api.Domain(
+    return session_puppet_enabled_sat.api.Domain(
         location=[module_puppet_loc], organization=[module_puppet_org]
     ).create()
 

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -22,7 +22,7 @@ def module_repo(module_repo_options, module_target_sat):
     return module_target_sat.api.Repository(**module_repo_options).create()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_product(function_org):
     return entities.Product(organization=function_org).create()
 
@@ -73,7 +73,7 @@ def module_rhst_repo(module_target_sat, module_org_with_manifest, module_promote
     return REPOS['rhst7']['id']
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def repo_setup():
     """
     This fixture is used to create an organization, product, repository, and lifecycle environment
@@ -85,7 +85,7 @@ def repo_setup():
     repo = entities.Repository(name=repo_name, product=product).create()
     lce = entities.LifecycleEnvironment(organization=org).create()
     details = {'org': org, 'product': product, 'repo': repo, 'lce': lce}
-    yield details
+    return details
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -73,7 +73,7 @@ def rhel_insights_vm(rhcloud_sat_host, organization_ak_setup, rhel_contenthost):
         org=org.label,
         rhel_distro=f"rhel{rhel_contenthost.os_version.major}",
     )
-    yield rhel_contenthost
+    return rhel_contenthost
 
 
 @pytest.fixture
@@ -93,4 +93,4 @@ def inventory_settings(rhcloud_sat_host):
 def rhcloud_capsule(capsule_host, rhcloud_sat_host):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     capsule_host.capsule_setup(sat_host=rhcloud_sat_host)
-    yield capsule_host
+    return capsule_host

--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -32,7 +32,7 @@ def default_ipa_host(module_target_sat):
     return IPAHost(module_target_sat)
 
 
-@pytest.fixture()
+@pytest.fixture
 def ldap_cleanup():
     """this is an extra step taken to clean any existing ldap source"""
     ldap_auth_sources = entities.AuthSourceLDAP().search()
@@ -41,7 +41,7 @@ def ldap_cleanup():
         for user in users:
             user.delete()
         ldap_auth.delete()
-    yield
+    return
 
 
 @pytest.fixture(scope='session')
@@ -101,7 +101,7 @@ def open_ldap_data():
     }
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def auth_source(ldap_cleanup, module_org, module_location, ad_data):
     ad_data = ad_data()
     return entities.AuthSourceLDAP(
@@ -124,7 +124,7 @@ def auth_source(ldap_cleanup, module_org, module_location, ad_data):
     ).create()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def auth_source_ipa(ldap_cleanup, default_ipa_host, module_org, module_location):
     return entities.AuthSourceLDAP(
         onthefly_register=True,
@@ -146,7 +146,7 @@ def auth_source_ipa(ldap_cleanup, default_ipa_host, module_org, module_location)
     ).create()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def auth_source_open_ldap(ldap_cleanup, module_org, module_location, open_ldap_data):
     return entities.AuthSourceLDAP(
         onthefly_register=True,
@@ -256,7 +256,7 @@ def ldap_auth_source(
     else:
         ldap_data['server_type'] = LDAP_SERVER_TYPE['UI']['posix']
         ldap_data['attr_login'] = LDAP_ATTR['login']
-    yield ldap_data, auth_source
+    return ldap_data, auth_source
 
 
 @pytest.fixture

--- a/pytest_fixtures/component/settings.py
+++ b/pytest_fixtures/component/settings.py
@@ -2,7 +2,7 @@
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def setting_update(request, target_sat):
     """
     This fixture is used to create an object of the provided settings parameter that we use in

--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -179,7 +179,7 @@ def module_sca_manifest():
         yield manifest
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_entitlement_manifest():
     """Yields a manifest in entitlement mode with subscriptions determined by the
     `manifest_category.entitlement` setting in conf/manifest.yaml."""
@@ -187,7 +187,7 @@ def function_entitlement_manifest():
         yield manifest
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_secondary_entitlement_manifest():
     """Yields a manifest in entitlement mode with subscriptions determined by the
     `manifest_category.entitlement` setting in conf/manifest.yaml.
@@ -196,7 +196,7 @@ def function_secondary_entitlement_manifest():
         yield manifest
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_sca_manifest():
     """Yields a manifest in Simple Content Access mode with subscriptions determined by the
     `manifest_category.golden_ticket` setting in conf/manifest.yaml."""
@@ -212,7 +212,7 @@ def smart_proxy_location(module_org, module_target_sat, default_smart_proxy):
     return location
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def upgrade_entitlement_manifest():
     """Returns a manifest in entitlement mode with subscriptions determined by the
     `manifest_category.entitlement` setting in conf/manifest.yaml. used only for

--- a/pytest_fixtures/component/templatesync.py
+++ b/pytest_fixtures/component/templatesync.py
@@ -7,7 +7,7 @@ from robottelo.constants import FOREMAN_TEMPLATE_ROOT_DIR
 from robottelo.logging import logger
 
 
-@pytest.fixture()
+@pytest.fixture
 def create_import_export_local_dir(target_sat):
     """Creates a local directory inside root_dir on satellite from where the templates will
         be imported from or exported to.
@@ -76,7 +76,7 @@ def git_pub_key(session_target_sat, git_port):
     res.raise_for_status()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def git_repository(git_port, git_pub_key, request):
     """Creates a new repository on git provider for exporting templates.
 
@@ -96,7 +96,7 @@ def git_repository(git_port, git_pub_key, request):
     res.raise_for_status()
 
 
-@pytest.fixture()
+@pytest.fixture
 def git_branch(git_repository):
     """Creates a new branch in the git repository for exporting templates.
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -94,7 +94,7 @@ def rhel9_contenthost(request):
         yield host
 
 
-@pytest.fixture()
+@pytest.fixture
 def content_hosts(request):
     """A function-level fixture that provides two rhel content hosts object"""
     with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
@@ -110,7 +110,7 @@ def mod_content_hosts(request):
         yield hosts
 
 
-@pytest.fixture()
+@pytest.fixture
 def registered_hosts(request, target_sat, module_org):
     """Fixture that registers content hosts to Satellite, based on rh_cloud setup"""
     with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
@@ -128,7 +128,7 @@ def katello_host_tools_host(target_sat, module_org, rhel_contenthost):
     repo = settings.repos['SATCLIENT_REPO'][f'RHEL{rhel_contenthost.os_version.major}']
     target_sat.register_host_custom_repo(module_org, rhel_contenthost, [repo])
     rhel_contenthost.install_katello_host_tools()
-    yield rhel_contenthost
+    return rhel_contenthost
 
 
 @pytest.fixture
@@ -143,7 +143,7 @@ def cockpit_host(class_target_sat, class_org, rhel_contenthost):
     rhel_contenthost.execute(f"hostnamectl set-hostname {rhel_contenthost.hostname} --static")
     rhel_contenthost.install_cockpit()
     rhel_contenthost.add_rex_key(satellite=class_target_sat)
-    yield rhel_contenthost
+    return rhel_contenthost
 
 
 @pytest.fixture
@@ -172,7 +172,7 @@ def katello_host_tools_tracer_host(rex_contenthost, target_sat):
             **{f'rhel{rhelver}_os': settings.repos[f'rhel{rhelver}_os']}
         )
     rex_contenthost.install_tracer()
-    yield rex_contenthost
+    return rex_contenthost
 
 
 @pytest.fixture

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -150,28 +150,28 @@ def session_capsule_host(request, capsule_factory):
 def capsule_configured(capsule_host, target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     capsule_host.capsule_setup(sat_host=target_sat)
-    yield capsule_host
+    return capsule_host
 
 
 @pytest.fixture
 def large_capsule_configured(large_capsule_host, target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     large_capsule_host.capsule_setup(sat_host=target_sat)
-    yield large_capsule_host
+    return large_capsule_host
 
 
 @pytest.fixture(scope='module')
 def module_capsule_configured(module_capsule_host, module_target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     module_capsule_host.capsule_setup(sat_host=module_target_sat)
-    yield module_capsule_host
+    return module_capsule_host
 
 
 @pytest.fixture(scope='session')
 def session_capsule_configured(session_capsule_host, session_target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
     session_capsule_host.capsule_setup(sat_host=session_target_sat)
-    yield session_capsule_host
+    return session_capsule_host
 
 
 @pytest.fixture(scope='module')
@@ -191,7 +191,7 @@ def module_capsule_configured_mqtt(module_capsule_configured):
     )
     result = module_capsule_configured.cli.Service.restart(options={'only': 'foreman-proxy'})
     assert result.status == 0, 'foreman-proxy restart unsuccessful'
-    yield module_capsule_configured
+    return module_capsule_configured
 
 
 @pytest.fixture(scope='module')
@@ -223,7 +223,7 @@ def module_capsule_configured_async_ssh(module_capsule_configured):
     """Configure the capsule instance with the satellite from settings.server.hostname,
     enable MQTT broker"""
     module_capsule_configured.set_rex_script_mode_provider('ssh-async')
-    yield module_capsule_configured
+    return module_capsule_configured
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/core/sys.py
+++ b/pytest_fixtures/core/sys.py
@@ -54,7 +54,7 @@ def puppet_proxy_port_range(session_puppet_enabled_sat):
 @pytest.fixture(scope='class')
 def class_cockpit_sat(class_subscribe_satellite):
     class_subscribe_satellite.install_cockpit()
-    yield class_subscribe_satellite
+    return class_subscribe_satellite
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/core/upgrade.py
+++ b/pytest_fixtures/core/upgrade.py
@@ -5,7 +5,7 @@ from robottelo.hosts import Capsule
 from robottelo.logging import logger
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def dependent_scenario_name(request):
     """
     This fixture is used to collect the dependent test case name.
@@ -15,7 +15,7 @@ def dependent_scenario_name(request):
         for mark in request.node.own_markers
         if 'depend_on' in mark.kwargs
     ][0]
-    yield depend_test_name
+    return depend_test_name
 
 
 @pytest.fixture(scope="session")

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -296,7 +296,7 @@ def test_positive_get_releases_content():
     act_key = entities.ActivationKey().create()
     response = client.get(act_key.path('releases'), auth=get_credentials(), verify=False).json()
     assert 'results' in response.keys()
-    assert type(response['results']) == list
+    assert isinstance(response['results'], list)
 
 
 @pytest.mark.tier2

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -83,7 +83,7 @@ def test_positive_create_with_query(controller):
 
 
 @pytest.mark.tier1
-@pytest.mark.parametrize('public', (True, False))
+@pytest.mark.parametrize('public', [True, False])
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_positive_create_public(controller, public):
     """Create a public bookmark
@@ -368,7 +368,7 @@ def test_negative_update_empty_query(controller):
 
 
 @pytest.mark.tier1
-@pytest.mark.parametrize('public', (True, False))
+@pytest.mark.parametrize('public', [True, False])
 @pytest.mark.parametrize('controller', CONTROLLERS)
 def test_positive_update_public(controller, public):
     """Update a bookmark public state to private and vice versa

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1199,7 +1199,7 @@ class TestCapsuleContentManagement:
         result = module_capsule_configured.nailgun_capsule.content_lifecycle_environments()
         # there can and will be LCEs from other tests and orgs, but len() >= 2
         assert len(result['results']) >= 2
-        assert lce1.id and lce2.id in [capsule_lce['id'] for capsule_lce in result['results']]
+        assert {lce1.id, lce2.id}.issubset([capsule_lce['id'] for capsule_lce in result['results']])
 
         # Create a Content View, add the repository and publish it.
         cv = target_sat.api.ContentView(

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -139,10 +139,10 @@ class TestSmartClassParameters:
             2. Error raised for invalid default value.
         """
         sc_param = module_puppet['sc_params'].pop()
+        sc_param.override = True
+        sc_param.parameter_type = test_data['sc_type']
+        sc_param.default_value = test_data['value']
         with pytest.raises(HTTPError) as context:
-            sc_param.override = True
-            sc_param.parameter_type = test_data['sc_type']
-            sc_param.default_value = test_data['value']
             sc_param.update(['override', 'parameter_type', 'default_value'])
         assert sc_param.read().default_value != test_data['value']
         assert 'Validation failed: Default value is invalid' in context.value.response.text
@@ -380,9 +380,9 @@ class TestSmartClassParameters:
         session_puppet_enabled_sat.api.OverrideValue(
             smart_class_parameter=sc_param, match='domain=example.com', value=gen_string('alpha')
         ).create()
+        sc_param.parameter_type = 'boolean'
+        sc_param.default_value = gen_string('alpha')
         with pytest.raises(HTTPError) as context:
-            sc_param.parameter_type = 'boolean'
-            sc_param.default_value = gen_string('alpha')
             sc_param.update(['parameter_type', 'default_value'])
         assert (
             'Validation failed: Default value is invalid, Lookup values is invalid'

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -244,8 +244,8 @@ def test_negative_update_invalid_name(
         location=[module_location], name=name, organization=[module_org], url=LIBVIRT_URL
     ).create()
     request.addfinalizer(compresource.delete)
+    compresource.name = new_name
     with pytest.raises(HTTPError):
-        compresource.name = new_name
         compresource.update(['name'])
     assert compresource.read().name == name
 
@@ -269,8 +269,8 @@ def test_negative_update_same_name(request, module_target_sat, module_org, modul
     new_compresource = module_target_sat.api.LibvirtComputeResource(
         location=[module_location], organization=[module_org], url=LIBVIRT_URL
     ).create()
+    new_compresource.name = name
     with pytest.raises(HTTPError):
-        new_compresource.name = name
         new_compresource.update(['name'])
     assert new_compresource.read().name != name
 
@@ -299,7 +299,7 @@ def test_negative_update_url(url, request, module_target_sat, module_org, module
         location=[module_location], organization=[module_org], url=LIBVIRT_URL
     ).create()
     request.addfinalizer(compresource.delete)
+    compresource.url = url
     with pytest.raises(HTTPError):
-        compresource.url = url
         compresource.update(['url'])
     assert compresource.read().url != url

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -240,8 +240,8 @@ class TestContentView:
         yum_repo = entities.Repository(product=module_product).create()
         yum_repo.sync()
         assert len(content_view.repository) == 0
+        content_view.repository = [yum_repo, yum_repo]
         with pytest.raises(HTTPError):
-            content_view.repository = [yum_repo, yum_repo]
             content_view.update(['repository'])
         assert len(content_view.read().repository) == 0
 
@@ -757,7 +757,7 @@ class TestContentViewUpdate:
     """Tests for updating content views."""
 
     @pytest.mark.parametrize(
-        'key, value',
+        ('key', 'value'),
         **(lambda x: {'argvalues': list(x.items()), 'ids': list(x.keys())})(
             {'description': gen_utf8(), 'name': gen_utf8()}
         ),
@@ -811,8 +811,8 @@ class TestContentViewUpdate:
 
         :CaseImportance: Critical
         """
+        module_cv.name = new_name
         with pytest.raises(HTTPError):
-            module_cv.name = new_name
             module_cv.update(['name'])
         cv = module_cv.read()
         assert cv.name != new_name

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -157,7 +157,7 @@ def assert_discovered_host_provisioned(channel, ksrepo):
         raise AssertionError(f'Timed out waiting for {pattern} from VM')
 
 
-@pytest.fixture()
+@pytest.fixture
 def discovered_host_cleanup(target_sat):
     hosts = target_sat.api.DiscoveredHost().search()
     for host in hosts:

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -899,8 +899,8 @@ class TestDockerContentView:
         cvv = content_view.read().version[0]
         lce = entities.LifecycleEnvironment(organization=module_org).create()
         cvv.promote(data={'environment_ids': lce.id, 'force': False})
+        lce.registry_name_pattern = new_pattern
         with pytest.raises(HTTPError):
-            lce.registry_name_pattern = new_pattern
             lce.update(['registry_name_pattern'])
 
 

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -48,6 +48,6 @@ def test_positive_get_summary():
     :CaseImportance: Critical
     """
     summary = entities.ForemanTask().summary()
-    assert type(summary) is list
+    assert isinstance(summary, list)
     for item in summary:
-        assert type(item) is dict
+        assert isinstance(item, dict)

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -165,8 +165,8 @@ def test_negative_update_name(module_lce, new_name):
 
     :parametrized: yes
     """
+    module_lce.name = new_name
     with pytest.raises(HTTPError):
-        module_lce.name = new_name
         module_lce.update(['name'])
     lce = module_lce.read()
     assert lce.name != new_name

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -41,7 +41,7 @@ class TestMedia:
     @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
-        'name, new_name',
+        ('name', 'new_name'),
         **parametrized(list(zip(valid_data_list().values(), valid_data_list().values())))
     )
     def test_positive_crud_with_name(self, module_org, name, new_name):

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -60,7 +60,7 @@ class TestPartitionTable:
 
     @pytest.mark.tier1
     @pytest.mark.parametrize(
-        'name, new_name',
+        ('name', 'new_name'),
         **parametrized(
             list(
                 zip(
@@ -95,7 +95,7 @@ class TestPartitionTable:
 
     @pytest.mark.tier1
     @pytest.mark.parametrize(
-        'layout, new_layout', **parametrized(list(zip(valid_data_list(), valid_data_list())))
+        ('layout', 'new_layout'), **parametrized(list(zip(valid_data_list(), valid_data_list())))
     )
     def test_positive_create_update_with_layout(self, target_sat, layout, new_layout):
         """Create new and update partition tables using different inputs as a

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -366,6 +366,10 @@ class TestUserRole:
         new_entity = self.set_taxonomies(entity_cls(), class_org, class_location)
         new_entity = new_entity.create()
         name = new_entity.get_fields()['name'].gen_value()
+        if entity_cls is entities.ActivationKey:
+            entity_cls(self.cfg, id=new_entity.id, name=name, organization=class_org)
+        else:
+            entity_cls(self.cfg, id=new_entity.id, name=name)
         with pytest.raises(HTTPError):
             entity_cls(self.cfg, id=new_entity.id, name=name).update(['name'])
         self.give_user_permission(_permission_name(entity_cls, 'update'))

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -65,10 +65,10 @@ def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, ta
     with pytest.raises(HTTPError) as error:
         reposet.disable(data=data)
         # assert error.value.response.status_code == 500
-        assert (
-            'Repository cannot be deleted since it has already been '
-            'included in a published Content View' in error.value.response.text
-        )
+    assert (
+        'Repository cannot be deleted since it has already been '
+        'included in a published Content View' in error.value.response.text
+    )
 
 
 @pytest.mark.tier1

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1187,7 +1187,8 @@ class TestRepository:
             f' --key /etc/pki/katello/private/pulp-client.key'
         )
         command_output = target_sat.execute('foreman-rake katello:correct_repositories COMMIT=true')
-        assert 'Recreating' in command_output.stdout and 'TaskError' not in command_output.stdout
+        assert 'Recreating' in command_output.stdout
+        assert 'TaskError' not in command_output.stdout
 
     @pytest.mark.tier2
     def test_positive_mirroring_policy(self, target_sat):

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -124,7 +124,8 @@ def test_rhcloud_inventory_api_e2e(
     infrastructure_type = [
         host['system_profile']['infrastructure_type'] for host in json_data['hosts']
     ]
-    assert 'physical' and 'virtual' in infrastructure_type
+    assert 'physical'
+    assert 'virtual' in infrastructure_type
 
     all_host_profiles = [host['system_profile'] for host in json_data['hosts']]
     for host_profiles in all_host_profiles:
@@ -351,7 +352,7 @@ def test_include_parameter_tags_setting(
     for host in json_data['hosts']:
         for tag in host['tags']:
             if tag['namespace'] == 'satellite_parameter':
-                assert type(tag['value']) is str
+                assert isinstance(tag['value'], str)
                 break
 
 

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -124,7 +124,7 @@ def test_rhcloud_inventory_api_e2e(
     infrastructure_type = [
         host['system_profile']['infrastructure_type'] for host in json_data['hosts']
     ]
-    assert 'physical'
+    assert 'physical' in infrastructure_type
     assert 'virtual' in infrastructure_type
 
     all_host_profiles = [host['system_profile'] for host in json_data['hosts']]

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -49,4 +49,4 @@ def test_positive_path():
     response = client.get(path, auth=get_credentials(), verify=False)
     assert response.status_code == http.client.OK
     assert 'application/json' in response.headers['content-type']
-    assert type(response.json()) is list
+    assert isinstance(response.json(), list)

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -38,7 +38,7 @@ class TestRole:
     @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
-        'name, new_name',
+        ('name', 'new_name'),
         **parametrized(list(zip(generate_strings_list(), generate_strings_list()))),
     )
     def test_positive_crud(self, name, new_name):
@@ -1245,6 +1245,7 @@ class TestCannedRole:
         entities.User(id=user.id).delete()
         with pytest.raises(HTTPError):
             user_role.read()
+        with pytest.raises(HTTPError):
             user.read()
         try:
             entities.Domain().search(
@@ -1318,9 +1319,9 @@ class TestCannedRole:
         test_role = entities.Role().create()
         sc = self.user_config(user, target_sat)
         test_role = entities.Role(sc, id=test_role.id).read()
+        test_role.organization = [role_taxonomies['org']]
+        test_role.location = [role_taxonomies['loc']]
         with pytest.raises(HTTPError):
-            test_role.organization = [role_taxonomies['org']]
-            test_role.location = [role_taxonomies['loc']]
             test_role.update(['organization', 'location'])
 
     @pytest.mark.tier2

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -343,8 +343,8 @@ def test_negative_update_parameter(new_name):
     sub_param = entities.Parameter(
         name=gen_string('utf8'), subnet=subnet.id, value=gen_string('utf8')
     ).create()
+    sub_param.name = new_name
     with pytest.raises(HTTPError):
-        sub_param.name = new_name
         sub_param.update(['name'])
 
 

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -208,8 +208,8 @@ class TestUser:
 
         :CaseImportance: Critical
         """
+        create_user.login = login
         with pytest.raises(HTTPError):
-            create_user.login = login
             create_user.update(['login'])
 
     @pytest.mark.tier1
@@ -284,8 +284,8 @@ class TestUser:
 
         :CaseImportance: Critical
         """
+        create_user.mail = mail
         with pytest.raises(HTTPError):
-            create_user.mail = mail
             create_user.update(['mail'])
 
     @pytest.mark.tier1

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -269,15 +269,15 @@ def test_negative_create_with_usage_limit_with_not_integers(module_org, limit):
     # invalid_values.append(0.5)
     with pytest.raises(CLIFactoryError) as raise_ctx:
         make_activation_key({'organization-id': module_org.id, 'max-hosts': limit})
-    if type(limit) is int:
+    if isinstance(limit, int):
         if limit < 1:
             assert 'Max hosts cannot be less than one' in str(raise_ctx)
-    if type(limit) is str:
+    if isinstance(limit, str):
         assert 'Numeric value is required.' in str(raise_ctx)
 
 
 @pytest.mark.tier3
-@pytest.mark.parametrize('invalid_values', ('-1', '-500', 0))
+@pytest.mark.parametrize('invalid_values', ['-1', '-500', 0])
 def test_negative_create_with_usage_limit_with_invalid_integers(module_org, invalid_values):
     """Create Activation key with invalid integers Usage Limit
 

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -46,7 +46,7 @@ class TestOSPComputeResourceTestCase:
     @pytest.fixture
     def osp_version(request):
         versions = {'osp16': settings.osp.api_url.osp16, 'osp17': settings.osp.api_url.osp17}
-        yield versions[getattr(request, 'param', 'osp16')]
+        return versions[getattr(request, 'param', 'osp16')]
 
     @pytest.mark.upgrade
     @pytest.mark.tier3

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2473,7 +2473,7 @@ class TestContentView:
         # role info (note: view_roles is not in the required permissions)
         with pytest.raises(CLIReturnCodeError) as context:
             Role.with_user(user_name, user_password).info({'id': role['id']})
-            assert '403 Forbidden' in str(context)
+        assert '403 Forbidden' in str(context)
         # Create a lifecycle environment
         env = cli_factory.make_lifecycle_environment({'organization-id': org['id']})
         # Create a product

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -68,7 +68,7 @@ def gen_int32(min_value=1):
 class TestDiscoveryRule:
     """Implements Foreman discovery Rules tests in CLI."""
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture
     def discoveryrule_factory(self, class_org, class_location, class_hostgroup):
         def _create_discoveryrule(org, loc, hostgroup, options=None):
             """Makes a new discovery rule and asserts its success"""

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -193,7 +193,7 @@ def hosts(request):
     """Deploy hosts via broker."""
     num_hosts = getattr(request, 'param', 2)
     with Broker(nick='rhel7', host_class=ContentHost, _count=num_hosts) as hosts:
-        if type(hosts) is not list or len(hosts) != num_hosts:
+        if not isinstance(hosts, list) or len(hosts) != num_hosts:
             pytest.fail('Failed to provision the expected number of hosts.')
         yield hosts
 
@@ -381,9 +381,9 @@ def cv_filter_cleanup(filter_id, cv, org, lce):
 
 
 @pytest.mark.tier3
-@pytest.mark.parametrize('filter_by_hc', ('id', 'name'), ids=('hc_id', 'hc_name'))
+@pytest.mark.parametrize('filter_by_hc', ['id', 'name'], ids=('hc_id', 'hc_name'))
 @pytest.mark.parametrize(
-    'filter_by_org', ('id', 'name', 'title'), ids=('org_id', 'org_name', 'org_title')
+    'filter_by_org', ['id', 'name', 'title'], ids=('org_id', 'org_name', 'org_title')
 )
 @pytest.mark.no_containers
 def test_positive_install_by_host_collection_and_org(
@@ -1009,10 +1009,10 @@ def test_host_errata_search_commands(
 
 
 @pytest.mark.tier3
-@pytest.mark.parametrize('sort_by_date', ('issued', 'updated'), ids=('issued_date', 'updated_date'))
+@pytest.mark.parametrize('sort_by_date', ['issued', 'updated'], ids=('issued_date', 'updated_date'))
 @pytest.mark.parametrize(
     'filter_by_org',
-    ('id', 'name', 'label', None),
+    ['id', 'name', 'label', None],
     ids=('org_id', 'org_name', 'org_label', 'no_org_filter'),
 )
 def test_positive_list_filter_by_org_sort_by_date(
@@ -1059,9 +1059,9 @@ def test_positive_list_filter_by_product_id(products_with_repos):
 
 
 @pytest.mark.tier3
-@pytest.mark.parametrize('filter_by_product', ('id', 'name'), ids=('product_id', 'product_name'))
+@pytest.mark.parametrize('filter_by_product', ['id', 'name'], ids=('product_id', 'product_name'))
 @pytest.mark.parametrize(
-    'filter_by_org', ('id', 'name', 'label'), ids=('org_id', 'org_name', 'org_label')
+    'filter_by_org', ['id', 'name', 'label'], ids=('org_id', 'org_name', 'org_label')
 )
 def test_positive_list_filter_by_product_and_org(
     products_with_repos, filter_by_product, filter_by_org
@@ -1125,7 +1125,7 @@ def test_negative_list_filter_by_product_name(products_with_repos):
 
 @pytest.mark.tier3
 @pytest.mark.parametrize(
-    'filter_by_org', ('id', 'name', 'label'), ids=('org_id', 'org_name', 'org_label')
+    'filter_by_org', ['id', 'name', 'label'], ids=('org_id', 'org_name', 'org_label')
 )
 def test_positive_list_filter_by_org(products_with_repos, filter_by_org):
     """Filter errata by org id, name, or label.

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -34,7 +34,7 @@ def module_perms():
     return perms
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_role():
     """Create a role that a filter would be assigned"""
     return make_role()

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -67,7 +67,7 @@ def module_default_proxy(module_target_sat):
     return module_target_sat.cli.Proxy.list({'search': f'url = {module_target_sat.url}:9090'})[0]
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def function_host(target_sat):
     host_template = target_sat.api.Host()
     host_template.create_missing()
@@ -90,7 +90,7 @@ def function_host(target_sat):
     Host.delete({'id': host['id']})
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def function_user(target_sat, function_host):
     """
     Returns dict with user object and with password to this user
@@ -116,7 +116,7 @@ def function_user(target_sat, function_host):
     user.delete()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def tracer_host(katello_host_tools_tracer_host):
     # create a custom, rhel version-specific mock-service repo
     rhelver = katello_host_tools_tracer_host.os_version.major
@@ -132,7 +132,7 @@ def tracer_host(katello_host_tools_tracer_host):
     )
     katello_host_tools_tracer_host.execute(f'systemctl start {settings.repos["MOCK_SERVICE_RPM"]}')
 
-    yield katello_host_tools_tracer_host
+    return katello_host_tools_tracer_host
 
 
 def update_smart_proxy(sat, location, smart_proxy):
@@ -1542,7 +1542,7 @@ def test_positive_provision_baremetal_with_uefi_secureboot():
     """
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def setup_custom_repo(target_sat, module_org, katello_host_tools_host):
     """Create custom repository content"""
     # get package details
@@ -1587,7 +1587,7 @@ def setup_custom_repo(target_sat, module_org, katello_host_tools_host):
     return details
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def yum_security_plugin(katello_host_tools_host):
     """Enable yum-security-plugin if the distro version requires it.
     Rhel6 yum version does not support updating of a specific advisory out of the box.
@@ -1856,10 +1856,10 @@ def test_positive_install_package_via_rex(
 
 # -------------------------- HOST SUBSCRIPTION SUBCOMMAND FIXTURES --------------------------
 @pytest.mark.skip_if_not_set('clients')
-@pytest.fixture(scope="function")
+@pytest.fixture
 def host_subscription_client(rhel7_contenthost, target_sat):
     rhel7_contenthost.install_katello_ca(target_sat)
-    yield rhel7_contenthost
+    return rhel7_contenthost
 
 
 @pytest.fixture
@@ -2533,14 +2533,14 @@ def test_positive_host_with_puppet(
     session_puppet_enabled_sat.cli.Host.delete({'id': host['id']})
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def function_proxy(session_puppet_enabled_sat, puppet_proxy_port_range):
     proxy = session_puppet_enabled_sat.cli_factory.make_proxy()
     yield proxy
     session_puppet_enabled_sat.cli.Proxy.delete({'id': proxy['id']})
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def function_host_content_source(
     session_puppet_enabled_sat,
     session_puppet_enabled_proxy,

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -34,7 +34,7 @@ from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
 from robottelo.utils.datafactory import generate_strings_list, parametrized
 
 
-@pytest.fixture()
+@pytest.fixture
 def ldap_tear_down():
     """Teardown the all ldap settings user, usergroup and ldap delete"""
     yield

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -78,7 +78,7 @@ def module_stash(request):
     # Please refer the documentation for more details on stash
     # https://docs.pytest.org/en/latest/reference/reference.html#stash
     request.node.stash[synced_repos] = {}
-    yield request.node.stash
+    return request.node.stash
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -33,7 +33,7 @@ from robottelo.utils.datafactory import (
 class TestModel:
     """Test class for Model CLI"""
 
-    @pytest.fixture()
+    @pytest.fixture
     def class_model(self):
         """Shared model for tests"""
         return make_model()
@@ -41,7 +41,7 @@ class TestModel:
     @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
-        'name, new_name',
+        ('name', 'new_name'),
         **parametrized(list(zip(valid_data_list().values(), valid_data_list().values())))
     )
     def test_positive_crud_with_name(self, name, new_name):

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -51,7 +51,7 @@ class TestPartitionTable:
     @pytest.mark.tier1
     @pytest.mark.upgrade
     @pytest.mark.parametrize(
-        'name, new_name',
+        ('name', 'new_name'),
         **parametrized(
             list(
                 zip(

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -47,7 +47,7 @@ from robottelo.hosts import ContentHost
 from robottelo.utils import ohsnap
 
 
-@pytest.fixture()
+@pytest.fixture
 def fixture_sca_vmsetup(request, module_sca_manifest_org, target_sat):
     """Create VM and register content host to Simple Content Access organization"""
     if '_count' in request.param.keys():
@@ -65,10 +65,10 @@ def fixture_sca_vmsetup(request, module_sca_manifest_org, target_sat):
             yield client
 
 
-@pytest.fixture()
+@pytest.fixture
 def infra_host(request, target_sat, module_capsule_configured):
     infra_hosts = {'target_sat': target_sat, 'module_capsule_configured': module_capsule_configured}
-    yield infra_hosts[request.param]
+    return infra_hosts[request.param]
 
 
 def assert_job_invocation_result(invocation_command_id, client_hostname, expected_result='success'):
@@ -715,7 +715,7 @@ class TestRexUsers:
         rexmanager = gen_string('alpha')
         make_user({'login': rexmanager, 'password': password, 'organization-ids': module_org.id})
         User.add_role({'login': rexmanager, 'role': 'Remote Execution Manager'})
-        yield (rexmanager, password)
+        return (rexmanager, password)
 
     @pytest.fixture(scope='class')
     def class_rexinfra_user(self, module_org):
@@ -741,7 +741,7 @@ class TestRexUsers:
         make_filter({'role-id': role['id'], 'permissions': permissions})
         User.add_role({'login': rexinfra, 'role': role['name']})
         User.add_role({'login': rexinfra, 'role': 'Remote Execution Manager'})
-        yield (rexinfra, password)
+        return (rexinfra, password)
 
     @pytest.mark.tier3
     @pytest.mark.upgrade

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -988,4 +988,4 @@ def test_negative_generate_hostpkgcompare_nonexistent_host():
                 'inputs': 'Host 1 = nonexistent1, ' 'Host 2 = nonexistent2',
             }
         )
-        assert "At least one of the hosts couldn't be found" in cm.exception.stderr
+    assert "At least one of the hosts couldn't be found" in cm.exception.stderr

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -44,7 +44,7 @@ class TestRole:
 
     @pytest.mark.tier1
     @pytest.mark.parametrize(
-        'name, new_name',
+        ('name', 'new_name'),
         **parametrized(
             list(zip(generate_strings_list(length=10), generate_strings_list(length=10)))
         ),
@@ -147,14 +147,13 @@ class TestRole:
 
         :BZ: 1296782
         """
-        with pytest.raises(CLIReturnCodeError) as err:
-            try:
-                Role.filters()
-            except CLIDataBaseError as err:
-                pytest.fail(err)
+        with pytest.raises(CLIReturnCodeError, CLIDataBaseError) as err:
+            Role.filters()
+        if isinstance(err.type, CLIDataBaseError):
+            pytest.fail(err)
         assert re.search('At least one of options .* is required', err.value.msg)
 
-    @pytest.fixture()
+    @pytest.fixture
     def make_role_with_permissions(self):
         """Create new role with a filter"""
         role = make_role()

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -66,7 +66,7 @@ def config_export_import_settings():
     Settings.set({'name': 'subscription_connection_enabled', 'value': subs_conn_enabled_value})
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def export_import_cleanup_function(target_sat, function_org):
     """Deletes export/import dirs of function org"""
     yield
@@ -75,7 +75,7 @@ def export_import_cleanup_function(target_sat, function_org):
     )
 
 
-@pytest.fixture(scope='function')  # perform the cleanup after each testcase of a module
+@pytest.fixture  # perform the cleanup after each testcase of a module
 def export_import_cleanup_module(target_sat, module_org):
     """Deletes export/import dirs of module_org"""
     yield
@@ -84,19 +84,19 @@ def export_import_cleanup_module(target_sat, module_org):
     )
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_import_org(target_sat):
     """Creates an Organization for content import."""
     org = target_sat.api.Organization().create()
-    yield org
+    return org
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_import_org_with_manifest(target_sat, function_import_org):
     """Creates and sets an Organization with a brand-new manifest for content import."""
     with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
         target_sat.upload_manifest(function_import_org.id, manifest)
-    yield function_import_org
+    return function_import_org
 
 
 @pytest.fixture(scope='module')
@@ -110,10 +110,10 @@ def module_synced_custom_repo(module_target_sat, module_org, module_product):
         }
     )
     module_target_sat.cli.Repository.synchronize({'id': repo['id']})
-    yield repo
+    return repo
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_synced_custom_repo(target_sat, function_org, function_product):
     repo = target_sat.cli_factory.make_repository(
         {
@@ -124,10 +124,10 @@ def function_synced_custom_repo(target_sat, function_org, function_product):
         }
     )
     target_sat.cli.Repository.synchronize({'id': repo['id']})
-    yield repo
+    return repo
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_synced_rhel_repo(request, target_sat, function_sca_manifest_org):
     """Enable and synchronize rhel content with immediate policy"""
     repo_dict = (
@@ -164,7 +164,7 @@ def function_synced_rhel_repo(request, target_sat, function_sca_manifest_org):
     return repo
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_synced_file_repo(target_sat, function_org, function_product):
     repo = target_sat.cli_factory.make_repository(
         {
@@ -175,10 +175,10 @@ def function_synced_file_repo(target_sat, function_org, function_product):
         }
     )
     target_sat.cli.Repository.synchronize({'id': repo['id']})
-    yield repo
+    return repo
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_synced_docker_repo(target_sat, function_org):
     product = target_sat.cli_factory.make_product({'organization-id': function_org.id})
     repo = target_sat.cli_factory.make_repository(
@@ -192,10 +192,10 @@ def function_synced_docker_repo(target_sat, function_org):
         }
     )
     target_sat.cli.Repository.synchronize({'id': repo['id']})
-    yield repo
+    return repo
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_synced_AC_repo(target_sat, function_org, function_product):
     repo = target_sat.cli_factory.make_repository(
         {
@@ -209,7 +209,7 @@ def function_synced_AC_repo(target_sat, function_org, function_product):
         }
     )
     target_sat.cli.Repository.synchronize({'id': repo['id']})
-    yield repo
+    return repo
 
 
 @pytest.mark.run_in_one_thread

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -210,10 +210,10 @@ def test_negative_update_attributes(options):
     options['id'] = subnet['id']
     with pytest.raises(CLIReturnCodeError, match='Could not update the subnet:'):
         Subnet.update(options)
-        # check - subnet is not updated
-        result = Subnet.info({'id': subnet['id']})
-        for key in options.keys():
-            assert subnet[key] == result[key]
+    # check - subnet is not updated
+    result = Subnet.info({'id': subnet['id']})
+    for key in options.keys():
+        assert subnet[key] == result[key]
 
 
 @pytest.mark.tier2

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -72,7 +72,7 @@ class TestUser:
                 yield make_role({'name': role_name})
 
         stubbed_roles = {role['id']: role for role in roles_helper()}
-        yield stubbed_roles
+        return stubbed_roles
 
     @pytest.mark.parametrize('email', **parametrized(valid_emails_list()))
     @pytest.mark.tier2

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -34,11 +34,11 @@ from robottelo.cli.usergroup import UserGroup, UserGroupExternal
 from robottelo.utils.datafactory import valid_usernames_list
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def function_user_group():
     """Create new usergroup per each test"""
     user_group = make_usergroup()
-    yield user_group
+    return user_group
 
 
 @pytest.mark.tier1
@@ -241,10 +241,10 @@ def test_negative_automate_bz1437578(ldap_auth_source, function_user_group):
                 'name': 'Domain Users',
             }
         )
-        assert (
-            'Could not create external user group: '
-            'Name is not found in the authentication source'
-            'Name Domain Users is a special group in AD.'
-            ' Unfortunately, we cannot obtain membership information'
-            ' from a LDAP search and therefore sync it.' == result
-        )
+    assert (
+        'Could not create external user group: '
+        'Name is not found in the authentication source'
+        'Name Domain Users is a special group in AD.'
+        ' Unfortunately, we cannot obtain membership information'
+        ' from a LDAP search and therefore sync it.' == result
+    )

--- a/tests/foreman/cli/test_webhook.py
+++ b/tests/foreman/cli/test_webhook.py
@@ -28,7 +28,7 @@ from robottelo.cli.webhook import Webhook
 from robottelo.constants import WEBHOOK_EVENTS, WEBHOOK_METHODS
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def webhook_factory(request, class_org, class_location):
     def _create_webhook(org, loc, options=None):
         """Function for creating a new Webhook

--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -83,7 +83,7 @@ def setup_capsules(
             {'id': capsule_id, 'organization-id': module_org.id}
         )
 
-    yield {
+    return {
         'capsule_1': module_lb_capsule[0],
         'capsule_2': module_lb_capsule[1],
     }

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -91,7 +91,7 @@ infoblox_plugin_opts = {
 
 @pytest.mark.tier4
 @pytest.mark.parametrize(
-    'command_args,command_opts,rpm_command',
+    ('command_args', 'command_opts', 'rpm_command'),
     params,
     ids=['isc_dhcp', 'infoblox_dhcp', 'infoblox_dns'],
 )

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -74,7 +74,7 @@ def set_certificate_in_satellite(server_type, sat, hostname=None):
         raise AssertionError(f'Failed to restart the httpd after applying {server_type} cert')
 
 
-@pytest.fixture()
+@pytest.fixture
 def ldap_tear_down(module_target_sat):
     """Teardown the all ldap settings user, usergroup and ldap delete"""
     yield
@@ -86,14 +86,14 @@ def ldap_tear_down(module_target_sat):
         ldap_auth.delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def external_user_count(module_target_sat):
     """return the external auth source user count"""
     users = module_target_sat.api.User().search()
-    yield len([user for user in users if user.auth_source_name == 'External'])
+    return len([user for user in users if user.auth_source_name == 'External'])
 
 
-@pytest.fixture()
+@pytest.fixture
 def groups_teardown(module_target_sat):
     """teardown for groups created for external/remote groups"""
     yield
@@ -106,7 +106,7 @@ def groups_teardown(module_target_sat):
             user_groups[0].delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def rhsso_groups_teardown(module_target_sat, default_sso_host):
     """Teardown the rhsso groups"""
     yield
@@ -365,6 +365,7 @@ def test_external_new_user_login_and_check_count_rhsso(
     with module_target_sat.ui_session(login=False) as rhsso_session:
         with pytest.raises(NavigationTriesExceeded) as error:
             rhsso_session.rhsso_login.login(login_details)
+        with pytest.raises(NavigationTriesExceeded) as error:
             rhsso_session.task.read_all()
         assert error.typename == 'NavigationTriesExceeded'
 
@@ -411,6 +412,7 @@ def test_login_failure_rhsso_user_if_internal_user_exist(
     with module_target_sat.ui_session(login=False) as rhsso_session:
         with pytest.raises(NavigationTriesExceeded) as error:
             rhsso_session.rhsso_login.login(login_details)
+        with pytest.raises(NavigationTriesExceeded) as error:
             rhsso_session.task.read_all()
         assert error.typename == 'NavigationTriesExceeded'
 

--- a/tests/foreman/destructive/test_ldapauthsource.py
+++ b/tests/foreman/destructive/test_ldapauthsource.py
@@ -34,20 +34,16 @@ def configure_hammer_session(sat, enable=True):
     sat.execute(f"echo '  :use_sessions: {'true' if enable else 'false'}' >> {HAMMER_CONFIG}")
 
 
-@pytest.fixture()
+@pytest.fixture
 def rh_sso_hammer_auth_setup(module_target_sat, default_sso_host, request):
     """rh_sso hammer setup before running the auth login tests"""
     configure_hammer_session(module_target_sat)
     client_config = {'publicClient': 'true'}
     default_sso_host.update_client_configuration(client_config)
-
-    def rh_sso_hammer_auth_cleanup():
-        """restore the hammer config backup file and rhsso client settings"""
-        module_target_sat.execute(f'mv {HAMMER_CONFIG}.backup {HAMMER_CONFIG}')
-        client_config = {'publicClient': 'false'}
-        default_sso_host.update_client_configuration(client_config)
-
-    request.addfinalizer(rh_sso_hammer_auth_cleanup)
+    yield
+    module_target_sat.execute(f'mv {HAMMER_CONFIG}.backup {HAMMER_CONFIG}')
+    client_config = {'publicClient': 'false'}
+    default_sso_host.update_client_configuration(client_config)
 
 
 def test_rhsso_login_using_hammer(

--- a/tests/foreman/destructive/test_ping.py
+++ b/tests/foreman/destructive/test_ping.py
@@ -29,7 +29,7 @@ def tomcat_service_teardown(request, module_target_sat):
     def _finalize():
         assert module_target_sat.cli.Service.start(options={'only': 'tomcat.service'}).status == 0
 
-    yield module_target_sat
+    return module_target_sat
 
 
 def test_negative_cli_ping_fail_status(tomcat_service_teardown):

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -188,7 +188,7 @@ class TestKatelloCertsCheck:
         result = target_sat.execute(command)
         self.validate_output(result, cert_data)
 
-    @pytest.mark.parametrize('error, cert_file, key_file, ca_file', invalid_inputs)
+    @pytest.mark.parametrize(('error', 'cert_file', 'key_file', 'ca_file'), invalid_inputs)
     @pytest.mark.tier1
     def test_katello_certs_check_output_invalid_input(
         self,
@@ -264,7 +264,7 @@ class TestKatelloCertsCheck:
                     assert message == check
                     break
             else:
-                assert False, f'Failed, Unable to find message "{message}" in result'
+                pytest.fail(f'Failed, Unable to find message "{message}" in result')
         target_sat.execute("date -s 'last year'")
 
     @pytest.mark.stubbed

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -65,7 +65,7 @@ def vm(module_repos_collection_with_manifest, rhel7_contenthost, target_sat):
     """Virtual machine registered in satellite"""
     module_repos_collection_with_manifest.setup_virtual_machine(rhel7_contenthost)
     rhel7_contenthost.add_rex_key(target_sat)
-    yield rhel7_contenthost
+    return rhel7_contenthost
 
 
 @pytest.fixture
@@ -75,7 +75,7 @@ def vm_module_streams(module_repos_collection_with_manifest, rhel8_contenthost, 
         rhel8_contenthost, install_katello_agent=False
     )
     rhel8_contenthost.add_rex_key(satellite=target_sat)
-    yield rhel8_contenthost
+    return rhel8_contenthost
 
 
 def set_ignore_facts_for_os(value=False):
@@ -997,7 +997,8 @@ def test_module_stream_actions_on_content_host(session, default_location, vm_mod
         )
         assert module_stream[0]['Name'] == FAKE_2_CUSTOM_PACKAGE_NAME
         assert module_stream[0]['Stream'] == stream_version
-        assert 'Enabled' and 'Installed' in module_stream[0]['Status']
+        assert 'Enabled' in module_stream[0]['Status']
+        assert 'Installed' in module_stream[0]['Status']
 
         # remove Module Stream
         result = session.contenthost.execute_module_stream_action(

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -2064,7 +2064,8 @@ def test_positive_update_inclusive_filter_package_version(session, module_org, t
             cv.name, VERSION, 'name = "{}" and version = "{}"'.format(package_name, '0.71')
         )
         assert len(packages) == 1
-        assert packages[0]['Name'] == package_name and packages[0]['Version'] == '0.71'
+        assert packages[0]['Name'] == package_name
+        assert packages[0]['Version'] == '0.71'
         packages = session.contentview.search_version_package(
             cv.name, VERSION, 'name = "{}" and version = "{}"'.format(package_name, '5.21')
         )
@@ -2085,7 +2086,8 @@ def test_positive_update_inclusive_filter_package_version(session, module_org, t
             cv.name, new_version, 'name = "{}" and version = "{}"'.format(package_name, '5.21')
         )
         assert len(packages) == 1
-        assert packages[0]['Name'] == package_name and packages[0]['Version'] == '5.21'
+        assert packages[0]['Name'] == package_name
+        assert packages[0]['Version'] == '5.21'
 
 
 @pytest.mark.skip_if_open('BZ:2086957')
@@ -2126,7 +2128,8 @@ def test_positive_update_exclusive_filter_package_version(session, module_org, t
             cv.name, VERSION, 'name = "{}" and version = "{}"'.format(package_name, '5.21')
         )
         assert len(packages) == 1
-        assert packages[0]['Name'] == package_name and packages[0]['Version'] == '5.21'
+        assert packages[0]['Name'] == package_name
+        assert packages[0]['Version'] == '5.21'
         packages = session.contentview.search_version_package(
             cv.name, VERSION, 'name = "{}" and version = "{}"'.format(package_name, '0.71')
         )
@@ -2147,7 +2150,8 @@ def test_positive_update_exclusive_filter_package_version(session, module_org, t
             cv.name, new_version, 'name = "{}" and version = "{}"'.format(package_name, '0.71')
         )
         assert len(packages) == 1
-        assert packages[0]['Name'] == package_name and packages[0]['Version'] == '0.71'
+        assert packages[0]['Name'] == package_name
+        assert packages[0]['Version'] == '0.71'
 
 
 @pytest.mark.skip_if_open('BZ:2086957')
@@ -2517,7 +2521,8 @@ def test_positive_update_filter_affected_repos(session, module_org, target_sat):
             cv.name, VERSION, 'name = "{}" and version = "{}"'.format(repo1_package_name, '4.2.8')
         )
         assert len(packages) == 1
-        assert packages[0]['Name'] == repo1_package_name and packages[0]['Version'] == '4.2.8'
+        assert packages[0]['Name'] == repo1_package_name
+        assert packages[0]['Version'] == '4.2.8'
         packages = session.contentview.search_version_package(
             cv.name, VERSION, 'name = "{}" and version = "{}"'.format(repo1_package_name, '4.2.9')
         )
@@ -2530,7 +2535,8 @@ def test_positive_update_filter_affected_repos(session, module_org, target_sat):
             'name = "{}" and version = "{}"'.format(repo2_package_name, '3.10.232'),
         )
         assert len(packages) == 1
-        assert packages[0]['Name'] == repo2_package_name and packages[0]['Version'] == '3.10.232'
+        assert packages[0]['Name'] == repo2_package_name
+        assert packages[0]['Version'] == '3.10.232'
 
 
 @pytest.mark.tier3
@@ -3041,10 +3047,8 @@ def test_positive_search_module_streams_in_content_view(session, module_org, tar
                 f'name = "{module_stream}" and stream = "{module_version}"',
             )
             assert len(module_streams) == 1
-            assert (
-                module_streams[0]['Name'] == module_stream
-                and module_streams[0]['Stream'] == module_version
-            )
+            assert module_streams[0]['Name'] == module_stream
+            assert module_streams[0]['Stream'] == module_version
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -180,7 +180,7 @@ def test_negative_delete_rule_with_non_admin_user(
         hostgroup=hg, organization=[module_org], location=[module_location]
     ).create()
     with Session(test_name, user=reader_user.login, password=reader_user.password) as session:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011
             session.discoveryrule.delete(dr.name)
         dr_val = session.discoveryrule.read_all()
         assert dr.name in [rule['Name'] for rule in dr_val]

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -155,12 +155,12 @@ def errata_status_installable():
     _set_setting_value(errata_status_installable, original_value)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def vm(module_repos_collection_with_setup, rhel7_contenthost, target_sat):
     """Virtual machine registered in satellite"""
     module_repos_collection_with_setup.setup_virtual_machine(rhel7_contenthost)
     rhel7_contenthost.add_rex_key(satellite=target_sat)
-    yield rhel7_contenthost
+    return rhel7_contenthost
 
 
 @pytest.mark.tier3

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -66,7 +66,7 @@ def ui_user(ui_user, smart_proxy_location, module_target_sat):
         id=ui_user.id,
         default_location=smart_proxy_location,
     ).update(['default_location'])
-    yield ui_user
+    return ui_user
 
 
 @pytest.fixture
@@ -735,9 +735,9 @@ def test_positive_check_permissions_affect_create_procedure(
     ]
     with Session(test_name, user=user.login, password=user_password) as session:
         for host_field in host_fields:
+            values = {host_field['name']: host_field['unexpected_value']}
+            values.update(host_field.get('other_fields_values', {}))
             with pytest.raises(NoSuchElementException) as context:
-                values = {host_field['name']: host_field['unexpected_value']}
-                values.update(host_field.get('other_fields_values', {}))
                 session.host.helper.read_create_view(values)
             error_message = str(context.value)
             assert host_field['unexpected_value'] in error_message

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -29,7 +29,7 @@ def module_rhel_client_by_ip(module_org, smart_proxy_location, rhel7_contenthost
     target_sat.api_utils.update_vm_host_location(
         rhel7_contenthost, location_id=smart_proxy_location.id
     )
-    yield rhel7_contenthost
+    return rhel7_contenthost
 
 
 @pytest.mark.tier4

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -59,7 +59,7 @@ def set_certificate_in_satellite(server_type, target_sat, hostname=None):
         raise AssertionError(f'Failed to restart the httpd after applying {server_type} cert')
 
 
-@pytest.fixture()
+@pytest.fixture
 def ldap_usergroup_name():
     """Return some random usergroup name,
     and attempt to delete such usergroup when test finishes.
@@ -71,7 +71,7 @@ def ldap_usergroup_name():
         user_groups[0].delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def ldap_tear_down():
     """Teardown the all ldap settings user, usergroup and ldap delete"""
     yield
@@ -83,14 +83,14 @@ def ldap_tear_down():
         ldap_auth.delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def external_user_count():
     """return the external auth source user count"""
     users = entities.User().search()
-    yield len([user for user in users if user.auth_source_name == 'External'])
+    return len([user for user in users if user.auth_source_name == 'External'])
 
 
-@pytest.fixture()
+@pytest.fixture
 def groups_teardown():
     """teardown for groups created for external/remote groups"""
     yield
@@ -101,7 +101,7 @@ def groups_teardown():
             user_groups[0].delete()
 
 
-@pytest.fixture()
+@pytest.fixture
 def rhsso_groups_teardown(default_sso_host):
     """Teardown the rhsso groups"""
     yield
@@ -109,7 +109,7 @@ def rhsso_groups_teardown(default_sso_host):
         default_sso_host.delete_rhsso_group(group_name)
 
 
-@pytest.fixture()
+@pytest.fixture
 def multigroup_setting_cleanup(default_ipa_host):
     """Adding and removing the user to/from ipa group"""
     sat_users = settings.ipa.groups
@@ -119,7 +119,7 @@ def multigroup_setting_cleanup(default_ipa_host):
     default_ipa_host.remove_user_from_usergroup(idm_users[1], sat_users[0])
 
 
-@pytest.fixture()
+@pytest.fixture
 def ipa_add_user(default_ipa_host):
     """Create an IPA user and delete it"""
     test_user = gen_string('alpha')

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -167,7 +167,7 @@ def test_positive_delete_with_lock_and_unlock(session):
         )
         assert session.partitiontable.search(name)[0]['Name'] == name
         session.partitiontable.lock(name)
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError):  # noqa: PT011 - TODO determine better exception
             session.partitiontable.delete(name)
         session.partitiontable.unlock(name)
         session.partitiontable.delete(name)

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -27,7 +27,7 @@ def template_data():
     return DataFile.OS_TEMPLATE_DATA_FILE.read_text()
 
 
-@pytest.fixture()
+@pytest.fixture
 def clone_setup(target_sat, module_org, module_location):
     name = gen_string('alpha')
     content = gen_string('alpha')

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -34,7 +34,7 @@ def module_vm_client_by_ip(rhel7_contenthost, module_org, smart_proxy_location, 
     target_sat.api_factory.update_vm_host_location(
         rhel7_contenthost, location_id=smart_proxy_location.id
     )
-    yield rhel7_contenthost
+    return rhel7_contenthost
 
 
 @pytest.mark.tier3

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -227,8 +227,8 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
     with Session(test_name, user_login, user_password) as session:
         # ensure that the created user is not a global admin user
         # check administer->users page
+        pswd = gen_string('alphanumeric')
         with pytest.raises(NavigationTriesExceeded):
-            pswd = gen_string('alphanumeric')
             session.user.create(
                 {
                     'user.login': gen_string('alphanumeric'),
@@ -748,7 +748,8 @@ def test_positive_reposet_disable(session, target_sat, function_entitlement_mani
                 )
             ]
         )
-        assert results and all([result == 'Syncing Complete.' for result in results])
+        assert results
+        assert all([result == 'Syncing Complete.' for result in results])
         session.redhatrepository.disable(repository_name)
         assert not session.redhatrepository.search(
             f'name = "{repository_name}"', category='Enabled'
@@ -799,7 +800,8 @@ def test_positive_reposet_disable_after_manifest_deleted(
                 )
             ]
         )
-        assert results and all([result == 'Syncing Complete.' for result in results])
+        assert results
+        assert all([result == 'Syncing Complete.' for result in results])
         # Delete manifest
         sub.delete_manifest(data={'organization_id': org.id})
         # Verify that the displayed repository name is correct
@@ -878,7 +880,8 @@ def test_positive_delete_rhel_repo(session, module_entitlement_manifest_org, tar
                 )
             ]
         )
-        assert results and all([result == 'Syncing Complete.' for result in results])
+        assert results
+        assert all([result == 'Syncing Complete.' for result in results])
         session.repository.delete(product_name, repository_name)
         assert not session.redhatrepository.search(
             f'name = "{repository_name}"', category='Enabled'

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -63,7 +63,7 @@ def module_rhc_org(module_target_sat):
     return org
 
 
-@pytest.fixture()
+@pytest.fixture
 def fixture_setup_rhc_satellite(
     request, module_target_sat, module_rhc_org, module_entitlement_manifest, target_sat
 ):

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -83,10 +83,10 @@ def test_positive_update_restrict_composite_view(session, setting_update, repo_s
                     session.contentview.promote(
                         composite_cv.name, 'Version 1.0', repo_setup['lce'].name
                     )
-                    assert (
-                        'Administrator -> Settings -> Content page using the '
-                        'restrict_composite_view flag.' in str(context.value)
-                    )
+                assert (
+                    'Administrator -> Settings -> Content page using the '
+                    'restrict_composite_view flag.' in str(context.value)
+                )
             else:
                 result = session.contentview.promote(
                     composite_cv.name, 'Version 1.0', repo_setup['lce'].name
@@ -140,7 +140,7 @@ def test_negative_validate_foreman_url_error_message(session, setting_update):
         invalid_value = [invalid_value for invalid_value in invalid_settings_values()][0]
         with pytest.raises(AssertionError) as context:
             session.settings.update(f'name = {property_name}', invalid_value)
-            assert 'Value is invalid: must be integer' in str(context.value)
+        assert 'Value is invalid: must be integer' in str(context.value)
 
 
 @pytest.mark.tier2
@@ -497,7 +497,7 @@ def test_negative_update_hostname_with_empty_fact(session, setting_update):
     with session:
         with pytest.raises(AssertionError) as context:
             session.settings.update(property_name, new_hostname)
-            assert 'can\'t be blank' in str(context.value)
+        assert 'can\'t be blank' in str(context.value)
 
 
 @pytest.mark.run_in_one_thread

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -406,7 +406,8 @@ def test_positive_view_vdc_guest_subscription_products(
             f'subscription_name = "{VDC_SUBSCRIPTION_NAME}" '
             f'and name = "{virt_who_hypervisor_host["name"]}"'
         )
-        assert content_hosts and content_hosts[0]['Name'] == virt_who_hypervisor_host['name']
+        assert content_hosts
+        assert content_hosts[0]['Name'] == virt_who_hypervisor_host['name']
         # ensure that hypervisor guests subscription provided products list is not empty and
         # that the product is in provided products.
         provided_products = session.subscription.provided_products(

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -32,7 +32,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
@@ -50,7 +50,7 @@ def form_data(default_org, target_sat):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     return target_sat.api.VirtWhoConfig(**form_data).create()
 
@@ -476,10 +476,9 @@ class TestVirtWhoConfigforEsx:
         env_error = (
             f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
         )
-        try:
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
             get_configure_option({option}, {config_file})
-        except Exception as VirtWhoError:
-            assert env_error == str(VirtWhoError)
+        assert str(exc_info.value) == env_error
         # Check /var/log/messages should not display warning message
         env_warning = f"Ignoring unknown configuration option \"{option}\""
         result = target_sat.execute(f'grep "{env_warning}" /var/log/messages')

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -29,7 +29,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
@@ -47,7 +47,7 @@ def form_data(default_org, target_sat):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     return target_sat.api.VirtWhoConfig(**form_data).create()
 

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -29,7 +29,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
@@ -45,7 +45,7 @@ def form_data(default_org, target_sat):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     return target_sat.api.VirtWhoConfig(**form_data).create()
 

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -29,7 +29,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
@@ -46,7 +46,7 @@ def form_data(default_org, target_sat):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     return target_sat.api.VirtWhoConfig(**form_data).create()
 

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -29,7 +29,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(default_org, target_sat):
     form = {
         'name': gen_string('alpha'),
@@ -48,7 +48,7 @@ def form_data(default_org, target_sat):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     virtwho_config = target_sat.api.VirtWhoConfig(**form_data).create()
     yield virtwho_config

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -38,7 +38,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
@@ -56,7 +56,7 @@ def form_data(target_sat, default_org):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
 
@@ -505,10 +505,9 @@ class TestVirtWhoConfigforEsx:
         env_error = (
             f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
         )
-        try:
+        with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
             get_configure_option({option}, {config_file})
-        except Exception as VirtWhoError:
-            assert env_error == str(VirtWhoError)
+        assert str(exc_info.value) == env_error
         # Check /var/log/messages should not display warning message
         env_warning = f"Ignoring unknown configuration option \"{option}\""
         result = target_sat.execute(f'grep "{env_warning}" /var/log/messages')

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -29,7 +29,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
@@ -47,7 +47,7 @@ def form_data(target_sat, default_org):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
 

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -29,7 +29,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
@@ -45,7 +45,7 @@ def form_data(target_sat, default_org):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
 

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -29,7 +29,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
@@ -46,7 +46,7 @@ def form_data(target_sat, default_org):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     return target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
 

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -29,7 +29,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data(target_sat, default_org):
     form = {
         'name': gen_string('alpha'),
@@ -48,7 +48,7 @@ def form_data(target_sat, default_org):
     return form
 
 
-@pytest.fixture()
+@pytest.fixture
 def virtwho_config(form_data, target_sat):
     virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
     yield virtwho_config

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -36,7 +36,7 @@ def module_user(request, module_target_sat, default_org, default_location):
         logger.warning('Unable to delete session user: %s', str(err))
 
 
-@pytest.fixture()
+@pytest.fixture
 def session(test_name, module_user):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -43,7 +43,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data():
     form = {
         'debug': True,
@@ -833,13 +833,10 @@ class TestVirtwhoConfigforEsx:
             env_error = (
                 f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
             )
-            try:
+            with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO find better exception
                 get_configure_option({option}, {config_file})
-            except Exception as VirtWhoError:
-                assert env_error == str(VirtWhoError)
+            assert str(exc_info.value) == env_error
             # Check /var/log/messages should not display warning message
             env_warning = f"Ignoring unknown configuration option \"{option}\""
             result = target_sat.execute(f'grep "{env_warning}" /var/log/messages')
             assert result.status == 1
-            session.virtwho_configure.delete(name)
-            assert not session.virtwho_configure.search(name)

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -30,7 +30,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data():
     form = {
         'debug': True,

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -30,7 +30,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data():
     form = {
         'debug': True,

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -30,7 +30,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data():
     form = {
         'debug': True,

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -30,7 +30,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def form_data():
     form = {
         'debug': True,

--- a/tests/robottelo/conftest.py
+++ b/tests/robottelo/conftest.py
@@ -13,13 +13,13 @@ def align_to_satellite():
     pass
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def dummy_test(request):
     """This should be indirectly parametrized to provide dynamic dummy_tests to exec_test"""
     return request.param
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture
 def exec_test(request, dummy_test):
     """Create a temporary file with the string provided by dummy_test, and run it with pytest.main
 

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -301,7 +301,7 @@ class BaseCliTestCase(unittest.TestCase):
         assert 1 == response
 
     @mock.patch('robottelo.cli.base.Base.command_requires_org')
-    def test_info_requires_organization_id(self, _):
+    def test_info_requires_organization_id(self, _):  # noqa: PT019 - not a fixture
         """Check info raises CLIError with organization-id is not present in
         options
         """

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -13,7 +13,7 @@ from robottelo.utils import datafactory
 class TestFilteredDataPoint:
     """Tests for :meth:`robottelo.utils.datafactory.filtered_datapoint` decorator"""
 
-    @pytest.fixture(scope="function")
+    @pytest.fixture
     def run_one_datapoint(self, request):
         # Modify run_one_datapoint on settings singleton based on the indirect param
         # default to false when not parametrized

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -9,7 +9,7 @@ from robottelo.utils import decorators
 class TestCacheable:
     """Tests for :func:`robottelo.utils.decorators.cacheable`."""
 
-    @pytest.fixture(scope="function")
+    @pytest.fixture
     def make_foo(self):
         mocked_object_cache_patcher = mock.patch.dict('robottelo.utils.decorators.OBJECT_CACHE')
         mocked_object_cache_patcher.start()

--- a/tests/robottelo/test_func_locker.py
+++ b/tests/robottelo/test_func_locker.py
@@ -193,7 +193,7 @@ def simple_function_not_locked():
 
 
 class TestFuncLocker:
-    @pytest.fixture(scope="function", autouse=True)
+    @pytest.fixture(autouse=True)
     def count_and_pool(self):
         global counter_file
         counter_file.write('0')
@@ -371,7 +371,9 @@ class TestFuncLocker:
         """Ensure that recursive calls to locked function is detected using
         lock_function decorator"""
         res = count_and_pool.apply_async(recursive_function, ())
-        with pytest.raises(func_locker.FunctionLockerError, match=r'.*recursion detected.*'):
+        with pytest.raises(  # noqa: PT012
+            func_locker.FunctionLockerError, match=r'.*recursion detected.*'
+        ):
             try:
                 res.get(timeout=5)
             except multiprocessing.TimeoutError:

--- a/tests/robottelo/test_func_shared.py
+++ b/tests/robottelo/test_func_shared.py
@@ -163,13 +163,13 @@ class TestFuncShared:
         # generate a new namespace
         scope = gen_string('alpha', 10)
         set_default_scope(scope)
-        yield scope
+        return scope
 
-    @pytest.fixture(scope='function', autouse=True)
+    @pytest.fixture(autouse=True)
     def enable(self):
         enable_shared_function(True)
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture
     def pool(self):
         pool = multiprocessing.Pool(DEFAULT_POOL_SIZE)
         yield pool

--- a/tests/robottelo/test_issue_handlers.py
+++ b/tests/robottelo/test_issue_handlers.py
@@ -342,8 +342,8 @@ class TestBugzillaIssueHandler:
     @pytest.mark.parametrize('issue', ["BZ123456", "XX:123456", "KK:89456", "123456", 999999])
     def test_invalid_handler(self, issue):
         """Assert is_open w/ invalid handlers raise AttributeError"""
+        issue_deselect = should_deselect(issue)
         with pytest.raises(AttributeError):
-            issue_deselect = should_deselect(issue)
             is_open(issue)
         assert issue_deselect is None
 

--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -26,7 +26,7 @@ class TestActivationKey:
     operated/modified.
     """
 
-    @pytest.fixture(scope='function')
+    @pytest.fixture
     def activation_key_setup(self, request, target_sat):
         """
         The purpose of this fixture is to setup the activation key based on the provided
@@ -45,7 +45,7 @@ class TestActivationKey:
             content_view=cv, organization=org, name=f"{request.param}_ak"
         ).create()
         ak_details = {'org': org, "cv": cv, 'ak': ak, 'custom_repo': custom_repo}
-        yield ak_details
+        return ak_details
 
     @pytest.mark.pre_upgrade
     @pytest.mark.parametrize(

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -51,7 +51,7 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
     """
 
     @pytest.fixture(scope="class")
-    def _setup_scenario(self, class_target_sat):
+    def setup_scenario(self, class_target_sat):
         """Import some parametrized puppet classes. This is required to make
         sure that we have smart class variable available.
         Read all available smart class parameters for imported puppet class to
@@ -100,7 +100,7 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
     @pytest.mark.pre_upgrade
     @pytest.mark.parametrize('count', list(range(1, 10)))
     def test_pre_puppet_class_parameter_data_and_type(
-        self, class_target_sat, count, _setup_scenario, save_test_data
+        self, class_target_sat, count, setup_scenario, save_test_data
     ):
         """Puppet Class parameters with different data type are created
 
@@ -116,7 +116,7 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
 
         :expectedresults: The parameters are updated with different data types
         """
-        save_test_data(_setup_scenario)
+        save_test_data(setup_scenario)
         data = _valid_sc_parameters_data()[count - 1]
         sc_param = class_target_sat.api.SmartClassParameters().search(
             query={'search': f'parameter="api_classparameters_scp_00{count}"'}
@@ -130,9 +130,10 @@ class TestScenarioPositivePuppetParameterAndDatatypeIntact:
         self._validate_value(data, sc_param)
 
     @pytest.mark.post_upgrade(depend_on=test_pre_puppet_class_parameter_data_and_type)
+    @pytest.mark.usefixtures('_clean_scenario')
     @pytest.mark.parametrize('count', list(range(1, 10)))
     def test_post_puppet_class_parameter_data_and_type(
-        self, count, _clean_scenario, class_pre_upgrade_data, class_target_sat
+        self, count, class_pre_upgrade_data, class_target_sat
     ):
         """Puppet Class Parameters value and type is intact post upgrade
 

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -90,7 +90,7 @@ class TestScenarioPositiveGCEHostComputeResource:
             image=module_gce_finishimg,
             root_pass=gen_string('alphanumeric'),
         ).create()
-        yield host
+        return host
 
     def google_host(self, googleclient):
         """Returns the Google Client Host object to perform the assertions"""


### PR DESCRIPTION
This is a big one! Most of the changes are automatic, but a number of these are manual. I've deselected rules relating to fixture naming, but we can have a conversation later about whether we want to adopt the underscore naming conventions for fixtures.

fixes #13037 