### PR TITLE
[6.14.z] fix for webhook event trigger test

### DIFF
--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -162,7 +162,9 @@ class TestWebhook:
         :CaseImportance: Critical
         """
         hook = target_sat.api.Webhooks(
-            event='actions.katello.repository.sync_succeeded', http_method='GET'
+            event='actions.katello.repository.sync_succeeded',
+            http_method='GET',
+            target_url=settings.repos.yum_0.url,
         ).create()
         repo = target_sat.api.Repository(
             organization=module_org, content_type='yum', url=settings.repos.yum_0.url


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13170

### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/13048 didn't get things 100% right, my apologies.

### Solution
Adding an existing target url the webhook can actually GET from to succeed

### Related Issues

This will need to get to 6.15 and 6.14. The 6.13 cherry-pick of https://github.com/SatelliteQE/robottelo/pull/13048 didn't happen yet, I will create a manual cherry-pick for it + changes from this pr.
