### PR TITLE
[6.12.z] Bump pre-commit from 3.4.0 to 3.5.0 (#12910)

### DIFF
--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,7 +2,7 @@
 flake8==6.1.0
 pytest-cov==4.1.0
 redis==5.0.1
-pre-commit==3.4.0
+pre-commit==3.5.0
 
 # For generating documentation.
 sphinx==7.2.6


### PR DESCRIPTION
(cherry picked from commit a044fd2b78516c1adb24709807b1d002873ec00c)

cherry-pick of #12910