### PR TITLE
Stream fix for e2e api http_proxy failure

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -96,12 +96,13 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
     # Use global_default_http_proxy
     repo_options['http_proxy_policy'] = 'global_default_http_proxy'
     repo_2 = module_target_sat.api.Repository(**repo_options).create()
+    repo_2.sync()
     assert repo_2.http_proxy_policy == 'global_default_http_proxy'
 
     # Update to selected_http_proxy
     repo_2.http_proxy_policy = 'none'
     repo_2.update(['http_proxy_policy'])
-    assert repo_2.http_proxy_policy == 'none'
+    assert repo_2.read().http_proxy_policy == 'none'
 
     # test scenario for yum type repo discovery.
     repo_name = 'fakerepo01'

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -118,16 +118,16 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
     assert yum_repo['output'][0] == f'{settings.repos.repo_discovery.url}/{repo_name}/'
 
     # test scenario for docker type repo discovery.
-    yum_repo = module_target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
+    docker_repo = module_target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
         data={
             "id": module_manifest_org.id,
             "url": 'quay.io',
             "content_type": "docker",
-            "search": 'quay/busybox',
+            "search": 'foreman/foreman',
         }
     )
-    assert len(yum_repo['output']) >= 1
-    assert 'quay/busybox' in yum_repo['output']
+    assert len(docker_repo['output']) > 0
+    assert docker_repo['result'] == 'success'
 
 
 @pytest.mark.upgrade

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -69,6 +69,7 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
         reposet=constants.REPOSET['rhae2'],
         releasever=None,
     )
+    module_target_sat.api.Repository(id=rh_repo_id).sync()
     rh_repo = module_target_sat.api.Repository(
         id=rh_repo_id,
         http_proxy_policy=http_proxy_policy,


### PR DESCRIPTION
This test already passes locally, but fails for the `auth` and `unauth-proxy` parameters in CI. 
`HTTPError 500: Internal Server Error: {"displayMessage":"Task {taks_id}: RuntimeError: The repository's publication is missing. Please run a 'complete sync' on repo_name."`

There seems to be a delay after create(), where the Metadata Generate tasks is still in progress when calling repo.update(). To resolve I have the repos wait for a sync before continuing, which in theory would wait for any in-progress metadata task.