### PR TITLE
[6.13.z] Add test case for ISS incomplete archive import

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1217,7 +1217,7 @@ class TestContentViewSync:
 
         # Corrupt the export archive so that it's incomplete
         tar_files = target_sat.execute(
-            f'find {PULP_EXPORT_DIR}{function_sca_manifest_org.name}/{cv["name"]}/ -name *.tar'
+            f'find {PULP_EXPORT_DIR}{function_sca_manifest_org.name}/{cv["name"]}/ -name *.tar.gz'
         ).stdout.splitlines()
         assert len(tar_files) == 1, 'Expected just one tar file in the export'
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13600

This PR just adds negative test case for ISS import of an incomplete export archive, which mocks interrupted data transfer.