### PR TITLE
Notifications: fix for long funning tasks

### DIFF
--- a/tests/foreman/api/test_notifications.py
+++ b/tests/foreman/api/test_notifications.py
@@ -84,8 +84,8 @@ def reschedule_long_running_tasks_notification(target_sat):
 
     assert (
         target_sat.execute(
-            f"FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE='{every_minute_cron_schedule}' "
-            "foreman-rake foreman_tasks:reschedule_long_running_tasks_checker"
+            "foreman-rake foreman_tasks:reschedule_long_running_tasks_checker "
+            f"FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE='{every_minute_cron_schedule}'"
         ).status
         == 0
     )
@@ -94,8 +94,8 @@ def reschedule_long_running_tasks_notification(target_sat):
 
     assert (
         target_sat.execute(
-            f"FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE='{default_cron_schedule}' "
-            "foreman-rake foreman_tasks:reschedule_long_running_tasks_checker"
+            "foreman-rake foreman_tasks:reschedule_long_running_tasks_checker "
+            f"FOREMAN_TASKS_CHECK_LONG_RUNNING_TASKS_CRONLINE='{default_cron_schedule}'"
         ).status
         == 0
     )


### PR DESCRIPTION
Notifications: fix for long funning tasks

For some reason, rake command in form `<ENV_VAR> foreman-rake ...`
started to ignore the ENV_VAR and the fix is to pass the ENV_VAR *after* the command,
i.e. - `foreman-rake ... <ENV_VAR>`.
