### PR TITLE
[6.14.z] Test markers as test fields in polarion

### DIFF
--- a/scripts/polarion-test-case-upload.sh
+++ b/scripts/polarion-test-case-upload.sh
@@ -68,7 +68,7 @@ from betelgeuse import default_config
 DEFAULT_APPROVERS_VALUE = '${POLARION_USERNAME}:approved'
 DEFAULT_STATUS_VALUE = 'approved'
 DEFAULT_SUBTYPE2_VALUE = '-'
-TESTCASE_CUSTOM_FIELDS = default_config.TESTCASE_CUSTOM_FIELDS + ('customerscenario',) + ('team',)
+TESTCASE_CUSTOM_FIELDS = default_config.TESTCASE_CUSTOM_FIELDS + ('customerscenario',) + ('team',) + ('markers',)
 REQUIREMENT_CUSTOM_FIELDS = default_config.REQUIREMENT_CUSTOM_FIELDS + ('team',)
 TRANSFORM_CUSTOMERSCENARIO_VALUE = default_config._transform_to_lower
 DEFAULT_CUSTOMERSCENARIO_VALUE = 'false'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13324

### Problem Statement
Test markers to be shown as test fields in polarion. 

To:
- Adhoc filter tests based on markers used by test
- Make reports in polarion based on the markers 

### Solution
- Betelgeuse should be reading markers on tests at test, class and module level: 
  - https://github.com/SatelliteQE/betelgeuse/pull/141 
- In robottelo, polarion test case upload scripts to read/include markers test fields in XML test case to import from polarion

### Related Issues
https://github.com/SatelliteQE/betelgeuse/pull/141

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->