### PR TITLE
[6.14.z] Fix scope mismatch issue for VMware tests

### DIFF
--- a/pytest_fixtures/component/provision_vmware.py
+++ b/pytest_fixtures/component/provision_vmware.py
@@ -4,7 +4,7 @@ import pytest
 from robottelo.config import settings
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def vmware(request):
     versions = {
         'vmware7': settings.vmware.vcenter7,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14010

### Problem Statement
VMware provisioning tests are failing due to scope mismatch error in `vmware` fixture

### Solution
Updating the `vmware` fixture to module scope to fix the issue