### PR TITLE
[6.14.z] fix server config from user and role test module

### DIFF
--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -587,7 +587,7 @@ class TestCannedRole:
         sc = self.user_config(user, target_sat)
         # Getting the domain from user
         with pytest.raises(HTTPError):
-            target_sat.api.Domain(sc, id=domain.id).read()
+            target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
     @pytest.mark.tier3
     def test_negative_access_entities_from_user(
@@ -620,7 +620,7 @@ class TestCannedRole:
         sc = self.user_config(user, target_sat)
         # Getting the domain from user
         with pytest.raises(HTTPError):
-            target_sat.api.Domain(sc, id=domain.id).read()
+            target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
     @pytest.mark.tier2
     def test_positive_override_cloned_role_filter(self, role_taxonomies, target_sat):
@@ -1018,13 +1018,13 @@ class TestCannedRole:
                 auth=(login, password), url=target_sat.url, verify=settings.server.verify_ca
             )
             try:
-                target_sat.api.Domain(sc).search(
+                target_sat.api.Domain(server_config=sc).search(
                     query={
                         'organization-id': role_taxonomies['org'].id,
                         'location-id': role_taxonomies['loc'].id,
                     }
                 )
-                target_sat.api.Subnet(sc).search(
+                target_sat.api.Subnet(server_config=sc).search(
                     query={
                         'organization-id': role_taxonomies['org'].id,
                         'location-id': role_taxonomies['loc'].id,
@@ -1032,8 +1032,8 @@ class TestCannedRole:
                 )
             except HTTPError as err:
                 pytest.fail(str(err))
-            assert domain.id in [dom.id for dom in target_sat.api.Domain(sc).search()]
-            assert subnet.id in [sub.id for sub in target_sat.api.Subnet(sc).search()]
+            assert domain.id in [dom.id for dom in target_sat.api.Domain(server_config=sc).search()]
+            assert subnet.id in [sub.id for sub in target_sat.api.Subnet(server_config=sc).search()]
 
     @pytest.mark.tier3
     def test_positive_user_group_users_access_contradict_as_org_admins(self):
@@ -1098,7 +1098,7 @@ class TestCannedRole:
         for user in [user_one, user_two]:
             sc = self.user_config(user, target_sat)
             with pytest.raises(HTTPError):
-                target_sat.api.Domain(sc, id=dom.id).read()
+                target_sat.api.Domain(server_config=sc, id=dom.id).read()
 
     @pytest.mark.tier2
     def test_negative_assign_taxonomies_by_org_admin(
@@ -1149,7 +1149,7 @@ class TestCannedRole:
             auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
         )
         # Getting the domain from user1
-        dom = target_sat.api.Domain(sc, id=dom.id).read()
+        dom = target_sat.api.Domain(server_config=sc, id=dom.id).read()
         dom.organization = [filter_taxonomies['org']]
         with pytest.raises(HTTPError):
             dom.update(['organization'])
@@ -1319,7 +1319,7 @@ class TestCannedRole:
         role_name = gen_string('alpha')
         with pytest.raises(HTTPError):
             target_sat.api.Role(
-                sc,
+                server_config=sc,
                 name=role_name,
                 organization=[role_taxonomies['org']],
                 location=[role_taxonomies['loc']],
@@ -1346,7 +1346,7 @@ class TestCannedRole:
         )
         test_role = target_sat.api.Role().create()
         sc = self.user_config(user, target_sat)
-        test_role = target_sat.api.Role(sc, id=test_role.id).read()
+        test_role = target_sat.api.Role(server_config=sc, id=test_role.id).read()
         test_role.organization = [role_taxonomies['org']]
         test_role.location = [role_taxonomies['loc']]
         with pytest.raises(HTTPError):
@@ -1386,7 +1386,7 @@ class TestCannedRole:
             auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
         )
         with pytest.raises(HTTPError):
-            target_sat.api.User(sc, id=1).read()
+            target_sat.api.User(server_config=sc, id=1).read()
 
     @pytest.mark.tier2
     @pytest.mark.upgrade
@@ -1435,7 +1435,7 @@ class TestCannedRole:
         user_login = gen_string('alpha')
         user_pass = gen_string('alphanumeric')
         user = target_sat.api.User(
-            sc_user,
+            server_config=sc_user,
             login=user_login,
             password=user_pass,
             role=[org_admin.id],
@@ -1476,7 +1476,7 @@ class TestCannedRole:
         test_user = self.create_simple_user(filter_taxos=role_taxonomies)
         sc = self.user_config(user, target_sat)
         try:
-            target_sat.api.User(sc, id=test_user.id).read()
+            target_sat.api.User(server_config=sc, id=test_user.id).read()
         except HTTPError as err:
             pytest.fail(str(err))
 
@@ -1518,7 +1518,9 @@ class TestCannedRole:
             auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
         )
         name = gen_string('alphanumeric')
-        location = target_sat.api.Location(sc, name=name, parent=role_taxonomies['loc'].id).create()
+        location = target_sat.api.Location(
+            server_config=sc, name=name, parent=role_taxonomies['loc'].id
+        ).create()
         assert location.name == name
 
     @pytest.mark.tier2
@@ -1550,7 +1552,7 @@ class TestCannedRole:
         test_user = self.create_simple_user(filter_taxos=filter_taxonomies)
         sc = self.user_config(user, target_sat)
         with pytest.raises(HTTPError):
-            target_sat.api.User(sc, id=test_user.id).read()
+            target_sat.api.User(server_config=sc, id=test_user.id).read()
 
     @pytest.mark.tier1
     def test_negative_create_taxonomies_by_org_admin(self, role_taxonomies, target_sat):
@@ -1586,11 +1588,11 @@ class TestCannedRole:
             auth=(user_login, user_pass), url=target_sat.url, verify=settings.server.verify_ca
         )
         with pytest.raises(HTTPError):
-            target_sat.api.Organization(sc, name=gen_string('alpha')).create()
+            target_sat.api.Organization(server_config=sc, name=gen_string('alpha')).create()
         if not is_open("BZ:1825698"):
             try:
                 loc_name = gen_string('alpha')
-                loc = target_sat.api.Location(sc, name=loc_name).create()
+                loc = target_sat.api.Location(server_config=sc, name=loc_name).create()
             except HTTPError as err:
                 pytest.fail(str(err))
             assert loc_name == loc.name
@@ -1643,7 +1645,7 @@ class TestCannedRole:
                 target_sat.api.Errata,
                 target_sat.api.OperatingSystem,
             ]:
-                entity(sc).search()
+                entity(server_config=sc).search()
         except HTTPError as err:
             pytest.fail(str(err))
 
@@ -1684,7 +1686,7 @@ class TestCannedRole:
             verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
-            target_sat.api.Architecture(sc).search()
+            target_sat.api.Architecture(server_config=sc).search()
         user = target_sat.api.User().search(
             query={'search': f"login={create_ldap['ldap_user_name']}"}
         )[0]
@@ -1692,7 +1694,7 @@ class TestCannedRole:
         user.update(['role'])
         # Trying to access the domain resource created in org admin role
         with pytest.raises(HTTPError):
-            target_sat.api.Domain(sc, id=domain.id).read()
+            target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
     @pytest.mark.tier3
     def test_negative_access_entities_from_ldap_user(
@@ -1729,7 +1731,7 @@ class TestCannedRole:
             verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
-            target_sat.api.Architecture(sc).search()
+            target_sat.api.Architecture(server_config=sc).search()
         user = target_sat.api.User().search(
             query={'search': f"login={create_ldap['ldap_user_name']}"}
         )[0]
@@ -1737,7 +1739,7 @@ class TestCannedRole:
         user.update(['role'])
         # Trying to access the Domain resource
         with pytest.raises(HTTPError):
-            target_sat.api.Domain(sc, id=domain.id).read()
+            target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
     @pytest.mark.tier3
     def test_positive_assign_org_admin_to_ldap_user_group(
@@ -1800,7 +1802,7 @@ class TestCannedRole:
                 verify=settings.server.verify_ca,
             )
             # Accessing the Domain resource
-            target_sat.api.Domain(sc, id=domain.id).read()
+            target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
     @pytest.mark.tier3
     def test_negative_assign_org_admin_to_ldap_user_group(
@@ -1861,7 +1863,7 @@ class TestCannedRole:
             )
             # Trying to access the Domain resource
             with pytest.raises(HTTPError):
-                target_sat.api.Domain(sc, id=domain.id).read()
+                target_sat.api.Domain(server_config=sc, id=domain.id).read()
 
 
 class TestRoleSearchFilter:

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -420,8 +420,12 @@ class TestUser:
         sc = ServerConfig(
             auth=(user.login, password), url=module_target_sat.url, verify=settings.server.verify_ca
         )
-        module_target_sat.api.TablePreferences(sc, user=user, name=name, columns=columns).create()
-        table_preferences = module_target_sat.api.TablePreferences(sc, user=user).search()
+        module_target_sat.api.TablePreferences(
+            server_config=sc, user=user, name=name, columns=columns
+        ).create()
+        table_preferences = module_target_sat.api.TablePreferences(
+            server_config=sc, user=user
+        ).search()
         assert len(table_preferences) == 1
         tp = table_preferences[0]
         assert hasattr(tp, 'name')
@@ -732,7 +736,7 @@ class TestActiveDirectoryUser:
             verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
-            target_sat.api.Architecture(sc).search()
+            target_sat.api.Architecture(server_config=sc).search()
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
@@ -783,7 +787,7 @@ class TestActiveDirectoryUser:
             verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
-            module_target_sat.api.Architecture(sc).search()
+            module_target_sat.api.Architecture(server_config=sc).search()
         user = module_target_sat.api.User().search(
             query={'search': 'login={}'.format(create_ldap['ldap_user_name'])}
         )[0]
@@ -800,7 +804,7 @@ class TestActiveDirectoryUser:
             module_target_sat.api.Errata,
             module_target_sat.api.OperatingSystem,
         ]:
-            entity(sc).search()
+            entity(server_config=sc).search()
 
 
 @pytest.mark.run_in_one_thread
@@ -865,7 +869,7 @@ class TestFreeIPAUser:
             verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
-            target_sat.api.Architecture(sc).search()
+            target_sat.api.Architecture(server_config=sc).search()
 
     @pytest.mark.tier3
     @pytest.mark.upgrade
@@ -906,7 +910,7 @@ class TestFreeIPAUser:
             verify=settings.server.verify_ca,
         )
         with pytest.raises(HTTPError):
-            target_sat.api.Architecture(sc).search()
+            target_sat.api.Architecture(server_config=sc).search()
         user = target_sat.api.User().search(
             query={'search': 'login={}'.format(create_ldap['username'])}
         )[0]
@@ -923,7 +927,7 @@ class TestFreeIPAUser:
             target_sat.api.Errata,
             target_sat.api.OperatingSystem,
         ]:
-            entity(sc).search()
+            entity(server_config=sc).search()
 
 
 class TestPersonalAccessToken:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13465

### Problem Statement
Few test form foreman/api for user and role were failing due to absense of `server_config` keyword argument.

### Solution
Provided fix will resovle issue, adding `server_config` parameter into entity calls.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->