### PR TITLE
[6.12.z] cli_factory job_invocation fix

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -48,10 +48,12 @@ def parse_csv(output):
     """Parse CSV output from Hammer CLI and convert it to python dictionary."""
     # ignore warning about puppet and ostree deprecation
     output.replace('Puppet and OSTree will no longer be supported in Katello 3.16\n', '')
+    is_rex = True if 'Job invocation' in output else False
     # Validate if the output is eligible for CSV conversions else return as it is
-    if not is_csv(output):
+    if not is_csv(output) and not is_rex:
         return output
-    reader = csv.reader(output.splitlines())
+    output = output.splitlines()[0:2] if is_rex else output.splitlines()
+    reader = csv.reader(output)
     # Generate the key names, spaces will be converted to dashes "-"
     keys = [_normalize(header) for header in next(reader)]
     # For each entry, create a dict mapping each key with each value


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13797

### Problem Statement

With recent changes in cli factory (I'd say both https://github.com/SatelliteQE/robottelo/pull/13491 and  https://github.com/SatelliteQE/robottelo/pull/13737 have a hand in this) a bunch of rex tests started to fail with  `box.exceptions.BoxValueError: Cannot extrapolate Box from string`

The job invocation hammer command returns something like  `'Message,Id\nJob invocation 12 created,12\n1 task(s), 1 success, 0 fail\n'`  which does not pass the is_csv check here https://github.com/jyejare/robottelo/blob/fcd09d84d933cf9e170291fac8e3c6af81f39870/robottelo/cli/hammer.py#L37 , but even if it did it would fail with the zip error as there are three lines

### Solution

Checking if the output is coming from the invocation command and adjusting accordingly.
