### PR TITLE
[6.15.z] Remove test_positive_insights_puppet_package_availability test

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -42,32 +42,6 @@ class TestCapsuleContentManagement:
     interactions and use capsule.
     """
 
-    @pytest.mark.tier3
-    @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
-    def test_positive_insights_puppet_package_availability(self, module_capsule_configured):
-        """Check `redhat-access-insights-puppet` package availability for
-        capsule
-
-        :BZ: 1315844
-
-        :id: a31b0e21-aa5d-44e2-a408-5e01b79db3a1
-
-        :CaseComponent: RHCloud-Insights
-
-        :Team: Platform
-
-        :customerscenario: true
-
-        :expectedresults: `redhat-access-insights-puppet` package is delivered
-            in capsule repo and is available for installation on capsule via
-            yum
-        """
-        package_name = 'redhat-access-insights-puppet'
-        result = module_capsule_configured.run(f'yum list {package_name} | grep @capsule')
-        if result.status != 0:
-            result = module_capsule_configured.run(f'yum list available | grep {package_name}')
-        assert result.status == 0
-
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
     def test_positive_uploaded_content_library_sync(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13936

### Problem Statement
- test_positive_insights_puppet_package_availability is no longer required as the old insights plugin was removed from Satellite a few versions back.

### Solution
- Remove the test.

### Related Issues
- https://issues.redhat.com/browse/SAT-22936 
- https://issues.redhat.com/browse/SAT-22935

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->