### PR TITLE
Yield details always, no need to check for SCA eligibility

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1498,9 +1498,8 @@ def test_positive_provision_baremetal_with_uefi_secureboot():
 def setup_custom_repo(target_sat, module_org, katello_host_tools_host, request):
     """Create custom repository content"""
 
-    if sca_eligible := module_org.sca_eligible().get('simple_content_access_eligible', False):
-        sca_enabled = module_org.simple_content_access
-        module_org.sca_disable()
+    sca_enabled = module_org.simple_content_access
+    module_org.sca_disable()
 
     # get package details
     details = {}
@@ -1546,9 +1545,9 @@ def setup_custom_repo(target_sat, module_org, katello_host_tools_host, request):
     )
     # refresh repository metadata
     katello_host_tools_host.subscription_manager_list_repos()
-    if sca_eligible:
-        yield
-        module_org.sca_enable() if sca_enabled else module_org.sca_disable()
+    if sca_enabled:
+        yield details
+        module_org.sca_enable()
     else:
         return details
 


### PR DESCRIPTION
### Problem Statement
* #12796 changed the behavior of `setup_custom_repo` that breaks the tests that depend on it. The fixture has to return/yield `details` always
* since https://bugzilla.redhat.com/show_bug.cgi?id=2159974 is fixed, we should not need to check for SCA eligibility

### Solution
* yield `details`
* remove SCA eligibility check




<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->