### PR TITLE
[6.12.z] updating the fedora image to 38 as latest using python 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM fedora:38
 MAINTAINER https://github.com/SatelliteQE
 
 RUN dnf install -y gcc git make cmake libffi-devel openssl-devel python3-devel \
@@ -6,7 +6,6 @@ RUN dnf install -y gcc git make cmake libffi-devel openssl-devel python3-devel \
 
 COPY / /robottelo/
 WORKDIR /robottelo
-RUN curl https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example -o broker_settings.yaml
 
 ENV PYCURL_SSL_LIBRARY=openssl
 RUN pip install -r requirements.txt


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13070

#### Problem Statement:
Using the latest Fedora 39 image with Python 3.12 as the default version is causing failures in building the SSH2 Python library, leading to an unsuccessful build of Robottelo.

#### Solution:
Pin the Dockerfile version for Robottelo to Fedora 38, which uses Python 3.11, to resolve compatibility issues and enable a successful build.