### PR TITLE
[6.13.z] fixing a forgotten make_job_invocaiton call

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1103,7 +1103,7 @@ class TestPullProviderRex:
             module_target_sat, make_user_job['id'], rhel_contenthost.hostname
         )
         # create a file as new user
-        invocation_command = module_target_sat.make_job_invocation(
+        invocation_command = module_target_sat.cli_factory.job_invocation(
             {
                 'job-template': 'Run Command - Script Default',
                 'inputs': f"command=touch /home/{username}/{filename}",


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13648

### Problem Statement
possibly overlooked in https://github.com/SatelliteQE/robottelo/pull/11544 , causing `AttributeError: 'Satellite' object has no attribute 'make_job_invocation'`

### Solution
fixed the syntax