### PR TITLE
[6.15 RFE] Prepare for sca only hammer 6.15

### DIFF
--- a/robottelo/cli/simple_content_access.py
+++ b/robottelo/cli/simple_content_access.py
@@ -27,14 +27,14 @@ class SimpleContentAccess(Base):
     command_base = 'simple-content-access'
 
     @classmethod
-    def disable(cls, options=None, timeout=None, raw=False):
+    def disable(cls, options=None, timeout=None, return_raw_response=False):
         """Disable simple content access for a manifest"""
         cls.command_sub = 'disable'
         return cls.execute(
             cls._construct_command(options),
             ignore_stderr=True,
             timeout=timeout,
-            return_raw_response=raw,
+            return_raw_response=return_raw_response,
         )
 
     @classmethod

--- a/robottelo/cli/simple_content_access.py
+++ b/robottelo/cli/simple_content_access.py
@@ -27,11 +27,14 @@ class SimpleContentAccess(Base):
     command_base = 'simple-content-access'
 
     @classmethod
-    def disable(cls, options=None, timeout=None):
+    def disable(cls, options=None, timeout=None, raw=False):
         """Disable simple content access for a manifest"""
         cls.command_sub = 'disable'
         return cls.execute(
-            cls._construct_command(options), return_raw_response=True, timeout=timeout
+            cls._construct_command(options),
+            ignore_stderr=True,
+            timeout=timeout,
+            return_raw_response=raw,
         )
 
     @classmethod

--- a/robottelo/cli/simple_content_access.py
+++ b/robottelo/cli/simple_content_access.py
@@ -30,7 +30,9 @@ class SimpleContentAccess(Base):
     def disable(cls, options=None, timeout=None):
         """Disable simple content access for a manifest"""
         cls.command_sub = 'disable'
-        return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)
+        return cls.execute(
+            cls._construct_command(options), return_raw_response=True, timeout=timeout
+        )
 
     @classmethod
     def enable(cls, options=None, timeout=None):

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -289,8 +289,8 @@ def test_positive_prepare_for_sca_only_hammer(function_org, target_sat):
     :expectedresults: Hammer returns a message notifying users that Simple Content Access
         will be required for all organizations in the next release
     """
-    org_results = target_sat.execute(
-        f'hammer organization update --id {function_org.id} --simple-content-access false'
+    org_results = target_sat.cli.Org.update(
+        {'simple-content-access': 'false', 'id': function_org.id}, return_raw_response=True
     )
     assert (
         'Simple Content Access will be required for all organizations in the next release'

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -296,7 +296,9 @@ def test_positive_prepare_for_sca_only_hammer(function_org, target_sat):
         'Simple Content Access will be required for all organizations in the next release'
         in str(org_results.stderr)
     )
-    sca_results = target_sat.cli.SimpleContentAccess.disable({'organization-id': function_org.id})
+    sca_results = target_sat.cli.SimpleContentAccess.disable(
+        {'organization-id': function_org.id}, raw=True
+    )
     assert (
         'Simple Content Access will be required for all organizations in the next release'
         in str(sca_results.stderr)

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -277,3 +277,27 @@ def test_positive_auto_attach_disabled_golden_ticket(
     with pytest.raises(CLIReturnCodeError) as context:
         target_sat.cli.Host.subscription_auto_attach({'host-id': host_id})
     assert "This host's organization is in Simple Content Access mode" in str(context.value)
+
+
+@pytest.mark.tier2
+def test_positive_prepare_for_sca_only_hammer(function_org, target_sat):
+    """Verify that upon certain actions, Hammer notifies users that Simple Content Access
+        will be required for all organizations in the next release
+
+    :id: d9985a84-883f-46e7-8352-dbb849dbfa34
+
+    :expectedresults: Hammer returns a message notifying users that Simple Content Access
+        will be required for all organizations in the next release
+    """
+    org_results = target_sat.execute(
+        f'hammer organization update --id {function_org.id} --simple-content-access false'
+    )
+    assert 'Simple Content Access will be required for all organizations in the next release' in str(
+        org_results.stderr
+    )
+    sca_results = target_sat.execute(
+        f'hammer simple-content-access disable --organization-id {function_org.id}'
+    )
+    assert 'Simple Content Access will be required for all organizations in the next release' in str(
+        sca_results.stderr
+    )

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -296,9 +296,7 @@ def test_positive_prepare_for_sca_only_hammer(function_org, target_sat):
         'Simple Content Access will be required for all organizations in the next release'
         in str(org_results.stderr)
     )
-    sca_results = target_sat.execute(
-        f'hammer simple-content-access disable --organization-id {function_org.id}'
-    )
+    sca_results = target_sat.cli.SimpleContentAccess.disable({'organization-id': function_org.id})
     assert (
         'Simple Content Access will be required for all organizations in the next release'
         in str(sca_results.stderr)

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -297,7 +297,7 @@ def test_positive_prepare_for_sca_only_hammer(function_org, target_sat):
         in str(org_results.stderr)
     )
     sca_results = target_sat.cli.SimpleContentAccess.disable(
-        {'organization-id': function_org.id}, raw=True
+        {'organization-id': function_org.id}, return_raw_response=True
     )
     assert (
         'Simple Content Access will be required for all organizations in the next release'

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -292,12 +292,14 @@ def test_positive_prepare_for_sca_only_hammer(function_org, target_sat):
     org_results = target_sat.execute(
         f'hammer organization update --id {function_org.id} --simple-content-access false'
     )
-    assert 'Simple Content Access will be required for all organizations in the next release' in str(
-        org_results.stderr
+    assert (
+        'Simple Content Access will be required for all organizations in the next release'
+        in str(org_results.stderr)
     )
     sca_results = target_sat.execute(
         f'hammer simple-content-access disable --organization-id {function_org.id}'
     )
-    assert 'Simple Content Access will be required for all organizations in the next release' in str(
-        sca_results.stderr
+    assert (
+        'Simple Content Access will be required for all organizations in the next release'
+        in str(sca_results.stderr)
     )


### PR DESCRIPTION
6.15 Features automation: SAT-20202

This test is verifying that hammer notifies users that Simple Content Access will be required for all organizations in the next release

copy of https://github.com/SatelliteQE/robottelo/pull/12963