### PR TITLE
[6.13.z] Fix host-collections tests

### DIFF
--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -30,15 +30,13 @@ from robottelo.utils.datafactory import (
 )
 
 
-def _make_fake_host_helper(module_org, module_target_sat):
+def _make_fake_host_helper(module_org, sat):
     """Make a new fake host"""
-    library = module_target_sat.cli.LifecycleEnvironment.info(
+    library = sat.cli.LifecycleEnvironment.info(
         {'organization-id': module_org.id, 'name': ENVIRONMENT}
     )
-    default_cv = module_target_sat.cli.ContentView.info(
-        {'organization-id': module_org.id, 'name': DEFAULT_CV}
-    )
-    return module_target_sat.cli_factory.make_fake_host(
+    default_cv = sat.cli.ContentView.info({'organization-id': module_org.id, 'name': DEFAULT_CV})
+    return sat.cli_factory.make_fake_host(
         {
             'content-view-id': default_cv['id'],
             'lifecycle-environment-id': library['id'],
@@ -262,7 +260,7 @@ def test_positive_host_collection_host_pagination(module_org, module_target_sat)
         {'organization-id': module_org.id}
     )
     host_ids = ','.join(
-        _make_fake_host_helper((module_org)['id'] for _ in range(2)), module_target_sat
+        _make_fake_host_helper(module_org, module_target_sat)['id'] for _ in range(2)
     )
     module_target_sat.cli.HostCollection.add_host(
         {'host-ids': host_ids, 'id': host_collection['id']}
@@ -316,7 +314,7 @@ def test_positive_register_host_ak_with_host_collection(module_org, module_ak_wi
 
     :CaseLevel: System
     """
-    host_info = _make_fake_host_helper(module_org)
+    host_info = _make_fake_host_helper(module_org, target_sat)
 
     hc = target_sat.cli_factory.make_host_collection({'organization-id': module_org.id})
     target_sat.cli.ActivationKey.add_host_collection(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13442

### Problem Statement
In #11544 we missed to update two callers of modified helper method, causing the tests to fail with error like this:
```
tests/foreman/cli/test_hostcollection.py:319: in test_positive_register_host_ak_with_host_collection
    host_info = _make_fake_host_helper(module_org)
E   TypeError: _make_fake_host_helper() missing 1 required positional argument: 'module_target_sat'
```

### Solution
Update the callers.

