### PR TITLE
[6.15.z] Intermittent failure of api::errata::e2e

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -224,8 +224,11 @@ def test_positive_install_multiple_in_host(target_sat, rhel_contenthost, module_
             search_rate=20,
             max_tries=15,
         )
+        rhel_contenthost.execute('subscription-manager repos')
         sleep(20)
-        assert rhel_contenthost.applicable_errata_count == pre_errata_count - 1
+        assert (
+            rhel_contenthost.applicable_errata_count == pre_errata_count - 1
+        ), f'Host applicable errata did not decrease by one, after installation of {errata}'
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13197

### Problem Statement
Intermittently, stream testing for api::test_errata.py::`test_positive_install_multiple_in_host`
will fail for one or more rhel version parameter. 
At the end, the check fails to assert that an errata install resulted in one less applicable erratum. 

The issue seems to be a post-install assertion will occur-
before the async errata applicability generate task finishes, or the task was not triggered.

### Solution
Trigger errata applicability generate after errata install, using `subscription-manager`.

### Related Issues
Most recently seen in errata-stream build from 11/17/2023, 02:38

```
tests/foreman/api/test_errata.py:228: in test_positive_install_multiple_in_host[rhel8]
    assert rhel_contenthost.applicable_errata_count == pre_errata_count - 1
E   AssertionError: assert 4 == (4 - 1)
```