### PR TITLE
Extend VMware provisioning tests for OS version check

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -449,14 +449,24 @@ class ContentHost(Host, ContentHostMixins):
 
     def wait_for_connection(self, timeout=180):
         try:
-            wait_for(
-                self.connect,
-                fail_condition=lambda res: res is not None,
-                handle_exception=True,
-                raise_original=True,
-                timeout=timeout,
-                delay=1,
-            )
+            if self.key_filename:
+                wait_for(
+                    lambda: self.connect(key_filename=self.key_filename),
+                    fail_condition=lambda res: res is not None,
+                    handle_exception=True,
+                    raise_original=True,
+                    timeout=timeout,
+                    delay=1,
+                )
+            else:
+                wait_for(
+                    self.connect,
+                    fail_condition=lambda res: res is not None,
+                    handle_exception=True,
+                    raise_original=True,
+                    timeout=timeout,
+                    delay=1,
+                )
         except (ConnectionRefusedError, ConnectionAbortedError, TimedOutError) as err:
             raise ContentHostError(
                 f'Unable to establsh SSH connection to host {self} after {timeout} seconds'


### PR DESCRIPTION
### Problem Statement
Bootdisk provisioning passes for VMware 8, but installed status isn't updated, we've BZ:2255264 reported for it, 

### Solution
Handling BZ:2255264 in automation while this is open, and extending the test to check OS version when provisioning is completed for all methods including bootdisk
