### PR TITLE
[6.14.z] adding customerscenario tag to libvirt e2e provision test

### DIFF
--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -467,6 +467,8 @@ def test_positive_provision_end_to_end(
     :parametrized: yes
 
     :BZ: 2236693
+
+    :customerscenario: true
     """
     sat = module_libvirt_provisioning_sat.sat
     cr_name = gen_string('alpha')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13252

### Problem Statement

The BZ associated with the test (BZ#2236693) recently got supplemented with a customer case link, which fired the weekly customerscenario check

### Solution

Adding customerscenario tag, cherry-picking all the way down

### Related Issues

Closes #13244
