### PR TITLE
[6.13.z] Fix ACS tests/fixures by avoiding zst repos

### DIFF
--- a/pytest_fixtures/component/acs.py
+++ b/pytest_fixtures/component/acs.py
@@ -1,14 +1,16 @@
 # Alternate Content Sources fixtures
 import pytest
 
-from robottelo.constants.repos import CUSTOM_FILE_REPO, CUSTOM_RPM_REPO
+from robottelo.config import settings
 
 
 @pytest.fixture(scope='module')
 def module_yum_repo(module_target_sat, module_org):
     product = module_target_sat.api.Product(organization=module_org).create()
     repo = module_target_sat.api.Repository(
-        product=product, content_type='yum', url=CUSTOM_RPM_REPO
+        product=product,
+        content_type='yum',
+        url=settings.repos.yum_0.url,
     ).create()
     repo.sync()
     return repo
@@ -18,7 +20,9 @@ def module_yum_repo(module_target_sat, module_org):
 def module_file_repo(module_target_sat, module_org):
     product = module_target_sat.api.Product(organization=module_org).create()
     repo = module_target_sat.api.Repository(
-        product=product, content_type='file', url=CUSTOM_FILE_REPO
+        product=product,
+        content_type='file',
+        url=settings.repos.file_type_repo.url,
     ).create()
     repo.sync()
     return repo

--- a/robottelo/constants/repos.py
+++ b/robottelo/constants/repos.py
@@ -1,9 +1,8 @@
 """Only External Repos url specific constants module"""
 
-PULP_FIXTURE_ROOT = 'https://fixtures.pulpproject.org/'
 PULP_SUBPATHS_COMBINED = {
-    'yum': ['rpm-zchunk/', 'rpm-modular/'],
-    'file': ['file-large/', 'file-many/'],
+    'yum': ['fake_yum0/', 'fake_yum1/'],
+    'file': ['pulp_remote/'],
 }
 CUSTOM_3RD_PARTY_REPO = 'http://repo.calcforge.org/fedora/21/x86_64/'
 CUSTOM_FILE_REPO = 'https://fixtures.pulpproject.org/file/'

--- a/tests/foreman/api/test_acs.py
+++ b/tests/foreman/api/test_acs.py
@@ -15,7 +15,8 @@ from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.constants.repos import PULP_FIXTURE_ROOT, PULP_SUBPATHS_COMBINED
+from robottelo.config import settings
+from robottelo.constants.repos import PULP_SUBPATHS_COMBINED
 
 
 @pytest.mark.e2e
@@ -66,7 +67,7 @@ def test_positive_CRUD_all_types(
     else:
         params.update(
             {
-                'base_url': PULP_FIXTURE_ROOT,
+                'base_url': settings.robottelo.REPOS_HOSTING_URL,
                 'subpaths': PULP_SUBPATHS_COMBINED[cnt_type],
                 'verify_ssl': 'false',
             }

--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -14,7 +14,8 @@
 from fauxfactory import gen_alphanumeric
 import pytest
 
-from robottelo.constants.repos import PULP_FIXTURE_ROOT, PULP_SUBPATHS_COMBINED
+from robottelo.config import settings
+from robottelo.constants.repos import PULP_SUBPATHS_COMBINED
 from robottelo.exceptions import CLIReturnCodeError
 
 ACS_UPDATED = 'Alternate Content Source updated.'
@@ -74,7 +75,7 @@ def test_positive_CRUD_all_types(
     else:
         params.update(
             {
-                'base-url': PULP_FIXTURE_ROOT,
+                'base-url': settings.robottelo.REPOS_HOSTING_URL,
                 'subpaths': PULP_SUBPATHS_COMBINED[cnt_type],
                 'verify-ssl': 'false',
             }
@@ -179,7 +180,7 @@ def test_negative_check_custom_rhui_validations(module_target_sat, acs_type, mod
             {
                 'name': gen_alphanumeric(),
                 'alternate-content-source-type': acs_type,
-                'base-url': PULP_FIXTURE_ROOT,
+                'base-url': settings.robottelo.REPOS_HOSTING_URL,
                 'verify-ssl': 'false',
                 'product-ids': module_yum_repo.product.id,
             }
@@ -217,7 +218,7 @@ def test_negative_check_simplified_validations(
         'content-type': cnt_type,
         'smart-proxy-ids': module_target_sat.nailgun_capsule.id,
         # forbidden options
-        'base-url': PULP_FIXTURE_ROOT,
+        'base-url': settings.robottelo.REPOS_HOSTING_URL,
         'subpaths': f'{gen_alphanumeric()}/',
         'verify-ssl': 'false',
         'ssl-ca-cert-id': '1',


### PR DESCRIPTION
### Problem Statement
Since [this BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2241934) hasn't been backported to `6.13.z` yet but the pulp fixtures (used in ACSes but also elsewhere) are using the zst compression now, repo sync of that repos fail in setup.

### Solution
Use old non-zst compressed repos instead.
