### PR TITLE
adding logic to remove passed tests video url from junit xml

### DIFF
--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -68,6 +68,9 @@ def pytest_runtest_makereport(item):
             if item.nodeid in test_results:
                 result_info = test_results[item.nodeid]
                 if result_info.outcome == 'passed':
+                    report.user_properties = [
+                        (key, value) for key, value in report.user_properties if key != 'video_url'
+                    ]
                     session_id_tuple = next(
                         (t for t in report.user_properties if t[0] == 'session_id'), None
                     )


### PR DESCRIPTION
### Problem Statement
Currently, we are not removing the video URLs from the JUnit XML file for the passed tests. These all URLs are getting added report portal links. All the passed and failed URLs are getting displayed.      

### Solution
This will remove the URL for the passed tests from the Junit XML file. The benefit is that no additional logic is required inside the report portal.    
