### PR TITLE
Fix reclaim_space endpoint path

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -153,7 +153,7 @@ API_PATHS = {
         '/katello/api/capsules/:id/content/sync',
         '/katello/api/capsules/:id/content/sync',
         '/katello/api/capsules/:id/content/sync',
-        '/katello/api/capsules/:id/reclaim_space',
+        '/katello/api/capsules/:id/content/reclaim_space',
     ),
     'capsules': ('/katello/api/capsules', '/katello/api/capsules/:id'),
     'common_parameters': (


### PR DESCRIPTION
### Problem Statement
In 6.15.0 the `reclaim_space` endpoint was moved behind the `content` section in [BZ#2218179](https://bugzilla.redhat.com/show_bug.cgi?id=2218179) (also see the 6.15 results for `tests.foreman.endtoend.test_api_endtoend.TestAvailableURLs.test_positive_get_links`, it fails)

### Solution
Move it in this test too.

