### PR TITLE
small correction in hammer repository create command

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2638,7 +2638,7 @@ class TestAnsibleCollectionRepository:
                 'product-id': prod_2['id'],
                 'url': published_url,
                 'content-type': 'ansible_collection',
-                'ansible-collection-reqirements': '{collections: \
+                'ansible-collection-requirements': '{collections: \
                     [{ name: theforeman.operations, version: "0.1.0"}]}',
             }
         )


### PR DESCRIPTION
### Problem Statement

1. Test `TestAnsibleCollectionRepository::test_positive_sync_ansible_collection_from_satellite[ansible_galaxy]` was failing due to wrong option passed to hammer command.

Applicable only for `6.14.z`, `6.15.z` and `stream`

>Error: Unrecognised option '--ansible-collection-reqirements'.

2. Also in **6.14.2** test run build no 33 of **Phoenix-content > foreman/cli/test/** detected one regression for test module / test case `test_repository.py::TestAnsibleCollectionRepository::test_positive_sync_ansible_collection[ansible_hub]` and error was related to repository synchronize. When tested locally test passed, wanted to make sure this test passes or not in CI so I would run separate PRT comment for that.

> trigger: test-robottelo
> pytest: tests/foreman/cli/test_repository.py::TestAnsibleCollectionRepository::test_positive_sync_ansible_collection
> 

### Solution
1. This PR will solve the above error.
2. Seperate PRT comment would be run for regression test, to make sure regression in test module
Local test result:

```
Launching pytest with arguments -k test_positive_sync_ansible_collection -vvs /__path__/robottelo/tests/foreman/cli/test_repository.py --no-header --no-summary -q in /__path__/robottelo

============================= test session starts ==============================
collecting ... 2024-01-31 19:00:13 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 169 items / 166 deselected / 3 selected

tests/foreman/cli/test_repository.py::TestAnsibleCollectionRepository::test_positive_sync_ansible_collection[ansible_galaxy] 
tests/foreman/cli/test_repository.py::TestAnsibleCollectionRepository::test_positive_sync_ansible_collection[ansible_hub] 
tests/foreman/cli/test_repository.py::TestAnsibleCollectionRepository::test_positive_sync_ansible_collection_from_satellite[ansible_galaxy] 

=========== 1 failed, 2 passed, 166 deselected in 389.82s (0:06:29) ============
PASSEDPASSEDFAILED
```

### Related Issues
No

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py::TestAnsibleCollectionRepository::test_positive_sync_ansible_collection_from_satellite
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->