### PR TITLE
additional check before create issue for failed cherrypick

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -97,10 +97,16 @@ jobs:
               labels: ["AutoMerge_Cherry_Picked"]
             })
 
+      - name: Check if cherrypick pr is created
+        uses: juliangruber/find-pull-request-action@v1
+        id: fpr
+        with:
+          branch: ${{ matrix.label }}
+
       ## Failure Logging to issues and GChat Group
       - name: Create Github issue on cherrypick failure
         id: create-issue
-        if: ${{ always() && steps.cherrypick.outcome != 'success' && startsWith(matrix.label, '6.') && matrix.label != github.base_ref }}
+        if: ${{ always() && steps.fpr.outputs.number != '' && steps.cherrypick.outcome != 'success' && startsWith(matrix.label, '6.') && matrix.label != github.base_ref }}
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ secrets.CHERRYPICK_PAT }}


### PR DESCRIPTION
### Problem Statement
There have been occurrences where the PR issue was created for passed cherrypicks as well. There has to be a check before creating an issue. The discussion and further details point to these comments  https://github.com/SatelliteQE/robottelo/pull/13831#issuecomment-1900151508  

### Solution
An additional check is added to this PR, it will try to check if the PR exists with that branch name, if yes then it will not raise any concerns or create issues.    


### Related Issues
https://github.com/SatelliteQE/robottelo/pull/13831#issuecomment-1900151508  


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->