### PR TITLE
[6.12.z] oscap helper function fix

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -43,7 +43,7 @@ ak_name = {
 }
 
 
-def fetch_scap_and_profile_id(scap_name, scap_profile, sat):
+def fetch_scap_and_profile_id(sat, scap_name, scap_profile):
     """Extracts the scap ID and scap profile id
 
     :param scap_name: Scap title


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13841

### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/11544 altered  `fetch_scap_and_profile_id` to use satellite, but the function defines it as the last parameter, while callers use it as the first one, hence `AttributeError: 'str' object has no attribute 'cli'`

### Solution
changing the order of parameters 


