### PR TITLE
[6.13.z] Cleanup video recording

### DIFF
--- a/conf/ui.yaml.template
+++ b/conf/ui.yaml.template
@@ -24,13 +24,15 @@ UI:
   WEBDRIVER: chrome
   # Binary location for selected wedriver (not needed if using saucelabs)
   WEBDRIVER_BINARY: /usr/bin/chromedriver
-
+  RECORD_VIDEO: false
+  GRID_URL: http://infra-grid.example.com:4444
   # Web_Kaifuku Settings (checkout https://github.com/RonnyPfannschmidt/webdriver_kaifuku)
   WEBKAIFUKU:
     webdriver: chrome/remote
     webdriver_options:
       command_executor: http://localhost:4444/wd/hub
       desired_capabilities:
+        se:recordVideo: '@jinja {{ this.ui.record_video }}'
         browserName: chrome
         chromeOptions:
           args:

--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -17,15 +17,16 @@ test_directories = [
 
 
 def _clean_video(session_id, test):
-    logger.info(f"cleaning up video files for session: {session_id} and test: {test}")
+    if settings.ui.record_video:
+        logger.info(f"cleaning up video files for session: {session_id} and test: {test}")
 
-    if settings.ui.grid_url and session_id:
-        grid = urlparse(url=settings.ui.grid_url)
-        infra_grid = Host(hostname=grid.hostname)
-        infra_grid.execute(command=f'rm -rf /var/www/html/videos/{session_id}')
-        logger.info(f"video cleanup for session {session_id} is complete")
-    else:
-        logger.warning("missing grid_url or session_id. unable to clean video files.")
+        if settings.ui.grid_url and session_id:
+            grid = urlparse(url=settings.ui.grid_url)
+            infra_grid = Host(hostname=grid.hostname)
+            infra_grid.execute(command=f'rm -rf /var/www/html/videos/{session_id}')
+            logger.info(f"video cleanup for session {session_id} is complete")
+        else:
+            logger.warning("missing grid_url or session_id. unable to clean video files.")
 
 
 def pytest_addoption(parser):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1829,10 +1829,10 @@ class Satellite(Capsule, SatelliteMixins):
         except Exception:
             raise
         finally:
-            video_url = settings.ui.grid_url.replace(
-                ':4444', f'/videos/{ui_session.ui_session_id}/video.mp4'
-            )
             if self.record_property is not None and settings.ui.record_video:
+                video_url = settings.ui.grid_url.replace(
+                    ':4444', f'/videos/{ui_session.ui_session_id}/video.mp4'
+                )
                 self.record_property('video_url', video_url)
                 self.record_property('session_id', ui_session.ui_session_id)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13713

### Problem Statement

* missing ui setting `record_video` breaks tests
* robottelo tests fail in teardwon despite `record_video` is set to false 

### Solution

* Only call related functionality when `record_video` is set to true
* Add settings options to config template

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->