### PR TITLE
[6.15.z] added bz tag to oscap longrun test

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -147,7 +147,9 @@ def test_positive_oscap_run_via_ansible(
 
     :expectedresults: REX job should be success and ARF report should be sent to satellite
 
-    :BZ: 1716307
+    :BZ: 1716307, 1992229
+
+    :customerscenario: true
 
     :CaseImportance: Critical
     """


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13982

### Problem Statement
just marking the bz for traceability

