### PR TITLE
CV already published + single LCE

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2015,16 +2015,19 @@ def test_negative_without_attach(
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
 def test_negative_without_attach_with_lce(
-    target_sat, host_subscription_client, function_org, function_lce
+    target_sat,
+    host_subscription_client,
+    function_org,
+    function_lce,
 ):
     """Attempt to enable a repository of a subscription that was not
-    attached to a host
+    attached to a host.
     This test is not using the host_subscription entities except
     subscription_name and repository_id
 
     :id: fc469e70-a7cb-4fca-b0ea-3c9e3dfff849
 
-    :expectedresults: repository not enabled on host
+    :expectedresults: Repository enabled due to SCA. Why is this "negative"? To keep history, because pre-6.16, this would have failed.
 
     :parametrized: yes
     """
@@ -2036,8 +2039,8 @@ def test_negative_without_attach_with_lce(
     target_sat.cli_factory.setup_org_for_a_rh_repo(
         {
             'product': PRDS['rhel'],
-            'repository-set': REPOSET['rhst7'],
-            'repository': REPOS['rhst7']['name'],
+            'repository-set': REPOSET['rhsclient7'],
+            'repository': REPOS['rhsclient7']['name'],
             'organization-id': function_org.id,
             'content-view-id': content_view.id,
             'lifecycle-environment-id': function_lce.id,
@@ -2046,27 +2049,18 @@ def test_negative_without_attach_with_lce(
         },
         force_use_cdn=True,
     )
-    host_lce = target_sat.api.LifecycleEnvironment(organization=function_org).create()
-    # refresh content view data
-    content_view.publish()
-    content_view.read().version[-1].promote(data={'environment_ids': host_lce.id, 'force': False})
 
     # register client
     host_subscription_client.register_contenthost(
         function_org.name,
-        lce=f'{host_lce.name}/{content_view.name}',
+        lce=f'{function_lce.name}/{content_view.name}',
         auto_attach=False,
     )
 
-    # get list of available subscriptions which are matched with default subscription
-    subscriptions = host_subscription_client.run(
-        f'subscription-manager list --available --matches "{DEFAULT_SUBSCRIPTION_NAME}" --pool-only'
-    )
-    pool_id = subscriptions.stdout.strip()
-    # attach to plain RHEL subsctiption
-    host_subscription_client.subscription_manager_attach_pool([pool_id])
     assert host_subscription_client.subscribed
-    host_subscription_client.enable_repo(REPOS['rhst7']['id'])
+    res = host_subscription_client.enable_repo(REPOS['rhsclient7']['id'])
+    assert res.status == 0
+    assert f"Repository '{REPOS['rhsclient7']['id']}' is enabled for this system." in res.stdout
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### Problem Statement
Fix the test. CV is already published and promoted by setup_org_for_a_rh_repo. Also, don't use 2 LCEs needlessly.