### PR TITLE
Fix discovery rule tests

### DIFF
--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -165,7 +165,7 @@ def test_positive_update_and_provision_with_rule_priority(
 
 @pytest.mark.tier3
 def test_positive_multi_provision_with_rule_limit(
-    module_target_sat, module_discovery_hostgroup, discovery_location, discovery_org
+    request, module_target_sat, module_discovery_hostgroup, discovery_location, discovery_org
 ):
     """Create a discovery rule with certain host limit and try to provision more than the passed limit
 
@@ -177,13 +177,12 @@ def test_positive_multi_provision_with_rule_limit(
 
     :CaseImportance: High
     """
-    for _ in range(2):
-        discovered_host = module_target_sat.api_factory.create_discovered_host()
-
+    discovered_host1 = module_target_sat.api_factory.create_discovered_host()
+    discovered_host2 = module_target_sat.api_factory.create_discovered_host()
     rule = module_target_sat.api.DiscoveryRule(
         max_count=1,
         hostgroup=module_discovery_hostgroup,
-        search_=f'name = {discovered_host["name"]}',
+        search_=f'name = {discovered_host1["name"]}',
         location=[discovery_location],
         organization=[discovery_org],
         priority=1000,
@@ -192,6 +191,10 @@ def test_positive_multi_provision_with_rule_limit(
     assert '1 discovered hosts were provisioned' in result['message']
 
     # Delete discovery rule
-    rule.delete()
-    with pytest.raises(HTTPError):
-        rule.read()
+    @request.addfinalizer
+    def _finalize():
+        rule.delete()
+        module_target_sat.api.Host(id=discovered_host1['id']).delete()
+        module_target_sat.api.DiscoveredHost(id=discovered_host2['id']).delete()
+        with pytest.raises(HTTPError):
+            rule.read()


### PR DESCRIPTION
Fix discovery rule tests-> The test was failing in the teardown when trying to delete the created location, we need to delete both the hosts to run the teardown properly