### PR TITLE
[6.15.z] small fix related to repo sync bulk canceled scenario

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1406,7 +1406,7 @@ class TestRepositorySync:
         time.sleep(30)
         target_sat.api.ForemanTask().bulk_cancel(data={"task_ids": sync_ids[5:]})
         for sync_id in sync_ids:
-            sync_result = target_sat.api.ForemanTask(id=sync_id).poll(canceled=True)
+            sync_result = target_sat.api.ForemanTask(id=sync_id).poll(must_succeed=False)
             assert (
                 'Task canceled' in sync_result['humanized']['errors']
                 or 'No content added' in sync_result['humanized']['output']
@@ -1667,7 +1667,7 @@ class TestDockerRepository:
         # Need to wait for sync to actually start up
         time.sleep(2)
         target_sat.api.ForemanTask().bulk_cancel(data={"task_ids": [sync_task['id']]})
-        sync_task = target_sat.api.ForemanTask(id=sync_task['id']).poll(canceled=True)
+        sync_task = target_sat.api.ForemanTask(id=sync_task['id']).poll(must_succeed=False)
         assert 'Task canceled' in sync_task['humanized']['errors']
         assert 'No content added' in sync_task['humanized']['output']
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13951

### Problem Statement
2 tests from `foreman/api/test_repository.py` were failing due to TyepError
Test cases name: `test_positive_cancel_docker_repo_sync` and `test_positive_bulk_cancel_sync`

> TypeError: ForemanTask.poll() got an unexpected keyword argument 'canceled'

### Solution
`Poll()` from `ForemaTask` of nailgun entities return status of task and the argument `must_succeed` would raised error if tasks finishes with other than success result, as we are cancelling sync so `poll` would raise error so passing `False` will resolve this error.

### Related Issues
No

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py::TestRepositorySync::test_positive_bulk_cancel_sync tests/foreman/api/test_repository.py::TestDockerRepository::test_positive_cancel_docker_repo_sync
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->