### PR TITLE
[6.14.z] Add host teardown for smart classparameters test

### DIFF
--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -66,6 +66,7 @@ class TestSmartClassParameters:
     @pytest.mark.e2e
     def test_positive_list(
         self,
+        request,
         session_puppet_enabled_sat,
         module_puppet_org,
         module_puppet_loc,
@@ -86,6 +87,7 @@ class TestSmartClassParameters:
             environment=module_puppet['env'].name,
         ).create()
         host.add_puppetclass(data={'puppetclass_id': module_puppet['class']['id']})
+        request.addfinalizer(host.delete)
         hostgroup = session_puppet_enabled_sat.cli_factory.hostgroup(
             {
                 'puppet-environment-id': module_puppet['env'].id,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13902

### Problem Statement
test_positive_test_hidden_parameter_value is failing due to no teardown present for the host in test_positive_list

### Solution
Add teardown for the host deletion 

