### PR TITLE
Fix UI AC repo test

### DIFF
--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -674,7 +674,7 @@ def test_positive_sync_ansible_collection_gallaxy_repo(session, module_prod):
             module_prod.name,
             {
                 'name': repo_name,
-                'repo_type': REPO_TYPE['ansible_collection'],
+                'repo_type': REPO_TYPE['ansible_collection'].replace('_', ' '),
                 'repo_content.requirements': requirements,
                 'repo_content.upstream_url': ANSIBLE_GALAXY,
             },


### PR DESCRIPTION
### Problem Statement
It seems I have broken one UI test in #13068 by [this change](https://github.com/SatelliteQE/robottelo/pull/13068/files#diff-9a55ae74469aa91ad5efb2b9068f73174467cd0c00d45abf7d35f9f2277a7632R225) since CLI/API use it with `_` but UI does not.

### Solution
Just replace the `_` in test. I think that defining new "UI only" constant would be even uglier.

Closing #13921 