### PR TITLE
[6.14.z] Add coverage for HTTP Proxy capsule install

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -291,7 +291,7 @@ def module_sat_ready_rhels(request):
 
 @pytest.fixture
 def cap_ready_rhel():
-    rhel_version = Version(settings.capsule.version.release)
+    rhel_version = Version(settings.capsule.version.rhel_version)
     deploy_args = {
         'deploy_rhel_version': rhel_version.base_version,
         'deploy_flavor': settings.flavors.default,

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1395,7 +1395,10 @@ def sat_non_default_install(module_sat_ready_rhels):
 @pytest.mark.e2e
 @pytest.mark.tier1
 @pytest.mark.pit_client
-def test_capsule_installation(sat_default_install, cap_ready_rhel, default_org):
+@pytest.mark.parametrize(
+    'setting_update', [f'http_proxy={settings.http_proxy.un_auth_proxy_url}'], indirect=True
+)
+def test_capsule_installation(sat_default_install, cap_ready_rhel, setting_update):
     """Run a basic Capsule installation
 
     :id: 64fa85b6-96e6-4fea-bea4-a30539d59e65
@@ -1412,6 +1415,10 @@ def test_capsule_installation(sat_default_install, cap_ready_rhel, default_org):
         3. health check runs successfully
 
     :CaseImportance: Critical
+
+    :BZ: 1984400
+
+    :customerscenario: true
     """
     # Get Capsule repofile, and enable and download satellite-capsule
     cap_ready_rhel.register_to_cdn()


### PR DESCRIPTION
### Problem Statement
6.14.z Manual cherry-pick for https://github.com/SatelliteQE/robottelo/pull/13507/commits

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->