### PR TITLE
[6.15.z] Update manifest fixture in registration test to resolve conflict

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -31,7 +31,7 @@ pytestmark = pytest.mark.tier1
 @pytest.mark.e2e
 @pytest.mark.no_containers
 def test_host_registration_end_to_end(
-    module_entitlement_manifest_org,
+    module_sca_manifest_org,
     module_location,
     module_activation_key,
     module_target_sat,
@@ -51,7 +51,7 @@ def test_host_registration_end_to_end(
 
     :customerscenario: true
     """
-    org = module_entitlement_manifest_org
+    org = module_sca_manifest_org
     command = module_target_sat.api.RegistrationCommand(
         organization=org,
         activation_keys=[module_activation_key.name],

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.tier1
 @pytest.mark.e2e
 @pytest.mark.no_containers
 def test_host_registration_end_to_end(
-    module_entitlement_manifest_org,
+    module_sca_manifest_org,
     module_location,
     module_activation_key,
     module_target_sat,
@@ -48,7 +48,7 @@ def test_host_registration_end_to_end(
 
     :customerscenario: true
     """
-    org = module_entitlement_manifest_org
+    org = module_sca_manifest_org
     result = rhel_contenthost.register(
         org, module_location, [module_activation_key.name], module_target_sat
     )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13616

### Problem Statement
There was a conflict in manifest fixture as both sca and non-sca enabled fixture was being used in same test case. 

### Solution
Updated the test case to fix the test failures.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->