### PR TITLE
[6.14.z] - Removing the direct Airgun imports from robottelo

### DIFF
--- a/tests/foreman/ui/test_branding.py
+++ b/tests/foreman/ui/test_branding.py
@@ -11,7 +11,6 @@
 :CaseImportance: High
 
 """
-from airgun.session import Session
 import pytest
 
 
@@ -31,7 +30,7 @@ def test_verify_satellite_login_screen_info(target_sat):
     :BZ: 1315849, 1367495, 1372436, 1502098, 1540710, 1582476, 1724738,
          1959135, 2076979, 1687250, 1686540, 1742872, 1805642, 2105949
     """
-    with Session(login=False) as session:
+    with target_sat.ui_session(login=False) as session:
         version = session.login.read_sat_version()
     assert f'Version {target_sat.version}' == version['login_text']
     assert 'Beta' not in version['login_text'], '"Beta" should not be there'

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -11,8 +11,6 @@
 :CaseImportance: High
 
 """
-from airgun.session import Session
-from nailgun import entities
 from nailgun.entity_mixins import TaskFailedError
 import pytest
 
@@ -23,7 +21,7 @@ from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.mark.tier2
-def test_positive_host_configuration_status(session):
+def test_positive_host_configuration_status(session, target_sat):
     """Check if the Host Configuration Status Widget links are working
 
     :id: ffb0a6a1-2b65-4578-83c7-61492122d865
@@ -41,9 +39,9 @@ def test_positive_host_configuration_status(session):
 
     :BZ: 1631219
     """
-    org = entities.Organization().create()
-    loc = entities.Location().create()
-    host = entities.Host(organization=org, location=loc).create()
+    org = target_sat.api.Organization().create()
+    loc = target_sat.api.Location().create()
+    host = target_sat.api.Host(organization=org, location=loc).create()
     criteria_list = [
         'Hosts that had performed modifications without error',
         'Hosts in error state',
@@ -94,7 +92,7 @@ def test_positive_host_configuration_status(session):
 
 
 @pytest.mark.tier2
-def test_positive_host_configuration_chart(session):
+def test_positive_host_configuration_chart(session, target_sat):
     """Check if the Host Configuration Chart is working in the Dashboard UI
 
     :id: b03314aa-4394-44e5-86da-c341c783003d
@@ -107,9 +105,9 @@ def test_positive_host_configuration_chart(session):
 
     :expectedresults: Chart showing correct data
     """
-    org = entities.Organization().create()
-    loc = entities.Location().create()
-    entities.Host(organization=org, location=loc).create()
+    org = target_sat.api.Organization().create()
+    loc = target_sat.api.Location().create()
+    target_sat.api.Host(organization=org, location=loc).create()
     with session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=loc.name)
@@ -120,7 +118,7 @@ def test_positive_host_configuration_chart(session):
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
-def test_positive_task_status(session):
+def test_positive_task_status(session, target_sat):
     """Check if the Task Status is working in the Dashboard UI and
         filter from Tasks index page is working correctly
 
@@ -141,9 +139,11 @@ def test_positive_task_status(session):
     :BZ: 1718889
     """
     url = 'www.non_existent_repo_url.org'
-    org = entities.Organization().create()
-    product = entities.Product(organization=org).create()
-    repo = entities.Repository(url=f'http://{url}', product=product, content_type='yum').create()
+    org = target_sat.api.Organization().create()
+    product = target_sat.api.Product(organization=org).create()
+    repo = target_sat.api.Repository(
+        url=f'http://{url}', product=product, content_type='yum'
+    ).create()
     with pytest.raises(TaskFailedError):
         repo.sync()
     with session:
@@ -222,9 +222,9 @@ def test_positive_user_access_with_host_filter(
     user_login = gen_string('alpha')
     user_password = gen_string('alphanumeric')
     org = function_entitlement_manifest_org
-    lce = entities.LifecycleEnvironment(organization=org).create()
+    lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     # create a role with necessary permissions
-    role = entities.Role().create()
+    role = target_sat.api.Role().create()
     user_permissions = {
         'Organization': ['view_organizations'],
         'Location': ['view_locations'],
@@ -233,7 +233,7 @@ def test_positive_user_access_with_host_filter(
     }
     target_sat.api_factory.create_role_permissions(role, user_permissions)
     # create a user and assign the above created role
-    entities.User(
+    target_sat.api.User(
         default_organization=org,
         organization=[org],
         default_location=module_location,
@@ -242,7 +242,7 @@ def test_positive_user_access_with_host_filter(
         login=user_login,
         password=user_password,
     ).create()
-    with Session(test_name, user=user_login, password=user_password) as session:
+    with target_sat.ui_session(test_name, user=user_login, password=user_password) as session:
         assert session.dashboard.read('HostConfigurationStatus')['total_count'] == 0
         assert len(session.dashboard.read('LatestErrata')['erratas']) == 0
         rhel_contenthost.add_rex_key(target_sat)
@@ -266,7 +266,7 @@ def test_positive_user_access_with_host_filter(
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_sync_overview_widget(session, module_org, module_product):
+def test_positive_sync_overview_widget(session, module_product, module_target_sat):
     """Check if the Sync Overview widget is working in the Dashboard UI
 
     :id: 553fbe33-0f6f-46fb-8d80-5d1d9ed483cf
@@ -280,7 +280,9 @@ def test_positive_sync_overview_widget(session, module_org, module_product):
 
     :BZ: 1995424
     """
-    repo = entities.Repository(url=settings.repos.yum_1.url, product=module_product).create()
+    repo = module_target_sat.api.Repository(
+        url=settings.repos.yum_1.url, product=module_product
+    ).create()
     with session:
         session.repository.synchronize(module_product.name, repo.name)
         sync_params = session.dashboard.read('SyncOverview')['syncs']

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -11,7 +11,6 @@
 :CaseImportance: High
 
 """
-from airgun.session import Session
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
 import pytest
 
@@ -82,7 +81,9 @@ def test_positive_crud_with_non_admin_user(
     new_priority = str(gen_integer(101, 200))
     hg = module_target_sat.api.HostGroup(organization=[module_org]).create()
     new_hg_name = module_target_sat.api.HostGroup(organization=[module_org]).create()
-    with Session(user=manager_user.login, password=manager_user.password) as session:
+    with module_target_sat.ui_session(
+        user=manager_user.login, password=manager_user.password
+    ) as session:
         session.location.select(loc_name=module_location.name)
         session.discoveryrule.create(
             {
@@ -145,7 +146,9 @@ def test_negative_delete_rule_with_non_admin_user(
         organization=[module_org],
         location=[module_location],
     ).create()
-    with Session(user=reader_user.login, password=reader_user.password) as session:
+    with module_target_sat.ui_session(
+        user=reader_user.login, password=reader_user.password
+    ) as session:
         with pytest.raises(ValueError):  # noqa: PT011 - TODO Adarsh determine better exception
             session.discoveryrule.delete(dr.name)
         dr_val = session.discoveryrule.read_all()

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -11,11 +11,9 @@
 :CaseImportance: High
 
 """
-from airgun.session import Session
 from broker import Broker
 from fauxfactory import gen_string
 from manifester import Manifester
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -50,9 +48,9 @@ RHVA_ERRATA_CVES = REAL_4_ERRATA_CVES
 pytestmark = [pytest.mark.run_in_one_thread]
 
 
-def _generate_errata_applicability(hostname):
+def _generate_errata_applicability(hostname, module_target_sat):
     """Force host to generate errata applicability"""
-    host = entities.Host().search(query={'search': f'name={hostname}'})[0].read()
+    host = module_target_sat.api.Host().search(query={'search': f'name={hostname}'})[0].read()
     host.errata_applicability(synchronous=False)
 
 
@@ -140,9 +138,9 @@ def erratatype_vm(module_repos_collection_with_setup, target_sat):
 
 
 @pytest.fixture
-def errata_status_installable():
+def errata_status_installable(module_target_sat):
     """Fixture to allow restoring errata_status_installable setting after usage"""
-    errata_status_installable = entities.Setting().search(
+    errata_status_installable = module_target_sat.api.Setting().search(
         query={'search': 'name="errata_status_installable"'}
     )[0]
     original_value = errata_status_installable.value
@@ -390,7 +388,7 @@ def test_positive_list(session, function_org_with_parameter, lce, target_sat):
     indirect=True,
 )
 def test_positive_list_permission(
-    test_name, module_org_with_parameter, module_repos_collection_with_setup
+    test_name, module_org_with_parameter, module_repos_collection_with_setup, module_target_sat
 ):
     """Show errata only if the User has permissions to view them
 
@@ -408,23 +406,25 @@ def test_positive_list_permission(
         product only.
     """
     module_org = module_org_with_parameter
-    role = entities.Role().create()
-    entities.Filter(
+    role = module_target_sat.api.Role().create()
+    module_target_sat.api.Filter(
         organization=[module_org],
-        permission=entities.Permission().search(
+        permission=module_target_sat.api.Permission().search(
             query={'search': 'resource_type="Katello::Product"'}
         ),
         role=role,
         search='name = "{}"'.format(PRDS['rhel']),
     ).create()
     user_password = gen_string('alphanumeric')
-    user = entities.User(
+    user = module_target_sat.api.User(
         default_organization=module_org,
         organization=[module_org],
         role=[role],
         password=user_password,
     ).create()
-    with Session(test_name, user=user.login, password=user_password) as session:
+    with module_target_sat.ui_session(
+        test_name, user=user.login, password=user_password
+    ) as session:
         assert (
             session.errata.search(RHVA_ERRATA_ID, applicable=False)[0]['Errata ID']
             == RHVA_ERRATA_ID
@@ -568,14 +568,16 @@ def test_positive_filter_by_environment(
             )
             assert _install_client_package(client, FAKE_1_CUSTOM_PACKAGE, errata_applicability=True)
         # Promote the latest content view version to a new lifecycle environment
-        content_view = entities.ContentView(
+        content_view = target_sat.api.ContentView(
             id=module_repos_collection_with_setup.setup_content_data['content_view']['id']
         ).read()
         content_view_version = content_view.version[-1].read()
         lce = content_view_version.environment[-1].read()
-        new_lce = entities.LifecycleEnvironment(organization=module_org, prior=lce).create()
+        new_lce = target_sat.api.LifecycleEnvironment(organization=module_org, prior=lce).create()
         content_view_version.promote(data={'environment_ids': new_lce.id})
-        host = entities.Host().search(query={'search': f'name={clients[0].hostname}'})[0].read()
+        host = (
+            target_sat.api.Host().search(query={'search': f'name={clients[0].hostname}'})[0].read()
+        )
         host.content_facet_attributes = {
             'content_view_id': content_view.id,
             'lifecycle_environment_id': new_lce.id,
@@ -616,7 +618,7 @@ def test_positive_filter_by_environment(
     indirect=True,
 )
 def test_positive_content_host_previous_env(
-    session, module_org_with_parameter, module_repos_collection_with_setup, vm
+    session, module_org_with_parameter, module_repos_collection_with_setup, vm, module_target_sat
 ):
     """Check if the applicable errata are available from the content
     host's previous environment
@@ -639,14 +641,16 @@ def test_positive_content_host_previous_env(
     hostname = vm.hostname
     assert _install_client_package(vm, FAKE_1_CUSTOM_PACKAGE, errata_applicability=True)
     # Promote the latest content view version to a new lifecycle environment
-    content_view = entities.ContentView(
+    content_view = module_target_sat.api.ContentView(
         id=module_repos_collection_with_setup.setup_content_data['content_view']['id']
     ).read()
     content_view_version = content_view.version[-1].read()
     lce = content_view_version.environment[-1].read()
-    new_lce = entities.LifecycleEnvironment(organization=module_org, prior=lce).create()
+    new_lce = module_target_sat.api.LifecycleEnvironment(
+        organization=module_org, prior=lce
+    ).create()
     content_view_version.promote(data={'environment_ids': new_lce.id})
-    host = entities.Host().search(query={'search': f'name={hostname}'})[0].read()
+    host = module_target_sat.api.Host().search(query={'search': f'name={hostname}'})[0].read()
     host.content_facet_attributes = {
         'content_view_id': content_view.id,
         'lifecycle_environment_id': new_lce.id,
@@ -914,7 +918,7 @@ def test_positive_filtered_errata_status_installable_param(
     :CaseImportance: Medium
     """
     org = function_entitlement_manifest_org
-    lce = entities.LifecycleEnvironment(organization=org).create()
+    lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     repos_collection = target_sat.cli_factory.RepositoryCollection(
         distro='rhel7',
         repositories=[
@@ -931,16 +935,16 @@ def test_positive_filtered_errata_status_installable_param(
         assert _install_client_package(client, FAKE_1_CUSTOM_PACKAGE, errata_applicability=True)
         # Adding content view filter and content view filter rule to exclude errata for the
         # installed package.
-        content_view = entities.ContentView(
+        content_view = target_sat.api.ContentView(
             id=repos_collection.setup_content_data['content_view']['id']
         ).read()
-        cv_filter = entities.ErratumContentViewFilter(
+        cv_filter = target_sat.api.ErratumContentViewFilter(
             content_view=content_view, inclusion=False
         ).create()
-        errata = entities.Errata(content_view_version=content_view.version[-1]).search(
+        errata = target_sat.api.Errata(content_view_version=content_view.version[-1]).search(
             query=dict(search=f'errata_id="{CUSTOM_REPO_ERRATA_ID}"')
         )[0]
-        entities.ContentViewFilterRule(content_view_filter=cv_filter, errata=errata).create()
+        target_sat.api.ContentViewFilterRule(content_view_filter=cv_filter, errata=errata).create()
         content_view.publish()
         content_view = content_view.read()
         content_view_version = content_view.version[-1]

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -18,7 +18,6 @@ import os
 import re
 
 from airgun.exceptions import DisabledWidgetError, NoSuchElementException
-from airgun.session import Session
 import pytest
 from wait_for import wait_for
 import yaml
@@ -482,7 +481,7 @@ def test_positive_view_hosts_with_non_admin_user(
     created_host = target_sat.api.Host(
         location=smart_proxy_location, organization=module_org
     ).create()
-    with Session(test_name, user=user.login, password=user_password) as session:
+    with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
         host = session.host.get_details(created_host.name, widget_names='breadcrumb')
         assert host['breadcrumb'] == created_host.name
         content_host = session.contenthost.read(created_host.name, widget_names='breadcrumb')
@@ -531,7 +530,7 @@ def test_positive_remove_parameter_non_admin_user(
         organization=module_org,
         host_parameters_attributes=[parameter],
     ).create()
-    with Session(test_name, user=user.login, password=user_password) as session:
+    with target_sat.ui_seesion(test_name, user=user.login, password=user_password) as session:
         values = session.host.read(host.name, 'parameters')
         assert values['parameters']['host_params'][0] == parameter
         session.host.update(host.name, {'parameters.host_params': []})
@@ -586,7 +585,7 @@ def test_negative_remove_parameter_non_admin_user(
         organization=module_org,
         host_parameters_attributes=[parameter],
     ).create()
-    with Session(test_name, user=user.login, password=user_password) as session:
+    with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
         values = session.host.read(host.name, 'parameters')
         assert values['parameters']['host_params'][0] == parameter
         with pytest.raises(NoSuchElementException) as context:
@@ -695,7 +694,7 @@ def test_positive_check_permissions_affect_create_procedure(
             'other_fields_values': {'host.lce': filter_lc_env.name},
         },
     ]
-    with Session(test_name, user=user.login, password=user_password) as session:
+    with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
         for host_field in host_fields:
             values = {host_field['name']: host_field['unexpected_value']}
             values.update(host_field.get('other_fields_values', {}))
@@ -2327,7 +2326,7 @@ def test_positive_host_registration_with_non_admin_user(
     role = target_sat.cli.Role.info({'name': 'Register hosts'})
     target_sat.cli.User.add_role({'id': user.id, 'role-id': role['id']})
 
-    with Session(test_name, user=user.login, password=user_password) as session:
+    with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
 
         cmd = session.host_new.get_register_command(
             {
@@ -2345,7 +2344,7 @@ def test_positive_host_registration_with_non_admin_user(
 
 
 @pytest.mark.tier2
-def test_all_hosts_delete(session, target_sat, function_org, function_location, new_host_ui):
+def test_all_hosts_delete(target_sat, function_org, function_location, new_host_ui):
     """Create a host and delete it through All Hosts UI
 
     :id: 42b4560c-bb57-4c58-928e-e5fd5046b93f
@@ -2364,7 +2363,7 @@ def test_all_hosts_delete(session, target_sat, function_org, function_location, 
 
 
 @pytest.mark.tier2
-def test_all_hosts_bulk_delete(session, target_sat, function_org, function_location, new_host_ui):
+def test_all_hosts_bulk_delete(target_sat, function_org, function_location, new_host_ui):
     """Create several hosts, and delete them via Bulk Actions in All Hosts UI
 
     :id: af1b4a66-dd83-47c3-904b-e8627119cc53

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -11,7 +11,6 @@
 :CaseImportance: High
 
 """
-from airgun.session import Session
 from navmazing import NavigationTriesExceeded
 import pytest
 
@@ -298,7 +297,7 @@ def test_positive_custom_user_view_lce(session, test_name, target_sat):
         lce_values = session.lifecycleenvironment.read_all()
         assert lce_name in lce_values['lce']
     # ensure the created user also can find the created lifecycle environment link
-    with Session(test_name, user_login, user_password) as non_admin_session:
+    with target_sat.ui_session(test_name, user_login, user_password) as non_admin_session:
         # to ensure that the created user has only the assigned
         # permissions, check that hosts menu tab does not exist
         with pytest.raises(NavigationTriesExceeded):

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -14,8 +14,6 @@
 from datetime import datetime, timedelta
 from random import randint, shuffle
 
-from airgun.session import Session
-from nailgun import entities
 from navmazing import NavigationTriesExceeded
 import pytest
 
@@ -41,19 +39,19 @@ from robottelo.utils.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
+def module_org(module_target_sat):
+    return module_target_sat.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
-def module_prod(module_org):
-    return entities.Product(organization=module_org).create()
+def module_prod(module_org, module_target_sat):
+    return module_target_sat.api.Product(organization=module_org).create()
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_create_in_different_orgs(session, module_org):
+def test_positive_create_in_different_orgs(session, module_org, module_target_sat):
     """Create repository in two different orgs with same name
 
     :id: 019c2242-8802-4bae-82c5-accf8f793dbc
@@ -62,9 +60,9 @@ def test_positive_create_in_different_orgs(session, module_org):
         organizations
     """
     repo_name = gen_string('alpha')
-    org2 = entities.Organization().create()
-    prod1 = entities.Product(organization=module_org).create()
-    prod2 = entities.Product(organization=org2).create()
+    org2 = module_target_sat.api.Organization().create()
+    prod1 = module_target_sat.api.Product(organization=module_org).create()
+    prod2 = module_target_sat.api.Product(organization=org2).create()
     with session:
         for org, prod in [[module_org, prod1], [org2, prod2]]:
             session.organization.select(org_name=org.name)
@@ -107,9 +105,9 @@ def test_positive_create_as_non_admin_user(module_org, test_name, target_sat):
             'sync_products',
         ],
     }
-    role = entities.Role().create()
+    role = target_sat.api.Role().create()
     target_sat.api_factory.create_role_permissions(role, user_permissions)
-    entities.User(
+    target_sat.api.User(
         login=user_login,
         password=user_password,
         role=[role],
@@ -117,8 +115,8 @@ def test_positive_create_as_non_admin_user(module_org, test_name, target_sat):
         default_organization=module_org,
         organization=[module_org],
     ).create()
-    product = entities.Product(organization=module_org).create()
-    with Session(test_name, user=user_login, password=user_password) as session:
+    product = target_sat.api.Product(organization=module_org).create()
+    with target_sat.ui_session(test_name, user=user_login, password=user_password) as session:
         # ensure that the created user is not a global admin user
         # check administer->organizations page
         with pytest.raises(NavigationTriesExceeded):
@@ -137,7 +135,7 @@ def test_positive_create_as_non_admin_user(module_org, test_name, target_sat):
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_create_yum_repo_same_url_different_orgs(session, module_prod):
+def test_positive_create_yum_repo_same_url_different_orgs(session, module_prod, module_target_sat):
     """Create two repos with the same URL in two different organizations.
 
     :id: f4cb00ed-6faf-4c79-9f66-76cd333299cb
@@ -145,12 +143,16 @@ def test_positive_create_yum_repo_same_url_different_orgs(session, module_prod):
     :expectedresults: Repositories are created and have equal number of packages.
     """
     # Create first repository
-    repo = entities.Repository(product=module_prod, url=settings.repos.yum_0.url).create()
+    repo = module_target_sat.api.Repository(
+        product=module_prod, url=settings.repos.yum_0.url
+    ).create()
     repo.sync()
     # Create second repository
-    org = entities.Organization().create()
-    product = entities.Product(organization=org).create()
-    new_repo = entities.Repository(product=product, url=settings.repos.yum_0.url).create()
+    org = module_target_sat.api.Organization().create()
+    product = module_target_sat.api.Product(organization=org).create()
+    new_repo = module_target_sat.api.Repository(
+        product=product, url=settings.repos.yum_0.url
+    ).create()
     new_repo.sync()
     with session:
         # Check packages number in first repository
@@ -194,9 +196,9 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
             'sync_products',
         ],
     }
-    role = entities.Role().create()
+    role = target_sat.api.Role().create()
     target_sat.api_factory.create_role_permissions(role, user_permissions)
-    entities.User(
+    target_sat.api.User(
         login=user_login,
         password=user_password,
         role=[role],
@@ -204,14 +206,14 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
         default_organization=module_org,
         organization=[module_org],
     ).create()
-    prod = entities.Product(organization=module_org).create()
-    repo = entities.Repository(product=prod, url=settings.repos.yum_2.url).create()
+    prod = target_sat.api.Product(organization=module_org).create()
+    repo = target_sat.api.Repository(product=prod, url=settings.repos.yum_2.url).create()
     repo.sync()
-    content_view = entities.ContentView(organization=module_org).create()
+    content_view = target_sat.api.ContentView(organization=module_org).create()
     content_view.repository = [repo]
     content_view = content_view.update(['repository'])
     content_view.publish()
-    with Session(test_name, user_login, user_password) as session:
+    with target_sat.ui_session(test_name, user_login, user_password) as session:
         # ensure that the created user is not a global admin user
         # check administer->users page
         pswd = gen_string('alphanumeric')
@@ -243,7 +245,7 @@ def test_positive_create_as_non_admin_user_with_cv_published(module_org, test_na
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.usefixtures('allow_repo_discovery')
-def test_positive_discover_repo_via_existing_product(session, module_org):
+def test_positive_discover_repo_via_existing_product(session, module_org, module_target_sat):
     """Create repository via repo-discovery under existing product
 
     :id: 9181950c-a756-456f-a46a-059e7a2add3c
@@ -251,7 +253,7 @@ def test_positive_discover_repo_via_existing_product(session, module_org):
     :expectedresults: Repository is discovered and created
     """
     repo_name = 'fakerepo01'
-    product = entities.Product(organization=module_org).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
     with session:
         session.organization.select(org_name=module_org.name)
         session.product.discover_repo(
@@ -297,7 +299,9 @@ def test_positive_discover_repo_via_new_product(session, module_org):
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.usefixtures('allow_repo_discovery')
-def test_positive_discover_module_stream_repo_via_existing_product(session, module_org):
+def test_positive_discover_module_stream_repo_via_existing_product(
+    session, module_org, module_target_sat
+):
     """Create repository with module streams via repo-discovery under an existing product.
 
     :id: e7b9e2c4-7ecd-4cde-8f74-961fbac8919c
@@ -315,7 +319,7 @@ def test_positive_discover_module_stream_repo_via_existing_product(session, modu
     """
     repo_name = gen_string('alpha')
     repo_label = gen_string('alpha')
-    product = entities.Product(organization=module_org).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
     with session:
         session.organization.select(org_name=module_org.name)
         session.product.discover_repo(
@@ -336,15 +340,15 @@ def test_positive_discover_module_stream_repo_via_existing_product(session, modu
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_sync_custom_repo_yum(session, module_org):
+def test_positive_sync_custom_repo_yum(session, module_org, module_target_sat):
     """Create Custom yum repos and sync it via the repos page.
 
     :id: afa218f4-e97a-4240-a82a-e69538d837a1
 
     :expectedresults: Sync procedure for specific yum repository is successful
     """
-    product = entities.Product(organization=module_org).create()
-    repo = entities.Repository(url=settings.repos.yum_1.url, product=product).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
+    repo = module_target_sat.api.Repository(url=settings.repos.yum_1.url, product=product).create()
     with session:
         result = session.repository.synchronize(product.name, repo.name)
         assert result['result'] == 'success'
@@ -357,7 +361,7 @@ def test_positive_sync_custom_repo_yum(session, module_org):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_sync_custom_repo_docker(session, module_org):
+def test_positive_sync_custom_repo_docker(session, module_org, module_target_sat):
     """Create Custom docker repos and sync it via the repos page.
 
     :id: 942e0b4f-3524-4f00-812d-bdad306f81de
@@ -365,8 +369,8 @@ def test_positive_sync_custom_repo_docker(session, module_org):
     :expectedresults: Sync procedure for specific docker repository is
         successful
     """
-    product = entities.Product(organization=module_org).create()
-    repo = entities.Repository(
+    product = module_target_sat.api.Product(organization=module_org).create()
+    repo = module_target_sat.api.Repository(
         url=CONTAINER_REGISTRY_HUB, product=product, content_type=REPO_TYPE['docker']
     ).create()
     with session:
@@ -376,7 +380,7 @@ def test_positive_sync_custom_repo_docker(session, module_org):
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_resync_custom_repo_after_invalid_update(session, module_org):
+def test_positive_resync_custom_repo_after_invalid_update(session, module_org, module_target_sat):
     """Create Custom yum repo and sync it via the repos page. Then try to
     change repo url to invalid one and re-sync that repository
 
@@ -389,8 +393,8 @@ def test_positive_resync_custom_repo_after_invalid_update(session, module_org):
 
     :BZ: 1487173, 1262313
     """
-    product = entities.Product(organization=module_org).create()
-    repo = entities.Repository(url=settings.repos.yum_1.url, product=product).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
+    repo = module_target_sat.api.Repository(url=settings.repos.yum_1.url, product=product).create()
     with session:
         result = session.repository.synchronize(product.name, repo.name)
         assert result['result'] == 'success'
@@ -408,7 +412,7 @@ def test_positive_resync_custom_repo_after_invalid_update(session, module_org):
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_resynchronize_rpm_repo(session, module_prod):
+def test_positive_resynchronize_rpm_repo(session, module_prod, module_target_sat):
     """Check that repository content is resynced after packages were removed
     from repository
 
@@ -418,7 +422,7 @@ def test_positive_resynchronize_rpm_repo(session, module_prod):
 
     :BZ: 1318004
     """
-    repo = entities.Repository(
+    repo = module_target_sat.api.Repository(
         url=settings.repos.yum_1.url, content_type=REPO_TYPE['yum'], product=module_prod
     ).create()
     with session:
@@ -442,7 +446,7 @@ def test_positive_resynchronize_rpm_repo(session, module_prod):
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod):
+def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod, module_target_sat):
     """Perform end to end testing for custom yum repository
 
     :id: 8baf11c9-019e-4625-a549-ec4cd9312f75
@@ -455,11 +459,11 @@ def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod):
     checksum_type = 'sha256'
     new_repo_name = gen_string('alphanumeric')
     new_checksum_type = 'sha1'
-    gpg_key = entities.GPGKey(
+    gpg_key = module_target_sat.api.GPGKey(
         content=DataFile.VALID_GPG_KEY_FILE.read_bytes(),
         organization=module_org,
     ).create()
-    new_gpg_key = entities.GPGKey(
+    new_gpg_key = module_target_sat.api.GPGKey(
         content=DataFile.VALID_GPG_KEY_BETA_FILE.read_bytes(),
         organization=module_org,
     ).create()
@@ -758,7 +762,7 @@ def test_positive_reposet_disable_after_manifest_deleted(
     :BZ: 1344391
     """
     org = function_entitlement_manifest_org
-    sub = entities.Subscription(organization=org)
+    sub = target_sat.api.Subscription(organization=org)
     sat_tools_repo = target_sat.cli_factory.SatelliteToolsRepository(distro='rhel7', cdn=True)
     repository_name = sat_tools_repo.data['repository']
     repository_name_orphaned = f'{repository_name} (Orphaned)'
@@ -798,7 +802,7 @@ def test_positive_reposet_disable_after_manifest_deleted(
 
 
 @pytest.mark.tier2
-def test_positive_delete_random_docker_repo(session, module_org):
+def test_positive_delete_random_docker_repo(session, module_org, module_target_sat):
     """Create Docker-type repositories on multiple products and
     delete a random repository from a random product.
 
@@ -808,9 +812,12 @@ def test_positive_delete_random_docker_repo(session, module_org):
         without altering the other products.
     """
     entities_list = []
-    products = [entities.Product(organization=module_org).create() for _ in range(randint(2, 5))]
+    products = [
+        module_target_sat.api.Product(organization=module_org).create()
+        for _ in range(randint(2, 5))
+    ]
     for product in products:
-        repo = entities.Repository(
+        repo = module_target_sat.api.Repository(
             url=CONTAINER_REGISTRY_HUB, product=product, content_type=REPO_TYPE['docker']
         ).create()
         entities_list.append((product.name, repo.name))
@@ -1178,7 +1185,7 @@ def test_positive_select_org_in_any_context():
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_sync_repo_and_verify_checksum(session, module_org):
+def test_positive_sync_repo_and_verify_checksum(session, module_org, module_target_sat):
     """Tests that Verify Content Checksum succeeds when executing from the products page
 
     :id: 577be1f8-7510-49d2-8b33-600db60bd960
@@ -1194,7 +1201,7 @@ def test_positive_sync_repo_and_verify_checksum(session, module_org):
     :expectedresults: Verify Content Checksum task succeeds
     """
     repo_name = gen_string('alpha')
-    product = entities.Product(organization=module_org).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
     with session:
         session.repository.create(
             product.name,
@@ -1210,7 +1217,7 @@ def test_positive_sync_repo_and_verify_checksum(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_sync_sha_repo(session, module_org):
+def test_positive_sync_sha_repo(session, module_org, module_target_sat):
     """Sync 'sha' repo successfully
 
     :id: 6172035f-96c4-41e4-a79b-acfaa78ad734
@@ -1222,7 +1229,7 @@ def test_positive_sync_sha_repo(session, module_org):
     :SubComponent: Candlepin
     """
     repo_name = gen_string('alpha')
-    product = entities.Product(organization=module_org).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
     with session:
         session.repository.create(
             product.name,
@@ -1237,7 +1244,7 @@ def test_positive_sync_sha_repo(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_sync_third_party_repo(session, module_org):
+def test_positive_sync_third_party_repo(session, module_org, module_target_sat):
     """Sync third part repo successfully
 
     :id: 655161e0-aa90-4c7c-9a0d-cb5b9f56eac3
@@ -1249,7 +1256,7 @@ def test_positive_sync_third_party_repo(session, module_org):
     :SubComponent: Pulp
     """
     repo_name = gen_string('alpha')
-    product = entities.Product(organization=module_org).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
     with session:
         session.repository.create(
             product.name,

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -13,8 +13,6 @@
 """
 import random
 
-from airgun.session import Session
-from nailgun import entities
 from navmazing import NavigationTriesExceeded
 import pytest
 
@@ -25,7 +23,7 @@ from robottelo.utils.datafactory import gen_string
 @pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, module_org, module_location):
+def test_positive_end_to_end(session, module_org, module_location, module_target_sat):
     """Perform end to end testing for role component
 
     :id: 3284016a-e2df-4a0e-aa24-c95ab132eec1
@@ -45,8 +43,8 @@ def test_positive_end_to_end(session, module_org, module_location):
     cloned_role_name = gen_string('alpha')
     new_role_name = gen_string('alpha')
     new_role_description = gen_string('alpha')
-    new_org = entities.Organization().create()
-    new_loc = entities.Location(organization=[new_org]).create()
+    new_org = module_target_sat.api.Organization().create()
+    new_loc = module_target_sat.api.Location(organization=[new_org]).create()
     with session:
         session.role.create(
             {
@@ -156,7 +154,9 @@ def test_positive_delete_cloned_builtin(session):
 
 
 @pytest.mark.tier2
-def test_positive_create_filter_without_override(session, module_org, module_location, test_name):
+def test_positive_create_filter_without_override(
+    session, module_org, module_location, test_name, module_target_sat
+):
     """Create filter in role w/o overriding it
 
     :id: a7f76f6e-6c13-4b34-b38c-19501b65786f
@@ -178,7 +178,7 @@ def test_positive_create_filter_without_override(session, module_org, module_loc
     role_name = gen_string('alpha')
     username = gen_string('alpha')
     password = gen_string('alpha')
-    subnet = entities.Subnet()
+    subnet = module_target_sat.api.Subnet()
     subnet.create_missing()
     subnet_name = subnet.name
     with session:
@@ -222,7 +222,7 @@ def test_positive_create_filter_without_override(session, module_org, module_loc
                 'locations.resources.assigned': [module_location.name],
             }
         )
-    with Session(test_name, user=username, password=password) as session:
+    with module_target_sat.ui_session(test_name, user=username, password=password) as session:
         session.subnet.create(
             {
                 'subnet.name': subnet_name,
@@ -239,7 +239,9 @@ def test_positive_create_filter_without_override(session, module_org, module_loc
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_create_non_overridable_filter(session, module_org, module_location, test_name):
+def test_positive_create_non_overridable_filter(
+    session, module_org, module_location, test_name, module_target_sat
+):
     """Create non overridden filter in role
 
     :id: 5ee281cf-28fa-439d-888d-b1f9aacc6d57
@@ -262,9 +264,9 @@ def test_positive_create_non_overridable_filter(session, module_org, module_loca
     username = gen_string('alpha')
     password = gen_string('alpha')
     new_name = gen_string('alpha')
-    user_org = entities.Organization().create()
-    user_loc = entities.Location().create()
-    arch = entities.Architecture().create()
+    user_org = module_target_sat.api.Organization().create()
+    user_loc = module_target_sat.api.Location().create()
+    arch = module_target_sat.api.Architecture().create()
     with session:
         session.role.create(
             {
@@ -293,7 +295,7 @@ def test_positive_create_non_overridable_filter(session, module_org, module_loca
                 'locations.resources.assigned': [user_loc.name],
             }
         )
-    with Session(test_name, user=username, password=password) as session:
+    with module_target_sat.ui_session(test_name, user=username, password=password) as session:
         session.architecture.update(arch.name, {'name': new_name})
         assert session.architecture.search(new_name)[0]['Name'] == new_name
         with pytest.raises(NavigationTriesExceeded):
@@ -302,7 +304,9 @@ def test_positive_create_non_overridable_filter(session, module_org, module_loca
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_create_overridable_filter(session, module_org, module_location, test_name):
+def test_positive_create_overridable_filter(
+    session, module_org, module_location, test_name, module_target_sat
+):
     """Create overridden filter in role
 
     :id: 325e7e3e-60fc-4182-9585-0449d9660e8d
@@ -327,9 +331,9 @@ def test_positive_create_overridable_filter(session, module_org, module_location
     role_name = gen_string('alpha')
     username = gen_string('alpha')
     password = gen_string('alpha')
-    role_org = entities.Organization().create()
-    role_loc = entities.Location().create()
-    subnet = entities.Subnet()
+    role_org = module_target_sat.api.Organization().create()
+    role_loc = module_target_sat.api.Location().create()
+    subnet = module_target_sat.api.Subnet()
     subnet.create_missing()
     subnet_name = subnet.name
     new_subnet_name = gen_string('alpha')
@@ -378,7 +382,7 @@ def test_positive_create_overridable_filter(session, module_org, module_location
                 'locations.resources.assigned': [role_loc.name, module_location.name],
             }
         )
-    with Session(test_name, user=username, password=password) as session:
+    with module_target_sat.ui_session(test_name, user=username, password=password) as session:
         session.organization.select(org_name=module_org.name)
         session.location.select(loc_name=module_location.name)
         session.subnet.create(
@@ -485,7 +489,7 @@ def test_positive_create_with_sc_parameter_permission(session_puppet_enabled_sat
 
 
 @pytest.mark.tier2
-def test_positive_create_filter_admin_user_with_locs(test_name):
+def test_positive_create_filter_admin_user_with_locs(test_name, module_target_sat):
     """Attempt to create a role filter by admin user, who has 6+ locations assigned.
 
     :id: 688ecb7d-1d49-494c-97cc-0d5e715f3bb1
@@ -501,10 +505,10 @@ def test_positive_create_filter_admin_user_with_locs(test_name):
     role_name = gen_string('alpha')
     resource_type = 'Architecture'
     permissions = ['view_architectures', 'edit_architectures']
-    org = entities.Organization().create()
-    locations = [entities.Location(organization=[org]).create() for _ in range(6)]
+    org = module_target_sat.api.Organization().create()
+    locations = [module_target_sat.api.Location(organization=[org]).create() for _ in range(6)]
     password = gen_string('alphanumeric')
-    user = entities.User(
+    user = module_target_sat.api.User(
         admin=True,
         organization=[org],
         location=locations,
@@ -512,7 +516,7 @@ def test_positive_create_filter_admin_user_with_locs(test_name):
         default_location=locations[0],
         password=password,
     ).create()
-    with Session(test_name, user=user.login, password=password) as session:
+    with module_target_sat.ui_session(test_name, user=user.login, password=password) as session:
         session.role.create({'name': role_name})
         assert session.role.search(role_name)[0]['Name'] == role_name
         session.filter.create(
@@ -523,7 +527,7 @@ def test_positive_create_filter_admin_user_with_locs(test_name):
 
 
 @pytest.mark.tier2
-def test_positive_create_filter_admin_user_with_orgs(test_name):
+def test_positive_create_filter_admin_user_with_orgs(test_name, module_target_sat):
     """Attempt to create a role filter by admin user, who has 10 organizations assigned.
 
     :id: 04208e17-34b5-46b1-84dd-b8a973521d30
@@ -540,9 +544,9 @@ def test_positive_create_filter_admin_user_with_orgs(test_name):
     resource_type = 'Architecture'
     permissions = ['view_architectures', 'edit_architectures']
     password = gen_string('alphanumeric')
-    organizations = [entities.Organization().create() for _ in range(10)]
-    loc = entities.Location(organization=[organizations[0]]).create()
-    user = entities.User(
+    organizations = [module_target_sat.api.Organization().create() for _ in range(10)]
+    loc = module_target_sat.api.Location(organization=[organizations[0]]).create()
+    user = module_target_sat.api.User(
         admin=True,
         organization=organizations,
         location=[loc],
@@ -550,7 +554,7 @@ def test_positive_create_filter_admin_user_with_orgs(test_name):
         default_location=loc,
         password=password,
     ).create()
-    with Session(test_name, user=user.login, password=password) as session:
+    with module_target_sat.ui_session(test_name, user=user.login, password=password) as session:
         session.role.create({'name': role_name})
         assert session.role.search(role_name)[0]['Name'] == role_name
         session.filter.create(

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -13,9 +13,7 @@
 """
 import math
 
-from airgun.session import Session
 from fauxfactory import gen_url
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -28,14 +26,14 @@ def invalid_settings_values():
     return [' ', '-1', 'text', '0']
 
 
-def add_content_views_to_composite(composite_cv, org, repo):
+def add_content_views_to_composite(composite_cv, org, repo, module_target_sat):
     """Add necessary number of content views to the composite one
 
     :param composite_cv: Composite content view object
     :param org: Organisation of satellite
     :param repo: repository need to added in content view
     """
-    content_view = entities.ContentView(organization=org).create()
+    content_view = module_target_sat.api.ContentView(organization=org).create()
     content_view.repository = [repo]
     content_view.update(['repository'])
     content_view.publish()
@@ -47,7 +45,9 @@ def add_content_views_to_composite(composite_cv, org, repo):
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 @pytest.mark.parametrize('setting_update', ['restrict_composite_view'], indirect=True)
-def test_positive_update_restrict_composite_view(session, setting_update, repo_setup):
+def test_positive_update_restrict_composite_view(
+    session, setting_update, repo_setup, module_target_sat
+):
     """Update settings parameter restrict_composite_view to Yes/True and ensure
     a composite content view may not be published or promoted, unless the component
     content view versions that it includes exist in the target environment.
@@ -61,9 +61,11 @@ def test_positive_update_restrict_composite_view(session, setting_update, repo_s
     :CaseImportance: Critical
     """
     property_name = setting_update.name
-    composite_cv = entities.ContentView(composite=True, organization=repo_setup['org']).create()
+    composite_cv = module_target_sat.api.ContentView(
+        composite=True, organization=repo_setup['org']
+    ).create()
     content_view = add_content_views_to_composite(
-        composite_cv, repo_setup['org'], repo_setup['repo']
+        composite_cv, repo_setup['org'], repo_setup['repo'], module_target_sat
     )
     composite_cv.publish()
     with session:
@@ -260,9 +262,9 @@ def test_negative_settings_access_to_non_admin(module_target_sat):
     """
     login = gen_string('alpha')
     password = gen_string('alpha')
-    entities.User(admin=False, login=login, password=password).create()
+    module_target_sat.api.User(admin=False, login=login, password=password).create()
     try:
-        with Session(user=login, password=password) as session:
+        with module_target_sat.ui_session(user=login, password=password) as session:
             result = session.settings.permission_denied()
             assert (
                 result == 'Permission denied You are not authorized to perform this action. '
@@ -375,7 +377,7 @@ def test_positive_update_email_delivery_method_sendmail(session, target_sat):
         "send_welcome_email": "",
     }
     mail_config_default_param = {
-        content: entities.Setting().search(query={'search': f'name={content}'})[0]
+        content: target_sat.api.Setting().search(query={'search': f'name={content}'})[0]
         for content in mail_config_default_param
     }
     mail_config_new_params = {

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -14,9 +14,7 @@
 from tempfile import mkstemp
 import time
 
-from airgun.session import Session
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -44,18 +42,18 @@ def golden_ticket_host_setup(function_entitlement_manifest_org, module_target_sa
         reposet=REPOSET['rhst7'],
         releasever=None,
     )
-    rh_repo = entities.Repository(id=rh_repo_id).read()
+    rh_repo = module_target_sat.api.Repository(id=rh_repo_id).read()
     rh_repo.sync()
-    custom_product = entities.Product(organization=org).create()
-    custom_repo = entities.Repository(
+    custom_product = module_target_sat.api.Product(organization=org).create()
+    custom_repo = module_target_sat.api.Repository(
         name=gen_string('alphanumeric').upper(), product=custom_product
     ).create()
     custom_repo.sync()
-    ak = entities.ActivationKey(
+    ak = module_target_sat.api.ActivationKey(
         content_view=org.default_content_view,
         max_hosts=100,
         organization=org,
-        environment=entities.LifecycleEnvironment(id=org.library.id),
+        environment=module_target_sat.api.LifecycleEnvironment(id=org.library.id),
         auto_attach=True,
     ).create()
     return org, ak
@@ -93,7 +91,7 @@ def test_positive_end_to_end(session, target_sat):
         'Note: Deleting a subscription manifest is STRONGLY discouraged.',
         'This action should only be taken for debugging purposes.',
     ]
-    org = entities.Organization().create()
+    org = target_sat.api.Organization().create()
     _, temporary_local_manifest_path = mkstemp(prefix='manifest-', suffix='.zip')
     with clone() as manifest:
         with open(temporary_local_manifest_path, 'wb') as file_handler:
@@ -147,8 +145,8 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name, target_
 
     :CaseImportance: Critical
     """
-    org = entities.Organization().create()
-    role = entities.Role(organization=[org]).create()
+    org = target_sat.api.Organization().create()
+    role = target_sat.api.Role(organization=[org]).create()
     target_sat.api_factory.create_role_permissions(
         role,
         {
@@ -162,14 +160,14 @@ def test_positive_access_with_non_admin_user_without_manifest(test_name, target_
         },
     )
     user_password = gen_string('alphanumeric')
-    user = entities.User(
+    user = target_sat.api.User(
         admin=False,
         role=[role],
         password=user_password,
         organization=[org],
         default_organization=org,
     ).create()
-    with Session(test_name, user=user.login, password=user_password) as session:
+    with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
         assert not session.subscription.has_manifest
 
 
@@ -193,20 +191,20 @@ def test_positive_access_with_non_admin_user_with_manifest(
     :CaseImportance: Critical
     """
     org = function_entitlement_manifest_org
-    role = entities.Role(organization=[org]).create()
+    role = target_sat.api.Role(organization=[org]).create()
     target_sat.api_factory.create_role_permissions(
         role,
         {'Katello::Subscription': ['view_subscriptions'], 'Organization': ['view_organizations']},
     )
     user_password = gen_string('alphanumeric')
-    user = entities.User(
+    user = target_sat.api.User(
         admin=False,
         role=[role],
         password=user_password,
         organization=[org],
         default_organization=org,
     ).create()
-    with Session(test_name, user=user.login, password=user_password) as session:
+    with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
         assert (
             session.subscription.search(f'name = "{DEFAULT_SUBSCRIPTION_NAME}"')[0]['Name']
             == DEFAULT_SUBSCRIPTION_NAME
@@ -230,23 +228,23 @@ def test_positive_access_manifest_as_another_admin_user(
 
     :CaseImportance: High
     """
-    org = entities.Organization().create()
+    org = target_sat.api.Organization().create()
     user1_password = gen_string('alphanumeric')
-    user1 = entities.User(
+    user1 = target_sat.api.User(
         admin=True, password=user1_password, organization=[org], default_organization=org
     ).create()
     user2_password = gen_string('alphanumeric')
-    user2 = entities.User(
+    user2 = target_sat.api.User(
         admin=True, password=user2_password, organization=[org], default_organization=org
     ).create()
     # use the first admin to upload a manifest
-    with Session(test_name, user=user1.login, password=user1_password) as session:
+    with target_sat.ui_session(test_name, user=user1.login, password=user1_password) as session:
         target_sat.upload_manifest(org.id, function_entitlement_manifest.content)
         assert session.subscription.has_manifest
         # store subscriptions that have "Red Hat" in the name for later
         rh_subs = session.subscription.search("Red Hat")
     # try to view and delete the manifest with another admin
-    with Session(test_name, user=user2.login, password=user2_password) as session:
+    with target_sat.ui_session(test_name, user=user2.login, password=user2_password) as session:
         assert session.subscription.has_manifest
         assert rh_subs == session.subscription.search("Red Hat")
         session.subscription.delete_manifest(
@@ -290,7 +288,7 @@ def test_positive_view_vdc_subscription_products(
     :parametrized: yes
     """
     org = function_entitlement_manifest_org
-    lce = entities.LifecycleEnvironment(organization=org).create()
+    lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     repos_collection = target_sat.cli_factory.RepositoryCollection(
         distro='rhel7',
         repositories=[target_sat.cli_factory.RHELAnsibleEngineRepository(cdn=True)],
@@ -349,7 +347,7 @@ def test_positive_view_vdc_guest_subscription_products(
     :parametrized: yes
     """
     org = function_entitlement_manifest_org
-    lce = entities.LifecycleEnvironment(organization=org).create()
+    lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     provisioning_server = settings.libvirt.libvirt_hostname
     rh_product_repository = target_sat.cli_factory.RHELAnsibleEngineRepository(cdn=True)
     product_name = rh_product_repository.data['product']
@@ -512,13 +510,15 @@ def test_positive_candlepin_events_processed_by_STOMP(
     :CaseImportance: High
     """
     org = function_entitlement_manifest_org
-    repo = entities.Repository(product=entities.Product(organization=org).create()).create()
+    repo = target_sat.api.Repository(
+        product=target_sat.api.Product(organization=org).create()
+    ).create()
     repo.sync()
-    ak = entities.ActivationKey(
+    ak = target_sat.api.ActivationKey(
         content_view=org.default_content_view,
         max_hosts=100,
         organization=org,
-        environment=entities.LifecycleEnvironment(id=org.library.id),
+        environment=target_sat.api.LifecycleEnvironment(id=org.library.id),
     ).create()
     rhel7_contenthost.install_katello_ca(target_sat)
     rhel7_contenthost.register_contenthost(org.name, ak.name)
@@ -534,6 +534,6 @@ def test_positive_candlepin_events_processed_by_STOMP(
             rhel7_contenthost.hostname, widget_names='details'
         )['details']['subscription_status']
         assert 'Fully entitled' in updated_sub_status
-        response = entities.Ping().search_json()['services']['candlepin_events']
+        response = target_sat.api.Ping().search_json()['services']['candlepin_events']
         assert response['status'] == 'ok'
         assert '0 Failed' in response['message']

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -13,7 +13,6 @@
 """
 import random
 
-from airgun.session import Session
 from fauxfactory import gen_email, gen_string
 import pytest
 
@@ -83,7 +82,7 @@ def test_positive_end_to_end(session, target_sat, test_name, module_org, module_
         assert session.user.search(new_name)[0]['Username'] == new_name
         assert not session.user.search(name)
         # Login into application using new user
-    with Session(test_name, new_name, password) as newsession:
+    with target_sat.ui_session(test_name, new_name, password) as newsession:
         newsession.organization.select(module_org.name)
         newsession.location.select(module_location.name)
         newsession.activationkey.create({'name': ak_name})
@@ -91,7 +90,7 @@ def test_positive_end_to_end(session, target_sat, test_name, module_org, module_
         current_user = newsession.activationkey.read(ak_name, 'current_user')['current_user']
         assert current_user == f'{firstname} {lastname}'
         # Delete user
-    with Session('deletehostsession') as deletehostsession:
+    with target_sat.ui_session('deletehostsession') as deletehostsession:
         deletehostsession.user.delete(new_name)
         assert not deletehostsession.user.search(new_name)
 
@@ -300,7 +299,7 @@ def test_positive_create_product_with_limited_user_permission(
         password=password,
         mail='test@test.com',
     ).create()
-    with Session(test_name, username, password) as newsession:
+    with target_sat.ui_session(test_name, username, password) as newsession:
         newsession.product.create(
             {'name': product_name, 'label': product_label, 'description': product_description}
         )

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -1,4 +1,3 @@
-from airgun.session import Session
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
@@ -37,7 +36,7 @@ def module_user(request, module_target_sat, default_org, default_location):
 
 
 @pytest.fixture
-def session(test_name, module_user):
+def session(test_name, module_user, module_target_sat):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared
     module user credentials to log in.
@@ -50,7 +49,7 @@ def session(test_name, module_user):
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
     """
-    return Session(test_name, module_user.login, module_user.password)
+    return module_target_sat.ui_session(test_name, module_user.login, module_user.password)
 
 
 @pytest.fixture(scope='module')
@@ -84,7 +83,7 @@ def module_user_sca(request, module_target_sat, module_org, module_location):
 
 
 @pytest.fixture
-def session_sca(test_name, module_user_sca):
+def session_sca(test_name, module_user_sca, module_target_sat):
     """Session fixture which automatically initializes (but does not start!)
     airgun UI session and correctly passes current test name to it. Uses shared
     module user credentials to log in.
@@ -97,4 +96,4 @@ def session_sca(test_name, module_user_sca):
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
     """
-    return Session(test_name, module_user_sca.login, module_user_sca.password)
+    return module_target_sat.ui_session(test_name, module_user_sca.login, module_user_sca.password)

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -13,7 +13,6 @@
 """
 from datetime import datetime
 
-from airgun.session import Session
 from fauxfactory import gen_string
 import pytest
 
@@ -369,7 +368,7 @@ class TestVirtwhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_virtwho_reporter_role(
-        self, default_org, org_session, test_name, form_data_ui
+        self, default_org, org_session, test_name, form_data_ui, target_sat
     ):
         """Verify the virt-who reporter role can TRULY work.
 
@@ -418,13 +417,15 @@ class TestVirtwhoConfigforEsx:
             assert user['roles']['resources']['assigned'] == ['Virt-who Reporter']
             restart_virtwho_service()
             assert get_virtwho_status() == 'running'
-            with Session(test_name, username, password) as newsession:
+            with target_sat.ui_session(test_name, username, password) as newsession:
                 assert not newsession.virtwho_configure.check_create_permission()['can_view']
             org_session.user.delete(username)
             assert not org_session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_viewer_role(self, default_org, org_session, test_name, form_data_ui):
+    def test_positive_virtwho_viewer_role(
+        self, default_org, org_session, test_name, form_data_ui, target_sat
+    ):
         """Verify the virt-who viewer role can TRULY work.
 
         :id: bf3be2e4-3853-41cc-9b3e-c8677f0b8c5f
@@ -469,7 +470,7 @@ class TestVirtwhoConfigforEsx:
             add_configure_option('rhsm_password', password, config_file)
             restart_virtwho_service()
             assert get_virtwho_status() == 'logerror'
-            with Session(test_name, username, password) as newsession:
+            with target_sat.ui_session(test_name, username, password) as newsession:
                 create_permission = newsession.virtwho_configure.check_create_permission()
                 update_permission = newsession.virtwho_configure.check_update_permission(
                     config_name
@@ -484,7 +485,9 @@ class TestVirtwhoConfigforEsx:
             assert not org_session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_virtwho_manager_role(self, default_org, org_session, test_name, form_data_ui):
+    def test_positive_virtwho_manager_role(
+        self, default_org, org_session, test_name, form_data_ui, target_sat
+    ):
         """Verify the virt-who manager role can TRULY work.
 
         :id: a72023fb-7b23-4582-9adc-c5227dc7859c
@@ -520,7 +523,7 @@ class TestVirtwhoConfigforEsx:
             org_session.user.update(username, {'roles.resources.assigned': ['Virt-who Manager']})
             user = org_session.user.read(username)
             assert user['roles']['resources']['assigned'] == ['Virt-who Manager']
-            with Session(test_name, username, password) as newsession:
+            with target_sat.ui_session(test_name, username, password) as newsession:
                 # create_virt_who_config
                 new_virt_who_name = gen_string('alpha')
                 form_data_ui['name'] = new_virt_who_name


### PR DESCRIPTION
cherry-pick of https://github.com/SatelliteQE/robottelo/pull/13273

### Problem Statement

- Remove the Airgun Imports from the Robottelo and Use `target_sat.ui_session` or `module_target_sat.ui`

### Solution

- UI tests are updated to use the modified "target_sat" or "module_target_sat" for efficient management of multiple browser sessions.
- The streamlined UI tests function correctly and manage browser sessions effectively.
- Remove the nailgun entities from the UI code considering the Airgun Imports (some more PR needs to be added remove this as not wanted to do everything in single PR)   
