### PR TITLE
[6.15.z] Add test scenario for disconnected option of rh_cloud report

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2207,11 +2207,13 @@ class Satellite(Capsule, SatelliteMixins):
             self.execute('systemctl daemon-reload && systemctl restart httpd.service').status == 0
         )
 
-    def generate_inventory_report(self, org):
+    def generate_inventory_report(self, org, disconnected='false'):
         """Function to perform inventory upload."""
         generate_report_task = 'ForemanInventoryUpload::Async::UploadReportJob'
         timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
-        self.api.Organization(id=org.id).rh_cloud_generate_report()
+        self.api.Organization(id=org.id).rh_cloud_generate_report(
+            data={'disconnected': disconnected}
+        )
         wait_for(
             lambda: self.api.ForemanTask()
             .search(query={'search': f'{generate_report_task} and started_at >= "{timestamp}"'})[0]

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -221,6 +221,7 @@ def test_inventory_upload_with_http_proxy():
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
+@pytest.mark.e2e
 def test_include_parameter_tags_setting(
     inventory_settings,
     rhcloud_manifest_org,
@@ -237,7 +238,7 @@ def test_include_parameter_tags_setting(
         2. Register a content host with satellite.
         3. Create a host parameter with long text value.
         4. Create Hostcollection with name containing double quotes.
-        5. Generate inventory report.
+        5. Generate inventory report with disconnected option.
         6. Assert that generated report contains valid json file.
         7. Observe the tag generated from the parameter.
 
@@ -272,7 +273,7 @@ def test_include_parameter_tags_setting(
     local_report_path = robottelo_tmp_dir.joinpath(f'{gen_alphanumeric()}_{org.id}.tar.xz')
     # Enable include_parameter_tags setting
     module_target_sat.update_setting('include_parameter_tags', True)
-    module_target_sat.generate_inventory_report(org)
+    module_target_sat.generate_inventory_report(org, disconnected='true')
     # Download report
     module_target_sat.api.Organization(id=org.id).rh_cloud_download_report(
         destination=local_report_path


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13210

### Problem Statement
We have a new option in rh_cloud report for generating inventory report without uploading it. 

### Solution
Add test scenario for the disconnected option of rh_cloud report

### Related Issues
See SAT-19991 for more info

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->