### PR TITLE
Add default content type as yum for make_repository helper

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -125,6 +125,7 @@ ENTITY_FIELDS = {
         '_entity_cls': 'Repository',
         'name': gen_alpha,
         'url': settings.repos.yum_1.url,
+        'content-type': 'yum',
     },
     'role': {'name': gen_alphanumeric},
     'filter': {},


### PR DESCRIPTION
### Problem Statement
Changes introduced in https://github.com/SatelliteQE/robottelo/pull/11544 removed the usage of old cli.factory in favor of new cli_factory helpers. And, I've observed a few failures related default content_type missing from `hammer repository create` command used by make_repository helper, and it was present earlier and missing in cli_factory method.
```
robottelo.exceptions.CLIFactoryError: Failed to create Repository with data:
{ 'http-proxy-policy': 'none',
  'name': 'sissapUBCf',
  'organization-id': 3,
  'product-id': '1',
  'url': 'http://testserver.example.com:50123/fake_yum0'}
Command "repository create" finished with status 64
stderr contains:
Could not create the repository:
  Missing arguments for '--content-type'.
```

### Solution
Add content_type=yum as default in make_repository helper of cli_factory

### Additional Info
#11544 cherrypicking was failed for 6.14.z or older, but it was merged before branching, so this will require cherrypicking to 6.15.z