### PR TITLE
Add missing on_premises_provisioning marker for capsule provisioning test

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -587,6 +587,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
 
 @pytest.mark.e2e
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
+@pytest.mark.on_premises_provisioning
 @pytest.mark.rhel_ver_match('[^6]')
 def test_capsule_pxe_provisioning(
     request,


### PR DESCRIPTION
### Problem Statement
Missing `on_premises_provisioning` marker for capsule provisioning test

### Solution
Adding `on_premises_provisioning` marker for capsule provisioning test

