### PR TITLE
[6.13.z] Use sca enabled manifest for test_positive_configure_cloud_connector

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -190,6 +190,16 @@ def module_extra_rhel_entitlement_manifest():
 
 
 @pytest.fixture(scope='module')
+def module_extra_rhel_sca_manifest():
+    """Yields a manifest in sca mode with subscriptions determined by the
+    'manifest_category.extra_rhel_entitlement` setting in conf/manifest.yaml."""
+    with Manifester(
+        manifest_category=settings.manifest.extra_rhel_entitlement, simple_content_access="enabled"
+    ) as manifest:
+        yield manifest
+
+
+@pytest.fixture(scope='module')
 def module_sca_manifest():
     """Yields a manifest in Simple Content Access mode with subscriptions determined by the
     `manifest_category.golden_ticket` setting in conf/manifest.yaml."""

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -65,13 +65,11 @@ def fixture_setup_rhc_satellite(
     request,
     module_target_sat,
     module_rhc_org,
-    module_extra_rhel_entitlement_manifest,
+    module_extra_rhel_sca_manifest,
 ):
     """Create Organization and activation key after successful test execution"""
     if settings.rh_cloud.crc_env == 'prod':
-        module_target_sat.upload_manifest(
-            module_rhc_org.id, module_extra_rhel_entitlement_manifest.content
-        )
+        module_target_sat.upload_manifest(module_rhc_org.id, module_extra_rhel_sca_manifest.content)
     yield
     if request.node.rep_call.passed:
         # Enable and sync required repos


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13908

### Problem Statement
- test_positive_configure_cloud_connector currently uses entitlement mode manifest.

### Solution
- Create module_extra_rhel_sca_manifest to create sca mode manifest.

### Related Issues
- https://issues.redhat.com/browse/SAT-21433

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->