### PR TITLE
[6.13.z] Update yum repo for ACSes

### DIFF
--- a/robottelo/constants/repos.py
+++ b/robottelo/constants/repos.py
@@ -2,7 +2,7 @@
 
 PULP_FIXTURE_ROOT = 'https://fixtures.pulpproject.org/'
 PULP_SUBPATHS_COMBINED = {
-    'yum': ['rpm-zchunk/', 'rpm-modular/'],
+    'yum': ['rpm-zstd-metadata/', 'rpm-modular/'],
     'file': ['file-large/', 'file-many/'],
 }
 CUSTOM_3RD_PARTY_REPO = 'http://repo.calcforge.org/fedora/21/x86_64/'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13365

### Problem Statement
`rpm-zchunk` repo was removed from fixtures, which makes some ACS tests to fail:
```
"description"=>"ACS remote for url \'https://fixtures.pulpproject.org/rpm-zchunk/\' raised an error \'404: Not Found\'. Please check your ACS remote configuration."
```

### Solution
Use another yum repo, preferably one with the new zst metadata compression.

