### PR TITLE
fix assert_job_invocation_status calls

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -461,7 +461,9 @@ class TestRemoteExecution:
             }
         )
         result = target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
-        assert_job_invocation_status(invocation_command['id'], client.hostname, 'queued')
+        assert_job_invocation_status(
+            target_sat, invocation_command['id'], client.hostname, 'queued'
+        )
         sleep(150)
         rec_logic = target_sat.cli.RecurringLogic.info({'id': result['recurring-logic-id']})
         assert rec_logic['state'] == 'finished'
@@ -544,7 +546,9 @@ class TestRemoteExecution:
                 }
             )
             result = target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
-            assert_job_invocation_status(invocation_command['id'], client.hostname, 'queued')
+            assert_job_invocation_status(
+                target_sat, invocation_command['id'], client.hostname, 'queued'
+            )
             rec_logic = target_sat.cli.RecurringLogic.info({'id': result['recurring-logic-id']})
             assert (
                 rec_logic['next-occurrence'] == exp[1]
@@ -1464,7 +1468,9 @@ class TestPullProviderRex:
             }
         )
         # assert the job is waiting to be picked up by client
-        assert_job_invocation_status(invocation_command['id'], rhel_contenthost.hostname, 'running')
+        assert_job_invocation_status(
+            module_target_sat, invocation_command['id'], rhel_contenthost.hostname, 'running'
+        )
         # start client on host
         result = rhel_contenthost.execute('systemctl start yggdrasild')
         assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'


### PR DESCRIPTION
### Problem Statement
 assert_job_invocation_status requires satellite as a first argument (since recent refactor), but the calls were not providing it, hence ~3 test failures

### Solution
Updating the calls to include target_sat. For reason unknown, this problem occurs only in master and 6.15