### PR TITLE
always expression was missing in the PR checking

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -100,6 +100,7 @@ jobs:
       - name: Check if cherrypick pr is created
         uses: juliangruber/find-pull-request-action@v1
         id: fpr
+        if: always()
         with:
           branch: "cherry-pick-${{ matrix.label }}-${{ github.sha }}"
           base: ${{ matrix.label }}


### PR DESCRIPTION
### Problem Statement
Some cherrypicks are failing and issues are also not being created.  https://github.com/SatelliteQE/robottelo/actions/runs/7459156590

### Solution
We were missing the `always()` expression that led to this problem. This PR will fix that issue  

### Related Issues
https://github.com/SatelliteQE/robottelo/actions/runs/7459156590

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->