### PR TITLE
[6.15.z] Added SCA enabled manifest in activation key and removed duplicate fixture

### DIFF
--- a/pytest_fixtures/component/activationkey.py
+++ b/pytest_fixtures/component/activationkey.py
@@ -6,13 +6,12 @@ from robottelo.utils.manifest import clone
 
 
 @pytest.fixture(scope='module')
-def module_activation_key(module_entitlement_manifest_org, module_target_sat):
+def module_activation_key(module_sca_manifest_org, module_target_sat):
     """Create activation key using default CV and library environment."""
     activation_key = module_target_sat.api.ActivationKey(
-        auto_attach=True,
-        content_view=module_entitlement_manifest_org.default_content_view.id,
-        environment=module_entitlement_manifest_org.library.id,
-        organization=module_entitlement_manifest_org,
+        content_view=module_sca_manifest_org.default_content_view.id,
+        environment=module_sca_manifest_org.library.id,
+        organization=module_sca_manifest_org,
     ).create()
     return activation_key
 

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -27,9 +27,9 @@ pytestmark = pytest.mark.tier1
 @pytest.mark.e2e
 @pytest.mark.no_containers
 def test_host_registration_end_to_end(
-    module_org,
+    module_entitlement_manifest_org,
     module_location,
-    module_ak_with_synced_repo,
+    module_activation_key,
     module_target_sat,
     module_capsule_configured,
     rhel_contenthost,
@@ -47,8 +47,9 @@ def test_host_registration_end_to_end(
 
     :customerscenario: true
     """
+    org = module_entitlement_manifest_org
     result = rhel_contenthost.register(
-        module_org, module_location, module_ak_with_synced_repo.name, module_target_sat
+        org, module_location, [module_activation_key.name], module_target_sat
     )
 
     rc = 1 if rhel_contenthost.os_version.major == 6 else 0
@@ -62,14 +63,14 @@ def test_host_registration_end_to_end(
     module_target_sat.cli.Capsule.update(
         {
             'name': module_capsule_configured.hostname,
-            'organization-ids': module_org.id,
+            'organization-ids': org.id,
             'location-ids': module_location.id,
         }
     )
     result = rhel_contenthost.register(
-        module_org,
+        org,
         module_location,
-        module_ak_with_synced_repo.name,
+        [module_activation_key.name],
         module_capsule_configured,
         force=True,
     )

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -34,7 +34,6 @@ from robottelo.constants import (
     ANY_CONTEXT,
     DEFAULT_CV,
     DEFAULT_LOC,
-    DEFAULT_SUBSCRIPTION_NAME,
     ENVIRONMENT,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_7_CUSTOM_PACKAGE,
@@ -95,30 +94,6 @@ def module_global_params(module_target_sat):
     # cleanup global parameters
     for global_parameter in global_parameters:
         global_parameter.delete()
-
-
-@pytest.fixture(scope='module')
-def module_activation_key(module_entitlement_manifest_org, module_target_sat):
-    """Create activation key using default CV and library environment."""
-    activation_key = module_target_sat.api.ActivationKey(
-        auto_attach=True,
-        content_view=module_entitlement_manifest_org.default_content_view.id,
-        environment=module_entitlement_manifest_org.library.id,
-        organization=module_entitlement_manifest_org,
-    ).create()
-
-    # Find the 'Red Hat Employee Subscription' and attach it to the activation key.
-    for subs in module_target_sat.api.Subscription(
-        organization=module_entitlement_manifest_org
-    ).search():
-        if subs.name == DEFAULT_SUBSCRIPTION_NAME:
-            # 'quantity' must be 1, not subscription['quantity']. Greater
-            # values produce this error: 'RuntimeError: Error: Only pools
-            # with multi-entitlement product subscriptions can be added to
-            # the activation key with a quantity greater than one.'
-            activation_key.add_subscriptions(data={'quantity': 1, 'subscription_id': subs.id})
-            break
-    return activation_key
 
 
 @pytest.fixture
@@ -2407,7 +2382,7 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
 
 def test_positive_host_registration_with_non_admin_user(
     test_name,
-    module_entitlement_manifest_org,
+    module_sca_manifest_org,
     module_location,
     target_sat,
     rhel8_contenthost,
@@ -2423,7 +2398,7 @@ def test_positive_host_registration_with_non_admin_user(
     :CaseLevel: Component
     """
     user_password = gen_string('alpha')
-    org = module_entitlement_manifest_org
+    org = module_sca_manifest_org
     role = target_sat.api.Role(organization=[org]).create()
 
     user_permissions = {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13082

### Problem Statement
Fix Registration test cases failing because of changed activation key fixture.
There was duplicate of the fixture `module_activation_key` so removed it from test_host.py and using sca_enabled_manifest in pytest_fixtures/component/activationkey.py

### Solution
Updated activation key fixture in the tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->