### PR TITLE
Removing changes associated with Bugbear rule B019

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ select = [
 ]
 
 ignore = [
+    "B019",  # lru_cache can lead to memory leaks - acceptable tradeoff
     "E501",  # line too long - handled by black
     "PT004", # pytest underscrore prefix for non-return fixtures
     "PT005", # pytest no underscrore prefix for return fixtures

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -4,7 +4,7 @@ It is not meant to be used directly, but as part of a robottelo.hosts.Satellite 
 example: my_satellite.cli_factory.make_org()
 """
 import datetime
-from functools import partial
+from functools import lru_cache, partial
 import inspect
 import os
 from os import chmod
@@ -14,7 +14,6 @@ from tempfile import mkstemp
 from time import sleep
 
 from box import Box
-from cachetools import cachedmethod
 from fauxfactory import (
     gen_alpha,
     gen_alphanumeric,
@@ -250,6 +249,7 @@ class CLIFactory:
         self._satellite = satellite
         self.__dict__.update(initiate_repo_helpers(self._satellite))
 
+    @lru_cache
     def __getattr__(self, name):
         """We intercept the usual attribute behavior on this class to emulate make_entity methods
         The keys in the dictionary above correspond to potential make_<key> methods
@@ -295,7 +295,7 @@ class CLIFactory:
                 if not key.startswith('_')
             }
 
-    @cachedmethod
+    @lru_cache
     def _find_entity_class(self, entity_name):
         entity_name = entity_name.replace('_', '').lower()
         for name, class_obj in self._satellite.cli.__dict__.items():

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -1,10 +1,10 @@
 import contextlib
+from functools import lru_cache
 import io
 import os
 import random
 import re
 
-from cachetools import cachedmethod
 import requests
 
 from robottelo.cli.proxy import CapsuleTunnelError
@@ -235,7 +235,7 @@ class SystemInfo:
         :rtype: int
         """
         port_pool_range = settings.fake_capsules.port_range
-        if isinstance(port_pool_range, list):
+        if isinstance(port_pool_range, str):
             port_pool_range = tuple(port_pool_range.split('-'))
         if isinstance(port_pool_range, tuple) and len(port_pool_range) == 2:
             port_pool = range(int(port_pool_range[0]), int(port_pool_range[1]))
@@ -358,6 +358,6 @@ class Factories:
             self._api_factory = APIFactory(self)
         return self._api_factory
 
-    @cachedmethod
+    @lru_cache
     def ui_factory(self, session):
         return UIFactory(self, session=session)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -17,7 +17,6 @@ import warnings
 from box import Box
 from broker import Broker
 from broker.hosts import Host
-from cachetools import cachedmethod
 from dynaconf.vendor.box.exceptions import BoxKeyError
 from fauxfactory import gen_alpha, gen_string
 from manifester import Manifester
@@ -2283,7 +2282,7 @@ class SSOHost(Host):
                 break
         return client_id
 
-    @cachedmethod
+    @lru_cache
     def get_rhsso_user_details(self, username):
         """Getter method to receive the user id"""
         result = self.execute(
@@ -2292,7 +2291,7 @@ class SSOHost(Host):
         result_json = json.loads(result.stdout)
         return result_json[0]
 
-    @cachedmethod
+    @lru_cache
     def get_rhsso_groups_details(self, group_name):
         """Getter method to receive the group id"""
         result = self.execute(f"{KEY_CLOAK_CLI} get groups -r {settings.rhsso.realm}")


### PR DESCRIPTION
This PR reverts the change from lru_cache to cachedmethod. The primary goal of the original change was to avoid memory leaks, due to lru_cache holding instances of a class alive longer than they should be.
However, for our test framework, the workaround to avoid these memory leaks really aren't worth it.

I also added an lru_cache to cli_factory.__getattr__, improving its recurring lookup time substantially.

Finally, I corrected a type check that was erroneously converted in the initial pass.