### PR TITLE
[6.15.z] Fix missing api param in target_sat call in SyncPlan test

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -837,7 +837,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
     )
     product = target_sat.api.Product(name=PRDS['rhel'], organization=org).search()[0]
     repo = target_sat.api.Repository(id=repo_id).read()
-    sync_plan = target_sat.SyncPlan(
+    sync_plan = target_sat.api.SyncPlan(
         organization=org,
         enabled=True,
         interval='hourly',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13370

Cleaning up SyncPlan test after big refactor. This was missing an api param on the target_sat call. 

trigger: test-robottelo
pytest: tests/foreman/api/test_syncplan.py -k 'test_positive_synchronize_rh_product_past_sync_date'
