### PR TITLE
[6.14] added available_remote_execution_features apipath

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -729,6 +729,7 @@ API_PATHS = {
         '/api/remote_execution_features',
         '/api/remote_execution_features/:id',
         '/api/remote_execution_features/:id',
+        '/api/api/hosts/:id/available_remote_execution_features',
     ),
     'scap_content_profiles': ('/api/compliance/scap_content_profiles',),
     'simple_content_access': (


### PR DESCRIPTION
### Problem Statement
this path has been added to foreman_remote_execution-10.1.0 as part of https://projects.theforeman.org/issues/36751, it is also present in 6.14.z that has foreman_remote_execution-10.1.1-1

note: this also needs to change in 6.15 and master, but there is a larger bunch of api changes that are currently being consulted with dev, so the PRs will follow later 