### PR TITLE
[6.15.z] Component Audit: Check org and loc change on Global Registration form

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -16,6 +16,8 @@
 
 :Upstream: No
 """
+import pytest
+
 from robottelo.utils.datafactory import gen_string
 
 
@@ -55,3 +57,45 @@ def test_positive_verify_default_values_for_global_registration(
     assert cmd['advanced']['update_packages'] is False
     assert cmd['advanced']['ignore_error'] is False
     assert cmd['advanced']['force'] is False
+
+
+@pytest.mark.tier2
+def test_positive_org_loc_change_for_registration(
+    module_activation_key,
+    module_org,
+    module_location,
+    target_sat,
+):
+    """Changing the organization and location to check if correct org and loc is updated on the global registration page as well as in the command
+
+    :id: e83ed6bc-ceae-4021-87fe-3ecde1cbf347
+
+    :expectedresults: organization and location is updated correctly on the global registration page as well as in the command.
+
+    :CaseLevel: Component
+
+    :CaseImportance: Medium
+    """
+    new_org = target_sat.api.Organization().create()
+    new_loc = target_sat.api.Location().create()
+    target_sat.api.ActivationKey(organization=new_org).create()
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
+        cmd = session.host.get_register_command()
+        expected_pairs = [
+            f'organization_id={module_org.id}',
+            f'location_id={module_location.id}',
+        ]
+        for pair in expected_pairs:
+            assert pair in cmd
+        # changing the org and loc to check if correct org and loc is updated on the registration command
+        session.organization.select(org_name=new_org.name)
+        session.location.select(loc_name=new_loc.name)
+        cmd = session.host.get_register_command()
+        expected_pairs = [
+            f'organization_id={new_org.id}',
+            f'location_id={new_loc.id}',
+        ]
+        for pair in expected_pairs:
+            assert pair in cmd


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13480

Registration Component Audit: Check org and loc change on the Global Registration form