### PR TITLE
[6.15.z] Notifications: new failed repo sync test

### DIFF
--- a/robottelo/cli/user.py
+++ b/robottelo/cli/user.py
@@ -105,3 +105,29 @@ class User(Base):
         """
         cls.command_sub = f'access-token {action}'
         return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def mail_notification_add(cls, options=None):
+        """
+        Usage:
+        hammer user mail-notification add [OPTIONS]
+
+        Options::
+
+            --interval VALUE                        Mail notification interval option, e.g. Daily,
+                                                    Weekly or Monthly.
+                                                    Required for summary notification
+            --location[-id|-title] VALUE/NUMBER     Set the current location context for the request
+            --mail-notification[-id] VALUE/NUMBER
+            --mail-query VALUE                      Relevant only for audit summary notification
+            --organization[-id|-title] VALUE/NUMBER Set the current organization context
+                                                    for the request
+            --subscription VALUE                    Mail notification subscription option, e.g.
+                                                    Subscribe, Subscribe to my hosts or
+                                                    Subscribe to all hosts. Required for host built
+                                                    and config error state
+            --user[-id] VALUE
+
+        """
+        cls.command_sub = 'mail-notification add'
+        return cls.execute(cls._construct_command(options), output_format='csv')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13203

Notifications: new test for failed repo sync

This patch adds new API test for mail notification for a failed repository sync.

Other changes:

- Waiting for desired e-mail has been refactored to `wait_for_mail` function so it is more reusable for other and future tests.
  Also `wait_for:fail_condition` lambda was fixed due to confusion about how it actually works.

- Fixed one assert in `test_positive_notification_for_long_running_tasks` test.
