### PR TITLE
[6.15.z] [Customer Case] Adding test for overriding repos no select all

### DIFF
--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -56,7 +56,7 @@ def test_positive_custom_products_disabled_by_default(
 
 
 @pytest.mark.rhel_ver_match('[^6]')
-def test_positive_override_custom_products_on_existing_host(
+def test_positive_override_custom_products_using_select_all(
     session,
     default_location,
     setup_content,
@@ -92,6 +92,53 @@ def test_positive_override_custom_products_on_existing_host(
         assert repo[0]['Status'] == 'Disabled'
         session.host_new.bulk_override_repo_sets(
             rhel_contenthost.hostname, 'Custom', "Override to enabled"
+        )
+        repo = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
+        assert repo[0]['Repository'] == custom_repo.name
+        assert repo[0]['Status'] == 'Enabled'
+
+
+@pytest.mark.rhel_ver_match('[^6]')
+def test_positive_override_custom_products_not_using_select_all(
+    session,
+    default_location,
+    setup_content,
+    rhel_contenthost,
+    target_sat,
+):
+    """Verify that custom products can be easily enabled/disabled on existing host
+    by individually selecting the repositories from the table instead of the select all method
+
+    :id: 9d5c05fb-3683-40a2-91fd-a3aa526b25f4
+
+    :setup:
+        1. Create custom product and upload repository
+        2. Attach to activation key
+
+    :steps:
+        1. Register Host
+        2. Assert that custom proudcts are disabled by default
+        3. Override custom products to enabled by selecting the repos individually and
+           using the new funtionality at the top
+        4. Assert custom products are now enabled
+
+    :expectedresults: Custom products should be easily enable NOT using the select all method
+
+    :BZ: 2256473
+
+    :parametrized: yes
+    """
+    ak, org, custom_repo = setup_content
+    rhel_contenthost.register(org, default_location, ak.name, target_sat)
+    assert rhel_contenthost.subscribed
+    with session:
+        session.organization.select(org.name)
+        session.location.select(default_location.name)
+        repo = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
+        assert repo[0]['Repository'] == custom_repo.name
+        assert repo[0]['Status'] == 'Disabled'
+        session.host_new.override_multiple_repo_sets(
+            rhel_contenthost.hostname, custom_repo.name, 'Custom', 'Override to enabled'
         )
         repo = session.host_new.get_repo_sets(rhel_contenthost.hostname, custom_repo.name)
         assert repo[0]['Repository'] == custom_repo.name


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13596

Adding customer case automation for overriding repos without using the select all method

