### PR TITLE
[6.15.z] New provisioning cleanup method to workaround BZ:2207698

### DIFF
--- a/pytest_fixtures/component/provision_capsule_pxe.py
+++ b/pytest_fixtures/component/provision_capsule_pxe.py
@@ -101,7 +101,7 @@ def capsule_provisioning_lce_sync_setup(module_capsule_configured, module_lce_li
     module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
         data={'environment_id': module_lce_library.id}
     )
-    sync_status = module_capsule_configured.nailgun_capsule.content_sync(timeout=600)
+    sync_status = module_capsule_configured.nailgun_capsule.content_sync(timeout='60m')
     assert sync_status['result'] == 'success', 'Capsule sync task failed.'
 
 

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -342,6 +342,19 @@ class ProvisioningSetup:
             == 0
         )
 
+    def provisioning_cleanup(self, hostname, interface='API'):
+        if interface == 'CLI':
+            if self.cli.Host.exists(search=('name', hostname)):
+                self.cli.Host.delete({'name': hostname})
+            assert not self.cli.Host.exists(search=('name', hostname))
+        else:
+            host = self.api.Host().search(query={'search': f'name="{hostname}"'})
+            if host:
+                host[0].delete()
+            assert not self.api.Host().search(query={'search': f'name={hostname}'})
+        # Workaround BZ: 2207698
+        assert self.cli.Service.restart().status == 0
+
 
 class Factories:
     """Mixin that provides attributes for each factory type"""

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -188,7 +188,6 @@ class TestDiscoveredHost:
         :Setup: Provisioning and discovery should be configured
 
         :steps:
-
             1. Boot up the host to discover
             2. Provision the host
 
@@ -215,8 +214,7 @@ class TestDiscoveredHost:
             host = sat.api.Host().search(query={"search": f'name={host.name}'})[0]
             assert host
             assert_discovered_host_provisioned(shell, module_provisioning_rhel_content.ksrepo)
-            host.delete()
-            assert not sat.api.Host().search(query={"search": f'name={host.name}'})
+            sat.provisioning_cleanup(host.name)
         provisioning_host.blank = True
 
     @pytest.mark.upgrade
@@ -265,8 +263,7 @@ class TestDiscoveredHost:
             host = sat.api.Host().search(query={"search": f'name={host.name}'})[0]
             assert host
             assert_discovered_host_provisioned(shell, module_provisioning_rhel_content.ksrepo)
-            host.delete()
-            assert not sat.api.Host().search(query={"search": f'name={host.name}'})
+            sat.provisioning_cleanup(host.name)
         pxeless_discovery_host.blank = True
 
     @pytest.mark.tier3

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -113,7 +113,8 @@ def test_rhel_pxe_provisioning(
     ).create(create_missing=False)
     # Clean up the host to free IP leases on Satellite.
     # broker should do that as a part of the teardown, putting here just to make sure.
-    request.addfinalizer(host.delete)
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+
     # Start the VM, do not ensure that we can connect to SSHD
     provisioning_host.power_control(ensure=False)
 
@@ -251,7 +252,8 @@ def test_rhel_ipxe_provisioning(
     ).create(create_missing=False)
     # Clean up the host to free IP leases on Satellite.
     # broker should do that as a part of the teardown, putting here just to make sure.
-    request.addfinalizer(host.delete)
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+
     # Start the VM, do not ensure that we can connect to SSHD
     provisioning_host.power_control(ensure=False)
 
@@ -378,7 +380,8 @@ def test_rhel_httpboot_provisioning(
     ).create(create_missing=False)
     # Clean up the host to free IP leases on Satellite.
     # broker should do that as a part of the teardown, putting here just to make sure.
-    request.addfinalizer(host.delete)
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+
     # Start the VM, do not ensure that we can connect to SSHD
     provisioning_host.power_control(ensure=False)
     # check for proper HTTP requests
@@ -507,7 +510,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
     ).create(create_missing=False)
     # Clean up the host to free IP leases on Satellite.
     # broker should do that as a part of the teardown, putting here just to make sure.
-    request.addfinalizer(host.delete)
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
     # Start the VM, do not ensure that we can connect to SSHD
     provisioning_host.power_control(ensure=False)
 
@@ -646,7 +649,7 @@ def test_capsule_pxe_provisioning(
     ).create(create_missing=False)
     # Clean up the host to free IP leases on Satellite.
     # broker should do that as a part of the teardown, putting here just to make sure.
-    request.addfinalizer(host.delete)
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
     # Start the VM, do not ensure that we can connect to SSHD
     provisioning_host.power_control(ensure=False)
     # Host should do call back to the Satellite reporting

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -155,7 +155,8 @@ def test_host_provisioning_with_external_puppetserver(
     ).create(create_missing=False)
     # Clean up the host to free IP leases on Satellite.
     # broker should do that as a part of the teardown, putting here just to make sure.
-    request.addfinalizer(host.delete)
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+
     # Start the VM, do not ensure that we can connect to SSHD
     provisioning_host.power_control(ensure=False)
 

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -486,7 +486,7 @@ def test_positive_provision_end_to_end(
         }
     )
     # teardown
-    request.addfinalizer(lambda: sat.cli.Host.delete({'id': host['id']}))
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host['name'], interface='CLI'))
 
     # checks
     hostname = f'{hostname}.{module_libvirt_provisioning_sat.domain.name}'

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -415,11 +415,11 @@ def test_positive_provision_rhev_with_host_group(
 
     :CaseAutomation: Automated
     """
-    cli = module_provisioning_sat.sat.cli
+    sat = module_provisioning_sat.sat
     cr_name = gen_string('alpha')
     org_name = module_sca_manifest_org.name
     loc_name = module_location.name
-    rhv_cr = cli.ComputeResource.create(
+    rhv_cr = sat.cli.ComputeResource.create(
         {
             'name': cr_name,
             'provider': 'Ovirt',
@@ -435,7 +435,7 @@ def test_positive_provision_rhev_with_host_group(
     assert rhv_cr['name'] == cr_name
     domain_name = module_provisioning_sat.domain.name
     subnet_name = module_provisioning_sat.subnet.name
-    hostgroup = cli.HostGroup.create(
+    hostgroup = sat.cli.HostGroup.create(
         {
             'name': gen_string('alpha'),
             'organization': org_name,
@@ -448,13 +448,13 @@ def test_positive_provision_rhev_with_host_group(
             'kickstart-repository-id': module_provisioning_rhel_content.ksrepo.id,
             'lifecycle-environment-id': module_sca_manifest_org.library.id,
             'operatingsystem': module_provisioning_rhel_content.os.title,
-            'pxe-loader': "PXELinux BIOS",
+            'pxe-loader': 'PXELinux BIOS',
             'partition-table': default_partitiontable.name,
             'compute-resource-id': rhv_cr.get('id'),
         }
     )
     host_name = gen_string('alpha').lower()
-    host = cli.Host.create(
+    host = sat.cli.Host.create(
         {
             'name': f'{host_name}',
             'organization': org_name,
@@ -467,7 +467,7 @@ def test_positive_provision_rhev_with_host_group(
             'mac': None,
             'compute-attributes': f"cluster={rhev.cluster_id},"
             "cores=1,"
-            "memory=4294967296,"  # 4 GiB
+            "memory=6442450944,"  # 6 GiB
             "start=1",
             'interface': (
                 f"compute_name=nic1, compute_network="
@@ -478,12 +478,12 @@ def test_positive_provision_rhev_with_host_group(
         }
     )
     # cleanup
-    request.addfinalizer(lambda: cli.Host.delete({'id': host['id']}))
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host['name'], interface='CLI'))
 
     # checks
     hostname = f'{host_name}.{domain_name}'
     assert hostname == host['name']
-    host_info = cli.Host.info({'name': hostname})
+    host_info = sat.cli.Host.info({'name': hostname})
     # Check on RHV, if VM exists
     assert rhev.rhv_api.does_vm_exist(hostname)
     # Get the information of created VM
@@ -501,12 +501,12 @@ def test_positive_provision_rhev_with_host_group(
     # the result of the installation. Wait until Satellite reports that the host is installed.
     exp_st = 'Pending installation'
     wait_for(
-        lambda: cli.Host.info({'id': host['id']})['status']['build-status'] != exp_st,
+        lambda: sat.cli.Host.info({'id': host['id']})['status']['build-status'] != exp_st,
         # timeout=200,  # no need to wait long, the host was already pingable
         timeout=4000,  # wait long because the ping check has not been done, TODO
         delay=10,
     )
-    host = cli.Host.info({'id': host['id']})
+    host = sat.cli.Host.info({'id': host['id']})
     assert host['status']['build-status'] == 'Installed'
 
 
@@ -577,11 +577,11 @@ def test_positive_provision_rhev_image_based_and_disassociate(
 
     :CaseAutomation: Automated
     """
-    cli = module_provisioning_sat.sat.cli
+    sat = module_provisioning_sat.sat
     org_name = module_org.name
     loc_name = module_location.name
     name = gen_string('alpha')
-    rhv_cr = cli.ComputeResource.create(
+    rhv_cr = sat.cli.ComputeResource.create(
         {
             'name': name,
             'provider': 'Ovirt',
@@ -598,7 +598,7 @@ def test_positive_provision_rhev_image_based_and_disassociate(
     host_name = gen_string('alpha').lower()
     # use some RHEL (usually latest)
     os = module_provisioning_rhel_content.os
-    image = cli.ComputeResource.image_create(
+    image = sat.cli.ComputeResource.image_create(
         {
             'compute-resource': rhv_cr['name'],
             'name': f'img {gen_string(str_type="alpha")}',
@@ -616,7 +616,7 @@ def test_positive_provision_rhev_image_based_and_disassociate(
     host = None  # to avoid UnboundLocalError in finally block
     rhv_vm = None
     try:
-        host = cli.Host.create(
+        host = sat.cli.Host.create(
             {
                 'name': f'{host_name}',
                 'organization': org_name,
@@ -631,7 +631,7 @@ def test_positive_provision_rhev_image_based_and_disassociate(
                 'mac': None,
                 'compute-attributes': f"cluster={rhev.cluster_id},"
                 "cores=1,"
-                "memory=4294967296,"  # 4 GiB
+                "memory=6442450944,"  # 6 GiB
                 "start=1",
                 'interface': (
                     f"compute_name=nic1, compute_network="
@@ -646,7 +646,7 @@ def test_positive_provision_rhev_image_based_and_disassociate(
         )
         hostname = f'{host_name}.{domain_name}'
         assert hostname == host['name']
-        host_info = cli.Host.info({'name': hostname})
+        host_info = sat.cli.Host.info({'name': hostname})
         # Check on RHV, if VM exists
         assert rhev.rhv_api.does_vm_exist(hostname)
         # Get the information of created VM
@@ -661,14 +661,14 @@ def test_positive_provision_rhev_image_based_and_disassociate(
         # that's enough.
 
         # Disassociate the host from the CR, check it's disassociated
-        cli.Host.disassociate({'name': hostname})
-        host_info = cli.Host.info({'name': hostname})
+        sat.cli.Host.disassociate({'name': hostname})
+        host_info = sat.cli.Host.info({'name': hostname})
         assert 'compute-resource' not in host_info
 
     finally:
         # Now, let's just remove the host
         if host is not None:
-            cli.Host.delete({'id': host['id']})
+            sat.provisioning_cleanup(host['name'], interface='CLI')
         # Delete the VM since the disassociated VM won't get deleted
         if rhv_vm is not None:
             rhv_vm.delete()

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -131,7 +131,7 @@ def test_positive_provision_end_to_end(
         }
     )
     # teardown
-    request.addfinalizer(lambda: sat.cli.Host.delete({'id': host['id']}))
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host['name'], interface='CLI'))
 
     hostname = f'{hostname}.{module_provisioning_sat.domain.name}'
     assert hostname == host['name']

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -36,7 +36,6 @@ def test_rhel_pxe_discovery_provisioning(
     :Setup: Satellite with Provisioning and Discovery features configured
 
     :steps:
-
         1. Boot up the host to discover
         2. Provision the host
 
@@ -68,15 +67,14 @@ def test_rhel_pxe_discovery_provisioning(
             'location-id': discovered_host.location.id,
         }
     )
-    # teardown
-    @request.addfinalizer
-    def _finalize():
-        host.delete()
-        assert not sat.api.Host().search(query={"search": f'name={host.name}'})
 
     assert 'Host created' in result[0]['message']
     host = sat.api.Host().search(query={"search": f'id={discovered_host.id}'})[0]
     assert host
+
+    # teardown
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
         timeout=1500,
@@ -131,16 +129,13 @@ def test_rhel_pxeless_discovery_provisioning(
             'location-id': discovered_host.location.id,
         }
     )
-
-    # teardown
-    @request.addfinalizer
-    def _finalize():
-        host.delete()
-        assert not sat.api.Host().search(query={"search": f'name={host.name}'})
-
     assert 'Host created' in result[0]['message']
     host = sat.api.Host().search(query={"search": f'id={discovered_host.id}'})[0]
     assert host
+
+    # teardown
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
         timeout=1500,

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -174,11 +174,7 @@ def test_positive_provision_end_to_end(
         assert session.host.search(name)[0]['Name'] == name
 
         # teardown
-        @request.addfinalizer
-        def _finalize():
-            host = sat.api.Host().search(query={'search': f'name="{name}"'})
-            if host:
-                host[0].delete()
+        request.addfinalizer(lambda: sat.provisioning_cleanup(name))
 
         # Check on Libvirt, if VM exists
         result = sat.execute(

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -51,6 +51,7 @@ def _is_host_reachable(host, retries=12, iteration_sleep=5, expect_reachable=Tru
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
 @pytest.mark.rhel_ver_match('9')
 def test_positive_provision_pxe_host(
+    request,
     session,
     module_location,
     module_org,
@@ -93,6 +94,10 @@ def test_positive_provision_pxe_host(
     discovered_host_name = discovered_host.name
     domain_name = provisioning_hostgroup.domain.read().name
     host_name = f'{discovered_host_name}.{domain_name}'
+
+    # Teardown
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host_name))
+
     with session:
         session.discoveredhosts.provision(
             discovered_host_name,
@@ -150,6 +155,7 @@ def test_positive_update_name(
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
 @pytest.mark.rhel_ver_match('9')
 def test_positive_auto_provision_host_with_rule(
+    request,
     session,
     module_org,
     module_location,
@@ -191,6 +197,9 @@ def test_positive_auto_provision_host_with_rule(
     discovered_host_name = discovered_host.name
     domain_name = provisioning_hostgroup.domain.read().name
     host_name = f'{discovered_host_name}.{domain_name}'
+
+    # Teardown
+    request.addfinalizer(lambda: sat.provisioning_cleanup(host_name))
 
     discovery_rule = sat.api.DiscoveryRule(
         max_count=10,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13818

### Problem Statement
Currently provisioning tests fails due to mentioned BZ where there are no new IPs available to offer

### Solution
Restarting services after a host is removed from a server seems to work well here, Thanks to @shubhamsg199 to find this workaround. So we're now introducing one new common cleanup method which deletes and restart services for us, and update all on_prem tests to use this new method.

We have tested this with Jenkins jobs on J-MR and the results seem promising!