### PR TITLE
[6.14.z] Fix test AK create with CV

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -154,10 +154,11 @@ def test_positive_create_with_cv(name, module_org, get_default_env, module_targe
     new_cv = module_target_sat.cli_factory.make_content_view(
         {'name': name, 'organization-id': module_org.id}
     )
+    module_target_sat.cli.ContentView.publish({'id': new_cv['id']})
     new_ak_cv = module_target_sat.cli_factory.make_activation_key(
         {
             'content-view': new_cv['name'],
-            'environment': get_default_env['name'],
+            'lifecycle-environment': get_default_env['name'],
             'organization-id': module_org.id,
         }
     )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13642

### Problem Statement
This parametrized test has been failing in 6.15 and 6.14 for some time. The error is
```
E   Warning: Option --environment is deprecated. Use --lifecycle-environment instead
E   Could not create the activation key:
E     Validation failed: Content view 'wMjLDMSyxhndvsDSHyvRFeLOBOZEhOXzLLPwsLcrCJvvAhR' is not in environment 'Library'
```
When creating an AK via UI we provide LCE first and then CV, which needs to be published/promoted to that LCE. Using that validation for CLI is right.

### Solution
1. Publish the CV so that it IS in Library LCE.
2. Replace deprecated `environment` with newer `lifecycle-environment`.

