### PR TITLE
[6.14.z] fix in ui_host fixture

### DIFF
--- a/pytest_fixtures/core/ui.py
+++ b/pytest_fixtures/core/ui.py
@@ -18,7 +18,7 @@ def ui_user(request, module_org, module_location, module_target_sat):
     test_module_name = request.module.__name__.split('.')[-1].split('_', 1)[-1]
     login = f"{test_module_name}_{gen_string('alphanumeric')}"
     password = gen_string('alphanumeric')
-    admin = request.param.get('admin', True)
+    admin = request.param.get('admin', True) if hasattr(request, 'param') else True
     logger.debug('Creating session user %r', login)
     user = module_target_sat.api.User(
         admin=admin,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13962

### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/13554 breaks every unparametrized session fixture with `AttributeError: 'SubRequest' object has no attribute 'param'`

### Solution

request.param is not expected at all times