### PR TITLE
[6.14.z] Move HTTP Proxy tests under correct component

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -56,6 +56,7 @@ CaseComponent:
     - ForemanMaintain
     - Hammer
     - Hammer-Content
+    - HTTPProxy
     - HostCollections
     - HostForm
     - HostGroup

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -2,7 +2,7 @@
 
 :Requirement: HttpProxy
 
-:CaseComponent: Repositories
+:CaseComponent: HTTPProxy
 
 :team: Phoenix-content
 

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -2,7 +2,7 @@
 
 :Requirement: HttpProxy
 
-:CaseComponent: Repositories
+:CaseComponent: HTTPProxy
 
 :team: Phoenix-content
 

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -2,7 +2,7 @@
 
 :Requirement: HttpProxy
 
-:CaseComponent: Repositories
+:CaseComponent: HTTPProxy
 
 :team: Phoenix-content
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14074

### Problem Statement
While HTTP Proxy does exist in BZ as a unique component and robotello has `{api|cli|ui}/http_proxy.py` modules too, the test cases still belong under the `Repository` component for some reason.

This doesn't seem logical and makes it more difficult to do TFA, so I believe we should create a separate component in robottelo and CI and flip the tests there.


### Solution
This PR (and another one in CI).
