### PR TITLE
[6.15.z] Add default provider/url for make_compute_resource helper

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -179,6 +179,8 @@ ENTITY_FIELDS = {
     },
     'compute_resource': {
         'name': gen_alphanumeric,
+        'provider': 'Libvirt',
+        'url': 'qemu+tcp://localhost:16509/system',
     },
     'org': {'_redirect': 'org_with_credentials'},
     'org_with_credentials': {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13283

### Problem Statement
Changes introduced in https://github.com/SatelliteQE/robottelo/pull/11544 removed the usage of old cli.factory in favor of new cli_factory helpers. And, I've observed a few failures related default provider and url missing from hammer compute-resource create command used by make_compute_resource helper, and it was present earlier and missing in cli_factory method.
```
robottelo.exceptions.CLIFactoryError: Failed to create ComputeResource with data:
{'name': 'm1TzNZ2Njt'}
Command "compute-resource create" finished with status 64
stderr contains:
Could not create the compute resource:
  Error: Options --name, --provider are required.
  
  See: 'hammer compute-resource create --help'.
```
### Solution
Add provider and url for libvirt as default in make_compute_resource helper of cli_factory

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->