### PR TITLE
[RFE] Check RHEL Lifecycle status in ContentHost UI

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -824,25 +824,9 @@ def test_apply_modular_errata_using_default_content_view(
     stream = '0'
     version = '20180704244205'
 
-    """rhel8_contenthost.install_katello_ca(target_sat)
+    rhel8_contenthost.install_katello_ca(target_sat)
     rhel8_contenthost.register_contenthost(
         module_entitlement_manifest_org.label, rhel8_module_ak.name
-    )"""
-
-    # Associate custom repos with org, lce, ak:
-    target_sat.cli_factory.setup_org_for_a_custom_repo(
-        {
-            'organization-id': module_entitlement_manifest_org.id,
-            'lifecycle-environment-id': default_lce.id,
-            'activationkey-id': rhel8_module_ak.id,
-            'content-view-id': rhel8_custom_repo_cv.id,
-        }
-    )
-    rhel8_contenthost.register(
-        activation_keys=rhel8_module_ak.name,
-        target=target_sat,
-        org=module_entitlement_manifest_org,
-        loc=None,
     )
     assert rhel8_contenthost.subscribed
     host = rhel8_contenthost.nailgun_host
@@ -850,7 +834,7 @@ def test_apply_modular_errata_using_default_content_view(
     # Assert no errata on host, no packages applicable or installable
     errata = _fetch_available_errata(module_entitlement_manifest_org, host, expected_amount=0)
     assert len(errata) == 0
-    # rhel8_contenthost.install_katello_host_tools()
+    rhel8_contenthost.install_katello_host_tools()
     # Install older version of module stream to generate the errata
     result = rhel8_contenthost.execute(
         f'yum -y module install {module_name}:{stream}:{version}',

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -824,9 +824,25 @@ def test_apply_modular_errata_using_default_content_view(
     stream = '0'
     version = '20180704244205'
 
-    rhel8_contenthost.install_katello_ca(target_sat)
+    """rhel8_contenthost.install_katello_ca(target_sat)
     rhel8_contenthost.register_contenthost(
         module_entitlement_manifest_org.label, rhel8_module_ak.name
+    )"""
+
+    # Associate custom repos with org, lce, ak:
+    target_sat.cli_factory.setup_org_for_a_custom_repo(
+        {
+            'organization-id': module_entitlement_manifest_org.id,
+            'lifecycle-environment-id': default_lce.id,
+            'activationkey-id': rhel8_module_ak.id,
+            'content-view-id': rhel8_custom_repo_cv.id,
+        }
+    )
+    rhel8_contenthost.register(
+        activation_keys=rhel8_module_ak.name,
+        target=target_sat,
+        org=module_entitlement_manifest_org,
+        loc=None,
     )
     assert rhel8_contenthost.subscribed
     host = rhel8_contenthost.nailgun_host
@@ -834,7 +850,7 @@ def test_apply_modular_errata_using_default_content_view(
     # Assert no errata on host, no packages applicable or installable
     errata = _fetch_available_errata(module_entitlement_manifest_org, host, expected_amount=0)
     assert len(errata) == 0
-    rhel8_contenthost.install_katello_host_tools()
+    # rhel8_contenthost.install_katello_host_tools()
     # Install older version of module stream to generate the errata
     result = rhel8_contenthost.execute(
         f'yum -y module install {module_name}:{stream}:{version}',

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -193,11 +193,6 @@ def test_positive_end_to_end(
     with session:
         session.location.select(default_location.name)
         session.organization.select(module_org.name)
-        # Ensure host status and details show correct RHEL lifecycle status
-        host_status = session.host.host_status(vm.hostname)
-        host_rhel_lcs = session.contenthost.read(vm.hostname, widget_names=['permission_denied'])
-        assert rhel_status in host_rhel_lcs['permission_denied']
-        assert rhel_status in host_status
         # Ensure content host is searchable
         found_chost = session.contenthost.search(f'{vm.hostname}')
         assert found_chost, f'Search for contenthost by name: "{vm.hostname}", returned no results.'
@@ -242,6 +237,11 @@ def test_positive_end_to_end(
             assert startdate in custom_sub['Expires']
         else:
             assert startdate in custom_sub['Starts']
+        # Ensure host status and details show correct RHEL lifecycle status
+        host_status = session.host.host_status(vm.hostname)
+        host_rhel_lcs = session.contenthost.read(vm.hostname, widget_names=['permission_denied'])
+        assert rhel_status in host_rhel_lcs['permission_denied']
+        assert rhel_status in host_status
         # Update description
         new_description = gen_string('alpha')
         session.contenthost.update(vm.hostname, {'details.description': new_description})
@@ -256,9 +256,7 @@ def test_positive_end_to_end(
         packages = session.contenthost.search_package(vm.hostname, FAKE_0_CUSTOM_PACKAGE_NAME)
         assert packages[0]['Installed Package'] == FAKE_0_CUSTOM_PACKAGE
         # Install errata
-        result = session.contenthost.install_errata(
-            vm.hostname, settings.repos.yum_6.errata[2], install_via='rex'
-        )
+        result = session.contenthost.install_errata(vm.hostname, FAKE_1_ERRATA_ID)
         assert result['overview']['hosts_table'][0]['Status'] == 'success'
         # Ensure errata installed
         packages = session.contenthost.search_package(vm.hostname, FAKE_2_CUSTOM_PACKAGE_NAME)


### PR DESCRIPTION
Extend UI::test_contenthost.py::`test_positive_end_to_end`: 
- To check the new `'RHEL Lifecycle status'` of the rhel host, and check `host status`.

Two helper methods:
- `get_supported_rhel_versions()` : to get all supported rhel versions for contenthosts in satellite.
- `get_rhel_lifecycle_support(rhel_version)` : to get expected RHEL Lifecycle status string, 
based on provided `rhel_version#` vs all supported `versions#` discovered.