### PR TITLE
[6.14.z] http proxy create location option support

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -506,7 +506,7 @@ def virtwho_package_locked():
     assert "Packages are locked" in result[1]
 
 
-def create_http_proxy(org, name=None, url=None, http_type='https'):
+def create_http_proxy(org, location, name=None, url=None, http_type='https'):
     """
     Creat a new http-proxy with attributes.
     :param name: Name of the proxy
@@ -524,6 +524,7 @@ def create_http_proxy(org, name=None, url=None, http_type='https'):
         name=http_proxy_name,
         url=http_proxy_url,
         organization=[org.id],
+        location=[location.id],
     ).create()
     return http_proxy.url, http_proxy.name, http_proxy.id
 

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -210,7 +210,7 @@ class TestVirtWhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_proxy_option(
-        self, default_org, form_data_api, virtwho_config_api, target_sat
+        self, default_org, default_location, form_data_api, virtwho_config_api, target_sat
     ):
         """Verify http_proxy option by "PUT
 
@@ -232,7 +232,7 @@ class TestVirtWhoConfigforEsx:
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == '*'
         # Check HTTTP Proxy and No_PROXY option
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org=default_org
+            http_type='http', org=default_org, location=default_location
         )
         no_proxy = 'test.satellite.com'
         virtwho_config_api.http_proxy_id = http_proxy_id
@@ -245,7 +245,9 @@ class TestVirtWhoConfigforEsx:
         assert get_configure_option('http_proxy', ETC_VIRTWHO_CONFIG) == http_proxy_url
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == no_proxy
         # Check HTTTPs Proxy option
-        https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(org=default_org)
+        https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(
+            org=default_org, location=default_location
+        )
         virtwho_config_api.http_proxy_id = https_proxy_id
         virtwho_config_api.update(['http_proxy_id'])
         deploy_configure_by_command(

--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -227,7 +227,9 @@ class TestVirtWhoConfigforEsx:
                 assert result.exclude_host_parents == regex
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, module_sca_manifest_org, form_data_api, target_sat):
+    def test_positive_proxy_option(
+        self, module_sca_manifest_org, default_location, form_data_api, target_sat
+    ):
         """Verify http_proxy option by "PUT
 
         /foreman_virt_who_configure/api/v2/configs/:id""
@@ -251,7 +253,7 @@ class TestVirtWhoConfigforEsx:
         assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == '*'
         # Check HTTTP Proxy and No_PROXY option
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org=module_sca_manifest_org
+            http_type='http', org=module_sca_manifest_org, location=default_location
         )
         no_proxy = 'test.satellite.com'
         virtwho_config.http_proxy_id = http_proxy_id
@@ -269,7 +271,7 @@ class TestVirtWhoConfigforEsx:
         assert result.no_proxy == no_proxy
         # Check HTTTPs Proxy option
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(
-            org=module_sca_manifest_org
+            org=module_sca_manifest_org, location=default_location
         )
         virtwho_config.http_proxy_id = https_proxy_id
         virtwho_config.update(['http_proxy_id'])

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -214,7 +214,7 @@ class TestVirtWhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_proxy_option(
-        self, default_org, form_data_cli, virtwho_config_cli, target_sat
+        self, default_org, default_location, form_data_cli, virtwho_config_cli, target_sat
     ):
         """Verify http_proxy option by hammer virt-who-config update"
 
@@ -227,7 +227,9 @@ class TestVirtWhoConfigforEsx:
         :BZ: 1902199
         """
         # Check the https proxy option, update it via http proxy name
-        https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(org=default_org)
+        https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(
+            org=default_org, location=default_location
+        )
         no_proxy = 'test.satellite.com'
         target_sat.cli.VirtWhoConfig.update(
             {'id': virtwho_config_cli['id'], 'http-proxy': https_proxy_name, 'no-proxy': no_proxy}
@@ -244,7 +246,7 @@ class TestVirtWhoConfigforEsx:
 
         # Check the http proxy option, update it via http proxy id
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org=default_org
+            http_type='http', org=default_org, location=default_location
         )
         target_sat.cli.VirtWhoConfig.update(
             {'id': virtwho_config_cli['id'], 'http-proxy-id': http_proxy_id}

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -250,7 +250,12 @@ class TestVirtWhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_proxy_option(
-        self, module_sca_manifest_org, form_data_cli, virtwho_config_cli, target_sat
+        self,
+        module_sca_manifest_org,
+        default_location,
+        form_data_cli,
+        virtwho_config_cli,
+        target_sat,
     ):
         """Verify http_proxy option by hammer virt-who-config update"
 
@@ -266,7 +271,7 @@ class TestVirtWhoConfigforEsx:
         """
         # Check the https proxy option, update it via http proxy name
         https_proxy_url, https_proxy_name, https_proxy_id = create_http_proxy(
-            org=module_sca_manifest_org
+            org=module_sca_manifest_org, location=default_location
         )
         no_proxy = 'test.satellite.com'
         target_sat.cli.VirtWhoConfig.update(
@@ -284,7 +289,7 @@ class TestVirtWhoConfigforEsx:
 
         # Check the http proxy option, update it via http proxy id
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org=module_sca_manifest_org
+            http_type='http', org=module_sca_manifest_org, location=default_location
         )
         target_sat.cli.VirtWhoConfig.update(
             {'id': virtwho_config_cli['id'], 'http-proxy-id': http_proxy_id}

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -215,7 +215,9 @@ class TestVirtwhoConfigforEsx:
         assert regex == get_configure_option('exclude_host_parents', config_file)
 
     @pytest.mark.tier2
-    def test_positive_proxy_option(self, default_org, virtwho_config_ui, org_session, form_data_ui):
+    def test_positive_proxy_option(
+        self, default_org, default_location, virtwho_config_ui, org_session, form_data_ui
+    ):
         """Verify 'HTTP Proxy' and 'Ignore Proxy' options.
 
         :id: 6659d577-0135-4bf0-81af-14b930011536
@@ -225,9 +227,11 @@ class TestVirtwhoConfigforEsx:
 
         :CaseImportance: Medium
         """
-        https_proxy, https_proxy_name, https_proxy_id = create_http_proxy(org=default_org)
+        https_proxy, https_proxy_name, https_proxy_id = create_http_proxy(
+            org=default_org, location=default_location
+        )
         http_proxy, http_proxy_name, http_proxy_id = create_http_proxy(
-            http_type='http', org=default_org
+            http_type='http', org=default_org, location=default_location
         )
         name = form_data_ui['name']
         config_id = get_configure_id(name)
@@ -547,7 +551,9 @@ class TestVirtwhoConfigforEsx:
             assert not org_session.user.search(username)
 
     @pytest.mark.tier2
-    def test_positive_overview_label_name(self, default_org, form_data_ui, org_session):
+    def test_positive_overview_label_name(
+        self, default_org, default_location, form_data_ui, org_session
+    ):
         """Verify the label name on virt-who config Overview Page.
 
         :id: 21df8175-bb41-422e-a263-8677bc3a9565
@@ -561,7 +567,9 @@ class TestVirtwhoConfigforEsx:
         name = gen_string('alpha')
         form_data_ui['name'] = name
         hypervisor_type = form_data_ui['hypervisor_type']
-        http_proxy_url, proxy_name, proxy_id = create_http_proxy(org=default_org)
+        http_proxy_url, proxy_name, proxy_id = create_http_proxy(
+            org=default_org, location=default_location
+        )
         form_data_ui['proxy'] = http_proxy_url
         form_data_ui['no_proxy'] = 'test.satellite.com'
         regex = '.*redhat.com'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13768

### Problem Statement
Fix the http proxy create without location can not find in Default Location
Realize http proxy create location option support

### Test Cases: PASS
```
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py -k test_positive_overview_label_name --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 33 deselected, 13 warnings in 120.91s (0:02:00)
2024-01-12 06:37:31 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx.py -k test_positive_proxy_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 33 deselected, 14 warnings in 250.38s (0:04:10)
2024-01-12 06:42:39 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx.py -k test_positive_proxy_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 19 deselected, 10 warnings in 155.33s (0:02:35)
2024-01-12 07:10:29 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/api/test_esx_sca.py -k test_positive_proxy_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 25 deselected, 10 warnings in 190.13s (0:03:10)
2024-01-12 07:18:12 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx.py -k test_positive_proxy_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 23 deselected, 10 warnings in 134.25s (0:02:14)
2024-01-12 07:20:52 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/cli/test_esx_sca.py -k test_positive_proxy_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 37 deselected, 10 warnings in 218.61s (0:03:38)
2024-01-12 07:24:57 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
```