### PR TITLE
[6.14.z] job invocation with credentials added

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -153,7 +153,10 @@ ENTITY_FIELDS = {
     'host_collection': {
         'name': gen_alpha,
     },
-    'job_invocation': {},
+    'job_invocation': {'_redirect': 'job_invocation_with_credentials'},
+    'job_invocation_with_credentials': {
+        '_entity_cls': 'JobInvocation',
+    },
     'job_template': {
         'job-category': 'Miscellaneous',
         'provider-type': 'SSH',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13987

### Problem Statement
make_job_invocation_with_credentials got dropped without replacement causing test failures
