### PR TITLE
Fix language setting

### DIFF
--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -40,7 +40,7 @@ def test_positive_end_to_end(session, target_sat, test_name, module_org, module_
     password = gen_string('alpha')
     email = gen_email()
     description = gen_string('alphanumeric')
-    language = 'en'
+    language = 'English (United States)'
     timezone = '(GMT+00:00) UTC'
     role = target_sat.api.Role().create().name
     with session:


### PR DESCRIPTION
### Problem Statement
in foreman 3.9 (6.15.z) 'en' was changed to 'English (United States)'


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->