### PR TITLE
[6.14.z] Check upgrade warning when KA enabled

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1745,6 +1745,8 @@ MAINTAIN_HAMMER_YML = "/etc/foreman-maintain/foreman-maintain-hammer.yml"
 SATELLITE_MAINTAIN_YML = "/etc/foreman-maintain/foreman_maintain.yml"
 FOREMAN_SETTINGS_YML = '/etc/foreman/settings.yaml'
 
+FOREMAN_NIGHTLY_URL = 'https://yum.theforeman.org/releases/nightly/el8/x86_64/'
+
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
 FOREMAN_TEMPLATE_IMPORT_API_URL = 'http://api.github.com/repos/SatelliteQE/foreman_templates'
 

--- a/tests/foreman/destructive/test_katello_agent.py
+++ b/tests/foreman/destructive/test_katello_agent.py
@@ -20,6 +20,7 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
+from robottelo.content_info import get_repo_files_by_url
 
 pytestmark = [
     pytest.mark.run_in_one_thread,
@@ -147,3 +148,49 @@ def test_positive_install_and_remove_package_group(katello_agent_client):
     sat.cli.Host.package_group_remove(hammer_args)
     for package in constants.FAKE_0_CUSTOM_PACKAGE_GROUP:
         assert client.run(f'rpm -q {package}').status != 0
+
+
+def test_positive_upgrade_warning(sat_with_katello_agent):
+    """Ensure a warning is dispayed when upgrading with katello-agent enabled.
+
+    :id: 2bfc5e3e-e147-4e7a-a25c-85be22ef6921
+
+    :expectedresults: Upgrade check fails and warning with proper message is displayed.
+
+    :CaseLevel: System
+    """
+    sat = sat_with_katello_agent
+    ver = sat.version.split('.')
+    target_ver = f'{ver[0]}.{int(ver[1]) + 1}'
+    warning = (
+        "The katello-agent feature is enabled on this system. As of Satellite 6.15, katello-agent "
+        "is removed and will no longer function. Before proceeding with the upgrade, you should "
+        "ensure that you have deployed and configured an alternative tool for remote package "
+        "management and patching for content hosts, such as Remote Execution (REX) with pull-based "
+        "transport. See the Managing Hosts guide in the Satellite documentation for more info. "
+        "Disable katello-agent with the command `satellite-installer --foreman-proxy-content-enable"
+        "-katello-agent false` before proceeding with the upgrade. Alternatively, you may skip "
+        "this check and proceed by running satellite-maintain again with the `--whitelist` option, "
+        "which will automatically uninstall katello-agent."
+    )
+
+    upstream_url = 'https://yum.theforeman.org/releases/nightly/el8/x86_64/'
+    upstream_files = get_repo_files_by_url(upstream_url)
+    fm_rpm = [item for item in upstream_files if 'foreman_maintain' in item]
+    assert fm_rpm, 'no upstream foreman-maintain package found'
+
+    for rpm in fm_rpm:
+        res = sat.execute(f'yum -y install {upstream_url}{rpm}')
+        assert res.status == 0, f'{rpm} installation failed'
+
+    sat.execute('satellite-maintain upgrade list-versions')
+    res = sat.execute('satellite-maintain upgrade list-versions')
+    assert res.status == 0, 'list-versions command failed'
+    assert target_ver in res.stdout, 'target version unavailable'
+
+    res = sat.execute(
+        f'satellite-maintain upgrade check --target-version="{target_ver}" '
+        '--whitelist="repositories-setup,repositories-validate" --assumeyes'
+    )
+    assert res.status, 'upgrade check passed unexpectedly'
+    assert warning in res.stdout, 'warning message missing or changed'


### PR DESCRIPTION
### Problem Statement
Satellite 6.14 is the last version which supports the Katello-Agent, so before upgrade the user must be warned appropriately and we should ensure he really is.

### Solution
Adding a test case which uses the latest foreman-maintain and ensures the upgrade check contains the warning.

