### PR TITLE
Fixes in cli_factory

### DIFF
--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -60,7 +60,7 @@ class Repository(Base):
         cls.command_sub = 'synchronize'
         return cls.execute(
             cls._construct_command(options),
-            output_format='csv',
+            output_format='base',
             ignore_stderr=True,
             return_raw_response=return_raw_response,
             timeout=timeout,

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -249,7 +249,6 @@ class CLIFactory:
         self._satellite = satellite
         self.__dict__.update(initiate_repo_helpers(self._satellite))
 
-    @lru_cache
     def __getattr__(self, name):
         """We intercept the usual attribute behavior on this class to emulate make_entity methods
         The keys in the dictionary above correspond to potential make_<key> methods

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -201,3 +201,19 @@ def test_positive_update_counts(target_sat, module_capsule_configured):
         search_rate=5,
         max_tries=5,
     )
+
+
+@pytest.mark.parametrize(
+    'repos_collection',
+    [
+        {
+            'distro': 'rhel8',
+            'YumRepository': {'url': settings.repos.module_stream_1.url},
+            'FileRepository': {'url': CUSTOM_FILE_REPO},
+        }
+    ],
+    indirect=True,
+)
+def test_dummie(repos_collection, function_org, function_lce):
+    repos_collection.setup_content(function_org.id, function_lce.id, upload_manifest=False)
+    pass

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -201,19 +201,3 @@ def test_positive_update_counts(target_sat, module_capsule_configured):
         search_rate=5,
         max_tries=5,
     )
-
-
-@pytest.mark.parametrize(
-    'repos_collection',
-    [
-        {
-            'distro': 'rhel8',
-            'YumRepository': {'url': settings.repos.module_stream_1.url},
-            'FileRepository': {'url': CUSTOM_FILE_REPO},
-        }
-    ],
-    indirect=True,
-)
-def test_dummie(repos_collection, function_org, function_lce):
-    repos_collection.setup_content(function_org.id, function_lce.id, upload_manifest=False)
-    pass


### PR DESCRIPTION
Try to run the `test_dummie` with and without the changes.

For the `csv` format you get:
```
E   ValueError: zip() argument 2 is shorter than argument 1
```

For the `@lru_cache` present you get:
```
E           Could not create the repository:
E             Validation failed: Name has already been taken for this product., Label has already been taken for this product., Download policy Cannot set attribute download_policy for content type file
```