### PR TITLE
[6.15] Prepare for SCA only deprecation 6.15

### DIFF
--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -367,7 +367,7 @@ def test_positive_product_view_organization_switch(session, module_org, module_p
 @pytest.mark.tier2
 def test_positive_prepare_for_sca_only_deprecation(target_sat):
     """Verify that Simple Content Access endpoints are depreacated and will be required
-        for all organizations in Satellite 6.16
+        for all organizations in Katello 4.12
     :id: 08539596-1bd3-4363-9737-e45f32ee5cbb
     :expectedresults: Attepting to create an Organization with sca set to False, will throw
         deprecation endpoint message
@@ -382,5 +382,5 @@ def test_positive_prepare_for_sca_only_deprecation(target_sat):
         )
         results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout
     assert (
-        'Simple Content Access will be required for all organizations in Satellite 6.16' in results
+        'Simple Content Access will be required for all organizations in Katello 4.12' in results
     )

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -366,12 +366,12 @@ def test_positive_product_view_organization_switch(session, module_org, module_p
 
 @pytest.mark.tier2
 def test_positive_prepare_for_sca_only_deprecation(target_sat):
-    """Verify that Simple Content Access endpoints are depreacated and will be required
+    """Verify that Simple Content Access endpoints are deprecated and will be required
         for all organizations in Katello 4.12
 
     :id: df7e6806-6664-4dc5-baf6-bb41935e3031
 
-    :expectedresults: Attepting to create an Organization with sca set to False, will throw
+    :expectedresults: Attempting to create an Organization with sca set to False, will throw
         deprecation endpoint message
     """
     with target_sat.ui_session() as session:

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -368,7 +368,9 @@ def test_positive_product_view_organization_switch(session, module_org, module_p
 def test_positive_prepare_for_sca_only_deprecation(target_sat):
     """Verify that Simple Content Access endpoints are depreacated and will be required
         for all organizations in Katello 4.12
-    :id: 08539596-1bd3-4363-9737-e45f32ee5cbb
+
+    :id: df7e6806-6664-4dc5-baf6-bb41935e3031
+
     :expectedresults: Attepting to create an Organization with sca set to False, will throw
         deprecation endpoint message
     """

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -362,3 +362,25 @@ def test_positive_product_view_organization_switch(session, module_org, module_p
         assert session.product.search(module_product.name)
         session.organization.select(org_name="Default Organization")
         assert not session.product.search(module_product.name) == module_product.name
+
+
+@pytest.mark.tier2
+def test_positive_prepare_for_sca_only_deprecation(target_sat):
+    """Verify that Simple Content Access endpoints are depreacated and will be required
+        for all organizations in Satellite 6.16
+    :id: 08539596-1bd3-4363-9737-e45f32ee5cbb
+    :expectedresults: Attepting to create an Organization with sca set to False, will throw
+        deprecation endpoint message
+    """
+    with target_sat.ui_session() as session:
+        session.organization.create(
+            {
+                'name': gen_string('alpha'),
+                'label': gen_string('alpha'),
+                'sca': False,
+            }
+        )
+        results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout
+    assert (
+        'Simple Content Access will be required for all organizations in Satellite 6.16' in results
+    )

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -381,6 +381,4 @@ def test_positive_prepare_for_sca_only_deprecation(target_sat):
             }
         )
         results = target_sat.execute('tail -100 /var/log/foreman/production.log').stdout
-    assert (
-        'Simple Content Access will be required for all organizations in Katello 4.12' in results
-    )
+    assert 'Simple Content Access will be required for all organizations in Katello 4.12' in results


### PR DESCRIPTION
6.15 Feature automation: SAT-20201

This test is verifying that that Simple Content Access endpoints are deprecated and will be required
for all organizations in Katello 4.12

Copy of https://github.com/SatelliteQE/robottelo/pull/13045