### PR TITLE
remove the unused testimony tokens & none used for reporting

### DIFF
--- a/scripts/polarion-test-case-upload.sh
+++ b/scripts/polarion-test-case-upload.sh
@@ -69,6 +69,11 @@ DEFAULT_APPROVERS_VALUE = '${POLARION_USERNAME}:approved'
 DEFAULT_STATUS_VALUE = 'approved'
 DEFAULT_SUBTYPE2_VALUE = '-'
 TESTCASE_CUSTOM_FIELDS = default_config.TESTCASE_CUSTOM_FIELDS + ('customerscenario',) + ('team',) + ('markers',)
+# converting TESTCASE_CUSTOM_FIELDS to list for removing tokens since the tokens are defined as defaults/mandatory in betelgeuse
+TESTCASE_CUSTOM_FIELDS = list(TESTCASE_CUSTOM_FIELDS)
+REMOVE_TOKEN_LIST = ['caselevel', 'upstream', 'testtype']
+TESTCASE_CUSTOM_FIELDS = tuple([token for token in TESTCASE_CUSTOM_FIELDS if token not in REMOVE_TOKEN_LIST])
+
 REQUIREMENT_CUSTOM_FIELDS = default_config.REQUIREMENT_CUSTOM_FIELDS + ('team',)
 TRANSFORM_CUSTOMERSCENARIO_VALUE = default_config._transform_to_lower
 DEFAULT_CUSTOMERSCENARIO_VALUE = 'false'

--- a/testimony.yaml
+++ b/testimony.yaml
@@ -121,15 +121,6 @@ CaseImportance:
     - Low
     required: true
     type: choice
-CaseLevel:
-    casesensitive: true
-    choices:
-    - Component
-    - Integration
-    - System
-    - Acceptance
-    required: true
-    type: choice
 CasePosNeg:
     casesensitive: false
     choices:
@@ -157,20 +148,6 @@ SubComponent:
     type: choice
 Subtype1: {}
 Teardown: {}
-TestType:
-    casesensitive: false
-    choices:
-    - Functional
-    - Structural
-    required: true
-    type: choice
-Upstream:
-    casesensitive: false
-    choices:
-    - 'Yes'
-    - 'No'
-    required: true
-    type: choice
 Parametrized:
     casesensitive: false
     choices:

--- a/tests/foreman/api/test_acs.py
+++ b/tests/foreman/api/test_acs.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: AlternateContentSources
 
 :Team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -50,7 +45,6 @@ def test_positive_CRUD_all_types(
         3. ACS can be updated and read with new name.
         4. ACS can be refreshed.
         5. ACS can be deleted.
-
     """
     if 'rhui' in request.node.name and 'file' in request.node.name:
         pytest.skip('unsupported parametrize combination')
@@ -127,7 +121,6 @@ def test_positive_run_bulk_actions(module_target_sat, module_yum_repo):
     :expectedresults:
         1. All ACSes can be refreshed via bulk action.
         2. Only the proper ACSes are deleted on bulk destroy.
-
     """
     acs_ids = []
     for i in range(3):

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -4,17 +4,13 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ActivationKeys
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
+
 """
 import http
 
@@ -278,8 +274,6 @@ def test_positive_get_releases_status_code(target_sat):
 
     :expectedresults: HTTP 200 is returned with an ``application/json``
         content-type
-
-    :CaseLevel: Integration
     """
     act_key = target_sat.api.ActivationKey().create()
     path = act_key.path('releases')
@@ -296,8 +290,6 @@ def test_positive_get_releases_content(target_sat):
     :id: 2fec3d71-33e9-40e5-b934-90b03afc26a1
 
     :expectedresults: A list of results is returned.
-
-    :CaseLevel: Integration
     """
     act_key = target_sat.api.ActivationKey().create()
     response = client.get(act_key.path('releases'), auth=get_credentials(), verify=False).json()
@@ -318,8 +310,6 @@ def test_positive_add_host_collections(module_org, module_target_sat):
         2. After associating an activation key with some set of host
            collections and reading that activation key, the correct host
            collections are listed.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -357,8 +347,6 @@ def test_positive_remove_host_collection(module_org, module_target_sat):
            list.
         3. Disassociating host collection from the activation key actually
            removes it from the list
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -451,8 +439,6 @@ def test_positive_fetch_product_content(
     :expectedresults: Both Red Hat and custom product subscriptions are
         assigned as Activation Key's product content
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     module_target_sat.upload_manifest(module_org.id, session_entitlement_manifest.content)
@@ -505,8 +491,6 @@ def test_positive_add_future_subscription():
     :expectedresults: The future-dated sub is successfully added to the key
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Ansible
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -33,7 +28,7 @@ def test_fetch_and_sync_ansible_playbooks(target_sat):
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
 
         1. Install ansible collection with playbooks.
         2. Try to fetch the playbooks via api.
@@ -79,7 +74,7 @@ def test_positive_ansible_job_on_host(
 
     :id: c8dcdc54-cb98-4b24-bff9-049a6cc36acb
 
-    :Steps:
+    :steps:
         1. Register a content host with satellite
         2. Import a role into satellite
         3. Assign that role to a host
@@ -220,7 +215,7 @@ def test_add_and_remove_ansible_role_hostgroup(target_sat):
 
     :id: 7672cf86-fa31-11ed-855a-0fd307d2d66b
 
-    :Steps:
+    :steps:
         1. Create a hostgroup
         2. Sync few ansible roles
         3. Assign a few ansible roles with the host group
@@ -260,7 +255,7 @@ def test_add_and_remove_ansible_role_hostgroup(target_sat):
 @pytest.fixture
 def filtered_user(target_sat, module_org, module_location):
     """
-    :Steps:
+    :steps:
         1. Create a role with a host view filtered
         2. Create a user with that role
         3. Setup a host

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_choice
 import pytest

--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: AuditLog
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Search
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -38,7 +33,7 @@ def test_positive_create_with_name(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark with a random name and valid controller.
         2. List the bookmarks.
@@ -64,7 +59,7 @@ def test_positive_create_with_query(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark with a random query and valid controller.
         2. List the bookmarks.
@@ -91,7 +86,7 @@ def test_positive_create_public(controller, public, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark with a valid controller and public attribute True or False.
         2. List the bookmarks.
@@ -116,7 +111,7 @@ def test_negative_create_with_invalid_name(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Attempt to create a bookmark with an invalid name.
         2. List the bookmarks.
@@ -144,7 +139,7 @@ def test_negative_create_empty_query(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Attempt to create a bookmark with a random name, valid controller, and empty query.
         2. List the bookmarks.
@@ -172,7 +167,7 @@ def test_negative_create_same_name(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark with a random name and valid controller.
         2. Attempt to create a second bookmark, using the same name as the previous bookmark.
@@ -202,7 +197,7 @@ def test_negative_create_null_public(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Attempt to create a bookmark with a random name and valid controller, with public
         attribute set to None.
@@ -233,7 +228,7 @@ def test_positive_update_name(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark with a valid controller.
         2. Update the bookmark with a random name.
@@ -260,7 +255,7 @@ def test_negative_update_same_name(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark with a random name and valid controller.
         2. Create a second bookmark for the same controller.
@@ -291,7 +286,7 @@ def test_negative_update_invalid_name(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark with valid controller.
         2. Attempt to update the bookmark with an invalid name.
@@ -320,7 +315,7 @@ def test_positive_update_query(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark with a valid controller.
         2. Update the bookmark's query with a random value.
@@ -347,7 +342,7 @@ def test_negative_update_empty_query(controller, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark for a valid controller.
         2. Attempt to update the query to an empty value.
@@ -376,7 +371,7 @@ def test_positive_update_public(controller, public, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
 
         1. Create a bookmark for a valid controller.
         2. Update the bookmark's public attribute.

--- a/tests/foreman/api/test_capsule.py
+++ b/tests/foreman/api/test_capsule.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Capsule
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from fauxfactory import gen_string, gen_url
 import pytest
@@ -43,7 +38,6 @@ def test_positive_update_capsule(target_sat, module_capsule_configured):
     :bz: 2077824
 
     :customerscenario: true
-
     """
     new_name = f'{gen_string("alpha")}-{module_capsule_configured.name}'
     capsule = target_sat.api.SmartProxy().search(
@@ -89,7 +83,6 @@ def test_negative_create_with_url(target_sat):
     :id: e48a6260-97e0-4234-a69c-77bbbcde85d6
 
     :expectedresults: Proxy is not created
-
     """
     # Create a random proxy
     with pytest.raises(HTTPError) as context:
@@ -125,7 +118,6 @@ def test_positive_update_url(request, target_sat):
     :id: 0305fd54-4e0c-4dd9-a537-d342c3dc867e
 
     :expectedresults: Capsule has the url updated
-
     """
     # Create fake capsule with name
     name = gen_string('alpha')
@@ -158,8 +150,6 @@ def test_positive_import_puppet_classes(
     :expectedresults: Puppet classes are imported from proxy
 
     :CaseComponent: Puppet
-
-    :CaseLevel: Integration
 
     :BZ: 1398695, 2142555
 

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -5,17 +5,12 @@ interactions and use capsule.
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: Capsule-Content
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime
 import re

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Puppet
 
 :CaseImportance: Medium
 
 :Team: Rocket
 
-:TestType: Functional
-
-:Upstream: No
 """
 import json
 from random import choice

--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 from requests.exceptions import HTTPError
@@ -37,8 +32,6 @@ def test_positive_create_with_name(name, target_sat):
 
     :CaseImportance: Critical
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     profile = target_sat.api.ComputeProfile(name=name).create()
@@ -56,8 +49,6 @@ def test_negative_create(name, target_sat):
 
     :CaseImportance: Critical
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     with pytest.raises(HTTPError):
@@ -74,8 +65,6 @@ def test_positive_update_name(new_name, target_sat):
     :expectedresults: Compute Profile is updated.
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
 
     :parametrized: yes
     """
@@ -96,8 +85,6 @@ def test_negative_update_name(new_name, target_sat):
 
     :CaseImportance: Critical
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     profile = target_sat.api.ComputeProfile().create()
@@ -117,8 +104,6 @@ def test_positive_delete(new_name, target_sat):
     :expectedresults: Compute Profile is deleted successfully.
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
 
     :parametrized: yes
     """

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ComputeResources-Azure
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -53,7 +48,6 @@ class TestAzureRMComputeResourceTestCase:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Component
         """
         # Create CR
         cr_name = gen_string('alpha')
@@ -108,7 +102,6 @@ class TestAzureRMComputeResourceTestCase:
 
         :expectedresults: Cloud init image should be added in AzureRM CR along with username
 
-        :CaseLevel: Integration
         """
 
         assert module_azurerm_cloudimg.architecture.id == sat_azure_default_architecture.id
@@ -128,7 +121,6 @@ class TestAzureRMComputeResourceTestCase:
 
         :expectedresults: All the networks from AzureRM CR should be available.
 
-        :CaseLevel: Integration
         """
         cr_nws = module_azurerm_cr.available_networks()
         portal_nws = azurermclient.list_network()
@@ -142,8 +134,6 @@ class TestAzureRMComputeResourceTestCase:
         :id: 65e03f7e-a2c7-4541-b92b-38d80ab48175
 
         :CaseImportance: Medium
-
-        :CaseLevel: Acceptance
 
         :CaseAutomation: ManualOnly
 
@@ -267,9 +257,7 @@ class TestAzureRMHostProvisioningTestCase:
 
         :id: ff27905f-fa3c-43ac-b969-9525b32f75f5
 
-        :CaseLevel: Component
-
-        ::CaseImportance: Critical
+        :CaseImportance: Critical
 
         :steps:
             1. Create a AzureRM Compute Resource and provision host.
@@ -299,8 +287,6 @@ class TestAzureRMHostProvisioningTestCase:
         """Host can be powered on and off
 
         :id: 9ced29d7-d866-4d0c-ac27-78753b5b5a94
-
-        :CaseLevel: System
 
         :steps:
             1. Create a AzureRM Compute Resource.
@@ -421,9 +407,7 @@ class TestAzureRMUserDataProvisioning:
 
         :id: df496d7c-3443-4afe-b807-5bbfc90e866e
 
-        :CaseLevel: Component
-
-        ::CaseImportance: Critical
+        :CaseImportance: Critical
 
         :steps:
             1. Create a AzureRM Compute Resource and provision host.
@@ -573,8 +557,6 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
         """Host can be provisioned on AzureRM using Custom Image
 
         :id: b5be5128-ad49-4dbd-a660-3e38ce012327
-
-        :CaseLevel: System
 
         :CaseImportance: Critical
 

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -7,17 +7,12 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-GCE
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -43,7 +38,6 @@ class TestGCEComputeResourceTestCases:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Component
         """
         cr_name = gen_string('alpha')
         # Testing Create
@@ -83,7 +77,6 @@ class TestGCEComputeResourceTestCases:
 
         :expectedresults: RHEL images from GCP are available to select in GCE CR
 
-        :CaseLevel: Integration
         """
         satgce_images = module_gce_compute.available_images()
         googleclient_images = googleclient.list_templates(
@@ -105,7 +98,6 @@ class TestGCEComputeResourceTestCases:
 
         :expectedresults: All the networks from Google CR should be available to select in GCE CR
 
-        :CaseLevel: Integration
         """
         gceavailable_networks = module_gce_compute.available_networks()
         satgce_networks = [net['name'] for net in gceavailable_networks['results']]
@@ -122,7 +114,6 @@ class TestGCEComputeResourceTestCases:
 
         :expectedresults: All the flavors from Google CR should be available to select in GCE Host
 
-        :CaseLevel: Integration
         """
         satgce_flavors = int(module_gce_compute.available_flavors()['total'])
         assert satgce_flavors > 1
@@ -143,7 +134,6 @@ class TestGCEComputeResourceTestCases:
 
         :expectedresults: Finish template image should be added in GCE CR along with username
 
-        :CaseLevel: Integration
         """
         assert module_gce_finishimg.compute_resource.id == module_gce_compute.id
         assert module_gce_finishimg.uuid == gce_latest_rhel_uuid
@@ -162,7 +152,6 @@ class TestGCEComputeResourceTestCases:
 
         :expectedresults: Cloud init image should be added in GCE CR along with username
 
-        :CaseLevel: Integration
         """
         assert module_gce_cloudimg.compute_resource.id == module_gce_compute.id
         assert module_gce_cloudimg.uuid == gce_custom_cloudinit_uuid
@@ -243,9 +232,7 @@ class TestGCEHostProvisioningTestCase:
 
         :id: 889975f2-56ca-4584-95a7-21c513969630
 
-        :CaseLevel: Component
-
-        ::CaseImportance: Critical
+        :CaseImportance: Critical
 
         :steps:
             1. Create a GCE Compute Resource
@@ -268,8 +255,6 @@ class TestGCEHostProvisioningTestCase:
         """Host can be powered on and off
 
         :id: b622c6fc-c45e-431d-8de3-9d0237873998
-
-        :CaseLevel: System
 
         :steps:
             1. Create a GCE Compute Resource

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -8,17 +8,12 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-libvirt
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -46,8 +41,6 @@ def test_positive_crud_libvirt_cr(module_target_sat, module_org, module_location
     :expectedresults: Compute resources are created with expected names
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
     """
     name = gen_string('alphanumeric')
     description = gen_string('alphanumeric')
@@ -111,8 +104,6 @@ def test_positive_create_with_name_description(
 
     :CaseImportance: Critical
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     compresource = module_target_sat.api.LibvirtComputeResource(
@@ -137,8 +128,6 @@ def test_positive_create_with_orgs_and_locs(request, module_target_sat):
         locations assigned
 
     :CaseImportance: High
-
-    :CaseLevel: Integration
     """
     orgs = [module_target_sat.api.Organization().create() for _ in range(2)]
     locs = [module_target_sat.api.Location(organization=[org]).create() for org in orgs]
@@ -161,8 +150,6 @@ def test_negative_create_with_invalid_name(name, module_target_sat, module_org, 
 
     :CaseImportance: High
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     with pytest.raises(HTTPError):
@@ -183,8 +170,6 @@ def test_negative_create_with_same_name(request, module_target_sat, module_org, 
     :expectedresults: Compute resources is not created
 
     :CaseImportance: High
-
-    :CaseLevel: Component
     """
     name = gen_string('alphanumeric')
     cr = module_target_sat.api.LibvirtComputeResource(
@@ -212,8 +197,6 @@ def test_negative_create_with_url(module_target_sat, module_org, module_location
 
     :CaseImportance: High
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     with pytest.raises(HTTPError):
@@ -234,8 +217,6 @@ def test_negative_update_invalid_name(
     :expectedresults: Compute resource is not updated
 
     :CaseImportance: High
-
-    :CaseLevel: Component
 
     :parametrized: yes
     """
@@ -259,8 +240,6 @@ def test_negative_update_same_name(request, module_target_sat, module_org, modul
     :expectedresults: Compute resources is not updated
 
     :CaseImportance: High
-
-    :CaseLevel: Component
     """
     name = gen_string('alphanumeric')
     compresource = module_target_sat.api.LibvirtComputeResource(
@@ -290,8 +269,6 @@ def test_negative_update_url(url, request, module_target_sat, module_org, module
     :expectedresults: Compute resources is not updated
 
     :CaseImportance: High
-
-    :CaseLevel: Component
 
     :parametrized: yes
     """

--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentCredentials
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from copy import copy
 

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentViews
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -118,8 +113,6 @@ class TestContentView:
         :expectedresults: It is possible to create a host and set its
             'content_view_id' facet attribute
 
-        :CaseLevel: Integration
-
         :CaseAutomation: Automated
 
         :CaseImportance: High
@@ -153,8 +146,6 @@ class TestContentView:
         :expectedresults: Cloned content view can be published and promoted to
             the same environment as the original content view
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         class_published_cloned_cv.read().version[0].promote(data={'environment_ids': module_lce.id})
@@ -173,8 +164,6 @@ class TestContentView:
         :expectedresults: Cloned content view can be published and promoted to
             a different environment as the original content view
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         le_clone = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
@@ -187,8 +176,6 @@ class TestContentView:
         :id: db452e0c-0c17-40f2-bab4-8467e7a875f1
 
         :expectedresults: Custom content assigned and present in content view
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
@@ -213,8 +200,6 @@ class TestContentView:
         :id: 9e4821cb-293a-4d84-bd1f-bb9fff36b143
 
         :expectedresults: Custom content (module streams) assigned and present in content view
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -241,8 +226,6 @@ class TestContentView:
 
         :expectedresults: User cannot add repos multiple times to the view
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         yum_repo = module_target_sat.api.Repository(product=module_product).create()
@@ -264,8 +247,6 @@ class TestContentView:
         :id: 1f473b02-5e2b-41ff-a706-c0635abc2476
 
         :expectedresults: Custom sha512 assigned and present in content view
-
-        :CaseLevel: Integration
 
         :CaseComponent: Pulp
 
@@ -428,8 +409,6 @@ class TestContentViewPublishPromote:
             content view can be published several times, and each content view
             version has at least one package.
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         content_view.repository = [self.yum_repo]
@@ -456,8 +435,6 @@ class TestContentViewPublishPromote:
         :expectedresults: Composite content view is published and corresponding
             version is assigned to it.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Critical
         """
         composite_cv = module_target_sat.api.ContentView(
@@ -483,8 +460,6 @@ class TestContentViewPublishPromote:
         :expectedresults: Composite content view is published several times and
             corresponding versions are assigned to it.
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         composite_cv = module_target_sat.api.ContentView(
@@ -509,8 +484,6 @@ class TestContentViewPublishPromote:
         :expectedresults: The content view has one repository, the content view
             version is in ``REPEAT + 1`` lifecycle environments and it has at
             least one package.
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -544,8 +517,6 @@ class TestContentViewPublishPromote:
         :expectedresults: Content view can be created and assigned to composite
             one through content view versions mechanism
 
-        :CaseLevel: Integration
-
         :CaseImportance: Critical
         """
         content_view.repository = [self.yum_repo]
@@ -576,8 +547,6 @@ class TestContentViewPublishPromote:
 
         :expectedresults: User cannot add components to the view
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         content_view.repository = [self.yum_repo]
@@ -606,8 +575,6 @@ class TestContentViewPublishPromote:
 
         :expectedresults: Composite content view version points to ``Library +
             1`` lifecycle environments after the promotions.
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -638,8 +605,6 @@ class TestContentViewPublishPromote:
         :expectedresults: Composite content view version points to ``Library +
             random`` lifecycle environments after the promotions.
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         composite_cv = module_target_sat.api.ContentView(
@@ -668,8 +633,6 @@ class TestContentViewPublishPromote:
         :id: 40d20aba-726f-48e3-93b7-fb1ab1851ac7
 
         :expectedresults: Content view promoted out of sequence properly
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -704,8 +667,6 @@ class TestContentViewPublishPromote:
         :id: 5557a33b-7a6f-45f5-9fe4-23a704ed9e21
 
         :expectedresults: Content view publish should not raise an exception.
-
-        :CaseLevel: Integration
 
         :CaseComponent: Pulp
 
@@ -801,8 +762,6 @@ class TestContentViewPublishPromote:
         :expectedresults: When appropriate, a ccv and it's cvs needs_publish flags get
             set or unset
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         composite_cv = target_sat.api.ContentView(composite=True).create()
@@ -861,8 +820,6 @@ class TestContentViewPublishPromote:
 
         :expectedresults: The publish_only_if_needed flag is working as intended, and is defaulted
             to false
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -997,8 +954,6 @@ class TestContentViewRedHatContent:
 
         :expectedresults: RH Content assigned and present in a view
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert len(self.yumcv.repository) == 1
@@ -1012,8 +967,6 @@ class TestContentViewRedHatContent:
 
         :expectedresults: Filtered RH content is available and can be seen in a
             view
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -1041,8 +994,6 @@ class TestContentViewRedHatContent:
         :expectedresults: edited content view save is successful and info is
             updated
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         cvf = target_sat.api.ErratumContentViewFilter(
@@ -1067,8 +1018,6 @@ class TestContentViewRedHatContent:
 
         :expectedresults: Content view can be published
 
-        :CaseLevel: Integration
-
         :CaseImportance: Critical
         """
         content_view.repository = [self.repo]
@@ -1084,8 +1033,6 @@ class TestContentViewRedHatContent:
         :id: 094a8c46-935b-4dbc-830e-19bec935276c
 
         :expectedresults: Content view can be published
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -1104,8 +1051,6 @@ class TestContentViewRedHatContent:
         :id: 991dd9cc-5818-42dc-9098-66b312adfd97
 
         :expectedresults: Content view can be promoted
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
@@ -1129,8 +1074,6 @@ class TestContentViewRedHatContent:
         :id: 8331ba11-1742-425f-83b1-6b06c5785572
 
         :expectedresults: Content view can be promoted
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -1165,8 +1108,6 @@ class TestContentViewRedHatContent:
 
         :expectedresults: All of the above steps should results in the CV needing to be
             be published
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -1251,8 +1192,6 @@ def test_positive_admin_user_actions(
     :expectedresults: The user can Read, Modify, Delete, Publish, Promote
         the content views
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     user_login = gen_string('alpha')
@@ -1310,8 +1249,6 @@ def test_positive_readonly_user_actions(target_sat, function_role, content_view,
 
     :expectedresults: User with read-only role for content view can view
         the repository in the content view
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -1376,8 +1313,6 @@ def test_negative_readonly_user_actions(
         create Product, Host Collection, or Activation key
 
     :BZ: 1922134
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -1453,8 +1388,6 @@ def test_negative_non_readonly_user_actions(target_sat, content_view, function_r
 
     :expectedresults: the user can perform different operations against
         content view, but not read it
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -1533,8 +1466,6 @@ class TestOstreeContentView:
         :expectedresults: Custom ostree content assigned and present in content
             view
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert len(content_view.repository) == 0
@@ -1552,8 +1483,6 @@ class TestOstreeContentView:
         :expectedresults: Content-view with Custom ostree published
             successfully
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         content_view.repository = [self.ostree_repo]
@@ -1569,8 +1498,6 @@ class TestOstreeContentView:
 
         :expectedresults: Content-view with custom ostree contents promoted
             successfully
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -1591,8 +1518,6 @@ class TestOstreeContentView:
 
         :expectedresults: Content-view with custom ostree and other contents
             promoted successfully
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -1636,8 +1561,6 @@ class TestContentViewRedHatOstreeContent:
         :expectedresults: RH atomic ostree content assigned and present in
             content view
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert len(content_view.repository) == 0
@@ -1655,8 +1578,6 @@ class TestContentViewRedHatOstreeContent:
         :expectedresults: Content-view with RH ostree contents published
             successfully
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         content_view.repository = [self.repo]
@@ -1672,8 +1593,6 @@ class TestContentViewRedHatOstreeContent:
 
         :expectedresults: Content-view with RH ostree contents promoted
             successfully
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -1696,8 +1615,6 @@ class TestContentViewRedHatOstreeContent:
 
         :expectedresults: Content-view with RH ostree and other contents
             promoted successfully
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -8,17 +8,12 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentViews
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import http
 from random import randint
@@ -79,8 +74,6 @@ class TestContentViewFilter:
         :expectedresults: An HTTP 200 response is received if a GET request is
             issued with no arguments specified.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         response = client.get(
@@ -98,8 +91,6 @@ class TestContentViewFilter:
 
         :expectedresults: An HTTP 200 response is received if a GET request is
             issued with bad arguments specified.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -123,7 +114,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter created successfully and has
             correct name and type
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.ErratumContentViewFilter(content_view=content_view, name=name).create()
         assert cvf.name == name
@@ -140,8 +130,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter created successfully and has
             correct name and type
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -164,8 +152,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter created successfully and has
             correct name and type
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         cvf = target_sat.api.RPMContentViewFilter(content_view=content_view, name=name).create()
@@ -184,7 +170,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter created successfully and has
             correct inclusion value
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(
             content_view=content_view, inclusion=inclusion
@@ -203,8 +188,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter created successfully and has
             correct description
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         cvf = target_sat.api.RPMContentViewFilter(
@@ -222,7 +205,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter created successfully and has
             repository assigned
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(
             content_view=content_view,
@@ -245,8 +227,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter created successfully and has
             'original packages' value
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -271,7 +251,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter created successfully and has both
             repositories assigned (yum and docker)
 
-        :CaseLevel: Integration
         """
         docker_repository = module_target_sat.api.Repository(
             content_type='docker',
@@ -305,7 +284,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter created successfully for both
             Include and Exclude Type
 
-        :CaseLevel: Integration
         """
         content_view.repository += [sync_repo_module_stream]
         content_view.update(['repository'])
@@ -331,8 +309,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter was not created
 
-        :CaseLevel: Integration
-
         :CaseImportance: Critical
         """
         with pytest.raises(HTTPError):
@@ -345,8 +321,6 @@ class TestContentViewFilter:
         :id: 73a64ca7-07a3-49ee-8921-0474a16a23ff
 
         :expectedresults: Second content view filter was not created
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -364,8 +338,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter is not created
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         with pytest.raises(HTTPError):
@@ -379,8 +351,6 @@ class TestContentViewFilter:
         :id: aa427770-c327-4ca1-b67f-a9a94edca784
 
         :expectedresults: Content view filter is not created
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -397,8 +367,6 @@ class TestContentViewFilter:
         :id: 07caeb9d-419d-43f8-996b-456b0cc0f70d
 
         :expectedresults: Content view filter was deleted
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
@@ -419,7 +387,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter updated successfully and name was
             changed
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(content_view=content_view).create()
         cvf.name = name
@@ -436,8 +403,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter updated successfully and
             description was changed
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -458,7 +423,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter updated successfully and
             inclusion value was changed
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(content_view=content_view).create()
         cvf.inclusion = inclusion
@@ -474,7 +438,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter updated successfully and has new
             repository assigned
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(
             content_view=content_view,
@@ -498,8 +461,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter updated successfully and has new
             repositories assigned
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -533,7 +494,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter updated successfully and
             'original packages' value was changed
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(
             content_view=content_view,
@@ -556,7 +516,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter was updated successfully and has
             both repositories assigned (yum and docker)
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(
             content_view=content_view,
@@ -588,8 +547,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter was not updated
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         cvf = target_sat.api.RPMContentViewFilter(content_view=content_view).create()
@@ -604,8 +561,6 @@ class TestContentViewFilter:
         :id: b68569f1-9f7b-4a95-9e2a-a5da348abff7
 
         :expectedresults: Content view filter was not updated
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -625,7 +580,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter was not updated
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(content_view=content_view).create()
         cvf.content_view.id = gen_integer(10000, 99999)
@@ -641,7 +595,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter was not updated
 
-        :CaseLevel: Integration
         """
         cvf = target_sat.api.RPMContentViewFilter(
             content_view=content_view,
@@ -659,8 +612,6 @@ class TestContentViewFilter:
         :id: e11ba045-da8a-4f26-a0b9-3b1149358717
 
         :expectedresults: Content view filter was not updated
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -696,8 +647,6 @@ class TestContentViewFilter:
 
         :expectedresults:
             1. Filters applied flag is set correctly per usage.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 
@@ -784,7 +733,6 @@ class TestContentViewFilterRule:
         :expectedresults: Content View should get published and promoted successfully
             with correct Module Stream count.
 
-        :CaseLevel: Integration
         """
         # Exclude module stream filter
         content_view = content_view_module_stream
@@ -840,7 +788,6 @@ class TestContentViewFilterRule:
         :expectedresults: Module Stream count changes automatically after including or
             excluding modular errata
 
-        :CaseLevel: Integration
         """
         content_view = content_view_module_stream
         cv_filter = target_sat.api.ErratumContentViewFilter(
@@ -890,7 +837,6 @@ class TestContentViewFilterRule:
 
         :expectedresults: Verify module stream and errata count should correct
 
-        :CaseLevel: Integration
         """
         content_view = content_view_module_stream
         # apply include errata filter
@@ -940,7 +886,6 @@ class TestContentViewFilterRule:
 
         :expectedresults: Verify dependant/non dependant module streams are getting fetched.
 
-        :CaseLevel: Integration
         """
         content_view = content_view_module_stream
         content_view.solve_dependencies = True

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentViews
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -52,8 +47,6 @@ def test_positive_create(module_cv):
 
     :expectedresults: Content View Version is created.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     # Fetch content view for latest information
@@ -76,8 +69,6 @@ def test_negative_create(module_org, module_target_sat):
 
     :expectedresults: Content View Version is not created
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     # The default content view cannot be published
@@ -98,8 +89,6 @@ def test_positive_promote_valid_environment(module_lce_cv, module_org, module_ta
     :id: f205ca06-8ab5-4546-83bd-deac4363d487
 
     :expectedresults: Promotion succeeds.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -131,8 +120,6 @@ def test_positive_promote_out_of_sequence_environment(module_org, module_lce_cv,
     :id: e88405de-843d-4279-9d81-cedaab7c23cf
 
     :expectedresults: The promotion succeeds.
-
-    :CaseLevel: Integration
     """
     # Create a new content view...
     cv = module_target_sat.api.ContentView(organization=module_org).create()
@@ -159,8 +146,6 @@ def test_negative_promote_valid_environment(module_lce_cv):
 
     :expectedresults: The promotion fails.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
     """
     lce1, _, default_cvv = module_lce_cv
@@ -176,8 +161,6 @@ def test_negative_promote_out_of_sequence_environment(module_lce_cv, module_org,
     :id: 621d1bb6-92c6-4209-8369-6ea14a4c8a01
 
     :expectedresults: The promotion fails.
-
-    :CaseLevel: Integration
     """
     # Create a new content view...
     cv = module_target_sat.api.ContentView(organization=module_org).create()
@@ -208,8 +191,6 @@ def test_positive_delete(module_org, module_product, module_target_sat):
     :id: 066dec47-c942-4c01-8956-359c8b23a6d4
 
     :expectedresults: Content version deleted successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -253,8 +234,6 @@ def test_positive_delete_non_default(module_org, module_target_sat):
 
     :expectedresults: Content view version deleted successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     content_view = module_target_sat.api.ContentView(organization=module_org).create()
@@ -288,8 +267,6 @@ def test_positive_delete_composite_version(module_org, module_target_sat):
     :id: b5bb547e-0174-464c-b974-0254d372cdd6
 
     :expectedresults: Content version deleted successfully
-
-    :CaseLevel: Integration
 
     :BZ: 1276479
     """
@@ -330,8 +307,6 @@ def test_negative_delete(module_org, module_target_sat):
 
     :expectedresults: Content view version is not deleted
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     content_view = module_target_sat.api.ContentView(organization=module_org).create()
@@ -352,7 +327,7 @@ def test_positive_remove_renamed_cv_version_from_default_env(module_org, module_
 
     :id: 7d5961d0-6a9a-4610-979e-cbc4ddbc50ca
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add a yum repo to the content view
@@ -362,8 +337,6 @@ def test_positive_remove_renamed_cv_version_from_default_env(module_org, module_
 
     :expectedresults: content view version is removed from Library
         environment
-
-    :CaseLevel: Integration
     """
     new_name = gen_string('alpha')
     # create yum product and repo
@@ -405,7 +378,7 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(module_org, mod
 
     :id: c7795762-93bd-419c-ac49-d10dc26b842b
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add docker repo(s) to it
@@ -416,8 +389,6 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(module_org, mod
 
     :expectedresults: Content view version exist only in DEV, QE and not in
         Library
-
-    :CaseLevel: Integration
     """
     lce_dev = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
     lce_qe = module_target_sat.api.LifecycleEnvironment(
@@ -465,7 +436,7 @@ def test_positive_remove_prod_promoted_cv_version_from_default_env(module_org, m
 
     :id: 24911876-7c2a-4a12-a3aa-98051dfda29d
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add yum repositories and docker repositories to CV
@@ -476,8 +447,6 @@ def test_positive_remove_prod_promoted_cv_version_from_default_env(module_org, m
 
     :expectedresults: Content view version exist only in DEV, QE, PROD and
         not in Library
-
-    :CaseLevel: Integration
     """
     lce_dev = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
     lce_qe = module_target_sat.api.LifecycleEnvironment(
@@ -534,7 +503,7 @@ def test_positive_remove_cv_version_from_env(module_org, module_target_sat):
 
     :id: 17cf18bf-09d5-4641-b0e0-c50e628fa6c8
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add a yum repo and a docker repo to the content view
@@ -548,8 +517,6 @@ def test_positive_remove_cv_version_from_env(module_org, module_target_sat):
 
     :expectedresults: Content view version exist in Library, DEV, QE,
         STAGE, PROD
-
-    :CaseLevel: Integration
     """
     lce_dev = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
     lce_qe = module_target_sat.api.LifecycleEnvironment(
@@ -616,7 +583,7 @@ def test_positive_remove_cv_version_from_multi_env(module_org, module_target_sat
 
     :id: 18b86a68-8e6a-43ea-b95e-188fba125a26
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add a yum repo and a docker repo to the content view
@@ -626,8 +593,6 @@ def test_positive_remove_cv_version_from_multi_env(module_org, module_target_sat
         5. Remove content view version from QE, STAGE and PROD
 
     :expectedresults: Content view version exists only in Library, DEV
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
     """
@@ -693,7 +658,7 @@ def test_positive_delete_cv_promoted_to_multi_env(module_org, module_target_sat)
 
     :id: c164bd97-e710-4a5a-9c9f-657e6bed804b
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add a yum repo and a docker repo to the content view
@@ -704,8 +669,6 @@ def test_positive_delete_cv_promoted_to_multi_env(module_org, module_target_sat)
            it's published/promoted versions from all environments
 
     :expectedresults: The content view doesn't exist
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -770,7 +733,7 @@ def test_positive_remove_cv_version_from_env_with_host_registered():
 
     :id: a5b9ba8b-80e6-4435-bc0a-041b3fda227c
 
-    :Steps:
+    :steps:
 
         1. Create a content view cv1
         2. Add a yum repo to the content view
@@ -795,8 +758,6 @@ def test_positive_remove_cv_version_from_env_with_host_registered():
         5. At content-host some package from cv1 is installable
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -810,7 +771,7 @@ def test_positive_delete_cv_multi_env_promoted_with_host_registered():
 
     :id: 10699af9-617e-4930-9c80-2827a0ba52eb
 
-    :Steps:
+    :steps:
 
         1. Create two content views, cv1 and cv2
         2. Add a yum repo to both content views
@@ -837,8 +798,6 @@ def test_positive_delete_cv_multi_env_promoted_with_host_registered():
         6. At content-host some package from cv2 is installable
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -850,7 +809,7 @@ def test_positive_remove_cv_version_from_multi_env_capsule_scenario():
 
     :id: 1e8a8e64-eec8-49e0-b121-919c53f416d2
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. module_lce_cv satellite to use a capsule and to sync all lifecycle
@@ -874,6 +833,4 @@ def test_positive_remove_cv_version_from_multi_env_capsule_scenario():
         Library and DEV and exists only in QE and PROD
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: Registration
 
 :Team: Rocket
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 import requests
@@ -256,7 +251,7 @@ def test_convert2rhel_oracle(module_target_sat, oracle, activation_key_rhel, ver
 
     :id: 7fd393f0-551a-4de0-acdd-7f026b485f79
 
-    :Steps:
+    :steps:
         0. Have host registered to Satellite
         1. Check for operating system
         2. Convert host to RHEL
@@ -308,7 +303,7 @@ def test_convert2rhel_centos(module_target_sat, centos, activation_key_rhel, ver
 
     :id: 6f698440-7d85-4deb-8dd9-363ea9003b92
 
-    :Steps:
+    :steps:
         0. Have host registered to Satellite
         1. Check for operating system
         2. Convert host to RHEL

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -8,11 +8,6 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
-:TestType: Functional
-
-:Upstream: No
 """
 import re
 
@@ -190,7 +185,7 @@ class TestDiscoveredHost:
 
         :Setup: Provisioning and discovery should be configured
 
-        :Steps:
+        :steps:
 
             1. Boot up the host to discover
             2. Provision the host
@@ -243,7 +238,7 @@ class TestDiscoveredHost:
         :Setup: Provisioning should be configured and a host should be
             discovered
 
-        :Steps: PUT /api/v2/discovered_hosts/:id
+        :steps: PUT /api/v2/discovered_hosts/:id
 
         :expectedresults: Host should be provisioned successfully
 
@@ -285,7 +280,7 @@ class TestDiscoveredHost:
         :Setup: Provisioning should be configured and a host should be
             discovered
 
-        :Steps: POST /api/v2/discovered_hosts/:id/auto_provision
+        :steps: POST /api/v2/discovered_hosts/:id/auto_provision
 
         :expectedresults: Selected Host should be auto-provisioned successfully
 
@@ -314,7 +309,7 @@ class TestDiscoveredHost:
         :Setup: Provisioning should be configured and more than one host should
             be discovered
 
-        :Steps: POST /api/v2/discovered_hosts/auto_provision_all
+        :steps: POST /api/v2/discovered_hosts/auto_provision_all
 
         :expectedresults: All discovered hosts should be auto-provisioned
             successfully
@@ -349,7 +344,7 @@ class TestDiscoveredHost:
             be discovered
             2. Add a NIC on discovered host
 
-        :Steps: PUT /api/v2/discovered_hosts/:id/refresh_facts
+        :steps: PUT /api/v2/discovered_hosts/:id/refresh_facts
 
         :expectedresults: Added Fact should be displayed on refreshing the
             facts
@@ -378,7 +373,7 @@ class TestDiscoveredHost:
 
         :Setup: Provisioning should be configured and a host should be discovered via PXE boot.
 
-        :Steps: PUT /api/v2/discovered_hosts/:id/reboot
+        :steps: PUT /api/v2/discovered_hosts/:id/reboot
 
         :expectedresults: Selected host should be rebooted successfully
 
@@ -423,7 +418,7 @@ class TestDiscoveredHost:
 
         :Setup: Provisioning should be configured and hosts should be discovered via PXE boot.
 
-        :Steps: PUT /api/v2/discovered_hosts/reboot_all
+        :steps: PUT /api/v2/discovered_hosts/reboot_all
 
         :expectedresults: All discovered hosst should be rebooted successfully
 
@@ -493,14 +488,12 @@ class TestFakeDiscoveryTests:
 
         :BZ: 1349364, 1392919
 
-        :Steps:
+        :steps:
 
             1. POST /api/v2/discovered_hosts/facts
             2. Read the created discovered host
 
         :expectedresults: Host should be created successfully
-
-        :CaseLevel: Integration
 
         :BZ: 1731112
         """
@@ -519,7 +512,7 @@ class TestFakeDiscoveryTests:
         :Setup: Provisioning should be configured and a host should be
             discovered
 
-        :Steps: DELETE /api/v2/discovered_hosts/:id
+        :steps: DELETE /api/v2/discovered_hosts/:id
 
         :expectedresults: Discovered Host should be deleted successfully
         """

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -8,13 +8,8 @@
 
 :Team: Rocket
 
-:TestType: Functional
-
-:CaseLevel: Acceptance
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_choice, gen_integer, gen_string
 import pytest

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -4,13 +4,8 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice, randint, shuffle
 
@@ -173,7 +168,6 @@ class TestDockerRepository:
         :expectedresults: Multiple docker repositories are created with a
             Docker upstream repository and they all belong to the same product.
 
-        :CaseLevel: Integration
         """
         for _ in range(randint(2, 5)):
             repo = _create_repository(module_target_sat, module_product)
@@ -189,7 +183,6 @@ class TestDockerRepository:
             Docker upstream repository and they all belong to their respective
             products.
 
-        :CaseLevel: Integration
         """
         for _ in range(randint(2, 5)):
             product = module_target_sat.api.Product(organization=module_org).create()
@@ -326,8 +319,6 @@ class TestDockerContentView:
     :CaseComponent: ContentViews
 
     :team: Phoenix-content
-
-    :CaseLevel: Integration
     """
 
     @pytest.mark.tier2
@@ -983,8 +974,6 @@ class TestDockerActivationKey:
     :CaseComponent: ActivationKeys
 
     :team: Phoenix-subscriptions
-
-    :CaseLevel: Integration
     """
 
     @pytest.mark.tier2
@@ -1019,7 +1008,6 @@ class TestDockerActivationKey:
         :expectedresults: Docker-based content view can be added and then
             removed from the activation key.
 
-        :CaseLevel: Integration
         """
         content_view = content_view_publish_promote
         ak = module_target_sat.api.ActivationKey(

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -8,17 +8,12 @@ http://theforeman.org/api/apidoc/v2/environments.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -205,8 +200,6 @@ def test_positive_update_loc(module_puppet_environment):
         field.
 
     :BZ: 1262029
-
-    :CaseLevel: Integration
     """
     names = {'location', 'location_ids', 'locations'}
     attributes = set(module_puppet_environment.update_json([]).keys())
@@ -223,8 +216,6 @@ def test_positive_update_org(module_puppet_environment):
         ``organization`` field.
 
     :BZ: 1262029
-
-    :CaseLevel: Integration
     """
     names = {'organization', 'organization_ids', 'organizations'}
     attributes = set(module_puppet_environment.update_json([]).keys())

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: ErrataManagement
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 # For ease of use hc refers to host-collection throughout this document
 from time import sleep
@@ -119,11 +114,9 @@ def test_positive_install_in_hc(module_org, activation_key, custom_repo, target_
 
     :Setup: Errata synced on satellite server.
 
-    :Steps: PUT /api/v2/hosts/bulk/update_content
+    :steps: PUT /api/v2/hosts/bulk/update_content
 
     :expectedresults: errata is installed in the host-collection.
-
-    :CaseLevel: System
 
     :BZ: 1983043
     """
@@ -177,8 +170,6 @@ def test_positive_install_multiple_in_host(target_sat, rhel_contenthost, module_
     :CaseImportance: Medium
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     ak = target_sat.api.ActivationKey(
         organization=module_org,
@@ -240,12 +231,10 @@ def test_positive_list(module_org, custom_repo, target_sat):
 
     :Setup: Errata synced on satellite server.
 
-    :Steps: Create two repositories each synced and containing errata
+    :steps: Create two repositories each synced and containing errata
 
     :expectedresults: Check that the errata belonging to one repo is not
         showing in the other.
-
-    :CaseLevel: System
     """
     repo1 = target_sat.api.Repository(id=custom_repo['repository-id']).read()
     repo2 = target_sat.api.Repository(
@@ -274,11 +263,9 @@ def test_positive_list_updated(module_org, custom_repo, target_sat):
 
     :Setup: Errata synced on satellite server.
 
-    :Steps: GET /katello/api/errata
+    :steps: GET /katello/api/errata
 
     :expectedresults: Errata is filtered by Org and sorted by Updated date.
-
-    :CaseLevel: System
     """
     repo = target_sat.api.Repository(id=custom_repo['repository-id']).read()
     assert repo.sync()['result'] == 'success'
@@ -297,11 +284,9 @@ def test_positive_sorted_issue_date_and_filter_by_cve(module_org, custom_repo, t
 
     :Setup: Errata synced on satellite server.
 
-    :Steps: GET /katello/api/errata
+    :steps: GET /katello/api/errata
 
     :expectedresults: Errata is sorted by issued date and filtered by CVE.
-
-    :CaseLevel: System
     """
     # Errata is sorted by issued date.
     erratum_list = target_sat.api.Errata(repository=custom_repo['repository-id']).search(
@@ -392,11 +377,9 @@ def test_positive_get_count_for_host(setup_content_rhel6, rhel6_contenthost, tar
         1. Errata synced on satellite server.
         2. Some Content hosts present.
 
-    :Steps: GET /api/v2/hosts
+    :steps: GET /api/v2/hosts
 
     :expectedresults: The available errata count is retrieved.
-
-    :CaseLevel: System
 
     :parametrized: yes
 
@@ -434,11 +417,9 @@ def test_positive_get_applicable_for_host(setup_content_rhel6, rhel6_contenthost
         1. Errata synced on satellite server.
         2. Some Content hosts present.
 
-    :Steps: GET /api/v2/hosts/:id/errata
+    :steps: GET /api/v2/hosts/:id/errata
 
     :expectedresults: The available errata is retrieved.
-
-    :CaseLevel: System
 
     :parametrized: yes
 
@@ -482,12 +463,10 @@ def test_positive_get_diff_for_cv_envs(target_sat):
         1. Errata synced on satellite server.
         2. Multiple environments present.
 
-    :Steps: GET /katello/api/compare
+    :steps: GET /katello/api/compare
 
     :expectedresults: Difference in errata between a set of environments
         for a content view is retrieved.
-
-    :CaseLevel: System
     """
     org = target_sat.api.Organization().create()
     env = target_sat.api.LifecycleEnvironment(organization=org).create()
@@ -540,7 +519,7 @@ def test_positive_incremental_update_required(
     :Setup:
         1. Errata synced on satellite server
 
-    :Steps:
+    :steps:
         1. Create VM as Content Host, registering to CV with custom errata
         2. Install package in VM so it needs one erratum
         3. Check if incremental_updates required:
@@ -557,8 +536,6 @@ def test_positive_incremental_update_required(
     :expectedresults: Incremental update requirement is detected.
 
     :parametrized: yes
-
-    :CaseLevel: System
 
     :BZ: 2013093
     """
@@ -661,8 +638,6 @@ def test_errata_installation_with_swidtags(
     :parametrized: yes
 
     :CaseImportance: Critical
-
-    :CaseLevel: System
     """
     module_name = 'kangaroo'
     version = '20180704111719'
@@ -817,8 +792,6 @@ def test_apply_modular_errata_using_default_content_view(
     :CaseAutomation: Automated
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     module_name = 'duck'
     stream = '0'
@@ -866,8 +839,6 @@ def test_apply_modular_errata_using_default_content_view(
         :customerscenario: true
 
         :BZ: 1463811
-
-        :CaseLevel: Integration
 
         :expectedresults: both repositories were successfully synchronized
         """

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -8,17 +8,12 @@ http://theforeman.org/api/apidoc/v2/filters.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: TasksPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -8,17 +8,12 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import http
 
@@ -93,8 +88,6 @@ def test_positive_search_by_org_id(target_sat):
         organization id was done
 
     :BZ: 1447958
-
-    :CaseLevel: Integration
     """
     host = target_sat.api.Host().create()
     # adding org id as GET parameter for correspondence with BZ
@@ -220,8 +213,6 @@ def test_positive_create_and_update_with_hostgroup(
     :id: 8f9601f9-afd8-4a88-8f28-a5cbc996e805
 
     :expectedresults: A host is created and updated with expected hostgroup assigned
-
-    :CaseLevel: Integration
     """
     module_published_cv.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
     hostgroup = module_target_sat.api.HostGroup(
@@ -260,8 +251,6 @@ def test_positive_create_inherit_lce_cv(
 
     :expectedresults: Host's lifecycle environment and content view match
         the ones specified in hostgroup
-
-    :CaseLevel: Integration
 
     :BZ: 1391656
     """
@@ -413,8 +402,6 @@ def test_positive_create_and_update_with_subnet(
     :id: 9aa97aff-8439-4027-89ee-01c643fbf7d1
 
     :expectedresults: A host is created and updated with expected subnet assigned
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(
         location=module_location, organization=module_org, subnet=module_default_subnet
@@ -438,8 +425,6 @@ def test_positive_create_and_update_with_compresource(
 
     :expectedresults: A host is created and updated with expected compute resource
         assigned
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(
         compute_resource=module_cr_libvirt, location=module_location, organization=module_org
@@ -460,8 +445,6 @@ def test_positive_create_and_update_with_model(module_model, module_target_sat):
     :id: 7a912a19-71e4-4843-87fd-bab98c156f4a
 
     :expectedresults: A host is created and updated with expected model assigned
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(model=module_model).create()
     assert host.model.read().name == module_model.name
@@ -480,8 +463,6 @@ def test_positive_create_and_update_with_user(
     :id: 72e20f8f-17dc-4e38-8ac1-d08df8758f56
 
     :expectedresults: A host is created and updated with expected user assigned
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(
         owner=module_user, owner_type='User', organization=module_org, location=module_location
@@ -504,8 +485,6 @@ def test_positive_create_and_update_with_usergroup(
     :id: 706e860c-8c05-4ddc-be20-0ecd9f0da813
 
     :expectedresults: A host is created and updated with expected user group assigned
-
-    :CaseLevel: Integration
     """
     user = module_target_sat.api.User(
         location=[module_location], organization=[module_org], role=[function_role]
@@ -619,8 +598,6 @@ def test_positive_create_and_update_with_compute_profile(module_compute_profile,
 
     :expectedresults: A host is created and updated with expected compute profile
         assigned
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(compute_profile=module_compute_profile).create()
     assert host.compute_profile.read().name == module_compute_profile.name
@@ -639,8 +616,6 @@ def test_positive_create_and_update_with_content_view(
     :id: 10f69c7a-088e-474c-b869-1ad12deda2ad
 
     :expectedresults: A host is created and updated with expected content view
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(
         organization=module_org,
@@ -710,8 +685,6 @@ def test_positive_end_to_end_with_image(
 
     :expectedresults: A host is created with expected image, image is removed and
         host is updated with expected image
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(
         organization=module_org,
@@ -780,8 +753,6 @@ def test_positive_create_and_update_domain(
     :id: 8ca9f67c-4c11-40f9-b434-4f200bad000f
 
     :expectedresults: A host is created and updated with expected domain
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(
         organization=module_org, location=module_location, domain=module_domain
@@ -805,8 +776,6 @@ def test_positive_create_and_update_env(
     :id: 87a08dbf-fd4c-4b6c-bf73-98ab70756fc6
 
     :expectedresults: A host is created and updated with expected environment
-
-    :CaseLevel: Integration
     """
     host = session_puppet_enabled_sat.api.Host(
         organization=module_puppet_org,
@@ -830,8 +799,6 @@ def test_positive_create_and_update_arch(module_architecture, module_target_sat)
     :id: 5f190b14-e6db-46e1-8cd1-e94e048e6a77
 
     :expectedresults: A host is created and updated with expected architecture
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(architecture=module_architecture).create()
     assert host.architecture.read().name == module_architecture.name
@@ -849,8 +816,6 @@ def test_positive_create_and_update_os(module_os, module_target_sat):
     :id: 46edced1-8909-4066-b196-b8e22512341f
 
     :expectedresults: A host is created updated with expected operating system
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host(operatingsystem=module_os).create()
     assert host.operatingsystem.read().name == module_os.name
@@ -873,8 +838,6 @@ def test_positive_create_and_update_medium(module_org, module_location, module_t
     :id: d81cb65c-48b3-4ce3-971e-51b9dd123697
 
     :expectedresults: A host is created and updated with expected medium
-
-    :CaseLevel: Integration
     """
     medium = module_target_sat.api.Media(
         organization=[module_org], location=[module_location]
@@ -938,8 +901,6 @@ def test_negative_update_arch(module_architecture, module_target_sat):
     :id: 07b9c0e7-f02b-4aff-99ae-5c203255aba1
 
     :expectedresults: A host is not updated
-
-    :CaseLevel: Integration
     """
     host = module_target_sat.api.Host().create()
     host.architecture = module_architecture
@@ -956,8 +917,6 @@ def test_negative_update_os(target_sat):
     :id: 40e79f73-6356-4d61-9806-7ade2f4f8829
 
     :expectedresults: A host is not updated
-
-    :CaseLevel: Integration
     """
     host = target_sat.api.Host().create()
     new_os = target_sat.api.OperatingSystem(
@@ -984,8 +943,6 @@ def test_positive_read_content_source_id(
         response
 
     :BZ: 1339613, 1488130
-
-    :CaseLevel: System
     """
     proxy = target_sat.api.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0].read()
     module_published_cv.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
@@ -1020,8 +977,6 @@ def test_positive_update_content_source_id(
         response
 
     :BZ: 1339613, 1488130
-
-    :CaseLevel: System
     """
     proxy = target_sat.api.SmartProxy().search(query={'url': f'{target_sat.url}:9090'})[0]
     module_published_cv.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
@@ -1065,8 +1020,6 @@ def test_positive_read_enc_information(
     :expectedresults: host ENC information read successfully
 
     :BZ: 1362372
-
-    :CaseLevel: Integration
     """
     lce = (
         session_puppet_enabled_sat.api.LifecycleEnvironment()
@@ -1127,8 +1080,6 @@ def test_positive_add_future_subscription():
         2. Add the subscription to the content host
 
     :expectedresults: The future-dated subscription was added to the host
-
-    :CaseLevel: Integration
     """
 
 
@@ -1148,8 +1099,6 @@ def test_positive_add_future_subscription_with_ak():
         3. Register a new content host with the activation key
 
     :expectedresults: The host was registered and future subscription added
-
-    :CaseLevel: Integration
     """
 
 
@@ -1168,8 +1117,6 @@ def test_negative_auto_attach_future_subscription():
         3. Run auto-attach on the content host
 
     :expectedresults: Only the current subscription was added to the host
-
-    :CaseLevel: Integration
     """
 
 
@@ -1189,8 +1136,6 @@ def test_positive_create_baremetal_with_bios():
     :expectedresults: Host is created
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -1210,8 +1155,6 @@ def test_positive_create_baremetal_with_uefi():
     :expectedresults: Host is created
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -1242,8 +1185,6 @@ def test_positive_verify_files_with_pxegrub_uefi():
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -1278,8 +1219,6 @@ def test_positive_verify_files_with_pxegrub_uefi_secureboot():
     :CaseComponent: TFTP
 
     :Team: Rocket
-
-    :CaseLevel: Integration
     """
 
 
@@ -1314,8 +1253,6 @@ def test_positive_verify_files_with_pxegrub2_uefi():
     :CaseComponent: TFTP
 
     :Team: Rocket
-
-    :CaseLevel: Integration
     """
 
 
@@ -1346,8 +1283,6 @@ def test_positive_verify_files_with_pxegrub2_uefi_secureboot():
         And record in /var/lib/dhcpd/dhcpd.leases points to the bootloader
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: Integration
 
     :CaseComponent: TFTP
 

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: HostCollections
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice, randint
 
@@ -205,8 +200,6 @@ def test_positive_add_host(module_org, fake_hosts, module_target_sat):
 
     :expectedresults: Host was added to the host collection.
 
-    :CaseLevel: Integration
-
     :BZ:1325989
     """
     host_collection = module_target_sat.api.HostCollection(organization=module_org).create()
@@ -223,8 +216,6 @@ def test_positive_add_hosts(module_org, fake_hosts, module_target_sat):
     :id: f76b4db1-ccd5-47ab-be15-8c7d91d03b22
 
     :expectedresults: Hosts were added to the host collection.
-
-    :CaseLevel: Integration
 
     :BZ: 1325989
     """

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: HostGroup
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import randint
 
@@ -62,7 +57,6 @@ class TestHostGroup:
 
         :BZ: 1107708, 1222118, 1487586
 
-        :CaseLevel: System
         """
         # Creating entities like organization, content view and lifecycle_env
         # with not utf-8 names for easier interaction with puppet environment
@@ -169,7 +163,6 @@ class TestHostGroup:
 
         :CaseImportance: Medium
 
-        :CaseLevel: System
         """
         lce = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
         content_view = module_target_sat.api.ContentView(organization=module_org).create()
@@ -247,8 +240,6 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is created with expected properties,
             updated and deleted
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -402,7 +393,6 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is created with expected realm assigned
 
-        :CaseLevel: Integration
         """
         realm = target_sat.api.Realm(
             location=[module_location],
@@ -427,7 +417,6 @@ class TestHostGroup:
         :expectedresults: A hostgroup is created with expected multiple
             locations assigned
 
-        :CaseLevel: Integration
         """
         locs = [
             module_target_sat.api.Location(organization=[module_org]).create()
@@ -449,7 +438,6 @@ class TestHostGroup:
         :expectedresults: A hostgroup is created with expected multiple
             organizations assigned
 
-        :CaseLevel: Integration
         """
         orgs = [target_sat.api.Organization().create() for _ in range(randint(3, 5))]
         hostgroup = target_sat.api.HostGroup(organization=orgs).create()
@@ -482,7 +470,6 @@ class TestHostGroup:
 
         :CaseImportance: Medium
 
-        :CaseLevel: Integration
         """
         new_proxy = session_puppet_enabled_sat.api.SmartProxy().search(
             query={'search': f'url = {session_puppet_enabled_sat.url}:9090'}
@@ -502,7 +489,6 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is updated with expected realm
 
-        :CaseLevel: Integration
         """
         realm = target_sat.api.Realm(
             location=[module_location],
@@ -535,7 +521,6 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is updated with expected puppet proxy
 
-        :CaseLevel: Integration
         """
         new_proxy = session_puppet_enabled_sat.api.SmartProxy().search(
             query={'search': f'url = {session_puppet_enabled_sat.url}:9090'}
@@ -554,7 +539,6 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is updated with expected puppet proxy
 
-        :CaseLevel: Integration
         """
         new_content_source = target_sat.api.SmartProxy().search(
             query={'search': f'url = {target_sat.url}:9090'}
@@ -573,7 +557,6 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is updated with expected locations
 
-        :CaseLevel: Integration
         """
         new_locs = [
             module_target_sat.api.Location(organization=[module_org]).create()
@@ -593,7 +576,6 @@ class TestHostGroup:
 
         :expectedresults: A hostgroup is updated with expected organizations
 
-        :CaseLevel: Integration
         """
         new_orgs = [target_sat.api.Organization().create() for _ in range(randint(3, 5))]
         hostgroup.organization = new_orgs
@@ -649,8 +631,6 @@ class TestHostGroup:
 
         :customerscenario: true
 
-        :CaseLevel: Integration
-
         :BZ: 1710853
         """
         group_params = {'name': gen_string('alpha'), 'value': gen_string('alpha')}
@@ -681,7 +661,6 @@ class TestHostGroupMissingAttr:
         :expectedresults: The response contains both values for the
             ``content_source`` field.
 
-        :CaseLevel: Integration
         """
         names = module_target_sat.api_factory.one_to_one_names('content_source')
         hostgroup_attrs = set(hostgroup.read_json().keys())
@@ -700,7 +679,6 @@ class TestHostGroupMissingAttr:
         :expectedresults: The response contains both values for the
             ``content_view`` field.
 
-        :CaseLevel: Integration
         """
         names = module_target_sat.api_factory.one_to_one_names('content_view')
         hostgroup_attrs = set(hostgroup.read_json().keys())
@@ -719,7 +697,6 @@ class TestHostGroupMissingAttr:
         :expectedresults: The response contains both values for the
             ``lifecycle_environment`` field.
 
-        :CaseLevel: Integration
         """
         names = module_target_sat.api_factory.one_to_one_names('lifecycle_environment')
         hostgroup_attrs = set(hostgroup.read_json().keys())
@@ -740,7 +717,6 @@ class TestHostGroupMissingAttr:
 
         :BZ: 1371900
 
-        :CaseLevel: Integration
         """
         proxy = session_puppet_enabled_sat.api.SmartProxy().search(
             query={'search': f'url = {session_puppet_enabled_sat.url}:9090'}
@@ -762,7 +738,6 @@ class TestHostGroupMissingAttr:
 
         :BZ: 1371900
 
-        :CaseLevel: Integration
         """
         proxy = session_puppet_enabled_sat.api.SmartProxy().search(
             query={'search': f'url = {session_puppet_enabled_sat.url}:9090'}

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -2,19 +2,14 @@
 
 :Requirement: HttpProxy
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
-
-:TestType: Functional
 
 :CaseImportance: High
 
 :CaseAutomation: Automated
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -157,8 +152,6 @@ def test_positive_auto_attach_with_http_proxy(
     :BZ: 2046337
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     org = function_entitlement_manifest_org
     lce = module_target_sat.api.LifecycleEnvironment(organization=org).create()

--- a/tests/foreman/api/test_ldapauthsource.py
+++ b/tests/foreman/api/test_ldapauthsource.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: LDAP
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -8,17 +8,12 @@ http://www.katello.org/docs/api/apidoc/lifecycle_environments.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: LifecycleEnvironments
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -138,8 +133,6 @@ def test_positive_update_description(module_lce, new_desc, module_target_sat):
 
     :expectedresults: Lifecycle environment is created and updated properly
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
 
     :parametrized: yes
@@ -197,7 +190,7 @@ def test_positive_search_in_org(name, target_sat):
 
     :id: 110e4777-c374-4365-b676-b1db4552fe51
 
-    :Steps:
+    :steps:
 
         1. Create an organization.
         2. Create a lifecycle environment belonging to the organization.
@@ -205,8 +198,6 @@ def test_positive_search_in_org(name, target_sat):
 
     :expectedresults: Only "Library" and the lifecycle environment just
         created are in the search results.
-
-    :CaseLevel: Integration
 
     :parametrized: yes
     """
@@ -232,11 +223,9 @@ def test_positive_create_environment_after_host_register():
         2. Create a new content host.
         3. Register the content host to the Library environment.
 
-    :Steps: Create a new environment.
+    :steps: Create a new environment.
 
     :expectedresults: The environment is created without any errors.
-
-    :CaseLevel: Integration
 
     :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -7,17 +7,12 @@ http://theforeman.org/api/apidoc/v2/locations.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: OrganizationsandLocations
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import randint
 
@@ -40,7 +35,6 @@ def valid_loc_data_list():
     Note: The maximum allowed length of location name is 246 only. This is an
     intended behavior (Also note that 255 is the standard across other
     entities.)
-
     """
     return dict(
         alpha=gen_string('alpha', randint(1, 246)),
@@ -127,7 +121,6 @@ class TestLocation:
         :expectedresults: Location created successfully and has correct
             organization assigned to it with expected title
 
-        :CaseLevel: Integration
         """
         location = target_sat.api.Location(organization=[make_orgs['org']]).create()
         assert location.organization[0].id == make_orgs['org'].id
@@ -208,7 +201,6 @@ class TestLocation:
         :expectedresults: Location updated successfully and has correct domain
             assigned
 
-        :CaseLevel: Integration
         """
         location = target_sat.api.Location().create()
 
@@ -247,8 +239,6 @@ class TestLocation:
 
         :BZ: 1398695
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         proxy_id_1 = make_proxies['proxy1']['id']
@@ -276,7 +266,6 @@ class TestLocation:
 
         :expectedresults: Location is not updated
 
-        :CaseLevel: Integration
         """
         location = target_sat.api.Location(domain=[target_sat.api.Domain().create()]).create()
         domain = target_sat.api.Domain().create()

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -88,7 +83,6 @@ class TestMedia:
 
         :expectedresults: Media entity is created and has proper location
 
-        :CaseLevel: Integration
         """
         media = module_target_sat.api.Media(
             organization=[module_org], location=[module_location]
@@ -103,7 +97,6 @@ class TestMedia:
 
         :expectedresults: Media entity is created and assigned to expected OS
 
-        :CaseLevel: Integration
         """
         os = module_target_sat.api.OperatingSystem().create()
         media = module_target_sat.api.Media(

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: API
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import http
 

--- a/tests/foreman/api/test_notifications.py
+++ b/tests/foreman/api/test_notifications.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Notifications
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from mailbox import mbox
 from re import findall

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: NotAutomated
 
-:CaseLevel: System
-
 :CaseComponent: Provisioning
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from http.client import NOT_FOUND
 import random
@@ -213,7 +208,6 @@ class TestOperatingSystem:
         :expectedresults: The operating system is created and points at the
             expected architectures.
 
-        :CaseLevel: Integration
         """
         amount = range(random.randint(3, 5))
         archs = [target_sat.api.Architecture().create() for _ in amount]
@@ -231,7 +225,6 @@ class TestOperatingSystem:
         :expectedresults: The operating system is created and points at the
             expected partition tables.
 
-        :CaseLevel: Integration
         """
         amount = range(random.randint(3, 5))
         ptables = [target_sat.api.PartitionTable().create() for _ in amount]
@@ -365,7 +358,6 @@ class TestOperatingSystem:
         :expectedresults: The operating system is updated and points at the
             expected medias.
 
-        :CaseLevel: Integration
         """
         initial_media = module_target_sat.api.Media(organization=[module_org]).create()
         os = module_target_sat.api.OperatingSystem(medium=[initial_media]).create()

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -7,17 +7,12 @@ http://<satellite-host>/apidoc/v2/organizations.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: OrganizationsandLocations
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import http
 import json
@@ -259,7 +254,6 @@ class TestOrganizationUpdate:
 
         :expectedresults: User is associated with organization.
 
-        :CaseLevel: Integration
         """
         user = target_sat.api.User().create()
         module_org.user = [user]
@@ -275,7 +269,6 @@ class TestOrganizationUpdate:
 
         :expectedresults: Subnet is associated with organization.
 
-        :CaseLevel: Integration
         """
         subnet = target_sat.api.Subnet().create()
         module_org.subnet = [subnet]
@@ -292,8 +285,6 @@ class TestOrganizationUpdate:
         :BZ: 1395229
 
         :expectedresults: Hostgroup is added to organization and then removed
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -317,7 +308,6 @@ class TestOrganizationUpdate:
 
         :BZ: 1395229
 
-        :CaseLevel: Integration
         """
         # Every Satellite has a built-in smart proxy, so let's find it
         smart_proxy = target_sat.api.SmartProxy().search(

--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SCAPPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SCAPPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -33,8 +28,6 @@ class TestOscapPolicy:
         :id: d0706e49-2a00-4495-86ea-1b53a6776b6f
 
         :expectedresults: All expected CRUD actions finished successfully
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
         """

--- a/tests/foreman/api/test_parameters.py
+++ b/tests/foreman/api/test_parameters.py
@@ -4,17 +4,11 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Parameters
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
-
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -8,17 +8,12 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -8,17 +8,12 @@ http://<satellite-host>/apidoc/v2/permissions.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from itertools import chain
 import json

--- a/tests/foreman/api/test_ping.py
+++ b/tests/foreman/api/test_ping.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: API
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -7,17 +7,12 @@ http://<sat6>/apidoc/v2/products.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -96,8 +91,6 @@ def test_positive_create_with_gpg(module_org, module_target_sat):
     :id: 57331c1f-15dd-4c9f-b8fc-3010847b2975
 
     :expectedresults: A product is created with the specified GPG key.
-
-    :CaseLevel: Integration
     """
     gpg_key = module_target_sat.api.GPGKey(
         content=DataFile.VALID_GPG_KEY_FILE.read_text(),
@@ -225,8 +218,6 @@ def test_positive_update_gpg(module_org, module_target_sat):
     :id: 3b08f155-a0d6-4987-b281-dc02e8d5a03e
 
     :expectedresults: The updated product points to a new GPG key.
-
-    :CaseLevel: Integration
     """
     # Create a product and make it point to a GPG key.
     gpg_key_1 = module_target_sat.api.GPGKey(
@@ -253,8 +244,6 @@ def test_positive_update_organization(module_org, module_target_sat):
     :id: b298957a-2cdb-4f17-a934-098612f3b659
 
     :expectedresults: The updated product points to a new organization
-
-    :CaseLevel: Integration
 
     :BZ: 1310422
     """
@@ -350,8 +339,6 @@ def test_positive_sync_several_repos(module_org, module_target_sat):
     :expectedresults: All repositories within a product are successfully
         synced.
 
-    :CaseLevel: Integration
-
     :BZ: 1389543
     """
     product = module_target_sat.api.Product(organization=module_org).create()
@@ -379,8 +366,6 @@ def test_positive_filter_product_list(module_entitlement_manifest_org, module_ta
     :id: e61fb63a-4552-4915-b13d-23ab80138249
 
     :expectedresults: Able to list the products based on defined filter.
-
-    :CaseLevel: Integration
 
     :BZ: 1667129
     """

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: NotAutomated
 
-:CaseLevel: System
-
 :CaseComponent: Provisioning
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import re
 

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Medium
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from packaging.version import Version

--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -11,13 +11,8 @@ http://theforeman.org/api/apidoc/v2/provisioning_templates.html
 
 :Team: Rocket
 
-:TestType: Functional
-
-:CaseLevel: Integration
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice
 
@@ -129,10 +124,7 @@ def tftpboot(module_org, module_target_sat):
 
 
 class TestProvisioningTemplate:
-    """Tests for provisioning templates
-
-    :CaseLevel: Acceptance
-    """
+    """Tests for provisioning templates"""
 
     @pytest.mark.tier1
     @pytest.mark.e2e
@@ -224,8 +216,6 @@ class TestProvisioningTemplate:
 
         :expectedresults: The response is a JSON payload, all templates are deployed to TFTP/HTTP
                           and are rendered correctly
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
 

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -2,8 +2,6 @@
 
 :Requirement: Registration
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Registration
 
 :CaseAutomation: Automated
@@ -12,9 +10,6 @@
 
 :Team: Rocket
 
-:TestType: Functional
-
-:Upstream: No
 """
 import uuid
 
@@ -110,8 +105,6 @@ def test_positive_allow_reregistration_when_dmi_uuid_changed(
     :customerscenario: true
 
     :BZ: 1747177,2229112
-
-    :CaseLevel: Integration
     """
     uuid_1 = str(uuid.uuid1())
     uuid_2 = str(uuid.uuid4())
@@ -148,8 +141,6 @@ def test_positive_update_packages_registration(
     :id: 3d0a3252-ab81-4acf-bca6-253b746f26bb
 
     :expectedresults: Package update is successful on host post registration.
-
-    :CaseLevel: Component
     """
     org = module_sca_manifest_org
     command = module_target_sat.api.RegistrationCommand(

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RemoteExecution
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Reporting
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import re
 

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from manifester import Manifester
 from nailgun.entity_mixins import call_entity_method_with_timeout
@@ -35,7 +30,7 @@ def test_negative_disable_repository_with_cv(module_entitlement_manifest_org, ta
 
     :id: e521a7a4-2502-4fe2-b297-a13fc99e679b
 
-    :Steps:
+    :steps:
         1. Enable and sync a RH Repo
         2. Create a Content View with Repository attached
         3. Publish Content View
@@ -77,7 +72,7 @@ def test_positive_update_repository_metadata(module_org, target_sat):
 
     :id: 6fe7bb3f-1640-4904-a223-b4764534afe8
 
-    :Steps:
+    :steps:
         1. Create a Product and Yum Repository
         2. Sync the Repository and returns its content_counts for rpm
         3. Update the url to a different Repo and re-sync the Repository
@@ -127,7 +122,7 @@ def test_positive_epel_repositories_with_mirroring_policy(
 
     :id: 5c4e0ba4-4486-4eaf-b6ad-62831b7353a4
 
-    :Steps:
+    :steps:
         1. Create a Epel repository with mirroring_policy set
         2. Sync the Repository and return its content_counts for rpm
         3. Assert content was synced and mirroring policy type is correct
@@ -150,8 +145,6 @@ def test_positive_sync_kickstart_repo(module_entitlement_manifest_org, target_sa
     :id: dbdabc0e-583c-4186-981a-a02844f90412
 
     :expectedresults: No encoding gzip errors present in /var/log/messages.
-
-    :CaseLevel: Integration
 
     :customerscenario: true
 
@@ -199,7 +192,7 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
 
     :id: d6e652d8-5f46-4d15-9191-d842466d45d0
 
-    :Steps:
+    :steps:
         1. Upload a manifest
         2. Delete the Subscription Allocation on RHSM
         3. Attempt to refresh the manifest
@@ -224,7 +217,7 @@ def test_positive_multiple_orgs_with_same_repo(target_sat):
 
     :id: 39cff8ea-969d-4b8f-9fb4-33b1ba768ff2
 
-    :Steps:
+    :steps:
         1. Create multiple organizations
         2. Sync the same repository to each organization
         3. Assert that each repository from each organization contain the same content counts
@@ -249,7 +242,7 @@ def test_positive_sync_mulitple_large_repos(module_target_sat, module_entitlemen
 
     :id: b51c4a3d-d532-4342-be61-e868f7c3a723
 
-    :Steps:
+    :steps:
         1. Enabled multiple large Repositories
                 Red Hat Enterprise Linux 8 for x86_64 - AppStream RPMs 8
                 Red Hat Enterprise Linux 8 for x86_64 - BaseOS RPMs 8
@@ -297,7 +290,7 @@ def test_positive_available_repositories_endpoint(module_sca_manifest_org, targe
 
     :id: f4c9d4a0-9a82-4f06-b772-b1f7e3f45e7d
 
-    :Steps:
+    :steps:
         1. Enable a Red Hat Repository
         2. Attempt to hit the enpoint:
            GET /katello/api/repository_sets/:id/available_repositories

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import re
 from string import punctuation
@@ -317,7 +312,6 @@ class TestRepository:
 
         :expectedresults: A repository is created with the given GPG key ID.
 
-        :CaseLevel: Integration
         """
         gpg_key = module_target_sat.api.GPGKey(
             organization=module_org,
@@ -336,7 +330,6 @@ class TestRepository:
         :expectedresults: The two repositories are successfully created and
             have given name.
 
-        :CaseLevel: Integration
         """
         org_2 = target_sat.api.Organization().create()
         product_2 = target_sat.api.Product(organization=org_2).create()
@@ -678,7 +671,6 @@ class TestRepository:
 
         :expectedresults: The updated repository points to a new GPG key.
 
-        :CaseLevel: Integration
         """
         # Create a repo and make it point to a GPG key.
         gpg_key_1 = module_target_sat.api.GPGKey(
@@ -705,7 +697,6 @@ class TestRepository:
 
         :expectedresults: The repository's contents include one RPM.
 
-        :CaseLevel: Integration
         """
         # Upload RPM content.
         repo.upload_content(files={'content': DataFile.RPM_TO_UPLOAD.read_bytes()})
@@ -867,7 +858,6 @@ class TestRepository:
 
         :expectedresults: The repo has at least one RPM.
 
-        :CaseLevel: Integration
         """
         repo.sync()
         assert repo.read().content_counts['rpm'] >= 1
@@ -901,7 +891,6 @@ class TestRepository:
 
         :expectedresults: Repository is created and synced
 
-        :CaseLevel: Integration
         """
         # Verify that repo is not yet synced
         assert repo.content_counts['rpm'] == 0
@@ -940,7 +929,6 @@ class TestRepository:
 
         :expectedresults: Repository is created but synchronization fails
 
-        :CaseLevel: Integration
         """
         with pytest.raises(TaskFailedError):
             repo.sync()
@@ -967,7 +955,6 @@ class TestRepository:
 
         :BZ: 1459845, 1318004
 
-        :CaseLevel: Integration
         """
         # Synchronize it
         repo.sync()
@@ -1023,7 +1010,6 @@ class TestRepository:
 
         :expectedresults: The repository deleted successfully.
 
-        :CaseLevel: Integration
         """
         repo.sync()
         # Check that there is at least one package
@@ -1057,8 +1043,6 @@ class TestRepository:
         :expectedresults: The repository data file successfully accessed.
 
         :BZ: 1242310
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -1099,8 +1083,6 @@ class TestRepository:
         :parametrized: yes
 
         :expectedresults: The repository data file is successfully accessed.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -1208,7 +1190,6 @@ class TestRepository:
         :expectedresults:
             1. The resync restores the original content properly.
 
-        :CaseLevel: System
         """
         repo_url = settings.repos.yum_0.url
         packages_count = constants.FAKE_0_YUM_REPO_PACKAGES_COUNT
@@ -1314,8 +1295,6 @@ class TestRepositorySync:
 
         :BZ: 1404345
 
-        :CaseLevel: Integration
-
         :expectedresults: repository was successfully synchronized
         """
         org = target_sat.api.Organization().create()
@@ -1333,7 +1312,6 @@ class TestRepositorySync:
 
         :expectedresults: Synced repo should fetch the data successfully.
 
-        :CaseLevel: Integration
         """
         repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
@@ -1365,8 +1343,6 @@ class TestRepositorySync:
         :expectedresults: Synced repo should fetch the data successfully and
          parse versions as string.
 
-        :CaseLevel: Integration
-
         :customerscenario: true
 
         :BZ: 1741011
@@ -1387,7 +1363,6 @@ class TestRepositorySync:
         :expectedresults: Synced repo should fetch the data successfully and
          it should contain the module streams.
 
-        :CaseLevel: Integration
         """
         pass
 
@@ -1790,7 +1765,6 @@ class TestDockerRepository:
 
         :BZ: 1475121
 
-        :CaseLevel: Integration
         """
         repo.sync()
         assert repo.read().content_counts['docker_manifest'] >= 1
@@ -1828,7 +1802,6 @@ class TestDockerRepository:
 
         :BZ: 1475121, 1580510
 
-        :CaseLevel: Integration
         """
         msg = "401, message=\'Unauthorized\'"
         with pytest.raises(TaskFailedError, match=msg):
@@ -1867,7 +1840,6 @@ class TestDockerRepository:
 
         :BZ: 1475121, 1580510
 
-        :CaseLevel: Integration
         """
         msg = "404, message=\'Not Found\'"
         with pytest.raises(TaskFailedError, match=msg):
@@ -1907,7 +1879,6 @@ class TestDockerRepository:
 
         :BZ: 1475121, 1580510
 
-        :CaseLevel: Integration
         """
         with pytest.raises(
             HTTPError,
@@ -2175,8 +2146,6 @@ class TestDockerRepository:
 #
 #         :expectedresults: Synced repo should fetch the data successfully.
 #
-#         :CaseLevel: Integration
-#
 #         :customerscenario: true
 #
 #         :BZ: 1625783
@@ -2277,8 +2246,6 @@ class TestSRPMRepositoryIgnoreContent:
 
     In particular sync of duplicate SRPMs would fail when using the flag
     ``ignorable_content``.
-
-    :CaseLevel: Integration
 
     :CaseComponent: Pulp
 
@@ -2389,7 +2356,7 @@ class TestFileRepository:
 
         :id: fdb46481-f0f4-45aa-b075-2a8f6725e51b
 
-        :Steps:
+        :steps:
             1. Create a File Repository
             2. Upload an arbitrary file to it
 
@@ -2418,7 +2385,7 @@ class TestFileRepository:
             1. Create a File Repository
             2. Upload an arbitrary file to it
 
-        :Steps: Retrieve file permissions from File Repository
+        :steps: Retrieve file permissions from File Repository
 
         :expectedresults: uploaded file permissions are kept after upload
 
@@ -2444,7 +2411,7 @@ class TestFileRepository:
             1. Create a File Repository
             2. Upload an arbitrary file to it
 
-        :Steps: Remove a file from File Repository
+        :steps: Remove a file from File Repository
 
         :expectedresults: file is not listed under File Repository after
             removal
@@ -2474,7 +2441,7 @@ class TestFileRepository:
             1. Create a directory to be synced with a pulp manifest on its root
             2. Make the directory available through http
 
-        :Steps:
+        :steps:
             1. Create a File Repository with url pointing to http url
                 created on setup
             2. Initialize synchronization
@@ -2497,7 +2464,7 @@ class TestFileRepository:
             1. Create a directory to be synced with a pulp manifest on its root
                 locally (on the Satellite/Foreman host)
 
-        :Steps:
+        :steps:
             1. Create a File Repository with url pointing to local url
                 created on setup
             2. Initialize synchronization
@@ -2523,7 +2490,7 @@ class TestFileRepository:
                 locally (on the Satellite/Foreman host)
             2. Make sure it contains synlinks
 
-        :Steps:
+        :steps:
             1. Create a File Repository with url pointing to local url
                 created on setup
             2. Initialize synchronization

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -7,17 +7,12 @@ https://theforeman.org/plugins/katello/3.16/api/apidoc/v2/repository_sets.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RHCloud-CloudConnector
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -44,7 +39,7 @@ def test_positive_configure_cloud_connector(target_sat, default_org, fixture_ena
 
     :id: 1338dc6a-12e0-4378-9a51-a33f4679ba30
 
-    :Steps:
+    :steps:
 
         1. Enable RH Cloud Connector
         2. Check if the task is completed successfully

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: RHCloud-Inventory
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_alphanumeric, gen_string
 import pytest
@@ -133,7 +128,7 @@ def test_rhcloud_inventory_api_hosts_synchronization(
 
     :id: 7be22e1c-906b-4ae5-93dd-5f79f395601c
 
-    :Steps:
+    :steps:
 
         1. Prepare machine and upload its data to Insights.
         2. Sync inventory status using RH Cloud plugin api.
@@ -171,7 +166,7 @@ def test_rhcloud_inventory_auto_upload_setting():
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Register a content host with satellite.
         2. Enable "Automatic inventory upload" setting.
         3. Verify that satellite automatically generate and upload
@@ -201,7 +196,7 @@ def test_inventory_upload_with_http_proxy():
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Create a http proxy which is using port 80.
         2. Update general and content proxy in Satellite settings.
         3. Register a content host with satellite.
@@ -233,7 +228,7 @@ def test_include_parameter_tags_setting(
 
     :id: 3136a1e3-f844-416b-8334-75b27fd9e3a1
 
-    :Steps:
+    :steps:
         1. Enable include_parameter_tags setting.
         2. Register a content host with satellite.
         3. Create a host parameter with long text value.

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -8,17 +8,12 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SubscriptionManagement
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import http
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -8,17 +8,12 @@ http://theforeman.org/api/apidoc/v2/roles.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from nailgun.config import ServerConfig
 import pytest
@@ -576,7 +571,6 @@ class TestCannedRole:
         :expectedresults: User should not be able to access any resources and
             permissions in taxonomies selected in Org Admin role
 
-        :CaseLevel: System
         """
         user = self.create_org_admin_user(
             target_sat, role_taxos=role_taxonomies, user_taxos=filter_taxonomies
@@ -609,7 +603,6 @@ class TestCannedRole:
         :expectedresults: User should not be able to access any resources and
             permissions in its own taxonomies
 
-        :CaseLevel: System
         """
         user = self.create_org_admin_user(
             target_sat, role_taxos=role_taxonomies, user_taxos=filter_taxonomies
@@ -636,7 +629,6 @@ class TestCannedRole:
 
         :expectedresults: Filter in cloned role should be overridden
 
-        :CaseLevel: Integration
         """
         role_name = gen_string('alpha')
         role = target_sat.api.Role(name=role_name).create()
@@ -679,7 +671,6 @@ class TestCannedRole:
                 None in cloned role
             2. Override flag is set to True in cloned role filter
 
-        :CaseLevel: Integration
         """
         role = target_sat.api.Role(
             name=gen_string('alpha'),
@@ -722,7 +713,6 @@ class TestCannedRole:
         :expectedresults: Unlimited and Override flags should be set to True on
             filter for filter that is overridden in parent role
 
-        :CaseLevel: Integration
         """
         role = target_sat.api.Role(
             name=gen_string('alpha'),
@@ -770,7 +760,6 @@ class TestCannedRole:
         :expectedresults: Both unlimited and override flag should be set to
             False on filter for filter that is not overridden in parent role
 
-        :CaseLevel: Integration
         """
         role = target_sat.api.Role(
             name=gen_string('alpha'),
@@ -811,7 +800,6 @@ class TestCannedRole:
         :expectedresults: Both unlimited and override flags should be set to
             False on filter for filter that is unlimited in parent role
 
-        :CaseLevel: Integration
         """
         role = target_sat.api.Role(
             name=gen_string('alpha'),
@@ -852,7 +840,6 @@ class TestCannedRole:
         :expectedresults: Both unlimited and Override flags should be set to
             True on filter for filter that is overridden in parent role
 
-        :CaseLevel: Integration
         """
         role = target_sat.api.Role(
             name=gen_string('alpha'),
@@ -895,8 +882,6 @@ class TestCannedRole:
             1. Unlimited flag should be set to True
             2. Override flag should be set to False
 
-        :CaseLevel: Integration
-
         :BZ: 1488908
         """
         role = target_sat.api.Role(
@@ -935,8 +920,6 @@ class TestCannedRole:
             1. Unlimited flag should be set to True
             2. Override flag should be set to False
 
-        :CaseLevel: Integration
-
         :BZ: 1488908
         """
         role = target_sat.api.Role(
@@ -974,7 +957,6 @@ class TestCannedRole:
         :expectedresults: Both the user should have access to the resources of
             organization A and Location A
 
-        :CaseLevel: System
         """
         org_admin = self.create_org_admin_role(
             target_sat, orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id]
@@ -1059,7 +1041,6 @@ class TestCannedRole:
             2. User assigned to Organization A and Location A should have
                 access to the resources of organization A and Location A
 
-        :CaseLevel: System
         """
 
     @pytest.mark.tier2
@@ -1082,7 +1063,6 @@ class TestCannedRole:
         :expectedresults: Both the user shouldn't have access to the resources
             of organization A,B and Location A,B
 
-        :CaseLevel: System
         """
         org_admin = self.create_org_admin_role(
             target_sat, orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id]
@@ -1124,7 +1104,6 @@ class TestCannedRole:
         :expectedresults: Org Admin should not be able to assign the
             organizations to any of its resources
 
-        :CaseLevel: Integration
         """
         org_admin = self.create_org_admin_role(
             target_sat, orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id]
@@ -1206,7 +1185,6 @@ class TestCannedRole:
         :expectedresults: Super admin should be able to access the target_sat.api in
             taxonomies assigned to Org Admin
 
-        :CaseLevel: Integration
         """
         user = self.create_org_admin_user(
             target_sat, role_taxos=role_taxonomies, user_taxos=role_taxonomies
@@ -1251,7 +1229,6 @@ class TestCannedRole:
         :expectedresults: Super admin should be able to access the target_sat.api in
             taxonomies assigned to Org Admin after deleting Org Admin
 
-        :CaseLevel: Integration
         """
         user = self.create_org_admin_user(
             target_sat, role_taxos=role_taxonomies, user_taxos=role_taxonomies
@@ -1367,7 +1344,6 @@ class TestCannedRole:
 
         :expectedresults: Org Admin should not have access of Admin user
 
-        :CaseLevel: Integration
         """
         org_admin = self.create_org_admin_role(
             target_sat, orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id]
@@ -1414,7 +1390,6 @@ class TestCannedRole:
 
         :customerscenario: true
 
-        :CaseLevel: Integration
         """
         org_admin = self.create_org_admin_role(
             target_sat, orgs=[role_taxonomies['org'].id], locs=[role_taxonomies['loc'].id]
@@ -1468,7 +1443,6 @@ class TestCannedRole:
         :expectedresults: Org Admin should be able to access users inside
             its taxonomies
 
-        :CaseLevel: Integration
         """
         user = self.create_org_admin_user(
             target_sat, role_taxos=role_taxonomies, user_taxos=role_taxonomies
@@ -1499,7 +1473,6 @@ class TestCannedRole:
         :expectedresults: after adding the needed permissions, user should be
             able to create nested locations
 
-        :CaseLevel: Integration
         """
         user_login = gen_string('alpha')
         user_pass = gen_string('alphanumeric')
@@ -1544,7 +1517,6 @@ class TestCannedRole:
         :expectedresults: Org Admin should not be able to access users outside
             its taxonomies
 
-        :CaseLevel: Integration
         """
         user = self.create_org_admin_user(
             target_sat, role_taxos=role_taxonomies, user_taxos=role_taxonomies
@@ -1669,8 +1641,6 @@ class TestCannedRole:
         :expectedresults: LDAP User should not be able to access resources and
             permissions in taxonomies selected in Org Admin role
 
-        :CaseLevel: System
-
         :CaseAutomation: Automated
         """
         org_admin = self.create_org_admin_role(
@@ -1716,8 +1686,6 @@ class TestCannedRole:
         :expectedresults: LDAP User should not be able to access any resources
             and permissions in its own taxonomies
 
-        :CaseLevel: System
-
         :CaseAutomation: Automated
         """
         org_admin = self.create_org_admin_role(
@@ -1761,8 +1729,6 @@ class TestCannedRole:
         :expectedresults: Users in LDAP usergroup should have access to the
             resources in taxonomies if the taxonomies of Org Admin role are
             same
-
-        :CaseLevel: System
 
         :CaseAutomation: Automated
         """
@@ -1824,8 +1790,6 @@ class TestCannedRole:
         :expectedresults: Users in LDAP usergroup should not have access to the
             resources in taxonomies if the taxonomies of Org Admin role is not
             same
-
-        :CaseLevel: System
 
         :CaseAutomation: Automated
         """

--- a/tests/foreman/api/test_settings.py
+++ b/tests/foreman/api/test_settings.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Settings
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -50,7 +45,6 @@ def test_positive_update_login_page_footer_text(setting_update):
     :parametrized: yes
 
     :expectedresults: Parameter is updated successfully
-
     """
     login_text_value = random.choice(list(valid_data_list().values()))
     setting_update.value = login_text_value
@@ -69,7 +63,6 @@ def test_positive_update_login_page_footer_text_without_value(setting_update):
     :parametrized: yes
 
     :expectedresults: login_text has empty value after update
-
     """
     setting_update.value = ""
     setting_update = setting_update.update({'value'})
@@ -88,7 +81,6 @@ def test_positive_update_login_page_footer_text_with_long_string(setting_update)
     :parametrized: yes
 
     :expectedresults: Parameter is updated
-
     """
     login_text_value = random.choice(list(generate_strings_list(1000)))
     setting_update.value = login_text_value
@@ -126,7 +118,6 @@ def test_positive_update_hostname_prefix_without_value(setting_update):
     :BZ: 1911228
 
     :expectedresults: Error should be raised on setting empty value for discovery_prefix setting
-
     """
     setting_update.value = ""
     with pytest.raises(HTTPError):
@@ -192,7 +183,7 @@ def test_positive_custom_repo_download_policy(setting_update, download_policy, t
 
     :id: d5150cce-ba85-4ea0-a8d1-6a54d0d29571
 
-    :Steps:
+    :steps:
         1. Create a product, Organization
         2. Update the Default Custom Repository download policy in the setting.
         3. Create a custom repo under the created organization.
@@ -205,8 +196,6 @@ def test_positive_custom_repo_download_policy(setting_update, download_policy, t
      repository.
 
     :CaseImportance: Medium
-
-    :CaseLevel: Acceptance
     """
     org = target_sat.api.Organization().create()
     prod = target_sat.api.Product(organization=org).create()

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -9,17 +9,12 @@ http://theforeman.org/api/apidoc/v2/1.15.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Networking
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import re
 
@@ -206,8 +201,6 @@ def test_positive_inherit_subnet_parmeters_in_host():
         2. The parameters from subnet should be displayed in
             host enc output
 
-    :CaseLevel: System
-
     :CaseImportance: Medium
 
     :BZ: 1470014
@@ -234,8 +227,6 @@ def test_positive_subnet_parameters_override_from_host():
         2. The new value should be assigned to parameter
         3. The parameter and value should be accessible as host parameters
 
-    :CaseLevel: Integration
-
     :CaseImportance: Medium
 
     :BZ: 1470014
@@ -257,8 +248,6 @@ def test_positive_subnet_parameters_override_impact_on_subnet(target_sat):
 
     :expectedresults: The override value of subnet parameter from host
         should not change actual value in subnet parameter
-
-    :CaseLevel: System
 
     :CaseImportance: Medium
     """
@@ -368,8 +357,6 @@ def test_positive_update_subnet_parameter_host_impact():
         2. The inherited subnet parameter in host enc should have
             updated name and value
 
-    :CaseLevel: Integration
-
     :BZ: 1470014
     """
 
@@ -415,8 +402,6 @@ def test_positive_delete_subnet_parameter_host_impact():
         1. The parameter should be deleted from host
         2. The parameter should be deleted from host enc
 
-    :CaseLevel: Integration
-
     :BZ: 1470014
     """
 
@@ -443,8 +428,6 @@ def test_positive_delete_subnet_overridden_parameter_host_impact():
         1. The parameter should not be deleted from host as it becomes
             host parameter now
         2. The parameter should not be deleted from host enc as well
-
-    :CaseLevel: Integration
 
     :BZ: 1470014
     """
@@ -512,8 +495,6 @@ def test_positive_subnet_parameter_priority():
         2. Host enc should display the parameter with value inherited from
             higher priority component(HostGroup in this case)
 
-    :CaseLevel: System
-
     :CaseImportance: Low
 
     :BZ: 1470014
@@ -542,8 +523,6 @@ def test_negative_component_overrides_subnet_parameter():
             lower priority component(domain in this case)
         2. Host enc should not display the parameter with value inherited
             from lower priority component(domain in this case)
-
-    :CaseLevel: System
 
     :CaseImportance: Low
 

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -8,17 +8,12 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: SubscriptionManagement
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun.config import ServerConfig

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -8,17 +8,12 @@ API reference for sync plans can be found on your Satellite:
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SyncPlans
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime, timedelta
 from time import sleep
@@ -485,8 +480,6 @@ def test_positive_add_product(module_org, target_sat):
     :expectedresults: A sync plan can be created and one product can be
         added to it.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     sync_plan = target_sat.api.SyncPlan(enabled=False, organization=module_org).create()
@@ -506,8 +499,6 @@ def test_positive_add_products(module_org, target_sat):
 
     :expectedresults: A sync plan can be created and two products can be
         added to it.
-
-    :CaseLevel: Integration
     """
     sync_plan = target_sat.api.SyncPlan(enabled=False, organization=module_org).create()
     products = [target_sat.api.Product(organization=module_org).create() for _ in range(2)]
@@ -527,8 +518,6 @@ def test_positive_remove_product(module_org, target_sat):
 
     :expectedresults: A sync plan can be created and one product can be
         removed from it.
-
-    :CaseLevel: Integration
 
     :BZ: 1199150
     """
@@ -553,8 +542,6 @@ def test_positive_remove_products(module_org, target_sat):
 
     :expectedresults: A sync plan can be created and both products can be
         removed from it.
-
-    :CaseLevel: Integration
     """
     sync_plan = target_sat.api.SyncPlan(enabled=False, organization=module_org).create()
     products = [target_sat.api.Product(organization=module_org).create() for _ in range(2)]
@@ -573,8 +560,6 @@ def test_positive_repeatedly_add_remove(module_org, request, target_sat):
 
     :expectedresults: A task is returned which can be used to monitor the
         additions and removals.
-
-    :CaseLevel: Integration
 
     :BZ: 1199150
     """
@@ -598,8 +583,6 @@ def test_positive_add_remove_products_custom_cron(module_org, request, target_sa
 
     :expectedresults: A sync plan can be created and both products can be
         removed from it.
-
-    :CaseLevel: Integration
     """
     cron_expression = gen_choice(valid_cron_expressions())
 
@@ -625,8 +608,6 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request,
     :expectedresults: Product was not synchronized
 
     :BZ: 1279539
-
-    :CaseLevel: System
     """
     product = target_sat.api.Product(organization=module_org).create()
     repo = target_sat.api.Repository(product=product).create()
@@ -657,8 +638,6 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request,
     :expectedresults: Product is synchronized successfully.
 
     :BZ: 1279539
-
-    :CaseLevel: System
     """
     interval = 60 * 60  # 'hourly' sync interval in seconds
     delay = 2 * 60
@@ -702,8 +681,6 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     :id: b70a0c50-7335-4285-b24c-edfc1187f034
 
     :expectedresults: Product is synchronized successfully.
-
-    :CaseLevel: System
 
     :BZ: 1655595, 1695733
     """
@@ -753,8 +730,6 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
     :id: e646196e-3951-4297-8c3c-1494d9895347
 
     :expectedresults: Products are synchronized successfully.
-
-    :CaseLevel: System
 
     :BZ: 1695733
     """
@@ -821,8 +796,6 @@ def test_positive_synchronize_rh_product_past_sync_date(
     :customerscenario: true
 
     :BZ: 1279539, 1879537
-
-    :CaseLevel: System
     """
     interval = 60 * 60  # 'hourly' sync interval in seconds
     delay = 2 * 60
@@ -886,8 +859,6 @@ def test_positive_synchronize_rh_product_future_sync_date(
     :id: 6697a00f-2181-4c2b-88eb-2333268d780b
 
     :expectedresults: Product is synchronized successfully.
-
-    :CaseLevel: System
     """
     delay = 2 * 60  # delay for sync date in seconds
     org = function_entitlement_manifest_org
@@ -944,8 +915,6 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     :id: d60e33a0-f75c-498e-9e6f-0a2025295a9d
 
     :expectedresults: Product is synchronized successfully.
-
-    :CaseLevel: System
     """
     delay = 2 * 60
     product = target_sat.api.Product(organization=module_org).create()
@@ -989,8 +958,6 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
     :expectedresults: Product is synchronized successfully.
 
     :BZ: 1396647
-
-    :CaseLevel: System
     """
     delay = 2 * 60
     product = target_sat.api.Product(organization=module_org).create()
@@ -1031,8 +998,6 @@ def test_positive_delete_one_product(module_org, target_sat):
 
     :expectedresults: A sync plan is created with one product and sync plan
         can be deleted.
-
-    :CaseLevel: Integration
     """
     sync_plan = target_sat.api.SyncPlan(organization=module_org).create()
     product = target_sat.api.Product(organization=module_org).create()
@@ -1051,8 +1016,6 @@ def test_positive_delete_products(module_org, target_sat):
 
     :expectedresults: A sync plan is created with one product and sync plan
         can be deleted.
-
-    :CaseLevel: Integration
     """
     sync_plan = target_sat.api.SyncPlan(organization=module_org).create()
     products = [target_sat.api.Product(organization=module_org).create() for _ in range(2)]
@@ -1072,8 +1035,6 @@ def test_positive_delete_synced_product(module_org, module_target_sat):
 
     :expectedresults: A sync plan is created with one synced product and
         sync plan can be deleted.
-
-    :CaseLevel: Integration
     """
     sync_plan = module_target_sat.api.SyncPlan(organization=module_org).create()
     product = module_target_sat.api.Product(organization=module_org).create()
@@ -1095,8 +1056,6 @@ def test_positive_delete_synced_product_custom_cron(module_org, module_target_sa
 
     :expectedresults: A sync plan is created with one synced product and
         sync plan can be deleted.
-
-    :CaseLevel: Integration
     """
     sync_plan = module_target_sat.api.SyncPlan(
         organization=module_org,

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ProvisioningTemplates
 
 :Team: Rocket
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: TemplatesPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
-:Upstream: No
 """
 import base64
 import json
@@ -35,10 +30,7 @@ git = settings.git
 
 
 class TestTemplateSyncTestCase:
-    """Implements TemplateSync tests from API
-
-    :CaseLevel: Acceptance
-    """
+    """Implements TemplateSync tests from API"""
 
     @pytest.fixture(scope='module', autouse=True)
     def setUpClass(self, module_target_sat):
@@ -74,7 +66,7 @@ class TestTemplateSyncTestCase:
 
         :id: 628a95d6-7a4e-4e56-ad7b-d9fecd34f765
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                import only the templates matching with regex e.g: `^atomic.*`
                refer to: `/apidoc/v2/template/import.html`
@@ -150,7 +142,7 @@ class TestTemplateSyncTestCase:
 
         :id: a6857454-249b-4a2e-9b53-b5d7b4eb34e3
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                import the templates NOT matching with regex e.g: `^freebsd.*`
                refer to: `/apidoc/v2/template/import.html` using the
@@ -194,7 +186,7 @@ class TestTemplateSyncTestCase:
     def test_import_template_with_puppet(self, parametrized_puppet_sat):
         """Importing puppet templates with enabled/disabled puppet module
 
-        :Steps:
+        :steps:
             1. Have enabled(disabled) puppet module
             2. Import template containing puppet
             3. Check if template was imported
@@ -243,7 +235,7 @@ class TestTemplateSyncTestCase:
 
         :id: 04a14a56-bd71-412b-b2da-4b8c3991c401
 
-        :Steps:
+        :steps:
             1. Create new taxonomies, lets say org X and loc Y.
             2. From X and Y taxonomies scope, Import template1 as associate 'never', where the
                 template contains the metadata anything other than X and Y taxonomies.
@@ -373,7 +365,7 @@ class TestTemplateSyncTestCase:
 
         :id: 8ea11a1a-165e-4834-9387-7accb4c94e77
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                import templates specifying a git subdirectory e.g:
                `-d {'dirname': 'test_sub_dir'}` in POST body
@@ -411,7 +403,7 @@ class TestTemplateSyncTestCase:
 
         :id: b7c98b75-4dd1-4b6a-b424-35b0f48c25db
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                export only the templates matching with regex e.g: `robottelo`
                refer to: `/apidoc/v2/template/export.html`
@@ -447,7 +439,7 @@ class TestTemplateSyncTestCase:
 
         :id: 2f8ad8f3-f02b-4b2d-85af-423a228976f3
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                export templates matching that does not matches regex e.g: `robottelo`
                using `negate` option.
@@ -482,7 +474,7 @@ class TestTemplateSyncTestCase:
 
         :id: ba8a34ce-c2c6-4889-8729-59714c0a4b19
 
-        :Steps:
+        :steps:
             1. Create a template in local directory and specify Org/Loc.
             2. Use import to pull this specific template (using filter).
             3. Using nailgun or direct API call
@@ -560,7 +552,7 @@ class TestTemplateSyncTestCase:
 
         :id: 74b0a701-341f-4062-9769-e5cb1a1c4792
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Impot a template with verbose `True` and `False` option
 
@@ -612,7 +604,7 @@ class TestTemplateSyncTestCase:
 
         :id: 4b866144-822c-4786-9188-53bc7e2dd44a
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Create a template and import it from a source
             2. Update the template data in source location
@@ -648,7 +640,7 @@ class TestTemplateSyncTestCase:
 
         :id: 64456c0c-c2c6-4a1c-a16e-54ca4a8b66d3
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Create a template and import it from a source
             2. Dont update the template data in source location
@@ -681,7 +673,7 @@ class TestTemplateSyncTestCase:
 
         :id: a5639368-3d23-4a37-974a-889e2ec0916e
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Create a template with some name and import it from a source
 
@@ -713,7 +705,7 @@ class TestTemplateSyncTestCase:
 
         :id: 5bc11163-e8f3-4744-8a76-5c16e6e46e86
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Create a template and import it from a source
 
@@ -740,7 +732,7 @@ class TestTemplateSyncTestCase:
 
         :id: da0b094c-6dc8-4526-b115-8e08bfb05fbb
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Create a template with some name and import it from a source
 
@@ -767,7 +759,7 @@ class TestTemplateSyncTestCase:
 
         :id: 6bd5bc6b-a7a2-4529-9df6-47a670cd86d8
 
-        :Steps:
+        :steps:
             1. Create a template with wrong syntax in metadata
             2. Using nailgun or direct API call
                Import above template
@@ -801,7 +793,7 @@ class TestTemplateSyncTestCase:
 
         :id: db68b5de-7647-4568-b79c-2aec3292328a
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Create template with name not matching filter
 
@@ -837,7 +829,7 @@ class TestTemplateSyncTestCase:
 
         :id: 259a8a3a-8749-442d-a2bc-51e9af89ce8c
 
-        :Steps:
+        :steps:
             1. Create a template without name in metadata
             2. Using nailgun or direct API call
                Import above template
@@ -871,7 +863,7 @@ class TestTemplateSyncTestCase:
 
         :id: d3f1ffe4-58d7-45a8-b278-74e081dc5062
 
-        :Steps:
+        :steps:
             1. Create a template without model keyword in metadata
             2. Using nailgun or direct API call
                Import above template
@@ -905,7 +897,7 @@ class TestTemplateSyncTestCase:
 
         :id: 5007b12d-1cf6-49e6-8e54-a189d1a209de
 
-        :Steps:
+        :steps:
             1. Create a template with blank model name in metadata
             2. Using nailgun or direct API call
                Import above template
@@ -938,7 +930,7 @@ class TestTemplateSyncTestCase:
 
         :id: 141b893d-72a3-47c2-bb03-004c757bcfc9
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Export all the templates
 
@@ -990,7 +982,7 @@ class TestTemplateSyncTestCase:
 
         :id: 19ed0e6a-ee77-4e28-86c9-49db1adec479
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Import template from a source
 
@@ -998,8 +990,6 @@ class TestTemplateSyncTestCase:
             1. Assert template import task and status logged to production log
 
         :Requirement: Take Templates out of tech preview
-
-        :CaseLevel: System
 
         :CaseImportance: Low
         """
@@ -1028,7 +1018,7 @@ class TestTemplateSyncTestCase:
 
         :id: 8ae370b1-84e8-436e-a7d7-99cd0b8f45b1
 
-        :Steps:
+        :steps:
             1. Using nailgun or direct API call
                Export template to destination
 
@@ -1036,8 +1026,6 @@ class TestTemplateSyncTestCase:
             1. Assert template export task and status logged to production log
 
         :Requirement: Take Templates out of tech preview
-
-        :CaseLevel: System
 
         :CaseImportance: Low
         """
@@ -1085,7 +1073,7 @@ class TestTemplateSyncTestCase:
 
         :id: 0bf6fe77-01a3-4843-86d6-22db5b8adf3b
 
-        :Steps:
+        :steps:
             1. Using nailgun export all templates to repository (ensure filters are empty)
 
         :expectedresults:
@@ -1126,7 +1114,7 @@ class TestTemplateSyncTestCase:
 
         :id: 95ac9543-d989-44f4-b4d9-18f20a0b58b9
 
-        :Steps:
+        :steps:
             1. Using nailgun import all templates from repository (ensure filters are empty)
 
         :expectedresults:
@@ -1158,7 +1146,7 @@ class TestTemplateSyncTestCase:
 
         :id: 88e21cad-448e-45e0-add2-94493a1319c5
 
-        :Steps:
+        :steps:
             1. Using nailgun try to import a locked template
 
         :expectedresults:
@@ -1207,7 +1195,7 @@ class TestTemplateSyncTestCase:
 
         :id: 936c91cc-1947-45b0-8bf0-79ba4be87b97
 
-        :Steps:
+        :steps:
             1. Using nailgun try to import a locked template with force parameter
 
         :expectedresults:

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -8,17 +8,12 @@ http://<satellite-host>/apidoc/v2/users.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import json
 import re
@@ -640,7 +635,6 @@ class TestSshKeyInUser:
 
         :expectedresults: SSH key should be added to host ENC output
 
-        :CaseLevel: Integration
         """
         org = class_target_sat.api.Organization().create()
         loc = class_target_sat.api.Location(organization=[org]).create()
@@ -709,7 +703,6 @@ class TestActiveDirectoryUser:
 
         :expectedresults: User is created without specifying the password
 
-        :CaseLevel: Integration
         """
         user = target_sat.api.User(
             login=username, auth_source=create_ldap['authsource'], password=''
@@ -728,7 +721,6 @@ class TestActiveDirectoryUser:
 
         :expectedresults: Log in to foreman successfully but cannot access target_sat.api.
 
-        :CaseLevel: System
         """
         sc = ServerConfig(
             auth=(create_ldap['ldap_user_name'], create_ldap['ldap_user_passwd']),
@@ -756,7 +748,6 @@ class TestActiveDirectoryUser:
         :expectedresults: LDAP User should be able to access all the resources
             and permissions in taxonomies selected in Org Admin role
 
-        :CaseLevel: System
         """
         # Workaround issue where, in an upgrade template, there is already
         # some auth source present with this user. That auth source instance
@@ -861,7 +852,6 @@ class TestFreeIPAUser:
 
         :expectedresults: Log in to foreman successfully but cannot access target_sat.api.
 
-        :CaseLevel: System
         """
         sc = ServerConfig(
             auth=(create_ldap['username'], create_ldap['ldap_user_passwd']),
@@ -889,7 +879,6 @@ class TestFreeIPAUser:
         :expectedresults: FreeIPA User should be able to access all the resources
             and permissions in taxonomies selected in Org Admin role
 
-        :CaseLevel: System
         """
         role_name = gen_string('alpha')
         default_org_admin = target_sat.api.Role().search(
@@ -949,8 +938,6 @@ class TestPersonalAccessToken:
             1. Should show output of the api endpoint
             2. When revoked, authentication error
 
-        :CaseLevel: System
-
         :CaseImportance: High
         """
 
@@ -973,10 +960,7 @@ class TestPersonalAccessToken:
             2. When an incorrect role and end point is used, missing
                permission should be displayed.
 
-        :CaseLevel: System
-
         :CaseImportance: High
-
         """
 
     @pytest.mark.tier2
@@ -992,8 +976,6 @@ class TestPersonalAccessToken:
             3. Try using the token with any end point.
 
         :expectedresults: Authentication error
-
-        :CaseLevel: System
 
         :CaseImportance: Medium
 

--- a/tests/foreman/api/test_usergroup.py
+++ b/tests/foreman/api/test_usergroup.py
@@ -7,17 +7,12 @@ https://theforeman.org/api/2.0/apidoc/v2/usergroups.html
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import randint
 
@@ -155,7 +150,6 @@ class TestUserGroup:
         :expectedresults: User group is created successfully and contains all
             expected user groups
 
-        :CaseLevel: Integration
         """
         sub_user_groups = [target_sat.api.UserGroup().create() for _ in range(randint(3, 5))]
         user_group = target_sat.api.UserGroup(usergroup=sub_user_groups).create()
@@ -234,7 +228,6 @@ class TestUserGroup:
 
         :expectedresults: User group is updated successfully.
 
-        :CaseLevel: Integration
         """
         users = [target_sat.api.User().create() for _ in range(2)]
         user_group = target_sat.api.UserGroup(user=[users[0]]).create()

--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: HooksandWebhooks
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import re
 

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Infrastructure
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -30,7 +25,7 @@ def test_positive_create_report(self):
 
     :Setup: abrt
 
-    :Steps: start a sleep process in background, kill it send the report
+    :steps: start a sleep process in background, kill it send the report
         using smart-proxy-abrt-send
 
     :expectedresults: A abrt report with ccpp.* extension  created under
@@ -39,7 +34,6 @@ def test_positive_create_report(self):
     :CaseAutomation: NotAutomated
 
     :CaseImportance: Critical
-
     """
 
 
@@ -51,7 +45,7 @@ def test_positive_create_reports(self):
 
     :Setup: abrt
 
-    :Steps:
+    :steps:
 
         1. Create multiple reports of abrt
         2. Keep track of counts
@@ -59,7 +53,6 @@ def test_positive_create_reports(self):
     :expectedresults: Count is updated in proper manner
 
     :CaseAutomation: NotAutomated
-
     """
 
 
@@ -71,12 +64,11 @@ def test_positive_update_timer(self):
 
     :Setup: abrt
 
-    :Steps: edit the timer for /etc/cron.d/rubygem-smart_proxy_abrt
+    :steps: edit the timer for /etc/cron.d/rubygem-smart_proxy_abrt
 
     :expectedresults: the timer file is edited
 
     :CaseAutomation: NotAutomated
-
     """
 
 
@@ -88,12 +80,11 @@ def test_positive_identify_hostname(self):
 
     :Setup: abrt
 
-    :Steps: UI => Settings => Abrt tab => edit hostnames
+    :steps: UI => Settings => Abrt tab => edit hostnames
 
     :expectedresults: Assertion of hostnames is possible
 
     :CaseAutomation: NotAutomated
-
     """
 
 
@@ -105,10 +96,9 @@ def test_positive_search_report(self):
 
     :Setup: abrt
 
-    :Steps: access /var/tmp/abrt/ccpp-* files
+    :steps: access /var/tmp/abrt/ccpp-* files
 
     :expectedresults: Assertion of parameters
 
     :CaseAutomation: NotAutomated
-
     """

--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: AlternateContentSources
 
 :Team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_alphanumeric
 import pytest
@@ -58,7 +53,6 @@ def test_positive_CRUD_all_types(
         3. ACS can be updated and read with new name.
         4. ACS can be refreshed.
         5. ACS can be deleted.
-
     """
     if 'rhui' in request.node.name and 'file' in request.node.name:
         pytest.skip('unsupported parametrize combination')
@@ -141,7 +135,6 @@ def test_negative_check_name_validation(module_target_sat, acs_type):
 
     :expectedresults:
         1. Should fail with validation error and proper message.
-
     """
     with pytest.raises(CLIReturnCodeError) as context:
         module_target_sat.cli.ACS.create({'alternate-content-source-type': acs_type})
@@ -167,7 +160,6 @@ def test_negative_check_custom_rhui_validations(module_target_sat, acs_type, mod
     :expectedresults:
         1. Should fail as base-url and verify-ssl are required.
         2. Should fail as product-ids is forbidden.
-
     """
     # Create with required missing
     with pytest.raises(CLIReturnCodeError) as context:
@@ -217,7 +209,6 @@ def test_negative_check_simplified_validations(
 
     :expectedresults:
         1. Should fail and list all the forbidden parameters must be blank.
-
     """
     # Create with forbidden present
     params = {

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ActivationKeys
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice
 import re
@@ -147,8 +142,6 @@ def test_positive_create_with_cv(name, module_org, get_default_env, module_targe
     :expectedresults: Activation key is created and has proper content view
         assigned
 
-    :CaseLevel: Integration
-
     :parametrized: yes
     """
     new_cv = module_target_sat.cli_factory.make_content_view(
@@ -206,8 +199,6 @@ def test_positive_create_content_and_check_enabled(module_org, module_target_sat
         successfully
 
     :BZ: 1361993
-
-    :CaseLevel: Integration
     """
     result = module_target_sat.cli_factory.setup_org_for_a_custom_repo(
         {'url': settings.repos.yum_0.url, 'organization-id': module_org.id}
@@ -367,8 +358,6 @@ def test_positive_delete_with_cv(module_org, module_target_sat):
     :id: bba323fa-0362-4a9b-97af-560d446cbb6c
 
     :expectedresults: Activation key is deleted
-
-    :CaseLevel: Integration
     """
     new_cv = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
     new_ak = module_target_sat.cli_factory.make_activation_key(
@@ -387,8 +376,6 @@ def test_positive_delete_with_lce(module_org, get_default_env, module_target_sat
     :id: e1830e52-5b1a-4ac4-8d0a-df6efb218a8b
 
     :expectedresults: Activation key is deleted
-
-    :CaseLevel: Integration
     """
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id, 'lifecycle-environment': get_default_env['name']}
@@ -477,8 +464,6 @@ def test_positive_update_lce(module_org, get_default_env, module_target_sat):
     :id: 55aaee60-b8c8-49f0-995a-6c526b9b653b
 
     :expectedresults: Activation key is updated
-
-    :CaseLevel: Integration
     """
     ak_env = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id, 'lifecycle-environment-id': get_default_env['id']}
@@ -511,8 +496,6 @@ def test_positive_update_cv(module_org, module_target_sat):
     :id: aa94997d-fc9b-4532-aeeb-9f27b9834914
 
     :expectedresults: Activation key is updated
-
-    :CaseLevel: Integration
     """
     cv = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
     ak_cv = module_target_sat.cli_factory.make_activation_key(
@@ -616,7 +599,7 @@ def test_positive_usage_limit(module_org, target_sat):
 
     :id: 00ded856-e939-4140-ac84-91b6a8643623
 
-    :Steps:
+    :steps:
 
         1. Create Activation key
         2. Update Usage Limit to a finite number
@@ -628,8 +611,6 @@ def test_positive_usage_limit(module_org, target_sat):
         shown
 
     :CaseImportance: Critical
-
-    :CaseLevel: System
     """
     env = target_sat.cli_factory.make_lifecycle_environment({'organization-id': module_org.id})
     new_cv = target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
@@ -670,8 +651,6 @@ def test_positive_update_host_collection(module_org, host_col_name, module_targe
 
     :expectedresults: Host collections are successfully associated to
         Activation key
-
-    :CaseLevel: Integration
 
     :parametrized: yes
     """
@@ -731,8 +710,6 @@ def test_positive_add_redhat_product(function_entitlement_manifest_org, target_s
 
     :expectedresults: RH products are successfully associated to Activation
         key
-
-    :CaseLevel: System
     """
     org = function_entitlement_manifest_org
 
@@ -763,8 +740,6 @@ def test_positive_add_custom_product(module_org, module_target_sat):
     :expectedresults: Custom products are successfully associated to
         Activation key
 
-    :CaseLevel: System
-
     :BZ: 1426386
     """
     result = module_target_sat.cli_factory.setup_org_for_a_custom_repo(
@@ -788,7 +763,7 @@ def test_positive_add_redhat_and_custom_products(
 
     :id: 74c77426-18f5-4abb-bca9-a2135f7fcc1f
 
-    :Steps:
+    :steps:
 
         1. Create Activation key
         2. Associate RH product(s) to Activation Key
@@ -796,8 +771,6 @@ def test_positive_add_redhat_and_custom_products(
 
     :expectedresults: RH/Custom product is successfully associated to
         Activation key
-
-    :CaseLevel: System
 
     :BZ: 1426386
     """
@@ -836,7 +809,7 @@ def test_positive_delete_manifest(function_entitlement_manifest_org, target_sat)
 
     :id: 8256ac6d-3f60-4668-897d-2e88d29532d3
 
-    :Steps:
+    :steps:
         1. Upload manifest
         2. Create activation key - attach some subscriptions
         3. Delete manifest
@@ -877,8 +850,6 @@ def test_positive_delete_subscription(function_entitlement_manifest_org, module_
 
     :expectedresults: Deleting subscription removes it from the Activation
         key
-
-    :CaseLevel: Integration
     """
     org = function_entitlement_manifest_org
     new_ak = module_target_sat.cli_factory.make_activation_key({'organization-id': org.id})
@@ -916,8 +887,6 @@ def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, target_sat)
         host
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     env = target_sat.cli_factory.make_lifecycle_environment({'organization-id': module_org.id})
     new_cv = target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
@@ -965,8 +934,6 @@ def test_positive_update_aks_to_chost_in_one_command(module_org):
 
     :expectedresults: Multiple Activation keys are attached to a Content
         host
-
-    :CaseLevel: System
     """
 
 
@@ -1048,7 +1015,7 @@ def test_positive_remove_host_collection_by_id(module_org, module_target_sat):
 
     :id: 20f8ecca-1756-4900-b966-f0144b6bd0aa
 
-    :Steps:
+    :steps:
 
         1. Create Activation key
         2. Create host collection
@@ -1060,8 +1027,6 @@ def test_positive_remove_host_collection_by_id(module_org, module_target_sat):
         key
 
     :CaseImportance: Medium
-
-    :CaseLevel: Integration
 
     :BZ: 1336716
     """
@@ -1099,7 +1064,7 @@ def test_positive_remove_host_collection_by_name(module_org, host_col, module_ta
 
     :id: 1a559a82-db5f-48b0-beeb-2fa02aed7ef9
 
-    :Steps:
+    :steps:
 
         1. Create Activation key
         2. Create host collection
@@ -1109,8 +1074,6 @@ def test_positive_remove_host_collection_by_name(module_org, host_col, module_ta
 
     :expectedresults: Host collection successfully removed from activation
         key
-
-    :CaseLevel: Integration
 
     :BZ: 1336716
 
@@ -1151,7 +1114,7 @@ def test_create_ak_with_syspurpose_set(module_entitlement_manifest_org, module_t
 
     :id: ac8931e5-7089-494a-adac-cee2a8ab57ee
 
-    :Steps:
+    :steps:
         1. Create Activation key with system purpose values set
         2. Read Activation key values and assert system purpose values are set
         3. Clear AK system purpose values
@@ -1202,7 +1165,7 @@ def test_update_ak_with_syspurpose_values(module_entitlement_manifest_org, modul
 
     :id: db943c05-70f1-4385-9537-fe23368a9dfd
 
-    :Steps:
+    :steps:
 
         1. Create Activation key with no system purpose values set
         2. Assert system purpose values are not set
@@ -1270,7 +1233,7 @@ def test_positive_add_subscription_by_id(module_entitlement_manifest_org, module
 
     :id: b884be1c-b35d-440a-9a9d-c854c83e10a7
 
-    :Steps:
+    :steps:
 
         1. Create Activation key
         2. Upload manifest and add subscription
@@ -1279,8 +1242,6 @@ def test_positive_add_subscription_by_id(module_entitlement_manifest_org, module
     :expectedresults: Subscription successfully added to activation key
 
     :BZ: 1463685
-
-    :CaseLevel: Integration
 
     :BZ: 1463685
     """
@@ -1346,7 +1307,6 @@ def test_negative_copy_with_same_name(module_org, module_target_sat):
     :id: f867c468-4155-495c-a1e5-c04d9868a2e0
 
     :expectedresults: Activation key is not successfully copied
-
     """
     parent_ak = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id}
@@ -1372,15 +1332,13 @@ def test_positive_copy_subscription(module_entitlement_manifest_org, module_targ
 
     :id: f4ee8096-4120-4d06-8c9a-57ac1eaa8f68
 
-    :Steps:
+    :steps:
 
         1. Create parent key and add content
         2. Copy Activation key by passing id of parent
         3. Verify content was successfully copied
 
     :expectedresults: Activation key is successfully copied
-
-    :CaseLevel: Integration
     """
     # Begin test setup
     org = module_entitlement_manifest_org
@@ -1410,7 +1368,7 @@ def test_positive_update_autoattach_toggle(module_org, module_target_sat):
 
     :id: de3b5fb7-7963-420a-b4c9-c66e78a111dc
 
-    :Steps:
+    :steps:
 
         1. Get the key's current auto attach value.
         2. Update the key with the value's inverse.
@@ -1455,7 +1413,7 @@ def test_negative_update_autoattach(module_org, module_target_sat):
 
     :id: 54b6f808-ff54-4e69-a54d-e1f99a4652f9
 
-    :Steps:
+    :steps:
 
         1. Attempt to update a key with incorrect auto-attach value
         2. Verify that an appropriate error message was returned
@@ -1484,7 +1442,7 @@ def test_positive_content_override(module_org, module_target_sat):
 
     :id: a4912cc0-3bf7-4e90-bb51-ec88b2fad227
 
-    :Steps:
+    :steps:
 
         1. Create activation key and add content
         2. Get the first product's label
@@ -1492,8 +1450,6 @@ def test_positive_content_override(module_org, module_target_sat):
         4. Verify that the command succeeded
 
     :expectedresults: Activation key content override was successful
-
-    :CaseLevel: System
     """
     result = module_target_sat.cli_factory.setup_org_for_a_custom_repo(
         {'url': settings.repos.yum_0.url, 'organization-id': module_org.id}
@@ -1574,8 +1530,6 @@ def test_positive_view_subscriptions_by_non_admin_user(
         subscription
 
     :BZ: 1406076
-
-    :CaseLevel: System
     """
     org = module_entitlement_manifest_org
     user_name = gen_alphanumeric()
@@ -1715,7 +1669,7 @@ def test_positive_ak_with_custom_product_on_rhel6(module_org, rhel6_contenthost,
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Create a custom repo
         2. Create ak and add custom repo to ak
         3. Add subscriptions to the ak

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Ansible
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -31,7 +26,7 @@ def test_positive_ansible_e2e(target_sat, module_org, rhel_contenthost):
 
     :id: 0c52bc63-a41a-4f48-a980-fe49b4ecdbdc
 
-    :Steps:
+    :steps:
         1. Register a content host with satellite
         2. Import a role into satellite
         3. Assign that role to a host
@@ -132,7 +127,7 @@ def test_add_and_remove_ansible_role_hostgroup(target_sat):
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Create a hostgroup
         2. Sync few ansible roles
         3. Assign a few ansible roles with the host group

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_choice
 import pytest

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Authentication
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from time import sleep
 
@@ -70,7 +65,7 @@ def test_positive_create_session(admin_user, target_sat):
 
     :id: fcee7f5f-1040-41a9-bf17-6d0c24a93e22
 
-    :Steps:
+    :steps:
 
         1. Set use_sessions, set short expiration time
         2. Authenticate, assert credentials are not demanded
@@ -109,7 +104,7 @@ def test_positive_disable_session(admin_user, target_sat):
 
     :id: 38ee0d85-c2fe-4cac-a992-c5dbcec11031
 
-    :Steps:
+    :steps:
 
         1. Set use_sessions
         2. Authenticate, assert credentials are not demanded
@@ -117,7 +112,6 @@ def test_positive_disable_session(admin_user, target_sat):
         3. Disable use_sessions
 
     :expectedresults: The session is terminated
-
     """
     result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
@@ -141,7 +135,7 @@ def test_positive_log_out_from_session(admin_user, target_sat):
 
     :id: 0ba05f2d-7b83-4b0c-a04c-80e62b7c4cf2
 
-    :Steps:
+    :steps:
 
         1. Set use_sessions
         2. Authenticate, assert credentials are not demanded
@@ -149,7 +143,6 @@ def test_positive_log_out_from_session(admin_user, target_sat):
         3. Run `hammer auth logout`
 
     :expectedresults: The session is terminated
-
     """
     result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
@@ -171,7 +164,7 @@ def test_positive_change_session(admin_user, non_admin_user, target_sat):
 
     :id: b6ea6f3c-fcbd-4e7b-97bd-f3e0e6b9da8f
 
-    :Steps:
+    :steps:
 
         1. Set use_sessions
         2. Authenticate, assert credentials are not demanded
@@ -181,7 +174,6 @@ def test_positive_change_session(admin_user, non_admin_user, target_sat):
     :CaseImportance: High
 
     :expectedresults: The session is altered
-
     """
     result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
@@ -202,7 +194,7 @@ def test_positive_session_survives_unauthenticated_call(admin_user, target_sat):
 
     :id: 8bc304a0-70ea-489c-9c3f-ea8343c5284c
 
-    :Steps:
+    :steps:
 
         1. Set use_sessions
         2. Authenticate, assert credentials are not demanded
@@ -212,7 +204,6 @@ def test_positive_session_survives_unauthenticated_call(admin_user, target_sat):
     :CaseImportance: Medium
 
     :expectedresults: The session is unchanged
-
     """
     result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
@@ -236,7 +227,7 @@ def test_positive_session_survives_failed_login(admin_user, non_admin_user, targ
 
     :BZ: 1465552
 
-    :Steps:
+    :steps:
 
         1. Set use_sessions
         2. Authenticate, assert credentials are not demanded
@@ -244,7 +235,6 @@ def test_positive_session_survives_failed_login(admin_user, non_admin_user, targ
         3. Run login with invalid credentials
 
     :expectedresults: The session is unchanged
-
     """
     result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'
@@ -275,7 +265,7 @@ def test_positive_session_preceeds_saved_credentials(admin_user, target_sat):
 
     :CaseImportance: High
 
-    :Steps:
+    :steps:
 
         1. Set use_sessions, set username and password,
            set short expiration time
@@ -285,7 +275,6 @@ def test_positive_session_preceeds_saved_credentials(admin_user, target_sat):
 
     :expectedresults: Session expires after specified time
         and saved credentials are not applied
-
     """
     try:
         idle_timeout = target_sat.cli.Settings.list({'search': 'name=idle_timeout'})[0]['value']
@@ -331,7 +320,6 @@ def test_negative_no_permissions(admin_user, non_admin_user, target_sat):
     :expectedresults: Command is not executed
 
     :CaseImportance: High
-
     """
     result = configure_sessions(target_sat)
     assert result == 0, 'Failed to configure hammer sessions'

--- a/tests/foreman/cli/test_bootdisk.py
+++ b/tests/foreman/cli/test_bootdisk.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: BootdiskPlugin
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_mac, gen_string
 import pytest

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Bootstrap
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -35,7 +30,7 @@ def test_positive_register(
 
     :id: e34561fd-e0d6-4587-84eb-f86bd131aab1
 
-    :Steps:
+    :steps:
 
         1. Ensure system is not registered
         2. Register a system

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Capsule
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 
@@ -29,8 +24,6 @@ def test_positive_import_puppet_classes(session_puppet_enabled_sat):
     :id: 42e3a9c0-62e1-4049-9667-f3c0cdfe0b04
 
     :expectedresults: Puppet classes are imported from proxy
-
-    :CaseLevel: Component
     """
     with session_puppet_enabled_sat as puppet_sat:
         port = puppet_sat.available_capsule_port
@@ -50,7 +43,7 @@ def test_positive_capsule_content():
 
     :Setup: Capsule with some content synced
 
-    :Steps:
+    :steps:
 
         1. Register a host to the capsule
         2. Sync content from capsule to the host

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: Capsule-Content
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Puppet
 
 :CaseImportance: Medium
 
 :Team: Rocket
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ComputeResources-Azure
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -73,7 +68,6 @@ class TestAzureRMComputeResourceTestCase:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Component
         """
         # Create CR
         cr_name = gen_string('alpha')
@@ -156,7 +150,6 @@ class TestAzureRMComputeResourceTestCase:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Integration
         """
 
         # Create
@@ -230,8 +223,6 @@ class TestAzureRMComputeResourceTestCase:
 
         :expectedresults: All the networks from AzureRM CR should be available.
 
-        :CaseLevel: Integration
-
         :BZ: 1850934
         """
 
@@ -255,7 +246,6 @@ class TestAzureRMComputeResourceTestCase:
 
         :expectedresults: Compute-profile values should be create with AzureRm CR
 
-        :CaseLevel: Integration
         """
         username = gen_string('alpha')
         password = gen_string('alpha')
@@ -398,9 +388,7 @@ class TestAzureRMFinishTemplateProvisioning:
 
         :id: 9e8242e5-3ef3-4884-a200-7ba79b8ef49f
 
-        :CaseLevel: Component
-
-        ::CaseImportance: Critical
+        :CaseImportance: Critical
 
         :steps:
             1. Create a AzureRM Compute Resource and provision host.
@@ -528,9 +516,7 @@ class TestAzureRMUserDataProvisioning:
 
         :id: c99d2679-1742-4ef3-9288-2961d18a30e7
 
-        :CaseLevel: Component
-
-        ::CaseImportance: Critical
+        :CaseImportance: Critical
 
         :steps:
             1. Create a AzureRM Compute Resource and provision host.

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -1,17 +1,12 @@
 """
 :Requirement: Computeresource EC2
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-EC2
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -53,8 +48,6 @@ def test_positive_create_ec2_with_custom_region(aws, module_target_sat):
     :CaseAutomation: Automated
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
     """
     cr_name = gen_string(str_type='alpha')
     cr_description = gen_string(str_type='alpha')

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -21,17 +21,12 @@ Subcommands::
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-libvirt
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -120,8 +115,6 @@ def test_positive_create_with_name(libvirt_url, module_target_sat):
     :expectedresults: Compute resource is created
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
     """
     module_target_sat.cli.ComputeResource.create(
         {
@@ -141,8 +134,6 @@ def test_positive_info(libvirt_url, module_target_sat):
     :expectedresults: Compute resource Info is displayed
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
     """
     name = gen_string('utf8')
     compute_resource = module_target_sat.cli_factory.compute_resource(
@@ -165,8 +156,6 @@ def test_positive_list(libvirt_url, module_target_sat):
     :expectedresults: Compute resource List is displayed
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
     """
     comp_res = module_target_sat.cli_factory.compute_resource(
         {'provider': FOREMAN_PROVIDERS['libvirt'], 'url': libvirt_url}
@@ -190,8 +179,6 @@ def test_positive_delete_by_name(libvirt_url, module_target_sat):
     :expectedresults: Compute resource deleted
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
     """
     comp_res = module_target_sat.cli_factory.compute_resource(
         {'provider': FOREMAN_PROVIDERS['libvirt'], 'url': libvirt_url}
@@ -215,8 +202,6 @@ def test_positive_create_with_libvirt(libvirt_url, options, target_sat):
 
     :CaseImportance: Critical
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     target_sat.cli.ComputeResource.create(
@@ -238,8 +223,6 @@ def test_positive_create_with_loc(libvirt_url, module_target_sat):
     :expectedresults: Compute resource is created and has location assigned
 
     :CaseImportance: High
-
-    :CaseLevel: Integration
     """
     location = module_target_sat.cli_factory.make_location()
     comp_resource = module_target_sat.cli_factory.compute_resource(
@@ -263,8 +246,6 @@ def test_positive_create_with_locs(libvirt_url, module_target_sat):
         locations assigned
 
     :CaseImportance: High
-
-    :CaseLevel: Integration
     """
     locations_amount = random.randint(3, 5)
     locations = [module_target_sat.cli_factory.make_location() for _ in range(locations_amount)]
@@ -294,8 +275,6 @@ def test_negative_create_with_name_url(libvirt_url, options, target_sat):
 
     :CaseImportance: High
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     with pytest.raises(CLIReturnCodeError):
@@ -317,8 +296,6 @@ def test_negative_create_with_same_name(libvirt_url, module_target_sat):
     :expectedresults: Compute resource not created
 
     :CaseImportance: High
-
-    :CaseLevel: Component
     """
     comp_res = module_target_sat.cli_factory.compute_resource(
         {'provider': FOREMAN_PROVIDERS['libvirt'], 'url': libvirt_url}
@@ -346,8 +323,6 @@ def test_positive_update_name(libvirt_url, options, module_target_sat):
     :expectedresults: Compute Resource successfully updated
 
     :CaseImportance: Critical
-
-    :CaseLevel: Component
 
     :parametrized: yes
     """
@@ -379,8 +354,6 @@ def test_negative_update(libvirt_url, options, module_target_sat):
 
     :CaseImportance: High
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     comp_res = module_target_sat.cli_factory.compute_resource(
@@ -411,8 +384,6 @@ def test_positive_create_with_console_password_and_name(
 
     :CaseImportance: High
 
-    :CaseLevel: Component
-
     :parametrized: yes
     """
     module_target_sat.cli.ComputeResource.create(
@@ -437,8 +408,6 @@ def test_positive_update_console_password(libvirt_url, set_console_password, mod
     :BZ: 1100344
 
     :CaseImportance: High
-
-    :CaseLevel: Component
 
     :parametrized: yes
     """

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -3,17 +3,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-OpenStack
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from box import Box
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -3,17 +3,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ComputeResources-RHEV
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -344,7 +339,6 @@ def test_negative_add_image_rhev_with_invalid_name(rhev, module_os, module_targe
            name parameter, compute-resource image create.
 
     :expectedresults: The image should not be added to the CR
-
     """
     if rhev.image_uuid is None:
         pytest.skip('Missing configuration for rhev.image_uuid')
@@ -538,8 +532,6 @@ def test_positive_provision_rhev_without_host_group(rhev):
     :expectedresults: The host should be provisioned successfully
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: Integration
     """
 
 

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -1,19 +1,14 @@
 """
 :Requirement: Computeresource Vmware
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-VMWare
 
 :Team: Rocket
-
-:TestType: Functional
 
 :CaseImportance: High
 
 :CaseAutomation: Automated
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -4,13 +4,10 @@
 
 :CaseAutomation: Automated
 
-:TestType: Functional
-
 :Team: Phoenix-content
 
 :CaseComponent: ContainerManagement-Content
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -52,8 +49,6 @@ class TestDockerClient:
     """Tests specific to using ``Docker`` as a client to pull Docker images
     from a Satellite 6 instance.
 
-    :CaseLevel: System
-
     :CaseImportance: Medium
     """
 
@@ -64,7 +59,7 @@ class TestDockerClient:
 
         :id: 023f0538-2aad-4f87-b8a8-6ccced648366
 
-        :Steps:
+        :steps:
 
             1. Publish and promote content view with Docker content
             2. Register Docker-enabled client against Satellite 6.

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -2,17 +2,12 @@
 
 :Requirement: Content Access
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts-Content
 
 :CaseAutomation: Automated
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 import time
 
@@ -236,8 +231,6 @@ def test_negative_unregister_and_pull_content(vm):
     :id: de0d0d91-b1e1-4f0e-8a41-c27df4d6b6fd
 
     :expectedresults: Host can no longer retrieve content from satellite
-
-    :CaseLevel: System
 
     :parametrized: yes
 

--- a/tests/foreman/cli/test_contentcredentials.py
+++ b/tests/foreman/cli/test_contentcredentials.py
@@ -6,17 +6,12 @@ Satellite 6.8
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentCredentials
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from tempfile import mkstemp
 
@@ -381,8 +376,6 @@ def test_positive_add_empty_product(target_sat, module_org):
     :id: 61c700db-43ab-4b8c-8527-f4cfc085afaa
 
     :expectedresults: gpg key is associated with product
-
-    :CaseLevel: Integration
     """
     gpg_key = target_sat.cli_factory.make_content_credential({'organization-id': module_org.id})
     product = target_sat.cli_factory.make_product(
@@ -400,8 +393,6 @@ def test_positive_add_product_with_repo(target_sat, module_org):
 
     :expectedresults: gpg key is associated with product as well as with
         the repository
-
-    :CaseLevel: Integration
     """
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
     repo = target_sat.cli_factory.make_repository(
@@ -427,8 +418,6 @@ def test_positive_add_product_with_repos(target_sat, module_org):
 
     :expectedresults: gpg key is associated with product as well as with
         the repositories
-
-    :CaseLevel: Integration
     """
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
     repos = [
@@ -456,8 +445,6 @@ def test_positive_add_repo_from_product_with_repo(target_sat, module_org):
 
     :expectedresults: gpg key is associated with the repository but not
         with the product
-
-    :CaseLevel: Integration
     """
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
     repo = target_sat.cli_factory.make_repository(
@@ -484,8 +471,6 @@ def test_positive_add_repo_from_product_with_repos(target_sat, module_org):
     :id: e3019a61-ec32-4044-9087-e420b8db4e09
 
     :expectedresults: gpg key is associated with the repository
-
-    :CaseLevel: Integration
     """
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
     repos = [
@@ -517,8 +502,6 @@ def test_positive_update_key_for_empty_product(target_sat, module_org):
 
     :expectedresults: gpg key is associated with product before/after
         update
-
-    :CaseLevel: Integration
     """
     # Create a product and a gpg key
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
@@ -555,8 +538,6 @@ def test_positive_update_key_for_product_with_repo(target_sat, module_org):
 
     :expectedresults: gpg key is associated with product before/after
         update as well as with the repository
-
-    :CaseLevel: Integration
     """
     # Create a product and a gpg key
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
@@ -602,8 +583,6 @@ def test_positive_update_key_for_product_with_repos(target_sat, module_org):
 
     :expectedresults: gpg key is associated with product before/after
         update as well as with the repositories
-
-    :CaseLevel: Integration
     """
     # Create a product and a gpg key
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
@@ -652,8 +631,6 @@ def test_positive_update_key_for_repo_from_product_with_repo(target_sat, module_
 
     :expectedresults: gpg key is associated with the repository
         before/after update, but not with the product
-
-    :CaseLevel: Integration
     """
     # Create a product and a gpg key
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
@@ -693,8 +670,6 @@ def test_positive_update_key_for_repo_from_product_with_repos(target_sat, module
     :expectedresults: gpg key is associated with a single repository
         before/after update and not associated with product or other
         repositories
-
-    :CaseLevel: Integration
     """
     # Create a product and a gpg key
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentViews
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -205,8 +200,6 @@ class TestContentView:
         :expectedresults: Edited content view save is successful and info is
             updated
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         # Create CV
@@ -289,7 +282,6 @@ class TestContentView:
 
         :CaseImportance: High
 
-        :CaseLevel: Integration
         """
         content_view = module_target_sat.cli_factory.make_content_view(
             {'organization-id': module_org.id}
@@ -372,7 +364,6 @@ class TestContentView:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Integration
         """
         content_view = module_target_sat.cli_factory.make_content_view(
             {'organization-id': module_org.id}
@@ -417,7 +408,6 @@ class TestContentView:
 
         :CaseImportance: Medium
 
-        :CaseLevel: Integration
         """
         env = [
             module_target_sat.cli_factory.make_lifecycle_environment(
@@ -484,7 +474,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         env = [
             module_target_sat.cli_factory.make_lifecycle_environment(
@@ -668,8 +657,6 @@ class TestContentView:
 
         :expectedresults: Composite content views are created
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         # Create REPO
@@ -713,8 +700,6 @@ class TestContentView:
             view associated to it
 
         :BZ: 1416857
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -764,8 +749,6 @@ class TestContentView:
 
         :expectedresults: Composite content view info output does not contain
             any values
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -820,8 +803,6 @@ class TestContentView:
 
         :BZ: 1416857
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         # Create new repository
@@ -874,8 +855,6 @@ class TestContentView:
 
         :BZ: 1487265
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         # Create first CV
@@ -911,8 +890,6 @@ class TestContentView:
 
         :BZ: 1487265
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         # Create CV
@@ -942,8 +919,6 @@ class TestContentView:
 
             :expectedresults: Composite content view component ids are similar to
                 the nested content view versions ids
-
-            :CaseLevel: Integration
 
             :CaseImportance: Low
             """
@@ -979,8 +954,6 @@ class TestContentView:
         :setup: Sync RH content
 
         :expectedresults: RH Content can be seen in the content view
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
@@ -1018,8 +991,6 @@ class TestContentView:
             a view
 
         :CaseImportance: Low
-
-        :CaseLevel: Integration
 
         :BZ: 1359665
         """
@@ -1064,7 +1035,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         filter_name = gen_string('alpha')
         repo_name = gen_string('alpha')
@@ -1112,7 +1082,6 @@ class TestContentView:
 
         :CaseImportance: High
 
-        :CaseLevel: Integration
         """
         new_repo = module_target_sat.cli_factory.make_repository(
             {'content-type': 'yum', 'product-id': module_product.id}
@@ -1172,7 +1141,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = module_target_sat.cli_factory.make_repository(
@@ -1209,7 +1177,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         new_repo = module_target_sat.cli_factory.make_repository(
             {'content-type': 'yum', 'product-id': module_product.id}
@@ -1247,7 +1214,6 @@ class TestContentView:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Integration
         """
         # Create CV
         new_cv = module_target_sat.cli_factory.make_content_view(
@@ -1287,7 +1253,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         # Create custom repo
         new_repo = module_target_sat.cli_factory.make_repository(
@@ -1348,7 +1313,6 @@ class TestContentView:
 
         :CaseImportance: High
 
-        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = module_target_sat.cli_factory.make_repository(
@@ -1395,7 +1359,6 @@ class TestContentView:
 
         :CaseImportance: High
 
-        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = module_target_sat.cli_factory.make_repository(
@@ -1452,7 +1415,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         environment = module_target_sat.cli_factory.make_lifecycle_environment(
             {'organization-id': module_org.id}
@@ -1482,7 +1444,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = module_target_sat.cli_factory.make_repository(
@@ -1527,7 +1488,6 @@ class TestContentView:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Integration
         """
         # Create CV
         new_cv = module_target_sat.cli_factory.make_content_view(
@@ -1561,7 +1521,6 @@ class TestContentView:
 
         :CaseImportance: High
 
-        :CaseLevel: Integration
         """
         # Create custom repo
         new_repo = module_target_sat.cli_factory.make_repository(
@@ -1615,7 +1574,6 @@ class TestContentView:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Integration
         """
         new_repo = module_target_sat.cli_factory.make_repository(
             {'content-type': 'yum', 'product-id': module_product.id}
@@ -1651,7 +1609,6 @@ class TestContentView:
 
             1. CV version with custom major and minor versions is created
 
-        :CaseLevel: System
         """
         org = module_target_sat.cli_factory.make_org()
         major = random.randint(1, 1000)
@@ -1687,7 +1644,6 @@ class TestContentView:
 
         :CaseImportance: Medium
 
-        :CaseLevel: Integration
         """
         software_repo = module_target_sat.cli_factory.make_repository(
             {
@@ -1756,7 +1712,6 @@ class TestContentView:
 
         :customerscenario: true
 
-        :CaseLevel: Integration
         """
         # Create new Yum repository
         yum_repo = module_target_sat.cli_factory.make_repository(
@@ -1824,8 +1779,6 @@ class TestContentView:
 
         :BZ: 1323751
 
-        :CaseLevel: Integration
-
         :customerscenario: true
 
         :CaseImportance: Medium
@@ -1871,7 +1824,6 @@ class TestContentView:
 
         :CaseImportance: Critical
 
-        :CaseLevel: Integration
         """
         repository = module_target_sat.cli_factory.make_repository(
             {'content-type': 'yum', 'product-id': module_product.id}
@@ -1931,8 +1883,6 @@ class TestContentView:
         :expectedresults: Content view version is updated in target
             environment.
 
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
@@ -2011,7 +1961,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         # Create REPO
         new_repo = module_target_sat.cli_factory.make_repository(
@@ -2098,8 +2047,6 @@ class TestContentView:
 
         :BZ: 1177766
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         content_view = module_target_sat.cli_factory.make_content_view(
@@ -2155,7 +2102,6 @@ class TestContentView:
 
         :CaseImportance: High
 
-        :CaseLevel: System
         """
         env = module_target_sat.cli_factory.make_lifecycle_environment(
             {'organization-id': module_org.id}
@@ -2194,8 +2140,6 @@ class TestContentView:
 
         :expectedresults: Content Host can be subscribed to content view with
             Red Hat repository
-
-        :CaseLevel: System
 
         :CaseImportance: Medium
         """
@@ -2246,8 +2190,6 @@ class TestContentView:
 
         :expectedresults: Content Host can be subscribed to filtered content
             view with Red Hat repository
-
-        :CaseLevel: System
 
         :BZ: 1359665
 
@@ -2320,8 +2262,6 @@ class TestContentView:
         :expectedresults: Content Host can be subscribed to content view with
             custom repository
 
-        :CaseLevel: System
-
         :CaseImportance: High
         """
         new_product = module_target_sat.cli_factory.make_product({'organization-id': module_org.id})
@@ -2375,7 +2315,6 @@ class TestContentView:
 
         :CaseImportance: High
 
-        :CaseLevel: System
         """
         env = module_target_sat.cli_factory.make_lifecycle_environment(
             {'organization-id': module_org.id}
@@ -2448,7 +2387,6 @@ class TestContentView:
 
         :parametrized: yes
 
-        :CaseLevel: System
         """
         # Note: this test has been stubbed waitin for bug 1511481 resolution
         # prepare the user and the required permissions data
@@ -2605,7 +2543,6 @@ class TestContentView:
 
         :parametrized: yes
 
-        :CaseLevel: System
         """
         # prepare the user and the required permissions data
         user_name = gen_alphanumeric()
@@ -2777,8 +2714,6 @@ class TestContentView:
         :expectedresults: Cloned content view can be published and promoted to
             the same environment as the original content view
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         cloned_cv_name = gen_string('alpha')
@@ -2818,7 +2753,6 @@ class TestContentView:
 
         :CaseImportance: Low
 
-        :CaseLevel: Integration
         """
         cloned_cv_name = gen_string('alpha')
         lc_env = module_target_sat.cli_factory.make_lifecycle_environment(
@@ -2893,7 +2827,7 @@ class TestContentView:
 
         :id: aa9bbfda-72e8-45ec-b26d-fdf2691980cf
 
-        :Steps:
+        :steps:
 
             1. Create a content view
             2. Add a yum repo to the content view
@@ -2903,8 +2837,6 @@ class TestContentView:
 
         :expectedresults: content view version is removed from Library
             environment
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -2969,7 +2901,7 @@ class TestContentView:
 
         :id: 6643837a-560a-47de-aa4d-90778914dcfa
 
-        :Steps:
+        :steps:
 
             1. Create a content view
             2. Add a yum repo to the content view
@@ -2981,8 +2913,6 @@ class TestContentView:
 
             1. Content view version exist only in DEV and not in Library
             2. The yum repo exists in content view version
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -3061,7 +2991,7 @@ class TestContentView:
 
         :id: e286697f-4113-40a3-b8e8-9ca50647e6d5
 
-        :Steps:
+        :steps:
 
             1. Create a content view
             2. Add docker repo(s) to it
@@ -3072,8 +3002,6 @@ class TestContentView:
 
         :expectedresults: Content view version exist only in DEV, QE and not in
             Library
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -3150,7 +3078,7 @@ class TestContentView:
 
         :id: ffe3d64e-c3d2-4889-9454-ccc6b10f4db7
 
-        :Steps:
+        :steps:
 
             1. Create a content view
             2. Add yum repositories and docker repositories to CV
@@ -3164,7 +3092,6 @@ class TestContentView:
 
         :CaseImportance: High
 
-        :CaseLevel: Integration
         """
         lce_dev = module_target_sat.cli_factory.make_lifecycle_environment(
             {'organization-id': module_org.id}
@@ -3257,7 +3184,7 @@ class TestContentView:
 
         :id: 577757ac-b184-4ece-9310-182dd5ceb718
 
-        :Steps:
+        :steps:
 
             1. Create a content view
             2. Add a yum repo and a docker repo to the content view
@@ -3271,8 +3198,6 @@ class TestContentView:
 
         :expectedresults: Content view version exist in Library, DEV, QE,
             STAGE, PROD
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -3385,7 +3310,7 @@ class TestContentView:
 
         :id: 997cfd7d-9029-47e2-a41e-84f4370b5ce5
 
-        :Steps:
+        :steps:
 
             1. Create a content view
             2. Add a yum repo and a docker to the content view
@@ -3395,8 +3320,6 @@ class TestContentView:
             5. Remove content view version from QE, STAGE and PROD
 
         :expectedresults: Content view version exists only in Library, DEV
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -3491,7 +3414,7 @@ class TestContentView:
 
         :id: 93dd7518-5901-4a71-a4c3-0f1215238b26
 
-        :Steps:
+        :steps:
 
             1. Create a content view
             2. Add a yum repo and a docker to the content view
@@ -3502,8 +3425,6 @@ class TestContentView:
                environments prior this step)
 
         :expectedresults: The content view doesn't exists
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -3603,7 +3524,7 @@ class TestContentView:
 
         :id: 001a2b76-a87b-4c11-8837-f5fe3c04a075
 
-        :Steps:
+        :steps:
 
             1. Create a content view cv1
             2. Add a yum repo to the content view
@@ -3630,7 +3551,6 @@ class TestContentView:
 
         :CaseAutomation: NotAutomated
 
-        :CaseLevel: System
         """
 
     @pytest.mark.stubbed
@@ -3642,7 +3562,7 @@ class TestContentView:
 
         :id: 82442d23-45b5-4d39-b867-c5d46bbcbbf9
 
-        :Steps:
+        :steps:
 
             1. Create two content view cv1 and cv2
             2. Add a yum repo to both content views
@@ -3670,7 +3590,6 @@ class TestContentView:
 
         :CaseAutomation: NotAutomated
 
-        :CaseLevel: System
         """
 
     @pytest.mark.run_in_one_thread
@@ -3687,7 +3606,7 @@ class TestContentView:
 
         :id: 3725fef6-73a4-4dcb-a306-70e6ba826a3d
 
-        :Steps:
+        :steps:
 
             1. Create a content view
             2. Setup satellite to use a capsule and to sync all lifecycle
@@ -3711,8 +3630,6 @@ class TestContentView:
             Library and DEV and exists only in QE and PROD
 
         :CaseAutomation: Automated
-
-        :CaseLevel: System
 
         :CaseImportance: High
         """
@@ -3911,8 +3828,6 @@ class TestContentView:
 
         :BZ: 1922134
 
-        :CaseLevel: Integration
-
         :CaseImportance: Critical
         """
         cv = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
@@ -3988,8 +3903,6 @@ class TestContentView:
 
         :BZ: 1464414
 
-        :CaseLevel: Integration
-
         :CaseImportance: Critical
         """
         cv = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
@@ -4062,7 +3975,6 @@ class TestContentView:
 
         :CaseImportance: Medium
 
-        :CaseLevel: Integration
         """
         repo = module_target_sat.cli_factory.make_repository(
             {
@@ -4156,14 +4068,12 @@ class TestContentViewFileRepo:
             2. Upload an arbitrary file to it
             3. Create a Content View (CV)
 
-        :Steps:
+        :steps:
             1. Add the FR to the CV
 
         :expectedresults: Check FR is added to CV
 
         :CaseAutomation: Automated
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 
@@ -4201,14 +4111,12 @@ class TestContentViewFileRepo:
             3. Create a Content View (CV)
             4. Add the FR to the CV
 
-        :Steps:
+        :steps:
             1. Remove the FR from the CV
 
         :expectedresults: Check FR is removed from CV
 
         :CaseAutomation: Automated
-
-        :CaseLevel: Integration
 
         :BZ: 1908465
         """
@@ -4241,14 +4149,13 @@ class TestContentViewFileRepo:
             5. Create a Capsule
             6. Connect the Capsule with Satellite/Foreman host
 
-        :Steps:
+        :steps:
             1. Start synchronization
 
         :expectedresults: Check CV with FR is synced over Capsule
 
         :CaseAutomation: NotAutomated
 
-        :CaseLevel: System
         """
 
     @pytest.mark.tier3
@@ -4267,15 +4174,13 @@ class TestContentViewFileRepo:
             4. Add the FR to the CV
             5. Create an Environment
 
-        :Steps:
+        :steps:
             1. Promote the CV to the Environment
 
         :expectedresults: Check arbitrary files from FR is available on
             content view version environment
 
         :CaseAutomation: Automated
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentViews
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -592,8 +587,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter updated successfully and has
             proper and expected name
 
-        :CaseLevel: Integration
-
         :CaseImportance: Critical
         """
         cvf_name = gen_string('utf8')
@@ -629,8 +622,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter updated successfully and has new
             repository affected
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
@@ -686,7 +677,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter updated successfully and has new
             repository affected
 
-        :CaseLevel: Integration
         """
         cvf_name = gen_string('utf8')
         module_target_sat.cli.ContentView.filter.create(
@@ -739,7 +729,6 @@ class TestContentViewFilter:
         :expectedresults: Content view filter updated successfully and has
             correct and expected value for inclusion parameter
 
-        :CaseLevel: Integration
         """
         cvf_name = gen_string('utf8')
         module_target_sat.cli.ContentView.filter.create(

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -8,11 +8,6 @@
 
 :Team: Rocket
 
-:TestType: Functional
-
-:CaseLevel: System
-
-:Upstream: No
 """
 import pytest
 from wait_for import wait_for
@@ -40,7 +35,7 @@ def test_rhel_pxe_discovery_provisioning(
 
     :Setup: Satellite with Provisioning and Discovery features configured
 
-    :Steps:
+    :steps:
 
         1. Boot up the host to discover
         2. Provision the host
@@ -166,7 +161,7 @@ def test_positive_provision_pxeless_bios_syslinux():
     :Setup:
         1. Craft the FDI with remaster the image to have ssh enabled
 
-    :Steps:
+    :steps:
         1. Create a BIOS VM and set it to boot from the FDI
         2. Run assertion steps #1-2
         3. Provision the discovered host using PXELinux loader
@@ -417,7 +412,7 @@ def test_positive_list_facts():
 
     :Setup: 1. Provisioning is configured and Host is already discovered
 
-    :Steps: Validate specified builtin and custom facts
+    :steps: Validate specified builtin and custom facts
 
     :expectedresults: All checked facts should be displayed correctly
 

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: DiscoveryPlugin
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from functools import partial
 import random
@@ -140,7 +135,6 @@ class TestDiscoveryRule:
         :expectedresults: Rule should be successfully created and has expected
             hostname value
 
-        :CaseLevel: Component
         """
         host_name = 'myhost'
         rule = discoveryrule_factory(options={'hostname': host_name})
@@ -239,7 +233,6 @@ class TestDiscoveryRule:
         :expectedresults: Rule should be successfully created and has expected
             hosts limit value
 
-        :CaseLevel: Component
         """
         hosts_limit = '5'
         rule = discoveryrule_factory(options={'hosts-limit': hosts_limit})
@@ -276,7 +269,6 @@ class TestDiscoveryRule:
 
         :expectedresults: Disabled rule should be successfully created
 
-        :CaseLevel: Component
         """
         rule = discoveryrule_factory(options={'enabled': 'false'})
         assert rule.enabled == 'false'
@@ -291,8 +283,6 @@ class TestDiscoveryRule:
         :expectedresults: Error should be raised and rule should not be created
 
         :CaseImportance: Medium
-
-        :CaseLevel: Component
 
         :parametrized: yes
         """
@@ -309,8 +299,6 @@ class TestDiscoveryRule:
         :expectedresults: Error should be raised and rule should not be created
 
         :CaseImportance: Medium
-
-        :CaseLevel: Component
 
         :BZ: 1378427
 
@@ -355,8 +343,6 @@ class TestDiscoveryRule:
         :id: 1045e2c4-e1f7-42c9-95f7-488fc79bf70b
 
         :expectedresults: Rule params are updated
-
-        :CaseLevel: Component
 
         :CaseImportance: Medium
         """
@@ -409,8 +395,6 @@ class TestDiscoveryRule:
         :id: 8293cc6a-d983-460a-b76e-221ad02b54b7
 
         :expectedresults: Rule params are not updated
-
-        :CaseLevel: Component
 
         :CaseImportance: Medium
 
@@ -507,7 +491,6 @@ class TestDiscoveryRuleRole:
 
         :expectedresults: Rule should be created and deleted successfully.
 
-        :CaseLevel: Integration
         """
         rule_name = gen_string('alpha')
         new_name = gen_string('alpha')
@@ -564,7 +547,6 @@ class TestDiscoveryRuleRole:
         :expectedresults: User should validation error and rule should not be
             deleted successfully.
 
-        :CaseLevel: Integration
         """
         rule = target_sat.cli_factory.make_discoveryrule(
             {

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -4,13 +4,8 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice, randint
 
@@ -169,7 +164,6 @@ class TestDockerRepository:
         :expectedresults: Multiple docker repositories are created with a
             Docker upstream repository and they all belong to the same product.
 
-        :CaseLevel: Integration
         """
         repo_names = set()
         for _ in range(randint(2, 5)):
@@ -191,7 +185,6 @@ class TestDockerRepository:
             Docker upstream repository and they all belong to their respective
             products.
 
-        :CaseLevel: Integration
         """
         for _ in range(randint(2, 5)):
             product = module_target_sat.cli_factory.make_product_wait(
@@ -404,8 +397,6 @@ class TestDockerContentView:
     :CaseComponent: ContentViews
 
     :team: Phoenix-content
-
-    :CaseLevel: Integration
     """
 
     @pytest.mark.tier2
@@ -1145,8 +1136,6 @@ class TestDockerActivationKey:
     :CaseComponent: ActivationKeys
 
     :team: Phoenix-subscriptions
-
-    :CaseLevel: Integration
     """
 
     @pytest.mark.tier2

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -195,8 +190,6 @@ def test_negative_create_with_invalid_dns_id(module_target_sat):
     :expectedresults: Error is raised and user friendly message returned
 
     :BZ: 1398392
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from random import choice
 
@@ -48,8 +43,6 @@ def test_negative_list_with_parameters(
 
     :expectedresults: Server returns empty result as there is no
         environment associated with location
-
-    :CaseLevel: Integration
 
     :BZ: 1337947
     """

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -4,17 +4,11 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ErrataManagement
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
-
-:Upstream: No
 """
 from datetime import date, datetime, timedelta
 from operator import itemgetter
@@ -264,7 +258,6 @@ def start_and_wait_errata_recalculate(sat, host):
 
     :param sat: Satellite instance to check for task(s)
     :param host: ContentHost instance to schedule errata recalculate
-
     """
     # Find any in-progress task for this host
     search = "label = Actions::Katello::Applicability::Hosts::BulkGenerate and result = pending"
@@ -454,8 +447,6 @@ def test_positive_install_by_host_collection_and_org(
 
     :expectedresults: Erratum is installed.
 
-    :CaseLevel: System
-
     :BZ: 1457977, 1983043
     """
     errata_id = REPO_WITH_ERRATA['errata'][0]['id']
@@ -505,8 +496,6 @@ def test_negative_install_erratum_on_host_collection(
     :expectedresults: Error message thrown. Not supported. Use the remote execution equivalent
 
     :CaseImportance: Low
-
-    :CaseLevel: System
     """
     module_target_sat.cli_factory.make_host_collection(
         {'organization-id': module_entitlement_manifest_org.id}
@@ -1032,8 +1021,6 @@ def test_negative_list_filter_by_product_name(products_with_repos, module_target
     :expectedresults: Error must be returned.
 
     :CaseImportance: Low
-
-    :CaseLevel: System
     """
     with pytest.raises(CLIReturnCodeError):
         module_target_sat.cli.Erratum.list(
@@ -1088,7 +1075,6 @@ def test_positive_list_filter_by_cve(module_sca_manifest_org, rh_repo, target_sa
     :Steps: erratum list --cve <cve_id>
 
     :expectedresults: Errata is filtered by CVE.
-
     """
     target_sat.cli.RepositorySet.enable(
         {

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Fact
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_foremantask.py
+++ b/tests/foreman/cli/test_foremantask.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: TasksPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -48,5 +43,4 @@ def test_positive_tasks_backup():
     :CaseImportance: High
 
     :CaseAutomation: NotAutomated
-
     """

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Parameters
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from functools import partial
 

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Hammer
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import io
 import json

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice
 import re
@@ -576,8 +571,6 @@ def test_positive_katello_and_openscap_loaded(target_sat):
         and foreman_openscap are available in help message
         (note: help is generated dynamically based on apipie cache)
 
-    :CaseLevel: System
-
     :customerscenario: true
 
     :CaseImportance: Medium
@@ -604,8 +597,6 @@ def test_positive_list_and_unregister(
         Unlike content host, host has not disappeared from list of hosts after unregistering.
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     rhel7_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
     assert rhel7_contenthost.subscribed
@@ -633,8 +624,6 @@ def test_positive_list_by_last_checkin(
     :BZ: 1285992
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(
@@ -661,8 +650,6 @@ def test_positive_list_infrastructure_hosts(
     :expectedresults: Infrastructure hosts are listed
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(
@@ -698,8 +685,6 @@ def test_positive_create_inherit_lce_cv(
     :expectedresults: Host's lifecycle environment and content view match
         the ones specified in hostgroup
 
-    :CaseLevel: Integration
-
     :BZ: 1391656
     """
     hostgroup = target_sat.api.HostGroup(
@@ -726,8 +711,6 @@ def test_positive_create_inherit_nested_hostgroup(target_sat):
     :id: 7bc95130-3f20-493d-b54c-04c444d97563
 
     :expectedresults: Host created successfully using host group title
-
-    :CaseLevel: System
 
     :customerscenario: true
 
@@ -789,8 +772,6 @@ def test_positive_list_with_nested_hostgroup(target_sat):
         nested host groups names in its hostgroup parameter
 
     :BZ: 1427554, 1955421
-
-    :CaseLevel: System
     """
     options = target_sat.api.Host()
     options.create_missing()
@@ -866,9 +847,7 @@ def test_negative_create_with_incompatible_pxe_loader():
       2. Files not deployed on TFTP
       3. Host not created
 
-        :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -983,8 +962,6 @@ def test_negative_update_arch(function_host, module_architecture, target_sat):
     :id: a86524da-8caf-472b-9a3d-17a4385c3a18
 
     :expectedresults: A host is not updated
-
-    :CaseLevel: Integration
     """
     with pytest.raises(CLIReturnCodeError):
         target_sat.cli.Host.update(
@@ -1003,8 +980,6 @@ def test_negative_update_os(target_sat, function_host, module_architecture):
     :id: ff13d2af-e54a-4daf-a24d-7ec930b4fbbe
 
     :expectedresults: A host is not updated
-
-    :CaseLevel: Integration
     """
     p_table = function_host['operating-system']['partition-table']
     p_table = target_sat.api.PartitionTable().search(query={'search': f'name="{p_table}"'})[0]
@@ -1034,7 +1009,7 @@ def test_hammer_host_info_output(target_sat, module_user):
 
     :id: 03468516-0ebb-11eb-8ad8-0c7a158cbff4
 
-    :Steps:
+    :steps:
         1. Update the host with any owner
         2. Get host info by running `hammer host info`
         3. Create new user and update his location and organization based on the hosts
@@ -1282,8 +1257,6 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(function_host, 
         from yaml format
 
     :BZ: 1315282
-
-    :CaseLevel: Integration
     """
     param_name = gen_string('alpha').lower()
     # long string that should be escaped and affected by line break with
@@ -1351,9 +1324,7 @@ def test_positive_provision_baremetal_with_bios_syslinux():
       6. GRUB config changes the boot order (boot local first)
       7. Hosts boots straight to RHEL after reboot (step #4)
 
-        :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1389,9 +1360,7 @@ def test_positive_provision_baremetal_with_uefi_syslinux():
       6. GRUB config changes the boot order (boot local first)
       7. Hosts boots straight to RHEL after reboot (step #4)
 
-        :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1430,9 +1399,7 @@ def test_positive_provision_baremetal_with_uefi_grub():
       7. Hosts boots straight to RHEL after reboot (step #4)
 
 
-        :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1473,9 +1440,7 @@ def test_positive_provision_baremetal_with_uefi_grub2():
       7. Hosts boots straight to RHEL after reboot (step #4)
 
 
-        :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1508,9 +1473,7 @@ def test_positive_provision_baremetal_with_uefi_secureboot():
 
     :expectedresults: Host is provisioned
 
-        :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
+    :CaseAutomation: NotAutomated
     """
 
 
@@ -1614,8 +1577,6 @@ def test_positive_report_package_installed_removed(
     :BZ: 1463809
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     client = katello_host_tools_host
     host_info = target_sat.cli.Host.info({'name': client.hostname})
@@ -1660,8 +1621,6 @@ def test_positive_package_applicability(katello_host_tools_host, setup_custom_re
     :BZ: 1463809
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     client = katello_host_tools_host
     host_info = target_sat.cli.Host.info({'name': client.hostname})
@@ -1724,8 +1683,6 @@ def test_positive_erratum_applicability(
     :BZ: 1463809,1740790
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     client = katello_host_tools_host
     host_info = target_sat.cli.Host.info({'name': client.hostname})
@@ -1779,8 +1736,6 @@ def test_positive_apply_security_erratum(katello_host_tools_host, setup_custom_r
     :expectedresults: erratum is recognized by the
         `yum update --security` command on client
 
-    :CaseLevel: System
-
     :customerscenario: true
 
     :BZ: 1420671
@@ -1818,8 +1773,6 @@ def test_positive_install_package_via_rex(
     :id: 751c05b4-d7a3-48a2-8860-f0d15fdce204
 
     :expectedresults: Package was installed
-
-    :CaseLevel: System
 
     :parametrized: yes
     """
@@ -1883,8 +1836,6 @@ def test_positive_register(
     :expectedresults: host successfully registered
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     hosts = target_sat.cli.Host.list(
         {
@@ -1947,8 +1898,6 @@ def test_positive_attach(
         enabled, and repository package installed
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     # create an activation key without subscriptions
     # register the client host
@@ -2004,8 +1953,6 @@ def test_positive_attach_with_lce(
         repository enabled, and repository package installed
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     host_subscription_client.register_contenthost(
         module_org.name,
@@ -2043,8 +1990,6 @@ def test_negative_without_attach(
     :expectedresults: repository list is empty
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     target_sat.cli.Host.subscription_register(
         {
@@ -2082,8 +2027,6 @@ def test_negative_without_attach_with_lce(
     :expectedresults: repository not enabled on host
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     content_view = target_sat.api.ContentView(organization=function_org).create()
     ak = target_sat.api.ActivationKey(
@@ -2146,8 +2089,6 @@ def test_positive_remove(
     :expectedresults: subscription successfully removed from host
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     target_sat.cli.Host.subscription_register(
         {
@@ -2221,8 +2162,6 @@ def test_positive_auto_attach(
         repository enabled, and repository package installed
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     target_sat.cli.Host.subscription_register(
         {
@@ -2257,8 +2196,6 @@ def test_positive_unregister_host_subscription(
     :expectedresults: host subscription is unregistered
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     # register the host client
     host_subscription_client.register_contenthost(
@@ -2315,8 +2252,6 @@ def test_syspurpose_end_to_end(
     :CaseImportance: Critical
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     # Create an activation key with test values
     purpose_addons = "test-addon1, test-addon2"
@@ -2576,8 +2511,6 @@ def test_positive_list_scparams(
 
     :expectedresults: Overridden sc-param from puppet
         class are listed
-
-    :CaseLevel: Integration
     """
     update_smart_proxy(session_puppet_enabled_sat, module_puppet_loc, session_puppet_enabled_proxy)
     # Create hostgroup with associated puppet class

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: HostCollections
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from broker import Broker
 from fauxfactory import gen_string
@@ -224,8 +219,6 @@ def test_positive_list_by_org_id(module_org, module_target_sat):
     :id: afbe077a-0de1-432c-a0c4-082129aab92e
 
     :expectedresults: Only host-collection within specific org is listed
-
-    :CaseLevel: Integration
     """
     # Create two host collections within different organizations
     module_target_sat.cli_factory.make_host_collection({'organization-id': module_org.id})
@@ -253,8 +246,6 @@ def test_positive_host_collection_host_pagination(module_org, module_target_sat)
 
     :expectedresults: Number of host per page follows per_page
         configuration restriction
-
-    :CaseLevel: Integration
     """
     host_collection = module_target_sat.cli_factory.make_host_collection(
         {'organization-id': module_org.id}
@@ -287,8 +278,6 @@ def test_positive_copy_by_id(module_org, module_target_sat):
     :expectedresults: Host collection is cloned successfully
 
     :BZ: 1328925
-
-    :CaseLevel: Integration
     """
     host_collection = module_target_sat.cli_factory.make_host_collection(
         {'name': gen_string('alpha', 15), 'organization-id': module_org.id}
@@ -311,8 +300,6 @@ def test_positive_register_host_ak_with_host_collection(module_org, module_ak_wi
     :expectedresults: Host successfully registered and listed in host collection
 
     :BZ: 1385814
-
-    :CaseLevel: System
     """
     host_info = _make_fake_host_helper(module_org, target_sat)
 

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: HostGroup
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_integer
 from nailgun import entities
@@ -116,8 +111,6 @@ def test_positive_create_with_multiple_entities_and_delete(
 
     :BZ: 1395254, 1313056
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     with session_puppet_enabled_sat:
@@ -215,8 +208,6 @@ def test_negative_create_with_content_source(module_org, module_target_sat):
     :BZ: 1260697
 
     :expectedresults: Hostgroup was not created
-
-    :CaseLevel: Integration
     """
     with pytest.raises(CLIFactoryError):
         module_target_sat.cli_factory.hostgroup(
@@ -248,8 +239,6 @@ def test_positive_update_hostgroup_with_puppet(
 
     :expectedresults: Hostgroup was successfully updated with new content
         source, name and puppet classes
-
-    :CaseLevel: Integration
     """
     with session_puppet_enabled_sat as puppet_sat:
         hostgroup = puppet_sat.cli_factory.hostgroup(
@@ -303,8 +292,6 @@ def test_positive_update_hostgroup(
 
     :expectedresults: Hostgroup was successfully updated with new content
         source and name
-
-    :CaseLevel: Integration
     """
     hostgroup = module_target_sat.cli_factory.hostgroup(
         {
@@ -338,8 +325,6 @@ def test_negative_update_content_source(hostgroup, content_source, module_target
 
     :expectedresults: Host group was not updated. Content source remains
         the same as it was before update
-
-    :CaseLevel: Integration
     """
     with pytest.raises(CLIReturnCodeError):
         module_target_sat.cli.HostGroup.update(
@@ -371,8 +356,6 @@ def test_negative_delete_by_id(module_target_sat):
     :id: 047c9f1a-4dd6-4fdc-b7ed-37cc725c68d3
 
     :expectedresults: HostGroup is not deleted
-
-    :CaseLevel: Integration
     """
     entity_id = invalid_id_list()[0]
     with pytest.raises(CLIReturnCodeError):
@@ -391,7 +374,6 @@ def test_positive_created_nested_hostgroup(module_org, module_target_sat):
     :customerscenario: true
 
     :CaseImportance: Low
-
     """
     parent_hg = module_target_sat.cli_factory.hostgroup({'organization-ids': module_org.id})
     nested = module_target_sat.cli_factory.hostgroup(
@@ -413,7 +395,7 @@ def test_positive_nested_hostgroup_info():
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
 
         1. Create parent hostgroup and nested hostgroup, with puppet environment, classes, and
            parameters on each.

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -2,19 +2,14 @@
 
 :Requirement: HttpProxy
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
-
-:TestType: Functional
 
 :CaseImportance: High
 
 :CaseAutomation: Automated
 
-:Upstream: No
 """
 from fauxfactory import gen_integer, gen_string, gen_url
 import pytest
@@ -99,7 +94,7 @@ def test_insights_client_registration_with_http_proxy():
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Create HTTP Proxy.
         2. Set created proxy as "Default HTTP Proxy" in settings.
         3. Edit /etc/resolv.conf and comment out all entries so that
@@ -130,7 +125,7 @@ def test_positive_set_content_default_http_proxy(block_fake_repo_access, target_
 
     :id: c12868eb-98f1-4763-a168-281ac44d9ff5
 
-    :Steps:
+    :steps:
             1. Create a product with repo.
             2. Create an un-authenticated proxy.
             3. Set the proxy to be the global default proxy.
@@ -139,7 +134,6 @@ def test_positive_set_content_default_http_proxy(block_fake_repo_access, target_
     :expectedresults:  Repo is synced
 
     :CaseImportance: High
-
     """
     org = target_sat.api.Organization().create()
     proxy_name = gen_string('alpha', 15)
@@ -184,7 +178,7 @@ def test_positive_environment_variable_unset_set():
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Export any environment variable from
            [http_proxy, https_proxy, ssl_cert_file, HTTP_PROXY, HTTPS_PROXY, SSL_CERT_FILE]
         2. satellite-installer
@@ -195,7 +189,6 @@ def test_positive_environment_variable_unset_set():
     :CaseImportance: High
 
     :CaseAutomation: NotAutomated
-
     """
 
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Installer
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RemoteExecution
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -158,7 +153,6 @@ def test_positive_view_dump(module_org, module_target_sat):
     :id: 25fcfcaa-fc4c-425e-919e-330e36195c4a
 
     :expectedresults: Verify no errors are thrown
-
     """
     template_name = gen_string('alpha', 7)
     module_target_sat.cli_factory.job_template(

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: LDAP
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -2,19 +2,14 @@
 
 :Requirement: leapp
 
-:CaseLevel: Integration
-
 :CaseComponent: Leappintegration
 
 :Team: Rocket
-
-:TestType: Functional
 
 :CaseImportance: High
 
 :CaseAutomation: Automated
 
-:Upstream: No
 """
 from broker import Broker
 import pytest
@@ -228,7 +223,7 @@ def test_leapp_upgrade_rhel(
 
     :id: 8eccc689-3bea-4182-84f3-c121e95d54c3
 
-    :Steps:
+    :steps:
         1. Import a subscription manifest and enable, sync source & target repositories
         2. Create LCE, Create CV, add repositories to it, publish and promote CV, Create AK, etc.
         3. Register content host with AK

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: LifecycleEnvironments
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from math import ceil
 

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: OrganizationsandLocations
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -282,7 +277,6 @@ class TestLocation:
 
         :BZ: 1398695
 
-        :CaseLevel: Integration
         """
         location = _location(request, target_sat)
         proxy = _proxy(request, target_sat)

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Logging
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Medium
 
-:Upstream: No
 """
 import re
 
@@ -222,8 +217,6 @@ def test_positive_logging_from_pulp3(module_org, target_sat):
     Verify Pulp3 logs are getting captured using pulp3 correlation ID
 
     :id: 8d5718e6-3442-47d6-b541-0aa78d007e8b
-
-    :CaseLevel: Component
 
     :CaseImportance: High
     """

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_alphanumeric
 import pytest
@@ -93,7 +88,6 @@ class TestMedium:
         :expectedresults: Operating system removed
 
 
-        :CaseLevel: Integration
         """
         medium = module_target_sat.cli_factory.make_medium()
         os = module_target_sat.cli_factory.make_os()

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Provisioning
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_alphanumeric, gen_string
 import pytest
@@ -223,7 +218,6 @@ class TestOperatingSystem:
 
         :expectedresults: Architecture is added to Operating System
 
-        :CaseLevel: Integration
         """
         architecture = target_sat.cli_factory.make_architecture()
         os = target_sat.cli_factory.make_os()
@@ -243,7 +237,6 @@ class TestOperatingSystem:
 
         :expectedresults: Provisioning template is added to Operating System
 
-        :CaseLevel: Integration
         """
         template = target_sat.cli_factory.make_template()
         os = target_sat.cli_factory.make_os()
@@ -265,7 +258,6 @@ class TestOperatingSystem:
 
         :expectedresults: Partition table is added to Operating System
 
-        :CaseLevel: Integration
         """
         # Create a partition table.
         ptable_name = target_sat.cli_factory.make_partition_table()['name']

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: OrganizationsandLocations
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -172,8 +167,6 @@ def test_positive_add_and_remove_subnets(module_org, module_target_sat):
     :expectedresults: Subnets are handled as expected
 
     :BZ: 1395229
-
-    :CaseLevel: Integration
     """
     subnets = [module_target_sat.cli_factory.make_subnet() for _ in range(0, 2)]
     module_target_sat.cli.Org.add_subnet({'name': module_org.name, 'subnet': subnets[0]['name']})
@@ -203,8 +196,6 @@ def test_positive_add_and_remove_users(module_org, module_target_sat):
         4. create and delete admin user by id
 
     :BZ: 1395229
-
-    :CaseLevel: Integration
     """
     user = module_target_sat.cli_factory.user()
     admin_user = module_target_sat.cli_factory.user({'admin': '1'})
@@ -250,8 +241,6 @@ def test_positive_add_and_remove_hostgroups(module_org, module_target_sat):
     :steps:
         1. add and remove hostgroup by name
         2. add and remove hostgroup by id
-
-    :CaseLevel: Integration
     """
     hostgroups = [module_target_sat.cli_factory.hostgroup() for _ in range(0, 2)]
 
@@ -291,8 +280,6 @@ def test_positive_add_and_remove_compute_resources(module_org, module_target_sat
     :steps:
         1. Add and remove compute resource by id
         2. Add and remove compute resource by name
-
-    :CaseLevel: Integration
     """
     compute_resources = [
         module_target_sat.cli_factory.compute_resource(
@@ -339,8 +326,6 @@ def test_positive_add_and_remove_media(module_org, module_target_sat):
     :steps:
         1. add and remove medium by id
         2. add and remove medium by name
-
-    :CaseLevel: Integration
     """
     media = [module_target_sat.cli_factory.make_medium() for _ in range(0, 2)]
     module_target_sat.cli.Org.add_medium({'id': module_org.id, 'medium-id': media[0]['id']})
@@ -370,8 +355,6 @@ def test_positive_add_and_remove_templates(module_org, module_target_sat):
     :steps:
         1. Add and remove template by id
         2. Add and remove template by name
-
-    :CaseLevel: Integration
     """
     # create and remove templates by name
     name = list(valid_data_list().values())[0]
@@ -428,8 +411,6 @@ def test_positive_add_and_remove_domains(module_org, module_target_sat):
     :steps:
         1. Add and remove domain by name
         2. Add and remove domain by id
-
-    :CaseLevel: Integration
     """
     domains = [module_target_sat.cli_factory.make_domain() for _ in range(0, 2)]
     module_target_sat.cli.Org.add_domain({'domain-id': domains[0]['id'], 'name': module_org.name})
@@ -456,8 +437,6 @@ def test_positive_add_and_remove_lce(module_org, module_target_sat):
     :steps:
         1. create and add lce to org
         2. remove lce from org
-
-    :CaseLevel: Integration
     """
     # Create a lifecycle environment.
     lc_env_name = module_target_sat.cli_factory.make_lifecycle_environment(
@@ -488,8 +467,6 @@ def test_positive_add_and_remove_capsules(proxy, module_org, module_target_sat):
     :steps:
         1. add and remove capsule by ip
         2. add and remove capsule by name
-
-    :CaseLevel: Integration
     """
     module_target_sat.cli.Org.add_smart_proxy({'id': module_org.id, 'smart-proxy-id': proxy['id']})
     org_info = module_target_sat.cli.Org.info({'name': module_org.name})
@@ -525,8 +502,6 @@ def test_positive_add_and_remove_locations(module_org, module_target_sat):
     :steps:
         1. add and remove locations by name
         2. add and remove locations by id
-
-    :CaseLevel: Integration
     """
     locations = [module_target_sat.cli_factory.make_location() for _ in range(0, 2)]
     module_target_sat.cli.Org.add_location(
@@ -600,7 +575,6 @@ def test_negative_create_with_invalid_name(name, module_target_sat):
     :parametrized: yes
 
     :expectedresults: organization is not created
-
     """
     with pytest.raises(CLIFactoryError):
         module_target_sat.cli_factory.make_org(
@@ -667,7 +641,6 @@ def test_negative_update_name(new_name, module_org, module_target_sat):
     :parametrized: yes
 
     :expectedresults: organization name is not updated
-
     """
     with pytest.raises(CLIReturnCodeError):
         module_target_sat.cli.Org.update({'id': module_org.id, 'new-name': new_name})
@@ -683,8 +656,6 @@ def test_positive_create_user_with_timezone(module_org, module_target_sat):
 
     :BZ: 1733269
 
-    :CaseLevel: Integration
-
     :CaseImportance: Medium
 
     :steps:
@@ -693,7 +664,6 @@ def test_positive_create_user_with_timezone(module_org, module_target_sat):
         3. Remove user from organization and validate
 
     :expectedresults: User created and removed successfully with valid timezone
-
     """
     users_timezones = [
         'Pacific Time (US & Canada)',

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -2,19 +2,14 @@
 
 :Requirement: Oscap
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SCAPPlugin
 
 :Team: Endeavour
-
-:TestType: Functional
 
 :CaseImportance: High
 
 :CaseAutomation: Automated
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -2,19 +2,14 @@
 
 :Requirement: tailoringfiles
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SCAPPlugin
 
 :Team: Endeavour
-
-:TestType: Functional
 
 :CaseImportance: High
 
 :CaseAutomation: Automated
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -94,7 +89,6 @@ def test_positive_list_by_repo_id(
     :id: 8cf1a973-031c-4c02-af14-0faba22ab60b
 
     :expectedresults: Ostree Branch List is displayed
-
     """
 
     branch = module_target_sat.cli.OstreeBranch.with_user(*ostree_user_credentials)
@@ -139,7 +133,6 @@ def test_positive_list_by_cv_id(ostree_repo_with_user, ostree_user_credentials, 
     :id: 3654f107-44ee-4af2-a9e4-f9fd8c68491e
 
     :expectedresults: Ostree Branch List is displayed
-
     """
     result = module_target_sat.cli.OstreeBranch.with_user(*ostree_user_credentials).list(
         {'content-view-id': ostree_repo_with_user['cv']['id']}

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import randint
 
@@ -134,7 +129,6 @@ class TestPartitionTable:
 
         :expectedresults: Operating system is added to partition table
 
-        :CaseLevel: Integration
         """
         ptable = module_target_sat.cli_factory.make_partition_table()
         os = module_target_sat.cli_factory.make_os()
@@ -159,7 +153,6 @@ class TestPartitionTable:
 
         :expectedresults: Operating system is added to partition table
 
-        :CaseLevel: Integration
         """
         ptable = module_target_sat.cli_factory.make_partition_table()
         os = module_target_sat.cli_factory.make_os()

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Hammer
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_alphanumeric, gen_integer, gen_string, gen_url
 import pytest
@@ -172,7 +167,6 @@ def test_product_list_with_default_settings(module_org, target_sat):
     :customerscenario: true
 
     :expectedresults: product/reporsitory list should work as expected.
-
     """
     org_id = str(module_org.id)
     default_product_name = gen_string('alpha')
@@ -227,7 +221,7 @@ def test_positive_product_sync_state(module_org, module_target_sat):
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Sync a custom repository that fails.
         2. Run `hammer product info --product-id <id>`.
         3. Successfully sync another repository under the same product.

--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: NotAutomated
 
-:CaseLevel: System
-
 :CaseComponent: Provisioning
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_provisioningtemplate.py
+++ b/tests/foreman/cli/test_provisioningtemplate.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ProvisioningTemplates
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 from random import randint
@@ -167,8 +162,6 @@ def test_positive_add_remove_os_by_id(module_target_sat, module_os_with_minor):
     :id: d9f481b3-9757-4208-b451-baf4792d4d70
 
     :expectedresults: Operating system is added/removed from the template
-
-    :CaseLevel: Integration
     """
     os = module_os_with_minor
     os_string = f'{os.name} {os.major}.{os.minor}'
@@ -212,8 +205,6 @@ def test_positive_clone(module_target_sat):
     :id: 27d69c1e-0d83-4b99-8a3c-4f1bdec3d261
 
     :expectedresults: The template is cloned successfully
-
-    :CaseLevel: Integration
     """
     cloned_template_name = gen_string('alpha')
     template = module_target_sat.cli_factory.make_template()

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Authentication
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -2,8 +2,6 @@
 
 :Requirement: Registration
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Registration
 
 :CaseAutomation: Automated
@@ -12,9 +10,6 @@
 
 :Team: Rocket
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -161,8 +156,6 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel_contenthost
     :expectedresults: host cannot be registered twice
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     rhel_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
     assert rhel_contenthost.subscribed

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RemoteExecution
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from calendar import monthrange
 from datetime import datetime, timedelta
@@ -596,7 +591,7 @@ class TestAnsibleREX:
 
         :id: a5fa20d8-c2bd-4bbf-a6dc-bf307b59dd8c
 
-        :Steps:
+        :steps:
 
             0. Create a VM and register to SAT and prepare for REX (ssh key)
 
@@ -609,8 +604,6 @@ class TestAnsibleREX:
         :expectedresults: multiple asserts along the code
 
         :CaseAutomation: Automated
-
-        :CaseLevel: System
 
         :parametrized: yes
         """
@@ -651,7 +644,7 @@ class TestAnsibleREX:
 
         :id: 49b0d31d-58f9-47f1-aa5d-561a1dcb0d66
 
-        :Steps:
+        :steps:
 
             0. Create a VM and register to SAT and prepare for REX (ssh key)
 
@@ -666,8 +659,6 @@ class TestAnsibleREX:
         :customerscenario: true
 
         :bz: 2129432
-
-        :CaseLevel: System
 
         :parametrized: yes
         """
@@ -703,7 +694,7 @@ class TestAnsibleREX:
 
         :id: ad0f108c-03f2-49c7-8732-b1056570567b
 
-        :Steps:
+        :steps:
 
             0. Create 2 hosts, disable foreman_tasks_proxy_batch_trigger
 
@@ -714,8 +705,6 @@ class TestAnsibleREX:
         :CaseAutomation: Automated
 
         :customerscenario: true
-
-        :CaseLevel: System
 
         :BZ: 1817320
 
@@ -759,15 +748,13 @@ class TestAnsibleREX:
         :Setup:
             0. Create 2 hosts
 
-        :Steps:
+        :steps:
 
             0. Run a bash command job with concurrency level 1
 
         :expectedresults: First subtask should run immediately, second one after the first one finishes
 
         :CaseAutomation: Automated
-
-        :CaseLevel: System
 
         :parametrized: yes
         """
@@ -837,7 +824,7 @@ class TestAnsibleREX:
 
         :id: 47ed82fb-77ca-43d6-a52e-f62bae5d3a42
 
-        :Steps:
+        :steps:
 
             0. Create a VM and register to SAT and prepare for REX (ssh key)
 
@@ -852,8 +839,6 @@ class TestAnsibleREX:
         :expectedresults: multiple asserts along the code
 
         :CaseAutomation: Automated
-
-        :CaseLevel: System
 
         :bz: 1872688, 1811166
 
@@ -918,7 +903,7 @@ class TestAnsibleREX:
     ):
         """Test whether Ansible collection can be installed via REX
 
-        :Steps:
+        :steps:
             1. Upload a manifest.
             2. Enable and sync Ansible repository.
             3. Register content host to Satellite.

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import random
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -3,17 +3,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Reporting
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from broker import Broker
 from fauxfactory import gen_alpha
@@ -120,7 +115,6 @@ def test_positive_report_help(module_target_sat):
     :expectedresults: report-templates command is included in help,
                       report-templates command details are displayed,
                       report-templates create command details are displayed
-
     """
     command_output = module_target_sat.cli.Base().execute('--help')
     assert 'report-template' in command_output
@@ -298,7 +292,6 @@ def test_positive_report_add_userinput(module_target_sat):
         1. hammer template-input create ...
 
     :expectedresults: User input is assigned to the report template
-
     """
     name = gen_alpha()
     report_template = module_target_sat.cli_factory.report_template({'name': name})
@@ -441,7 +434,6 @@ def test_positive_applied_errata():
 
     :expectedresults: 1. A report is generated with all applied errata listed
                       2,3. A report is generated asynchronously
-
     """
 
 

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice
 from string import punctuation
@@ -730,8 +725,6 @@ class TestRepository:
 
         :expectedresults: Repository is created and synced
 
-        :CaseLevel: Integration
-
         :CaseImportance: Critical
         """
         # Repo is not yet synced
@@ -756,8 +749,6 @@ class TestRepository:
         :parametrized: yes
 
         :expectedresults: Repository is created and synced
-
-        :CaseLevel: Integration
 
         :CaseImportance: Critical
         """
@@ -799,7 +790,6 @@ class TestRepository:
 
         :BZ: 1328092
 
-        :CaseLevel: Integration
         """
         # Assertion that repo is not yet synced
         assert repo['sync']['status'] == 'Not Synced'
@@ -840,7 +830,6 @@ class TestRepository:
 
         :BZ: 1405503, 1453118
 
-        :CaseLevel: Integration
         """
         # Try to synchronize it
         repo_sync = target_sat.cli.Repository.synchronize({'id': repo['id'], 'async': True})
@@ -1122,7 +1111,6 @@ class TestRepository:
 
         :BZ: 1459845, 1459874, 1318004
 
-        :CaseLevel: Integration
         """
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = target_sat.cli.Repository.info({'id': repo['id']})
@@ -1179,7 +1167,7 @@ class TestRepository:
             3. Delete one package from repo 1.
             4. Sync the second repo (repo 2) from the first repo (repo 1).
 
-        :Steps:
+        :steps:
             1. Check that the package deleted from repo 1 was removed from repo 2.
 
         :expectedresults: A package removed from repo 1 is removed from repo 2 when synced.
@@ -1250,8 +1238,6 @@ class TestRepository:
         :expectedresults: No SRPM Content is Synced
 
         :BZ: 1591358
-
-        :CaseLevel: Integration
 
         """
         target_sat.cli.Repository.synchronize({'id': repo['id']})
@@ -1681,7 +1667,7 @@ class TestRepository:
 
         :BZ: 1436209,1410916
 
-        :Steps:
+        :steps:
             1. Setup a restricted user with permissions that filter the
                products with names like Test_* or "rhel7*"
             2. Create a content view
@@ -1697,7 +1683,6 @@ class TestRepository:
                view, assert that the restricted user still cannot view the
                product repository.
 
-        :CaseLevel: Integration
         """
         required_permissions = {
             'Katello::Product': (
@@ -1980,7 +1965,7 @@ class TestRepository:
         :Setup:
             1. valid yum repo with Module Streams.
 
-        :Steps:
+        :steps:
             1. Create Yum Repository with url contain module-streams
             2. Initialize synchronization
             3. Another Repository with same Url
@@ -2049,7 +2034,7 @@ class TestRepository:
         :Setup:
             1. valid yum repo with Module Streams.
 
-        :Steps:
+        :steps:
             1. Create Yum Repositories with url contain module-streams and Products
             2. Initialize synchronization
             3. Verify the module-stream list with various inputs options
@@ -2087,7 +2072,7 @@ class TestRepository:
         :Setup:
             1. valid yum repo with Module Streams.
 
-        :Steps:
+        :steps:
             1. Create Yum Repositories with url contain module-streams
             2. Initialize synchronization
             3. Verify the module-stream info with various inputs options
@@ -2121,7 +2106,7 @@ class TestRepository:
 
         :BZ: 1756951, 2002653
 
-        :Steps:
+        :steps:
             1. Import manifest and enable a Red Hat repository.
             2. Attempt to update the Red Hat repository:
                # hammer repository update --id <id> --url http://example.com/repo
@@ -2359,9 +2344,8 @@ class TestRepository:
 #         :parametrized: yes
 #
 #         :expectedresults: Ostree repository is created and synced
-#
-#         :CaseLevel: Integration
-#
+
+
 #         :BZ: 1625783
 #         """
 #         # Synchronize it
@@ -2546,8 +2530,6 @@ class TestAnsibleCollectionRepository:
 
         :expectedresults: All content synced successfully
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
 
         :parametrized: yes
@@ -2579,8 +2561,6 @@ class TestAnsibleCollectionRepository:
         :id: 4858227e-1669-476d-8da3-4e6bfb6b7e2a
 
         :expectedresults: All content exported and imported successfully
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 
@@ -2639,8 +2619,6 @@ class TestAnsibleCollectionRepository:
         :id: f7897a56-d014-4189-b4c7-df8f15aaf30a
 
         :expectedresults: All content synced successfully
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 
@@ -2813,11 +2791,9 @@ class TestGitPuppetMirror:
 
         :id: 89211cd5-82b8-4391-b729-a7502e57f824
 
-        :CaseLevel: Integration
-
         :Setup: Assure local GIT puppet has been created and found by pulp
 
-        :Steps: Create link to local puppet mirror via cli
+        :steps: Create link to local puppet mirror via cli
 
         :expectedresults: Content source containing local GIT puppet mirror
             content is created
@@ -2832,11 +2808,9 @@ class TestGitPuppetMirror:
 
         :id: 341f40f2-3501-4754-9acf-7cda1a61f7db
 
-        :CaseLevel: Integration
-
         :Setup: Assure local GIT puppet has been created and found by pulp
 
-        :Steps: Modify details for existing puppet repo (name, etc.) via cli
+        :steps: Modify details for existing puppet repo (name, etc.) via cli
 
         :expectedresults: Content source containing local GIT puppet mirror
             content is modified
@@ -2852,11 +2826,9 @@ class TestGitPuppetMirror:
 
         :id: a243f5bb-5186-41b3-8e8a-07d5cc784ccd
 
-        :CaseLevel: Integration
-
         :Setup: Assure local GIT puppet has been created and found by pulp
 
-        :Steps: Delete link to local puppet mirror via cli
+        :steps: Delete link to local puppet mirror via cli
 
         :expectedresults: Content source containing local GIT puppet mirror
             content no longer exists/is available.
@@ -2871,11 +2843,9 @@ class TestGitPuppetMirror:
 
         :id: 8582529f-3112-4b49-8d8f-f2bbf7dceca7
 
-        :CaseLevel: Integration
-
         :Setup: Assure remote GIT puppet has been created and found by pulp
 
-        :Steps: Create link to local puppet mirror via cli
+        :steps: Create link to local puppet mirror via cli
 
         :expectedresults: Content source containing remote GIT puppet mirror
             content is created
@@ -2890,11 +2860,9 @@ class TestGitPuppetMirror:
 
         :id: 582c50b3-3b90-4244-b694-97642b1b13a9
 
-        :CaseLevel: Integration
-
         :Setup: Assure remote  GIT puppet has been created and found by pulp
 
-        :Steps: modify details for existing puppet repo (name, etc.) via cli
+        :steps: modify details for existing puppet repo (name, etc.) via cli
 
         :expectedresults: Content source containing remote GIT puppet mirror
             content is modified
@@ -2910,11 +2878,9 @@ class TestGitPuppetMirror:
 
         :id: 0a23f969-b202-4c6c-b12e-f651a0b7d049
 
-        :CaseLevel: Integration
-
         :Setup: Assure remote GIT puppet has been created and found by pulp
 
-        :Steps: Delete link to remote puppet mirror via cli
+        :steps: Delete link to remote puppet mirror via cli
 
         :expectedresults: Content source containing remote GIT puppet mirror
             content no longer exists/is available.
@@ -2929,11 +2895,9 @@ class TestGitPuppetMirror:
 
         :id: a46c16bd-0986-48db-8e62-aeb3907ba4d2
 
-        :CaseLevel: Integration
-
         :Setup: git mirror (local or remote) exists as a content source
 
-        :Steps: Attempt to sync content from mirror via cli
+        :steps: Attempt to sync content from mirror via cli
 
         :expectedresults: Content is pulled down without error
 
@@ -2950,11 +2914,9 @@ class TestGitPuppetMirror:
 
         :id: 0d58d180-9836-4524-b608-66b67f9cab12
 
-        :CaseLevel: Integration
-
         :Setup: git mirror (local or remote) exists as a content source
 
-        :Steps: Attempt to create a scheduled sync content from mirror, via cli
+        :steps: Attempt to create a scheduled sync content from mirror, via cli
 
         :expectedresults: Content is pulled down without error  on expected
             schedule
@@ -2969,11 +2931,9 @@ class TestGitPuppetMirror:
 
         :id: 02f06092-dd6c-49fa-be9f-831e52476e41
 
-        :CaseLevel: Integration
-
         :Setup: git mirror (local or remote) exists as a content source
 
-        :Steps: Attempt to list contents of repo via cli
+        :steps: Attempt to list contents of repo via cli
 
         :expectedresults: Spot-checked items (filenames, dates, perhaps
             checksums?) are correct.
@@ -2998,7 +2958,7 @@ class TestFileRepository:
 
         :parametrized: yes
 
-        :Steps:
+        :steps:
             1. Create a File Repository
             2. Upload an arbitrary file to it
 
@@ -3039,7 +2999,7 @@ class TestFileRepository:
             1. Create a File Repository
             2. Upload an arbitrary file to it
 
-        :Steps: Retrieve file permissions from File Repository
+        :steps: Retrieve file permissions from File Repository
 
         :expectedresults: uploaded file permissions are kept after upload
 
@@ -3066,7 +3026,7 @@ class TestFileRepository:
             1. Create a File Repository
             2. Upload an arbitrary file to it
 
-        :Steps: Remove a file from File Repository
+        :steps: Remove a file from File Repository
 
         :expectedresults: file is not listed under File Repository after
             removal
@@ -3122,7 +3082,7 @@ class TestFileRepository:
             1. Create a directory to be synced with a pulp manifest on its root
             2. Make the directory available through http
 
-        :Steps:
+        :steps:
             1. Create a File Repository with url pointing to http url
                 created on setup
             2. Initialize synchronization
@@ -3152,7 +3112,7 @@ class TestFileRepository:
             1. Create a directory to be synced with a pulp manifest on its root
                 locally (on the Satellite/Foreman host)
 
-        :Steps:
+        :steps:
             1. Create a File Repository with url pointing to local url
                 created on setup
             2. Initialize synchronization
@@ -3190,7 +3150,7 @@ class TestFileRepository:
                 locally (on the Satellite/Foreman host)
             2. Make sure it contains symlinks
 
-        :Steps:
+        :steps:
             1. Create a File Repository with url pointing to local url
                 created on setup
             2. Initialize synchronization
@@ -3232,7 +3192,7 @@ class TestFileRepository:
             4. Add some text keyword to the file locally.
             5. Upload new version of file.
 
-        :Steps:
+        :steps:
             1. Check that the repo contains only the new version of the file
 
         :expectedresults: The file is not duplicated and only the latest version of the file
@@ -3295,7 +3255,7 @@ def test_copy_package_group_between_repos():
         2. Create another product and create a yum repo (repo 2)
         3. Select the package group from repo 1 and sync it to repo 2
 
-    :Steps:
+    :steps:
         Assert the list of package in repo 2 matches the group list from repo 1
 
     :CaseAutomation: NotAutomated
@@ -3320,7 +3280,7 @@ def test_include_and_exclude_content_units():
         4. Select a package and exclude its dependencies
         5. Copy packages from repo 1 to repo 2
 
-    :Steps:
+    :steps:
         Assert the list of packages in repo 2 matches the packages selected in repo 1,
         including only those dependencies expected.
 
@@ -3347,7 +3307,7 @@ def test_copy_erratum_and_RPMs_within_a_date_range():
         5. Copy filtered list of items from repo 1 to repo 2
         6. Repeat using errata in place of RPMs
 
-    :Steps:
+    :steps:
         Assert the list of packages or errata in repo 2 matches those selected
         and filtered in repo 1, including those dependencies expected.
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: RHCloud-Inventory
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime
 import time
@@ -41,7 +36,7 @@ def test_positive_inventory_generate_upload_cli(
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
 
         0. Create a VM and register to insights within org having manifest.
         1. Generate and upload report for all organizations
@@ -64,8 +59,6 @@ def test_positive_inventory_generate_upload_cli(
     :BZ: 1957129, 1895953, 1956190
 
     :CaseAutomation: Automated
-
-    :CaseLevel: System
     """
     org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:report:generate_upload'
@@ -112,7 +105,7 @@ def test_positive_inventory_recommendation_sync(
 
     :id: 361af91d-1246-4308-9cc8-66beada7d651
 
-    :Steps:
+    :steps:
 
         0. Create a VM and register to insights within org having manifest.
         1. Sync insights recommendation using following foreman-rake command.
@@ -123,8 +116,6 @@ def test_positive_inventory_recommendation_sync(
     :BZ: 1957186
 
     :CaseAutomation: Automated
-
-    :CaseLevel: System
     """
     org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_insights:sync'
@@ -156,7 +147,7 @@ def test_positive_sync_inventory_status(
 
     :id: 915ffbfd-c2e6-4296-9d69-f3f9a0e79b32
 
-    :Steps:
+    :steps:
 
         0. Create a VM and register to insights within org having manifest.
         1. Sync inventory status for specific organization.
@@ -168,8 +159,6 @@ def test_positive_sync_inventory_status(
     :BZ: 1957186
 
     :CaseAutomation: Automated
-
-    :CaseLevel: System
     """
     org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:sync'
@@ -203,7 +192,7 @@ def test_max_org_size_variable():
 
     :id: 7dd964c3-fde8-4335-ab13-02329119d7f6
 
-    :Steps:
+    :steps:
 
         1. Register few content hosts with satellite.
         2. Change value of max_org_size for testing purpose(See BZ#1962694#c2).
@@ -218,8 +207,6 @@ def test_max_org_size_variable():
     :BZ: 1962694
 
     :CaseAutomation: ManualOnly
-
-    :CaseLevel: System
     """
 
 
@@ -229,7 +216,7 @@ def test_satellite_inventory_slice_variable():
 
     :id: ffbef1c7-08f3-444b-9255-2251d5594fcb
 
-    :Steps:
+    :steps:
 
         1. Register few content hosts with satellite.
         2. Set SATELLITE_INVENTORY_SLICE_SIZE=1 dynflow environment variable.
@@ -244,8 +231,6 @@ def test_satellite_inventory_slice_variable():
     :BZ: 1945661
 
     :CaseAutomation: ManualOnly
-
-    :CaseLevel: System
     """
 
 
@@ -255,7 +240,7 @@ def test_rhcloud_external_links():
 
     :id: bc7f6354-ed3e-4ac5-939d-90bfe4177043
 
-    :Steps:
+    :steps:
 
         1. Go to Configure > Inventory upload
         2. Go to Configure > Insights
@@ -267,8 +252,6 @@ def test_rhcloud_external_links():
     :BZ: 1975093
 
     :CaseAutomation: ManualOnly
-
-    :CaseLevel: System
     """
 
 
@@ -278,7 +261,7 @@ def test_positive_generate_all_reports_job(target_sat):
 
     :id: a9e4bfdb-6d7c-4f8c-ae57-a81442926dd8
 
-    :Steps:
+    :steps:
         1. Disable the Automatic Inventory upload setting.
         2. Execute Foreman GenerateAllReportsJob via foreman-rake.
 
@@ -289,8 +272,6 @@ def test_positive_generate_all_reports_job(target_sat):
     :customerscenario: true
 
     :CaseAutomation: Automated
-
-    :CaseLevel: System
     """
     try:
         target_sat.update_setting('allow_auto_inventory_upload', False)

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from math import ceil
 from random import choice
@@ -281,7 +276,6 @@ class TestSystemAdmin:
             4. System Admin role should be able to create Organization admins
             5. User with sys admin role should be able to edit filters on roles
 
-        :CaseLevel: System
         """
         org = target_sat.cli_factory.make_org()
         location = target_sat.cli_factory.make_location()

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: InterSatelliteSync
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import os
 from time import sleep
@@ -239,8 +234,6 @@ class TestRepositoryExport:
             1. Complete export succeeds, exported files are present on satellite machine.
             2. Incremental export succeeds, exported files are present on satellite machine.
 
-        :CaseLevel: System
-
         :BZ: 1944733
 
         :customerscenario: true
@@ -298,7 +291,6 @@ class TestRepositoryExport:
             1. Complete export succeeds, exported files are present on satellite machine.
             2. Incremental export succeeds, exported files are present on satellite machine.
 
-        :CaseLevel: System
         """
         # Create cv and publish
         cv_name = gen_string('alpha')
@@ -352,7 +344,6 @@ class TestRepositoryExport:
         :expectedresults:
             1. Repository was successfully exported, exported files are present on satellite machine
 
-        :CaseLevel: System
         """
         # Create cv and publish
         cv_name = gen_string('alpha')
@@ -562,8 +553,6 @@ class TestContentViewSync:
             1. CV version custom contents has been exported to directory.
             2. All The exported custom contents has been imported in org/satellite.
 
-        :CaseLevel: System
-
         :BZ: 1832858
 
         :customerscenario: true
@@ -653,8 +642,6 @@ class TestContentViewSync:
         :expectedresults:
             1. Default Organization View version custom contents has been exported.
             2. All the exported custom contents has been imported in org/satellite.
-
-        :CaseLevel: System
 
         :BZ: 1671319
 
@@ -753,7 +740,6 @@ class TestContentViewSync:
             1. Filtered CV version custom contents has been exported to directory
             2. Filtered exported custom contents has been imported in org/satellite
 
-        :CaseLevel: System
         """
         exporting_cv_name = importing_cvv = gen_string('alpha')
         exporting_cv, exporting_cvv = _create_cv(
@@ -846,7 +832,6 @@ class TestContentViewSync:
             2. Promoted CV version contents has been imported successfully.
             3. The imported CV should only be published and not promoted.
 
-        :CaseLevel: System
         """
         import_cv_name = class_export_entities['exporting_cv_name']
         export_cv_id = class_export_entities['exporting_cv']['id']
@@ -932,7 +917,6 @@ class TestContentViewSync:
 
         :customerscenario: true
 
-        :CaseLevel: System
         """
         # Create cv and publish
         cv_name = gen_string('alpha')
@@ -1728,8 +1712,6 @@ class TestContentViewSync:
             1. Complete and incremental export succeed.
             2. All files referenced in the repomd.xml files are present in the exports.
 
-        :CaseLevel: System
-
         :BZ: 2212523
 
         :customerscenario: true
@@ -1814,7 +1796,6 @@ class TestInterSatelliteSync:
 
         :CaseAutomation: NotAutomated
 
-        :CaseLevel: System
         """
 
     @pytest.mark.stubbed
@@ -1836,7 +1817,6 @@ class TestInterSatelliteSync:
 
         :CaseAutomation: NotAutomated
 
-        :CaseLevel: System
         """
 
     @pytest.mark.stubbed
@@ -1854,7 +1834,6 @@ class TestInterSatelliteSync:
 
         :CaseAutomation: NotAutomated
 
-        :CaseLevel: System
         """
 
     @pytest.mark.tier3
@@ -1886,7 +1865,6 @@ class TestInterSatelliteSync:
                in the importing organization and content counts match.
             2. Incremental export and import succeeds, content counts match the updated counts.
 
-        :CaseLevel: System
         """
         export_cc = target_sat.cli.Repository.info({'id': function_synced_custom_repo.id})[
             'content-counts'
@@ -1972,8 +1950,6 @@ class TestInterSatelliteSync:
 
         :expectedresults:
             1. All exports and imports succeed.
-
-        :CaseLevel: System
 
         :CaseImportance: Medium
 
@@ -2073,8 +2049,6 @@ class TestInterSatelliteSync:
 
         :expectedresults:
             1. Repository can be enabled and synced from Upstream to Downstream Satellite.
-
-        :CaseLevel: System
 
         :BZ: 2112098
 
@@ -2188,7 +2162,6 @@ class TestInterSatelliteSync:
 
         :CaseAutomation: NotAutomated
 
-        :CaseLevel: System
         """
 
 
@@ -2295,8 +2268,6 @@ class TestNetworkSync:
 
         :expectedresults:
             1. Repository can be enabled and synced.
-
-        :CaseLevel: System
 
         :BZ: 2213128
 

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Settings
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 from time import sleep
@@ -60,7 +55,6 @@ def test_positive_update_hostname_prefix_without_value(setting_update, module_ta
     :BZ: 1470083
 
     :expectedresults: Error should be raised on setting empty value for discovery_prefix setting
-
     """
     with pytest.raises(CLIReturnCodeError):
         module_target_sat.cli.Settings.set({'name': "discovery_prefix", 'value': ""})
@@ -76,7 +70,6 @@ def test_positive_update_hostname_default_prefix(setting_update, module_target_s
     :parametrized: yes
 
     :expectedresults: Default set prefix should be updated with new value
-
     """
     hostname_prefix_value = gen_string('alpha')
     module_target_sat.cli.Settings.set({'name': "discovery_prefix", 'value': hostname_prefix_value})
@@ -128,7 +121,6 @@ def test_positive_update_login_page_footer_text(setting_update, module_target_sa
     :parametrized: yes
 
     :expectedresults: Parameter is updated successfully
-
     """
     login_text_value = random.choice(list(valid_data_list().values()))
     module_target_sat.cli.Settings.set({'name': "login_text", 'value': login_text_value})
@@ -151,7 +143,6 @@ def test_positive_update_login_page_footer_text_without_value(setting_update, mo
     :parametrized: yes
 
     :expectedresults: Message on login screen should be removed
-
     """
     module_target_sat.cli.Settings.set({'name': "login_text", 'value': ""})
     login_text = module_target_sat.cli.Settings.list({'search': 'name=login_text'})[0]
@@ -464,8 +455,6 @@ def test_positive_failed_login_attempts_limit(setting_update, target_sat):
        7. Return the setting to previous value
 
     :CaseImportance: Critical
-
-    :CaseLevel: System
 
     :parametrized: yes
 

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: LDAP
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Networking
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Medium
 
-:Upstream: No
 """
 import random
 import re

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: SubscriptionManagement
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -91,8 +86,6 @@ def test_positive_enable_manifest_reposet(function_entitlement_manifest_org, mod
 
     :expectedresults: you are able to enable and synchronize repository
         contained in a manifest
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SyncPlans
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime, timedelta
 from time import sleep
@@ -349,8 +344,6 @@ def test_positive_info_with_assigned_product(module_org, module_target_sat):
     :BZ: 1390545
 
     :CaseImportance: Critical
-
-    :CaseLevel: Integration
     """
     prod1 = gen_string('alpha')
     prod2 = gen_string('alpha')
@@ -384,8 +377,6 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request,
     :expectedresults: Repository was not synchronized
 
     :BZ: 1279539
-
-    :CaseLevel: System
     """
     new_sync_plan = target_sat.cli_factory.sync_plan(
         {
@@ -415,8 +406,6 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request,
     :expectedresults: Product is synchronized successfully.
 
     :BZ: 1279539
-
-    :CaseLevel: System
     """
     interval = 60 * 60  # 'hourly' sync interval in seconds
     delay = 2 * 60
@@ -466,8 +455,6 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     :id: 635bffe2-df98-4971-8950-40edc89e479e
 
     :expectedresults: Product is synchronized successfully.
-
-    :CaseLevel: System
 
     :BZ: 1655595
     """
@@ -525,8 +512,6 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
     :id: dd262cf3-b836-422c-baca-b3adbc532478
 
     :expectedresults: Products are synchronized successfully.
-
-    :CaseLevel: System
 
     :BZ: 1655595
     """
@@ -606,8 +591,6 @@ def test_positive_synchronize_rh_product_past_sync_date(
     :expectedresults: Product is synchronized successfully.
 
     :BZ: 1279539
-
-    :CaseLevel: System
     """
     interval = 60 * 60  # 'hourly' sync interval in seconds
     delay = 2 * 60
@@ -672,8 +655,6 @@ def test_positive_synchronize_rh_product_future_sync_date(
     :id: 6ce2f777-f230-4bb8-9822-2cf3580c21aa
 
     :expectedresults: Product is synchronized successfully.
-
-    :CaseLevel: System
 
     :BZ: 1655595
     """
@@ -746,8 +727,6 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     :id: 8d882e8b-b5c1-4449-81c6-0efd31ad75a7
 
     :expectedresults: Product is synchronized successfully.
-
-    :CaseLevel: System
     """
     delay = 2 * 60
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
@@ -797,8 +776,6 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
     :expectedresults: Product is synchronized successfully.
 
     :BZ: 1396647
-
-    :CaseLevel: System
     """
     delay = 2 * 60
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: TemplatesPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
-:Upstream: No
 """
 import base64
 
@@ -66,7 +61,7 @@ class TestTemplateSyncTestCase:
 
         :id: b80fbfc4-bcab-4a5d-b6c1-0e22906cd8ab
 
-        :Steps:
+        :steps:
             1. Import some of the locked template specifying the `force`
                parameter `false`.
             2. After ensuring the template is not updated, Import same locked template
@@ -134,7 +129,7 @@ class TestTemplateSyncTestCase:
 
         :id: 5b0be026-2983-4570-bc63-d9aba36fca65
 
-        :Steps:
+        :steps:
             1. Repository contains file with same name as exported template.
             2. Export "Atomic Kickstart default" templates to git repo.
 
@@ -201,7 +196,7 @@ class TestTemplateSyncTestCase:
 
         :id: fd583f85-f170-4b93-b9b1-36d72f31c31f
 
-        :Steps:
+        :steps:
             1. Export only the templates matching with regex e.g: `^atomic.*` to git repo.
 
         :expectedresults:
@@ -242,7 +237,7 @@ class TestTemplateSyncTestCase:
 
         :bz: 1778177
 
-        :Steps: Export the templates matching with regex e.g: `ansible` to /tmp directory.
+        :steps: Export the templates matching with regex e.g: `ansible` to /tmp directory.
 
         :expectedresults: The templates are exported /tmp directory
 

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -10,17 +10,12 @@ When testing email validation [1] and [2] should be taken into consideration.
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import datetime
 import random
@@ -205,7 +200,6 @@ class TestUser:
 
         :expectedresults: User is created with orgs, orgs are updated
 
-        :CaseLevel: Integration
         """
         orgs_amount = 2
         orgs = [module_target_sat.cli_factory.make_org() for _ in range(orgs_amount)]
@@ -247,7 +241,6 @@ class TestUser:
 
         :BZ: 1763816
 
-        :CaseLevel: Integration
         """
         login = gen_string('alpha')
         password = gen_string('alpha')
@@ -280,7 +273,7 @@ class TestUser:
 
         :id: f0993495-5117-461d-a116-44867b820139
 
-        :Steps: Update current User with all different Language options
+        :steps: Update current User with all different Language options
 
         :expectedresults: Current User is updated
 
@@ -309,7 +302,6 @@ class TestUser:
 
         :expectedresults: Roles are added to user and deleted successfully
 
-        :CaseLevel: Integration
         """
         user = module_target_sat.cli_factory.user()
         original_role_names = set(user['roles'])
@@ -415,8 +407,6 @@ class TestPersonalAccessToken:
             1. Should show output of the api endpoint
             2. When revoked, authentication error
 
-        :CaseLevel: System
-
         :CaseImportance: High
         """
         user = target_sat.cli_factory.user({'admin': '1'})
@@ -453,8 +443,6 @@ class TestPersonalAccessToken:
             2. When an incorrect end point is used, missing
                permission should be displayed.
 
-        :CaseLevel: System
-
         :CaseImportance: High
         """
         user = target_sat.cli_factory.user()
@@ -486,8 +474,6 @@ class TestPersonalAccessToken:
             3. Try using the token with any end point.
 
         :expectedresults: Authentication error
-
-        :CaseLevel: System
 
         :CaseImportance: Medium
         """
@@ -526,8 +512,6 @@ class TestPersonalAccessToken:
             4. Revoke the token and then test for end point.
 
         :expectedresults: Non admin user is able to view only the assigned entity
-
-        :CaseLevel: System
 
         :CaseImportance: High
 
@@ -574,8 +558,6 @@ class TestPersonalAccessToken:
             2. Set the expired time to a past datetime
 
         :expectedresults: token is not created with invalid or past expire time
-
-        :CaseLevel: System
 
         :CaseImportance: Medium
 

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -118,8 +113,6 @@ def test_positive_add_and_remove_elements(module_target_sat):
 
     :expectedresults: Elements are added to user group and then removed
                       successfully.
-
-    :CaseLevel: Integration
     """
     role = module_target_sat.cli_factory.make_role()
     user_group = module_target_sat.cli_factory.usergroup()
@@ -165,8 +158,6 @@ def test_positive_remove_user_assigned_to_usergroup(module_target_sat):
 
     :customerscenario: true
 
-    :CaseLevel: Integration
-
     :BZ: 1667704
     """
     user = module_target_sat.cli_factory.user()
@@ -189,8 +180,6 @@ def test_positive_automate_bz1426957(ldap_auth_source, function_user_group, targ
     :expectedresults: Roles from usergroup is applied on AD user successfully.
 
     :customerscenario: true
-
-    :CaseLevel: Integration
 
     :BZ: 1426957, 1667704
     """
@@ -229,8 +218,6 @@ def test_negative_automate_bz1437578(ldap_auth_source, function_user_group, modu
     :parametrized: yes
 
     :expectedresults: Error message as Domain Users is a special group in AD.
-
-    :CaseLevel: Integration
 
     :BZ: 1437578
     """

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from broker import Broker
 import pytest

--- a/tests/foreman/cli/test_webhook.py
+++ b/tests/foreman/cli/test_webhook.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: HooksandWebhooks
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from functools import partial
 from random import choice

--- a/tests/foreman/destructive/conftest.py
+++ b/tests/foreman/destructive/conftest.py
@@ -20,7 +20,6 @@ def session(module_target_sat, test_name, ui_user, request):
             with session:
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
-
     """
     with module_target_sat.ui_session(test_name, ui_user.login, ui_user.password) as session:
         yield session

--- a/tests/foreman/destructive/test_ansible.py
+++ b/tests/foreman/destructive/test_ansible.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Ansible
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -30,7 +25,7 @@ def test_positive_persistent_ansible_cfg_change(target_sat):
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Update value in ansible.cfg.
         2. Verify value is updated in the file.
         3. Run "satellite-installer".
@@ -53,7 +48,7 @@ def test_positive_import_all_roles(target_sat):
 
     :id: 53fe3857-a08f-493d-93c7-3fed331ed391
 
-    :Steps:
+    :steps:
 
         1. Navigate to the Configure > Roles page.
         2. Click the `Import from [hostname]` button.

--- a/tests/foreman/destructive/test_auth.py
+++ b/tests/foreman/destructive/test_auth.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Authentication
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -38,7 +33,6 @@ def test_positive_password_reset(target_sat):
     :expectedresults: verify the 'foreman-rake permissions:reset' command for the admin user
 
     :CaseImportance: High
-
     """
     result = target_sat.execute('foreman-rake permissions:reset')
     assert result.status == 0

--- a/tests/foreman/destructive/test_capsule.py
+++ b/tests/foreman/destructive/test_capsule.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Capsule
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -32,8 +27,6 @@ def test_positive_capsule_certs_generate_with_special_char(target_sat):
     :id: e9dc6a64-4be4-11ed-8b27-9f5cc2f1b246
 
     :expectedresults: capsule-certs-generate works
-
-    :CaseLevel: Component
 
     :BZ: 1908841
 

--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: Capsule
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 from wrapanapi import VmState
@@ -183,7 +178,7 @@ def test_loadbalancer_install_package(
 
     :id: bd3c2e50-18e2-4be7-8a7f-c32472e17c61
 
-    :Steps:
+    :steps:
         1. run `subscription-manager register --org=Your_Organization \
             --activationkey=Your_Activation_Key \`
         2. Try package installation
@@ -195,8 +190,7 @@ def test_loadbalancer_install_package(
     :expectedresults: The client should be get the package irrespective of the capsule
         registration.
 
-    :CaseLevel: Integration
-    """
+        """
     # Register content host
     result = rhel7_contenthost.register(
         org=module_org,
@@ -255,15 +249,13 @@ def test_client_register_through_lb(
 
     :id: c7e47d61-167b-4fc2-8d1a-d9a64350fdc4
 
-    :Steps:
+    :steps:
         1. Setup capsules, host and loadbalancer.
         2. Generate curl command for host registration.
         3. Register host through loadbalancer using global registration
 
     :expectedresults: Global Registration should have option to register through
     loadbalancer and host should get registered successfully.
-
-    :CaseLevel: Integration
 
     :BZ: 1963266
 

--- a/tests/foreman/destructive/test_capsulecontent.py
+++ b/tests/foreman/destructive/test_capsulecontent.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: Capsule-Content
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from box import Box
 from fauxfactory import gen_alpha
@@ -52,7 +47,6 @@ def test_positive_sync_without_deadlock(
     :customerscenario: true
 
     :BZ: 2062526
-
     """
     # Note: As of now BZ#2122872 prevents us to use the originally intended RHEL7 repo because
     # of a memory leak causing Satellite OOM crash in this scenario. Therefore, for now we use

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: SatelliteClone
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Hosts-Content
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -32,8 +27,6 @@ def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
     :id: 71ae6a56-30bb-11eb-8489-d46d6dd3b5b2
 
     :expectedresults: Package should get installed even after foreman service is stopped
-
-    :CaseLevel: System
 
     :CaseImportance: Medium
 

--- a/tests/foreman/destructive/test_contentview.py
+++ b/tests/foreman/destructive/test_contentview.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentViews
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from nailgun.entity_mixins import TaskFailedError
 import pytest

--- a/tests/foreman/destructive/test_discoveredhost.py
+++ b/tests/foreman/destructive/test_discoveredhost.py
@@ -8,11 +8,6 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
-:TestType: Functional
-
-:Upstream: No
 """
 from copy import copy
 import re
@@ -210,7 +205,7 @@ def test_positive_provision_pxe_host_dhcp_change():
     :Setup: Provisioning should be configured and a host should be
         discovered
 
-    :Steps:
+    :steps:
         1. Set some dhcp range in dhcpd.conf in satellite.
         2. Create subnet entity in satellite with a range different from whats defined
             in `dhcpd.conf`.

--- a/tests/foreman/destructive/test_foreman_rake.py
+++ b/tests/foreman/destructive/test_foreman_rake.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
-:TestType: Functional
-
 :CaseImportance: Medium
 
 :CaseComponent: TasksPlugin
 
 :Team: Endeavour
 
-:Upstream: No
 """
 import pytest
 
@@ -28,7 +23,7 @@ def test_positive_katello_reimport(target_sat):
 
     :id: b4119265-1bf0-4b0b-8b96-43f68af39708
 
-    :Steps: Have satellite up and run 'foreman-rake katello:reimport'
+    :steps: Have satellite up and run 'foreman-rake katello:reimport'
 
     :expectedresults: Successfully reimport without errors
 

--- a/tests/foreman/destructive/test_foreman_service.py
+++ b/tests/foreman/destructive/test_foreman_service.py
@@ -4,13 +4,8 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
-:TestType: Functional
-
 :CaseImportance: Medium
 
-:Upstream: No
 """
 import pytest
 
@@ -29,7 +24,7 @@ def test_positive_foreman_service_auto_restart(foreman_service_teardown):
 
     :id: 766560b8-30bb-11eb-8dae-d46d6dd3b5b2
 
-    :Steps:
+    :steps:
         1. Stop the Foreman Service
         2. Make any API call to Satellite
 

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from airgun.exceptions import NoSuchElementException
 import pytest
@@ -40,8 +35,6 @@ class TestHostCockpit:
         :expectedresults: Cockpit page is loaded and displays sat host info
 
         :BZ: 1876220
-
-        :CaseLevel: System
 
         :steps:
             1. kill the cockpit service.

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -2,17 +2,12 @@
 
 :Requirement: Infoblox, Installer
 
-:CaseLevel: System
-
 :CaseComponent: DHCPDNS
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_mac, gen_string
 import pytest
@@ -100,7 +95,7 @@ def test_plugin_installation(target_sat, command_args, command_opts, rpm_command
 
     :id: c75aa5f3-870a-4f4a-9d7a-0a871b47fd6f
 
-    :Steps: Run installer with mininum options required to install plugins
+    :steps: Run installer with mininum options required to install plugins
 
     :expectedresults: Plugins install successfully
 

--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Installer
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from fauxfactory import gen_domain, gen_string
 import pytest
@@ -54,8 +49,6 @@ def test_installer_sat_pub_directory_accessibility(target_sat):
         2. It should not be accessible if accessibility is disabled in custom_hiera.yaml file.
 
     :CaseImportance: High
-
-    :CaseLevel: System
 
     :BZ: 1960801
 

--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -4,17 +4,11 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: Certificates
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
-
-:Upstream: No
 
 """
 import re

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: LDAP
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import os
 from time import sleep
@@ -224,7 +219,6 @@ def test_single_sign_on_ldap_ipa_server(
     :expectedresults: After single sign on user should redirected from /extlogin to /hosts page
 
     :BZ: 1941997
-
     """
     result = target_sat.execute(f'echo {settings.ipa.password} | kinit {settings.ipa.user}')
     assert result.status == 0
@@ -249,7 +243,6 @@ def test_single_sign_on_ldap_ad_server(
         using curl. It should navigate to hosts page. (verify using url only)
 
     :BZ: 1941997
-
     """
     # create the kerberos ticket for authentication
     result = target_sat.execute(f'echo {settings.ldap.password} | kinit {settings.ldap.username}')
@@ -460,7 +453,6 @@ def test_user_permissions_rhsso_user_after_group_delete(
 
     :expectedresults: external rhsso user's permissions should get revoked after external rhsso
         group deletion.
-
     """
     default_sso_host.get_rhsso_client_id()
     username = settings.rhsso.rhsso_user
@@ -618,7 +610,6 @@ def test_permissions_external_ldap_mapped_rhsso_group(
 
     :expectedresults: The external ldap mapped rhsso user should contain the permissions
         based on the user group level
-
     """
     ad_data = ad_data()
     login_details = {
@@ -663,7 +654,6 @@ def test_negative_negotiate_login_without_ticket(
     :expectedresults:
         1. Proper messages are returned in all cases.
         2. Login and hosts listing fails without Kerberos ticket.
-
     """
     result = parametrized_enrolled_sat.cli.Auth.status()
     assert NO_KERB_MSG in str(result)
@@ -702,7 +692,6 @@ def test_positive_negotiate_login_with_ticket(
         2. Negotiate login works with the ticket.
         3. External user is created and permissions enforcing works.
         4. Proper messages are returned in all cases.
-
     """
     auth_type = request.node.callspec.params['parametrized_enrolled_sat']
     user = (
@@ -766,7 +755,6 @@ def test_positive_negotiate_CRUD(
         3. Listing and CRUD operations via hammer succeed.
 
     :BZ: 2122617
-
     """
     auth_type = request.node.callspec.params['parametrized_enrolled_sat']
     user = (
@@ -843,7 +831,6 @@ def test_positive_negotiate_logout(
         1. Session is closed on log out properly on logout.
         2. Hammer command fails after log out.
         3. Proper messages are returned in all cases.
-
     """
     auth_type = request.node.callspec.params['parametrized_enrolled_sat']
     user = (
@@ -906,7 +893,6 @@ def test_positive_autonegotiate(
     :expectedresults:
         1. Kerberos ticket can be acquired.
         2. Automatic login occurs on first hammer command, user is created
-
     """
     auth_type = request.node.callspec.params['parametrized_enrolled_sat']
     user = (
@@ -966,7 +952,6 @@ def test_positive_negotiate_manual_with_autonegotiation_disabled(
         1. Kerberos ticket can be acquired.
         2. Manual login successful, user is created.
         3. Session is kept for following Hammer commands.
-
     """
     with parametrized_enrolled_sat.omit_credentials():
         auth_type = request.node.callspec.params['parametrized_enrolled_sat']
@@ -1047,7 +1032,6 @@ def test_negative_autonegotiate_with_autonegotiation_disabled(
         1. Kerberos ticket can be acquired.
         2. Autonegotiation doesn't occur
         3. Action is denied and user not created because the user isn't authenticated.
-
     """
     with parametrized_enrolled_sat.omit_credentials():
         auth_type = request.node.callspec.params['parametrized_enrolled_sat']

--- a/tests/foreman/destructive/test_ldapauthsource.py
+++ b/tests/foreman/destructive/test_ldapauthsource.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: LDAP
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from time import sleep
 

--- a/tests/foreman/destructive/test_leapp_satellite.py
+++ b/tests/foreman/destructive/test_leapp_satellite.py
@@ -2,17 +2,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Upgrades
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from broker import Broker
 import pytest

--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import re
 

--- a/tests/foreman/destructive/test_ping.py
+++ b/tests/foreman/destructive/test_ping.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Hammer
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/destructive/test_puppetplugin.py
+++ b/tests/foreman/destructive/test_puppetplugin.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/destructive/test_realm.py
+++ b/tests/foreman/destructive/test_realm.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Authentication
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -2,8 +2,6 @@
 
 :Requirement: Registration
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Registration
 
 :CaseAutomation: Automated
@@ -11,10 +9,6 @@
 :CaseImportance: High
 
 :Team: Rocket
-
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/destructive/test_remoteexecution.py
+++ b/tests/foreman/destructive/test_remoteexecution.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RemoteExecution
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import client

--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -4,17 +4,11 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: satellite-change-hostname
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
-
-:Upstream: No
 
 """
 from fauxfactory import gen_string

--- a/tests/foreman/destructive/test_repository.py
+++ b/tests/foreman/destructive/test_repository.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from nailgun.entity_mixins import TaskFailedError
 import pytest

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: API
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from collections import defaultdict
 import http

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hammer
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_alphanumeric, gen_ipaddr
 import pytest

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -2,19 +2,14 @@
 
 :Requirement: Infoblox, Installer
 
-:CaseLevel: System
-
 :CaseAutomation: Automated
 
 :CaseComponent: DHCPDNS
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -27,12 +22,10 @@ def test_dhcp_ip_range():
 
     :id: ba957e82-79bb-11e6-94c5-68f72889dc7f
 
-    :Steps: Provision a host with infoblox as dhcp provider
+    :steps: Provision a host with infoblox as dhcp provider
 
     :expectedresults: Check host ip is on infoblox range configured by
         option --foreman-proxy-plugin-dhcp-infoblox-use-ranges=true
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
     """
@@ -46,14 +39,12 @@ def test_dns_records():
 
     :id: 007ad06e-79bc-11e6-885f-68f72889dc7f
 
-    :Steps:
+    :steps:
 
         1. Provision a host with infoblox as dns provider
         2. Update a DNS record on infoblox
 
     :expectedresults: Check host dns is updated accordingly to infoblox
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Installer
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 import requests
@@ -1577,8 +1572,6 @@ def test_positive_selinux_foreman_module(target_sat):
         1. Check "foreman-selinux" package availability on satellite.
         2. Check SELinux foreman module on satellite.
 
-    :CaseLevel: System
-
     :expectedresults: Foreman RPM and SELinux module are both present on the satellite
     """
     rpm_result = target_sat.execute('rpm -q foreman-selinux')
@@ -1623,8 +1616,6 @@ def test_positive_check_installer_hammer_ping(target_sat):
     :customerscenario: true
 
     :expectedresults: All services are active (running)
-
-    :CaseLevel: System
     """
     # check status reported by hammer ping command
     result = target_sat.execute('hammer ping')
@@ -1692,8 +1683,6 @@ def test_satellite_installation_on_ipv6():
         4: Satellite service restart should work.
         5: After system reboot all the services comes to up state.
 
-    :CaseLevel: System
-
     :CaseAutomation: NotAutomated
     """
 
@@ -1714,8 +1703,6 @@ def test_capsule_installation_on_ipv6():
         2. After installation, All the Services should be up and running.
         3. Satellite service restart should work.
         4. After system reboot all the services come to up state.
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
     """
@@ -1738,8 +1725,6 @@ def test_installer_check_on_ipv6():
     :expectedresults:
         1. Tuning parameter set successfully for medium size.
         2. custom-hiera.yaml related changes should be successfully applied.
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
     """
@@ -1765,8 +1750,6 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
         2. It should not be accessible if accessibility is disabled in custom_hiera.yaml file.
 
     :CaseImportance: High
-
-    :CaseLevel: System
 
     :BZ: 1860519
 
@@ -1823,7 +1806,6 @@ def test_satellite_installation(installer_satellite):
         5. redis is set as default foreman cache
 
     :CaseImportance: Critical
-
     """
     common_sat_install_assertions(installer_satellite)
 

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts-Content
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime, timedelta
 
@@ -192,8 +187,6 @@ def test_positive_noapply_api(
         Content view has a newer version
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     # Promote CV to new LCE
     versions = sorted(module_cv.read().version, key=lambda ver: ver.id)

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SCAPPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from broker import Broker
 from fauxfactory import gen_string
@@ -344,7 +339,7 @@ def test_positive_has_arf_report_summary_page():
 
     :id: 25be7898-50c5-4825-adc7-978c7b4e3488
 
-    :Steps:
+    :steps:
         1. Make sure the oscap report with it's corresponding hostname
            is visible in the UI.
         2. Click on the host name to access the oscap report.
@@ -352,8 +347,6 @@ def test_positive_has_arf_report_summary_page():
     :expectedresults: Oscap ARF reports should have summary page.
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -364,7 +357,7 @@ def test_positive_view_full_report_button():
 
     :id: 5a41916d-66db-4d2f-8261-b83f833189b9
 
-    :Steps:
+    :steps:
         1. Make sure the oscap report with it's corresponding hostname
            is visible in the UI.
         2. Click on the host name to access the oscap report.
@@ -373,8 +366,6 @@ def test_positive_view_full_report_button():
         actual HTML report.
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -386,7 +377,7 @@ def test_positive_download_xml_button():
 
     :id: 07a5f495-a702-4ca4-b5a4-579a133f9181
 
-    :Steps:
+    :steps:
         1. Make sure the oscap report with it's corresponding hostname
            is visible in the UI.
         2. Click on the host name to access the oscap report.
@@ -395,8 +386,6 @@ def test_positive_download_xml_button():
         the xml report.
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -408,15 +397,13 @@ def test_positive_select_oscap_proxy():
 
     :id: d56576c8-6fab-4af6-91c1-6a56d9cca94b
 
-    :Steps: Choose the Oscap Proxy/capsule appropriately for the host or
+    :steps: Choose the Oscap Proxy/capsule appropriately for the host or
         host-groups.
 
     :expectedresults: Should have an Oscap-Proxy select box while filling
         hosts and host-groups form.
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -427,7 +414,7 @@ def test_positive_delete_multiple_arf_reports():
 
     :id: c1a8ce02-f42f-4c48-893d-8f31432b5520
 
-    :Steps:
+    :steps:
         1. Run Oscap scans are run for multiple Hosts.
         2. Make sure the oscap reports with it's corresponding hostnames
            are visible in the UI.
@@ -437,8 +424,6 @@ def test_positive_delete_multiple_arf_reports():
     :expectedresults: Multiple Oscap ARF reports can be deleted.
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 
@@ -452,8 +437,6 @@ def test_positive_reporting_emails_of_oscap_reports():
     :expectedresults: Whether email reporting of oscap reports is possible.
 
     :CaseAutomation: NotAutomated
-
-    :CaseLevel: System
     """
 
 

--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 import yaml

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -4,17 +4,13 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
+
 """
 import re
 

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import time
 

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 import yaml

--- a/tests/foreman/maintain/test_offload_DB.py
+++ b/tests/foreman/maintain/test_offload_DB.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: ManualOnly
 
-:CaseLevel: Integration
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -28,12 +23,10 @@ def test_offload_internal_db_to_external_db_host():
 
     :id: d07235c8-4584-469a-a87d-ace4dadb0a1f
 
-    :Steps: Run satellite-installer with foreman, candlepin and pulpcore options
+    :steps: Run satellite-installer with foreman, candlepin and pulpcore options
         referring to external DB host
 
     :expectedresults: Installed successful, all services running
-
-    :CaseLevel: Integration
 
     :CaseComponent: Installer
     """

--- a/tests/foreman/maintain/test_packages.py
+++ b/tests/foreman/maintain/test_packages.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/sanity/test_bvt.py
+++ b/tests/foreman/sanity/test_bvt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: BVT
 
 :Team: JPL
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import re
 
@@ -76,8 +71,6 @@ def test_all_interfaces_are_accessible(target_sat):
     :id: 0a212120-8e49-4489-a1a4-4272004e16dc
 
     :expectedresults: All three satellite interfaces are accessible
-
-
     """
     errors = {}
     # API Interface

--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -2,19 +2,14 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Dynflow
 
 :Team: Endeavour
 
 :Requirement: Dynflow
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
-:TestType: Functional
-
 :CaseImportance: High
 
 :CaseComponent: AnsibleCollection
 
 :Team: Platform
 
-:Upstream: No
 """
 import pytest
 
@@ -46,7 +41,6 @@ def test_positive_ansible_modules_installation(target_sat):
 
     :expectedresults: ansible-collection-redhat-satellite package is
         available and supported modules are contained
-
     """
     # list installed modules
     result = target_sat.execute(f'ls {FAM_MODULE_PATH} | grep .py$ | sed "s/.[^.]*$//"')
@@ -72,7 +66,6 @@ def test_positive_import_run_roles(sync_roles, target_sat):
     :id: d3379fd3-b847-43ce-a51f-c02170e7b267
 
     :expectedresults: fam roles import and run successfully
-
     """
     roles = sync_roles.get('roles')
     target_sat.cli.Host.ansible_roles_assign({'ansible-roles': roles, 'name': target_sat.hostname})

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -4,17 +4,11 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: Certificates
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
-
-:Upstream: No
 
 """
 import re

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: Pulp
 
 :team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime
 import json

--- a/tests/foreman/ui/test_acs.py
+++ b/tests/foreman/ui/test_acs.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: AlternateContentSources
 
 :Team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ActivationKeys
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -39,8 +34,6 @@ def test_positive_end_to_end_crud(session, module_org):
     :id: b6b98c45-e41e-4c7a-9be4-997273b7e24d
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -91,8 +84,6 @@ def test_positive_end_to_end_register(
     :expectedresults: Content host was registered successfully using activation
         key, association is reflected on webUI
 
-    :CaseLevel: System
-
     :parametrized: yes
 
     :CaseImportance: High
@@ -126,8 +117,6 @@ def test_positive_create_with_cv(session, module_org, cv_name, target_sat):
     :parametrized: yes
 
     :expectedresults: Activation key is created
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     env_name = gen_string('alpha')
@@ -154,8 +143,6 @@ def test_positive_search_scoped(session, module_org, target_sat):
     :expectedresults: Search functionality returns correct activation key
 
     :BZ: 1259374
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -190,8 +177,6 @@ def test_positive_create_with_host_collection(session, module_org):
     :id: 0e4ad2b4-47a7-4087-828f-2b0535a97b69
 
     :expectedresults: Activation key is created
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     hc = entities.HostCollection(organization=module_org).create()
@@ -211,8 +196,6 @@ def test_positive_create_with_envs(session, module_org, target_sat):
     :id: f75e994a-6da1-40a3-9685-f8387388b3f0
 
     :expectedresults: Activation key is created
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     cv_name = gen_string('alpha')
@@ -241,8 +224,6 @@ def test_positive_add_host_collection_non_admin(module_org, test_name, target_sa
         listed
 
     :BZ: 1473212
-
-    :CaseLevel: Integration
     """
     ak_name = gen_string('alpha')
     hc = entities.HostCollection(organization=module_org).create()
@@ -277,8 +258,6 @@ def test_positive_remove_host_collection_non_admin(module_org, test_name, target
 
     :expectedresults: Activation key is created, removed host collection is not
         listed
-
-    :CaseLevel: Integration
     """
     ak_name = gen_string('alpha')
     hc = entities.HostCollection(organization=module_org).create()
@@ -314,8 +293,6 @@ def test_positive_delete_with_env(session, module_org, target_sat):
     :id: b6019881-3d6e-4b75-89f5-1b62aff3b1ca
 
     :expectedresults: Activation key is deleted
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     cv_name = gen_string('alpha')
@@ -338,8 +315,6 @@ def test_positive_delete_with_cv(session, module_org, target_sat):
     :id: 7e40e1ed-8314-406b-9451-05f64806a6e6
 
     :expectedresults: Activation key is deleted
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     cv_name = gen_string('alpha')
@@ -364,8 +339,6 @@ def test_positive_update_env(session, module_org, target_sat):
     :id: 895cda6a-bb1e-4b94-a858-95f0be78a17b
 
     :expectedresults: Activation key is updated
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     cv_name = gen_string('alpha')
@@ -395,14 +368,12 @@ def test_positive_update_cv(session, module_org, cv2_name, target_sat):
 
     :parametrized: yes
 
-    :Steps:
+    :steps:
         1. Create Activation key
         2. Update the Content view with another Content view which has custom
             products
 
     :expectedresults: Activation key is updated
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     env1_name = gen_string('alpha')
@@ -434,15 +405,13 @@ def test_positive_update_rh_product(function_entitlement_manifest_org, session, 
 
     :id: 9b0ac209-45de-4cc4-97e8-e191f3f37239
 
-    :Steps:
+    :steps:
 
         1. Create an activation key
         2. Update the content view with another content view which has RH
             products
 
     :expectedresults: Activation key is updated
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     env1_name = gen_string('alpha')
@@ -491,8 +460,6 @@ def test_positive_add_rh_product(function_entitlement_manifest_org, session, tar
     :id: d805341b-6d2f-4e16-8cb4-902de00b9a6c
 
     :expectedresults: RH products are successfully associated to Activation key
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     cv_name = gen_string('alpha')
@@ -528,8 +495,6 @@ def test_positive_add_custom_product(session, module_org, target_sat):
 
     :expectedresults: Custom products are successfully associated to Activation
         key
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     cv_name = gen_string('alpha')
@@ -561,15 +526,13 @@ def test_positive_add_rh_and_custom_products(
 
     :id: 3d8876fa-1412-47ca-a7a4-bce2e8baf3bc
 
-    :Steps:
+    :steps:
         1. Create Activation key
         2. Associate RH product(s) to Activation Key
         3. Associate custom product(s) to Activation Key
 
     :expectedresults: RH/Custom product is successfully associated to
         Activation key
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     rh_repo = {
@@ -626,8 +589,6 @@ def test_positive_fetch_product_content(target_sat, function_entitlement_manifes
         assigned as Activation Key's product content
 
     :BZ: 1426386, 1432285
-
-    :CaseLevel: Integration
     """
     org = function_entitlement_manifest_org
     rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
@@ -675,8 +636,6 @@ def test_positive_access_non_admin_user(session, test_name):
         admin user
 
     :BZ: 1463813
-
-    :CaseLevel: Integration
     """
     ak_name = gen_string('alpha')
     non_searchable_ak_name = gen_string('alpha')
@@ -787,8 +746,6 @@ def test_positive_add_docker_repo_cv(session, module_org):
 
     :expectedresults: Content view with docker repo can be added to
         activation key
-
-    :CaseLevel: Integration
     """
     lce = entities.LifecycleEnvironment(organization=module_org).create()
     repo = entities.Repository(
@@ -823,8 +780,6 @@ def test_positive_add_docker_repo_ccv(session, module_org):
 
     :expectedresults: Docker-based content view can be added to activation
         key
-
-    :CaseLevel: Integration
     """
     lce = entities.LifecycleEnvironment(organization=module_org).create()
     repo = entities.Repository(
@@ -861,7 +816,7 @@ def test_positive_add_host(session, module_org, rhel6_contenthost, target_sat):
 
     :id: 886e9ea5-d917-40e0-a3b1-41254c4bf5bf
 
-    :Steps:
+    :steps:
         1. Create Activation key
         2. Create different hosts
         3. Associate the hosts to Activation key
@@ -869,8 +824,6 @@ def test_positive_add_host(session, module_org, rhel6_contenthost, target_sat):
     :expectedresults: Hosts are successfully associated to Activation key
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     ak = entities.ActivationKey(
         environment=entities.LifecycleEnvironment(
@@ -897,7 +850,7 @@ def test_positive_delete_with_system(session, rhel6_contenthost, target_sat):
 
     :id: 86cd070e-cf46-4bb1-b555-e7cb42e4dc9f
 
-    :Steps:
+    :steps:
         1. Create an Activation key
         2. Register systems to it
         3. Delete the Activation key
@@ -905,8 +858,6 @@ def test_positive_delete_with_system(session, rhel6_contenthost, target_sat):
     :expectedresults: Activation key is deleted
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     name = gen_string('alpha')
     cv_name = gen_string('alpha')
@@ -939,7 +890,7 @@ def test_negative_usage_limit(session, module_org, target_sat):
 
     :id: 9fe2d661-66f8-46a4-ae3f-0a9329494bdd
 
-    :Steps:
+    :steps:
         1. Create Activation key
         2. Update Usage Limit to a finite number
         3. Register Systems to match the Usage Limit
@@ -947,8 +898,6 @@ def test_negative_usage_limit(session, module_org, target_sat):
             Limit
 
     :expectedresults: System Registration fails. Appropriate error shown
-
-    :CaseLevel: System
     """
     name = gen_string('alpha')
     hosts_limit = '1'
@@ -982,8 +931,6 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenth
     :expectedresults: Multiple Activation keys are attached to a system
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     key_1_name = gen_string('alpha')
     key_2_name = gen_string('alpha')
@@ -1046,8 +993,6 @@ def test_positive_host_associations(session, target_sat):
     :customerscenario: true
 
     :BZ: 1344033, 1372826, 1394388
-
-    :CaseLevel: System
     """
     org = entities.Organization().create()
     org_entities = target_sat.cli_factory.setup_org_for_a_custom_repo(
@@ -1110,8 +1055,6 @@ def test_positive_service_level_subscription_with_custom_product(
     :BZ: 1394357
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     org = function_entitlement_manifest_org
     entities_ids = target_sat.cli_factory.setup_org_for_a_custom_repo(
@@ -1155,15 +1098,13 @@ def test_positive_delete_manifest(session, function_entitlement_manifest_org):
 
     :id: 512d8e41-b937-451e-a9c6-840457d3d7d4
 
-    :Steps:
+    :steps:
         1. Create Activation key
         2. Associate a manifest to the Activation Key
         3. Delete the manifest
 
     :expectedresults: Deleting a manifest removes it from the Activation
         key
-
-    :CaseLevel: Integration
     """
     org = function_entitlement_manifest_org
     # Create activation key
@@ -1202,7 +1143,7 @@ def test_positive_ak_with_custom_product_on_rhel6(session, rhel6_contenthost, ta
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Create a custom repo
         2. Create ak and add custom repo to ak
         3. Add subscriptions to the ak
@@ -1211,8 +1152,6 @@ def test_positive_ak_with_custom_product_on_rhel6(session, rhel6_contenthost, ta
     :expectedresults: Host is registered successfully
 
     :bz: 2038388
-
-    :CaseLevel: Integration
     """
     org = target_sat.api.Organization().create()
     entities_ids = target_sat.cli_factory.setup_org_for_a_custom_repo(

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Ansible
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -29,7 +24,7 @@ def test_positive_create_and_delete_variable(target_sat):
 
     :id: 7006d7c7-788a-4447-a564-d6b03ec06aaf
 
-    :Steps:
+    :steps:
 
         1. Import Ansible roles if none have been imported yet.
         2. Create an Ansible variable with only a name and an assigned Ansible role.
@@ -61,7 +56,7 @@ def test_positive_create_variable_with_overrides(target_sat):
 
     :id: 90acea37-4c2f-42e5-92a6-0c88148f4fb6
 
-    :Steps:
+    :steps:
 
         1. Import Ansible roles if none have been imported yet.
         2. Create an Anible variable, populating all fields on the creation form.
@@ -167,7 +162,7 @@ def test_positive_ansible_custom_role(target_sat, session, module_org, rhel_cont
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Register a content host with satellite
         2. Create a  custom role and import  into satellite
         3. Assign that role to a host
@@ -249,9 +244,7 @@ def test_positive_host_role_information(target_sat, function_host):
 
     :id: 7da913ef-3b43-4bfa-9a45-d895431c8b56
 
-    :CaseLevel: System
-
-    :Steps:
+    :steps:
         1. Register a RHEL host to Satellite.
         2. Import all roles available by default.
         3. Assign one role to the RHEL host.
@@ -259,7 +252,6 @@ def test_positive_host_role_information(target_sat, function_host):
         5. Select the 'Ansible' tab, then the 'Inventory' sub-tab.
 
     :expectedresults: Roles assigned directly to the Host are visible on the subtab.
-
     """
     SELECTED_ROLE = 'RedHatInsights.insights-client'
 
@@ -289,9 +281,7 @@ def test_positive_role_variable_information(self):
 
     :id: 4ab2813a-6b83-4907-b104-0473465814f5
 
-    :CaseLevel: System
-
-    :Steps:
+    :steps:
         1. Register a RHEL host to Satellite.
         2. Import all roles available by default.
         3. Create a host group and assign one of the Ansible roles to the host group.
@@ -303,7 +293,6 @@ def test_positive_role_variable_information(self):
         9. Select the 'Ansible' tab, then the 'Variables' sub-tab.
 
     :expectedresults: The variables information for the given Host is visible.
-
     """
 
 
@@ -314,9 +303,7 @@ def test_positive_assign_role_in_new_ui(self):
 
     :id: 044f38b4-cff2-4ddc-b93c-7e9f2826d00d
 
-    :CaseLevel: System
-
-    :Steps:
+    :steps:
         1. Register a RHEL host to Satellite.
         2. Import all roles available by default.
         3. Navigate to the new UI for the given Host.
@@ -325,7 +312,6 @@ def test_positive_assign_role_in_new_ui(self):
         6. Using the popup, assign a role to the Host.
 
     :expectedresults: The Role is successfully assigned to the Host, and shows up on the UI
-
     """
 
 
@@ -336,9 +322,7 @@ def test_positive_remove_role_in_new_ui(self):
 
     :id: d6de5130-45f6-4349-b490-fbde2aed082c
 
-    :CaseLevel: System
-
-    :Steps:
+    :steps:
         1. Register a RHEL host to Satellite.
         2. Import all roles available by default.
         3. Assign a role to the host.
@@ -349,5 +333,4 @@ def test_positive_remove_role_in_new_ui(self):
 
     :expectedresults: The Role is successfully removed from the Host, and no longer shows
         up on the UI
-
     """

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: Low
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -29,8 +24,6 @@ def test_positive_end_to_end(session):
     :id: eef14b29-9f5a-41aa-805e-73398ed2b112
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Medium
-
 :CaseComponent: AuditLog
 
 :Team: Endeavour
 
-:TestType: Functional
-
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -39,8 +34,6 @@ def test_positive_create_event(session, module_org, module_location):
     :expectedresults: Audit entry for created host contains valid data
 
     :CaseAutomation: Automated
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
 
@@ -87,8 +80,6 @@ def test_positive_audit_comment(session, module_org):
 
     :CaseAutomation: Automated
 
-    :CaseLevel: Component
-
     :CaseImportance: Low
     """
     name = gen_string('alpha')
@@ -122,8 +113,6 @@ def test_positive_update_event(session, module_org):
 
     :CaseAutomation: Automated
 
-    :CaseLevel: Integration
-
     :CaseImportance: Medium
 
     :bz: 2222890
@@ -156,8 +145,6 @@ def test_positive_delete_event(session, module_org):
 
     :CaseAutomation: Automated
 
-    :CaseLevel: Component
-
     :CaseImportance: Medium
     """
     architecture = entities.Architecture().create()
@@ -182,8 +169,6 @@ def test_positive_add_event(session, module_org):
     :expectedresults: Audit entry for added environment contains valid data
 
     :CaseAutomation: Automated
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Search
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from airgun.exceptions import NoSuchElementException
 from airgun.session import Session
@@ -71,8 +66,6 @@ def test_positive_end_to_end(session, ui_entity):
 
     :expectedresults: All expected CRUD actions finished successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     name = gen_string('alpha')
@@ -105,7 +98,7 @@ def test_positive_create_bookmark_public(session, ui_entity, default_viewer_role
 
     :Setup: Create a non-admin user with 'viewer' role
 
-    :Steps:
+    :steps:
 
         1. Navigate to the entity page
         2. Choose "bookmark this search" from the search drop-down menu
@@ -120,8 +113,6 @@ def test_positive_create_bookmark_public(session, ui_entity, default_viewer_role
 
     :expectedresults: No errors, public bookmarks is displayed for all users,
         non-public bookmark is displayed for creator but not for different user
-
-    :CaseLevel: Integration
     """
     public_name = gen_string('alphanumeric')
     nonpublic_name = gen_string('alphanumeric')
@@ -151,7 +142,7 @@ def test_positive_update_bookmark_public(
            public and one private
         2. Create a non-admin user with 'viewer' role
 
-    :Steps:
+    :steps:
 
         1. Login to Satellite server (establish a UI session) as the
            pre-created user
@@ -176,8 +167,6 @@ def test_positive_update_bookmark_public(
 
     :expectedresults: New public bookmark is listed, and the private one is
         hidden
-
-    :CaseLevel: Integration
 
     :BZ: 2141187
 
@@ -222,15 +211,13 @@ def test_negative_delete_bookmark(ui_entity, default_viewer_role, test_name):
         2. Create a non-admin user without destroy_bookmark role (e.g.
            viewer)
 
-    :Steps:
+    :steps:
 
         1. Login to Satellite server (establish a UI session) as a
            non-admin user
         2. List the bookmarks (Navigate to Administer -> Bookmarks)
 
     :expectedresults: The delete buttons are not displayed
-
-    :CaseLevel: Integration
     """
     bookmark = entities.Bookmark(controller=ui_entity['controller'], public=True).create()
     with Session(
@@ -252,15 +239,13 @@ def test_negative_create_with_duplicate_name(session, ui_entity):
 
         1. Create a bookmark of a random name with random query.
 
-    :Steps:
+    :steps:
 
         1. Create new bookmark with duplicate name.
 
     :expectedresults: Bookmark can't be created, submit button is disabled
 
     :BZ: 1920566, 1992652
-
-    :CaseLevel: Integration
     """
     query = gen_string('alphanumeric')
     bookmark = entities.Bookmark(controller=ui_entity['controller'], public=True).create()

--- a/tests/foreman/ui/test_branding.py
+++ b/tests/foreman/ui/test_branding.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Branding
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from airgun.session import Session
 import pytest
@@ -27,13 +22,11 @@ def test_verify_satellite_login_screen_info(target_sat):
 
     :id: f48110ad-29b4-49b1-972a-a70075a05732
 
-    :Steps: Get the info from the login screen
+    :steps: Get the info from the login screen
 
     :expectedresults:
         1. Correct Satellite version
         2. If 'Beta' is present, should fail until a GA snap is received
-
-    :CaseLevel: System
 
     :BZ: 1315849, 1367495, 1372436, 1502098, 1540710, 1582476, 1724738,
          1959135, 2076979, 1687250, 1686540, 1742872, 1805642, 2105949

--- a/tests/foreman/ui/test_capsulecontent.py
+++ b/tests/foreman/ui/test_capsulecontent.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: Capsule-Content
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -29,8 +24,6 @@ def test_positive_end_to_end(session, module_location, module_org):
     :id: 5445fc7e-7b3f-472f-8a94-93f89aca6c22
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: ComputeResources
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from nailgun import entities
 import pytest
@@ -62,8 +57,6 @@ def test_positive_end_to_end(session, rhev_data, module_org, module_location):
 
     :expectedresults: All expected CRUD actions finished successfully.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     name = gen_string('alpha')
@@ -105,8 +98,6 @@ def test_positive_add_resource(session, rhev_data):
 
     :expectedresults: resource created successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     # Our RHEV testing uses custom cert which we specify manually.
@@ -138,8 +129,6 @@ def test_positive_edit_resource_description(session, rhev_data):
     :parametrized: yes
 
     :expectedresults: resource updated successfully and has new description
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     description = gen_string('alpha')
@@ -173,8 +162,6 @@ def test_positive_list_resource_vms(session, rhev_data):
     :parametrized: yes
 
     :expectedresults: VMs listed for provided compute resource
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     with session:
@@ -205,8 +192,6 @@ def test_positive_resource_vm_power_management(session, rhev_data):
 
     :expectedresults: virtual machine is powered on or powered off depending on
         its initial state
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     with session:
@@ -248,8 +233,6 @@ def test_positive_VM_import(session, module_org, module_location, rhev_data):
     :parametrized: yes
 
     :expectedresults: VM is shown as Host in Foreman
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
 
@@ -380,8 +363,6 @@ def test_positive_image_end_to_end(session, rhev_data, module_location, target_s
     :id: 62a5c52f-dd15-45e7-8200-c64bb335474f
 
     :expectedresults: All expected CRUD actions finished successfully.
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ComputeResources-Azure
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -91,7 +86,6 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
     sat_azure_loc,
     module_azure_hg,
 ):
-
     """Provision Host with hostgroup and Compute-profile using
     finish template on AzureRm compute resource
 
@@ -100,8 +94,6 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
     :expectedresults:
             1. Host is provisioned.
             2. Host is deleted Successfully.
-
-    :CaseLevel: System
 
     :BZ: 1850934
     """
@@ -175,7 +167,6 @@ def test_positive_azurerm_host_provision_ud(
     sat_azure_loc,
     module_azure_hg,
 ):
-
     """Provision a Host with hostgroup and Compute-profile using
     cloud-init image on AzureRm compute resource
 
@@ -184,8 +175,6 @@ def test_positive_azurerm_host_provision_ud(
     :expectedresults: Host is provisioned successfully.
 
     :CaseImportance: Critical
-
-    :CaseLevel: System
 
     :BZ: 1850934
     """

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-EC2
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -55,7 +50,7 @@ def test_positive_default_end_to_end_with_custom_profile(
 
     :id: 33f80a8f-2ecf-4f15-b0c3-aab5fe0ac8d3
 
-    :Steps:
+    :steps:
 
         1. Create an EC2 compute resource with default properties and taxonomies.
         2. Update the compute resource name and add new taxonomies.
@@ -64,8 +59,6 @@ def test_positive_default_end_to_end_with_custom_profile(
 
     :expectedresults: The EC2 compute resource is created, updated, compute profile associated and
         deleted.
-
-    :CaseLevel: Integration
 
     :BZ: 1451626, 2032530
 
@@ -162,8 +155,6 @@ def test_positive_create_ec2_with_custom_region(session, module_ec2_settings):
         successfully.
 
     :BZ: 1456942
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-GCE
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import json
 import random
@@ -43,7 +38,7 @@ def test_positive_default_end_to_end_with_custom_profile(
 
     :id: 59ffd83e-a984-4c22-b91b-cad055b4fbd7
 
-    :Steps:
+    :steps:
 
         1. Create an GCE compute resource with default properties.
         2. Update the compute resource name and add new taxonomies.
@@ -52,8 +47,6 @@ def test_positive_default_end_to_end_with_custom_profile(
 
     :expectedresults: The GCE compute resource is created, updated, compute profile associated and
         deleted.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -167,8 +160,6 @@ def test_positive_gce_provision_end_to_end(
     :id: 8d1877bb-fbc2-4969-a13e-e95e4df4f4cd
 
     :expectedresults: Host is provisioned successfully
-
-    :CaseLevel: System
     """
     name = f'test{gen_string("alpha", 4).lower()}'
     hostname = f'{name}.{gce_domain.name}'
@@ -253,8 +244,6 @@ def test_positive_gce_cloudinit_provision_end_to_end(
     :id: 6ee63ec6-2e8e-4ed6-ae48-e68b078233c6
 
     :expectedresults: Host is provisioned successfully
-
-    :CaseLevel: System
     """
     name = f'test{gen_string("alpha", 4).lower()}'
     hostname = f'{name}.{gce_domain.name}'

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ComputeResources-libvirt
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice
 
@@ -43,8 +38,6 @@ def test_positive_end_to_end(session, module_target_sat, module_org, module_loca
     :id: 7ef925ac-5aec-4e9d-b786-328a9b219c01
 
     :expectedresults: All expected CRUD actions finished successfully.
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
 
@@ -143,8 +136,6 @@ def test_positive_provision_end_to_end(
     :id: 2678f95f-0c0e-4b46-a3c1-3f9a954d3bde
 
     :expectedresults: Host is provisioned successfully
-
-    :CaseLevel: System
 
     :customerscenario: true
 

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -8,13 +8,8 @@
 
 :Team: Rocket
 
-:CaseLevel: Acceptance
-
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from math import floor, log10
 from random import choice
@@ -92,8 +87,6 @@ def test_positive_end_to_end(session, module_org, module_location):
     :id: 47fc9e77-5b22-46b4-a76c-3217434fde2f
 
     :expectedresults: All expected CRUD actions finished successfully.
-
-    :CaseLevel: Integration
     """
     cr_name = gen_string('alpha')
     new_cr_name = gen_string('alpha')
@@ -172,8 +165,6 @@ def test_positive_retrieve_virtual_machine_list(session):
         2. Go to "Virtual Machines" tab.
 
     :expectedresults: The Virtual machines should be displayed
-
-    :CaseLevel: Integration
     """
     cr_name = gen_string('alpha')
     vm_name = settings.vmware.vm_name
@@ -202,8 +193,6 @@ def test_positive_image_end_to_end(session, target_sat):
     :id: 6b7949ef-c684-40aa-b181-11f8d4cd39c6
 
     :expectedresults: All expected CRUD actions finished successfully.
-
-    :CaseLevel: Integration
     """
     cr_name = gen_string('alpha')
     image_name = gen_string('alpha')
@@ -263,8 +252,6 @@ def test_positive_resource_vm_power_management(session):
     :id: faeabe45-5112-43a6-bde9-f869dfb26cf5
 
     :expectedresults: virtual machine is powered on or powered off depending on its initial state
-
-    :CaseLevel: Integration
     """
     cr_name = gen_string('alpha')
     vm_name = settings.vmware.vm_name
@@ -321,8 +308,6 @@ def test_positive_select_vmware_custom_profile_guest_os_rhel7(session):
     :expectedresults: Guest OS RHEL7 is selected successfully.
 
     :BZ: 1315277
-
-    :CaseLevel: Integration
     """
     cr_name = gen_string('alpha')
     guest_os_name = 'Red Hat Enterprise Linux 7 (64-bit)'
@@ -363,8 +348,6 @@ def test_positive_access_vmware_with_custom_profile(session):
 
     :expectedresults: The Compute Resource created and associated to compute profile (3-Large)
         with provided values.
-
-    :CaseLevel: Integration
     """
     cr_name = gen_string('alpha')
     data_store_summary_string = _get_vmware_datastore_summary_string()
@@ -486,8 +469,6 @@ def test_positive_virt_card(session, target_sat, module_location, module_org):
     :parametrized: no
 
     :expectedresults: Virtualization card appears in the new Host UI for the VM
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Low
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -33,8 +28,6 @@ def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_class):
     :id: 3ac47175-1239-4481-9ae2-e31980fb6607
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ContainerManagement-Content
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from nailgun import entities
 import pytest
@@ -59,8 +54,6 @@ def test_positive_search(session, module_org, module_product, module_repository)
 
     :expectedresults: The docker image tag can be searched and found,
         details are read
-
-    :CaseLevel: Integration
 
     :BZ: 2009069, 2242515
     """

--- a/tests/foreman/ui/test_contentcredentials.py
+++ b/tests/foreman/ui/test_contentcredentials.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentCredentials
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -44,8 +39,6 @@ def test_positive_end_to_end(session, target_sat, module_org, gpg_content):
     :id: d1a8cc1b-a072-465b-887d-5bca0acd21c3
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -123,8 +116,6 @@ def test_positive_add_empty_product(session, target_sat, module_org, gpg_content
     :id: e18ae9f5-43d9-4049-92ca-1eafaca05096
 
     :expectedresults: gpg key is associated with product
-
-    :CaseLevel: Integration
     """
     prod_name = gen_string('alpha')
     gpg_key = target_sat.api.GPGKey(content=gpg_content, organization=module_org).create()
@@ -146,8 +137,6 @@ def test_positive_add_product_with_repo(session, target_sat, module_org, gpg_con
 
     :expectedresults: gpg key is associated with product as well as with
         the repository
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     gpg_key = target_sat.api.GPGKey(
@@ -181,8 +170,6 @@ def test_positive_add_product_with_repos(session, target_sat, module_org, gpg_co
     :id: 0edffad7-0ab4-4bef-b16b-f6c8de55b0dc
 
     :expectedresults: gpg key is properly associated with repositories
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     gpg_key = target_sat.api.GPGKey(
@@ -211,8 +198,6 @@ def test_positive_add_repo_from_product_with_repo(session, target_sat, module_or
 
     :expectedresults: gpg key is associated with the repository but not
         with the product
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     gpg_key = target_sat.api.GPGKey(
@@ -244,8 +229,6 @@ def test_positive_add_repo_from_product_with_repos(session, target_sat, module_o
 
     :expectedresults: gpg key is associated with one of the repositories
         but not with the product
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     gpg_key = target_sat.api.GPGKey(
@@ -280,8 +263,6 @@ def test_positive_add_product_using_repo_discovery(session, gpg_path):
         the repositories
 
     :BZ: 1210180, 1461804, 1595792
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     product_name = gen_string('alpha')
@@ -327,8 +308,6 @@ def test_positive_add_product_and_search(session, target_sat, module_org, gpg_co
         gpg key 'Product' tab
 
     :BZ: 1411800
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     gpg_key = target_sat.api.GPGKey(
@@ -364,8 +343,6 @@ def test_positive_update_key_for_product_using_repo_discovery(session, gpg_path)
         repository before/after update
 
     :BZ: 1210180, 1461804
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -416,8 +393,6 @@ def test_positive_update_key_for_empty_product(session, target_sat, module_org, 
 
     :expectedresults: gpg key is associated with product before/after
         update
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -448,8 +423,6 @@ def test_positive_update_key_for_product_with_repo(session, target_sat, module_o
 
     :expectedresults: gpg key is associated with product as well as with
         repository after update
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -482,8 +455,6 @@ def test_positive_update_key_for_product_with_repos(session, target_sat, module_
 
     :expectedresults: gpg key is associated with product as well as with
         repositories after update
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -518,8 +489,6 @@ def test_positive_update_key_for_repo_from_product_with_repo(
 
     :expectedresults: gpg key is associated with repository after update
         but not with product.
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
@@ -557,8 +526,6 @@ def test_positive_update_key_for_repo_from_product_with_repos(
 
     :expectedresults: gpg key is associated with single repository
         after update but not with product
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Hosts-Content
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime, timedelta
 import re
@@ -173,8 +168,6 @@ def test_positive_end_to_end(
     :expectedresults: content host details are the same as expected, package
         and errata installation are successful
 
-    :CaseLevel: System
-
     :parametrized: yes
 
     :CaseImportance: Critical
@@ -301,8 +294,6 @@ def test_positive_end_to_end_bulk_update(session, default_location, vm, target_s
     :BZ: 1712069, 1838800
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     hc_name = gen_string('alpha')
     description = gen_string('alpha')
@@ -385,8 +376,6 @@ def test_positive_search_by_subscription_status(session, default_location, vm):
     :BZ: 1406855, 1498827, 1495271
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     with session:
         session.location.select(default_location.name)
@@ -435,8 +424,6 @@ def test_positive_toggle_subscription_status(session, default_location, vm):
     :customerscenario: true
 
     :BZ: 1836868
-
-    :CaseLevel: System
 
     :parametrized: yes
 
@@ -494,8 +481,6 @@ def test_negative_install_package(session, default_location, vm):
     :expectedresults: Task finished with warning
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     with session:
         session.location.select(default_location.name)
@@ -531,8 +516,6 @@ def test_positive_remove_package(session, default_location, vm):
     :expectedresults: Package was successfully removed
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     vm.download_install_rpm(settings.repos.yum_6.url, FAKE_0_CUSTOM_PACKAGE)
     with session:
@@ -570,8 +553,6 @@ def test_positive_upgrade_package(session, default_location, vm):
     :expectedresults: Package was successfully upgraded
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     vm.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     with session:
@@ -610,8 +591,6 @@ def test_positive_install_package_group(session, default_location, vm):
     :expectedresults: Package group was successfully installed
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     with session:
         session.location.select(default_location.name)
@@ -651,8 +630,6 @@ def test_positive_remove_package_group(session, default_location, vm):
     :expectedresults: Package group was successfully removed
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     with session:
         session.location.select(default_location.name)
@@ -696,8 +673,6 @@ def test_positive_search_errata_non_admin(
         listed
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     vm.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     with Session(
@@ -751,8 +726,6 @@ def test_positive_ensure_errata_applicability_with_host_reregistered(session, de
     :BZ: 1463818
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     vm.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     result = vm.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
@@ -811,8 +784,6 @@ def test_positive_host_re_registration_with_host_rename(
     :BZ: 1762793
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     vm.run(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}')
     result = vm.run(f'rpm -q {FAKE_1_CUSTOM_PACKAGE}')
@@ -880,8 +851,6 @@ def test_positive_check_ignore_facts_os_setting(session, default_location, vm, m
     :BZ: 1155704
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     major = str(gen_integer(15, 99))
     minor = str(gen_integer(1, 9))
@@ -950,8 +919,6 @@ def test_positive_virt_who_hypervisor_subscription_status(
     :BZ: 1336924, 1860928
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -1035,8 +1002,6 @@ def test_module_stream_actions_on_content_host(session, default_location, vm_mod
     :expectedresults: Remote execution for module actions should succeed.
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     stream_version = '5.21'
     run_remote_command_on_content_host('dnf -y upload-profile', vm_module_streams)
@@ -1157,8 +1122,6 @@ def test_module_streams_customize_action(session, default_location, vm_module_st
 
     :expectedresults: Remote execution for module actions should be succeed.
 
-    :CaseLevel: System
-
     :parametrized: yes
 
     :CaseImportance: Medium
@@ -1225,8 +1188,6 @@ def test_install_modular_errata(session, default_location, vm_module_streams):
     :expectedresults: Modular Errata should get installed on content host.
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     stream_version = '0'
     module_name = 'kangaroo'
@@ -1306,8 +1267,6 @@ def test_module_status_update_from_content_host_to_satellite(
     :expectedresults: module stream status should get updated in Satellite
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     module_name = 'walrus'
     stream_version = '0.71'
@@ -1372,8 +1331,6 @@ def test_module_status_update_without_force_upload_package_profile(
     :id: 16675b57-71c2-4aee-950b-844aa32002d1
 
     :expectedresults: module stream status should get updated in Satellite
-
-    :CaseLevel: System
 
     :parametrized: yes
 
@@ -1457,8 +1414,6 @@ def test_module_stream_update_from_satellite(session, default_location, vm_modul
     :expectedresults: module stream should get updated.
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     module_name = 'duck'
     stream_version = '0'
@@ -1535,8 +1490,6 @@ def test_syspurpose_attributes_empty(session, default_location, vm_module_stream
 
     :expectedresults: Syspurpose attrs are empty, and syspurpose status is set as 'Not specified'
 
-    :CaseLevel: System
-
     :parametrized: yes
 
     :CaseImportance: High
@@ -1576,8 +1529,6 @@ def test_set_syspurpose_attributes_cli(session, default_location, vm_module_stre
     :id: d898a3b0-2941-4fed-a725-2b8e911bba77
 
     :expectedresults: Syspurpose attributes set for the content host
-
-    :CaseLevel: System
 
     :parametrized: yes
 
@@ -1623,8 +1574,6 @@ def test_unset_syspurpose_attributes_cli(session, default_location, vm_module_st
     :id: f83ba174-20ab-4ef2-a9e2-d913d20a0b2d
 
     :expectedresults: Syspurpose attributes are empty
-
-    :CaseLevel: System
 
     :parametrized: yes
 
@@ -1675,8 +1624,6 @@ def test_syspurpose_matched(session, default_location, vm_module_streams):
 
     :expectedresults: Syspurpose status is Matched
 
-    :CaseLevel: System
-
     :parametrized: yes
 
     :CaseImportance: High
@@ -1717,8 +1664,6 @@ def test_syspurpose_bulk_action(session, default_location, vm):
     :bz: 1905979, 1931527
 
     :expectedresults: Syspurpose parameters are set and reflected on the host
-
-    :CaseLevel: System
 
     :CaseImportance: High
     """
@@ -1763,8 +1708,6 @@ def test_syspurpose_mismatched(session, default_location, vm_module_streams):
     :id: de71cfd7-eeb8-4a4c-b448-8c5aa5af7f06
 
     :expectedresults: Syspurpose status is 'Mismatched'
-
-    :CaseLevel: System
 
     :parametrized: yes
 
@@ -1850,8 +1793,6 @@ def test_search_for_virt_who_hypervisors(session, default_location):
     :BZ: 1653386
 
     :customerscenario: true
-
-    :CaseLevel: System
 
     :CaseImportance: Medium
     """

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentViews
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -31,8 +26,6 @@ def test_positive_create_cv(session, target_sat):
         2. Search for the CV
 
     :expectedresults: CV is visible in the UI, and matches the given name
-
-    :CaseLevel: System
 
     :CaseImportance: High
     """
@@ -54,8 +47,6 @@ def test_no_blank_page_on_language_switch(session, target_sat, module_org):
         2. Attempt to view the CV UI, and read the CV table
 
     :expectedresults: CV UI is visible, and isn't a blank page
-
-    :CaseLevel: System
 
     :BZ: 2163538
 

--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -7,17 +7,12 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: ContentViews
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import datetime
 from random import randint
@@ -78,8 +73,6 @@ def test_positive_add_custom_content(session):
 
     :expectedresults: Custom content can be seen in a view
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     org = entities.Organization().create()
@@ -112,8 +105,6 @@ def test_positive_end_to_end(session, module_org, target_sat):
 
     :expectedresults: content view is created, updated with repo publish and
         promoted to next selected env
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -149,8 +140,6 @@ def test_positive_publish_version_changes_in_source_env(session, module_org):
 
     :expectedresults: Content view version is updated in source
         environment.
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -203,8 +192,6 @@ def test_positive_repo_count_for_composite_cv(session, module_org, target_sat):
 
     :BZ: 1431778
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     lce = entities.LifecycleEnvironment(organization=module_org).create()
@@ -251,8 +238,6 @@ def test_positive_create_composite(
     :setup: sync multiple content source/types (RH, custom, etc.)
 
     :expectedresults: Composite content views are created
-
-    :CaseLevel: System
 
     :CaseImportance: High
     """
@@ -306,8 +291,6 @@ def test_positive_add_rh_content(session, function_entitlement_manifest_org, tar
 
     :expectedresults: RH Content can be seen in a view
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     cv_name = gen_string('alpha')
@@ -339,8 +322,6 @@ def test_positive_add_docker_repo(session, module_org, module_prod):
 
     :expectedresults: The repo is added to a non-composite content view
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     content_view = entities.ContentView(composite=False, organization=module_org).create()
@@ -362,8 +343,6 @@ def test_positive_add_docker_repos(session, module_org, module_prod):
 
     :expectedresults: The repos are added to a non-composite content
         view.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
     """
@@ -392,8 +371,6 @@ def test_positive_add_synced_docker_repo(session, module_org, module_prod):
     :expectedresults: Synchronized docker repository was successfully added
         to content view.
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     content_view = entities.ContentView(composite=False, organization=module_org).create()
@@ -417,8 +394,6 @@ def test_positive_add_docker_repo_to_ccv(session, module_org, module_prod):
 
     :expectedresults: The repository is added to a content view which
         is then added to a composite content view.
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -445,8 +420,6 @@ def test_positive_add_docker_repos_to_ccv(session, module_org, module_prod):
 
     :expectedresults: The repository is added to a random number of content
         views which are then added to a composite content view.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
     """
@@ -481,8 +454,6 @@ def test_positive_publish_with_docker_repo(session, module_org, module_prod):
     :expectedresults: The repo is added to a content view which is then
         successfully published.
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     content_view = entities.ContentView(composite=False, organization=module_org).create()
@@ -506,8 +477,6 @@ def test_positive_publish_with_docker_repo_composite(session, module_org, module
     :expectedresults: The docker repository is added to a content view
         which is then published only once and then added to a composite
         content view which is also published only once.
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -536,8 +505,6 @@ def test_positive_publish_multiple_with_docker_repo(session, module_org, module_
     :expectedresults: Content view with docker repo is successfully published
         multiple times.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
     """
     repo = entities.Repository(
@@ -560,8 +527,6 @@ def test_positive_publish_multiple_with_docker_repo_composite(session, module_or
 
     :expectedresults: Composite content view with docker repo is successfully
         published multiple times.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
     """
@@ -590,8 +555,6 @@ def test_positive_promote_with_docker_repo(session, module_org, module_prod):
     :expectedresults: Docker repository is promoted to content view
         found in the specific lifecycle-environment.
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     lce = entities.LifecycleEnvironment(organization=module_org).create()
@@ -617,8 +580,6 @@ def test_positive_promote_multiple_with_docker_repo(session, module_org, module_
 
     :expectedresults: Docker repository is promoted to content view
         found in the specific lifecycle-environments.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
     """
@@ -646,8 +607,6 @@ def test_positive_promote_with_docker_repo_composite(session, module_org, module
 
     :expectedresults: Docker repository is promoted to content view
         found in the specific lifecycle-environment.
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -681,8 +640,6 @@ def test_positive_promote_multiple_with_docker_repo_composite(session, module_or
     :expectedresults: Docker repository is promoted to content view
         found in the specific lifecycle-environments.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
     """
     repo = entities.Repository(
@@ -713,8 +670,6 @@ def test_negative_add_components_to_non_composite(session):
 
     :expectedresults: User cannot add components to the view
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
     """
     cv1_name = gen_string('alpha')
@@ -742,8 +697,6 @@ def test_positive_add_unpublished_cv_to_composite(session):
         2. Create a new composite content view
 
     :expectedresults: Non-composite content view is added to composite one
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
 
@@ -786,8 +739,6 @@ def test_positive_add_non_composite_cv_to_composite(session):
         2. Published non-composite content view is successfully added to
             composite content view.
         3. Composite content view is successfully published
-
-    :CaseLevel: Integration
 
     :BZ: 1367123
 
@@ -834,8 +785,6 @@ def test_positive_check_composite_cv_addition_list_versions(session):
     :expectedresults: second non-composite content view version should be
         listed as default one to be added to composite view
 
-    :CaseLevel: Integration
-
     :BZ: 1411074
 
     :CaseImportance: Low
@@ -873,8 +822,6 @@ def test_negative_add_dupe_repos(session, module_org, target_sat):
 
     :expectedresults: User cannot add repos multiple times to the view
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
     """
     cv_name = gen_string('alpha')
@@ -900,8 +847,6 @@ def test_positive_publish_with_custom_content(session, module_org, target_sat):
     :setup: Multiple environments for an org; custom content synced
 
     :expectedresults: Content view can be published
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -929,8 +874,6 @@ def test_positive_publish_with_rh_content(session, function_entitlement_manifest
     :setup: RH content synced
 
     :expectedresults: Content view can be published
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -969,8 +912,6 @@ def test_positive_publish_composite_with_custom_content(
     :setup: Multiple environments for an org; custom content synced
 
     :expectedresults: Composite content view can be published
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -1062,8 +1003,6 @@ def test_positive_publish_version_changes_in_target_env(session, module_org, tar
 
     :expectedresults: Content view version is updated in target environment.
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     cv_name = gen_string('alpha')
@@ -1114,8 +1053,6 @@ def test_positive_promote_with_custom_content(session, module_org, target_sat):
 
     :expectedresults: Content view can be promoted
 
-    :CaseLevel: Integration
-
     :BZ: 1361793
 
     :CaseImportance: Critical
@@ -1159,8 +1096,6 @@ def test_positive_promote_with_rh_content(session, function_entitlement_manifest
 
     :expectedresults: Content view can be promoted
 
-    :CaseLevel: System
-
     :CaseImportance: Critical
     """
     cv_name = gen_string('alpha')
@@ -1201,8 +1136,6 @@ def test_positive_promote_composite_with_custom_content(
     :steps: create a composite view containing multiple content types
 
     :expectedresults: Composite content view can be promoted
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -1334,8 +1267,6 @@ def test_negative_add_same_package_filter_twice(session, module_org, target_sat)
 
     :expectedresults: Same package filter can not be added again
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     cv_name = gen_string('alpha')
@@ -1371,7 +1302,7 @@ def test_positive_remove_cv_version_from_default_env(session, module_org, target
 
     :id: 43c83c15-c883-45a7-be05-d9b26da99e3c
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add a yum repo to it
@@ -1380,8 +1311,6 @@ def test_positive_remove_cv_version_from_default_env(session, module_org, target
 
     :expectedresults: content view version is removed from Library
         environment
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -1411,7 +1340,7 @@ def test_positive_remove_promoted_cv_version_from_default_env(session, module_or
 
     :id: a8649444-b063-4fb4-b932-a3fae7d4021d
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add a yum repos to the content view
@@ -1423,8 +1352,6 @@ def test_positive_remove_promoted_cv_version_from_default_env(session, module_or
 
         1. Content view version exist only in DEV and not in Library
         2. The yum repos exists in content view version
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -1458,7 +1385,7 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(session, module
 
     :id: 71ad8b72-68c4-4c98-9387-077f54ef0184
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add docker repo(s) to it
@@ -1469,8 +1396,6 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(session, module
 
     :expectedresults: Content view version exist only in DEV, QE and not in
         Library
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
     """
@@ -1528,7 +1453,7 @@ def test_positive_remove_cv_version_from_env(session, module_org, repos_collecti
 
     :id: d1da23ee-a5db-4990-9572-1a0919a9fe1c
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add a yum repo and a docker repo to the content view
@@ -1540,8 +1465,6 @@ def test_positive_remove_cv_version_from_env(session, module_org, repos_collecti
         7. Promote again from DEV -> QE
 
     :expectedresults: Content view version exist in Library, DEV, QE
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -1588,7 +1511,7 @@ def test_positive_delete_cv_promoted_to_multi_env(session, module_org, target_sa
 
     :id: f16f2db5-7f5b-4ebb-863e-6c18ff745ce4
 
-    :Steps:
+    :steps:
 
         1. Create a content view
         2. Add a yum repo to the content view
@@ -1598,8 +1521,6 @@ def test_positive_delete_cv_promoted_to_multi_env(session, module_org, target_sa
         6. Delete the content view.
 
     :expectedresults: The content view doesn't exists.
-
-    :CaseLevel: Integration
 
     :CaseImportance:High
     """
@@ -1633,8 +1554,6 @@ def test_positive_delete_composite_version(session, module_org, target_sat):
     :id: b2d9b21d-1e0d-40f1-9bbc-3c88cddd4f5e
 
     :expectedresults: Deletion was performed successfully
-
-    :CaseLevel: Integration
 
     :BZ: 1276479
 
@@ -1672,8 +1591,6 @@ def test_positive_delete_non_default_version(session, target_sat):
 
     :expectedresults: Deletion was performed successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     repo_name = gen_string('alpha')
@@ -1705,8 +1622,6 @@ def test_positive_delete_version_with_ak(session):
     :id: 0da50b26-f82b-4663-9372-4c39270d4323
 
     :expectedresults: Delete operation was performed successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -1747,8 +1662,6 @@ def test_positive_clone_within_same_env(session, module_org, target_sat):
 
     :BZ: 1461017
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     repo_name = gen_string('alpha')
@@ -1779,8 +1692,6 @@ def test_positive_clone_within_diff_env(session, module_org, target_sat):
         environment than initial one
 
     :BZ: 1461017
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -1820,8 +1731,6 @@ def test_positive_remove_filter(session, module_org):
 
     :expectedresults: content views filter removed successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
     """
     filter_name = gen_string('alpha')
@@ -1848,8 +1757,6 @@ def test_positive_add_package_filter(session, module_org, target_sat):
 
     :expectedresults: content views filter created and selected packages can be
         added for inclusion
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -1892,8 +1799,6 @@ def test_positive_add_package_inclusion_filter_and_publish(session, module_org, 
     :id: 58c32cb5-1392-478e-807a-9c023d5ca0ea
 
     :expectedresults: Package is included in content view version
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -1939,8 +1844,6 @@ def test_positive_add_package_exclusion_filter_and_publish(session, module_org, 
 
     :expectedresults: Package is excluded from content view version
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     filter_name = gen_string('alpha')
@@ -1985,8 +1888,6 @@ def test_positive_remove_package_from_exclusion_filter(session, module_org, targ
 
     :expectedresults: Package was successfully removed from content view
         filter and is present in next published content view version
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -2034,8 +1935,6 @@ def test_positive_update_inclusive_filter_package_version(session, module_org, t
 
     :expectedresults: Version was updated, next content view version contains
         package with updated version
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -2098,8 +1997,6 @@ def test_positive_update_exclusive_filter_package_version(session, module_org, t
 
     :expectedresults: Version was updated, next content view version
         contains package with updated version
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -2215,8 +2112,6 @@ def test_positive_edit_rh_custom_spin(session, target_sat):
     :expectedresults: edited content view save is successful and info is
         updated
 
-    :CaseLevel: System
-
     :CaseImportance: High
     """
     filter_name = gen_string('alpha')
@@ -2275,8 +2170,6 @@ def test_positive_promote_with_rh_custom_spin(session, target_sat):
     :id: 7d93c81f-2815-4b0e-b72c-23a902fe34b1
 
     :expectedresults: Content view can be promoted
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -2368,8 +2261,6 @@ def test_positive_add_errata_filter(session, module_org, target_sat):
     :expectedresults: content views filter created and selected errata-id
         can be added for inclusion/exclusion
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     filter_name = gen_string('alpha')
@@ -2406,8 +2297,6 @@ def test_positive_add_module_stream_filter(session, module_org, target_sat):
 
     :expectedresults: content views filter created and selected module stream
         can be added for inclusion/exclusion
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -2448,8 +2337,6 @@ def test_positive_add_package_group_filter(session, module_org, target_sat):
     :expectedresults: content views filter created and selected package
         groups can be added for inclusion/exclusion
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
     """
     filter_name = gen_string('alpha')
@@ -2483,8 +2370,6 @@ def test_positive_update_filter_affected_repos(session, module_org, target_sat):
     :expectedresults: Affected repos were updated, after new content view
         version publishing only updated repos are affected by content view
         filter
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -2550,8 +2435,6 @@ def test_positive_search_composite(session):
 
     :BZ: 1259374
 
-    :CaseLevel: Integration
-
     :CaseImportance: Low
     """
     composite_name = gen_string('alpha')
@@ -2583,8 +2466,6 @@ def test_positive_publish_with_repo_with_disabled_http(session, module_org, targ
     :expectedresults: Content view is published successfully
 
     :BZ: 1355752
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
     """
@@ -2631,8 +2512,6 @@ def test_positive_subscribe_system_with_custom_content(
 
     :expectedresults: Systems can be subscribed to content view(s)
 
-    :CaseLevel: Integration
-
     :parametrized: yes
 
     :CaseImportance: High
@@ -2666,8 +2545,6 @@ def test_positive_delete_with_kickstart_repo_and_host_group(
     :expectedresults: Deletion was performed successfully
 
     :BZ: 1417072
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -2744,8 +2621,6 @@ def test_positive_rh_mixed_content_end_to_end(
     :expectedresults: CV should be published and promoted with RH OSTree and all
         other contents. Then version is removed successfully.
 
-    :CaseLevel: System
-
     :customerscenario: true
 
     :CaseImportance: High
@@ -2799,8 +2674,6 @@ def test_positive_errata_inc_update_list_package(session, target_sat):
         in new content view version
 
     :CaseImportance: High
-
-    :CaseLevel: Integration
     """
     org = entities.Organization().create()
     product = entities.Product(organization=org).create()
@@ -2858,7 +2731,7 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, target_
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
 
         1. Create a custom repo with filters that excludes the updated package
         2. Create content view with custom repo publish and
@@ -2887,8 +2760,6 @@ def test_positive_composite_child_inc_update(session, rhel7_contenthost, target_
     :CaseImportance: Medium
 
     :parametrized: yes
-
-    :CaseLevel: Integration
     """
     org = entities.Organization().create()
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -2982,8 +2853,6 @@ def test_positive_module_stream_end_to_end(session, module_org, target_sat):
     :expectedresults: Content view works properly with module_streams and
         count shown should be correct
 
-    :CaseLevel: Integration
-
     :CaseImportance: Medium
     """
     repo_name = gen_string('alpha')
@@ -3024,8 +2893,6 @@ def test_positive_search_module_streams_in_content_view(session, module_org, tar
 
     :expectedresults: Searching for module streams should work inside content
         view version
-
-    :CaseLevel: Integration
 
     :CaseImportance: Low
     """
@@ -3068,8 +2935,6 @@ def test_positive_non_admin_user_actions(session, module_org, test_name, target_
         the content views
 
     :BZ: 1461017
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -3160,8 +3025,6 @@ def test_positive_readonly_user_actions(module_org, test_name, target_sat):
     :expectedresults: User with read-only role for content view can view
         the repository in the content view
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     user_login = gen_string('alpha')
@@ -3213,8 +3076,6 @@ def test_negative_read_only_user_actions(session, module_org, test_name, target_
         create activation key, or see repo discovery
 
     :BZ: 1922134
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -3317,8 +3178,6 @@ def test_negative_non_readonly_user_actions(module_org, test_name, target_sat):
         read role
 
     :expectedresults: the user cannot access content views web resources
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -3714,7 +3573,7 @@ def test_positive_no_duplicate_key_violate_unique_constraint_using_filters(
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Sync rhel tools 6.10 repo
         2. Create cv and add rhel repo
         3. Create include package filter for 'foreman-cli' and 'katello-agent'
@@ -3739,8 +3598,6 @@ def test_positive_no_duplicate_key_violate_unique_constraint_using_filters(
             katello-host-tools-fact-plugin
 
     :CaseImportance: Medium
-
-    :CaseLevel: Integration
     """
     cv = gen_string('alpha')
     filter_name = gen_string('alpha')

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Dashboard
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from airgun.session import Session
 from nailgun import entities
@@ -35,7 +30,7 @@ def test_positive_host_configuration_status(session):
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
 
         1. Navigate to Monitor -> Dashboard
         2. Review the Host Configuration Status
@@ -45,8 +40,6 @@ def test_positive_host_configuration_status(session):
     :expectedresults: Each link shows the right info
 
     :BZ: 1631219
-
-    :CaseLevel: Integration
     """
     org = entities.Organization().create()
     loc = entities.Location().create()
@@ -106,15 +99,13 @@ def test_positive_host_configuration_chart(session):
 
     :id: b03314aa-4394-44e5-86da-c341c783003d
 
-    :Steps:
+    :steps:
 
         1. Navigate to Monitor -> Dashboard
         2. Review the Host Configuration Chart widget
         3. Check that chart contains correct percentage value
 
     :expectedresults: Chart showing correct data
-
-    :CaseLevel: Integration
     """
     org = entities.Organization().create()
     loc = entities.Location().create()
@@ -135,7 +126,7 @@ def test_positive_task_status(session):
 
     :id: fb667d6a-7255-4341-9f79-2f03d19e8e0f
 
-    :Steps:
+    :steps:
 
         1. Navigate to Monitor -> Dashboard
         2. Review the Latest Warning/Error Tasks widget
@@ -148,8 +139,6 @@ def test_positive_task_status(session):
         from Tasks dashboard
 
     :BZ: 1718889
-
-    :CaseLevel: Integration
     """
     url = 'www.non_existent_repo_url.org'
     org = entities.Organization().create()
@@ -215,7 +204,7 @@ def test_positive_user_access_with_host_filter(
 
     :id: 24b4b371-cba0-4bc8-bc6a-294c62e0586d
 
-    :Steps:
+    :steps:
 
         1. Specify proper filter with permission for your role
         2. Create new user and assign role to it
@@ -229,8 +218,6 @@ def test_positive_user_access_with_host_filter(
     :BZ: 1417114
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     user_login = gen_string('alpha')
     user_password = gen_string('alphanumeric')
@@ -280,12 +267,11 @@ def test_positive_user_access_with_host_filter(
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_sync_overview_widget(session, module_org, module_product):
-
     """Check if the Sync Overview widget is working in the Dashboard UI
 
     :id: 553fbe33-0f6f-46fb-8d80-5d1d9ed483cf
 
-    :Steps:
+    :steps:
         1. Sync some repositories
         2. Navigate to Monitor -> Dashboard
         3. Review the Sync Overview widget
@@ -293,8 +279,6 @@ def test_positive_sync_overview_widget(session, module_org, module_product):
     :expectedresults: Correct data should appear in the widget
 
     :BZ: 1995424
-
-    :CaseLevel: Integration
     """
     repo = entities.Repository(url=settings.repos.yum_1.url, product=module_product).create()
     with session:

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -8,11 +8,6 @@
 
 :Team: Rocket
 
-:TestType: Functional
-
-:CaseLevel: System
-
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: DiscoveryPlugin
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from airgun.session import Session
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
@@ -77,8 +72,6 @@ def test_positive_crud_with_non_admin_user(
     :id: 6a03983b-363d-4646-b277-34af5f5abc55
 
     :expectedresults: All crud operations should work with non_admin user.
-
-    :CaseLevel: Integration
     """
     rule_name = gen_string('alpha')
     search = gen_string('alpha')
@@ -138,8 +131,6 @@ def test_negative_delete_rule_with_non_admin_user(
 
     :expectedresults: User should validation error and rule should not be
         deleted successfully.
-
-    :CaseLevel: Integration
     """
     hg_name = gen_string('alpha')
     rule_name = gen_string('alpha')
@@ -172,7 +163,7 @@ def test_positive_list_host_based_on_rule_search_query(
 
     :id: f7473fa2-7349-42d3-9cdb-f74b55d2f440
 
-    :Steps:
+    :steps:
 
         1. discovered host with cpu_count = 2
         2. Define a rule 'rule1' with search query cpu_count = 2

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -40,8 +35,6 @@ def test_positive_set_parameter(session, valid_domain_name, param_value):
     :parametrized: yes
 
     :expectedresults: Domain parameter is created.
-
-    :CaseLevel: Integration
     """
     new_param = {'name': gen_string('alpha', 255), 'value': param_value}
     with session:
@@ -61,8 +54,6 @@ def test_negative_set_parameter(session, valid_domain_name):
     :id: 1c647d66-6a3f-4d88-8e6b-60f2fc7fd603
 
     :expectedresults: Domain parameter is not updated. Error is raised
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """
@@ -85,8 +76,6 @@ def test_negative_set_parameter_same(session, valid_domain_name):
 
     :expectedresults: Domain parameter with same values is not created.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Medium
     """
     param_name = gen_string('alpha')
@@ -107,8 +96,6 @@ def test_positive_remove_parameter(session, valid_domain_name):
     :id: 8f7f8501-cf39-418f-a412-1a4b53698bc3
 
     :expectedresults: Domain parameter is removed
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """
@@ -132,8 +119,6 @@ def test_positive_end_to_end(session, module_org, module_location, valid_domain_
     :id: ce90fd87-3e63-4298-a771-38f4aacce091
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ErrataManagement
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime
 
@@ -278,8 +273,6 @@ def test_end_to_end(
     :BZ: 2029192
 
     :customerscenario: true
-
-    :CaseLevel: System
     """
 
     ERRATA_DETAILS = {
@@ -410,7 +403,7 @@ def test_content_host_errata_page_pagination(session, function_org_with_paramete
 
     :id: 6363eda7-a162-4a4a-b70f-75decbd8202e
 
-    :Steps:
+    :steps:
         1. Install more than 20 packages that need errata
         2. View Content Host's Errata page
         3. Assert total_pages > 1
@@ -432,8 +425,6 @@ def test_content_host_errata_page_pagination(session, function_org_with_paramete
     :customerscenario: true
 
     :BZ: 1662254, 1846670
-
-    :CaseLevel: System
     """
 
     org = function_org_with_parameter
@@ -497,15 +488,13 @@ def test_positive_list(session, function_org_with_parameter, lce, target_sat):
 
     :Setup: Errata synced on satellite server.
 
-    :Steps: Create two Orgs each having a product synced which contains errata.
+    :steps: Create two Orgs each having a product synced which contains errata.
 
     :expectedresults: Check that the errata belonging to one Org is not showing in the other.
 
     :BZ: 1659941, 1837767
 
     :customerscenario: true
-
-    :CaseLevel: Integration
     """
     org = function_org_with_parameter
     rc = target_sat.cli_factory.RepositoryCollection(
@@ -551,12 +540,10 @@ def test_positive_list_permission(
         2. Make sure that they both have errata.
         3. Create a user with view access on one product and not on the other.
 
-    :Steps: Go to Content -> Errata.
+    :steps: Go to Content -> Errata.
 
     :expectedresults: Check that the new user is able to see errata for one
         product only.
-
-    :CaseLevel: Integration
     """
     module_org = module_org_with_parameter
     role = entities.Role().create()
@@ -608,15 +595,13 @@ def test_positive_apply_for_all_hosts(
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
 
         1. Go to Content -> Errata. Select an erratum -> Content Hosts tab.
         2. Select all Content Hosts and apply the erratum.
 
     :expectedresults: Check that the erratum is applied in all the content
         hosts.
-
-    :CaseLevel: System
     """
     with Broker(
         nick=module_repos_collection_with_setup.distro, host_class=ContentHost, _count=2
@@ -660,14 +645,12 @@ def test_positive_view_cve(session, module_repos_collection_with_setup):
 
     :Setup: Errata synced on satellite server.
 
-    :Steps: Go to Content -> Errata.  Select an Errata.
+    :steps: Go to Content -> Errata.  Select an Errata.
 
     :expectedresults:
 
         1. Check if the CVE information is shown in Errata Details page.
         2. Check if 'N/A' is displayed if CVE information is not present.
-
-    :CaseLevel: Integration
     """
     with session:
         errata_values = session.errata.read(RHVA_ERRATA_ID)
@@ -706,12 +689,10 @@ def test_positive_filter_by_environment(
 
     :Setup: Errata synced on satellite server.
 
-    :Steps: Go to Content -> Errata.  Select an Errata -> Content Hosts tab
+    :steps: Go to Content -> Errata.  Select an Errata -> Content Hosts tab
         -> Filter content hosts by Environment.
 
     :expectedresults: Content hosts can be filtered by Environment.
-
-    :CaseLevel: System
     """
     module_org = module_org_with_parameter
     with Broker(
@@ -781,14 +762,12 @@ def test_positive_content_host_previous_env(
         1. Make sure multiple environments are present.
         2. Content host's previous environments have additional errata.
 
-    :Steps: Go to Content Hosts -> Select content host -> Errata Tab ->
+    :steps: Go to Content Hosts -> Select content host -> Errata Tab ->
         Select Previous environments.
 
     :expectedresults: The errata from previous environments are displayed.
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     module_org = module_org_with_parameter
     hostname = vm.hostname
@@ -840,13 +819,11 @@ def test_positive_content_host_library(session, module_org_with_parameter, vm):
         1. Make sure multiple environments are present.
         2. Content host's Library environment has additional errata.
 
-    :Steps: Go to Content Hosts -> Select content host -> Errata Tab -> Select 'Library'.
+    :steps: Go to Content Hosts -> Select content host -> Errata Tab -> Select 'Library'.
 
     :expectedresults: The errata from Library are displayed.
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     hostname = vm.hostname
     assert vm.execute(f'yum install -y {FAKE_1_CUSTOM_PACKAGE}').status == 0
@@ -880,14 +857,12 @@ def test_positive_content_host_search_type(session, erratatype_vm):
 
     :customerscenario: true
 
-    :Steps: Search for errata on content host by type (e.g. 'type = security')
+    :steps: Search for errata on content host by type (e.g. 'type = security')
      Step 1 Search for "type = security", assert expected amount and IDs found
      Step 2 Search for "type = bugfix", assert expected amount and IDs found
      Step 3 Search for "type = enhancement", assert expected amount and IDs found
 
     :BZ: 1653293
-
-    :CaseLevel: Integration
     """
 
     pkgs = ' '.join(FAKE_9_YUM_OUTDATED_PACKAGES)
@@ -955,15 +930,13 @@ def test_positive_show_count_on_content_host_page(
         1. Errata synced on satellite server.
         2. Some content hosts are present.
 
-    :Steps: Go to Hosts -> Content Hosts.
+    :steps: Go to Hosts -> Content Hosts.
 
     :expectedresults: The available errata count is displayed.
 
     :BZ: 1484044, 1775427
 
     :customerscenario: true
-
-    :CaseLevel: System
     """
     vm = erratatype_vm
     hostname = vm.hostname
@@ -1013,13 +986,11 @@ def test_positive_show_count_on_content_host_details_page(
         1. Errata synced on satellite server.
         2. Some content hosts are present.
 
-    :Steps: Go to Hosts -> Content Hosts -> Select Content Host -> Details page.
+    :steps: Go to Hosts -> Content Hosts -> Select Content Host -> Details page.
 
     :expectedresults: The errata section should be displayed with Security, Bug fix, Enhancement.
 
     :BZ: 1484044
-
-    :CaseLevel: System
     """
     vm = erratatype_vm
     hostname = vm.hostname
@@ -1059,7 +1030,7 @@ def test_positive_filtered_errata_status_installable_param(
 
     :id: ed94cf34-b8b9-4411-8edc-5e210ea6af4f
 
-    :Steps:
+    :steps:
 
         1. Prepare setup: Create Lifecycle Environment, Content View,
             Activation Key and all necessary repos
@@ -1075,8 +1046,6 @@ def test_positive_filtered_errata_status_installable_param(
     :BZ: 1368254, 2013093
 
     :CaseImportance: Medium
-
-    :CaseLevel: System
     """
     org = function_entitlement_manifest_org
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -1175,7 +1144,7 @@ def test_content_host_errata_search_commands(
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1.  host list --search "errata_status = security_needed"
         2.  host list --search "errata_status = errata_needed"
         3.  host list --search "applicable_errata = RHSA-2012:0055"

--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -23,14 +18,11 @@ import pytest
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, host_ui_options):
-
     """Perform end to end testing for hardware model component
 
     :id: 93663cc9-7c8f-4f43-8050-444be1313bed
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import copy
 import csv
@@ -137,8 +132,6 @@ def test_positive_end_to_end(session, module_global_params, target_sat, host_ui_
         and deleted.
 
     :BZ: 1419161
-
-    :CaseLevel: System
     """
     api_values, host_name = host_ui_options
     global_params = [
@@ -199,8 +192,6 @@ def test_positive_read_from_details_page(session, module_host_template):
     :id: ffba5d40-918c-440e-afbb-6b910db3a8fb
 
     :expectedresults: Host is created and has expected content
-
-    :CaseLevel: System
     """
 
     template = module_host_template
@@ -233,8 +224,6 @@ def test_positive_read_from_edit_page(session, host_ui_options):
     :id: 758fcab3-b363-4bfc-8f5d-173098a7e72d
 
     :expectedresults: Host is created and has expected content
-
-    :CaseLevel: System
     """
     api_values, host_name = host_ui_options
     with session:
@@ -282,8 +271,6 @@ def test_positive_assign_taxonomies(
 
     :expectedresults: Host Assign Organization and Location actions are
         working as expected.
-
-    :CaseLevel: Integration
     """
     host = target_sat.api.Host(organization=module_org, location=smart_proxy_location).create()
     with session:
@@ -345,8 +332,6 @@ def test_positive_assign_compliance_policy(session, scap_policy, target_sat, fun
         expected.
 
     :BZ: 1862135
-
-    :CaseLevel: Integration
     """
     org = function_host.organization.read()
     loc = function_host.location.read()
@@ -398,8 +383,6 @@ def test_positive_export(session, target_sat, function_org, function_location):
     :id: ffc512ad-982e-4b60-970a-41e940ebc74c
 
     :expectedresults: csv file contains same values as on web UI
-
-    :CaseLevel: System
     """
     hosts = [
         target_sat.api.Host(organization=function_org, location=function_location).create()
@@ -469,9 +452,6 @@ def test_negative_delete_primary_interface(session, host_ui_options):
     :BZ: 1417119
 
     :expectedresults: Interface was not deleted
-
-
-    :CaseLevel: System
     """
     values, host_name = host_ui_options
     interface_id = values['interfaces.interface.device_identifier']
@@ -498,8 +478,6 @@ def test_positive_view_hosts_with_non_admin_user(
 
     :expectedresults: user with only view_hosts, edit_hosts and view_organization permissions
         is able to read content hosts and hosts
-
-    :CaseLevel: Component
     """
     user_password = gen_string('alpha')
     role = target_sat.api.Role(organization=[module_org]).create()
@@ -537,8 +515,6 @@ def test_positive_remove_parameter_non_admin_user(
 
     :expectedresults: user with sufficient permissions may remove host
         parameter
-
-    :CaseLevel: System
     """
     user_password = gen_string('alpha')
     parameter = {'name': gen_string('alpha'), 'value': gen_string('alpha')}
@@ -593,8 +569,6 @@ def test_negative_remove_parameter_non_admin_user(
 
     :expectedresults: user with insufficient permissions is unable to
         remove host parameter, 'Remove' link is not visible for him
-
-    :CaseLevel: System
     """
 
     user_password = gen_string('alpha')
@@ -649,8 +623,6 @@ def test_positive_check_permissions_affect_create_procedure(
         entities for create host procedure that he has access to
 
     :BZ: 1293716
-
-    :CaseLevel: System
     """
     # Create two lifecycle environments
     lc_env = target_sat.api.LifecycleEnvironment(organization=function_org).create()
@@ -765,8 +737,6 @@ def test_positive_search_by_parameter(session, module_org, smart_proxy_location,
     :expectedresults: Only one specific host is returned by search
 
     :BZ: 1725686
-
-    :CaseLevel: Integration
     """
     param_name = gen_string('alpha')
     param_value = gen_string('alpha')
@@ -800,8 +770,6 @@ def test_positive_search_by_parameter_with_different_values(
     :expectedresults: Only one specific host is returned by search
 
     :BZ: 1725686
-
-    :CaseLevel: Integration
     """
     param_name = gen_string('alpha')
     param_values = [gen_string('alpha'), gen_string('alphanumeric')]
@@ -836,8 +804,6 @@ def test_positive_search_by_parameter_with_prefix(
 
     :expectedresults: All assigned hosts to organization are returned by
         search
-
-    :CaseLevel: Integration
     """
     param_name = gen_string('alpha')
     param_value = gen_string('alpha')
@@ -875,8 +841,6 @@ def test_positive_search_by_parameter_with_operator(
         search
 
     :BZ: 1463806
-
-    :CaseLevel: Integration
     """
     param_name = gen_string('alpha')
     param_value = gen_string('alpha')
@@ -917,8 +881,6 @@ def test_positive_search_with_org_and_loc_context(
     :BZ: 1405496
 
     :customerscenario: true
-
-    :CaseLevel: Integration
     """
     host = target_sat.api.Host(organization=function_org, location=function_location).create()
     with session:
@@ -942,8 +904,6 @@ def test_positive_search_by_org(session, smart_proxy_location, target_sat):
         result is returned
 
     :BZ: 1447958
-
-    :CaseLevel: Integration
     """
     host = target_sat.api.Host(location=smart_proxy_location).create()
     org = host.organization.read()
@@ -963,8 +923,6 @@ def test_positive_validate_inherited_cv_lce_ansiblerole(session, target_sat, mod
 
     :expectedresults: Host's lifecycle environment, content view and ansible role match
        the ones specified in hostgroup.
-
-    :CaseLevel: Integration
 
     :customerscenario: true
 
@@ -1038,8 +996,6 @@ def test_positive_global_registration_form(
     :customerscenario: true
 
     :expectedresults: The curl command contains all required parameters
-
-    :CaseLevel: Integration
     """
     # rex and insights parameters are only specified in curl when differing from
     # inerited parameters
@@ -1116,8 +1072,6 @@ def test_positive_global_registration_end_to_end(
          client work out of the box
 
     :parametrized: yes
-
-    :CaseLevel: Integration
     """
     # make sure global parameters for rex and insights are set to true
     insights_cp = (
@@ -1251,8 +1205,6 @@ def test_global_registration_form_populate(
         e.g. activation key, operating system, life-cycle environment, host parameters for
         remote-execution, insights setup.
 
-    :CaseLevel: Integration
-
     :steps:
         1. create and sync repository
         2. create the content view and activation-key
@@ -1329,8 +1281,6 @@ def test_global_registration_with_capsule_host(
 
     :expectedresults: Host is successfully registered with capsule host,
         remote execution and insights client work out of the box
-
-    :CaseLevel: Integration
 
     :steps:
         1. create and sync repository
@@ -1424,8 +1374,6 @@ def test_global_registration_with_gpg_repo_and_default_package(
     :expectedresults: Host is successfully registered, gpg repo is enabled
         and default package is installed.
 
-    :CaseLevel: Integration
-
     :steps:
         1. create and sync repository
         2. create the content view and activation-key
@@ -1492,8 +1440,6 @@ def test_global_registration_upgrade_subscription_manager(
     :expectedresults: Host is successfully registered, repo is enabled
         on advanced tab and subscription-manager is updated.
 
-    :CaseLevel: Integration
-
     :steps:
         1. Create activation-key
         2. Open the global registration form, add repo and activation key
@@ -1545,8 +1491,6 @@ def test_global_re_registration_host_with_force_ignore_error_options(
 
     :expectedresults: Verify the force and ignore checkbox options
 
-    :CaseLevel: Integration
-
     :steps:
         1. create and sync repository
         2. create the content view and activation-key
@@ -1590,8 +1534,6 @@ def test_global_registration_token_restriction(
     :expectedresults: global registration token should be restricted for any api calls
         other than the registration
 
-    :CaseLevel: Integration
-
     :steps:
         1. open the global registration form and generate the curl token
         2. use that curl token to execute other api calls e.g. GET /hosts, /users
@@ -1631,8 +1573,6 @@ def test_positive_bulk_delete_host(session, smart_proxy_location, target_sat, fu
     :expectedresults: All selected hosts should be deleted successfully
 
     :BZ: 1368026
-
-    :CaseLevel: System
     """
     host_template = target_sat.api.Host(organization=function_org, location=smart_proxy_location)
     host_template.create_missing()
@@ -1668,8 +1608,6 @@ def test_positive_read_details_page_from_new_ui(session, host_ui_options):
     :id: ef0c5942-9049-11ec-8029-98fa9b6ecd5a
 
     :expectedresults: Host is created and has expected content
-
-    :CaseLevel: System
     """
     with session:
         api_values, host_name = host_ui_options
@@ -1702,8 +1640,6 @@ def test_rex_new_ui(session, target_sat, rex_contenthost):
 
     :expectedresults: Remote execution succeeded and the job is visible on Recent jobs card on
         Overview tab
-
-    :CaseLevel: System
     """
     hostname = rex_contenthost.hostname
     job_args = {
@@ -1739,8 +1675,6 @@ def test_positive_manage_table_columns(session, current_sat_org, current_sat_loc
 
     :expectedresults: Check if the custom columns were set properly, i.e., are displayed
         or not displayed in the table.
-
-    :CaseLevel: System
 
     :BZ: 1813274
 
@@ -1791,8 +1725,6 @@ def test_positive_host_details_read_templates(
     :BZ: 2128038
 
     :customerscenario: true
-
-    :CaseLevel: System
     """
     host = target_sat.api.Host().search(query={'search': f'name={target_sat.hostname}'})[0]
     api_templates = [template['name'] for template in host.list_provisioning_templates()]
@@ -1843,7 +1775,6 @@ def test_positive_update_delete_package(
         9. Delete the package
 
     :expectedresults: The package is updated and deleted
-
     """
     client = rhel_contenthost
     client.add_rex_key(target_sat)
@@ -1961,7 +1892,6 @@ def test_positive_apply_erratum(
         5. Select errata and apply via rex.
 
     :expectedresults: The erratum is applied
-
     """
     # install package
     client = rhel_contenthost
@@ -2042,7 +1972,6 @@ def test_positive_crud_module_streams(
         5. Reset the Module stream
 
     :expectedresults: Module streams can be enabled, installed, removed and reset using the new UI.
-
     """
     module_name = 'duck'
     client = rhel_contenthost
@@ -2132,8 +2061,6 @@ def test_positive_inherit_puppet_env_from_host_group_when_action(
     :expectedresults: Expected puppet environment is inherited to the host
 
     :BZ: 1414914
-
-    :CaseLevel: System
     """
     host = session_puppet_enabled_sat.api.Host(
         organization=module_puppet_org, location=module_puppet_loc
@@ -2186,8 +2113,6 @@ def test_positive_create_with_puppet_class(
     :id: d883f169-1105-435c-8422-a7160055734a
 
     :expectedresults: Host is created and contains correct puppet class
-
-    :CaseLevel: System
     """
 
     host_template = session_puppet_enabled_sat.api.Host(
@@ -2247,8 +2172,6 @@ def test_positive_inherit_puppet_env_from_host_group_when_create(
     :expectedresults: Expected puppet environment is inherited to the form
 
     :BZ: 1414914
-
-    :CaseLevel: Integration
     """
 
     hg_name = gen_string('alpha')
@@ -2300,8 +2223,6 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(
         2. host parameter value is the same when restored from yaml format
 
     :BZ: 1315282
-
-    :CaseLevel: System
     """
     host_template = session_puppet_enabled_sat.api.Host(
         organization=module_puppet_org, location=module_puppet_loc
@@ -2360,9 +2281,7 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
 
     :Team: Phoenix-subscriptions
 
-    :CaseLevel: System
-
-    :Steps:
+    :steps:
         1. Register a RHEL host to Satellite.
         2. Prepare katello-tracer to be installed
         3. Navigate to the Traces tab in New Host UI
@@ -2370,7 +2289,6 @@ def test_positive_tracer_enable_reload(tracer_install_host, target_sat):
 
     :expectedresults: The Tracer tab message updates accordingly during the process, and displays
         the state the correct Title
-
     """
     host = (
         target_sat.api.Host().search(query={'search': tracer_install_host.hostname})[0].read_json()
@@ -2408,8 +2326,6 @@ def test_positive_host_registration_with_non_admin_user(
     :id: 35458bbc-4556-41b9-ba26-ae0b15179731
 
     :expectedresults: User with register hosts permission able to register hosts.
-
-    :CaseLevel: Component
     """
     user_password = gen_string('alpha')
     org = module_sca_manifest_org
@@ -2460,8 +2376,6 @@ def test_all_hosts_delete(session, target_sat, function_org, function_location, 
     :CaseComponent:Hosts-Content
 
     :Team: Phoenix-subscriptions
-
-    :CaseLevel: System
     """
     host = target_sat.api.Host(organization=function_org, location=function_location).create()
     with target_sat.ui_session() as session:
@@ -2481,8 +2395,6 @@ def test_all_hosts_bulk_delete(session, target_sat, function_org, function_locat
     :CaseComponent:Hosts-Content
 
     :Team: Phoenix-subscriptions
-
-    :CaseLevel: System
     """
     for _ in range(10):
         target_sat.api.Host(organization=function_org, location=function_location).create()

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: HostCollections
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import time
 
@@ -221,8 +216,6 @@ def test_positive_end_to_end(
 
     :expectedresults: All expected CRUD actions finished successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     hc_name = gen_string('alpha')
@@ -273,8 +266,6 @@ def test_negative_install_via_remote_execution(
 
     :expectedresults: The package is not installed, and the job invocation
         status contains some expected values: hosts information, jos status.
-
-    :CaseLevel: Integration
     """
     hosts = []
     for _ in range(2):
@@ -313,8 +304,6 @@ def test_negative_install_via_custom_remote_execution(
 
     :expectedresults: The package is not installed, and the job invocation
         status contains some expected values: hosts information, jos status.
-
-    :CaseLevel: Integration
     """
     hosts = []
     for _ in range(2):
@@ -348,8 +337,6 @@ def test_positive_add_host(session, module_target_sat):
     :id: 80824c9f-15a1-4f76-b7ac-7d9ca9f6ed9e
 
     :expectedresults: Host is added to Host Collection successfully
-
-    :CaseLevel: System
     """
     hc_name = gen_string('alpha')
     org = module_target_sat.api.Organization().create()
@@ -384,8 +371,6 @@ def test_positive_install_package(
 
     :expectedresults: Package was successfully installed on all the hosts
         in host collection
-
-    :CaseLevel: System
     """
     with session:
         session.organization.select(org_name=module_org_with_parameter.name)
@@ -410,8 +395,6 @@ def test_positive_remove_package(
 
     :expectedresults: Package was successfully removed from all the hosts
         in host collection
-
-    :CaseLevel: System
     """
     _install_package_with_assertion(vm_content_hosts, constants.FAKE_0_CUSTOM_PACKAGE)
     with session:
@@ -438,8 +421,6 @@ def test_positive_upgrade_package(
 
     :expectedresults: Package was successfully upgraded on all the hosts in
         host collection
-
-    :CaseLevel: System
     """
     _install_package_with_assertion(vm_content_hosts, constants.FAKE_1_CUSTOM_PACKAGE)
     with session:
@@ -465,8 +446,6 @@ def test_positive_install_package_group(
 
     :expectedresults: Package group was successfully installed on all the
         hosts in host collection
-
-    :CaseLevel: System
     """
     with session:
         session.organization.select(org_name=module_org_with_parameter.name)
@@ -492,8 +471,6 @@ def test_positive_remove_package_group(
 
     :expectedresults: Package group was successfully removed  on all the
         hosts in host collection
-
-    :CaseLevel: System
     """
     for client in vm_content_hosts:
         result = client.run(f'yum groups install -y {constants.FAKE_0_CUSTOM_PACKAGE_GROUP_NAME}')
@@ -525,8 +502,6 @@ def test_positive_install_errata(
 
     :expectedresults: Errata was successfully installed in all the hosts in
         host collection
-
-    :CaseLevel: System
     """
     _install_package_with_assertion(vm_content_hosts, constants.FAKE_1_CUSTOM_PACKAGE)
     with session:
@@ -594,8 +569,6 @@ def test_positive_change_assigned_content(
            names
 
     :BZ: 1315280
-
-    :CaseLevel: System
     """
     new_lce_name = gen_string('alpha')
     new_cv_name = gen_string('alpha')
@@ -663,7 +636,7 @@ def test_negative_hosts_limit(
 
     :id: 57b70977-2110-47d9-be3b-461ad15c70c7
 
-    :Steps:
+    :steps:
         1. Create Host Collection entity that can contain only one Host
             (using Host Limit field)
         2. Create Host and add it to Host Collection. Check that it was
@@ -673,8 +646,6 @@ def test_negative_hosts_limit(
 
     :expectedresults: Second host is not added to Host Collection and
         appropriate error is shown
-
-    :CaseLevel: System
     """
     hc_name = gen_string('alpha')
     org = module_target_sat.api.Organization().create()
@@ -728,7 +699,7 @@ def test_positive_install_module_stream(
 
     :id: e5d882e0-3520-4cb6-8629-ef4c18692868
 
-    :Steps:
+    :steps:
         1. Run dnf upload profile to sync module streams from hosts to Satellite
         2. Navigate to host_collection
         3. Install the module stream duck
@@ -737,8 +708,6 @@ def test_positive_install_module_stream(
 
     :expectedresults: Module-Stream should get installed on all the hosts
         in host collection
-
-    :CaseLevel: System
     """
     _run_remote_command_on_content_hosts('dnf -y upload-profile', vm_content_hosts_module_stream)
     with session:
@@ -778,7 +747,7 @@ def test_positive_install_modular_errata(
 
     :id: 8d6fb447-af86-4084-a147-7910f0cecdef
 
-    :Steps:
+    :steps:
         1. Generate modular errata by installing older version of module stream
         2. Run dnf upload-profile
         3. Install the modular errata by 'remote execution'
@@ -786,8 +755,6 @@ def test_positive_install_modular_errata(
 
     :expectedresults: Modular Errata should get installed on all hosts in host
         collection.
-
-    :CaseLevel: System
     """
     stream = "0"
     version = "20180704111719"

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -6,15 +6,10 @@
 
 :CaseComponent: HostGroup
 
-:CaseLevel: Integration
-
 :Team: Endeavour
-
-:TestType: Functional
 
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -179,7 +174,7 @@ def test_positive_create_new_host():
 
     :id: 49704437-5ca1-46cb-b74e-de58396add37
 
-    :Steps:
+    :steps:
 
         1. Create hostgroup with the Content Source field populated.
         2. Create host from Hosts > Create Host, selecting the hostgroup in the Host Group field.
@@ -202,7 +197,7 @@ def test_positive_nested_host_groups(
 
     :id: 547f8e72-df65-48eb-aeb1-6b5fd3cbf4e5
 
-    :Steps:
+    :steps:
 
         1. Create the parent host-group.
         2. Create, Update and Delete the nested host-group.
@@ -276,7 +271,7 @@ def test_positive_clone_host_groups(
 
     :id: 9f02dcc5-98aa-48bd-8114-edd3a0be65c1
 
-    :Steps:
+    :steps:
         1. Create the host-group.
         2. Clone the host-group created in step 1
         3. Update and Delete the cloned host-group.

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -2,19 +2,14 @@
 
 :Requirement: HttpProxy
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
-
-:TestType: Functional
 
 :CaseImportance: High
 
 :CaseAutomation: Automated
 
-:Upstream: No
 """
 from fauxfactory import gen_integer, gen_string, gen_url
 import pytest
@@ -31,8 +26,6 @@ def test_positive_create_update_delete(module_org, module_location, target_sat):
     :id: 0c7cdf3d-778f-427a-9a2f-42ad7c23aa15
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -196,7 +189,7 @@ def test_set_default_http_proxy(module_org, module_location, setting_update, tar
 
     :id: e93733e1-5c05-4b7f-89e4-253b9ce55a5a
 
-    :Steps:
+    :steps:
         1. Navigate to Infrastructure > Http Proxies
         2. Create a Http Proxy
         3. GoTo to Administer > Settings > content tab
@@ -210,8 +203,6 @@ def test_set_default_http_proxy(module_org, module_location, setting_update, tar
     :expectedresults: Setting "Default HTTP Proxy" to "no global default" result in success.'''
 
     :CaseImportance: Medium
-
-    :CaseLevel: Acceptance
     """
     property_name = setting_update.name
 
@@ -242,12 +233,11 @@ def test_set_default_http_proxy(module_org, module_location, setting_update, tar
 def test_check_http_proxy_value_repository_details(
     function_org, function_location, function_product, setting_update, target_sat
 ):
-
     """Deleted Global Http Proxy is reflected in repository details page".
 
     :id: 3f64255a-ef6c-4acb-b99b-e5579133b564
 
-    :Steps:
+    :steps:
         1. Create Http Proxy (Go to Infrastructure > Http Proxies > New Http Proxy)
         2. GoTo to Administer > Settings > content tab
         3. Update the "Default HTTP Proxy" with created above.
@@ -264,8 +254,6 @@ def test_check_http_proxy_value_repository_details(
         2. "HTTP Proxy" field  in repository details page should be set to Global Default (None).
 
     :CaseImportance: Medium
-
-    :CaseLevel: Acceptance
     """
 
     property_name = setting_update.name
@@ -310,7 +298,7 @@ def test_http_proxy_containing_special_characters():
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Navigate to Infrastructure > Http Proxies
         2. Create HTTP Proxy with special characters in password.
         3. Go To to Administer > Settings > content tab

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RemoteExecution
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from inflection import camelize
 import pytest
@@ -42,7 +37,7 @@ def test_positive_run_default_job_template_by_ip(
 
     :Setup: Use pre-defined job template.
 
-    :Steps:
+    :steps:
 
         1. Set remote_execution_connect_by_ip on host to true
         2. Navigate to an individual host and click Run Job
@@ -52,8 +47,6 @@ def test_positive_run_default_job_template_by_ip(
     :expectedresults: Verify the job was successfully ran against the host
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     hostname = module_rhel_client_by_ip.hostname
     with session:
@@ -83,7 +76,7 @@ def test_positive_run_custom_job_template_by_ip(
 
     :Setup: Create a working job template.
 
-    :Steps:
+    :steps:
 
         1. Set remote_execution_connect_by_ip on host to true
         2. Navigate to an individual host and click Run Job
@@ -93,8 +86,6 @@ def test_positive_run_custom_job_template_by_ip(
     :expectedresults: Verify the job was successfully ran against the host
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     hostname = module_rhel_client_by_ip.hostname
     job_template_name = gen_string('alpha')
@@ -139,7 +130,7 @@ def test_positive_schedule_recurring_host_job(self):
 
     :Team: Rocket
 
-    :Steps:
+    :steps:
         1. Register a RHEL host to Satellite.
         2. Import all roles available by default.
         3. Assign a role to host.
@@ -151,7 +142,6 @@ def test_positive_schedule_recurring_host_job(self):
 
     :expectedresults: The scheduled Job appears in the Job Invocation list at the appointed
         time
-
     """
 
 
@@ -166,7 +156,7 @@ def test_positive_schedule_recurring_hostgroup_job(self):
 
     :Team: Rocket
 
-    :Steps:
+    :steps:
         1. Register a RHEL host to Satellite.
         2. Import all roles available by default.
         3. Assign a role to host.
@@ -178,5 +168,4 @@ def test_positive_schedule_recurring_hostgroup_job(self):
 
     :expectedresults: The scheduled Job appears in the Job Invocation list at the appointed
         time
-
     """

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RemoteExecution
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -28,8 +23,6 @@ def test_positive_end_to_end(session, module_org, module_location, target_sat):
     :id: 2e0e31c5-e557-4151-83f9-21820c9cb1be
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: LDAP
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import os
 
@@ -144,8 +139,6 @@ def test_positive_end_to_end(session, ldap_auth_source, ldap_tear_down):
 
     :expectedresults: All expected CRUD actions finished successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
 
     :parametrized: yes
@@ -247,7 +240,7 @@ def test_positive_add_katello_role(
 
     :id: aa5e3bf4-cb42-43a4-93ea-a2eea54b847a
 
-    :Steps:
+    :steps:
         1. Create an UserGroup.
         2. Assign some foreman roles to UserGroup.
         3. Create and associate an External UserGroup.
@@ -503,7 +496,7 @@ def test_positive_add_admin_role_with_org_loc(
     :setup: LDAP Auth Source should be created with Org and Location
             Associated.
 
-    :Steps:
+    :steps:
         1. Create an UserGroup.
         2. Assign admin role to UserGroup.
         3. Create and associate an External UserGroup.
@@ -563,7 +556,7 @@ def test_positive_add_foreman_role_with_org_loc(
     :setup: LDAP Auth Source should be created with Org and Location
             Associated.
 
-    :Steps:
+    :steps:
 
         1. Create an UserGroup.
         2. Assign some foreman roles to UserGroup.
@@ -629,7 +622,7 @@ def test_positive_add_katello_role_with_org(
 
     :setup: LDAP Auth Source should be created with Organization associated.
 
-    :Steps:
+    :steps:
         1. Create an UserGroup.
         2. Assign some katello roles to UserGroup.
         3. Create and associate an External UserGroup.
@@ -955,7 +948,7 @@ def test_onthefly_functionality(session, ldap_auth_source, ldap_tear_down):
 
     :id: 6998de30-ef77-11ea-a0ce-0c7a158cbff4
 
-    :Steps:
+    :steps:
         1. Create an auth source with onthefly disabled
         2. Try login with a user from auth source
 
@@ -1043,7 +1036,7 @@ def test_verify_attribute_of_users_are_updated(session, ldap_auth_source, ldap_t
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Create authsource with onthefly disabled
         2. Create a user manually and select the authsource created
         3. Attributes of the user (like names and email) should be synced.
@@ -1220,7 +1213,7 @@ def test_positive_group_sync_open_ldap_authsource(
 
     :BZ: 1883209
 
-    :Steps:
+    :steps:
         1. Create an UserGroup.
         2. Assign some foreman roles to UserGroup.
         3. Create and associate an External OpenLDAP UserGroup.
@@ -1267,7 +1260,7 @@ def test_verify_group_permissions(
 
     :id: 7e2ef59c-0c68-11eb-b6f3-0c7a158cbff4
 
-    :Steps:
+    :steps:
         1. Create two usergroups and link it with external group having a
         user in common
         2. Give those usergroup different permissions
@@ -1315,7 +1308,7 @@ def test_verify_ldap_filters_ipa(
 
     :id: 0052b272-08b1-11eb-80c6-0c7a158cbff4
 
-    :Steps:
+    :steps:
         1. Create authsource with onthefly enabled and ldap filter
         2. Verify login from users according to the filter
 

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: LifecycleEnvironments
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from airgun.session import Session
 from navmazing import NavigationTriesExceeded
@@ -41,8 +36,6 @@ def test_positive_end_to_end(session):
     :id: b2293de9-7a71-462e-b988-321b07c01642
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -79,8 +72,6 @@ def test_positive_create_chain(session):
     :id: ed3d2c88-ef0a-4a1a-9f11-5bdb2119fc18
 
     :expectedresults: Environment is created
-
-    :CaseLevel: Integration
     """
     lce_path_name = gen_string('alpha')
     lce_name = gen_string('alpha')
@@ -120,8 +111,6 @@ def test_positive_search_lce_content_view_packages_by_full_name(session, module_
     :expectedresults: only the searched packages where found
 
     :BZ: 1432155
-
-    :CaseLevel: System
     """
     packages = [
         {'name': FAKE_0_CUSTOM_PACKAGE_NAME, 'full_names': [FAKE_0_CUSTOM_PACKAGE]},
@@ -173,8 +162,6 @@ def test_positive_search_lce_content_view_packages_by_name(session, module_org, 
     :expectedresults: only the searched packages where found
 
     :BZ: 1432155
-
-    :CaseLevel: System
     """
     packages = [
         {'name': FAKE_0_CUSTOM_PACKAGE_NAME, 'packages_count': 1},
@@ -218,8 +205,6 @@ def test_positive_search_lce_content_view_module_streams_by_name(session, module
         5. Search by module stream names
 
     :expectedresults: only the searched module streams where found
-
-    :CaseLevel: System
     """
     module_streams = [
         {'name': FAKE_1_CUSTOM_PACKAGE_NAME, 'streams_count': 2},
@@ -254,7 +239,7 @@ def test_positive_custom_user_view_lce(session, test_name, target_sat):
 
     :BZ: 1420511
 
-    :Steps:
+    :steps:
 
         As an admin user:
 
@@ -281,8 +266,6 @@ def test_positive_custom_user_view_lce(session, test_name, target_sat):
 
     :expectedresults: The additional lifecycle environment is viewable and
         accessible by the custom user.
-
-    :CaseLevel: Integration
     """
     role_name = gen_string('alpha')
     lce_name = gen_string('alpha')

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: OrganizationsandLocations
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_ipaddr, gen_string
 from nailgun import entities
@@ -33,8 +28,6 @@ def test_positive_end_to_end(session):
     :id: dba5d94d-0c18-4db0-a9e8-66599bffc5d9
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -125,8 +118,6 @@ def test_positive_update_with_all_users(session):
         was enabled and then disabled afterwards
 
     :BZ: 1321543, 1479736, 1479736
-
-    :CaseLevel: Integration
     """
     user = entities.User().create()
     loc = entities.Location().create()
@@ -161,8 +152,6 @@ def test_positive_add_org_hostgroup_template(session):
 
     :expectedresults: organization, hostgroup, provisioning template are
         added to location
-
-    :CaseLevel: Integration
     """
     org = entities.Organization().create()
     loc = entities.Location().create()
@@ -203,8 +192,6 @@ def test_positive_update_compresource(session):
     :id: 1d24414a-666d-490d-89b9-cd0704684cdd
 
     :expectedresults: compute resource is added and removed from the location
-
-    :CaseLevel: Integration
     """
     url = LIBVIRT_RESOURCE_URL % settings.libvirt.libvirt_hostname
     resource = entities.LibvirtComputeResource(url=url).create()

--- a/tests/foreman/ui/test_media.py
+++ b/tests/foreman/ui/test_media.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: Low
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -31,8 +26,6 @@ def test_positive_end_to_end(session, module_org, module_location):
     :id: fb7a248a-21ef-43b2-a488-8d7628a55ccd
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -55,8 +50,6 @@ def test_positive_module_stream_details_search_in_repo(session, module_org, modu
 
     :expectedresults: Content search functionality works as intended and
         expected module_streams are present inside of repository
-
-    :CaseLevel: Integration
 
     :BZ: 1948758
     """

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Provisioning
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -30,8 +25,6 @@ def test_positive_end_to_end(session, module_org, module_location, target_sat):
     :id: 280afff3-ebf4-4a54-af11-200327b8957b
 
     :expectedresults: All scenarios flows work properly
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -154,8 +147,6 @@ def test_positive_verify_os_name(session, target_sat):
     :expectedresults: The full operating system name is displayed in the title column.
 
     :BZ: 1778503
-
-    :CaseLevel: Component
 
     :CaseImportance: Low
     """

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: OrganizationsandLocations
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -58,8 +53,6 @@ def test_positive_end_to_end(session):
     :id: abe878a9-a6bc-41e5-a39a-0fed9012b80f
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -208,8 +201,6 @@ def test_positive_create_with_all_users(session):
     :expectedresults: Organization and user entities assigned to each other
 
     :BZ: 1321543
-
-    :CaseLevel: Integration
     """
     user = entities.User().create()
     org = entities.Organization().create()
@@ -233,8 +224,6 @@ def test_positive_update_compresource(session):
     :id: a49349b9-4637-4ef6-b65b-bd3eccb5a12a
 
     :expectedresults: Compute resource is added and then removed.
-
-    :CaseLevel: Integration
     """
     url = f'{LIBVIRT_RESOURCE_URL}{settings.libvirt.libvirt_hostname}'
     resource = entities.LibvirtComputeResource(url=url).create()
@@ -265,8 +254,6 @@ def test_positive_delete_with_manifest_lces(session, target_sat, function_entitl
 
     :expectedresults: Organization is deleted successfully.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     org = function_entitlement_manifest_org
@@ -294,8 +281,6 @@ def test_positive_download_debug_cert_after_refresh(
 
     :expectedresults: Scenario passed successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     org = function_entitlement_manifest_org
@@ -317,14 +302,12 @@ def test_positive_errata_view_organization_switch(
 
     :id: faad9cf3-f8d5-49a6-87d1-431837b67675
 
-    :Steps: Create an Organization having a product synced which contains errata.
+    :steps: Create an Organization having a product synced which contains errata.
 
     :expectedresults: Verify that the errata belonging to one Organization is not
                       showing in the Default organization.
 
     :CaseImportance: High
-
-    :CaseLevel: Integration
     """
     rc = module_target_sat.cli_factory.RepositoryCollection(
         repositories=[module_target_sat.cli_factory.YumRepository(settings.repos.yum_3.url)]
@@ -346,15 +329,13 @@ def test_positive_product_view_organization_switch(session, module_org, module_p
 
     :id: 50cc459a-3a23-433a-99b9-9f3b929e6d64
 
-    :Steps:
+    :steps:
             1. Create an Organization having a product and verify that product is present in
                the Organization.
             2. Switch the Organization to default and verify that product is not visible in it.
 
     :expectedresults: Verify that the Product belonging to one Organization is not visible in
                       another organization.
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SCAPPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import os
 
@@ -45,7 +40,7 @@ def test_positive_end_to_end(
 
     :id: 9870555d-0b60-41ab-a481-81d4d3f78fec
 
-    :Steps:
+    :steps:
 
         1. Create an openscap content.
         2. Read values from created entity.
@@ -53,8 +48,6 @@ def test_positive_end_to_end(
         4. Delete openscap content
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
     """
     title = gen_string('alpha')
     new_title = gen_string('alpha')
@@ -93,7 +86,7 @@ def test_negative_create_with_same_name(session, oscap_content_path, default_org
 
     :id: f5c6491d-b83c-4ca2-afdf-4bb93e6dd92b
 
-    :Steps:
+    :steps:
 
         1. Create an openscap content.
         2. Provide all the appropriate parameters.
@@ -128,7 +121,7 @@ def test_external_disa_scap_content(session, default_org, default_location):
 
     :id: 5f29254e-7c15-45e1-a2ec-4da1d3d8d74d
 
-    :Steps:
+    :steps:
 
         1. Create an openscap content with external DISA SCAP content.
         2. Assert that openscap content has been created.

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SCAPPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from nailgun import entities
 import pytest
@@ -47,7 +42,7 @@ def test_positive_check_dashboard(
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
 
         1. Create new host group
         2. Create new host using host group from step 1
@@ -58,8 +53,6 @@ def test_positive_check_dashboard(
         data
 
     :BZ: 1424936
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     oscap_content_title = gen_string('alpha')
@@ -123,8 +116,6 @@ def test_positive_end_to_end(
     :id: 39c26f89-3147-4f27-bf5e-810f0ba721d8
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SCAPPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from nailgun import entities
 import pytest
@@ -30,8 +25,6 @@ def test_positive_end_to_end(session, tailoring_file_path, default_org, default_
     :id: 9aebccb8-6837-4583-8a8a-8883480ab688
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -82,8 +77,6 @@ def test_positive_search_in_repo(session, module_org, module_yum_repo):
 
     :expectedresults: Content search functionality works as intended and
         expected packages are present inside of repository
-
-    :CaseLevel: Integration
     """
     with session:
         session.organization.select(org_name=module_org.name)
@@ -108,8 +101,6 @@ def test_positive_search_in_multiple_repos(session, module_org, module_yum_repo,
         expected packages are present inside of repositories
 
     :BZ: 1514457
-
-    :CaseLevel: Integration
     """
     with session:
         session.organization.select(org_name=module_org.name)
@@ -138,8 +129,6 @@ def test_positive_check_package_details(session, module_org, module_yum_repo):
 
     :expectedresults: Package is present inside of repository and has all
         expected values in details section
-
-    :CaseLevel: Integration
 
     :customerscenario: true
     """
@@ -181,8 +170,6 @@ def test_positive_check_custom_package_details(session, module_org, module_yum_r
     :expectedresults: Package is present inside of repository and it
         possible to view its details
 
-    :CaseLevel: Integration
-
     :customerscenario: true
 
     :BZ: 1387766, 1394390
@@ -210,8 +197,6 @@ def test_positive_rh_repo_search_and_check_file_list(session, module_org, module
 
     :expectedresults: Content search functionality works as intended and
         package contains expected list of files
-
-    :CaseLevel: System
     """
     with session:
         session.organization.select(org_name=module_org.name)

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -36,8 +31,6 @@ def test_positive_create_default_for_organization(session):
 
     :expectedresults: New partition table is created and is present in the
         list of selected partition tables for any new organization
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """
@@ -66,8 +59,6 @@ def test_positive_create_custom_organization(session):
     :expectedresults: New partition table is created and is not present in
         the list of selected partition tables for any new organization
 
-    :CaseLevel: Integration
-
     :CaseImportance: Medium
     """
     name = gen_string('alpha')
@@ -94,8 +85,6 @@ def test_positive_create_default_for_location(session):
 
     :expectedresults: New partition table is created and is present in the
         list of selected partition tables for any new location
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """
@@ -124,8 +113,6 @@ def test_positive_create_custom_location(session):
     :expectedresults: New partition table is created and is not present in
         the list of selected partition tables for any new location
 
-    :CaseLevel: Integration
-
     :CaseImportance: Medium
     """
     name = gen_string('alpha')
@@ -151,8 +138,6 @@ def test_positive_delete_with_lock_and_unlock(session):
 
     :expectedresults: New partition table is created and not deleted when
         locked and only deleted after unlock
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """
@@ -181,8 +166,6 @@ def test_positive_clone(session):
     :id: 6050f66f-82e0-4694-a482-5ea449ed9a9d
 
     :expectedresults: New partition table is created and cloned successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """
@@ -218,8 +201,6 @@ def test_positive_end_to_end(session, module_org, module_location, template_data
     :id: ade8e9b8-01a7-476b-ad01-f3e6c119ec25
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import timedelta
 
@@ -45,8 +40,6 @@ def test_positive_end_to_end(session, module_org):
     :id: d0e1f0d1-2380-4508-b270-62c1d8b3e2ff
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """
@@ -113,8 +106,6 @@ def test_positive_create_in_different_orgs(session, product_name):
 
     :expectedresults: Product is created successfully in both
         organizations.
-
-    :CaseLevel: Integration
     """
     orgs = [entities.Organization().create() for _ in range(2)]
     with session:
@@ -133,8 +124,6 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
     :id: 4a87b533-12b6-4d4e-8a99-4bb95efc4321
 
     :expectedresults: Ensure sync get created and assigned to Product.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """
@@ -180,7 +169,7 @@ def test_positive_bulk_action_advanced_sync(session, module_org):
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Enable or create a repository and sync it.
         2. Navigate to Content > Product > click on the product.
         3. Click Select Action > Advanced Sync.

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ProvisioningTemplates
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -50,13 +45,11 @@ def test_positive_clone(module_org, module_location, target_sat, clone_setup):
 
     :id: 912f1619-4bb0-4e0f-88ce-88b5726fdbe0
 
-    :Steps:
+    :steps:
         1.  Go to Provisioning template UI
         2.  Choose a template and attempt to clone it
 
     :expectedresults: The template is cloned
-
-    :CaseLevel: Integration
     """
     clone_name = gen_string('alpha')
     with target_sat.ui_session() as session:
@@ -81,13 +74,11 @@ def test_positive_clone_locked(target_sat):
 
     :id: 2df8550a-fe7d-405f-ab48-2896554cda12
 
-    :Steps:
+    :steps:
         1.  Go to Provisioning template UI
         2.  Choose a locked provisioning template and attempt to clone it
 
     :expectedresults: The template is cloned
-
-    :CaseLevel: Integration
     """
     clone_name = gen_string('alpha')
     with target_sat.ui_session() as session:
@@ -111,8 +102,6 @@ def test_positive_end_to_end(module_org, module_location, template_data, target_
     :id: b44d4cc8-b78e-47cf-9993-0bb871ac2c96
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -190,7 +179,7 @@ def test_positive_verify_supported_templates_rhlogo(target_sat, module_org, modu
 
     :id: 2df8550a-fe7d-405f-ab48-2896554cda14
 
-    :Steps:
+    :steps:
         1.  Go to Provisioning template UI
         2.  Choose a any provisioning template and check if its supported or not
 

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Low
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -28,8 +23,6 @@ def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_org, modu
     :id: f837eec0-101c-4aff-a270-652005bdee51
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Low
 
-:Upstream: No
 """
 import pytest
 
@@ -30,8 +25,6 @@ def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_org, modu
     :id: 2ef32b2d-acdd-4cb1-a760-da4fd1166167
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -73,8 +66,6 @@ def test_positive_availability_for_host_and_hostgroup_in_multiple_orgs(
         organization where it is present in
 
     :BZ: 543178
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -2,8 +2,6 @@
 
 :Requirement: Registration
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Registration
 
 :CaseAutomation: Automated
@@ -11,10 +9,6 @@
 :CaseImportance: Critical
 
 :Team: Rocket
-
-:TestType: Functional
-
-:Upstream: No
 """
 from airgun.exceptions import DisabledWidgetError
 import pytest
@@ -34,8 +28,6 @@ def test_positive_verify_default_values_for_global_registration(
 
     :expectedresults: Default fields in the form should be auto-populated
         e.g. organization, location, rex, insights setup, etc
-
-    :CaseLevel: Component
 
     :steps:
         1. Check for the default values in the global registration template
@@ -74,8 +66,6 @@ def test_positive_org_loc_change_for_registration(
     :id: e83ed6bc-ceae-4021-87fe-3ecde1cbf347
 
     :expectedresults: organization and location is updated correctly on the global registration page as well as in the command.
-
-    :CaseLevel: Component
 
     :CaseImportance: Medium
     """

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RemoteExecution
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import datetime
 import time
@@ -35,7 +30,7 @@ def test_positive_run_default_job_template_by_ip(session, rex_contenthost, modul
 
     :Setup: Use pre-defined job template.
 
-    :Steps:
+    :steps:
 
         1. Navigate to an individual host and click Run Job
         2. Select the job and appropriate template
@@ -48,8 +43,6 @@ def test_positive_run_default_job_template_by_ip(session, rex_contenthost, modul
     :bz: 1898656
 
     :customerscenario: true
-
-    :CaseLevel: Integration
     """
     hostname = rex_contenthost.hostname
     with session:
@@ -90,7 +83,7 @@ def test_positive_run_custom_job_template_by_ip(session, module_org, rex_content
 
     :Setup: Create a working job template.
 
-    :Steps:
+    :steps:
 
         1. Set remote_execution_connect_by_ip on host to true
         2. Navigate to an individual host and click Run Job
@@ -100,8 +93,6 @@ def test_positive_run_custom_job_template_by_ip(session, module_org, rex_content
     :expectedresults: Verify the job was successfully ran against the host
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
 
     hostname = rex_contenthost.hostname
@@ -147,7 +138,7 @@ def test_positive_run_job_template_multiple_hosts_by_ip(
 
     :Setup: Create a working job template.
 
-    :Steps:
+    :steps:
 
         1. Set remote_execution_connect_by_ip on hosts to true
         2. Navigate to the hosts page and select at least two hosts
@@ -156,8 +147,6 @@ def test_positive_run_job_template_multiple_hosts_by_ip(
         5. Run the job
 
     :expectedresults: Verify the job was successfully ran against the hosts
-
-    :CaseLevel: System
     """
     host_names = []
     for vm in registered_hosts:
@@ -196,7 +185,7 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
 
     :Setup: Use pre-defined job template.
 
-    :Steps:
+    :steps:
 
         1. Set remote_execution_connect_by_ip on host to true
         2. Navigate to an individual host and click Run Job
@@ -211,8 +200,6 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
         2. Verify the job was successfully ran after the designated time
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     job_time = 10 * 60
     hostname = rex_contenthost.hostname
@@ -280,7 +267,7 @@ def test_positive_ansible_job_check_mode(session):
 
     :id: 7aeb7253-e555-4e28-977f-71f16d3c32e2
 
-    :Steps:
+    :steps:
 
         1. Set the value of the ansible_roles_check_mode parameter to true on a host
         2. Associate one or more Ansible roles with the host
@@ -288,8 +275,6 @@ def test_positive_ansible_job_check_mode(session):
 
     :expectedresults: Verify that the roles were run in check mode
                       (i.e. no changes were made on the host)
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -306,15 +291,13 @@ def test_positive_ansible_config_report_failed_tasks_errors(session):
 
     :id: 1a91e534-143f-4f35-953a-7ad8b7d2ddf3
 
-    :Steps:
+    :steps:
 
         1. Import Ansible roles
         2. Assign Ansible roles to a host
         3. Run Ansible roles on host
 
     :expectedresults: Verify that any task failures are listed as errors in the config report
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -331,7 +314,7 @@ def test_positive_ansible_config_report_changes_notice(session):
 
     :id: 8c90f179-8b70-4932-a477-75dc3566c437
 
-    :Steps:
+    :steps:
 
         1. Import Ansible Roles
         2. Assign Ansible roles to a host
@@ -339,8 +322,6 @@ def test_positive_ansible_config_report_changes_notice(session):
 
     :expectedresults: Verify that any tasks that make changes on the host
                       are listed as notice in the config report
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -357,13 +338,11 @@ def test_positive_ansible_variables_imported_with_roles(session):
 
     :id: 107c53e8-5a8a-4291-bbde-fbd66a0bb85e
 
-    :Steps:
+    :steps:
 
         1. Import Ansible roles
 
     :expectedresults: Verify that any variables in the role were also imported to Satellite
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -380,13 +359,11 @@ def test_positive_roles_import_in_background(session):
 
     :id: 4f1c7b76-9c67-42b2-9a73-980ca1f05abc
 
-    :Steps:
+    :steps:
 
         1. Import Ansible roles
 
     :expectedresults: Verify that the UI is accessible while roles are importing
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -403,14 +380,12 @@ def test_positive_ansible_roles_ignore_list(session):
 
     :id: 6fa1d8f0-b583-4a07-88eb-c9ae7fcd0219
 
-    :Steps:
+    :steps:
 
         1. Add roles to the ignore list in Administer > Settings > Ansible
         2. Navigate to Configure > Roles
 
     :expectedresults: Verify that any roles on the ignore list are not available for import
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -428,15 +403,13 @@ def test_positive_ansible_variables_installed_with_collection(session):
 
     :id: 7ff88022-fe9b-482f-a6bb-3922036a1e1c
 
-    :Steps:
+    :steps:
 
         1. Install an Ansible collection
         2. Navigate to Configure > Variables
 
     :expectedresults: Verify that any variables associated with the collection
                       are present on Configure > Variables
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -453,7 +426,7 @@ def test_positive_install_ansible_collection_via_job_invocation(session):
 
     :id: d4096aef-f6fc-41b6-ae56-d19b1f49cd42
 
-    :Steps:
+    :steps:
 
         1. Enable a host for remote execution
         2. Navigate to Hosts > Schedule Remote Job
@@ -463,8 +436,6 @@ def test_positive_install_ansible_collection_via_job_invocation(session):
         6. Click "Submit"
 
     :expectedresults: The Ansible collection is successfully installed on the host
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -481,7 +452,7 @@ def test_positive_set_ansible_role_order_per_host(session):
 
     :id: 24fbcd60-7cd1-46ff-86ac-16d6b436202c
 
-    :Steps:
+    :steps:
 
         1. Enable a host for remote execution
         2. Navigate to Hosts > All Hosts > $hostname > Edit > Ansible Roles
@@ -490,8 +461,6 @@ def test_positive_set_ansible_role_order_per_host(session):
         5. Run Ansible roles on the host
 
     :expectedresults: The roles are run in the specified order
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -508,7 +477,7 @@ def test_positive_set_ansible_role_order_per_hostgroup(session):
 
     :id: 9eb5bc8e-081a-45b9-8751-f4220c944da6
 
-    :Steps:
+    :steps:
 
         1. Enable a host for remote execution
         2. Create a host group
@@ -519,8 +488,6 @@ def test_positive_set_ansible_role_order_per_hostgroup(session):
         7. Run Ansible roles on the host group
 
     :expectedresults: The roles are run in the specified order
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 
@@ -537,7 +504,7 @@ def test_positive_matcher_field_highlight(session):
 
     :id: 67b45cfe-31bb-41a8-b88e-27917c68f33e
 
-    :Steps:
+    :steps:
 
         1. Navigate to Configure > Variables > $variablename
         2. Select the "Override" checkbox in the "Default Behavior" section
@@ -547,8 +514,6 @@ def test_positive_matcher_field_highlight(session):
         6. Add text to the "Value" input field
 
     :expectedresults: The background of each field turns yellow when a change is made
-
-    :CaseLevel: System
 
     :CaseAutomation: NotAutomated
 

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: Reporting
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import csv
 import json
@@ -145,8 +140,6 @@ def test_positive_end_to_end(session, module_org, module_location):
 
     :expectedresults: All expected CRUD actions finished successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     name = gen_string('alpha')
@@ -245,8 +238,6 @@ def test_positive_generate_registered_hosts_report(target_sat, module_org, modul
     :expectedresults: The Host - Registered Content Hosts report is generated (with host filter)
                       and it contains created host with correct data
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     # generate Host Status report
@@ -299,8 +290,6 @@ def test_positive_generate_subscriptions_report_json(
     :id: b44d4cd8-a88e-47cf-9993-0bb871ac2c96
 
     :expectedresults: The Subscriptions report is generated in JSON
-
-    :CaseLevel: Integration
 
     :CaseImportance: Medium
     """
@@ -496,6 +485,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
         4. Wait for dynflow
         5. As a different user, try to download the generated report
     :expectedresults: Report can't be downloaded. Error.
+
     :CaseImportance: High
     """
 

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime, timedelta
 from random import randint, shuffle
@@ -65,8 +60,6 @@ def test_positive_create_in_different_orgs(session, module_org):
 
     :expectedresults: Repository is created successfully for both
         organizations
-
-    :CaseLevel: Integration
     """
     repo_name = gen_string('alpha')
     org2 = entities.Organization().create()
@@ -100,8 +93,6 @@ def test_positive_create_as_non_admin_user(module_org, test_name, target_sat):
     :expectedresults: Repository successfully created
 
     :BZ: 1426393
-
-    :CaseLevel: Integration
     """
     user_login = gen_string('alpha')
     user_password = gen_string('alphanumeric')
@@ -152,8 +143,6 @@ def test_positive_create_yum_repo_same_url_different_orgs(session, module_prod):
     :id: f4cb00ed-6faf-4c79-9f66-76cd333299cb
 
     :expectedresults: Repositories are created and have equal number of packages.
-
-    :CaseLevel: Integration
     """
     # Create first repository
     repo = entities.Repository(product=module_prod, url=settings.repos.yum_0.url).create()
@@ -191,8 +180,6 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
     :expectedresults: New repository successfully created by non admin user
 
     :BZ: 1447829
-
-    :CaseLevel: Integration
     """
     user_login = gen_string('alpha')
     user_password = gen_string('alphanumeric')
@@ -262,8 +249,6 @@ def test_positive_discover_repo_via_existing_product(session, module_org):
     :id: 9181950c-a756-456f-a46a-059e7a2add3c
 
     :expectedresults: Repository is discovered and created
-
-    :CaseLevel: Integration
     """
     repo_name = 'fakerepo01'
     product = entities.Product(organization=module_org).create()
@@ -290,8 +275,6 @@ def test_positive_discover_repo_via_new_product(session, module_org):
     :id: dc5281f8-1a8a-4a17-b746-728f344a1504
 
     :expectedresults: Repository is discovered and created
-
-    :CaseLevel: Integration
     """
     product_name = gen_string('alpha')
     repo_name = 'fakerepo01'
@@ -319,11 +302,9 @@ def test_positive_discover_module_stream_repo_via_existing_product(session, modu
 
     :id: e7b9e2c4-7ecd-4cde-8f74-961fbac8919c
 
-    :CaseLevel: Integration
-
     :BZ: 1676642
 
-    :Steps:
+    :steps:
         1. Create a product.
         2. From Content > Products, click on the Repo Discovery button.
         3. Enter a url containing a yum repository with module streams, e.g.,
@@ -361,8 +342,6 @@ def test_positive_sync_custom_repo_yum(session, module_org):
     :id: afa218f4-e97a-4240-a82a-e69538d837a1
 
     :expectedresults: Sync procedure for specific yum repository is successful
-
-    :CaseLevel: Integration
     """
     product = entities.Product(organization=module_org).create()
     repo = entities.Repository(url=settings.repos.yum_1.url, product=product).create()
@@ -385,8 +364,6 @@ def test_positive_sync_custom_repo_docker(session, module_org):
 
     :expectedresults: Sync procedure for specific docker repository is
         successful
-
-    :CaseLevel: Integration
     """
     product = entities.Product(organization=module_org).create()
     repo = entities.Repository(
@@ -411,8 +388,6 @@ def test_positive_resync_custom_repo_after_invalid_update(session, module_org):
         procedure for specific yum repository is successful
 
     :BZ: 1487173, 1262313
-
-    :CaseLevel: Integration
     """
     product = entities.Product(organization=module_org).create()
     repo = entities.Repository(url=settings.repos.yum_1.url, product=product).create()
@@ -440,8 +415,6 @@ def test_positive_resynchronize_rpm_repo(session, module_prod):
     :id: dc415563-c9b8-4e3c-9d2a-f4ac251c7d35
 
     :expectedresults: Repository has updated non-zero package count
-
-    :CaseLevel: Integration
 
     :BZ: 1318004
     """
@@ -475,8 +448,6 @@ def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod):
     :id: 8baf11c9-019e-4625-a549-ec4cd9312f75
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -542,8 +513,6 @@ def test_positive_end_to_end_custom_module_streams_crud(session, module_org, mod
 
     :expectedresults: All expected CRUD actions finished successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
     """
     repo_name = gen_string('alpha')
@@ -587,8 +556,6 @@ def test_positive_upstream_with_credentials(session, module_prod):
         1. The custom repository is created with upstream credentials.
         2. The custom repository upstream credentials are updated.
         3. The credentials are cleared.
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
 
@@ -648,8 +615,7 @@ def test_positive_upstream_with_credentials(session, module_prod):
 #
 #     :expectedresults: All expected CRUD actions finished successfully
 #
-#     :CaseLevel: Integration
-#
+#     #
 #     :CaseImportance: High
 #
 #     :BZ: 1467722
@@ -688,10 +654,7 @@ def test_positive_sync_ansible_collection_gallaxy_repo(session, module_prod):
 
     :expectedresults: All content synced successfully
 
-    :CaseLevel: Integration
-
     :CaseImportance: High
-
     """
     repo_name = f'gallaxy-{gen_string("alpha")}'
     requirements = '''
@@ -728,8 +691,6 @@ def test_positive_no_errors_on_repo_scan(target_sat, function_sca_manifest_org):
     :customerscenario: True
 
     :BZ: 1994212
-
-    :CaseLevel: Integration
     """
     sat_rpm_extras = target_sat.cli_factory.RHELServerExtras(cdn=True)
     with target_sat.ui_session() as session:
@@ -749,8 +710,6 @@ def test_positive_reposet_disable(session, target_sat, function_entitlement_mani
     :id: de596c56-1327-49e8-86d5-a1ab907f26aa
 
     :expectedresults: RH repo was disabled
-
-    :CaseLevel: Integration
     """
     org = function_entitlement_manifest_org
     sat_tools_repo = target_sat.cli_factory.SatelliteToolsRepository(distro='rhel7', cdn=True)
@@ -797,8 +756,6 @@ def test_positive_reposet_disable_after_manifest_deleted(
     :expectedresults: RH repo was disabled
 
     :BZ: 1344391
-
-    :CaseLevel: Integration
     """
     org = function_entitlement_manifest_org
     sub = entities.Subscription(organization=org)
@@ -849,8 +806,6 @@ def test_positive_delete_random_docker_repo(session, module_org):
 
     :expectedresults: Random repository can be deleted from random product
         without altering the other products.
-
-    :CaseLevel: Integration
     """
     entities_list = []
     products = [entities.Product(organization=module_org).create() for _ in range(randint(2, 5))]
@@ -878,8 +833,6 @@ def test_positive_delete_rhel_repo(session, module_entitlement_manifest_org, tar
     :customerscenario: true
 
     :expectedresults: Repository can be successfully deleted
-
-    :CaseLevel: Integration
 
     :BZ: 1152672
     """
@@ -929,8 +882,6 @@ def test_positive_recommended_repos(session, module_entitlement_manifest_org):
            1. Shows repositories as per On/Off 'Recommended Repositories'.
            2. Check last Satellite version Capsule/Tools repos do not exist.
 
-    :CaseLevel: Integration
-
     :BZ: 1776108
     """
     with session:
@@ -963,7 +914,7 @@ def test_positive_upload_resigned_rpm():
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Buld or prepare an unsigned rpm.
         2. Create a gpg key.
         3. Use the gpg key to sign the rpm with sha1.
@@ -989,7 +940,7 @@ def test_positive_remove_srpm_change_checksum():
 
     :BZ: 1850914
 
-    :Steps:
+    :steps:
         1. Sync a repository that contains rpms and srpms and uses sha1 repodata.
         2. Re-sync the repository after an srpm has been removed and its repodata regenerated
            using sha256.
@@ -1011,7 +962,7 @@ def test_positive_repo_discovery_change_ssl():
 
     :BZ: 1789848
 
-    :Steps:
+    :steps:
         1. Navigate to Content > Products > click on 'Repo Discovery'.
         2. Set the repository type to 'Yum Repositories'.
         3. Enter an upstream URL to discover and click on 'Discover'.
@@ -1035,7 +986,7 @@ def test_positive_remove_credentials(session, function_product, function_org, fu
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Create a custom repository, with a repository type of 'yum' and an upstream username
         and password.
         3. Remove the saved credentials by clicking the delete icon next to the 'Upstream
@@ -1079,7 +1030,7 @@ def test_sync_status_persists_after_task_delete(session, module_prod, module_org
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Sync a custom Repo.
         2. Navigate to Content > Sync Status. Assert status is Synced.
         3. Use foreman-rake console to delete the Sync task.
@@ -1136,7 +1087,7 @@ def test_positive_sync_status_repo_display():
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Import manifest and enable RHEL 8 repositories.
         2. Navigate to Content > Sync Status.
 
@@ -1157,7 +1108,7 @@ def test_positive_search_enabled_kickstart_repos():
 
     :BZ: 1724807, 1829817
 
-    :Steps:
+    :steps:
         1. Import a manifest
         2. Navigate to Content > Red Hat Repositories, and enable some kickstart repositories.
         3. In the search bar on the right side, select 'Enabled/Both'.
@@ -1180,7 +1131,7 @@ def test_positive_rpm_metadata_display():
 
     :BZ: 1904369
 
-    :Steps:
+    :steps:
         1. Enable and sync a repository, e.g.,
            'Red Hat Satellite Tools 6.9 for RHEL 7 Server RPMs x86_64'.
         2. Navigate to Content > Packages > click on a package in the repository (e.g.,
@@ -1210,7 +1161,7 @@ def test_positive_select_org_in_any_context():
 
     :BZ: 1860957
 
-    :Steps:
+    :steps:
         1. Set "Any organization" and "Any location" on top
         2. Click on Content -> "Sync Status"
         3. "Select an Organization" page will come up.
@@ -1236,7 +1187,7 @@ def test_positive_sync_repo_and_verify_checksum(session, module_org):
 
     :BZ: 1951626
 
-    :Steps:
+    :steps:
         1. Enable and sync repository
         2. Go to Products -> Select Action -> Verify Content Checksum
 

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RHCloud-CloudConnector
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime, timedelta
 
@@ -120,15 +115,13 @@ def test_positive_configure_cloud_connector(
 
     :id: 67e45cfe-31bb-51a8-b88f-27918c68f32e
 
-    :Steps:
+    :steps:
 
         1. Navigate to Configure > Inventory Upload
         2. Click Configure Cloud Connector
         3. Open the started job and wait until it is finished
 
     :expectedresults: The Cloud Connector has been installed and the service is running
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
 

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: RHCloud-Inventory
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime
 
@@ -46,7 +41,7 @@ def test_rhcloud_insights_e2e(
 
     :id: d952e83c-3faf-4299-a048-2eb6ccb8c9c2
 
-    :Steps:
+    :steps:
         1. Prepare misconfigured machine and upload its data to Insights.
         2. In Satellite UI, go to Configure -> Insights -> Sync recommendations.
         3. Run remediation for "OpenSSH config permissions" recommendation against host.
@@ -141,7 +136,7 @@ def test_insights_reporting_status():
 
     :id: 75629a08-b585-472b-a295-ce497075e519
 
-    :Steps:
+    :steps:
         1. Register a satellite content host with insights.
         2. Change 48 hours of wait time to 4 minutes in insights_client_report_status.rb file.
             See foreman_rh_cloud PR#596.
@@ -167,7 +162,7 @@ def test_recommendation_sync_for_satellite():
 
     :id: ee3feba3-c255-42f1-8293-b04d540dcca5
 
-    :Steps:
+    :steps:
         1. Register Satellite with insights.(satellite-installer --register-with-insights)
         2. Add RH cloud token in settings.
         3. Go to Configure > Insights > Click on Sync recommendations button.
@@ -194,7 +189,7 @@ def test_host_sorting_based_on_recommendation_count():
 
     :id: b1725ec1-60db-422e-809d-f81d99ae156e
 
-    :Steps:
+    :steps:
         1. Register few satellite content host with insights.
         2. Sync Insights recommendations.
         3. Go to Hosts > All Host
@@ -227,7 +222,7 @@ def test_host_details_page(
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
         1. Prepare misconfigured machine and upload its data to Insights.
         2. Sync insights recommendations.
         3. Sync RH Cloud inventory status.

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: System
-
 :CaseComponent: RHCloud-Inventory
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime, timedelta
 
@@ -150,7 +145,7 @@ def test_rh_cloud_inventory_settings(
 
     :customerscenario: true
 
-    :Steps:
+    :steps:
 
         1. Prepare machine and upload its data to Insights.
         2. Go to Configure > Inventory upload > enable “Obfuscate host names” setting.
@@ -294,7 +289,7 @@ def test_failed_inventory_upload():
 
     :id: 230d3fc3-2810-4385-b07b-30f9bf632488
 
-    :Steps:
+    :steps:
         1. Register a satellite content host with insights.
         2. Change 'DEST' from /var/lib/foreman/red_hat_inventory/uploads/uploader.sh
             to an invalid url.
@@ -318,7 +313,7 @@ def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
 
     :id: 1d90bb24-2380-4653-8ed6-a084fce66d1e
 
-    :Steps:
+    :steps:
         1. Don't import manifest to satellite.
         3. Go to Configure > Inventory upload > Click on restart button.
 

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -36,8 +31,6 @@ def test_positive_end_to_end(session, module_org, module_location):
     :id: 3284016a-e2df-4a0e-aa24-c95ab132eec1
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :customerscenario: true
 

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: Settings
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import math
 
@@ -64,8 +59,6 @@ def test_positive_update_restrict_composite_view(session, setting_update, repo_s
     :expectedresults: Parameter is updated successfully
 
     :CaseImportance: Critical
-
-    :CaseLevel: Acceptance
     """
     property_name = setting_update.name
     composite_cv = entities.ContentView(composite=True, organization=repo_setup['org']).create()
@@ -110,7 +103,6 @@ def test_positive_httpd_proxy_url_update(session, setting_update):
     :BZ: 1677282
 
     :CaseImportance: Medium
-
     """
     property_name = setting_update.name
     with session:
@@ -214,8 +206,6 @@ def test_positive_update_login_page_footer_text(session, setting_update):
     :customerscenario: true
 
     :BZ: 2157869
-
-    :CaseLevel: Acceptance
     """
     property_name = setting_update.name
     default_value = setting_update.default
@@ -259,8 +249,6 @@ def test_negative_settings_access_to_non_admin(module_target_sat):
     :expectedresults: Administer -> Settings tab should not be available to non admin users
 
     :CaseImportance: Medium
-
-    :CaseLevel: Acceptance
     """
     login = gen_string('alpha')
     password = gen_string('alpha')
@@ -306,8 +294,6 @@ def test_positive_update_email_delivery_method_smtp():
 
     :CaseImportance: Critical
 
-    :CaseLevel: Acceptance
-
     :CaseAutomation: NotAutomated
     """
 
@@ -341,8 +327,6 @@ def test_negative_update_email_delivery_method_smtp():
 
     :CaseImportance: Critical
 
-    :CaseLevel: Acceptance
-
     :CaseAutomation: NotAutomated
     """
 
@@ -372,8 +356,6 @@ def test_positive_update_email_delivery_method_sendmail(session, target_sat):
     :BZ: 2080324
 
     :CaseImportance: Critical
-
-    :CaseLevel: Acceptance
     """
     property_name = "Email"
     mail_config_default_param = {
@@ -436,8 +418,6 @@ def test_negative_update_email_delivery_method_sendmail():
 
     :CaseImportance: Critical
 
-    :CaseLevel: Acceptance
-
     :CaseAutomation: NotAutomated
     """
 
@@ -468,8 +448,6 @@ def test_positive_email_yaml_config_precedence():
 
     :CaseImportance: Critical
 
-    :CaseLevel: Acceptance
-
     :CaseAutomation: NotAutomated
     """
 
@@ -481,7 +459,7 @@ def test_negative_update_hostname_with_empty_fact(session, setting_update):
 
     :id: e0eaab69-4926-4c1e-b111-30c51ede273e
 
-    :Steps:
+    :steps:
 
         1. Goto settings ->Discovered tab -> Hostname_facts
         2. Set empty hostname_facts (without any value)
@@ -494,7 +472,6 @@ def test_negative_update_hostname_with_empty_fact(session, setting_update):
 
     :expectedresults: Error should be raised on setting empty value for
         hostname_facts setting
-
     """
     new_hostname = ""
     property_name = setting_update.name
@@ -512,7 +489,7 @@ def test_positive_entries_per_page(session, setting_update):
 
     :id: 009026b6-7550-40aa-9f78-5eb7f7e3800f
 
-    :Steps:
+    :steps:
         1. Navigate to Administer > Settings > General tab
         2. Update the entries per page value
         3. GoTo Monitor > Tasks Table > Pagination
@@ -529,8 +506,6 @@ def test_positive_entries_per_page(session, setting_update):
     :BZ: 1746221
 
     :CaseImportance: Medium
-
-    :CaseLevel: Acceptance
     """
     property_name = setting_update.name
     property_value = 19

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from random import choice, uniform
 
@@ -79,8 +74,6 @@ def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_classes, 
     :id: 05ccb04e-5d21-44cc-a01c-807469be06c0
 
     :expectedresults: All expected basic actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -200,8 +193,6 @@ def test_positive_create_matcher_attribute_priority(
         8.  Resubmit the same form to check bz-1241249
 
     :expectedresults: The YAML output has the value only for fqdn matcher.
-
-    :CaseLevel: Integration
 
     :BZ: 1241249
 
@@ -380,8 +371,6 @@ def test_positive_update_matcher_from_attribute(
         1.  The host/hostgroup is saved with changes.
         2.  Matcher value in parameter is updated from fqdn/hostgroup.
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     sc_param = sc_params_list.pop()
@@ -448,8 +437,6 @@ def test_positive_impact_parameter_delete_attribute(
         1.  The matcher for deleted attribute removed from parameter.
         2.  On recreating attribute, the matcher should not reappear
             in parameter.
-
-    :CaseLevel: Integration
     """
     sc_param = sc_params_list.pop()
     matcher_value = gen_string('alpha')
@@ -521,8 +508,6 @@ def test_positive_hidden_value_in_attribute(
         3.  In parameter, new matcher created for fqdn/hostgroup.
         4.  And the value shown hidden.
         5.  Parameter is successfully unhidden.
-
-    :CaseLevel: Integration
 
     :CaseImportance: Critical
     """

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Networking
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_ipaddr
 import pytest
@@ -39,8 +34,6 @@ def test_positive_end_to_end(session, module_target_sat, module_dom):
     :id: f77031c9-2ca8-44db-8afa-d0212aeda540
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: SubscriptionManagement
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from tempfile import mkstemp
 import time
@@ -150,8 +145,6 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name, target_
 
     :BZ: 1417082
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     org = entities.Organization().create()
@@ -197,8 +190,6 @@ def test_positive_access_with_non_admin_user_with_manifest(
 
     :customerscenario: true
 
-    :CaseLevel: Integration
-
     :CaseImportance: Critical
     """
     org = function_entitlement_manifest_org
@@ -236,8 +227,6 @@ def test_positive_access_manifest_as_another_admin_user(
     :BZ: 1669241
 
     :customerscenario: true
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -299,8 +288,6 @@ def test_positive_view_vdc_subscription_products(
     :BZ: 1366327
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     org = function_entitlement_manifest_org
     lce = entities.LifecycleEnvironment(organization=org).create()
@@ -359,8 +346,6 @@ def test_positive_view_vdc_guest_subscription_products(
     :BZ: 1395788, 1506636, 1487317
 
     :parametrized: yes
-
-    :CaseLevel: System
     """
     org = function_entitlement_manifest_org
     lce = entities.LifecycleEnvironment(organization=org).create()

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Repositories
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -70,8 +65,6 @@ def test_positive_sync_rh_repos(session, target_sat, module_entitlement_manifest
     :id: e30f6509-0b65-4bcc-a522-b4f3089d3911
 
     :expectedresults: Sync procedure for RedHat Repos is successful
-
-    :CaseLevel: Integration
     """
     repos = (
         target_sat.cli_factory.SatelliteCapsuleRepository(cdn=True),
@@ -113,8 +106,6 @@ def test_positive_sync_custom_ostree_repo(session, module_custom_product):
 
     :customerscenario: true
 
-    :CaseLevel: Integration
-
     :BZ: 1625783
     """
     repo = entities.Repository(
@@ -139,15 +130,13 @@ def test_positive_sync_rh_ostree_repo(session, target_sat, module_entitlement_ma
 
     :id: 4d28fff0-5fda-4eee-aa0c-c5af02c31de5
 
-    :Steps:
+    :steps:
         1. Import a valid manifest
         2. Enable the OStree repo and sync it
 
     :customerscenario: true
 
     :expectedresults: ostree repo should be synced successfully from CDN
-
-    :CaseLevel: Integration
 
     :BZ: 1625783
     """
@@ -175,8 +164,6 @@ def test_positive_sync_docker_via_sync_status(session, module_org):
 
     :expectedresults: Sync procedure for specific docker repository is
         successful
-
-    :CaseLevel: Integration
     """
     product = entities.Product(organization=module_org).create()
     repo_name = gen_string('alphanumeric')

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SyncPlans
 
 :team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime, timedelta
 import time
@@ -60,8 +55,6 @@ def test_positive_end_to_end(session, module_org, target_sat):
     :expectedresults: All CRUD actions for component finished successfully
 
     :customerscenario: true
-
-    :CaseLevel: Integration
 
     :BZ: 1693795
     """
@@ -115,8 +108,6 @@ def test_positive_end_to_end_custom_cron(session):
     :id: 48c88529-6318-47b0-97bc-eb46aae0294a
 
     :expectedresults: All CRUD actions for component finished successfully
-
-    :CaseLevel: Integration
     """
     plan_name = gen_string('alpha')
     description = gen_string('alpha')
@@ -198,8 +189,6 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
     :id: c551ef9a-6e5a-435a-b24d-e86de203a2bb
 
     :expectedresults: Product is synchronized successfully.
-
-    :CaseLevel: System
     """
     plan_name = gen_string('alpha')
     product = entities.Product(organization=module_org).create()
@@ -266,8 +255,6 @@ def test_positive_synchronize_custom_product_custom_cron_past_sync_date(
     :id: 4d9ed0bf-a63c-44de-846d-7cf302273bcc
 
     :expectedresults: Product is synchronized successfully.
-
-    :CaseLevel: System
     """
     plan_name = gen_string('alpha')
     product = entities.Product(organization=module_org).create()

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Integration
-
 :CaseComponent: TemplatesPlugin
 
 :Team: Endeavour
 
-:TestType: Functional
-
-:Upstream: No
 """
 from fauxfactory import gen_string
 from nailgun import entities
@@ -45,7 +40,7 @@ def test_positive_import_templates(session, templates_org, templates_loc):
 
     :bz: 1778181, 1778139
 
-    :Steps:
+    :steps:
 
         1. Navigate to Host -> Sync Templates, and choose Import.
         2. Select fields:
@@ -102,7 +97,7 @@ def test_positive_export_templates(session, create_import_export_local_dir, targ
 
     :bz: 1778139
 
-    :Steps:
+    :steps:
 
         1. Navigate to Host -> Sync Templates, and choose Export.
         2. Select fields:
@@ -163,7 +158,7 @@ def test_positive_export_filtered_templates_to_git(session, git_repository, git_
 
     :id: e4de338a-9ab9-492e-ac42-6cc2ebcd1792
 
-    :Steps:
+    :steps:
         1. Export only the templates matching with regex e.g: `^atomic.*` to git repo.
 
     :expectedresults:

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import random
 
@@ -35,8 +30,6 @@ def test_positive_end_to_end(session, target_sat, test_name, module_org, module_
     :id: 2794fdd0-cfe3-4f1a-aa5f-25b2d211ae12
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """
@@ -111,8 +104,6 @@ def test_positive_create_with_multiple_roles(session, target_sat):
 
     :expectedresults: User is created successfully and has proper roles
         assigned
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     role1 = gen_string('alpha')
@@ -142,8 +133,6 @@ def test_positive_create_with_all_roles(session):
     :id: 814593ca-1566-45ea-9eff-e880183b1ee3
 
     :expectedresults: User is created successfully
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     password = gen_string('alpha')
@@ -169,8 +158,6 @@ def test_positive_create_with_multiple_orgs(session, target_sat):
     :id: d74c0284-3995-4a4a-8746-00858282bf5d
 
     :expectedresults: User is created successfully
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     org_name1 = gen_string('alpha')
@@ -205,8 +192,6 @@ def test_positive_update_with_multiple_roles(session, target_sat):
     :id: 127fb368-09fd-4f10-8319-566a1bcb5cd2
 
     :expectedresults: User is updated successfully
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     role_names = [target_sat.api.Role().create().name for _ in range(3)]
@@ -233,8 +218,6 @@ def test_positive_update_with_all_roles(session):
     :id: cd7a9cfb-a700-45f2-a11d-bba6be3c810d
 
     :expectedresults: User is updated successfully
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     password = gen_string('alpha')
@@ -260,8 +243,6 @@ def test_positive_update_orgs(session, target_sat):
     :id: a207188d-1ad1-4ff1-9906-bae1d91104fd
 
     :expectedresults: User is updated
-
-    :CaseLevel: Integration
     """
     name = gen_string('alpha')
     password = gen_string('alpha')
@@ -294,8 +275,6 @@ def test_positive_create_product_with_limited_user_permission(
     :expectedresults: User successfully creates new product
 
     :customerscenario: true
-
-    :CaseLevel: Component
 
     :CaseImportance: High
 
@@ -344,8 +323,6 @@ def test_personal_access_token_admin():
         1. Should show output of the api endpoint
         2. When revoked, authentication error
 
-    :CaseLevel: System
-
     :CaseImportance: High
     """
 
@@ -369,8 +346,6 @@ def test_positive_personal_access_token_user_with_role():
         2. When an incorrect role and end point is used, missing
            permission should be displayed.
 
-    :CaseLevel: System
-
     :CaseImportance: High
     """
 
@@ -388,8 +363,6 @@ def test_expired_personal_access_token():
         3. Try using the token with any end point.
 
     :expectedresults: Authentication error
-
-    :CaseLevel: System
 
     :CaseImportance: Medium
     """

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string, gen_utf8
 from nailgun import entities
@@ -29,8 +24,6 @@ def test_positive_delete_with_user(session, module_org, module_location):
     :id: 2bda3db5-f54f-412f-831f-8e005631f271
 
     :expectedresults: Usergroup is deleted but added user is not
-
-    :CaseLevel: Integration
     """
     user_name = gen_string('alpha')
     group_name = gen_utf8(smp=False)
@@ -59,8 +52,6 @@ def test_positive_end_to_end(session, module_org, module_location):
     :id: c1c7c383-b118-4caf-a5ef-4e75fdbbacdc
 
     :expectedresults: All expected CRUD actions finished successfully
-
-    :CaseLevel: Integration
 
     :CaseImportance: High
     """

--- a/tests/foreman/ui/test_webhook.py
+++ b/tests/foreman/ui/test_webhook.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: HooksandWebhooks
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string, gen_url
 import pytest

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -42,8 +37,6 @@ class TestVirtWhoConfigforEsx:
         :id: 72d74c05-2580-4f38-b6c0-999ff470d4d6
 
         :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -94,8 +87,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: debug option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         options = {'true': '1', 'false': '0', '1': '1', '0': '0'}
@@ -119,8 +110,6 @@ class TestVirtWhoConfigforEsx:
         :id: 65f4138b-ca8f-4f1e-805c-1a331b951be5
 
         :expectedresults: interval option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -155,8 +144,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: hypervisor_id option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         # esx and rhevm support hwuuid option
@@ -182,8 +169,6 @@ class TestVirtWhoConfigforEsx:
         :id: 1f251d89-5e22-4470-be4c-0aeba84c0273
 
         :expectedresults: filter and filter_hosts can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -235,8 +220,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: http_proxy/https_proxy and no_proxy option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
 
         :BZ: 1902199
@@ -282,8 +265,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: Config can be searched in org list
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         command = get_configure_command(virtwho_config_api.id, default_org.name)
@@ -302,8 +283,6 @@ class TestVirtWhoConfigforEsx:
         :id: 3a79d65a-e206-4693-a5ba-59f6c44c984e
 
         :expectedresults: Config can be created and deployed without any error
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 
@@ -357,8 +336,6 @@ class TestVirtWhoConfigforEsx:
         :expectedresults:
             the option "env=" should be removed from etc/virt-who.d/virt-who.conf
             /var/log/messages should not display warning message
-
-        :CaseLevel: Integration
 
         :customerscenario: true
 

--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :Team: Phoenix
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -41,8 +36,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: Config can be created and deployed
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_api.status == 'unknown'
@@ -64,8 +57,6 @@ class TestVirtWhoConfigforEsx:
         :id: 61eeef42-12a0-4b92-9b87-c409b2507052
 
         :expectedresults: debug option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -90,8 +81,6 @@ class TestVirtWhoConfigforEsx:
         :id: aa9c7f19-c402-4197-9d3a-1379d9126620
 
         :expectedresults: interval option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -126,8 +115,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: hypervisor_id option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         for value in ['uuid', 'hostname']:
@@ -155,8 +142,6 @@ class TestVirtWhoConfigforEsx:
         :expectedresults:
             1. filter and filter_hosts can be updated.
             2. create virt-who config with filter and filter_hosts options work well.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -253,8 +238,6 @@ class TestVirtWhoConfigforEsx:
             1. http_proxy and no_proxy option can be updated.
             2. create virt-who config with http_proxy and no_proxy options work well.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
 
         :BZ: 1902199
@@ -330,8 +313,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: Config can be searched in org list
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         command = get_configure_command(virtwho_config_api.id, module_sca_manifest_org.name)
@@ -350,8 +331,6 @@ class TestVirtWhoConfigforEsx:
         :id: 7d957371-ae2e-440d-8e19-22eb34922b36
 
         :expectedresults: Config can be created and deployed without any error
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 
@@ -405,8 +384,6 @@ class TestVirtWhoConfigforEsx:
         :expectedresults:
             1. the option "env=" should be removed from etc/virt-who.d/virt-who.conf
             2. /var/log/messages should not display warning message
-
-        :CaseLevel: Integration
 
         :customerscenario: true
 

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -38,8 +33,6 @@ class TestVirtWhoConfigforHyperv:
         :id: f5228e01-bb8d-4c8e-877e-cd8bc494f00e
 
         :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -89,8 +82,6 @@ class TestVirtWhoConfigforHyperv:
         :id: 16344235-1607-4f60-950b-5a91546cf8f4
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -38,8 +33,6 @@ class TestVirtWhoConfigforHyperv:
 
         :expectedresults: Config can be created and deployed
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_api.status == 'unknown'
@@ -61,8 +54,6 @@ class TestVirtWhoConfigforHyperv:
         :id: 893c043f-a22d-4564-99ce-b7dcc14059bf
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -39,8 +34,6 @@ class TestVirtWhoConfigforKubevirt:
         :id: 97f776af-cbd0-4885-9a74-603a3bc01157
 
         :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -90,8 +83,6 @@ class TestVirtWhoConfigforKubevirt:
         :id: c1ca38e8-6030-4a3f-8880-00ab3f29574a
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -36,8 +31,6 @@ class TestVirtWhoConfigforKubevirt:
 
         :expectedresults: Config can be created and deployed
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_api.status == 'unknown'
@@ -59,8 +52,6 @@ class TestVirtWhoConfigforKubevirt:
         :id: 9072c1c8-1ea3-4311-99c9-94d3d3a0e8d8
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -38,8 +33,6 @@ class TestVirtWhoConfigforLibvirt:
         :id: 2598cfa8-3bec-4f41-9911-979ae92c89c0
 
         :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -89,8 +82,6 @@ class TestVirtWhoConfigforLibvirt:
         :id: 37a08451-2add-4c5c-bab6-ebe002a746f1
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -36,8 +31,6 @@ class TestVirtWhoConfigforLibvirt:
 
         :expectedresults: Config can be created and deployed
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_api.status == 'unknown'
@@ -57,8 +50,6 @@ class TestVirtWhoConfigforLibvirt:
         :id: 60f373f0-5179-4531-834d-c297f9f7ea2d
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -42,8 +37,6 @@ class TestVirtWhoConfigforNutanix:
         :id: b1d8d261-80e0-498f-89fc-b1a246b46b83
 
         :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -98,8 +91,6 @@ class TestVirtWhoConfigforNutanix:
 
         :expectedresults: hypervisor_id option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         values = ['uuid', 'hostname']
@@ -125,8 +116,6 @@ class TestVirtWhoConfigforNutanix:
         :expectedresults:
             Config can be created and deployed
             The prism_central has been set in /etc/virt-who.d/vir-who.conf file
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -198,8 +187,6 @@ class TestVirtWhoConfigforNutanix:
 
         :expectedresults: prism_flavor option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         value = 'central'
@@ -228,7 +215,6 @@ class TestVirtWhoConfigforNutanix:
             5. message Host UUID {system_uuid} found for VM: {guest_uuid} exist in rhsm.log
             6. ahv_internal_debug bas been set to true in virt-who-config-X.conf
             7. warning message does not exist in log file /var/log/rhsm/rhsm.log
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :Team: Phoenix
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -39,8 +34,6 @@ class TestVirtWhoConfigforNutanix:
 
         :expectedresults: Config can be created and deployed
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_api.status == 'unknown'
@@ -62,8 +55,6 @@ class TestVirtWhoConfigforNutanix:
         :id: 850cc280-3f5a-498e-9132-5672dfe2f865
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -89,8 +80,6 @@ class TestVirtWhoConfigforNutanix:
         :expectedresults:
             Config can be created and deployed
             The prism_central has been set in /etc/virt-who.d/vir-who.conf file
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -134,8 +123,6 @@ class TestVirtWhoConfigforNutanix:
         :id: f6ca8722-8f39-47b2-b7c0-e0c554aa7c65
 
         :expectedresults: prism_flavor option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import re
 
@@ -47,8 +42,6 @@ class TestVirtWhoConfigforEsx:
         :id: 1885dd56-e3f9-43a7-af27-e496967b6256
 
         :expectedresults: Config can be created and deployed
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -92,8 +85,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: debug option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         virtwho_config = target_sat.cli.VirtWhoConfig.create(form_data_cli)['general-information']
@@ -122,8 +113,6 @@ class TestVirtWhoConfigforEsx:
         :id: 5d558bca-534c-4bd4-b401-a0c362033c57
 
         :expectedresults: interval option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -155,8 +144,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: hypervisor_id option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         # esx and rhevm support hwuuid option
@@ -183,8 +170,6 @@ class TestVirtWhoConfigforEsx:
         :id: aaf45c5e-9504-47ce-8f25-b8073c2de036
 
         :expectedresults: filter and filter_hosts can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -237,8 +222,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: http_proxy and no_proxy option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
 
         :BZ: 1902199
@@ -281,8 +264,6 @@ class TestVirtWhoConfigforEsx:
             rhsm_hostname, rhsm_prefix are ecpected
             rhsm_username is not a login account
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         config_file = get_configure_file(virtwho_config_cli['id'])
@@ -303,8 +284,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults:
             hypervisor/guest json can be posted and the task is success status
-
-        :CaseLevel: Integration
 
         :customerscenario: true
 
@@ -335,8 +314,6 @@ class TestVirtWhoConfigforEsx:
             virt-who packages can be installed
             the virt-who plugin can be deployed successfully
 
-        :CaseLevel: Integration
-
         :customerscenario: true
 
         :CaseImportance: Medium
@@ -365,8 +342,6 @@ class TestVirtWhoConfigforEsx:
         :id: 9892a94e-ff4b-44dd-87eb-1289d4a965be
 
         :expectedresults: Config can be created and deployed without any error
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 
@@ -415,8 +390,6 @@ class TestVirtWhoConfigforEsx:
         :expectedresults:
             the option "env=" should be removed from etc/virt-who.d/virt-who.conf
             /var/log/messages should not display warning message
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :Team: Phoenix
 
-:TestType: Functional
-
-:Upstream: No
 """
 import re
 
@@ -49,8 +44,6 @@ class TestVirtWhoConfigforEsx:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_cli['status'] == 'No Report Yet'
@@ -68,8 +61,6 @@ class TestVirtWhoConfigforEsx:
         :id: 995a6709-e839-4198-89db-37cde8fd0a7b
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -96,8 +87,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults: debug option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         assert virtwho_config_cli['name'] == form_data_cli['name']
@@ -119,8 +108,6 @@ class TestVirtWhoConfigforEsx:
         :id: 8d22c7b8-756b-4f79-83be-34ccb2609388
 
         :expectedresults: name option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -144,8 +131,6 @@ class TestVirtWhoConfigforEsx:
         :id: 9b2ffa5a-c0e9-43e7-bf63-f64832cf7715
 
         :expectedresults: interval option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -186,8 +171,6 @@ class TestVirtWhoConfigforEsx:
         :expectedresults:
             1. filter and filter_hosts can be updated.
             2. create virt-who config with filter and filter_hosts options work well.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -273,8 +256,6 @@ class TestVirtWhoConfigforEsx:
             1. http_proxy and no_proxy option can be updated.
             2. create virt-who config with http_proxy and no_proxy options work well.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
 
         :BZ: 1902199
@@ -355,8 +336,6 @@ class TestVirtWhoConfigforEsx:
             1. rhsm_hostname, rhsm_prefix are expected
             2. rhsm_username is not a login account
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         config_file = get_configure_file(virtwho_config_cli['id'])
@@ -377,8 +356,6 @@ class TestVirtWhoConfigforEsx:
 
         :expectedresults:
             hypervisor/guest json can be posted and the task is success status
-
-        :CaseLevel: Integration
 
         :customerscenario: true
 
@@ -409,8 +386,6 @@ class TestVirtWhoConfigforEsx:
             1. virt-who packages can be installed
             2. the virt-who plugin can be deployed successfully
 
-        :CaseLevel: Integration
-
         :customerscenario: true
 
         :CaseImportance: Medium
@@ -436,8 +411,6 @@ class TestVirtWhoConfigforEsx:
         :id: a691267a-008e-4f22-ab49-c1ec1612a628
 
         :expectedresults: Config can be created and deployed without any error
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 
@@ -492,8 +465,6 @@ class TestVirtWhoConfigforEsx:
         :expectedresults:
             1. the option "env=" should be removed from etc/virt-who.d/virt-who.conf
             2. /var/log/messages should not display warning message
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -40,8 +35,6 @@ class TestVirtWhoConfigforHyperv:
         :expectedresults:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -80,8 +73,6 @@ class TestVirtWhoConfigforHyperv:
         :id: 8e234492-33cb-4523-abb3-582626ad704c
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -40,8 +35,6 @@ class TestVirtWhoConfigforHyperv:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_cli['status'] == 'No Report Yet'
@@ -60,8 +53,6 @@ class TestVirtWhoConfigforHyperv:
         :id: 3fb2702a-567c-4bc9-a692-e4a01ff520f3
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -40,8 +35,6 @@ class TestVirtWhoConfigforKubevirt:
         :expectedresults:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -80,8 +73,6 @@ class TestVirtWhoConfigforKubevirt:
         :id: 57b89c7e-538e-4ab8-98b5-af4b9f587792
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -38,8 +33,6 @@ class TestVirtWhoConfigforKubevirt:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_cli['status'] == 'No Report Yet'
@@ -56,8 +49,6 @@ class TestVirtWhoConfigforKubevirt:
 
         :id: b60f449d-6698-4a3a-be07-7440c2d9ba20
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -40,8 +35,6 @@ class TestVirtWhoConfigforLibvirt:
         :expectedresults:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -80,8 +73,6 @@ class TestVirtWhoConfigforLibvirt:
         :id: 082a0eec-f024-4605-b876-a8959cf68e0c
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -38,8 +33,6 @@ class TestVirtWhoConfigforLibvirt:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_cli['status'] == 'No Report Yet'
@@ -57,8 +50,6 @@ class TestVirtWhoConfigforLibvirt:
         :id: e68421b5-ff3d-4f25-926d-8330b92f2cdf
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -43,8 +38,6 @@ class TestVirtWhoConfigforNutanix:
         :expectedresults:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -84,8 +77,6 @@ class TestVirtWhoConfigforNutanix:
 
         :expectedresults: hypervisor_id option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         values = ['uuid', 'hostname']
@@ -114,8 +105,6 @@ class TestVirtWhoConfigforNutanix:
         :expectedresults:
             Config can be created and deployed
             The prism_central has been set in /etc/virt-who.d/vir-who.conf file
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -171,8 +160,6 @@ class TestVirtWhoConfigforNutanix:
 
         :expectedresults: prism_central option can be updated.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         value = 'central'
@@ -207,11 +194,11 @@ class TestVirtWhoConfigforNutanix:
             5. message Host UUID {system_uuid} found for VM: {guest_uuid} exist in rhsm.log
             6. ahv_internal_debug bas been set to true in virt-who-config-X.conf
             7. warning message does not exist in log file /var/log/rhsm/rhsm.log
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 
         :BZ: 2141719
+
         :customerscenario: true
         """
         command = get_configure_command(virtwho_config_cli['id'], default_org.name)

--- a/tests/foreman/virtwho/cli/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/cli/test_nutanix_sca.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :Team: Phoenix
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -41,8 +36,6 @@ class TestVirtWhoConfigforNutanix:
             1. Config can be created and deployed
             2. Config can be created, fetch and deploy
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert virtwho_config_cli['status'] == 'No Report Yet'
@@ -60,8 +53,6 @@ class TestVirtWhoConfigforNutanix:
         :id: 565228cd-2124-41ed-89b7-84ec6ff77213
 
         :expectedresults: hypervisor_id option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -91,8 +82,6 @@ class TestVirtWhoConfigforNutanix:
             1. Config can be created and deployed
             2. The prism_central has been set in /etc/virt-who.d/vir-who.conf file
             3. Config can be created, fetch and deploy
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -134,8 +123,6 @@ class TestVirtWhoConfigforNutanix:
         :id: 68c75ae0-0beb-483e-874a-b14f8171f40a
 
         :expectedresults: prism_central option can be updated.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -49,7 +49,6 @@ def session(test_name, module_user):
             with session:
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
-
     """
     return Session(test_name, module_user.login, module_user.password)
 
@@ -97,6 +96,5 @@ def session_sca(test_name, module_user_sca):
             with session:
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
-
     """
     return Session(test_name, module_user_sca.login, module_user_sca.password)

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from datetime import datetime
 
@@ -59,8 +54,6 @@ class TestVirtwhoConfigforEsx:
             4. Virtual sku can be generated and attached
             5. Config can be deleted
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
@@ -93,8 +86,6 @@ class TestVirtwhoConfigforEsx:
             1. if debug is checked, VIRTWHO_DEBUG=1 in /etc/sysconfig/virt-who
             2. if debug is unchecked, VIRTWHO_DEBUG=0 in /etc/sysconfig/virt-who
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         name = form_data_ui['name']
@@ -123,8 +114,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             VIRTWHO_INTERVAL can be changed in /etc/sysconfig/virt-who if the
             dropdown option is selected to Every 2/4/8/12/24 hours, Every 2/3 days.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -162,8 +151,6 @@ class TestVirtwhoConfigforEsx:
             hypervisor_id can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to uuid/hwuuid/hostname.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         name = form_data_ui['name']
@@ -192,8 +179,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             1. if filtering is selected to Whitelist, 'Filter hosts' can be set.
             2. if filtering is selected to Blacklist, 'Exclude hosts' can be set.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 
@@ -239,8 +224,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             http_proxy/https_proxy and NO_PROXY will be setting in /etc/sysconfig/virt-who.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         https_proxy, https_proxy_name, https_proxy_id = create_http_proxy(org=default_org)
@@ -279,8 +262,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             'Virt-who Manager', 'Virt-who Reporter', 'Virt-who Viewer' existing
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         roles = {
@@ -311,15 +292,13 @@ class TestVirtwhoConfigforEsx:
 
         :id: 5d61ce00-a640-4823-89d4-7b1d02b50ea6
 
-        :Steps:
+        :steps:
 
             1. Create a Virt-who Configuration
             2. Navigate Monitor -> Dashboard
             3. Review the Virt-who Configurations Status widget
 
         :expectedresults: The widget is updated with all details.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -572,8 +551,6 @@ class TestVirtwhoConfigforEsx:
 
         :BZ: 1649928
 
-        :CaseLevel: Integration
-
         :customerscenario: true
 
         :CaseImportance: Medium
@@ -638,8 +615,6 @@ class TestVirtwhoConfigforEsx:
 
         :BZ: 1652323
 
-        :CaseLevel: Integration
-
         :customerscenario: true
 
         :CaseImportance: Medium
@@ -673,8 +648,6 @@ class TestVirtwhoConfigforEsx:
         :id: 654f869e-182b-4951-bc4e-8761d666a449
 
         :expectedresults: Config can be created and deployed without any error
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 
@@ -729,8 +702,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             the option "env=" should be removed from etc/virt-who.d/virt-who.conf
             /var/log/messages should not display warning message
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 from datetime import datetime
 
@@ -57,8 +52,6 @@ class TestVirtwhoConfigforEsx:
             4. Virtual sku can be generated and attached
             5. Config can be deleted
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
@@ -74,8 +67,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             1. if debug is checked, VIRTWHO_DEBUG=1 in /etc/sysconfig/virt-who
             2. if debug is unchecked, VIRTWHO_DEBUG=0 in /etc/sysconfig/virt-who
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -105,8 +96,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             VIRTWHO_INTERVAL can be changed in /etc/sysconfig/virt-who if the
             dropdown option is selected to Every 2/4/8/12/24 hours, Every 2/3 days.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -144,8 +133,6 @@ class TestVirtwhoConfigforEsx:
             hypervisor_id can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to uuid/hwuuid/hostname.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         name = form_data_ui['name']
@@ -181,7 +168,6 @@ class TestVirtwhoConfigforEsx:
             'Filter hosts' can be set.
             4. Create virtwho config if filtering is selected to Blacklist,
             'Exclude hosts' can be set.
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 
@@ -267,8 +253,6 @@ class TestVirtwhoConfigforEsx:
 
         :BZ: 1652323
 
-        :CaseLevel: Integration
-
         :customerscenario: true
 
         :CaseImportance: Medium
@@ -304,8 +288,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             1. the option "env=" should be removed from etc/virt-who.d/virt-who.conf
             2. /var/log/messages should not display warning message
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 
@@ -343,8 +325,6 @@ class TestVirtwhoConfigforEsx:
 
         :expectedresults:
             'Virt-who Manager', 'Virt-who Reporter', 'Virt-who Viewer' existing
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -385,8 +365,6 @@ class TestVirtwhoConfigforEsx:
             1. Verify the virt-who server can no longer connect to the
                Satellite.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Low
         """
         name = gen_string('alpha')
@@ -416,8 +394,6 @@ class TestVirtwhoConfigforEsx:
             Virt-who Reporter Role granting minimal set of permissions for virt-who
             to upload the report, it can be used if you configure virt-who manually
             and want to use user that has locked down account.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -476,8 +452,6 @@ class TestVirtwhoConfigforEsx:
             Virt-who Viewer Role granting permissions to see all configurations
             including their configuration scripts, which means viewers could still
             deploy the virt-who instances for existing virt-who configurations.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -541,7 +515,6 @@ class TestVirtwhoConfigforEsx:
         :expectedresults:
             Virt-who Manager Role granting all permissions to manage virt-who configurations,
             user needs this role to create, delete or update configurations.
-        :CaseLevel: Integration
 
         :CaseImportance: Low
         """
@@ -604,8 +577,6 @@ class TestVirtwhoConfigforEsx:
         :id: 0cefdbb3-fc23-49c4-b1fb-78004db1c7bc
 
         :expectedresults: Config can be created and deployed without any error
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
 

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -44,8 +39,6 @@ class TestVirtwhoConfigforHyperv:
             3. Report is sent to satellite
             4. Virtual sku can be generated and attached
             5. Config can be deleted
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -80,8 +73,6 @@ class TestVirtwhoConfigforHyperv:
         :expectedresults:
             hypervisor_id can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to uuid/hwuuid/hostname.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -42,8 +37,6 @@ class TestVirtwhoConfigforHyperv:
             4. Virtual sku can be generated and attached
             5. Config can be deleted
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
@@ -59,8 +52,6 @@ class TestVirtwhoConfigforHyperv:
         :expectedresults:
             1. hypervisor_id can be changed in virt-who-config-{}.conf if the
                 dropdown option is selected to uuid/hwuuid/hostname.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -44,8 +39,6 @@ class TestVirtwhoConfigforKubevirt:
             3. Report is sent to satellite
             4. Virtual sku can be generated and attached
             5. Config can be deleted
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -80,8 +73,6 @@ class TestVirtwhoConfigforKubevirt:
         :expectedresults:
             hypervisor_id can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to uuid/hwuuid/hostname.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -42,8 +37,6 @@ class TestVirtwhoConfigforKubevirt:
             4. Virtual sku can be generated and attached
             5. Config can be deleted
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
@@ -59,8 +52,6 @@ class TestVirtwhoConfigforKubevirt:
         :expectedresults:
             1. hypervisor_id can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to uuid/hwuuid/hostname.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -44,8 +39,6 @@ class TestVirtwhoConfigforLibvirt:
             3. Report is sent to satellite
             4. Virtual sku can be generated and attached
             5. Config can be deleted
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -80,8 +73,6 @@ class TestVirtwhoConfigforLibvirt:
         :expectedresults:
             hypervisor_id can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to uuid/hwuuid/hostname.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 import pytest
 
@@ -42,8 +37,6 @@ class TestVirtwhoConfigforLibvirt:
             4. Virtual sku can be generated and attached
             5. Config can be deleted
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
@@ -59,8 +52,6 @@ class TestVirtwhoConfigforLibvirt:
         :expectedresults:
             1. hypervisor_id can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to uuid/hwuuid/hostname.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -48,8 +43,6 @@ class TestVirtwhoConfigforNutanix:
             3. Report is sent to satellite
             4. Virtual sku can be generated and attached
             5. Config can be deleted
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -85,8 +78,6 @@ class TestVirtwhoConfigforNutanix:
             hypervisor_id can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to uuid/hwuuid/hostname.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         name = form_data_ui['name']
@@ -120,8 +111,6 @@ class TestVirtwhoConfigforNutanix:
             4. The prism_central has been set true in /etc/virt-who.d/vir-who.conf file
             5. Virtual sku can be generated and attached
             6. Config can be deleted
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -180,8 +169,6 @@ class TestVirtwhoConfigforNutanix:
             prism_flavor can be changed in virt-who-config-{}.conf if the
             dropdown option is selected to prism central.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         name = form_data_ui['name']
@@ -216,7 +203,6 @@ class TestVirtwhoConfigforNutanix:
             5. message Host UUID {system_uuid} found for VM: {guest_uuid} exist in rhsm.log
             6. ahv_internal_debug bas been set to true in virt-who-config-X.conf
             7. warning message does not exist in log file /var/log/rhsm/rhsm.log
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -4,15 +4,10 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :Team: Phoenix-subscriptions
 
-:TestType: Functional
-
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -45,8 +40,6 @@ class TestVirtwhoConfigforNutanix:
             3. Report is sent to satellite
             4. Config can be deleted
 
-        :CaseLevel: Integration
-
         :CaseImportance: High
         """
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
@@ -62,8 +55,6 @@ class TestVirtwhoConfigforNutanix:
         :expectedresults:
             1. hypervisor_id can be changed in virt-who-config-{}.conf if the
                 dropdown option is selected to uuid/hwuuid/hostname.
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
         """
@@ -100,8 +91,6 @@ class TestVirtwhoConfigforNutanix:
             4. The prism_central has been set true in /etc/virt-who.d/vir-who.conf file
             5. Virtual sku can be generated and attached
             6. Config can be deleted
-
-        :CaseLevel: Integration
 
         :CaseImportance: High
         """
@@ -147,8 +136,6 @@ class TestVirtwhoConfigforNutanix:
             1. prism_flavor can be changed in virt-who-config-{}.conf if the
                 dropdown option is selected to prism central.
 
-        :CaseLevel: Integration
-
         :CaseImportance: Medium
         """
         name = form_data_ui['name']
@@ -183,8 +170,6 @@ class TestVirtwhoConfigforNutanix:
             5. message Host UUID {system_uuid} found for VM: {guest_uuid} exist in rhsm.log
             6. ahv_internal_debug bas been set to true in virt-who-config-X.conf
             7. warning message does not exist in log file /var/log/rhsm/rhsm.log
-
-        :CaseLevel: Integration
 
         :CaseImportance: Medium
 

--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ActivationKeys
 
 :Team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/upgrades/test_bookmarks.py
+++ b/tests/upgrades/test_bookmarks.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Search
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 
@@ -34,7 +29,7 @@ class TestPublicDisableBookmark:
 
         :id: preupgrade-13904b14-6340-4b85-a56f-98080cf50a92
 
-        :Steps:
+        :steps:
 
             1. Create public disabled bookmarks before the upgrade for all system entities
             using available bookmark data.
@@ -71,7 +66,7 @@ class TestPublicDisableBookmark:
 
         :id: postupgrade-13904b14-6340-4b85-a56f-98080cf50a92
 
-        :Steps:
+        :steps:
 
             1. Check the bookmark status after post-upgrade.
             2. Remove the bookmark.
@@ -105,7 +100,7 @@ class TestPublicEnableBookmark:
 
         :id: preupgrade-93c419db-66b4-4c9a-a82a-a6a68703881f
 
-        :Steps:
+        :steps:
             1. Create public enable bookmarks before the upgrade for all system entities
             using available bookmark data.
             2. Check the bookmark attribute(controller, name, query public) status
@@ -140,7 +135,7 @@ class TestPublicEnableBookmark:
 
         :id: postupgrade-93c419db-66b4-4c9a-a82a-a6a68703881f
 
-        :Steps:
+        :steps:
             1. Check the bookmark status after post-upgrade.
             2. Remove the bookmark.
 

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Capsule
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import os
 

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import json
 

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -7,17 +7,12 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts-Content
 
 :Team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ContentViews
 
 :Team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_alpha
 import pytest

--- a/tests/upgrades/test_discovery.py
+++ b/tests/upgrades/test_discovery.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: DiscoveryImage
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import re
 

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ErrataManagement
 
 :Team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: Critical
 
-:Upstream: No
 """
 import pytest
 from wait_for import wait_for

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest
@@ -114,9 +109,7 @@ class TestScenarioPositiveGCEHostComputeResource:
 
         :id: 889975f2-56ca-4584-95a7-21c513969630
 
-        :CaseLevel: Component
-
-        ::CaseImportance: Critical
+        :CaseImportance: Critical
 
         :steps:
             1. Create a GCE Compute Resource

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Hosts-Content
 
 :Team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_hostgroup.py
+++ b/tests/upgrades/test_hostgroup.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: HostGroup
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Installer
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import filecmp
 

--- a/tests/upgrades/test_provisioningtemplate.py
+++ b/tests/upgrades/test_provisioningtemplate.py
@@ -8,13 +8,8 @@
 
 :Team: Rocket
 
-:TestType: Functional
-
-:CaseLevel: Integration
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/upgrades/test_puppet.py
+++ b/tests/upgrades/test_puppet.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Puppet
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: Medium
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: RemoteExecution
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Repositories
 
 :Team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: NotAutomated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_satellite_maintain.py
+++ b/tests/upgrades/test_satellite_maintain.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: ForemanMaintain
 
 :Team: Platform
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import re
 

--- a/tests/upgrades/test_satellitesync.py
+++ b/tests/upgrades/test_satellitesync.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Component
-
 :CaseComponent: InterSatelliteSync
 
 :Team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_subnet.py
+++ b/tests/upgrades/test_subnet.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: NotAutomated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Networking
 
 :Team: Rocket
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SubscriptionManagement
 
 :Team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from manifester import Manifester
 import pytest

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: SyncPlans
 
 :Team: Phoenix-content
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_choice
 import pytest

--- a/tests/upgrades/test_user.py
+++ b/tests/upgrades/test_user.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: NotAutomated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 import pytest
 

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: UsersRoles
 
 :Team: Endeavour
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -4,17 +4,12 @@
 
 :CaseAutomation: Automated
 
-:CaseLevel: Acceptance
-
 :CaseComponent: Virt-whoConfigurePlugin
 
 :Team: Phoenix-subscriptions
 
-:TestType: Functional
-
 :CaseImportance: High
 
-:Upstream: No
 """
 from fauxfactory import gen_string
 import pytest


### PR DESCRIPTION
### Problem Statement
Remove 3 tokens from Robottelo which are not useful or not being used anywhere in reporting:

TestType
Upstream
CaseLevel

### Solution
removed these three token from the test docstring, This will need some testing against Polarian staging host.    
