### PR TITLE
[6.15.z] Fix and update installer ping test

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1620,18 +1620,10 @@ def test_positive_check_installer_hammer_ping(target_sat):
     """
     # check status reported by hammer ping command
     result = target_sat.execute('hammer ping')
-    test_result = {}
-    service = None
-    for line in result.stdout.strip().replace(' ', '').split('\n'):
-        if line.split(':')[0] not in ('Status', 'ServerResponse', 'message'):
-            service = line.split(':')[0]
-            test_result[service] = {}
-        else:
-            key, value = line.split(":", 1)
-            test_result[service][key] = value
-
-    not_ok = {svc: result for svc, result in test_result.items() if result['Status'] != 'ok'}
-    assert not not_ok
+    assert result.status == 0
+    for line in result.stdout.split('\n'):
+        if 'Status' in line:
+            assert 'ok' in line
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13614

### Problem Statement
This test is failing on stream because hammer ping now has a couple new lines that are nested for the cache

### Solution
Simplify the assertion so it's much easier.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->