### PR TITLE
Use rsync to copy /var/lib/pulp after satellite-clone

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -4,7 +4,8 @@ from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
 import pytest
 
-from robottelo.constants import DEFAULT_ARCHITECTURE, PRDS, REPOS, REPOSET
+from robottelo.config import settings
+from robottelo.constants import DEFAULT_ARCHITECTURE, DEFAULT_ORG, PRDS, REPOS, REPOSET
 
 
 @pytest.fixture(scope='module')
@@ -100,6 +101,16 @@ def module_repository(os_path, module_product, module_target_sat):
     repo = module_target_sat.api.Repository(product=module_product, url=os_path).create()
     call_entity_method_with_timeout(module_target_sat.api.Repository(id=repo.id).sync, timeout=3600)
     return repo
+
+
+@pytest.fixture
+def custom_synced_repo(target_sat):
+    custom_repo = target_sat.api.Repository(
+        product=target_sat.api.Product(organization=DEFAULT_ORG).create(),
+        url=settings.repos.yum_0.url,
+    ).create()
+    custom_repo.sync()
+    return custom_repo
 
 
 def _simplify_repos(request, repos):

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -29,7 +29,9 @@ pytestmark = pytest.mark.destructive
 @pytest.mark.e2e
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
 @pytest.mark.parametrize('skip_pulp', [False, True], ids=['include_pulp', 'skip_pulp'])
-def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pulp):
+def test_positive_clone_backup(
+    target_sat, sat_ready_rhel, backup_type, skip_pulp, custom_synced_repo
+):
     """Make an online/offline backup with/without pulp data of Satellite and clone it (restore it).
 
     :id: 5b9182d5-6789-4d2c-bcc3-6641b96ab277
@@ -45,12 +47,14 @@ def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pul
 
     :parametrized: yes
 
-    :BZ: 2142514
+    :BZ: 2142514, 2013776
 
     :customerscenario: true
     """
     rhel_version = sat_ready_rhel._v_major
     sat_version = 'stream' if target_sat.is_stream else target_sat.version
+
+    pulp_artifact_len = len(target_sat.execute('ls /var/lib/pulp/media/artifact').stdout)
 
     # SATELLITE PART - SOURCE SERVER
     # Enabling and starting services
@@ -66,16 +70,6 @@ def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pul
     assert backup_result.status == 0
     sat_backup_dir = backup_result.stdout.strip().split()[-2]
 
-    if skip_pulp:
-        # Copying satellite pulp data to target RHEL
-        assert sat_ready_rhel.execute('mkdir -p /var/lib/pulp').status == 0
-        assert (
-            target_sat.execute(
-                f'''sshpass -p "{SSH_PASS}" scp -o StrictHostKeyChecking=no \
-                -r /var/lib/pulp root@{sat_ready_rhel.hostname}:/var/lib/pulp/pulp'''
-            ).status
-            == 0
-        )
     # Copying satellite backup to target RHEL
     assert (
         target_sat.execute(
@@ -117,6 +111,22 @@ def test_positive_clone_backup(target_sat, sat_ready_rhel, backup_type, skip_pul
     assert sat_ready_rhel.execute('satellite-clone -y', timeout='3h').status == 0
     cloned_sat = Satellite(sat_ready_rhel.hostname)
     assert cloned_sat.cli.Health.check().status == 0
+
+    # If --skip-pulp-data make sure you can rsync /var/lib/pulp over per BZ#2013776
+    if skip_pulp:
+        # Copying satellite pulp data to target RHEL
+        assert (
+            target_sat.execute(
+                f'sshpass -p "{SSH_PASS}" rsync -e "ssh -o StrictHostKeyChecking=no" --archive --partial --progress --compress '
+                f'/var/lib/pulp root@{sat_ready_rhel.hostname}:/var/lib/'
+            ).status
+            == 0
+        )
+
+    # Make sure all of the pulp data that was on the original Satellite is on the clone
+    assert (
+        len(sat_ready_rhel.execute('ls /var/lib/pulp/media/artifact').stdout) == pulp_artifact_len
+    )
 
 
 @pytest.mark.pit_server


### PR DESCRIPTION
### Problem Statement
https://bugzilla.redhat.com/show_bug.cgi?id=2013776 details running rsync to copy pulp data from the Satellite to the target server after running satellite-clone. This is due to satellite-clone using satellite-maintain restore which runs the installer with --reset-data.

### Solution
Switch satellite-clone tests that are running --skip-pulp-data for the backup to rsync the pulp data after we run the clone process.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->