### PR TITLE
Update ping call for certs check

### DIFF
--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -54,7 +54,7 @@ def test_positive_update_katello_certs(cert_setup_destructive_teardown):
         # assert no hammer ping SSL cert error
         result = satellite.execute('hammer ping')
         assert 'SSL certificate verification failed' not in result.stdout
-        assert result.stdout.count('ok') == 8
+        assert result.stdout.count('ok') == 9
         # assert all services are running
         result = satellite.execute('satellite-maintain health check --label services-up -y')
         assert result.status == 0, 'Not all services are running'
@@ -97,7 +97,7 @@ def test_regeneration_ssl_build_certs(target_sat):
     # assert no hammer ping SSL cert error
     result = target_sat.execute('hammer ping')
     assert 'SSL certificate verification failed' not in result.stdout
-    assert result.stdout.count('ok') == 8
+    assert result.stdout.count('ok') == 9
     # assert all services are running
     result = target_sat.execute('satellite-maintain health check --label services-up -y')
     assert result.status == 0, 'Not all services are running'


### PR DESCRIPTION
### Problem Statement
Katello-certs-check tests fail when checking for 8 services reporting 'ok' status.

### Solution
Change to 9 services since we now report the default redis cache in hammer ping.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->