### PR TITLE
[6.13.z] Fix parametrization in test_positive_reboot_all_pxe_hosts

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -238,13 +238,10 @@ def provision_multiple_hosts(module_ssh_key_file, pxe_loader, request):
     cd_iso = (
         ""  # TODO: Make this an optional fixture parameter (update vm_firmware when adding this)
     )
-    # Keeping the default value to 2
-    count = request.param if request.param is not None else 2
-
     with Broker(
         workflow="deploy-configure-pxe-provisioning-host-rhv",
         host_class=ContentHost,
-        _count=count,
+        _count=getattr(request, 'param', 2),
         target_vlan_id=vlan_id,
         target_vm_firmware=pxe_loader.vm_firmware,
         target_vm_cd_iso=cd_iso,

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -400,9 +400,7 @@ class TestDiscoveredHost:
 
     @pytest.mark.on_premises_provisioning
     @pytest.mark.parametrize('module_provisioning_sat', ['discovery'], indirect=True)
-    @pytest.mark.parametrize('pxe_loader', ['bios'], indirect=True)
     @pytest.mark.rhel_ver_match('9')
-    @pytest.mark.parametrize('provision_multiple_hosts', [2])
     @pytest.mark.tier3
     def test_positive_reboot_all_pxe_hosts(
         self,
@@ -418,13 +416,15 @@ class TestDiscoveredHost:
 
         :parametrized: yes
 
-        :Setup: Provisioning should be configured and hosts should be discovered via PXE boot.
+        :setup: Provisioning should be configured and hosts should be discovered via PXE boot.
 
         :steps: PUT /api/v2/discovered_hosts/reboot_all
 
         :expectedresults: All discovered hosst should be rebooted successfully
 
         :CaseImportance: Medium
+
+        :BZ: 2264195
         """
         sat = module_discovery_sat.sat
         for host in provision_multiple_hosts:
@@ -440,8 +440,9 @@ class TestDiscoveredHost:
             discovered_host.location = provisioning_hostgroup.location[0]
             discovered_host.organization = provisioning_hostgroup.organization[0]
             discovered_host.build = True
+        # Until BZ 2264195 is resolved, reboot_all is expected to fail
         result = sat.api.DiscoveredHost().reboot_all()
-        assert 'Discovered hosts are rebooting now' in result['message']
+        assert 'Discovered hosts are rebooting now' in result['success_msg']
 
 
 class TestFakeDiscoveryTests:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13949

### Problem Statement
Missing `indirect=True` in parametrization  for provision_multiple_hosts fixture which causes,
```
tests/foreman/api/test_discoveredhost.py:427: in test_positive_reboot_all_pxe_hosts
    for host in provision_multiple_hosts:
E   TypeError: 'int' object is not iterable
```

### Solution
using getattr to set count as default for this fixture, and removing `@pytest.mark.parametrize` for this fixture, along with mark for pxe_loader fixture which also has bios set as default.

