### PR TITLE
[6.12.z] Markers as test property in reports (#13043)

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -116,8 +116,18 @@ def pytest_collection_modifyitems(items, config):
 
         # add markers as user_properties so they are recorded in XML properties of the report
         # pytest-ibutsu will include user_properties dict in testresult metadata
+        markers_prop_data = []
+        exclude_markers = ['parametrize', 'skipif', 'usefixtures', 'skip_if_not_set']
         for marker in item.iter_markers():
-            item.user_properties.append((marker.name, next(iter(marker.args), None)))
+            prop = marker.name
+            if prop in exclude_markers:
+                continue
+            if marker_val := next(iter(marker.args), None):
+                prop = '='.join([prop, str(marker_val)])
+            markers_prop_data.append(prop)
+        item.user_properties.append(("markers", ", ".join(markers_prop_data)))
+
+        # Version specific user properties
         item.user_properties.append(("BaseOS", rhel_version))
         item.user_properties.append(("SatelliteVersion", sat_version))
         item.user_properties.append(("SnapVersion", snap_version))


### PR DESCRIPTION
### Problem Statement
Cherrypick failed for https://github.com/SatelliteQE/robottelo/pull/13043 to 6.12.z

### Solution
Manually cherrypicking !

### Related Issues
None

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->