### PR TITLE
[6.12.z] Create distinction between the product-ready OS and the product WFs

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -10,6 +10,8 @@ CAPSULE:
     # The base os rhel version where the capsule installed
     # RHEL_VERSION:
   # The Ansible Tower workflow used to deploy a capsule
-  DEPLOY_WORKFLOW: deploy-capsule
+  DEPLOY_WORKFLOWS:
+    PRODUCT: deploy-capsule  # workflow to deploy OS with product running on top of it
+    OS: deploy-rhel  # workflow to deploy OS that is ready to run the product
   # Dictionary of arguments which should be passed along to the deploy workflow
   DEPLOY_ARGUMENTS:

--- a/conf/migrations.py
+++ b/conf/migrations.py
@@ -1,0 +1,37 @@
+"""Robottelo configuration migrations
+
+This module contains functions that are run after the configuration is loaded. Each function
+should be named `migration_<YYMMDD>_<description>` and accept two parameters: `settings` and
+`data`. `settings` is a `dynaconf` `Box` object containing the configuration. `data` is a
+`dict` that can be used to store settings that will be merged with the rest of the settings.
+The functions should not return anything.
+"""
+
+from packaging.version import Version
+
+from robottelo.logging import logger
+
+
+def migration_231129_deploy_workflow(settings, data):
+    """Migrates {server,capsule}.deploy_workflow to {server,capsule}.deploy_workflows"""
+    for product_type in ['server', 'capsule']:
+        # If the product_type has a deploy_workflow and it is a string, and
+        # it does not have a deploy_workflows set
+        if (
+            settings[product_type].get('deploy_workflow')
+            and isinstance(settings[product_type].deploy_workflow, str)
+            and not settings[product_type].get('deploy_workflows')
+        ):
+            sat_rhel_version = settings[product_type].version.rhel_version
+            data[product_type] = {}
+            # Set the deploy_workflows to a dict with product and os keys
+            # Get the OS workflow from the content_host config
+            data[product_type].deploy_workflows = {
+                'product': settings[product_type].deploy_workflow,
+                'os': settings.content_host[
+                    f'rhel{Version(str(sat_rhel_version)).major}'
+                ].vm.workflow,
+            }
+            logger.info(
+                f'Migrated {product_type}.DEPLOY_WORKFLOW to {product_type}.DEPLOY_WORKFLOWS'
+            )

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -27,7 +27,9 @@ SERVER:
   # this setting determines if they will be automatically checked in
   AUTO_CHECKIN: False
   # The Ansible Tower workflow used to deploy a satellite
-  DEPLOY_WORKFLOW: "deploy-sat-jenkins"
+  DEPLOY_WORKFLOWS:
+    PRODUCT: deploy-satellite  # workflow to deploy OS with product running on top of it
+    OS: deploy-rhel  # workflow to deploy OS that is ready to run the product
   # Dictionary of arguments which should be passed along to the deploy workflow
   # DEPLOY_ARGUMENTS:
   # HTTP scheme when building the server URL

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -23,7 +23,9 @@ VALIDATORS = dict(
         ),
         Validator('server.admin_password', default='changeme'),
         Validator('server.admin_username', default='admin'),
-        Validator('server.deploy_workflow', must_exist=True),
+        Validator('server.deploy_workflows', must_exist=True, is_type_of=dict),
+        Validator('server.deploy_workflows.product', must_exist=True),
+        Validator('server.deploy_workflows.os', must_exist=True),
         Validator('server.deploy_arguments', must_exist=True, is_type_of=dict, default={}),
         Validator('server.scheme', default='https'),
         Validator('server.port', default=443),
@@ -67,7 +69,9 @@ VALIDATORS = dict(
     capsule=[
         Validator('capsule.version.release', must_exist=True),
         Validator('capsule.version.source', must_exist=True),
-        Validator('capsule.deploy_workflow', must_exist=True),
+        Validator('capsule.deploy_workflows', must_exist=True, is_type_of=dict),
+        Validator('capsule.deploy_workflows.product', must_exist=True),
+        Validator('capsule.deploy_workflows.os', must_exist=True),
         Validator('capsule.deploy_arguments', must_exist=True, is_type_of=dict, default={}),
     ],
     certs=[

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -67,7 +67,7 @@ def lru_sat_ready_rhel(rhel_ver):
         'deploy_rhel_version': rhel_version,
         'deploy_flavor': settings.flavors.default,
         'promtail_config_template_file': 'config_sat.j2',
-        'workflow': settings.content_host.get(f'rhel{Version(rhel_version).major}').vm.workflow,
+        'workflow': settings.server.deploy_workflows.os,
     }
     sat_ready_rhel = Broker(**deploy_args, host_class=Satellite).checkout()
     return sat_ready_rhel


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13177

### Problem Statement
There is no distinction between content host deployment workflows and workflows to deploy the operating system on which the product is supposed to be installed. That causes issues in the PIT server testing scenario.
We would like to add a test to install Satellite and Capsule to the test collection, but we need to have a separate content host deployment workflow and the `sat_ready_rhel` and `cap_ready_rhel` workflows. That is due to the need to install the product on top of a non-released OS that we deploy using a workflow that is different from the one that we use for the content host deployment.

### Solution
Create a distinction between the two workflows in the configuration and use the configuration.

### Related Issues
satelliteqe/satellite-jenkins!1173
[SAT-21475](https://issues.redhat.com/browse/SAT-21475)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->