### PR TITLE
[6.14.z] [Test Fix] test_negative_generate_hostpkgcompare_nonexistent_host

### DIFF
--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -985,7 +985,7 @@ def test_negative_generate_hostpkgcompare_nonexistent_host(module_target_sat):
                 'inputs': 'Host 1 = nonexistent1, ' 'Host 2 = nonexistent2',
             }
         )
-    assert "At least one of the hosts couldn't be found" in cm.exception.stderr
+    assert "At least one of the hosts couldn't be found" in cm.value.stderr
 
 
 @pytest.mark.rhel_ver_list([7, 8, 9])


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14068

### Problem Statement

test_negative_generate_hostpkgcompare_nonexistent_host is failing due to our of date attributes in assertion 

### Solution

Change cm.exeption.stderr to cm.value.stderr


