### PR TITLE
[Test Fix] Updating Tools repo to Utils repo in the recommended repos test

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -878,7 +878,7 @@ def test_positive_delete_rhel_repo(session, module_entitlement_manifest_org, tar
 
 
 @pytest.mark.tier2
-def test_positive_recommended_repos(session, module_entitlement_manifest_org):
+def test_positive_recommended_repos(session, module_sca_manifest_org):
     """list recommended repositories using
      On/Off 'Recommended Repositories' toggle.
 
@@ -893,7 +893,7 @@ def test_positive_recommended_repos(session, module_entitlement_manifest_org):
     :BZ: 1776108
     """
     with session:
-        session.organization.select(module_entitlement_manifest_org.name)
+        session.organization.select(module_sca_manifest_org.name)
         rrepos_on = session.redhatrepository.read(recommended_repo='on')
         assert REPOSET['rhel7'] in [repo['name'] for repo in rrepos_on]
         assert REPOSET['rhsclient7'] in [repo['name'] for repo in rrepos_on]

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -901,14 +901,14 @@ def test_positive_recommended_repos(session, module_entitlement_manifest_org):
         assert REPOSET['rhsclient9'] in [repo['name'] for repo in rrepos_on]
         v = get_sat_version()
         sat_version = f'{v.major}.{v.minor}'
-        cap_utils_repos = [
+        cap_utils_main_repos = [
             repo['name']
             for repo in rrepos_on
             if 'Utils' in repo['name'] or 'Capsule' in repo['name'] or 'Maintenance' in repo['name']
         ]
-        cap_tools_repos = [repo for repo in cap_utils_repos if repo.split()[4] != sat_version]
+        rec_repos = [repo for repo in cap_utils_main_repos if repo.split()[4] != sat_version]
         assert (
-            not cap_tools_repos
+            not rec_repos
         ), 'Utils/Capsule/Maintenance repos do not match with Satellite version'
         rrepos_off = session.redhatrepository.read(recommended_repo='off')
         assert len(rrepos_off) > len(rrepos_on)

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -900,10 +900,10 @@ def test_positive_recommended_repos(session, module_entitlement_manifest_org):
         cap_tool_repos = [
             repo['name']
             for repo in rrepos_on
-            if 'Tools' in repo['name'] or 'Capsule' in repo['name']
+            if 'Utils' in repo['name'] or 'Capsule' in repo['name']
         ]
         cap_tools_repos = [repo for repo in cap_tool_repos if repo.split()[4] != sat_version]
-        assert not cap_tools_repos, 'Tools/Capsule repos do not match with Satellite version'
+        assert not cap_tools_repos, 'Utils/Capsule repos do not match with Satellite version'
         rrepos_off = session.redhatrepository.read(recommended_repo='off')
         assert len(rrepos_off) > len(rrepos_on)
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -887,7 +887,8 @@ def test_positive_recommended_repos(session, module_entitlement_manifest_org):
     :expectedresults:
 
            1. Shows repositories as per On/Off 'Recommended Repositories'.
-           2. Check last Satellite version Capsule/Tools repos do not exist.
+           2. Check that client repositories are in 'Recommended Repsitories'.
+           2. Check last Satellite version Utils/Capsule/Maintenance repos do not exist.
 
     :BZ: 1776108
     """
@@ -895,15 +896,20 @@ def test_positive_recommended_repos(session, module_entitlement_manifest_org):
         session.organization.select(module_entitlement_manifest_org.name)
         rrepos_on = session.redhatrepository.read(recommended_repo='on')
         assert REPOSET['rhel7'] in [repo['name'] for repo in rrepos_on]
+        assert REPOSET['rhsclient7'] in [repo['name'] for repo in rrepos_on]
+        assert REPOSET['rhsclient8'] in [repo['name'] for repo in rrepos_on]
+        assert REPOSET['rhsclient9'] in [repo['name'] for repo in rrepos_on]
         v = get_sat_version()
         sat_version = f'{v.major}.{v.minor}'
-        cap_tool_repos = [
+        cap_utils_repos = [
             repo['name']
             for repo in rrepos_on
-            if 'Utils' in repo['name'] or 'Capsule' in repo['name']
+            if 'Utils' in repo['name'] or 'Capsule' in repo['name'] or 'Maintenance' in repo['name']
         ]
-        cap_tools_repos = [repo for repo in cap_tool_repos if repo.split()[4] != sat_version]
-        assert not cap_tools_repos, 'Utils/Capsule repos do not match with Satellite version'
+        cap_tools_repos = [repo for repo in cap_utils_repos if repo.split()[4] != sat_version]
+        assert (
+            not cap_tools_repos
+        ), 'Utils/Capsule/Maintenance repos do not match with Satellite version'
         rrepos_off = session.redhatrepository.read(recommended_repo='off')
         assert len(rrepos_off) > len(rrepos_on)
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -888,7 +888,7 @@ def test_positive_recommended_repos(session, module_sca_manifest_org):
 
            1. Shows repositories as per On/Off 'Recommended Repositories'.
            2. Check that client repositories are in 'Recommended Repositories'.
-           3. Check last Satellite version Utils/Capsule/Maintenance repos do not exist.
+           3. Check that the Utils/Capsule/Maintenance repos for previous versions do not exist.
 
     :BZ: 1776108
     """

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -887,18 +887,19 @@ def test_positive_recommended_repos(session, module_sca_manifest_org):
     :expectedresults:
 
            1. Shows repositories as per On/Off 'Recommended Repositories'.
-           2. Check that client repositories are in 'Recommended Repsitories'.
-           2. Check last Satellite version Utils/Capsule/Maintenance repos do not exist.
+           2. Check that client repositories are in 'Recommended Repositories'.
+           3. Check last Satellite version Utils/Capsule/Maintenance repos do not exist.
 
     :BZ: 1776108
     """
     with session:
         session.organization.select(module_sca_manifest_org.name)
         rrepos_on = session.redhatrepository.read(recommended_repo='on')
-        assert REPOSET['rhel7'] in [repo['name'] for repo in rrepos_on]
-        assert REPOSET['rhsclient7'] in [repo['name'] for repo in rrepos_on]
-        assert REPOSET['rhsclient8'] in [repo['name'] for repo in rrepos_on]
-        assert REPOSET['rhsclient9'] in [repo['name'] for repo in rrepos_on]
+        all_recommended_repos = [repo['name'] for repo in rrepos_on]
+        assert REPOSET['rhel7'] in all_recommended_repos
+        assert REPOSET['rhsclient7'] in all_recommended_repos
+        assert REPOSET['rhsclient8'] in all_recommended_repos
+        assert REPOSET['rhsclient9'] in all_recommended_repos
         v = get_sat_version()
         sat_version = f'{v.major}.{v.minor}'
         cap_utils_main_repos = [

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -907,9 +907,7 @@ def test_positive_recommended_repos(session, module_sca_manifest_org):
             if 'Utils' in repo['name'] or 'Capsule' in repo['name'] or 'Maintenance' in repo['name']
         ]
         rec_repos = [repo for repo in cap_utils_main_repos if repo.split()[4] != sat_version]
-        assert (
-            not rec_repos
-        ), 'Utils/Capsule/Maintenance repos do not match with Satellite version'
+        assert not rec_repos, 'Utils/Capsule/Maintenance repos do not match with Satellite version'
         rrepos_off = session.redhatrepository.read(recommended_repo='off')
         assert len(rrepos_off) > len(rrepos_on)
 


### PR DESCRIPTION
The Tools repository was removed and is not longer in the recommended repo list. Switching the repository check to use the Utils and Capsule repositories instead