### PR TITLE
Fix upload_manifest to handle case where manifest.content is not set

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -146,7 +146,7 @@ class ContentInfo:
 
         """
         if not isinstance(manifest, bytes | io.BytesIO):
-            if manifest.content is None:
+            if not hasattr(manifest, 'content') or manifest.content is None:
                 manifest = clone()
         if timeout is None:
             # Set the timeout to 1500 seconds to align with the API timeout.


### PR DESCRIPTION
### Problem Statement
Currently, there are many intermittent test failures like below where we use `module_sca_manifest_org` are seen in automation runs, where we don't have content property set in manifester object.
```
pytest_fixtures/component/taxonomy.py:102: in module_sca_manifest_org
    module_target_sat.upload_manifest(module_org.id, module_sca_manifest.content)
robottelo/host_helpers/satellite_mixins.py:149: in upload_manifest
    if manifest.content is None:
E   AttributeError: 'NoneType' object has no attribute 'content'
```
### Solution
Update upload_manifest to handle case where manifest.content is not set, or when manifest.content is None

**Local test results:** 
```
In [3]: manifest = Manifester(manifest_category=settings.manifest.golden_ticket)

In [4]: manifest.content
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[4], line 1
----> 1 manifest.content

AttributeError: 'Manifester' object has no attribute 'content'

In [5]: hasattr(manifest, 'content')
Out[5]: False

In [6]: not hasattr(manifest, 'content') or manifest.content is None
Out[6]: True

In [7]: manifest.content = None

In [8]: not hasattr(manifest, 'content') or manifest.content is None
Out[8]: True
```