### PR TITLE
[6.15.z] RHEL Lifecycle status column, RFE for 6.15.0

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1763,6 +1763,7 @@ def test_positive_manage_table_columns(session, current_sat_org, current_sat_loc
         'Last report': False,
         'Comment': False,
         'Installable updates': True,
+        'RHEL Lifecycle status': False,
         'Registered': True,
         'Last checkin': True,
         'IPv4': True,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13237

### Solution
Add UI check for new column, for 'RHEL Lifecycle status' 6.15.0 RFE.

### Related Issues
Depends on navigation fix in [airgun#1051](https://github.com/SatelliteQE/airgun/pull/1051).

### PRT test case
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py::test_positive_manage_table_columns
airgun: 1051
