### PR TITLE
First tests for new All Hosts page

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2475,7 +2475,7 @@ def test_positive_host_registration_with_non_admin_user(
 
 
 @pytest.mark.tier2
-def test_all_hosts_delete(session, target_sat, default_org, default_location, new_host_ui):
+def test_all_hosts_delete(session, target_sat, function_org, function_location, new_host_ui):
     """Create a host and delete it through All Hosts UI
 
     :id: 42b4560c-bb57-4c58-928e-e5fd5046b93f
@@ -2488,8 +2488,10 @@ def test_all_hosts_delete(session, target_sat, default_org, default_location, ne
 
     :CaseLevel: System
     """
-    host = target_sat.api.Host(organization=default_org, location=default_location).create()
+    host = target_sat.api.Host(organization=function_org, location=function_location).create()
     with target_sat.ui_session() as session:
+        session.organization.select(function_org.name)
+        session.location.select(function_location.name)
         session.all_hosts.delete(host.name)
         assert session.all_hosts.search(host.name) is None
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2492,30 +2492,26 @@ def test_all_hosts_delete(session, target_sat, function_org, function_location, 
     with target_sat.ui_session() as session:
         session.organization.select(function_org.name)
         session.location.select(function_location.name)
-        session.all_hosts.delete(host.name)
-        assert session.all_hosts.search(host.name) is None
+        assert session.all_hosts.delete(host.name)
 
 
 @pytest.mark.tier2
 def test_all_hosts_bulk_delete(session, target_sat, function_org, function_location, new_host_ui):
     """Create several hosts, and delete them via Bulk Actions in All Hosts UI
+
     :id: af1b4a66-dd83-47c3-904b-e8627119cc53
 
     :expectedresults: Successful deletion of multiple hosts at once through Bulk Action
 
-    :CaseComponent: Hosts-Content
+    :CaseComponent:Hosts-Content
 
     :Team: Phoenix-content
 
     :CaseLevel: System
     """
-    hosts = [
+    for _ in range(10):
         target_sat.api.Host(organization=function_org, location=function_location).create()
-        for _ in range(3)
-    ]
     with target_sat.ui_session() as session:
         session.organization.select(function_org.name)
         session.location.select(function_location.name)
-        session.all_hosts.bulk_delete_all()
-        for host in hosts:
-            assert session.all_hosts.search(host.name) is None
+        assert session.all_hosts.bulk_delete_all()

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -136,6 +136,20 @@ def tracer_install_host(rex_contenthost, target_sat):
     return rex_contenthost
 
 
+@pytest.fixture
+def new_host_ui(target_sat):
+    """Changes the setting to use the New All Host UI
+    then returns it back to the normal value"""
+    all_hosts_setting = target_sat.api.Setting().search(
+        query={'search': f'name={"new_hosts_page"}'}
+    )[0]
+    all_hosts_setting.value = 'True'
+    all_hosts_setting.update({'value'})
+    yield
+    all_hosts_setting.value = 'False'
+    all_hosts_setting.update({'value'})
+
+
 @pytest.mark.e2e
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_global_params, target_sat, host_ui_options):
@@ -2458,3 +2472,48 @@ def test_positive_host_registration_with_non_admin_user(
         # Verify server.hostname and server.port from subscription-manager config
         assert target_sat.hostname == rhel8_contenthost.subscription_config['server']['hostname']
         assert constants.CLIENT_PORT == rhel8_contenthost.subscription_config['server']['port']
+
+
+@pytest.mark.tier2
+def test_all_hosts_delete(session, target_sat, default_org, default_location, new_host_ui):
+    """Create a host and delete it through All Hosts UI
+
+    :id: 42b4560c-bb57-4c58-928e-e5fd5046b93f
+
+    :expectedresults: Successful deletion of a host through the table dropdown
+
+    :CaseComponent:Hosts-Content
+
+    :Team: Phoenix-content
+
+    :CaseLevel: System
+    """
+    host = target_sat.api.Host(organization=default_org, location=default_location).create()
+    with target_sat.ui_session() as session:
+        session.all_hosts.delete(host.name)
+        assert session.all_hosts.search(host.name) is None
+
+
+@pytest.mark.tier2
+def test_all_hosts_bulk_delete(session, target_sat, function_org, function_location, new_host_ui):
+    """Create several hosts, and delete them via Bulk Actions in All Hosts UI
+    :id: af1b4a66-dd83-47c3-904b-e8627119cc53
+
+    :expectedresults: Successful deletion of multiple hosts at once through Bulk Action
+
+    :CaseComponent: Hosts-Content
+
+    :Team: Phoenix-content
+
+    :CaseLevel: System
+    """
+    hosts = [
+        target_sat.api.Host(organization=function_org, location=function_location).create()
+        for _ in range(3)
+    ]
+    with target_sat.ui_session() as session:
+        session.organization.select(function_org.name)
+        session.location.select(function_location.name)
+        session.all_hosts.bulk_delete_all()
+        for host in hosts:
+            assert session.all_hosts.search(host.name) is None


### PR DESCRIPTION
This is testing the first set of features for the new All Hosts page. Currently this only includes the Bulk Delete feature, as well as bulk content source change. This PR includes tests for delete and bulk delete, as the Content Source change feature is something with no current coverage, despite being introduced in 6.12

This is a gap I'll look to address in the future in a seperate PR, as part of ongoing coverage increases.
Requires: 


trigger: test-robottelo
airgun: 1039
pytest: tests/foreman/ui/test_host.py -k 'test_all_hosts_delete'
