### PR TITLE
[6.15.z] Fix SRPMs label in hammer repository info

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1243,7 +1243,7 @@ class TestRepository:
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['sync']['status'] == 'Success'
-        assert repo['content-counts']['source-rpms'] == '0', 'content not ignored correctly'
+        assert repo['content-counts']['srpms'] == '0', 'content not ignored correctly'
 
     @pytest.mark.tier1
     @pytest.mark.skipif(
@@ -1839,8 +1839,7 @@ class TestRepository:
         )
         assert f"Successfully uploaded file '{SRPM_TO_UPLOAD}'" in result[0]['message']
         assert (
-            int(target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['source-rpms'])
-            == 1
+            int(target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['srpms']) == 1
         )
 
         # Remove uploaded SRPM
@@ -1852,8 +1851,7 @@ class TestRepository:
             }
         )
         assert (
-            int(target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['source-rpms'])
-            == 0
+            int(target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['srpms']) == 0
         )
 
     @pytest.mark.upgrade
@@ -1895,8 +1893,7 @@ class TestRepository:
         assert len(srpm_list) == 1
         assert target_sat.cli.Srpm.info({'id': srpm_list[0]['id']})[0]['filename'] == SRPM_TO_UPLOAD
         assert (
-            int(target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['source-rpms'])
-            == 1
+            int(target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['srpms']) == 1
         )
         assert (
             len(
@@ -1944,7 +1941,7 @@ class TestRepository:
             }
         )
         assert int(
-            target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['source-rpms']
+            target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['srpms']
         ) == len(target_sat.cli.Srpm.list({'repository-id': repo['id']}))
 
     @pytest.mark.tier1

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -151,7 +151,7 @@ def function_synced_rh_repo(request, target_sat, function_sca_manifest_org):
     )
     # Update the download policy to 'immediate' and sync
     target_sat.cli.Repository.update({'download-policy': 'immediate', 'id': repo['id']})
-    target_sat.cli.Repository.synchronize({'id': repo['id']}, timeout=7200000)
+    target_sat.cli.Repository.synchronize({'id': repo['id']}, timeout='2h')
     repo = target_sat.cli.Repository.info(
         {
             'organization-id': function_sca_manifest_org.id,
@@ -605,8 +605,9 @@ class TestContentViewSync:
                 'organization-id': function_import_org.id,
             }
         )
-        for item in ['packages', 'source-rpms', 'package-groups', 'errata', 'module-streams']:
-            assert exported_repo['content-counts'][item] == imported_repo['content-counts'][item]
+        assert (
+            exported_repo['content-counts'] == imported_repo['content-counts']
+        ), 'Exported and imported counts do not match'
 
     @pytest.mark.upgrade
     @pytest.mark.tier3
@@ -940,7 +941,7 @@ class TestContentViewSync:
         # Export cv
         export = target_sat.cli.ContentExport.completeVersion(
             {'id': cvv['id'], 'organization-id': function_sca_manifest_org.id},
-            timeout=7200000,
+            timeout='2h',
         )
         # Verify export directory is not empty
         assert target_sat.validate_pulp_filepath(function_sca_manifest_org, PULP_EXPORT_DIR) != ''
@@ -952,7 +953,7 @@ class TestContentViewSync:
         target_sat.cli.Settings.set({'name': 'subscription_connection_enabled', 'value': "No"})
         target_sat.cli.ContentImport.version(
             {'organization-id': function_import_org_with_manifest.id, 'path': import_path},
-            timeout=7200000,
+            timeout='2h',
         )
         importing_cvv = target_sat.cli.ContentView.info(
             {'name': cv_name, 'organization-id': function_import_org_with_manifest.id}
@@ -977,8 +978,9 @@ class TestContentViewSync:
                 'organization-id': function_import_org_with_manifest.id,
             }
         )
-        for item in ['packages', 'source-rpms', 'package-groups', 'errata', 'module-streams']:
-            assert exported_repo['content-counts'][item] == imported_repo['content-counts'][item]
+        assert (
+            exported_repo['content-counts'] == imported_repo['content-counts']
+        ), 'Exported and imported counts do not match'
 
     @pytest.mark.tier2
     def test_positive_export_cv_with_on_demand_repo(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13971

### Problem Statement
Source RPMs label returned by `hammer repository info` has changed from `source-rpms` to `SRPMs` in 6.15.0 snap 8.0
```
[root@jwst ~]# hammer repository info --id 1474
Id:                 1474
Name:               Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.9
...
Content Counts:     
    Packages:       5230
    SRPMs:          0   <---- this used to be called 'source-rpms'
    Module Streams: 0
    Package Groups: 76
    Errata:         0
```

making several ISS and Repository tests to fail like this
```
tests/foreman/cli/test_repository.py:1246: in test_positive_synchronize_rpm_repo_ignore_SRPM
    assert repo['content-counts']['source-rpms'] == '0', 'content not ignored correctly'
E   KeyError: 'source-rpms'
```

### Solution
Since the change doesn't feel like product issue I tend to fix it on the test side.
Also addidng tiny fix for timeouts for better readibility.