### PR TITLE
fixing the prt comment copy to cherry-pick branch

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -77,11 +77,12 @@ jobs:
       - name: Add Parent PR's PRT comment to Auto_Cherry_Picked PR's
         id: add-parent-prt-comment
         if: ${{ always() && steps.cherrypick.outcome == 'success' }}
-        run: |
-          curl -X POST -H "Authorization: token ${{ secrets.CHERRYPICK_PAT }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/issues/${{ steps.cherrypick.outputs.number }}/comments" \
-            -d "{\"body\":\"${{ needs.find-the-parent-prt-comment.outputs.prt_comment }}\"}"
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ${{ needs.find-the-parent-prt-comment.outputs.prt_comment }}
+          pr_number: ${{ steps.cherrypick.outputs.number  }}
+          GITHUB_TOKEN: ${{ secrets.CHERRYPICK_PAT }}
 
       - name: is autoMerging enabled for Auto CherryPicked PRs ?
         if: ${{ always() && steps.cherrypick.outcome == 'success' && contains(github.event.pull_request.labels.*.name, 'AutoMerge_Cherry_Picked') }}


### PR DESCRIPTION
### Problem Statement
PRT comment was not getting copied due to the change when we tried to move from GHA to curl. After looking at the challenges with curl there are a lot of validation needs to be added which is overhead 

### Solution
This PR will fix the PRT comment copy to all cherry-pick branches. It will be using thollander/actions-comment-pull-request@v2 GHA to fix this. 

### More Information 
Verified this on own robottelo fork 

https://github.com/omkarkhatavkar/robottelo/pull/174
https://github.com/omkarkhatavkar/robottelo/pull/172

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->