### PR TITLE
[6.14.z] Use rsync to copy /var/lib/pulp after satellite-clone

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -4,7 +4,8 @@ from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
 import pytest
 
-from robottelo.constants import DEFAULT_ARCHITECTURE, PRDS, REPOS, REPOSET
+from robottelo.config import settings
+from robottelo.constants import DEFAULT_ARCHITECTURE, DEFAULT_ORG, PRDS, REPOS, REPOSET
 
 
 @pytest.fixture(scope='module')
@@ -99,6 +100,16 @@ def module_repository(os_path, module_product, module_target_sat):
     repo = module_target_sat.api.Repository(product=module_product, url=os_path).create()
     call_entity_method_with_timeout(module_target_sat.api.Repository(id=repo.id).sync, timeout=3600)
     return repo
+
+
+@pytest.fixture
+def custom_synced_repo(target_sat):
+    custom_repo = target_sat.api.Repository(
+        product=target_sat.api.Product(organization=DEFAULT_ORG).create(),
+        url=settings.repos.yum_0.url,
+    ).create()
+    custom_repo.sync()
+    return custom_repo
 
 
 def _simplify_repos(request, repos):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13443

### Problem Statement
https://bugzilla.redhat.com/show_bug.cgi?id=2013776 details running rsync to copy pulp data from the Satellite to the target server after running satellite-clone. This is due to satellite-clone using satellite-maintain restore which runs the installer with --reset-data.

### Solution
Switch satellite-clone tests that are running --skip-pulp-data for the backup to rsync the pulp data after we run the clone process.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->