### PR TITLE
[6.12.z] Sync project dependencies

### DIFF
--- a/.github/workflows/auto_cherry_pick_merge.yaml
+++ b/.github/workflows/auto_cherry_pick_merge.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - id: automerge
         name: Auto merge of cherry-picked PRs.
-        uses: "pascalgn/automerge-action@v0.15.6"
+        uses: "pascalgn/automerge-action@v0.16.2"
         env:
           GITHUB_TOKEN: "${{ secrets.CHERRYPICK_PAT }}"
           MERGE_LABELS: "AutoMerge_Cherry_Picked, Auto_Cherry_Picked"

--- a/.github/workflows/auto_cherry_pick_merge.yaml
+++ b/.github/workflows/auto_cherry_pick_merge.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Wait for other status checks to Pass
         id: waitforstatuschecks
-        uses: lewagon/wait-on-check-action@v1.3.1
+        uses: lewagon/wait-on-check-action@v1.3.3
         with:
           ref: ${{ github.head_ref }}
           repo-token: ${{ secrets.CHERRYPICK_PAT }}

--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Wait for other status checks to Pass
         id: waitforstatuschecks
-        uses: lewagon/wait-on-check-action@v1.3.1
+        uses: lewagon/wait-on-check-action@v1.3.3
         with:
           ref: ${{ github.head_ref }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -47,7 +47,7 @@ jobs:
 
       - id: automerge
         name: Auto merge of dependabot PRs.
-        uses: "pascalgn/automerge-action@v0.15.6"
+        uses: "pascalgn/automerge-action@v0.16.2"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "dependencies"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set Up Python-${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set Up Python-${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ navmazing==1.2.2
 productmd==1.38
 pyotp==2.9.0
 python-box==7.1.1
-pytest==7.4.3
+pytest==7.4.4
 pytest-services==2.2.1
 pytest-mock==3.12.0
 pytest-reportportal==5.3.1


### PR DESCRIPTION
### Problem Statement
Our GHA automation failed to backport some of the patches. They were not backported till today.

### Solution
Backport missing patches - this PR.

### Related Issues
* https://github.com/SatelliteQE/robottelo/issues/13306
* https://github.com/SatelliteQE/robottelo/issues/13549
*  #13581
* https://github.com/SatelliteQE/robottelo/issues/13727