### PR TITLE
[6.14.z] fixing the incorrect recording video url

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1872,7 +1872,7 @@ class Satellite(Capsule, SatelliteMixins):
             raise
         finally:
             video_url = settings.ui.grid_url.replace(
-                ':4444', f'/videos/{ui_session.ui_session_id}.mp4'
+                ':4444', f'/videos/{ui_session.ui_session_id}/video.mp4'
             )
             if self.record_property is not None and settings.ui.record_video:
                 self.record_property('video_url', video_url)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13714

### Problem Statement
fixing the incorrect recording video URL for recorded failed tests.  

### Solution
This PR will fix the URL and point to the correct URL in the report portal. 
