### PR TITLE
[6.15.z] setup_org_for_a_rh_repo fix

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -729,13 +729,7 @@ class CLIFactory:
         # If manifest does not exist, clone and upload it
         if len(self._satellite.cli.Subscription.exists({'organization-id': org_id})) == 0:
             with clone() as manifest:
-                self._satellite.put(manifest.path, manifest.name)
-            try:
-                self._satellite.cli.Subscription.upload(
-                    {'file': manifest.name, 'organization-id': org_id}
-                )
-            except CLIReturnCodeError as err:
-                raise CLIFactoryError(f'Failed to upload manifest\n{err.msg}') from err
+                self._satellite.upload_manifest(org_id, manifest.content)
         # Enable repo from Repository Set
         try:
             self._satellite.cli.RepositorySet.enable(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13970

### Problem Statement
```
AttributeError: 'Manifest' object has no attribute 'path'
```

### Solution
Follow idiom of creating a temporary file and into it, copying an in-memory object, then using it as a file.

I'm not sure how and when it got broken, I hit it when looking at the results of `test_negative_without_attach_with_lce`. I haven't yet tested extensively to make sure this doesn't break function `_setup_org_for_a_rh_repo` in other cases but it seems like it couldn't have worked.