### PR TITLE
[6.14.z] Non tabular output denied for CSV conversion

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -34,10 +34,23 @@ def _normalize_obj(obj):
     return obj
 
 
+def is_csv(output):
+    """Verifies if the output string is eligible for converting into CSV"""
+    sniffer = csv.Sniffer()
+    try:
+        sniffer.sniff(output)
+        return True
+    except csv.Error:
+        return False
+
+
 def parse_csv(output):
     """Parse CSV output from Hammer CLI and convert it to python dictionary."""
     # ignore warning about puppet and ostree deprecation
     output.replace('Puppet and OSTree will no longer be supported in Katello 3.16\n', '')
+    # Validate if the output is eligible for CSV conversions else return as it is
+    if not is_csv(output):
+        return output
     reader = csv.reader(output.splitlines())
     # Generate the key names, spaces will be converted to dashes "-"
     keys = [_normalize(header) for header in next(reader)]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13737

### Problem Statement

The CLI command output containing non-tabular string is not eligible for CSV conversation.

e.g:

STDOUT like 
```
stdout:
    Added Rpms: 32, Errata: 4
    Total steps: 84/84
    --------------------------------
    Associating Content: 39/39
    Downloading Artifacts: 0/0
    Downloading Metadata Files: 6/6
    Parsed Advisories: 4/4
    Parsed Comps: 3/3
    Parsed Packages: 32/32
    Skipping Packages: 0/0
    Un-Associating Content: 0/0
```

Here zipping in csv conversion function trying to zip the first row of 2 key_value pairs `Added Rpms: 32, Errata: 4` with 1 row of key_value from next line ` Total steps: 84/84`. Since strict is set to `True` the numbe of contents from first row and second row should match which does match with the tabular format but not the above-like output. Making the the strict zipping to fail.

### Solution
Returning the output as is if the output is not sniffed using CSV Sniffer for CSV conversion eligibility.

Trying to make it simple though, we could also return all key-value pairs from such output but if the Team demands for it! Since its not returning all key value pairs for such output nobody complaints about it in the past so for now we should be good with the simple solution.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->