### PR TITLE
[6.12.z] extra check not recording property incase of video recording is false

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1767,8 +1767,9 @@ class Satellite(Capsule, SatelliteMixins):
             video_url = settings.ui.grid_url.replace(
                 ':4444', f'/videos/{ui_session.ui_session_id}.mp4'
             )
-            self.record_property('video_url', video_url)
-            self.record_property('session_id', ui_session.ui_session_id)
+            if self.record_property is not None and settings.ui.record_video:
+                self.record_property('video_url', video_url)
+                self.record_property('session_id', ui_session.ui_session_id)
 
     @property
     def satellite(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13475

### Problem Statement
Currently, every time we record a video URL is a JUnit report, which is not necessary in case the video recording is false.

### Solution
Adding extra layer check to see record_property is not null and video recording is true 

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->