### PR TITLE
[6.15.z] recording ui-session-id for report portal logging

### DIFF
--- a/pytest_fixtures/core/ui.py
+++ b/pytest_fixtures/core/ui.py
@@ -49,7 +49,8 @@ def session(target_sat, test_name, ui_user, request):
                 session.architecture.create({'name': 'bar'})
 
     """
-    return target_sat.ui_session(test_name, ui_user.login, ui_user.password)
+    with target_sat.ui_session(test_name, ui_user.login, ui_user.password) as session:
+        yield session
 
 
 @pytest.fixture

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1729,6 +1729,7 @@ class Satellite(Capsule, SatelliteMixins):
         # create dummy classes for later population
         self._api = type('api', (), {'_configured': False})
         self._cli = type('cli', (), {'_configured': False})
+        self.record_property = None
 
     def _swap_nailgun(self, new_version):
         """Install a different version of nailgun from GitHub and invalidate the module cache."""
@@ -1817,6 +1818,7 @@ class Satellite(Capsule, SatelliteMixins):
         yield
         self.omitting_credentials = False
 
+    @contextmanager
     def ui_session(self, testname=None, user=None, password=None, url=None, login=True):
         """Initialize an airgun Session object and store it as self.ui_session"""
 
@@ -1829,14 +1831,24 @@ class Satellite(Capsule, SatelliteMixins):
                 if frame.function.startswith('test_'):
                     return frame.function
 
-        return Session(
-            session_name=testname or get_caller(),
-            user=user or settings.server.admin_username,
-            password=password or settings.server.admin_password,
-            url=url,
-            hostname=self.hostname,
-            login=login,
-        )
+        try:
+            ui_session = Session(
+                session_name=testname or get_caller(),
+                user=user or settings.server.admin_username,
+                password=password or settings.server.admin_password,
+                url=url,
+                hostname=self.hostname,
+                login=login,
+            )
+            yield ui_session
+        except Exception:
+            raise
+        finally:
+            video_url = settings.ui.grid_url.replace(
+                ':4444', f'/videos/{ui_session.ui_session_id}.mp4'
+            )
+            self.record_property('video_url', video_url)
+            self.record_property('session_id', ui_session.ui_session_id)
 
     @property
     def satellite(self):

--- a/tests/foreman/destructive/conftest.py
+++ b/tests/foreman/destructive/conftest.py
@@ -22,4 +22,5 @@ def session(module_target_sat, test_name, ui_user, request):
                 session.architecture.create({'name': 'bar'})
 
     """
-    return module_target_sat.ui_session(test_name, ui_user.login, ui_user.password)
+    with module_target_sat.ui_session(test_name, ui_user.login, ui_user.password) as session:
+        yield session


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13055

### Problem Statement

Currently, We are unable to retrieve the Selenium UI session ID from the Airgun GitHub repository and integrate it into our automation testing tool, Robottelo. This session ID is crucial because during the test recording process, videos are generated by the Selenium Airgun repository, and these videos are associated with specific UI session IDs. To improve our testing workflow and enhance the usability of our test results, we need to establish a mechanism that allows us to access this session ID within Robottelo and incorporate it into the JUnit XML results. By doing so, we can leverage the power of the Report Portal logging system, enabling other team members to easily locate and access the video links associated with each test result for comprehensive test result review.

### Solution

- The ui_session_record_property fixture is now function-scoped to ensure it is created once per test function.
- The fixture uses record_property to load properties like video_link and session_id.
- The ui_session_record_property fixture returns a Satellite instance with an associated AirgunSession instance, including the updated ui_session_id attribute.

#### Airgun PR
https://github.com/SatelliteQE/airgun/pull/1038

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->