### PR TITLE
[6.13.z] Fix domain read in discovery auto provision test

### DIFF
--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -194,7 +194,7 @@ def test_positive_auto_provision_host_with_rule(
     discovered_host.build = True
 
     discovered_host_name = discovered_host.name
-    domain_name = provisioning_hostgroup.domain.name
+    domain_name = provisioning_hostgroup.domain.read().name
     host_name = f'{discovered_host_name}.{domain_name}'
 
     discovery_rule = sat.api.DiscoveryRule(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13708

### Problem Statement
```
tests/foreman/ui/test_discoveredhost.py:197: in test_positive_auto_provision_host_with_rule
    domain_name = provisioning_hostgroup.domain.name
E   AttributeError: 'Domain' object has no attribute 'name'
```

### Solution
read Domain first after that name attribute is accessible, same is present in other tests