### PR TITLE
[6.14.z] virtwho config hammer deploy option name organization-title and location-id support

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -526,3 +526,17 @@ def create_http_proxy(org, name=None, url=None, http_type='https'):
         organization=[org.id],
     ).create()
     return http_proxy.url, http_proxy.name, http_proxy.id
+
+
+def get_configure_command_option(deploy_type, args, org=DEFAULT_ORG):
+    """Return the deploy command line based on option.
+    :param str option: the unique id of the configure file you have created.
+    :param str org: the satellite organization name.
+    """
+    username, password = Base._get_username_password()
+    if deploy_type == 'location-id':
+        return f"hammer -u {username} -p {password} virt-who-config deploy --id {args['id']} --location-id '{args['location-id']}' "
+    elif deploy_type == 'organization-title':
+        return f"hammer -u {username} -p {password} virt-who-config deploy --id {args['id']} --organization-title '{args['organization-title']}' "
+    elif deploy_type == 'name':
+        return f"hammer -u {username} -p {password} virt-who-config deploy --name {args['name']} --organization '{org}' "

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -37,8 +37,12 @@ from robottelo.utils.virtwho import (
 class TestVirtWhoConfigforEsx:
     @pytest.mark.tier2
     @pytest.mark.upgrade
-    @pytest.mark.parametrize('deploy_type_cli', ['id', 'script'], indirect=True)
-    def test_positive_deploy_configure_by_id_script(
+    @pytest.mark.parametrize(
+        'deploy_type_cli',
+        ['id', 'script', 'name', 'location-id', 'organization-title'],
+        indirect=True,
+    )
+    def test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle(
         self, module_sca_manifest_org, target_sat, virtwho_config_cli, deploy_type_cli
     ):
         """Verify "hammer virt-who-config deploy & fetch"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13632

virtwho config hammer deploy option name organization-title and location-id support
Satellite6.15 PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle[name] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 37 deselected, 10 warnings in 121.35s (0:02:01)
2024-01-08 01:21:37 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle[organization-title] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 37 deselected, 10 warnings in 109.41s (0:01:49)
2024-01-08 01:29:53 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script_name_locationid_organizationtitle[location-id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 37 deselected, 10 warnings in 108.15s (0:01:48)
2024-01-08 02:00:09 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
```