### PR TITLE
Coverage:Bug 2158702

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -647,6 +647,6 @@ class TestVirtwhoConfigforEsx:
         assert get_configure_option('encrypted_password', config_file)
         res = org_session.virtwho_configure.read_edit(name)
         assert 'encrypted-' in res['hypervisor_content']['password']
-        org_session.virtwho_configure.edit(name, {'hypervisor_password': "Welcome1!"})
+        org_session.virtwho_configure.edit(name, {'hypervisor_password': gen_string('alpha')})
         results = org_session.virtwho_configure.read(name)
         assert 'encrypted_password=$cr_password' in results['deploy']['script']


### PR DESCRIPTION
Coverage [Bug 2158702](https://bugzilla.redhat.com/show_bug.cgi?id=2158702)
Test Case: PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest  ./tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_hypervisor_password_option --disable-pytest-warnings -q
2024-01-11 02:00:13 - robottelo - WARNING - Dynaconf validation failed, continuing for the sake of unit tests
    certs.cert_file is required in env main
=============================================================================================== test session starts ===============================================================================================

============================================================================ 1 passed, 35 deselected, 13 warnings in 169.65s (0:02:49) ============================================================================

```

This PR depend on the airgun PR support Bug 2158702:read virt-who config Edit view page info support #1136
 https://github.com/SatelliteQE/airgun/pull/1136