### PR TITLE
fix in test_permission

### DIFF
--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -374,7 +374,7 @@ class TestUserRole:
         self.give_user_permission(_permission_name(entity_cls, 'update'), target_sat)
         # update() calls read() under the hood, which triggers
         # permission error
-        if entity_cls is target_sat.api.ActivationKey:
+        if entity_cls is entities.ActivationKey:
             entity_cls(self.cfg, id=new_entity.id, name=name, organization=class_org).update_json(
                 ['name']
             )


### PR DESCRIPTION
### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/12989 swapped `entities` for `target_sat.api` but:

```
(Pdb) entities.ActivationKey
<class 'nailgun.entities.ActivationKey'>
(Pdb) target_sat.api.ActivationKey
<class 'robottelo.hosts.Satellite.api.<locals>.inject_config.<locals>.DecClass'>
```
which breaks the if condition in this test

### Solution

Swapping back to entities, as it is still heavily used in that module. Deferring further changes to component evaluation

