### PR TITLE
[6.15.z] ensure mqtt capsule is not bypassed

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -73,6 +73,12 @@ def test_positive_run_capsule_upgrade_playbook(module_capsule_configured, target
 @pytest.mark.tier3
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_list('8')
+@pytest.mark.parametrize(
+    'setting_update',
+    ['remote_execution_global_proxy=False'],
+    ids=["no_global_proxy"],
+    indirect=True,
+)
 def test_negative_time_to_pickup(
     module_org,
     module_target_sat,
@@ -80,6 +86,7 @@ def test_negative_time_to_pickup(
     module_ak_with_cv,
     module_capsule_configured_mqtt,
     rhel_contenthost,
+    setting_update,
 ):
     """Time to pickup setting is honored for host registered to mqtt
 
@@ -130,13 +137,6 @@ def test_negative_time_to_pickup(
     # stop yggdrasil client on host
     result = rhel_contenthost.execute('systemctl stop yggdrasild')
     assert result.status == 0, f'Failed to stop yggdrasil on client: {result.stderr}'
-
-    # Make sure the job is executed by the registered-trough capsule
-    global_ttp = module_target_sat.api.Setting().search(
-        query={'search': 'name="remote_execution_global_proxy"'}
-    )[0]
-    global_ttp.value = False
-    global_ttp.update(['value'])
 
     # run script provider rex command with time_to_pickup
     job = module_target_sat.api.JobInvocation().run(

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1235,6 +1235,12 @@ class TestPullProviderRex:
     @pytest.mark.upgrade
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_match('[^6].*')
+    @pytest.mark.parametrize(
+        'setting_update',
+        ['remote_execution_global_proxy=False'],
+        ids=["no_global_proxy"],
+        indirect=True,
+    )
     def test_positive_run_job_on_host_converted_to_pull_provider(
         self,
         module_org,
@@ -1243,6 +1249,7 @@ class TestPullProviderRex:
         module_target_sat,
         module_capsule_configured_mqtt,
         rhel_contenthost,
+        setting_update,
     ):
         """Run custom template on host converted to mqtt
 
@@ -1339,6 +1346,12 @@ class TestPullProviderRex:
     @pytest.mark.e2e
     @pytest.mark.no_containers
     @pytest.mark.rhel_ver_match('[^6].*')
+    @pytest.mark.parametrize(
+        'setting_update',
+        ['remote_execution_global_proxy=False'],
+        ids=["no_global_proxy"],
+        indirect=True,
+    )
     def test_positive_run_job_on_host_registered_to_pull_provider(
         self,
         module_org,
@@ -1347,6 +1360,7 @@ class TestPullProviderRex:
         module_ak_with_cv,
         module_capsule_configured_mqtt,
         rhel_contenthost,
+        setting_update,
     ):
         """Run custom template on host registered to mqtt, check effective user setting
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13817

### Problem Statement
With global proxy setting on, it is possible that if the mqtt capsule is not reached, the default one is used instead. In such case we wouldn't find out there is a problem. 

### Solution
This PR forces the registered through capsule for the tests using external capsule