### PR TITLE
cli org test fix

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -520,7 +520,13 @@ def test_positive_add_and_remove_locations(module_org, module_target_sat):
         {'location': locations[1]['name'], 'id': module_org.id}
     )
     org_info = module_target_sat.cli.Org.info({'id': module_org.id})
-    assert not org_info.get('locations'), "Failed to remove locations"
+    found_locations = (
+        org_info.get('locations')
+        if isinstance(org_info.get('locations'), list)
+        else [org_info.get('locations')]
+    )
+    assert locations[0]['name'] not in found_locations, "Failed to remove locations"
+    assert locations[1]['name'] not in found_locations, "Failed to remove locations"
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
### Problem Statement
Default location can be assigned to the organization, causing test flakiness

### Solution
Adjusting assertions to this possibility

