### PR TITLE
Random Fixes in pytest plugins

### DIFF
--- a/pytest_plugins/factory_collection.py
+++ b/pytest_plugins/factory_collection.py
@@ -12,6 +12,9 @@ def pytest_collection_modifyitems(session, items, config):
 
     factory_fixture_names = [m[0] for m in getmembers(sat_cap_factory, isfunction)]
     for item in items:
-        has_factoryfixture = set(item.fixturenames).intersection(set(factory_fixture_names))
+        itemfixtures = [
+            itm for itm in item.fixturenames if itm not in ('satellite_factory', 'capsule_factory')
+        ]
+        has_factoryfixture = set(itemfixtures).intersection(set(factory_fixture_names))
         if has_factoryfixture:
             item.add_marker('factory_instance')

--- a/pytest_plugins/requirements/update_requirements.py
+++ b/pytest_plugins/requirements/update_requirements.py
@@ -22,10 +22,10 @@ def pytest_report_header(config):
     e.g:
 
     # Following will update the mandatory requirements
-    # pytest tests/foreman --collect-only --upgrade-required-reqs
+    # pytest tests/foreman --collect-only --update-required-reqs
 
     # Following will update the mandatory and optional requirements
-    # pytest tests/foreman --collect-only --upgrade-all-reqs
+    # pytest tests/foreman --collect-only --update-all-reqs
     """
     if updater.req_deviation:
         print(f"Mandatory Requirements Mismatch: {' '.join(updater.req_deviation)}")
@@ -46,5 +46,5 @@ def pytest_report_header(config):
     if updater.req_deviation or updater.opt_deviation:
         print(
             "To update mismatched requirements, run the pytest command with "
-            "'--upgrade-required-reqs' OR '--upgrade-all-reqs' option."
+            "'--update-required-reqs' OR '--update-all-reqs' option."
         )


### PR DESCRIPTION
### Problem Statement
1. In factory collection plugin, The factory instance marker was being added to test cases using `satellite_factory` and `caspule_factory` fixtures, which is anyways being used in all test cases through target_sat hence all the tests were being collected/discollected.
2. In reqs plugin, the message to update the reqs was wrong.

### Solution
1. Now, the `satellite_factory` and `caspule_factory` fixtures would be ignored from factory fixtures and rest would be taken into account to filter the tests.
2. Updated the message to show the right messsage.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->