### PR TITLE
remove test_installer_inventory_plugin_update

### DIFF
--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -19,7 +19,6 @@
 from fauxfactory import gen_domain, gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.constants import SATELLITE_ANSWER_FILE
 from robottelo.utils.installer import InstallerCommand
 
@@ -87,46 +86,6 @@ def test_installer_sat_pub_directory_accessibility(target_sat):
     )
     command_output = target_sat.execute('satellite-installer', timeout='20m')
     assert 'Success!' in command_output.stdout
-
-
-def test_installer_inventory_plugin_update(target_sat):
-    """DB consistency should not break after enabling the inventory plugin flags
-
-    :id: a2b66d38-e819-428f-9529-23bed398c916
-
-    :steps:
-        1. Enable the cloud inventory plugin flag
-
-    :expectedresults: inventory flag should be updated successfully without any db consistency
-        error.
-
-    :CaseImportance: High
-
-    :CaseLevel: System
-
-    :BZ: 1863597
-
-    :customerscenario: true
-
-    """
-    target_sat.create_custom_repos(rhel7=settings.repos.rhel7_os)
-    installer_cmd = target_sat.install(
-        InstallerCommand(
-            'enable-foreman-plugin-rh-cloud',
-            foreman_proxy_plugin_remote_execution_script_install_key=['true'],
-        )
-    )
-    assert 'Success!' in installer_cmd.stdout
-    verify_rhcloud_flag = target_sat.install(
-        InstallerCommand(help='|grep "\'foreman_plugin_rh_cloud\' puppet module (default: true)"')
-    )
-    assert 'true' in verify_rhcloud_flag.stdout
-    verify_proxy_plugin_flag = target_sat.install(
-        InstallerCommand(
-            **{'full-help': '| grep -A1 foreman-proxy-plugin-remote-execution-script-install-key'}
-        )
-    )
-    assert '(current: true)' in verify_proxy_plugin_flag.stdout
 
 
 def test_positive_mismatched_satellite_fqdn(target_sat, set_random_fqdn):


### PR DESCRIPTION
Since rh cloud plugin is installed by default (Satellite 6.8) the test does not do what was intended. Original purpose was to change plugin state from disabled to enabled, but it won't change because it's already installed.