### PR TITLE
Changes to Master due to new 6.15 and 6.16

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,7 @@ updates:
     labels:
       - "CherryPick"
       - "dependencies"
+      - "6.15.z"
       - "6.14.z"
       - "6.13.z"
       - "6.12.z"
@@ -24,6 +25,7 @@ updates:
     labels:
       - "CherryPick"
       - "dependencies"
+      - "6.15.z"
       - "6.14.z"
       - "6.13.z"
       - "6.12.z"

--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -15,9 +15,9 @@ ROBOTTELO:
   RUN_ONE_DATAPOINT: false
   # Satellite version supported by this branch
   # UNDR version is used for some URL composition
-  SATELLITE_VERSION: "6.15"
+  SATELLITE_VERSION: "6.16"
   # The Base OS RHEL Version(x.y) where the satellite would be installed
-  RHEL_VERSION: "7.9"
+  RHEL_VERSION: "8.9"
   # Dynaconf and Dynaconf hooks related options
   SETTINGS:
     GET_FRESH: true

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -16,9 +16,9 @@ class Colored(Box):
 
 
 # This should be updated after each version branch
-SATELLITE_VERSION = "6.15"
+SATELLITE_VERSION = "6.16"
 SATELLITE_OS_VERSION = "8"
-SAT_NON_GA_VERSIONS = ['6.14', '6.15']
+SAT_NON_GA_VERSIONS = ['6.15', '6.16']
 
 # Default system ports
 HTTPS_PORT = '443'

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1458,7 +1458,6 @@ class TestCapsuleContentManagement:
 
         module_capsule_configured.wait_for_sync()
 
-    @pytest.mark.stream
     @pytest.mark.parametrize(
         'repos_collection',
         [
@@ -1597,7 +1596,6 @@ class TestCapsuleContentManagement:
                 [repo.content_counts.get(key) == cnt['counts'].get(key) for key in common_keys]
             )
 
-    @pytest.mark.stream
     @pytest.mark.order(1)
     def test_positive_content_counts_blank_update(
         self,

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -675,7 +675,6 @@ class TestContentViewFilter:
         with pytest.raises(HTTPError):
             cvf.update(['repository'])
 
-    @pytest.mark.stream
     @pytest.mark.tier2
     @pytest.mark.parametrize(
         'filter_type', ['erratum', 'package_group', 'rpm', 'modulemd', 'docker']

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -116,7 +116,6 @@ def test_plugin_installation(target_sat, command_args, command_opts, rpm_command
     assert target_sat.execute(rpm_command).status == 0
 
 
-@pytest.mark.stream
 @pytest.mark.e2e
 @pytest.mark.parametrize('module_sync_kickstart_content', [8], indirect=True)
 def test_infoblox_end_to_end(

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -125,7 +125,6 @@ def test_positive_service_stop_start(sat_maintain):
     assert result.status == 0
 
 
-@pytest.mark.stream
 @pytest.mark.upgrade
 @pytest.mark.include_capsule
 @pytest.mark.usefixtures('start_satellite_services')

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -551,7 +551,6 @@ def test_positive_entries_per_page(session, setting_update):
 
 
 @pytest.mark.tier2
-@pytest.mark.stream
 def test_positive_setting_display_fqdn_for_hosts(session, target_sat):
     """Verify setting display_fqdn_for_hosts set as Yes/No, and FQDN is used for host's name
     if it's set to Yes else not, according to setting set.


### PR DESCRIPTION
### Problem Statement
New 6.15 downstream and master points to stream that is 6.16

### Solution
- Dependabot.yaml cherrypicks to 6.15
- Robottelo conf and constants now uses 6.16 and 6.15 satellite versions 

### Related Issues
https://github.com/SatelliteQE/robottelo/pull/13168

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->