### PR TITLE
[6.12.z] Remove BZ check which is migrated to Jira and Add new BZ check causing selinux denials

### DIFF
--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -32,15 +32,13 @@ def test_selinux_status(target_sat):
 
     :expectedresults: SELinux is enabled and there are no denials
 
-    :customerscenario: true
-
-    :BZ: 2131031
+    :BZ: 2263294
     """
     # check SELinux is enabled
     result = target_sat.execute('getenforce')
     assert 'Enforcing' in result.stdout
     # check there are no SELinux denials
-    if not is_open('BZ:2131031'):
+    if not is_open('BZ:2263294'):
         result = target_sat.execute('ausearch --input-logs -m avc -ts today --raw')
         assert result.status == 1, 'Some SELinux denials were found in journal.'
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13923

### Problem Statement
The BZ in the test case has been migrated to jira so the check doesn't work.
The older BZ is entirely unrelated to the test  case so removed it but we ran into another issue and raised a BZ for it -> BZ#2263294
### Solution
Removing the check from the test.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->