### PR TITLE
adding the missing sha with branch name in gha

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -101,7 +101,8 @@ jobs:
         uses: juliangruber/find-pull-request-action@v1
         id: fpr
         with:
-          branch: ${{ matrix.label }}
+          branch: "cherry-pick-${{ matrix.label }}-${{ github.sha }}"
+          base: ${{ matrix.label }}
 
       ## Failure Logging to issues and GChat Group
       - name: Create Github issue on cherrypick failure


### PR DESCRIPTION
### Problem Statement
after running https://github.com/SatelliteQE/robottelo/pull/13858 with production to realised that the matrix branch is not a direct branch we need the sha with the branch name.

### Solution
This will fix the whole thing with the correct branching name. Tested Here https://github.com/omkarkhatavkar/robottelo/actions/runs/7629781738/job/20783989147.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->