### PR TITLE
[6.15.z] create report template w/o name

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -362,8 +362,7 @@ def test_positive_generate_report_sanitized():
 
 
 @pytest.mark.tier2
-@pytest.mark.stubbed
-def test_negative_create_report_without_name():
+def test_negative_create_report_without_name(module_target_sat):
     """Try to create a report template with empty name
 
     :id: a4b577db-144e-4771-a42e-e93887464986
@@ -378,6 +377,9 @@ def test_negative_create_report_without_name():
 
     :CaseImportance: Medium
     """
+    with pytest.raises(HTTPError) as report_response:
+        module_target_sat.api.ReportTemplate(name=' ', template=gen_string('alpha')).create()
+    assert "Name can't be blank" in report_response.value.response.text
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14035

### Problem Statement
Create template report with blank name

### Solution
Given solution will not create template report without name, it should give error.

### Related Issues
No
