### PR TITLE
[6.15.z] Add test for registration with rex pull-mode

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -126,6 +126,20 @@ def session_satellite_host(request, satellite_factory):
         yield sat
 
 
+@pytest.fixture(scope='module')
+def module_satellite_mqtt(module_target_sat):
+    """Configure satellite with MQTT broker enabled"""
+    module_target_sat.set_rex_script_mode_provider('pull-mqtt')
+    # lower the mqtt_resend_interval interval
+    module_target_sat.set_mqtt_resend_interval('30')
+    result = module_target_sat.execute('systemctl status mosquitto')
+    assert result.status == 0, 'MQTT broker is not running'
+    result = module_target_sat.execute('firewall-cmd --permanent --add-port="1883/tcp"')
+    assert result.status == 0, 'Failed to open mqtt port on capsule'
+    module_target_sat.execute('firewall-cmd --reload')
+    return module_target_sat
+
+
 @pytest.fixture
 def capsule_host(request, capsule_factory):
     """A fixture that provides a Capsule based on config settings"""

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1648,11 +1648,13 @@ class Capsule(ContentHost, CapsuleMixins):
     def set_rex_script_mode_provider(self, mode='ssh'):
         """Set provider for remote execution script mode. One of: ssh(default),
         pull-mqtt, ssh-async"""
-        installer_opts = {
-            'foreman-proxy-templates': 'true',
-            'foreman-proxy-registration': 'true',
-            'foreman-proxy-plugin-remote-execution-script-mode': mode,
-        }
+
+        installer_opts = {'foreman-proxy-plugin-remote-execution-script-mode': mode}
+
+        if self.__class__.__name__ == 'Capsule':
+            installer_opts['foreman-proxy-templates'] = 'true'
+            installer_opts['foreman-proxy-registration'] = 'true'
+
         enable_mqtt_command = InstallerCommand(
             installer_opts=installer_opts,
         )

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -1,0 +1,96 @@
+"""Tests for registration.
+
+:Requirement: Registration
+
+:CaseLevel: Acceptance
+
+:CaseComponent: Registration
+
+:CaseAutomation: Automated
+
+:CaseImportance: High
+
+:Team: Rocket
+
+:TestType: Functional
+
+:Upstream: No
+"""
+import pytest
+
+from robottelo.config import settings
+
+
+@pytest.mark.tier3
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('[^6]')
+def test_host_registration_rex_pull_mode(
+    module_org,
+    module_satellite_mqtt,
+    module_location,
+    module_ak_with_cv,
+    module_capsule_configured_mqtt,
+    rhel_contenthost,
+):
+    """Verify content host registration with Satellite/Capsule as MQTT broker
+
+    :id: a082f599-fbf7-4779-aa18-5139e2bce779
+
+    :expectedresults: Host registered successfully with MQTT broker
+
+    :parametrized: yes
+    """
+    org = module_org
+    client_repo = settings.repos.SATCLIENT_REPO[f'rhel{rhel_contenthost.os_version.major}']
+    # register host to satellite with pull provider rex
+    command = module_satellite_mqtt.api.RegistrationCommand(
+        organization=org,
+        location=module_location,
+        activation_keys=[module_ak_with_cv.name],
+        setup_remote_execution_pull=True,
+        insecure=True,
+        repo=client_repo,
+    ).create()
+    result = rhel_contenthost.execute(command)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    # check mqtt client is running
+    result = rhel_contenthost.execute('systemctl status yggdrasild')
+    assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+    assert rhel_contenthost.execute('yggdrasil status').status == 0
+    mqtt_url = f'mqtts://{module_satellite_mqtt.hostname}:1883'
+    assert rhel_contenthost.execute(f'cat /etc/yggdrasil/config.toml | grep {mqtt_url}').status == 0
+
+    # Update module_capsule_configured_mqtt to include module_org/module_location
+    nc = module_capsule_configured_mqtt.nailgun_smart_proxy
+    module_satellite_mqtt.api.SmartProxy(id=nc.id, organization=[org]).update(['organization'])
+    module_satellite_mqtt.api.SmartProxy(id=nc.id, location=[module_location]).update(['location'])
+
+    # register host to capsule with pull provider rex
+    command = module_satellite_mqtt.api.RegistrationCommand(
+        smart_proxy=nc,
+        organization=org,
+        location=module_location,
+        activation_keys=[module_ak_with_cv.name],
+        setup_remote_execution_pull=True,
+        repo=client_repo,
+        insecure=True,
+        force=True,
+    ).create()
+    result = rhel_contenthost.execute(command)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    # check mqtt client is running
+    result = rhel_contenthost.execute('systemctl status yggdrasild')
+    assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+    assert rhel_contenthost.execute('yggdrasil status').status == 0
+    new_mqtt_url = f'mqtts://{module_capsule_configured_mqtt.hostname}:1883'
+    assert (
+        rhel_contenthost.execute(f'cat /etc/yggdrasil/config.toml | grep {new_mqtt_url}').status
+        == 0
+    )
+    # After force register existing config.toml is saved as backup
+    assert (
+        rhel_contenthost.execute(f'cat /etc/yggdrasil/config.toml.bak | grep {mqtt_url}').status
+        == 0
+    )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13565

### Problem Statement
Missing test coverage for registration with rex pull-mode against Satellite and Capsule

### Solution
Add test coverage for registration with rex pull-mode against Satellite and Capsule
