### PR TITLE
[6.15.z] Remove LCE option from register helper and assert in form test

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -699,7 +699,6 @@ class ContentHost(Host, ContentHostMixins):
         setup_insights=False,
         setup_remote_execution=True,
         setup_remote_execution_pull=False,
-        lifecycle_environment=None,
         operating_system=None,
         packages=None,
         repo=None,
@@ -721,7 +720,6 @@ class ContentHost(Host, ContentHostMixins):
         :param setup_insights: Install and register Insights client, requires OS repo.
         :param setup_remote_execution: Copy remote execution SSH key.
         :param setup_remote_execution_pull: Deploy pull provider client on host
-        :param lifecycle_environment: Lifecycle environment.
         :param operating_system: Operating system.
         :param packages: A list of packages to install on the host when registered.
         :param repo: Repository to be added before the registration is performed, supply url.
@@ -760,8 +758,6 @@ class ContentHost(Host, ContentHostMixins):
         elif target is not None and target.__class__.__name__ not in ['Capsule', 'Satellite']:
             raise ValueError('Global registration method can be used with Satellite/Capsule only')
 
-        if lifecycle_environment is not None:
-            options['lifecycle-environment-id'] = lifecycle_environment.id
         if operating_system is not None:
             options['operatingsystem-id'] = operating_system.id
         if hostgroup is not None:

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1306,7 +1306,6 @@ def test_global_registration_form_populate(
         )
         assert hg_name in cmd['general']['host_group']
         assert module_ak_with_cv.name in cmd['general']['activation_key_helper']
-        assert module_lce.name in cmd['advanced']['life_cycle_env_helper']
         assert constants.FAKE_0_CUSTOM_PACKAGE in cmd['advanced']['install_packages_helper']
 
         session.organization.select(org_name=new_org.name)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13341

### Problem Statement
 LCE option is removed from registration in 6.15

### Solution
Removing LCE option check registration form populate test, and also from register helper (confirmed this option isn't used by any test)

### Related Issues
Katello PR https://github.com/Katello/katello/pull/10764
Airgun PR https://github.com/SatelliteQE/airgun/pull/1069