### PR TITLE
[6.15.z] Add coverage for HTTP Proxy capsule install

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1406,7 +1406,10 @@ def sat_non_default_install(module_sat_ready_rhels):
 @pytest.mark.e2e
 @pytest.mark.tier1
 @pytest.mark.pit_client
-def test_capsule_installation(sat_non_default_install, cap_ready_rhel):
+@pytest.mark.parametrize(
+    'setting_update', [f'http_proxy={settings.http_proxy.un_auth_proxy_url}'], indirect=True
+)
+def test_capsule_installation(sat_non_default_install, cap_ready_rhel, setting_update):
     """Run a basic Capsule installation with fapolicyd
 
     :id: 64fa85b6-96e6-4fea-bea4-a30539d59e65
@@ -1424,6 +1427,10 @@ def test_capsule_installation(sat_non_default_install, cap_ready_rhel):
         3. health check runs successfully
 
     :CaseImportance: Critical
+
+    :BZ: 1984400
+
+    :customerscenario: true
     """
     # Get Capsule repofile, and enable and download satellite-capsule
     org = sat_non_default_install.api.Organization().create()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13507

### Problem Statement
https://bugzilla.redhat.com/show_bug.cgi?id=1984400 details how having an HTTP Proxy set in the settings can cause capsule installation / upgrade fail.

### Solution
Add coverage here by setting an HTTP proxy before running a capsule installation to ensure we don't regress.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->