### PR TITLE
fixed the auto-cherry-picking issue cause due github action failure

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Add Parent PR's PRT comment to Auto_Cherry_Picked PR's
         id: add-parent-prt-comment
-        if: ${{ always() && steps.cherrypick.outcome == 'success' }}
+        if: ${{ always() && needs.find-the-parent-prt-comment.outputs.prt_comment != '' && steps.cherrypick.outcome == 'success' }}
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
@@ -98,17 +98,24 @@ jobs:
             })
 
       - name: Check if cherrypick pr is created
-        uses: juliangruber/find-pull-request-action@v1
-        id: fpr
+        id: search_pr
         if: always()
-        with:
-          branch: "cherry-pick-${{ matrix.label }}-${{ github.sha }}"
-          base: ${{ matrix.label }}
+        run: |
+          PR_TITLE="[${{ matrix.label }}] ${{ env.title }}"
+          API_URL="https://api.github.com/repos/${{ github.repository }}/pulls?state=open"
+          PR_SEARCH_RESULT=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$API_URL" | jq --arg title "$PR_TITLE" '.[] | select(.title == $title)')
+          if [ -n "$PR_SEARCH_RESULT" ]; then
+            echo "pr_found=true" >> $GITHUB_OUTPUT
+            echo "PR is Found with title $PR_TITLE"
+          else
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "PR is not Found with title $PR_TITLE"
+          fi
 
-      ## Failure Logging to issues and GChat Group
+      ## Failure Logging to issues
       - name: Create Github issue on cherrypick failure
         id: create-issue
-        if: ${{ always() && steps.fpr.outputs.number != '' && steps.cherrypick.outcome != 'success' && startsWith(matrix.label, '6.') && matrix.label != github.base_ref }}
+        if: ${{ always() && steps.search_pr.outputs.pr_found == 'false' && steps.cherrypick.outcome != 'success' && startsWith(matrix.label, '6.') && matrix.label != github.base_ref }}
         uses: dacbd/create-issue-action@main
         with:
           token: ${{ secrets.CHERRYPICK_PAT }}


### PR DESCRIPTION
### Problem Statement
Previously, community GitHub actions were encountering issues where they persisted in identifying base issues even after they had been merged, failing to trigger issue creation as intended. Despite thorough testing, these issues persisted, prompting a reassessment of the underlying logic.

### Solution
To address this recurring problem, I have implemented a custom bash script to ensure accurate behavior and resolve the persistence of identifying merged base issues. By relying on our bash script, I aim to mitigate these issues effectively. Further testing is required to validate the efficacy of this solution thoroughly. 

### Related Issues
many cherrypicks are not getting raised : 
https://github.com/SatelliteQE/robottelo/actions/workflows/auto_cherry_pick.yml?query=is%3Afailure
https://github.com/SatelliteQE/robottelo/actions/runs/7819038827

### Tested Conditions 

- Cherry-Pick Failure -> Create Issue:
https://github.com/omkarkhatavkar/robottelo/actions/runs/7830716259/job/21365439760

- Cherry-Pick Failure -> Still PR was created -> No issue should be created 
https://github.com/omkarkhatavkar/robottelo/actions/runs/7830295405/job/21363996182
   

- Cherry-Pick Success with PRT Comment 
https://github.com/omkarkhatavkar/robottelo/actions/runs/7830544273/job/21364838469

- Cherry-Pick Success with No PRT Comment 
https://github.com/omkarkhatavkar/robottelo/actions/runs/7830418652/job/21364411904
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->