### PR TITLE
added test_positive_host_registration_with_non_admin_user

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -13,7 +13,7 @@
 """
 import uuid
 
-from fauxfactory import gen_ipaddr, gen_mac
+from fauxfactory import gen_ipaddr, gen_mac, gen_string
 import pytest
 from requests import HTTPError
 
@@ -262,3 +262,57 @@ def test_negative_capsule_without_registration_enabled(
         "Proxy lacks one of the following features: 'Registration', 'Templates'"
         in context.value.response.text
     )
+
+
+@pytest.mark.rhel_ver_match('[^6]')
+def test_positive_host_registration_with_non_admin_user(
+    module_org,
+    module_location,
+    module_activation_key,
+    module_target_sat,
+    rhel_contenthost,
+):
+    """Verify host registration with non admin user
+
+    :id: 02bdda6a-010d-4098-a7e0-e4b5e8416ce3
+
+    :steps:
+        1. Enable the required repositories on the satellite and get a host(RHEL7/RHEL8/RHEL9)
+        2. Create a non-admin user and assign "Register Hosts" role to it.
+        3. Create an activation key and assign CV and LCE to it.
+        4. Login Satellite with new user and generate curl command to register host with all setup options set to NO.
+        5. Run the curl command on the host.
+
+    :expectedresults: Host registered successfully with all setup options set to 'NO' for non admin user
+
+    :BZ: 2211484
+
+    :customerscenario: true
+    """
+    changed_org_admin = module_target_sat.api.Role().search(
+        query={'search': 'name="Register hosts"'}
+    )
+    module_target_sat.api.User(
+        role=changed_org_admin,
+        admin=False,
+        login=gen_string('alpha'),
+        password=gen_string('alpha'),
+        organization=[module_org],
+        location=[module_location],
+    ).create()
+    command = module_target_sat.api.RegistrationCommand(
+        organization=module_org,
+        activation_keys=[module_activation_key.name],
+        location=module_location,
+        setup_insights=False,
+        setup_remote_execution=False,
+        setup_remote_execution_pull=False,
+        update_packages=False,
+    ).create()
+    result = rhel_contenthost.execute(command)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    package = constants.FAKE_7_CUSTOM_PACKAGE
+    assert_info = ['dnf -y install insights-client', 'Starting deployment of REX pull provider',
+                   f'yum install - y {package}', '/usr/sbin/restorecon']
+    for data in assert_info:
+        assert data not in result.stdout

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -285,7 +285,7 @@ def test_positive_host_registration_with_non_admin_user_with_setup_false(
         3. Create an activation key and assign CV and LCE to it.
         4. Create new user and generate curl command to register host
 
-    :expectedresults: Host registered successfully with all setup options set to 'NO' for non admin user
+    :expectedresults: Host registered successfully with all setup options set to 'NO' with non-admin user
 
     :BZ: 2211484
 


### PR DESCRIPTION
### Problem Statement
Global Registration using an new user with "Register Hosts" role ignores all the setup options.

### Solution
Provided solution will fix the global registration problem with non-admin user

### Related Issues
No
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_registration.py::test_positive_host_registration_with_non_admin_user
