### PR TITLE
[6.13.z] Add basic fixture cli

### DIFF
--- a/pytest_plugins/fspath_plugins.py
+++ b/pytest_plugins/fspath_plugins.py
@@ -12,5 +12,5 @@ def pytest_collection_modifyitems(session, items, config):
         if item.nodeid.startswith('tests/robottelo/') or item.nodeid.startswith('tests/upgrades/'):
             continue
 
-        endpoint = endpoint_regex.findall(item.location[0])[0]
-        item.user_properties.append(('endpoint', endpoint))
+        if endpoints := endpoint_regex.findall(item.location[0]):
+            item.user_properties.append(('endpoint', endpoints[0]))

--- a/pytest_plugins/issue_handlers.py
+++ b/pytest_plugins/issue_handlers.py
@@ -214,7 +214,9 @@ def generate_issue_collection(items, config):  # pragma: no cover
         filepath, lineno, testcase = item.location
         # Component and importance marks are determined by testimony tokens
         # Testimony.yaml as of writing has both as required, so any
-        component_mark = item.get_closest_marker('component').args[0]
+        if not (components := item.get_closest_marker('component')):
+            continue
+        component_mark = components.args[0]
         component_slug = slugify_component(component_mark, False)
         importance_mark = item.get_closest_marker('importance').args[0]
         for marker in item.iter_markers():

--- a/scripts/fixture_cli.py
+++ b/scripts/fixture_cli.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+import click
+import pytest
+
+
+@click.command()
+@click.argument("fixtures", nargs=-1, required=True)
+@click.option(
+    "--from-file",
+    "-f",
+    type=click.File("w"),
+    help="Run the fixtures from within a file, inheriting the file's context.",
+)
+def run_fixtures(fixtures, from_file):
+    """Create a temporary test that depends on each fixture, then run it.
+
+    You can also run the fixtures from the context of a file, which is useful when testing fixtures
+    that don't live at a global scope.
+
+    Examples:
+        python scripts/fixture_cli.py module_published_cv module_subscribe_satellite
+        python scripts/fixture_cli.py module_lce --from-file tests/foreman/api/test_activationkey.py
+    """
+    fixture_string = ", ".join(filter(None, fixtures))
+    test_template = f"def test_fake({fixture_string}):\n    assert True"
+    if from_file:
+        from_file = Path(from_file.name)
+        # inject the test at the end of the file
+        with from_file.open("a") as f:
+            eof_pos = f.tell()
+            f.write(f"\n\n{test_template}")
+        pytest.main(["-qq", str(from_file.resolve()), "-k", "test_fake"])
+        # remove the test from the file
+        with from_file.open("r+") as f:
+            f.seek(eof_pos)
+            f.truncate()
+    else:
+        temp_file = Path("test_DELETEME.py")
+        temp_file.write_text(test_template)
+        pytest.main(["-qq", str(temp_file)])
+        temp_file.unlink()
+
+
+if __name__ == "__main__":
+    run_fixtures()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13101

This change adds a new fixture_cli.py script under the scripts directory.

The basic usage of this script is to take in a space-separated list of global fixtures and run them together in a single temporary test.

e.g. python scripts/fixture_cli.py module_ak_with_synced_repo module_lce

Additionally, I had to make some minor adjustments to a couple of plugins since this temporary test doesn't follow the same rules as the rest of our framework.

