### PR TITLE
[6.12.z] Fix libvirt/ec2 compute resource tests

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -179,8 +179,6 @@ ENTITY_FIELDS = {
     },
     'compute_resource': {
         'name': gen_alphanumeric,
-        'provider': 'Libvirt',
-        'url': 'qemu+tcp://localhost:16509/system',
     },
     'org': {'_redirect': 'org_with_credentials'},
     'org_with_credentials': {

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -242,7 +242,13 @@ def test_positive_create_with_loc(libvirt_url, module_target_sat):
     :CaseLevel: Integration
     """
     location = module_target_sat.cli_factory.make_location()
-    comp_resource = module_target_sat.cli_factory.compute_resource({'location-ids': location['id']})
+    comp_resource = module_target_sat.cli_factory.compute_resource(
+        {
+            'location-ids': location['id'],
+            'provider': FOREMAN_PROVIDERS['libvirt'],
+            'url': libvirt_url,
+        }
+    )
     assert len(comp_resource['locations']) == 1
     assert comp_resource['locations'][0] == location['name']
 
@@ -263,7 +269,11 @@ def test_positive_create_with_locs(libvirt_url, module_target_sat):
     locations_amount = random.randint(3, 5)
     locations = [module_target_sat.cli_factory.make_location() for _ in range(locations_amount)]
     comp_resource = module_target_sat.cli_factory.compute_resource(
-        {'location-ids': [location['id'] for location in locations]}
+        {
+            'location-ids': [location['id'] for location in locations],
+            'provider': FOREMAN_PROVIDERS['libvirt'],
+            'url': libvirt_url,
+        }
     )
     assert len(comp_resource['locations']) == locations_amount
     for location in locations:
@@ -310,7 +320,9 @@ def test_negative_create_with_same_name(libvirt_url, module_target_sat):
 
     :CaseLevel: Component
     """
-    comp_res = module_target_sat.cli_factory.compute_resource()
+    comp_res = module_target_sat.cli_factory.compute_resource(
+        {'provider': FOREMAN_PROVIDERS['libvirt'], 'url': libvirt_url}
+    )
     with pytest.raises(CLIReturnCodeError):
         module_target_sat.cli.ComputeResource.create(
             {
@@ -339,7 +351,9 @@ def test_positive_update_name(libvirt_url, options, module_target_sat):
 
     :parametrized: yes
     """
-    comp_res = module_target_sat.cli_factory.compute_resource()
+    comp_res = module_target_sat.cli_factory.compute_resource(
+        {'provider': FOREMAN_PROVIDERS['libvirt'], 'url': libvirt_url}
+    )
     options.update({'name': comp_res['name']})
     # update Compute Resource
     module_target_sat.cli.ComputeResource.update(options)
@@ -369,7 +383,9 @@ def test_negative_update(libvirt_url, options, module_target_sat):
 
     :parametrized: yes
     """
-    comp_res = module_target_sat.cli_factory.compute_resource()
+    comp_res = module_target_sat.cli_factory.compute_resource(
+        {'provider': FOREMAN_PROVIDERS['libvirt'], 'url': libvirt_url}
+    )
     with pytest.raises(CLIReturnCodeError):
         module_target_sat.cli.ComputeResource.update(dict({'name': comp_res['name']}, **options))
     result = module_target_sat.cli.ComputeResource.info({'id': comp_res['id']})

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -35,7 +35,7 @@ def _proxy(request, target_sat):
 
 
 def _location(request, target_sat, options=None):
-    location = target_sat.cli_factory.make_location(options=options)
+    location = target_sat.cli_factory.make_location(options)
 
     @request.addfinalizer
     def _cleanup():
@@ -101,7 +101,12 @@ def _host_group(request, target_sat):
 
 
 def _compute_resource(request, target_sat):
-    compute_resource = target_sat.cli_factory.compute_resource()
+    compute_resource = target_sat.cli_factory.compute_resource(
+        {
+            'provider': 'Libvirt',
+            'url': 'qemu+tcp://localhost:16509/system',
+        }
+    )
 
     @request.addfinalizer
     def _cleanup():
@@ -155,14 +160,15 @@ class TestLocation:
         description = gen_string('utf8')
         subnet = _subnet(request, target_sat)
         domains = [_domain(request, target_sat) for _ in range(0, 2)]
-        host_groups = [_host_group(request) for _ in range(0, 3)]
-        medium = _medium(request)
-        compute_resource = _compute_resource(request)
-        template = _template(request)
-        user = _user(request)
+        host_groups = [_host_group(request, target_sat) for _ in range(0, 3)]
+        medium = _medium(request, target_sat)
+        compute_resource = _compute_resource(request, target_sat)
+        template = _template(request, target_sat)
+        user = _user(request, target_sat)
 
         location = _location(
             request,
+            target_sat,
             {
                 'description': description,
                 'subnet-ids': subnet['id'],
@@ -230,7 +236,7 @@ class TestLocation:
 
         """
         parent_location = _location(request, target_sat)
-        location = _location(request, {'parent-id': parent_location['id']})
+        location = _location(request, target_sat, {'parent-id': parent_location['id']})
         assert location['parent'] == parent_location['name']
 
     @pytest.mark.tier1
@@ -343,7 +349,7 @@ class TestLocation:
         :CaseImportance: High
         """
         parent_location = _location(request, target_sat)
-        location = _location(request, {'parent-id': parent_location['id']})
+        location = _location(request, target_sat, {'parent-id': parent_location['id']})
 
         parent_location_2 = _location(request, target_sat)
         target_sat.cli.Location.update({'id': location['id'], 'parent-id': parent_location_2['id']})
@@ -365,7 +371,7 @@ class TestLocation:
         :CaseImportance: High
         """
         parent_location = _location(request, target_sat)
-        location = _location(request, {'parent-id': parent_location['id']})
+        location = _location(request, target_sat, {'parent-id': parent_location['id']})
 
         # set parent as child
         with pytest.raises(CLIReturnCodeError):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13408

Fix libvirt/ec2 compute resource tests