### PR TITLE
[6.15.z] fixture support for virt-who config cli : data_form deploy_type virtwho_config delete_host& manifest content move

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -65,6 +65,7 @@ pytest_plugins = [
     'pytest_fixtures.component.templatesync',
     'pytest_fixtures.component.user',
     'pytest_fixtures.component.user_role',
+    'pytest_fixtures.component.virtwho_config',
     # upgrade
     'pytest_plugins.upgrade.scenario_workers',
 ]

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -1,0 +1,347 @@
+import pytest
+
+from robottelo.config import settings
+from robottelo.utils.datafactory import gen_string
+from robottelo.utils.virtwho import (
+    deploy_configure_by_command,
+    deploy_configure_by_script,
+    get_configure_command,
+    get_guest_info,
+)
+
+LOGGEDOUT = 'Logged out.'
+
+
+@pytest.fixture
+def org_module(request, default_org, module_sca_manifest_org):
+    if 'sca' in request.module.__name__.split('.')[-1]:
+        org_module = module_sca_manifest_org
+    else:
+        org_module = default_org
+    return org_module
+
+
+@pytest.fixture
+def org_session(request, session, session_sca):
+    if 'sca' in request.module.__name__.split('.')[-1]:
+        org_session = session_sca
+    else:
+        org_session = session
+    return org_session
+
+
+@pytest.fixture
+def form_data_cli(request, target_sat, org_module):
+    hypervisor_type = request.module.__name__.split('.')[-1].split('_', 1)[-1]
+    if 'esx' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor-id': 'hostname',
+            'hypervisor-type': settings.virtwho.esx.hypervisor_type,
+            'hypervisor-server': settings.virtwho.esx.hypervisor_server,
+            'organization-id': org_module.id,
+            'filtering-mode': 'none',
+            'satellite-url': target_sat.hostname,
+            'hypervisor-username': settings.virtwho.esx.hypervisor_username,
+            'hypervisor-password': settings.virtwho.esx.hypervisor_password,
+        }
+    elif 'hyperv' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor-id': 'hostname',
+            'hypervisor-type': settings.virtwho.hyperv.hypervisor_type,
+            'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
+            'organization-id': org_module.id,
+            'filtering-mode': 'none',
+            'satellite-url': target_sat.hostname,
+            'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
+            'hypervisor-password': settings.virtwho.hyperv.hypervisor_password,
+        }
+    elif 'kubevirt' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor-id': 'hostname',
+            'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
+            'organization-id': org_module.id,
+            'filtering-mode': 'none',
+            'satellite-url': target_sat.hostname,
+            'kubeconfig-path': settings.virtwho.kubevirt.hypervisor_config_file,
+        }
+    elif 'libvirt' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor-id': 'hostname',
+            'hypervisor-type': settings.virtwho.libvirt.hypervisor_type,
+            'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
+            'organization-id': org_module.id,
+            'filtering-mode': 'none',
+            'satellite-url': target_sat.hostname,
+            'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
+        }
+    elif 'nutanix' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor-id': 'hostname',
+            'hypervisor-type': settings.virtwho.ahv.hypervisor_type,
+            'hypervisor-server': settings.virtwho.ahv.hypervisor_server,
+            'organization-id': org_module.id,
+            'filtering-mode': 'none',
+            'satellite-url': target_sat.hostname,
+            'hypervisor-username': settings.virtwho.ahv.hypervisor_username,
+            'hypervisor-password': settings.virtwho.ahv.hypervisor_password,
+            'prism-flavor': settings.virtwho.ahv.prism_flavor,
+            'ahv-internal-debug': 'false',
+        }
+    return form
+
+
+@pytest.fixture
+def form_data_api(request, target_sat, org_module):
+    hypervisor_type = request.module.__name__.split('.')[-1].split('_', 1)[-1]
+    if 'esx' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.esx.hypervisor_type,
+            'hypervisor_server': settings.virtwho.esx.hypervisor_server,
+            'organization_id': org_module.id,
+            'filtering_mode': 'none',
+            'satellite_url': target_sat.hostname,
+            'hypervisor_username': settings.virtwho.esx.hypervisor_username,
+            'hypervisor_password': settings.virtwho.esx.hypervisor_password,
+        }
+    elif 'hyperv' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
+            'hypervisor_server': settings.virtwho.hyperv.hypervisor_server,
+            'organization_id': org_module.id,
+            'filtering_mode': 'none',
+            'satellite_url': target_sat.hostname,
+            'hypervisor_username': settings.virtwho.hyperv.hypervisor_username,
+            'hypervisor_password': settings.virtwho.hyperv.hypervisor_password,
+        }
+    elif 'kubevirt' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
+            'organization_id': org_module.id,
+            'filtering_mode': 'none',
+            'satellite_url': target_sat.hostname,
+            'kubeconfig_path': settings.virtwho.kubevirt.hypervisor_config_file,
+        }
+    elif 'libvirt' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.libvirt.hypervisor_type,
+            'hypervisor_server': settings.virtwho.libvirt.hypervisor_server,
+            'organization_id': org_module.id,
+            'filtering_mode': 'none',
+            'satellite_url': target_sat.hostname,
+            'hypervisor_username': settings.virtwho.libvirt.hypervisor_username,
+        }
+    elif 'nutanix' in hypervisor_type:
+        form = {
+            'name': gen_string('alpha'),
+            'debug': 1,
+            'interval': '60',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.ahv.hypervisor_type,
+            'hypervisor_server': settings.virtwho.ahv.hypervisor_server,
+            'organization_id': org_module.id,
+            'filtering_mode': 'none',
+            'satellite_url': target_sat.hostname,
+            'hypervisor_username': settings.virtwho.ahv.hypervisor_username,
+            'hypervisor_password': settings.virtwho.ahv.hypervisor_password,
+            'prism_flavor': settings.virtwho.ahv.prism_flavor,
+            'ahv_internal_debug': 'false',
+        }
+    return form
+
+
+@pytest.fixture
+def form_data_ui(request, target_sat, org_module):
+    hypervisor_type = request.module.__name__.split('.')[-1].split('_', 1)[-1]
+    if 'esx' in hypervisor_type:
+        form = {
+            'debug': True,
+            'interval': 'Every hour',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.esx.hypervisor_type,
+            'hypervisor_content.server': settings.virtwho.esx.hypervisor_server,
+            'hypervisor_content.username': settings.virtwho.esx.hypervisor_username,
+            'hypervisor_content.password': settings.virtwho.esx.hypervisor_password,
+        }
+    elif 'hyperv' in hypervisor_type:
+        form = {
+            'debug': True,
+            'interval': 'Every hour',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.hyperv.hypervisor_type,
+            'hypervisor_content.server': settings.virtwho.hyperv.hypervisor_server,
+            'hypervisor_content.username': settings.virtwho.hyperv.hypervisor_username,
+            'hypervisor_content.password': settings.virtwho.hyperv.hypervisor_password,
+        }
+    elif 'kubevirt' in hypervisor_type:
+        form = {
+            'debug': True,
+            'interval': 'Every hour',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.kubevirt.hypervisor_type,
+            'hypervisor_content.kubeconfig': settings.virtwho.kubevirt.hypervisor_config_file,
+        }
+    elif 'libvirt' in hypervisor_type:
+        form = {
+            'debug': True,
+            'interval': 'Every hour',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.libvirt.hypervisor_type,
+            'hypervisor_content.server': settings.virtwho.libvirt.hypervisor_server,
+            'hypervisor_content.username': settings.virtwho.libvirt.hypervisor_username,
+        }
+    elif 'nutanix' in hypervisor_type:
+        form = {
+            'debug': True,
+            'interval': 'Every hour',
+            'hypervisor_id': 'hostname',
+            'hypervisor_type': settings.virtwho.ahv.hypervisor_type,
+            'hypervisor_content.server': settings.virtwho.ahv.hypervisor_server,
+            'hypervisor_content.username': settings.virtwho.ahv.hypervisor_username,
+            'hypervisor_content.password': settings.virtwho.ahv.hypervisor_password,
+            'hypervisor_content.prism_flavor': "Prism Element",
+            'ahv_internal_debug': False,
+        }
+    return form
+
+
+@pytest.fixture
+def virtwho_config_cli(form_data_cli, target_sat):
+    virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)['general-information']
+    yield virtwho_config_cli
+    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
+    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data_cli['name']))
+
+
+@pytest.fixture
+def virtwho_config_api(form_data_api, target_sat):
+    virtwho_config_api = target_sat.api.VirtWhoConfig(**form_data_api).create()
+    yield virtwho_config_api
+    virtwho_config_api.delete()
+    assert not target_sat.api.VirtWhoConfig().search(
+        query={'search': f"name={form_data_api['name']}"}
+    )
+
+
+@pytest.fixture
+def virtwho_config_ui(form_data_ui, target_sat, org_session):
+    name = gen_string('alpha')
+    form_data_ui['name'] = name
+    with org_session:
+        org_session.virtwho_configure.create(form_data_ui)
+        yield virtwho_config_ui
+        org_session.virtwho_configure.delete(name)
+        assert not org_session.virtwho_configure.search(name)
+
+
+@pytest.fixture
+def deploy_type_cli(
+    request,
+    org_module,
+    form_data_cli,
+    virtwho_config_cli,
+    target_sat,
+):
+    deploy_type = request.param.lower()
+    assert virtwho_config_cli['status'] == 'No Report Yet'
+    if "id" in deploy_type:
+        command = get_configure_command(virtwho_config_cli['id'], org_module.name)
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
+        )
+    elif "script" in deploy_type:
+        script = target_sat.cli.VirtWhoConfig.fetch(
+            {'id': virtwho_config_cli['id']}, output_format='base'
+        )
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
+        )
+    return hypervisor_name, guest_name
+
+
+@pytest.fixture
+def deploy_type_api(
+    request,
+    org_module,
+    form_data_api,
+    virtwho_config_api,
+    target_sat,
+):
+    deploy_type = request.param.lower()
+    assert virtwho_config_api.status == 'unknown'
+    if "id" in deploy_type:
+        command = get_configure_command(virtwho_config_api.id, org_module.name)
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data_api['hypervisor_type'], debug=True, org=org_module.label
+        )
+    elif "script" in deploy_type:
+        script = virtwho_config_api.deploy_script()
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script['virt_who_config_script'],
+            form_data_api['hypervisor_type'],
+            debug=True,
+            org=org_module.label,
+        )
+    return hypervisor_name, guest_name
+
+
+@pytest.fixture
+def deploy_type_ui(
+    request,
+    org_module,
+    form_data_ui,
+    org_session,
+    virtwho_config_ui,
+    target_sat,
+):
+    deploy_type = request.param.lower()
+    values = org_session.virtwho_configure.read(form_data_ui['name'])
+    if "id" in deploy_type:
+        command = values['deploy']['command']
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data_ui['hypervisor_type'], debug=True, org=org_module.label
+        )
+    elif "script" in deploy_type:
+        script = values['deploy']['script']
+        hypervisor_name, guest_name = deploy_configure_by_script(
+            script, form_data_ui['hypervisor_type'], debug=True, org=org_module.label
+        )
+    return hypervisor_name, guest_name
+
+
+@pytest.fixture
+def delete_host(form_data_api, target_sat):
+    guest_name, _ = get_guest_info(form_data_api['hypervisor_type'])
+    results = target_sat.api.Host().search(query={'search': guest_name})
+    if results:
+        target_sat.api.Host(id=results[0].read_json()['id']).delete()

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -30,7 +30,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.mark.delete_host
+@pytest.mark.usefixtures('delete_host')
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -27,7 +27,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.mark.delete_host
+@pytest.mark.usefixtures('delete_host')
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -30,7 +30,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.mark.delete_host
+@pytest.mark.usefixtures('delete_host')
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_api', ['id', 'script'], indirect=True)

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -28,7 +28,6 @@ from robottelo.utils.virtwho import (
     create_http_proxy,
     deploy_configure_by_command,
     deploy_configure_by_command_check,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
@@ -37,37 +36,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture
-def form_data(target_sat, default_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.esx.hypervisor_type,
-        'hypervisor-server': settings.virtwho.esx.hypervisor_server,
-        'organization-id': default_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.esx.hypervisor_username,
-        'hypervisor-password': settings.virtwho.esx.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, target_sat, virtwho_config_cli, deploy_type_cli
     ):
         """Verify " hammer virt-who-config deploy"
 
@@ -79,20 +52,9 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        hypervisor_name, guest_name = deploy_type_cli
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
@@ -123,7 +85,7 @@ class TestVirtWhoConfigforEsx:
             assert result.strip() == 'Subscription attached to the host successfully.'
 
     @pytest.mark.tier2
-    def test_positive_debug_option(self, default_org, form_data, target_sat):
+    def test_positive_debug_option(self, default_org, form_data_cli, target_sat):
         """Verify debug option by hammer virt-who-config update"
 
         :id: c98bc518-828c-49ba-a644-542db3190263
@@ -134,8 +96,8 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-        assert virtwho_config['name'] == form_data['name']
+        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data_cli)['general-information']
+        assert virtwho_config['name'] == form_data_cli['name']
         new_name = gen_string('alphanumeric')
         target_sat.cli.VirtWhoConfig.update({'id': virtwho_config['id'], 'new-name': new_name})
         virt_who_instance_name = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
@@ -147,12 +109,14 @@ class TestVirtWhoConfigforEsx:
             target_sat.cli.VirtWhoConfig.update({'id': virtwho_config['id'], 'debug': key})
             command = get_configure_command(virtwho_config['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=default_org.label
+                command, form_data_cli['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
 
     @pytest.mark.tier2
-    def test_positive_interval_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_interval_option(
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
+    ):
         """Verify interval option by hammer virt-who-config update"
 
         :id: 5d558bca-534c-4bd4-b401-a0c362033c57
@@ -174,16 +138,16 @@ class TestVirtWhoConfigforEsx:
             '4320': '259200',
         }
         for key, value in sorted(options.items(), key=lambda item: int(item[0])):
-            target_sat.cli.VirtWhoConfig.update({'id': virtwho_config['id'], 'interval': key})
-            command = get_configure_command(virtwho_config['id'], default_org.name)
+            target_sat.cli.VirtWhoConfig.update({'id': virtwho_config_cli['id'], 'interval': key})
+            command = get_configure_command(virtwho_config_cli['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=default_org.label
+                command, form_data_cli['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -199,19 +163,21 @@ class TestVirtWhoConfigforEsx:
         values = ['uuid', 'hostname', 'hwuuid']
         for value in values:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], default_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=default_org.label
+                command, form_data_cli['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
-    def test_positive_filter_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_filter_option(
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
+    ):
         """Verify filter option by hammer virt-who-config update"
 
         :id: aaf45c5e-9504-47ce-8f25-b8073c2de036
@@ -223,34 +189,48 @@ class TestVirtWhoConfigforEsx:
         :CaseImportance: Medium
         """
         regex = '.*redhat.com'
-        whitelist = {'id': virtwho_config['id'], 'filtering-mode': 'whitelist', 'whitelist': regex}
-        blacklist = {'id': virtwho_config['id'], 'filtering-mode': 'blacklist', 'blacklist': regex}
+        whitelist = {
+            'id': virtwho_config_cli['id'],
+            'filtering-mode': 'whitelist',
+            'whitelist': regex,
+        }
+        blacklist = {
+            'id': virtwho_config_cli['id'],
+            'filtering-mode': 'blacklist',
+            'blacklist': regex,
+        }
         # esx support filter-host-parents and exclude-host-parents options
         whitelist['filter-host-parents'] = regex
         blacklist['exclude-host-parents'] = regex
-        config_file = get_configure_file(virtwho_config['id'])
-        command = get_configure_command(virtwho_config['id'], default_org.name)
+        config_file = get_configure_file(virtwho_config_cli['id'])
+        command = get_configure_command(virtwho_config_cli['id'], default_org.name)
         # Update Whitelist and check the result
         target_sat.cli.VirtWhoConfig.update(whitelist)
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['connection']['filtering'] == 'Whitelist'
         assert result['connection']['filtered-hosts'] == regex
         assert result['connection']['filter-host-parents'] == regex
-        deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], org=default_org.label
+        )
         assert get_configure_option('filter_hosts', config_file) == regex
         assert get_configure_option('filter_host_parents', config_file) == regex
         # Update Blacklist and check the result
         target_sat.cli.VirtWhoConfig.update(blacklist)
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['connection']['filtering'] == 'Blacklist'
         assert result['connection']['excluded-hosts'] == regex
         assert result['connection']['exclude-host-parents'] == regex
-        deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], org=default_org.label
+        )
         assert get_configure_option('exclude_hosts', config_file) == regex
         assert get_configure_option('exclude_host_parents', config_file) == regex
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_proxy_option(
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
+    ):
         """Verify http_proxy option by hammer virt-who-config update"
 
         :id: 409d108e-e814-482b-93ed-09db89d21dda
@@ -267,13 +247,15 @@ class TestVirtWhoConfigforEsx:
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(org=default_org)
         no_proxy = 'test.satellite.com'
         target_sat.cli.VirtWhoConfig.update(
-            {'id': virtwho_config['id'], 'http-proxy': https_proxy_name, 'no-proxy': no_proxy}
+            {'id': virtwho_config_cli['id'], 'http-proxy': https_proxy_name, 'no-proxy': no_proxy}
         )
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['http-proxy']['http-proxy-name'] == https_proxy_name
         assert result['connection']['ignore-proxy'] == no_proxy
-        command = get_configure_command(virtwho_config['id'], default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
+        command = get_configure_command(virtwho_config_cli['id'], default_org.name)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], org=default_org.label
+        )
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
 
@@ -282,13 +264,15 @@ class TestVirtWhoConfigforEsx:
             http_type='http', org=default_org
         )
         target_sat.cli.VirtWhoConfig.update(
-            {'id': virtwho_config['id'], 'http-proxy-id': http_proxy_id}
+            {'id': virtwho_config_cli['id'], 'http-proxy-id': http_proxy_id}
         )
-        deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], org=default_org.label
+        )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
 
     @pytest.mark.tier2
-    def test_positive_rhsm_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_rhsm_option(self, default_org, form_data_cli, virtwho_config_cli, target_sat):
         """Verify rhsm options in the configure file"
 
         :id: b5b93d4d-e780-41c0-9eaa-2407cc1dcc9b
@@ -301,9 +285,11 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        config_file = get_configure_file(virtwho_config['id'])
-        command = get_configure_command(virtwho_config['id'], default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
+        config_file = get_configure_file(virtwho_config_cli['id'])
+        command = get_configure_command(virtwho_config_cli['id'], default_org.name)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], org=default_org.label
+        )
         rhsm_username = get_configure_option('rhsm_username', config_file)
         assert not target_sat.cli.User.exists(search=('login', rhsm_username))
         assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
@@ -339,7 +325,7 @@ class TestVirtWhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_foreman_packages_protection(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """foreman-protector should allow virt-who to be installed
 
@@ -358,16 +344,21 @@ class TestVirtWhoConfigforEsx:
         :BZ: 1783987
         """
         virtwho_package_locked()
-        command = get_configure_command(virtwho_config['id'], default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        command = get_configure_command(virtwho_config_cli['id'], default_org.name)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], org=default_org.label
+        )
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
+            'general-information'
+        ]['status']
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_hypervisor_password_with_special_characters(
-        self, default_org, form_data, target_sat
+        self, default_org, form_data_cli, target_sat
     ):
         """Verify " hammer virt-who-config deploy hypervisor with special characters"
 
@@ -384,8 +375,8 @@ class TestVirtWhoConfigforEsx:
         :customerscenario: true
         """
         # check the hypervisor password contains single quotes
-        form_data['hypervisor-password'] = "Tes't"
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+        form_data_cli['hypervisor-password'] = "Tes't"
+        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data_cli)['general-information']
         assert virtwho_config['status'] == 'No Report Yet'
         command = get_configure_command(virtwho_config['id'], default_org.name)
         deploy_status = deploy_configure_by_command_check(command)
@@ -397,11 +388,11 @@ class TestVirtWhoConfigforEsx:
             == settings.virtwho.esx.hypervisor_username
         )
         target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data_cli['name']))
 
         # check the hypervisor password contains backtick
-        form_data['hypervisor-password'] = r"my\`password"
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+        form_data_cli['hypervisor-password'] = r"my\`password"
+        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data_cli)['general-information']
         assert virtwho_config['status'] == 'No Report Yet'
         command = get_configure_command(virtwho_config['id'], default_org.name)
         deploy_status = deploy_configure_by_command_check(command)
@@ -414,7 +405,9 @@ class TestVirtWhoConfigforEsx:
         )
 
     @pytest.mark.tier2
-    def test_positive_remove_env_option(self, default_org, form_data, virtwho_config, target_sat):
+    def test_positive_remove_env_option(
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
+    ):
         """remove option 'env=' from the virt-who configuration file and without any error
 
         :id: 509add77-dce7-4ba4-b9e5-2a5818c39731
@@ -431,17 +424,17 @@ class TestVirtWhoConfigforEsx:
 
         :customerscenario: true
         """
-        command = get_configure_command(virtwho_config['id'], default_org.name)
+        command = get_configure_command(virtwho_config_cli['id'], default_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=default_org.label
+            command, form_data_cli['hypervisor-type'], debug=True, org=default_org.label
         )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
         option = "env"
-        config_file = get_configure_file(virtwho_config['id'])
+        config_file = get_configure_file(virtwho_config_cli['id'])
         env_error = (
             f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
         )

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -26,7 +26,6 @@ from robottelo.utils.virtwho import (
     create_http_proxy,
     deploy_configure_by_command,
     deploy_configure_by_command_check,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
@@ -35,38 +34,12 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture
-def form_data(target_sat, module_sca_manifest_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.esx.hypervisor_type,
-        'hypervisor-server': settings.virtwho.esx.hypervisor_server,
-        'organization-id': module_sca_manifest_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.esx.hypervisor_username,
-        'hypervisor-password': settings.virtwho.esx.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, target_sat, virtwho_config_cli, deploy_type_cli
     ):
         """Verify "hammer virt-who-config deploy & fetch"
 
@@ -80,27 +53,15 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -114,20 +75,20 @@ class TestVirtWhoConfigforEsx:
         """
         for value in ['uuid', 'hostname']:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
     def test_positive_debug_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify debug option by hammer virt-who-config update"
 
@@ -139,19 +100,19 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        assert virtwho_config['name'] == form_data['name']
+        assert virtwho_config_cli['name'] == form_data_cli['name']
         options = {'false': '0', 'no': '0', 'true': '1', 'yes': '1'}
         for key, value in options.items():
-            target_sat.cli.VirtWhoConfig.update({'id': virtwho_config['id'], 'debug': key})
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            target_sat.cli.VirtWhoConfig.update({'id': virtwho_config_cli['id'], 'debug': key})
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('debug', ETC_VIRTWHO_CONFIG) == value
 
     @pytest.mark.tier2
     def test_positive_name_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify debug option by hammer virt-who-config update"
 
@@ -163,20 +124,20 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        assert virtwho_config['name'] == form_data['name']
+        assert virtwho_config_cli['name'] == form_data_cli['name']
         new_name = gen_string('alphanumeric')
-        target_sat.cli.VirtWhoConfig.update({'id': virtwho_config['id'], 'new-name': new_name})
-        virt_who_instance_name = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
-            'general-information'
-        ]['name']
+        target_sat.cli.VirtWhoConfig.update({'id': virtwho_config_cli['id'], 'new-name': new_name})
+        virt_who_instance_name = target_sat.cli.VirtWhoConfig.info(
+            {'id': virtwho_config_cli['id']}
+        )['general-information']['name']
         assert virt_who_instance_name == new_name
         target_sat.cli.VirtWhoConfig.update(
-            {'id': virtwho_config['id'], 'new-name': form_data['name']}
+            {'id': virtwho_config_cli['id'], 'new-name': form_data_cli['name']}
         )
 
     @pytest.mark.tier2
     def test_positive_interval_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify interval option by hammer virt-who-config update"
 
@@ -199,10 +160,10 @@ class TestVirtWhoConfigforEsx:
             '4320': '259200',
         }
         for key, value in options.items():
-            target_sat.cli.VirtWhoConfig.update({'id': virtwho_config['id'], 'interval': key})
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            target_sat.cli.VirtWhoConfig.update({'id': virtwho_config_cli['id'], 'interval': key})
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('interval', ETC_VIRTWHO_CONFIG) == value
 
@@ -212,8 +173,8 @@ class TestVirtWhoConfigforEsx:
     def test_positive_filter_option(
         self,
         module_sca_manifest_org,
-        form_data,
-        virtwho_config,
+        form_data_cli,
+        virtwho_config_cli,
         target_sat,
         filter_type,
         option_type,
@@ -235,7 +196,7 @@ class TestVirtWhoConfigforEsx:
             # Update whitelist or blacklist and check the result
             if filter_type == "whitelist":
                 whitelist = {
-                    'id': virtwho_config['id'],
+                    'id': virtwho_config_cli['id'],
                     'filtering-mode': 'whitelist',
                     'whitelist': regex,
                 }
@@ -244,17 +205,17 @@ class TestVirtWhoConfigforEsx:
                 target_sat.cli.VirtWhoConfig.update(whitelist)
             elif filter_type == "blacklist":
                 blacklist = {
-                    'id': virtwho_config['id'],
+                    'id': virtwho_config_cli['id'],
                     'filtering-mode': 'blacklist',
                     'blacklist': regex,
                 }
                 blacklist['exclude-host-parents'] = regex
                 target_sat.cli.VirtWhoConfig.update(blacklist)
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
             if filter_type == "whitelist":
                 assert result['connection']['filtering'] == 'Whitelist'
@@ -270,14 +231,16 @@ class TestVirtWhoConfigforEsx:
                 assert get_configure_option('exclude_host_parents', config_file) == regex
         elif option_type == "create":
             # Create a new virt-who config with filtering-mode whitelist or blacklist
-            target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-            assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-            form_data['filtering-mode'] = filter_type
-            form_data[filter_type] = regex
-            form_data['filter-host-parents'] = regex
-            form_data['exclude-host-parents'] = regex
-            virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
+            assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data_cli['name']))
+            form_data_cli['filtering-mode'] = filter_type
+            form_data_cli[filter_type] = regex
+            form_data_cli['filter-host-parents'] = regex
+            form_data_cli['exclude-host-parents'] = regex
+            virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)[
+                'general-information'
+            ]
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             if filter_type == "whitelist":
                 assert result['connection']['filtering'] == 'Whitelist'
                 assert result['connection']['filtered-hosts'] == regex
@@ -286,11 +249,11 @@ class TestVirtWhoConfigforEsx:
                 assert result['connection']['filtering'] == 'Blacklist'
                 assert result['connection']['excluded-hosts'] == regex
                 assert result['connection']['exclude-host-parents'] == regex
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
-            config_file = get_configure_file(virtwho_config['id'])
+            config_file = get_configure_file(virtwho_config_cli['id'])
             if filter_type == "whitelist":
                 assert get_configure_option('filter_hosts', config_file) == regex
                 assert get_configure_option('filter_host_parents', config_file) == regex
@@ -300,7 +263,7 @@ class TestVirtWhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_proxy_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify http_proxy option by hammer virt-who-config update"
 
@@ -322,14 +285,14 @@ class TestVirtWhoConfigforEsx:
         )
         no_proxy = 'test.satellite.com'
         target_sat.cli.VirtWhoConfig.update(
-            {'id': virtwho_config['id'], 'http-proxy': https_proxy_name, 'no-proxy': no_proxy}
+            {'id': virtwho_config_cli['id'], 'http-proxy': https_proxy_name, 'no-proxy': no_proxy}
         )
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['http-proxy']['http-proxy-name'] == https_proxy_name
         assert result['connection']['ignore-proxy'] == no_proxy
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
         )
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
@@ -339,46 +302,50 @@ class TestVirtWhoConfigforEsx:
             http_type='http', org=module_sca_manifest_org
         )
         target_sat.cli.VirtWhoConfig.update(
-            {'id': virtwho_config['id'], 'http-proxy-id': http_proxy_id}
+            {'id': virtwho_config_cli['id'], 'http-proxy-id': http_proxy_id}
         )
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
         )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
 
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data_cli['name']))
 
         # Check the http proxy option, create virt-who config via http proxy id
-        form_data['http-proxy-id'] = http_proxy_id
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        form_data_cli['http-proxy-id'] = http_proxy_id
+        virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)[
+            'general-information'
+        ]
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
         )
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data_cli['name']))
 
         # Check the https proxy option, create virt-who config via http proxy name
         no_proxy = 'test.satellite.com'
-        form_data['http-proxy'] = https_proxy_name
-        form_data['no-proxy'] = no_proxy
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        form_data_cli['http-proxy'] = https_proxy_name
+        form_data_cli['no-proxy'] = no_proxy
+        virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)[
+            'general-information'
+        ]
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['http-proxy']['http-proxy-name'] == https_proxy_name
         assert result['connection']['ignore-proxy'] == no_proxy
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
         )
-        get_configure_file(virtwho_config['id'])
+        get_configure_file(virtwho_config_cli['id'])
         assert get_configure_option('https_proxy', ETC_VIRTWHO_CONFIG) == https_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
 
     @pytest.mark.tier2
     def test_positive_rhsm_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify rhsm options in the configure file"
 
@@ -392,10 +359,10 @@ class TestVirtWhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        config_file = get_configure_file(virtwho_config['id'])
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        config_file = get_configure_file(virtwho_config_cli['id'])
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
         )
         rhsm_username = get_configure_option('rhsm_username', config_file)
         assert not target_sat.cli.User.exists(search=('login', rhsm_username))
@@ -432,7 +399,7 @@ class TestVirtWhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_foreman_packages_protection(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """foreman-protector should allow virt-who to be installed
 
@@ -451,18 +418,18 @@ class TestVirtWhoConfigforEsx:
         :BZ: 1783987
         """
         virtwho_package_locked()
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
         )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
 
     @pytest.mark.tier2
     def test_positive_deploy_configure_hypervisor_password_with_special_characters(
-        self, module_sca_manifest_org, form_data, target_sat
+        self, module_sca_manifest_org, form_data_cli, target_sat
     ):
         """Verify "hammer virt-who-config deploy hypervisor with special characters"
 
@@ -479,40 +446,44 @@ class TestVirtWhoConfigforEsx:
         :customerscenario: true
         """
         # check the hypervisor password contains single quotes
-        form_data['hypervisor-password'] = "Tes't"
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-        assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        form_data_cli['hypervisor-password'] = "Tes't"
+        virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)[
+            'general-information'
+        ]
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_status = deploy_configure_by_command_check(command)
         assert deploy_status == 'Finished successfully'
-        config_file = get_configure_file(virtwho_config['id'])
+        config_file = get_configure_file(virtwho_config_cli['id'])
         assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
         assert (
             get_configure_option('username', config_file)
             == settings.virtwho.esx.hypervisor_username
         )
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data_cli['name']))
 
         # check the hypervisor password contains backtick
-        form_data['hypervisor-password'] = r"my\`password"
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-        assert virtwho_config['status'] == 'No Report Yet'
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        form_data_cli['hypervisor-password'] = r"my\`password"
+        virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)[
+            'general-information'
+        ]
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_status = deploy_configure_by_command_check(command)
         assert deploy_status == 'Finished successfully'
-        config_file = get_configure_file(virtwho_config['id'])
+        config_file = get_configure_file(virtwho_config_cli['id'])
         assert get_configure_option('rhsm_hostname', config_file) == target_sat.hostname
         assert (
             get_configure_option('username', config_file)
             == settings.virtwho.esx.hypervisor_username
         )
-        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+        target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config_cli['name']})
+        assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data_cli['name']))
 
     @pytest.mark.tier2
     def test_positive_remove_env_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """remove option 'env=' from the virt-who configuration file and without any error
 
@@ -530,17 +501,17 @@ class TestVirtWhoConfigforEsx:
 
         :customerscenario: true
         """
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+            command, form_data_cli['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
         )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
         option = "env"
-        config_file = get_configure_file(virtwho_config['id'])
+        config_file = get_configure_file(virtwho_config_cli['id'])
         env_error = (
             f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
         )

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -16,50 +16,22 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture
-def form_data(target_sat, default_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.hyperv.hypervisor_type,
-        'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
-        'organization-id': default_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
-        'hypervisor-password': settings.virtwho.hyperv.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_cli, target_sat, deploy_type_cli
     ):
         """Verify " hammer virt-who-config deploy & fetch"
 
@@ -73,20 +45,9 @@ class TestVirtWhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        hypervisor_name, guest_name = deploy_type_cli
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
@@ -112,7 +73,7 @@ class TestVirtWhoConfigforHyperv:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -127,13 +88,13 @@ class TestVirtWhoConfigforHyperv:
         values = ['uuid', 'hostname']
         for value in values:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], default_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=default_org.label
+                command, form_data_cli['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -16,50 +16,21 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture
-def form_data(target_sat, module_sca_manifest_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.hyperv.hypervisor_type,
-        'hypervisor-server': settings.virtwho.hyperv.hypervisor_server,
-        'organization-id': module_sca_manifest_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.hyperv.hypervisor_username,
-        'hypervisor-password': settings.virtwho.hyperv.hypervisor_password,
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforHyperv:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
     ):
         """Verify " hammer virt-who-config deploy & fetch"
 
@@ -73,27 +44,16 @@ class TestVirtWhoConfigforHyperv:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
 
     @pytest.mark.tier2
+    @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -107,13 +67,13 @@ class TestVirtWhoConfigforHyperv:
         """
         for value in ['uuid', 'hostname']:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -16,48 +16,22 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture
-def form_data(target_sat, default_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization-id': default_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'kubeconfig-path': settings.virtwho.kubevirt.hypervisor_config_file,
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_cli, target_sat, deploy_type_cli
     ):
         """Verify " hammer virt-who-config deploy & fetch"
 
@@ -71,20 +45,9 @@ class TestVirtWhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        hypervisor_name, guest_name = deploy_type_cli
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
@@ -110,7 +73,7 @@ class TestVirtWhoConfigforKubevirt:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -125,13 +88,13 @@ class TestVirtWhoConfigforKubevirt:
         values = ['uuid', 'hostname']
         for value in values:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], default_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=default_org.label
+                command, form_data_cli['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -14,48 +14,21 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture
-def form_data(target_sat, module_sca_manifest_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.kubevirt.hypervisor_type,
-        'organization-id': module_sca_manifest_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'kubeconfig-path': settings.virtwho.kubevirt.hypervisor_config_file,
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforKubevirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
     ):
         """Verify " hammer virt-who-config deploy & fetch"
 
@@ -69,27 +42,15 @@ class TestVirtWhoConfigforKubevirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -102,13 +63,13 @@ class TestVirtWhoConfigforKubevirt:
         """
         for value in ['uuid', 'hostname']:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -16,49 +16,22 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture
-def form_data(target_sat, default_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.libvirt.hypervisor_type,
-        'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
-        'organization-id': default_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_cli, target_sat, deploy_type_cli
     ):
         """Verify " hammer virt-who-config deploy & fetch"
 
@@ -72,20 +45,9 @@ class TestVirtWhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        hypervisor_name, guest_name = deploy_type_cli
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
@@ -111,7 +73,7 @@ class TestVirtWhoConfigforLibvirt:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -126,13 +88,13 @@ class TestVirtWhoConfigforLibvirt:
         values = ['uuid', 'hostname']
         for value in values:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], default_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=default_org.label
+                command, form_data_cli['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -14,49 +14,21 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
-    deploy_configure_by_script,
     get_configure_command,
     get_configure_file,
     get_configure_option,
 )
 
 
-@pytest.fixture
-def form_data(target_sat, module_sca_manifest_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.libvirt.hypervisor_type,
-        'hypervisor-server': settings.virtwho.libvirt.hypervisor_server,
-        'organization-id': module_sca_manifest_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.libvirt.hypervisor_username,
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforLibvirt:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
     ):
         """Verify " hammer virt-who-config deploy & fetch"
 
@@ -70,27 +42,15 @@ class TestVirtWhoConfigforLibvirt:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -104,13 +64,13 @@ class TestVirtWhoConfigforLibvirt:
         """
         for value in ['uuid', 'hostname']:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -16,7 +16,6 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
@@ -31,39 +30,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture
-def form_data(target_sat, default_org):
-    form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.ahv.hypervisor_type,
-        'hypervisor-server': settings.virtwho.ahv.hypervisor_server,
-        'organization-id': default_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.ahv.hypervisor_username,
-        'hypervisor-password': settings.virtwho.ahv.hypervisor_password,
-        'prism-flavor': settings.virtwho.ahv.prism_flavor,
-        'ahv-internal-debug': 'false',
-    }
-    return form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, default_org, form_data, virtwho_config, target_sat, deploy_type
+        self, default_org, virtwho_config_cli, target_sat, deploy_type_cli
     ):
         """Verify "hammer virt-who-config deploy & fetch"
 
@@ -77,20 +48,9 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], default_org.name)
-            hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=default_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        hypervisor_name, guest_name = deploy_type_cli
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
@@ -116,7 +76,7 @@ class TestVirtWhoConfigforNutanix:
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -131,21 +91,21 @@ class TestVirtWhoConfigforNutanix:
         values = ['uuid', 'hostname']
         for value in values:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], default_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], default_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=default_org.label
+                command, form_data_cli['hypervisor-type'], org=default_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
-        self, default_org, form_data, target_sat, deploy_type
+        self, default_org, form_data_cli, target_sat, deploy_type
     ):
         """Verify "hammer virt-who-config deploy" on nutanix prism central mode
 
@@ -159,20 +119,20 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        form_data['prism-flavor'] = "central"
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+        form_data_cli['prism-flavor'] = "central"
+        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data_cli)['general-information']
         assert virtwho_config['status'] == 'No Report Yet'
         if deploy_type == "id":
             command = get_configure_command(virtwho_config['id'], default_org.name)
             hypervisor_name, guest_name = deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=default_org.label
+                command, form_data_cli['hypervisor-type'], debug=True, org=default_org.label
             )
         elif deploy_type == "script":
             script = target_sat.cli.VirtWhoConfig.fetch(
                 {'id': virtwho_config['id']}, output_format='base'
             )
             hypervisor_name, guest_name = deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=default_org.label
+                script, form_data_cli['hypervisor-type'], debug=True, org=default_org.label
             )
         # Check the option "prism_central=true" should be set in etc/virt-who.d/virt-who.conf
         config_file = get_configure_file(virtwho_config['id'])
@@ -203,7 +163,7 @@ class TestVirtWhoConfigforNutanix:
 
     @pytest.mark.tier2
     def test_positive_prism_central_prism_central_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify prism_central option by hammer virt-who-config update"
 
@@ -217,19 +177,23 @@ class TestVirtWhoConfigforNutanix:
         """
         value = 'central'
         result = target_sat.cli.VirtWhoConfig.update(
-            {'id': virtwho_config['id'], 'prism-flavor': value}
+            {'id': virtwho_config_cli['id'], 'prism-flavor': value}
         )
-        assert result[0]['message'] == f"Virt Who configuration [{virtwho_config['name']}] updated"
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        assert (
+            result[0]['message'] == f"Virt Who configuration [{virtwho_config_cli['name']}] updated"
+        )
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['general-information']['ahv-prism-flavor'] == value
-        config_file = get_configure_file(virtwho_config['id'])
-        command = get_configure_command(virtwho_config['id'], default_org.name)
-        deploy_configure_by_command(command, form_data['hypervisor-type'], org=default_org.label)
+        config_file = get_configure_file(virtwho_config_cli['id'])
+        command = get_configure_command(virtwho_config_cli['id'], default_org.name)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], org=default_org.label
+        )
         assert get_configure_option("prism_central", config_file) == 'true'
 
     @pytest.mark.tier2
     def test_positive_ahv_internal_debug_option(
-        self, default_org, form_data, virtwho_config, target_sat
+        self, default_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify ahv_internal_debug option by hammer virt-who-config"
 
@@ -250,14 +214,14 @@ class TestVirtWhoConfigforNutanix:
         :BZ: 2141719
         :customerscenario: true
         """
-        command = get_configure_command(virtwho_config['id'], default_org.name)
+        command = get_configure_command(virtwho_config_cli['id'], default_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=default_org.label
+            command, form_data_cli['hypervisor-type'], debug=True, org=default_org.label
         )
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['general-information']['enable-ahv-debug'] == 'no'
         # ahv_internal_debug does not set in virt-who-config-X.conf
-        config_file = get_configure_file(virtwho_config['id'])
+        config_file = get_configure_file(virtwho_config_cli['id'])
         option = 'ahv_internal_debug'
         env_error = f"option {option} is not exist or not be enabled in {config_file}"
         with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
@@ -270,18 +234,22 @@ class TestVirtWhoConfigforNutanix:
         # Update ahv_internal_debug option to true
         value = 'true'
         result = target_sat.cli.VirtWhoConfig.update(
-            {'id': virtwho_config['id'], 'ahv-internal-debug': value}
+            {'id': virtwho_config_cli['id'], 'ahv-internal-debug': value}
         )
-        assert result[0]['message'] == f"Virt Who configuration [{virtwho_config['name']}] updated"
-        command = get_configure_command(virtwho_config['id'], default_org.name)
+        assert (
+            result[0]['message'] == f"Virt Who configuration [{virtwho_config_cli['name']}] updated"
+        )
+        command = get_configure_command(virtwho_config_cli['id'], default_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], debug=True, org=default_org.label
+            command, form_data_cli['hypervisor-type'], debug=True, org=default_org.label
         )
-        assert get_hypervisor_ahv_mapping(form_data['hypervisor-type']) == 'Host UUID found for VM'
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        assert (
+            get_hypervisor_ahv_mapping(form_data_cli['hypervisor-type']) == 'Host UUID found for VM'
+        )
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['general-information']['enable-ahv-debug'] == 'yes'
         # ahv_internal_debug bas been set to true in virt-who-config-X.conf
-        config_file = get_configure_file(virtwho_config['id'])
+        config_file = get_configure_file(virtwho_config_cli['id'])
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'

--- a/tests/foreman/virtwho/cli/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/cli/test_nutanix_sca.py
@@ -16,10 +16,8 @@
 
 :Upstream: No
 """
-from fauxfactory import gen_string
 import pytest
 
-from robottelo.config import settings
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
     deploy_configure_by_script,
@@ -29,38 +27,11 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.fixture
-def form_data(target_sat, module_sca_manifest_org):
-    sca_form = {
-        'name': gen_string('alpha'),
-        'debug': 1,
-        'interval': '60',
-        'hypervisor-id': 'hostname',
-        'hypervisor-type': settings.virtwho.ahv.hypervisor_type,
-        'hypervisor-server': settings.virtwho.ahv.hypervisor_server,
-        'organization-id': module_sca_manifest_org.id,
-        'filtering-mode': 'none',
-        'satellite-url': target_sat.hostname,
-        'hypervisor-username': settings.virtwho.ahv.hypervisor_username,
-        'hypervisor-password': settings.virtwho.ahv.hypervisor_password,
-        'prism-flavor': settings.virtwho.ahv.prism_flavor,
-    }
-    return sca_form
-
-
-@pytest.fixture
-def virtwho_config(form_data, target_sat):
-    virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
-    yield virtwho_config
-    target_sat.cli.VirtWhoConfig.delete({'name': virtwho_config['name']})
-    assert not target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
-
-
 class TestVirtWhoConfigforNutanix:
     @pytest.mark.tier2
-    @pytest.mark.parametrize('deploy_type', ['id', 'script'])
+    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat, deploy_type
+        self, module_sca_manifest_org, virtwho_config_cli, target_sat, deploy_type_cli
     ):
         """Verify "hammer virt-who-config deploy & fetch"
 
@@ -74,27 +45,15 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        assert virtwho_config['status'] == 'No Report Yet'
-        if deploy_type == "id":
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
-            deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        elif deploy_type == "script":
-            script = target_sat.cli.VirtWhoConfig.fetch(
-                {'id': virtwho_config['id']}, output_format='base'
-            )
-            deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
-            )
-        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})[
+        assert virtwho_config_cli['status'] == 'No Report Yet'
+        virt_who_instance = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})[
             'general-information'
         ]['status']
         assert virt_who_instance == 'OK'
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify hypervisor_id option by hammer virt-who-config update"
 
@@ -108,21 +67,21 @@ class TestVirtWhoConfigforNutanix:
         """
         for value in ['uuid', 'hostname']:
             target_sat.cli.VirtWhoConfig.update(
-                {'id': virtwho_config['id'], 'hypervisor-id': value}
+                {'id': virtwho_config_cli['id'], 'hypervisor-id': value}
             )
-            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+            result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
             assert result['connection']['hypervisor-id'] == value
-            config_file = get_configure_file(virtwho_config['id'])
-            command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+            config_file = get_configure_file(virtwho_config_cli['id'])
+            command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+                command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
             )
             assert get_configure_option('hypervisor_id', config_file) == value
 
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type', ['id', 'script'])
     def test_positive_prism_central_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, form_data, target_sat, deploy_type
+        self, module_sca_manifest_org, target_sat, form_data_cli, deploy_type
     ):
         """Verify "hammer virt-who-config deploy & fetch" on nutanix prism central mode
 
@@ -137,20 +96,26 @@ class TestVirtWhoConfigforNutanix:
 
         :CaseImportance: High
         """
-        form_data['prism-flavor'] = "central"
-        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data)['general-information']
+        form_data_cli['prism-flavor'] = "central"
+        virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data_cli)['general-information']
         assert virtwho_config['status'] == 'No Report Yet'
         if deploy_type == "id":
             command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
             deploy_configure_by_command(
-                command, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+                command,
+                form_data_cli['hypervisor-type'],
+                debug=True,
+                org=module_sca_manifest_org.label,
             )
         elif deploy_type == "script":
             script = target_sat.cli.VirtWhoConfig.fetch(
                 {'id': virtwho_config['id']}, output_format='base'
             )
             deploy_configure_by_script(
-                script, form_data['hypervisor-type'], debug=True, org=module_sca_manifest_org.label
+                script,
+                form_data_cli['hypervisor-type'],
+                debug=True,
+                org=module_sca_manifest_org.label,
             )
         # Check the option "prism_central=true" should be set in etc/virt-who.d/virt-who.conf
         config_file = get_configure_file(virtwho_config['id'])
@@ -162,7 +127,7 @@ class TestVirtWhoConfigforNutanix:
 
     @pytest.mark.tier2
     def test_positive_prism_element_prism_central_option(
-        self, module_sca_manifest_org, form_data, virtwho_config, target_sat
+        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify prism_central option by hammer virt-who-config update"
 
@@ -176,14 +141,16 @@ class TestVirtWhoConfigforNutanix:
         """
         value = 'central'
         result = target_sat.cli.VirtWhoConfig.update(
-            {'id': virtwho_config['id'], 'prism-flavor': value}
+            {'id': virtwho_config_cli['id'], 'prism-flavor': value}
         )
-        assert result[0]['message'] == f"Virt Who configuration [{virtwho_config['name']}] updated"
-        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config['id']})
+        assert (
+            result[0]['message'] == f"Virt Who configuration [{virtwho_config_cli['name']}] updated"
+        )
+        result = target_sat.cli.VirtWhoConfig.info({'id': virtwho_config_cli['id']})
         assert result['general-information']['ahv-prism-flavor'] == value
-        config_file = get_configure_file(virtwho_config['id'])
-        command = get_configure_command(virtwho_config['id'], module_sca_manifest_org.name)
+        config_file = get_configure_file(virtwho_config_cli['id'])
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
         deploy_configure_by_command(
-            command, form_data['hypervisor-type'], org=module_sca_manifest_org.label
+            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
         )
         assert get_configure_option("prism_central", config_file) == 'true'

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -41,7 +41,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.mark.delete_host
+@pytest.mark.usefixtures('delete_host')
 class TestVirtwhoConfigforEsx:
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -38,7 +38,7 @@ from robottelo.utils.virtwho import (
 )
 
 
-@pytest.mark.delete_host
+@pytest.mark.usefixtures('delete_host')
 class TestVirtwhoConfigforEsx:
     @pytest.mark.tier2
     @pytest.mark.upgrade


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/12619

Tasks:
1. fixture support for virt-who config cli : data_form deploy_type virtwho_config delete_host
2. module_sca_manifest content move because module_sca_manifest.content can not found

Cases PASS
```
(robottlo_vv311) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx.py  --disable-pytest-warnings -q
............                                                                                                                                                                                                [100%]

12 passed, 12 deselected, 7 warnings in 1140.02s (0:19:00)
(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx_sca.py --disable-pytest-warnings -q
................                                                                                                                                                                                            [100%]
16 passed, 16 deselected, 7 warnings in 2903.38s (0:48:23)

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_hyperv.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected in 574.06s (0:09:34)

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_hyperv_sca.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected in 539.66s (0:08:59)

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_libvirt**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 5 warnings in 622.06s (0:10:22)

(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_kubevirt**.py --disable-pytest-warnings -q
......                                                                                                                                                                                                      [100%]
6 passed, 6 deselected, 5 warnings in 832.63s (0:13:52)
(robottelo_vv_311_master) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_nutanix**.py --disable-pytest-warnings -q
.............                                                                                                                                                                                               [100%]
13 passed, 13 deselected, 5 warnings in 1341.35s (0:22:21)
```