### PR TITLE
Skip Capsule provisioning test

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -590,6 +590,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
 
 @pytest.mark.e2e
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi'], indirect=True)
+@pytest.mark.skip(reason='Skipping till we have destructive support')
 @pytest.mark.on_premises_provisioning
 @pytest.mark.rhel_ver_match('[^6]')
 def test_capsule_pxe_provisioning(


### PR DESCRIPTION
Skipping Capsule provisioning test as this test needs to be run on destructive sat and in the provisioning pipeline, we use one VLAN for the satellite whereas in the Capsule test, we need one more VLAN which directly affects the other tests
