### PR TITLE
Test fix for discovery reboot_all scenario

### DIFF
--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -414,7 +414,6 @@ class TestDiscoveredHost:
         provision_multiple_hosts,
         provisioning_hostgroup,
         pxe_loader,
-        count,
     ):
         """Rebooting all pxe-based discovered hosts
 


### PR DESCRIPTION
### Problem Statement
`test_positive_reboot_all_pxe_hosts` is failing due to ` fixture 'count' not found`

### Solution
Removing `count`