### PR TITLE
[6.15.z] Rename test to reflect it tests proxy id

### DIFF
--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -32,7 +32,7 @@ def test_negative_create_name_only(module_target_sat):
 
 
 @pytest.mark.tier1
-def test_negative_create_invalid_id(module_target_sat):
+def test_negative_create_invalid_proxy_id(module_target_sat):
     """Create a realm with an invalid proxy ID
 
     :id: 916bd1fb-4649-469c-b511-b0b07301a990


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14063

null