### PR TITLE
Change team to pheonix-subscriptions to match the Hosts-Content team

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2459,7 +2459,7 @@ def test_all_hosts_delete(session, target_sat, function_org, function_location, 
 
     :CaseComponent:Hosts-Content
 
-    :Team: Phoenix-content
+    :Team: Phoenix-subscriptions
 
     :CaseLevel: System
     """
@@ -2480,7 +2480,7 @@ def test_all_hosts_bulk_delete(session, target_sat, function_org, function_locat
 
     :CaseComponent:Hosts-Content
 
-    :Team: Phoenix-content
+    :Team: Phoenix-subscriptions
 
     :CaseLevel: System
     """


### PR DESCRIPTION
Changing the team of these 2 tests to Phoenix-subscriptions to match the component, quick merge would be appreciated.