### PR TITLE
Fix virtwho UI cases failed for _GeneratorContextManager object has no attribute virtwho_configure

### DIFF
--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -49,7 +49,9 @@ def session(test_name, module_user, module_target_sat):
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
     """
-    with module_target_sat.ui_session(test_name, module_user.login, module_user.password) as session:
+    with module_target_sat.ui_session(
+        test_name, module_user.login, module_user.password
+    ) as session:
         return session
 
 
@@ -97,5 +99,7 @@ def session_sca(test_name, module_user_sca, module_target_sat):
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
     """
-    with module_target_sat.ui_session(test_name, module_user_sca.login, module_user_sca.password) as session_sca:
+    with module_target_sat.ui_session(
+        test_name, module_user_sca.login, module_user_sca.password
+    ) as session_sca:
         return session_sca

--- a/tests/foreman/virtwho/conftest.py
+++ b/tests/foreman/virtwho/conftest.py
@@ -49,7 +49,8 @@ def session(test_name, module_user, module_target_sat):
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
     """
-    return module_target_sat.ui_session(test_name, module_user.login, module_user.password)
+    with module_target_sat.ui_session(test_name, module_user.login, module_user.password) as session:
+        return session
 
 
 @pytest.fixture(scope='module')
@@ -96,4 +97,5 @@ def session_sca(test_name, module_user_sca, module_target_sat):
                 # your ui test steps here
                 session.architecture.create({'name': 'bar'})
     """
-    return module_target_sat.ui_session(test_name, module_user_sca.login, module_user_sca.password)
+    with module_target_sat.ui_session(test_name, module_user_sca.login, module_user_sca.password) as session_sca:
+        return session_sca


### PR DESCRIPTION
UI cases failed for the error
```  @pytest.fixture
    def virtwho_config_ui(form_data_ui, target_sat, org_session):
        name = gen_string('alpha')
        form_data_ui['name'] = name
        with org_session:
>           org_session.virtwho_configure.create(form_data_ui)
E           AttributeError: '_GeneratorContextManager' object has no attribute 'virtwho_configure'

pytest_fixtures/component/virtwho_config.py:262: AttributeError
_ ERROR at setup of TestVirtwhoConfigforLibvirt.test_positive_hypervisor_id_option _
```

Cases  : PASS
```

(robottelo_vv_615) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest  ./tests/foreman/virtwho/ui/test_hyperv.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 29 warnings in 1242.08s (0:20:42)
2024-02-03 07:17:23 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

(robottelo_vv_615) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest  ./tests/foreman/virtwho/ui/test_hyperv_sca.py --disable-pytest-warnings -q
...                                                                                                                                                                                                         [100%]
3 passed, 3 deselected, 21 warnings in 731.53s (0:12:11)
2024-02-03 07:31:57 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
```