### PR TITLE
Configurable Ignore list of markers test field in polarion tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Version updates managed by dependabot
 
-betelgeuse==1.10.0
+betelgeuse==1.11.0
 broker[docker]==0.4.1
 cryptography==41.0.7
 deepdiff==6.7.1

--- a/scripts/polarion-test-case-upload.sh
+++ b/scripts/polarion-test-case-upload.sh
@@ -74,6 +74,7 @@ TRANSFORM_CUSTOMERSCENARIO_VALUE = default_config._transform_to_lower
 DEFAULT_CUSTOMERSCENARIO_VALUE = 'false'
 DEFAULT_REQUIREMENT_TEAM_VALUE = None
 TRANSFORM_REQUIREMENT_TEAM_VALUE = default_config._transform_to_lower
+MARKERS_IGNORE_LIST = ['parametrize', 'skip.*', 'usefixtures', 'rhel_ver_.*']
 EOF
 
 set -x


### PR DESCRIPTION
### Problem Statement
The list of markers to be ignored during polarion tests collection in `markers` field is missing.

### Solution
New variable `MARKERS_IGNORE_LIST`  in `betelgeuse_config.py` should ignore these markers while test collection by betelgeuse.

### Related Issues
https://github.com/SatelliteQE/betelgeuse/pull/141

