### PR TITLE
Candore dependency to use with robottelo image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 
 betelgeuse==1.10.0
 broker[docker]==0.4.1
+candore==1.0.1
 cryptography==41.0.7
 deepdiff==6.7.1
 dynaconf[vault]==3.2.4


### PR DESCRIPTION
### Problem Statement

Candore isnt available in robottelo image to run extraction and comparision of pre and post-data in candore CI pipeline using robottelo image for data population using robottelo-cli.

### Solution

Install candore dependency for robottelo to use in image.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->