### PR TITLE
adding the missing properties

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -119,6 +119,7 @@ def pytest_collection_modifyitems(items, config):
         markers_prop_data = []
         exclude_markers = ['parametrize', 'skipif', 'usefixtures', 'skip_if_not_set']
         for marker in item.iter_markers():
+            item.user_properties.append((marker.name, next(iter(marker.args), None)))
             prop = marker.name
             if prop in exclude_markers:
                 continue


### PR DESCRIPTION
### Problem Statement
Because of not having `component = <value>` as part of item properties, the report portal launch having problems. It creased the unknown component launch.     

### Solution
After this fix, it will resolve that issue.  As the component property will be available  

