### PR TITLE
virtwho config hammer deploy option name organization-title and location-id support

### DIFF
--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -6,6 +6,7 @@ from robottelo.utils.virtwho import (
     deploy_configure_by_command,
     deploy_configure_by_script,
     get_configure_command,
+    get_configure_command_option,
     get_guest_info,
 )
 
@@ -271,6 +272,7 @@ def deploy_type_cli(
     form_data_cli,
     virtwho_config_cli,
     target_sat,
+    default_location,
 ):
     deploy_type = request.param.lower()
     assert virtwho_config_cli['status'] == 'No Report Yet'
@@ -285,6 +287,24 @@ def deploy_type_cli(
         )
         hypervisor_name, guest_name = deploy_configure_by_script(
             script, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
+        )
+    elif deploy_type == "name":
+        command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
+        )
+    elif deploy_type == "organization-title":
+        virtwho_config_cli['organization-title'] = org_module.title
+        command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
+        )
+    elif deploy_type == "location-id":
+        virtwho_config_cli['location-id'] = default_location.id
+        command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
+        print(command)
+        hypervisor_name, guest_name = deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
         )
     return hypervisor_name, guest_name
 

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -283,7 +283,7 @@ def deploy_type_cli(
         hypervisor_name, guest_name = deploy_configure_by_script(
             script, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
         )
-    elif deploy_type == "organization-title":
+    elif deploy_type == 'organization-title':
         virtwho_config_cli['organization-title'] = org_module.title
     elif deploy_type == "location-id":
         virtwho_config_cli['location-id'] = default_location.id

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -285,7 +285,7 @@ def deploy_type_cli(
         )
     elif deploy_type == 'organization-title':
         virtwho_config_cli['organization-title'] = org_module.title
-    elif deploy_type == "location-id":
+    elif deploy_type == 'location-id':
         virtwho_config_cli['location-id'] = default_location.id
     if deploy_type in ['id', 'name', 'organization-title', 'location-id']:
         if 'id' in deploy_type:

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -292,7 +292,6 @@ def deploy_type_cli(
             command = get_configure_command(virtwho_config_cli['id'], org_module.name)
         else:
             command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
-            print(command)
         hypervisor_name, guest_name = deploy_configure_by_command(
             command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
         )

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -276,33 +276,23 @@ def deploy_type_cli(
 ):
     deploy_type = request.param.lower()
     assert virtwho_config_cli['status'] == 'No Report Yet'
-    if "id" in deploy_type:
-        command = get_configure_command(virtwho_config_cli['id'], org_module.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
-        )
-    elif "script" in deploy_type:
+    if "script" in deploy_type:
         script = target_sat.cli.VirtWhoConfig.fetch(
             {'id': virtwho_config_cli['id']}, output_format='base'
         )
         hypervisor_name, guest_name = deploy_configure_by_script(
             script, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
         )
-    elif deploy_type == "name":
-        command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
-        )
     elif deploy_type == "organization-title":
         virtwho_config_cli['organization-title'] = org_module.title
-        command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
-        hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
-        )
     elif deploy_type == "location-id":
         virtwho_config_cli['location-id'] = default_location.id
-        command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
-        print(command)
+    if deploy_type in ['id', 'name', 'organization-title', 'location-id']:
+        if "id" in deploy_type:
+            command = get_configure_command(virtwho_config_cli['id'], org_module.name)
+        else:
+            command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)
+            print(command)
         hypervisor_name, guest_name = deploy_configure_by_command(
             command, form_data_cli['hypervisor-type'], debug=True, org=org_module.label
         )

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -276,7 +276,7 @@ def deploy_type_cli(
 ):
     deploy_type = request.param.lower()
     assert virtwho_config_cli['status'] == 'No Report Yet'
-    if "script" in deploy_type:
+    if 'script' in deploy_type:
         script = target_sat.cli.VirtWhoConfig.fetch(
             {'id': virtwho_config_cli['id']}, output_format='base'
         )

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -288,7 +288,7 @@ def deploy_type_cli(
     elif deploy_type == "location-id":
         virtwho_config_cli['location-id'] = default_location.id
     if deploy_type in ['id', 'name', 'organization-title', 'location-id']:
-        if "id" in deploy_type:
+        if 'id' in deploy_type:
             command = get_configure_command(virtwho_config_cli['id'], org_module.name)
         else:
             command = get_configure_command_option(deploy_type, virtwho_config_cli, org_module.name)

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -526,3 +526,25 @@ def create_http_proxy(org, name=None, url=None, http_type='https'):
         organization=[org.id],
     ).create()
     return http_proxy.url, http_proxy.name, http_proxy.id
+
+
+def get_configure_command_option(deploy_type, args, org=DEFAULT_ORG):
+    """Return the deploy command line based on option.
+    :param str option: the unique id of the configure file you have created.
+    :param str org: the satellite organization name.
+    """
+    username, password = Base._get_username_password()
+    if deploy_type == 'location-id':
+        return "hammer -u {} -p {} virt-who-config deploy --id {} --location-id '{}' ".format(
+            username, password, args['id'], args['location-id']
+        )
+    elif deploy_type == 'organization-title':
+        return (
+            "hammer -u {} -p {} virt-who-config deploy --id {} --organization-title '{}' ".format(
+                username, password, args['id'], args['organization-title']
+            )
+        )
+    elif deploy_type == 'name':
+        return "hammer -u {} -p {} virt-who-config deploy --name {} --organization '{}' ".format(
+            username, password, args['name'], org
+        )

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -535,16 +535,8 @@ def get_configure_command_option(deploy_type, args, org=DEFAULT_ORG):
     """
     username, password = Base._get_username_password()
     if deploy_type == 'location-id':
-        return "hammer -u {} -p {} virt-who-config deploy --id {} --location-id '{}' ".format(
-            username, password, args['id'], args['location-id']
-        )
+        return f"hammer -u {username} -p {password} virt-who-config deploy --id {args['id']} --location-id '{args['location-id']}' "
     elif deploy_type == 'organization-title':
-        return (
-            "hammer -u {} -p {} virt-who-config deploy --id {} --organization-title '{}' ".format(
-                username, password, args['id'], args['organization-title']
-            )
-        )
+        return f"hammer -u {username} -p {password} virt-who-config deploy --id {args['id']} --organization-title '{args['organization-title']}' "
     elif deploy_type == 'name':
-        return "hammer -u {} -p {} virt-who-config deploy --name {} --organization '{}' ".format(
-            username, password, args['name'], org
-        )
+        return f"hammer -u {username} -p {password} virt-who-config deploy --name {args['name']} --organization '{org}' "

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -37,8 +37,12 @@ from robottelo.utils.virtwho import (
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
-    def test_positive_deploy_configure_by_id_script(
+    @pytest.mark.parametrize(
+        'deploy_type_cli',
+        ['id', 'script', 'name', 'location-id', 'organization-title'],
+        indirect=True,
+    )
+    def test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle(
         self, module_sca_manifest_org, target_sat, virtwho_config_cli, deploy_type_cli
     ):
         """Verify "hammer virt-who-config deploy & fetch"


### PR DESCRIPTION
virtwho config hammer deploy option name organization-title and location-id support
Satellite6.15 PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle[name] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 37 deselected, 10 warnings in 121.35s (0:02:01)
2024-01-08 01:21:37 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle[organization-title] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 37 deselected, 10 warnings in 109.41s (0:01:49)
2024-01-08 01:29:53 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle[location-id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 37 deselected, 10 warnings in 108.15s (0:01:48)
2024-01-08 02:00:09 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
```