### PR TITLE
[6.14.z] Add custom pytest hook for test result handling and video cleanup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -20,6 +20,7 @@ pytest_plugins = [
     'pytest_plugins.factory_collection',
     'pytest_plugins.requirements.update_requirements',
     'pytest_plugins.sanity_plugin',
+    'pytest_plugins.video_cleanup',
     # Fixtures
     'pytest_fixtures.core.broker',
     'pytest_fixtures.core.sat_cap_factory',

--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -1,0 +1,74 @@
+from urllib.parse import urlparse
+
+from box import Box
+from broker.hosts import Host
+import pytest
+
+from robottelo.config import settings
+from robottelo.logging import logger
+
+test_results = {}
+test_directories = [
+    'tests/foreman/destructive',
+    'tests/foreman/ui',
+    'tests/foreman/sanity',
+    'tests/foreman/virtwho',
+]
+
+
+def _clean_video(session_id, test):
+    logger.info(f"cleaning up video files for session: {session_id} and test: {test}")
+
+    if settings.ui.grid_url and session_id:
+        grid = urlparse(url=settings.ui.grid_url)
+        infra_grid = Host(hostname=grid.hostname)
+        infra_grid.execute(command=f'rm -rf /var/www/html/videos/{session_id}')
+        logger.info(f"video cleanup for session {session_id} is complete")
+    else:
+        logger.warning("missing grid_url or session_id. unable to clean video files.")
+
+
+def pytest_addoption(parser):
+    """Custom pytest option to skip video cleanup on test success.
+    Args:
+        parser (object): The pytest command-line option parser.
+    Options:
+        --skip-video-cleanup: Skip video cleaning on test success (default: False).
+    """
+    parser.addoption(
+        "--skip-video-cleanup",
+        action="store_true",
+        default=False,
+        help="Skip video cleaning on test success",
+    )
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item):
+    """Custom pytest hook to capture test outcomes and perform video cleanup.
+    Note:
+        This hook captures test results during 'call' and performs video cleanup
+        during 'teardown' if the test passed and the '--skip-video-cleanup' option is not set.
+    """
+    outcome = yield
+    report = outcome.get_result()
+    skip_video_cleanup = item.config.getoption("--skip-video-cleanup", False)
+
+    if not skip_video_cleanup and any(directory in report.fspath for directory in test_directories):
+        if report.when == "call":
+            test_results[item.nodeid] = Box(
+                {
+                    'outcome': report.outcome,
+                    'duration': report.duration,
+                    'longrepr': str(report.longrepr),
+                }
+            )
+        if report.when == "teardown":
+            if item.nodeid in test_results:
+                result_info = test_results[item.nodeid]
+                if result_info.outcome == 'passed':
+                    session_id_tuple = next(
+                        (t for t in report.user_properties if t[0] == 'session_id'), None
+                    )
+                    session_id = session_id_tuple[1] if session_id_tuple else None
+                    _clean_video(session_id, item.nodeid)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13186

### Problem Statement
The existing testing framework lacked a mechanism for customized handling of test results and video cleanup after test execution. Additionally, there was no option to skip video cleaning when tests succeeded.

### Solution
Introduce a custom pytest hook, your_custom_runtest_makereport_hook, with tryfirst=True and hookwrapper=True. This hook intercepts test outcomes, records relevant information for tests in specified directories during 'call', and, during 'teardown', extracts the session_id to call _clean_video() if a test fails and video cleanup is not skipped.

Furthermore, add a new pytest option, --skip-video-cleanup, with action='store_true', default value False, and a help message. This option allows users to skip video cleaning on test success and can be set via the command line when running pytest.
