### PR TITLE
[6.13.z] Remove BROKER_DIRECTORY from robottelo config

### DIFF
--- a/conf/broker.yaml.template
+++ b/conf/broker.yaml.template
@@ -1,7 +1,5 @@
 BROKER:
-    # The path where your broker settings and inventory are located
-    # If you leave it blank, the default is the output of `broker --version`
-    BROKER_DIRECTORY:
+    # Broker has its own config which you can find by running `broker --version`
     HOST_WORKFLOWS:
         POWER_CONTROL: vm-power-operation
         EXTEND: extend-vm

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -48,15 +48,6 @@ def get_settings():
 
 
 settings = get_settings()
-
-
-if not os.getenv('BROKER_DIRECTORY'):
-    # set the BROKER_DIRECTORY envar so broker knows where to operate from
-    if _broker_dir := settings.robottelo.get('BROKER_DIRECTORY'):
-        logger.debug(f'Setting BROKER_DIRECTORY to {_broker_dir}')
-        os.environ['BROKER_DIRECTORY'] = _broker_dir
-
-
 robottelo_tmp_dir = Path(settings.robottelo.tmp_dir)
 robottelo_tmp_dir.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13027

This is something that broker handles on its own and, due to import timing, isn't handled correctly in robottelo anyway. Removing the field and config mechanism should eliminate confusion around this behavior.