### PR TITLE
Add test for fapolicyd installation

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -291,7 +291,7 @@ def module_sat_ready_rhels(request):
 
 @pytest.fixture
 def cap_ready_rhel():
-    rhel_version = Version(settings.capsule.version.release)
+    rhel_version = Version(settings.capsule.version.rhel_version)
     deploy_args = {
         'deploy_rhel_version': rhel_version.base_version,
         'deploy_flavor': settings.flavors.default,

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -125,7 +125,7 @@ def setup_capsule(satellite, capsule, org, registration_args=None, installation_
     capsule.unregister()
 
     # Add a manifest to the Satellite
-    with Manifester(manifest_category=settings.manifest.golden_ticket) as manifest:
+    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
         satellite.upload_manifest(org.id, manifest.content)
 
     # Enable RHEL 8 BaseOS and AppStream repos and sync
@@ -151,7 +151,7 @@ def setup_capsule(satellite, capsule, org, registration_args=None, installation_
         f'{file} root@{capsule.hostname}:{file}'
     )
     capsule.install_katello_ca(satellite)
-    capsule.register_contenthost(**registration_args)
+    capsule.register_contenthost(org=org.label, **registration_args)
     return capsule.install(cmd_args)
 
 


### PR DESCRIPTION
### Problem Statement
Missing test coverage for Satellite and Capsule installation with fapolicyd

### Solution
Update existing test for fapolicyd

### Related Issues
- https://issues.redhat.com/browse/SAT-20551

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->