### PR TITLE
Fix parametrization in capsule provisioning fixture

### DIFF
--- a/pytest_fixtures/component/provision_capsule_pxe.py
+++ b/pytest_fixtures/component/provision_capsule_pxe.py
@@ -173,7 +173,7 @@ def capsule_provisioning_rhel_content(
     that is specified in `request.param`.
     """
     sat = capsule_provisioning_sat.sat
-    rhel_ver = request.param
+    rhel_ver = request.param['rhel_version']
     repo_names = []
     if int(rhel_ver) <= 7:
         repo_names.append(f'rhel{rhel_ver}')


### PR DESCRIPTION
### Problem Statement
Missed in https://github.com/SatelliteQE/robottelo/pull/13241

### Solution
Update `s/request.param/request.param['rhel_version']` for parametrization

### Related Issues
Already updated and tested this in cherrypick PRs https://github.com/SatelliteQE/robottelo/pull/13557 and it works, so just need this change in master 