### PR TITLE
Add negative tests for registration without AK (#13490)

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -20,6 +20,7 @@ import uuid
 
 from fauxfactory import gen_ipaddr, gen_mac
 import pytest
+from requests import HTTPError
 
 from robottelo import constants
 from robottelo.config import settings
@@ -213,3 +214,16 @@ def test_positive_rex_interface_for_global_registration(
             assert interface['execution'] is True
             assert interface['ip'] == ip
             assert interface['mac'] == mac_address
+
+
+@pytest.mark.tier1
+def test_negative_global_registration_without_ak(module_target_sat):
+    """Attempt to register a host without ActivationKey
+
+    :id: e48a6260-97e0-4234-a69c-77bbbcde85de
+
+    :expectedresults: Generate command is disabled without ActivationKey
+    """
+    with pytest.raises(HTTPError) as context:
+        module_target_sat.api.RegistrationCommand().create()
+    assert 'Missing activation key!' in context.value.response.text

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -20,6 +20,7 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import CLIENT_PORT
+from robottelo.exceptions import CLIReturnCodeError
 
 pytestmark = pytest.mark.tier1
 
@@ -171,3 +172,19 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel_contenthost
     # host being already registered.
     assert result.status == 1
     assert 'This system is already registered' in str(result.stderr)
+
+
+@pytest.mark.tier1
+def test_negative_global_registration_without_ak(module_target_sat):
+    """Attempt to register a host without ActivationKey
+
+    :id: e48a6260-97e0-4234-a69c-77bbbcde85df
+
+    :expectedresults: Generate command is disabled without ActivationKey
+    """
+    with pytest.raises(CLIReturnCodeError) as context:
+        module_target_sat.cli.HostRegistration.generate_command(options=None)
+    assert (
+        'Failed to generate registration command:\n  Missing activation key!'
+        in context.value.message
+    )

--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -16,9 +16,12 @@
 
 :Upstream: No
 """
+from airgun.exceptions import DisabledWidgetError
 import pytest
 
 from robottelo.utils.datafactory import gen_string
+
+pytestmark = pytest.mark.tier1
 
 
 def test_positive_verify_default_values_for_global_registration(
@@ -108,3 +111,22 @@ def test_positive_org_loc_change_for_registration(
         ]
         for pair in expected_pairs:
             assert pair in cmd
+
+
+def test_negative_global_registration_without_ak(
+    module_target_sat,
+    module_org,
+    module_location,
+):
+    """Attempt to register a host without ActivationKey
+
+    :id: 34122bf3-ae23-47ca-ba3d-da0653d8fd36
+
+    :expectedresults: Generate command is disabled without ActivationKey
+    """
+    with module_target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
+        with pytest.raises(DisabledWidgetError) as context:
+            session.host.get_register_command()
+        assert 'Generate registration command button is disabled' in str(context.value)


### PR DESCRIPTION
(cherry picked from commit 48735b00ba4b7acbd983bd06e9f2342fbfa08163)
Manual cheryypick of https://github.com/SatelliteQE/robottelo/pull/13490

Dependant PRs:
https://github.com/SatelliteQE/airgun/pull/1095
