### PR TITLE
[6.14.z] Remove unnecessary on_premises_provisioning marker

### DIFF
--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -196,7 +196,6 @@ def test_positive_add_org_hostgroup_template(session):
 
 
 @pytest.mark.skip_if_not_set('libvirt')
-@pytest.mark.on_premises_provisioning
 @pytest.mark.tier2
 def test_positive_update_compresource(session):
     """Add/Remove compute resource from/to location


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13343

Removing unnecessary on_premises_provisioning marker