### PR TITLE
[6.15.z] Test for the change host's content source feature

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -719,10 +719,10 @@ class ContentHost(Host, ContentHostMixins):
         """Registers content host to the Satellite or Capsule server
         using a global registration template.
 
-        :param target: Satellite or Capusle object to register to, required.
         :param org: Organization to register content host to. Previously required, pass None to omit
         :param loc: Location to register content host for, Previously required, pass None to omit.
         :param activation_keys: Activation key name to register content host with, required.
+        :param target: Satellite or Capsule object to register to, required.
         :param setup_insights: Install and register Insights client, requires OS repo.
         :param setup_remote_execution: Copy remote execution SSH key.
         :param setup_remote_execution_pull: Deploy pull provider client on host


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14004

### Problem Statement
Create a test for the change host's content source feature.


### Solution
Fixture and test were created.
The fixture does the necessary setup on the satellite, host, and capsule.
Test exercises different ways how to change the host's content source.

Needs [Airgun#1226](https://github.com/SatelliteQE/airgun/pull/1226).


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->