### PR TITLE
[6.14.z] [TestFix] Replacing 'content' with 'file' option in reporttemplate create

### DIFF
--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -321,9 +321,7 @@ def test_positive_dump_report(module_target_sat):
     """
     name = gen_alpha()
     content = gen_alpha()
-    report_template = module_target_sat.cli_factory.report_template(
-        {'name': name, 'content': content}
-    )
+    report_template = module_target_sat.cli_factory.report_template({'name': name, 'file': content})
     result = module_target_sat.cli.ReportTemplate.dump({'id': report_template['id']})
     assert content in result
 
@@ -402,9 +400,7 @@ def test_positive_generate_report_sanitized(module_target_sat):
         }
     )
 
-    report_template = module_target_sat.cli_factory.report_template(
-        {'content': REPORT_TEMPLATE_FILE}
-    )
+    report_template = module_target_sat.cli_factory.report_template({'file': REPORT_TEMPLATE_FILE})
 
     result = module_target_sat.cli.ReportTemplate.generate({'name': report_template['name']})
     assert 'Name,Operating System' in result  # verify header of custom template


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13973

### Problem Statement
Both of these tests are failing due to an unrecognised option --content. 

```Could not create the report template:
  Error: Unrecognised option '--content'.
```


### Solution
Replace 'content' with 'file'

### Related Issues
Looks like it was related to these two PRs
https://github.com/SatelliteQE/robottelo/pull/8441
https://github.com/SatelliteQE/robottelo/pull/9324