### PR TITLE
[6.15.z] Add test for BZ:2193010 in provisioning templates

### DIFF
--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -472,7 +472,7 @@ class TestProvisioningTemplate:
         :expectedresults: Rendered template should contain value set as per use_graphical_installer
                           host parameter for respective rhel hosts.
 
-        :BZ: 2106753
+        :BZ: 2106753, 2193010
 
         :customerscenario: true
         """
@@ -486,6 +486,8 @@ class TestProvisioningTemplate:
         render = host.read_template(data={'template_kind': 'provision'})['template']
         assert 'skipx' in render
         assert 'text' in render
+        assert 'chvt 1' in render
+
         # Using use_graphical_installer host param to override and use graphical mode to boot
         host.host_parameters_attributes = [
             {'name': 'use_graphical_installer', 'value': 'true', 'parameter_type': 'boolean'}
@@ -494,6 +496,7 @@ class TestProvisioningTemplate:
         render = host.read_template(data={'template_kind': 'provision'})['template']
         assert 'graphical' in render
         assert 'skipx' not in render
+        assert 'chvt 6' in render
 
     @pytest.mark.rhel_ver_match('[8]')
     def test_positive_template_check_aap_snippet(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14027

### Problem Statement
Missing coverage for BZ:2193010 

### Solution
Add check in existing test to cover  BZ:2193010  