### PR TITLE
setup_org_for_a_rh_repo fix

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -726,17 +726,7 @@ class CLIFactory:
         # If manifest does not exist, clone and upload it
         if len(self._satellite.cli.Subscription.exists({'organization-id': org_id})) == 0:
             with clone() as manifest:
-                remote_name = gen_alpha()
-                _, temporary_local_manifest_path = mkstemp(prefix='manifest-', suffix='.zip')
-                with open(temporary_local_manifest_path, 'wb') as file_handler:
-                    file_handler.write(manifest.content.read())
-                    self._satellite.put(temporary_local_manifest_path, remote_name)
-            try:
-                self._satellite.cli.Subscription.upload(
-                    {'file': remote_name, 'organization-id': org_id}
-                )
-            except CLIReturnCodeError as err:
-                raise CLIFactoryError(f'Failed to upload manifest\n{err.msg}') from err
+                self._satellite.upload_manifest(org_id, manifest.content)
         # Enable repo from Repository Set
         try:
             self._satellite.cli.RepositorySet.enable(


### PR DESCRIPTION
### Problem Statement
```
AttributeError: 'Manifest' object has no attribute 'path'
```

### Solution
Follow idiom of creating a temporary file and into it, copying an in-memory object, then using it as a file.

I'm not sure how and when it got broken, I hit it when looking at the results of `test_negative_without_attach_with_lce`. I haven't yet tested extensively to make sure this doesn't break function `_setup_org_for_a_rh_repo` in other cases but it seems like it couldn't have worked.