### PR TITLE
[6.13.z] SAT-21433: Enable and sync rhel8_bos repo for rhc tests

### DIFF
--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -86,9 +86,12 @@ def fixture_setup_rhc_satellite(
         repo2_id = module_target_sat.api_factory.enable_sync_redhat_repo(
             constants.REPOS['rhel7'], module_rhc_org.id
         )
+        repo3_id = module_target_sat.api_factory.enable_sync_redhat_repo(
+            constants.REPOS['rhel8_bos'], module_rhc_org.id
+        )
         # Add repos to Content view
         content_view = module_target_sat.api.ContentView(
-            organization=module_rhc_org, repository=[repo1_id, repo2_id]
+            organization=module_rhc_org, repository=[repo1_id, repo2_id, repo3_id]
         ).create()
         content_view.publish()
         # Create Activation key


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13400

### Problem Statement
Currently, Iqe tests are failing to install insights-client as it has a dependency on some other package. 

### Solution
Enable rhel baseos to resolve issue.

### Related Issues
- https://issues.redhat.com/browse/SAT-21433 

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->