### PR TITLE
Add API tests for capsule content counts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ productmd==1.37
 pyotp==2.9.0
 python-box==7.1.1
 pytest==7.4.3
+pytest-order==1.1.0
 pytest-services==2.2.1
 pytest-mock==3.12.0
 pytest-reportportal==5.3.0

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -222,7 +222,7 @@ REPO_TYPE = {
     'yum': "yum",
     'ostree': "ostree",
     'docker': "docker",
-    'ansible_collection': "ansible collection",
+    'ansible_collection': "ansible_collection",
     'file': "file",
 }
 

--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -123,6 +123,12 @@ class YumRepository(BaseRepository):
     _type = constants.REPO_TYPE['yum']
 
 
+class FileRepository(BaseRepository):
+    """Custom File repository"""
+
+    _type = constants.REPO_TYPE['file']
+
+
 class DockerRepository(BaseRepository):
     """Custom Docker repository"""
 
@@ -143,6 +149,34 @@ class DockerRepository(BaseRepository):
                 'content-type': self.content_type,
                 'url': self.url,
                 'docker-upstream-name': self.upstream_name,
+            }
+        )
+        self._repo_info = repo_info
+        if synchronize:
+            self.synchronize()
+        return repo_info
+
+
+class AnsibleRepository(BaseRepository):
+    """Custom Ansible Collection repository"""
+
+    _type = constants.REPO_TYPE['ansible_collection']
+
+    def __init__(self, url=None, distro=None, requirements=None):
+        self._requirements = requirements
+        super().__init__(url=url, distro=distro)
+
+    @property
+    def requirements(self):
+        return self._requirements
+
+    def create(self, organization_id, product_id, download_policy=None, synchronize=True):
+        repo_info = self.satellite.cli_factory.make_repository(
+            {
+                'product-id': product_id,
+                'content-type': self.content_type,
+                'url': self.url,
+                'ansible-collection-requirements': f'{{collections: {self.requirements}}}',
             }
         )
         self._repo_info = repo_info


### PR DESCRIPTION
### Problem Statement
Satellite 6.15 will introduce new a feature to provide content counts synced to a Capsule and it needs to be tested.

### Solution
This PR adds test cases to verify capsule content counts via API for unfiltered and filtered mixed-content CVs and a few additions to support it.
