### PR TITLE
[6.12.z] fixed api audit tests

### DIFF
--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -38,7 +38,7 @@ def test_positive_create_by_type(target_sat):
     :CaseImportance: Medium
     """
     for entity_item in [
-        {'entity': target_sat.api.Architecture()},
+        {'entity': target_sat.api.Architecture(), 'entity_type': 'architecture'},
         {
             'entity': target_sat.api.AuthSourceLDAP(),
             'entity_type': 'auth_source',
@@ -50,15 +50,16 @@ def test_positive_create_by_type(target_sat):
             'entity_type': 'compute_resource',
             'value_template': '{entity.name} (Libvirt)',
         },
-        {'entity': target_sat.api.Domain()},
-        {'entity': target_sat.api.Host()},
-        {'entity': target_sat.api.HostGroup()},
+        {'entity': target_sat.api.Domain(), 'entity_type': 'domain'},
+        {'entity': target_sat.api.Host(), 'entity_type': 'host'},
+        {'entity': target_sat.api.HostGroup(), 'entity_type': 'hostgroup'},
         {
             'entity': target_sat.api.Image(
                 compute_resource=target_sat.api.LibvirtComputeResource().create()
-            )
+            ),
+            'entity_type': 'image',
         },
-        {'entity': target_sat.api.Location()},
+        {'entity': target_sat.api.Location(), 'entity_type': 'location'},
         {'entity': target_sat.api.Media(), 'entity_type': 'medium'},
         {
             'entity': target_sat.api.OperatingSystem(),
@@ -66,14 +67,19 @@ def test_positive_create_by_type(target_sat):
             'value_template': '{entity.name} {entity.major}',
         },
         {'entity': target_sat.api.PartitionTable(), 'entity_type': 'ptable'},
-        {'entity': target_sat.api.Role()},
+        {'entity': target_sat.api.Role(), 'entity_type': 'role'},
         {
             'entity': target_sat.api.Subnet(),
+            'entity_type': 'subnet',
             'value_template': '{entity.name} ({entity.network}/{entity.cidr})',
         },
         {'entity': target_sat.api.ProvisioningTemplate(), 'entity_type': 'provisioning_template'},
-        {'entity': target_sat.api.User(), 'value_template': '{entity.login}'},
-        {'entity': target_sat.api.UserGroup()},
+        {
+            'entity': target_sat.api.User(),
+            'value_template': '{entity.login}',
+            'entity_type': 'user',
+        },
+        {'entity': target_sat.api.UserGroup(), 'entity_type': 'usergroup'},
         {'entity': target_sat.api.ContentView(), 'entity_type': 'katello/content_view'},
         {'entity': target_sat.api.LifecycleEnvironment(), 'entity_type': 'katello/kt_environment'},
         {'entity': target_sat.api.ActivationKey(), 'entity_type': 'katello/activation_key'},
@@ -85,10 +91,11 @@ def test_positive_create_by_type(target_sat):
         },
     ]:
         created_entity = entity_item['entity'].create()
-        entity_type = entity_item.get('entity_type', created_entity.__class__.__name__.lower())
         value_template = entity_item.get('value_template', '{entity.name}')
         entity_value = value_template.format(entity=created_entity)
-        audits = target_sat.api.Audit().search(query={'search': f'type={entity_type}'})
+        audits = target_sat.api.Audit().search(
+            query={'search': f'type={entity_item["entity_type"]}'}
+        )
         entity_audits = [entry for entry in audits if entry.auditable_name == entity_value]
         assert entity_audits, (
             f'audit not found by name "{entity_value}" for entity: '
@@ -113,21 +120,19 @@ def test_positive_update_by_type(target_sat):
     :CaseImportance: Medium
     """
     for entity in [
-        target_sat.api.Architecture(),
-        target_sat.api.Domain(),
-        target_sat.api.HostGroup(),
-        target_sat.api.Location(),
-        target_sat.api.Role(),
-        target_sat.api.UserGroup(),
+        {'entity': target_sat.api.Architecture(), 'entity_type': 'architecture'},
+        {'entity': target_sat.api.Domain(), 'entity_type': 'domain'},
+        {'entity': target_sat.api.HostGroup(), 'entity_type': 'hostgroup'},
+        {'entity': target_sat.api.Location(), 'entity_type': 'location'},
+        {'entity': target_sat.api.Role(), 'entity_type': 'role'},
+        {'entity': target_sat.api.UserGroup(), 'entity_type': 'usergroup'},
     ]:
-        created_entity = entity.create()
+        created_entity = entity['entity'].create()
         name = created_entity.name
         new_name = gen_string('alpha')
         created_entity.name = new_name
         created_entity = created_entity.update(['name'])
-        audits = target_sat.api.Audit().search(
-            query={'search': f'type={created_entity.__class__.__name__.lower()}'}
-        )
+        audits = target_sat.api.Audit().search(query={'search': f'type={entity["entity_type"]}'})
         entity_audits = [entry for entry in audits if entry.auditable_name == name]
         assert entity_audits, f'audit not found by name "{name}"'
         audit = entity_audits[0]
@@ -150,19 +155,16 @@ def test_positive_delete_by_type(target_sat):
     :CaseImportance: Medium
     """
     for entity in [
-        target_sat.api.Architecture(),
-        target_sat.api.Domain(),
-        target_sat.api.Host(),
-        target_sat.api.HostGroup(),
-        target_sat.api.Location(),
-        target_sat.api.Role(),
-        target_sat.api.UserGroup(),
+        {'entity': target_sat.api.Architecture(), 'entity_type': 'architecture'},
+        {'entity': target_sat.api.Domain(), 'entity_type': 'domain'},
+        {'entity': target_sat.api.HostGroup(), 'entity_type': 'hostgroup'},
+        {'entity': target_sat.api.Location(), 'entity_type': 'location'},
+        {'entity': target_sat.api.Role(), 'entity_type': 'role'},
+        {'entity': target_sat.api.UserGroup(), 'entity_type': 'usergroup'},
     ]:
-        created_entity = entity.create()
+        created_entity = entity['entity'].create()
         created_entity.delete()
-        audits = target_sat.api.Audit().search(
-            query={'search': f'type={created_entity.__class__.__name__.lower()}'}
-        )
+        audits = target_sat.api.Audit().search(query={'search': f'type={entity["entity_type"]}'})
         entity_audits = [entry for entry in audits if entry.auditable_name == created_entity.name]
         assert entity_audits, f'audit not found by name "{created_entity.name}"'
         audit = entity_audits[0]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13368

### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/12989 swapped entities for target_sat.api, but:
```
ent = entities.Architecture()
ent.__class__.__name__.lower()
'architecture'

ent_new = target_sat.api.Architecture()
ent_new.__class__.__name__.lower()
'decclass'
```

Hence test failures

### Solution
made the search type explicit, not too happy about test not reusing the same data but went for the fast solution with component evaluation in sight for this one 