### PR TITLE
[6.14.z] Get rid of deprecated mirror-on-sync

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -499,7 +499,7 @@ def class_export_entities(module_org, module_target_sat):
     exporting_repo = module_target_sat.cli_factory.make_repository(
         {
             'name': exporting_repo_name,
-            'mirror-on-sync': 'no',
+            'mirroring-policy': 'mirror_content_only',
             'download-policy': 'immediate',
             'product-id': product['id'],
         }
@@ -1273,7 +1273,7 @@ class TestContentViewSync:
             {
                 'name': gen_string('alpha'),
                 'download-policy': 'immediate',
-                'mirror-on-sync': 'no',
+                'mirroring-policy': 'mirror_content_only',
                 'product-id': product['id'],
             }
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13425

### Problem Statement
`mirror-on-sync` was deprecated and replaced by `mirroring-policy` in Katello 4.8.0 (see https://projects.theforeman.org/issues/36140)

However, it seems there are last two remaining occurrences in robottelo which need to be updated if we don't wish to see errors like this:
```
Command "repository create" finished with status 64
stderr contains:
Could not create the repository:
  Error: Unrecognised option '--mirror-on-sync'.
```

### Solution
Get rid of the deprecated `mirror-on-sync` option.
