### PR TITLE
[6.14.z] Correct Casecomponent in upgrades/test_classparameter.py

### DIFF
--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -6,7 +6,7 @@
 
 :CaseLevel: Acceptance
 
-:CaseComponent: Parameters
+:CaseComponent: Puppet
 
 :Team: Rocket
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13621

### Problem Statement
Wrong component assigned for pupper classparameter tests in upgrades

### Solution
Correct component assignment for pupper classparameter tests in upgrades
