### PR TITLE
[6.15.z] moving from module_entitlement_manifest_org to module_sca_manifest_org

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1305,7 +1305,7 @@ class TestRepositorySync:
 
     @pytest.mark.tier2
     @pytest.mark.build_sanity
-    def test_positive_sync_rh(self, module_entitlement_manifest_org, target_sat):
+    def test_positive_sync_rh(self, module_sca_manifest_org, target_sat):
         """Sync RedHat Repository.
 
         :id: d69c44cd-753c-4a75-9fd5-a8ed963b5e04
@@ -1315,7 +1315,7 @@ class TestRepositorySync:
         """
         repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_entitlement_manifest_org.id,
+            org_id=module_sca_manifest_org.id,
             product=constants.PRDS['rhel'],
             repo=constants.REPOS['rhst7']['name'],
             reposet=constants.REPOSET['rhst7'],


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14096

### Problem Statement
(https://github.com/Katello/katello/pull/10875) `/katello/api/organizations/6/simple_content_access/disable` is being removed from stream/6.16

### Solution
need to move from module_entitlement_manifest_org to module_sca_manifest_org in code base


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->