### PR TITLE
Temporarily add docker and paramiko deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,13 @@ betelgeuse==1.11.0
 # broker[docker]==0.4.1 - Temporarily disabled, see below
 cryptography==42.0.2
 deepdiff==6.7.1
+docker==7.0.0  # Temporary until Broker is back on PyPi
 dynaconf[vault]==3.2.4
 fauxfactory==3.1.0
 jinja2==3.1.3
 manifester==0.0.14
 navmazing==1.2.2
+paramiko==3.4.0  # Temporary until Broker is back on PyPi
 productmd==1.38
 pyotp==2.9.0
 python-box==7.1.1


### PR DESCRIPTION
Since we're currently installing broker from github, we can't install the extra deps. Until it is back, we need to explicitly add in docker and its ssh support layer paramiko.
