### PR TITLE
Bump EL8, EL9 versions in leapp upgrade test

### DIFF
--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -27,8 +27,8 @@ from robottelo.logging import logger
 synced_repos = pytest.StashKey[dict]
 
 RHEL7_VER = '7.9'
-RHEL8_VER = '8.8'
-RHEL9_VER = '9.2'
+RHEL8_VER = '8.9'
+RHEL9_VER = '9.3'
 
 RHEL_REPOS = {
     'rhel7_server': {


### PR DESCRIPTION
### Problem Statement
Older versions are in use to test leapp upgrade, which are now EUS

### Solution
Bump to latest available versions
