### PR TITLE
[6.14.z] Parametrize Satellite and Capsule deployments

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 
 from broker import Broker
+from packaging.version import Version
 import pytest
 from wait_for import wait_for
 
@@ -244,11 +245,12 @@ def parametrized_enrolled_sat(
 
 
 def get_deploy_args(request):
+    rhel_version = get_sat_rhel_version()
     deploy_args = {
-        'deploy_rhel_version': get_sat_rhel_version().base_version,
+        'deploy_rhel_version': rhel_version.base_version,
         'deploy_flavor': settings.flavors.default,
         'promtail_config_template_file': 'config_sat.j2',
-        'workflow': 'deploy-rhel',
+        'workflow': settings.content_host.get(f'rhel{rhel_version.major}').vm.workflow,
     }
     if hasattr(request, 'param'):
         if isinstance(request.param, dict):
@@ -274,11 +276,12 @@ def module_sat_ready_rhels(request):
 
 @pytest.fixture
 def cap_ready_rhel():
-    rhel8 = settings.content_host.rhel8.vm
+    rhel_version = Version(settings.capsule.version.release)
+    settings.content_host.get(f'rhel{rhel_version.major}').vm.workflow
     deploy_args = {
-        'deploy_rhel_version': rhel8.deploy_rhel_version,
-        'deploy_flavor': 'satqe-ssd.standard.std',
-        'workflow': rhel8.workflow,
+        'deploy_rhel_version': rhel_version.base_version,
+        'deploy_flavor': settings.flavors.default,
+        'workflow': settings.content_host.get(f'rhel{rhel_version.major}').vm.workflow,
     }
     with Broker(**deploy_args, host_class=Capsule) as host:
         yield host

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -69,11 +69,12 @@ POWER_OPERATIONS = {
 
 @lru_cache
 def lru_sat_ready_rhel(rhel_ver):
+    rhel_version = rhel_ver or settings.server.version.rhel_version
     deploy_args = {
-        'deploy_rhel_version': rhel_ver or settings.server.version.rhel_version,
+        'deploy_rhel_version': rhel_version,
         'deploy_flavor': settings.flavors.default,
         'promtail_config_template_file': 'config_sat.j2',
-        'workflow': 'deploy-rhel',
+        'workflow': settings.content_host.get(f'rhel{Version(rhel_version).major}').vm.workflow,
     }
     sat_ready_rhel = Broker(**deploy_args, host_class=Satellite).checkout()
     return sat_ready_rhel


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13152

### Problem Statement
Some of our deployments have hardcoded deploy arguments. These should come from the config.

### Solution
Take the deployment arguments from the config.
