### PR TITLE
zip_longest instead of zip in parse_csv

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -1,7 +1,10 @@
 """Helpers to interact with hammer command line utility."""
 import csv
+from itertools import zip_longest
 import json
 import re
+
+from robottelo.logging import logger
 
 
 def _normalize(header):
@@ -34,30 +37,22 @@ def _normalize_obj(obj):
     return obj
 
 
-def is_csv(output):
-    """Verifies if the output string is eligible for converting into CSV"""
-    sniffer = csv.Sniffer()
-    try:
-        sniffer.sniff(output)
-        return True
-    except csv.Error:
-        return False
-
-
 def parse_csv(output):
     """Parse CSV output from Hammer CLI and convert it to python dictionary."""
     # ignore warning about puppet and ostree deprecation
     output.replace('Puppet and OSTree will no longer be supported in Katello 3.16\n', '')
-    is_rex = True if 'Job invocation' in output else False
-    # Validate if the output is eligible for CSV conversions else return as it is
-    if not is_csv(output) and not is_rex:
-        return output
-    output = output.splitlines()[0:2] if is_rex else output.splitlines()
+    output = output.splitlines()
     reader = csv.reader(output)
     # Generate the key names, spaces will be converted to dashes "-"
     keys = [_normalize(header) for header in next(reader)]
     # For each entry, create a dict mapping each key with each value
-    return [dict(zip(keys, values, strict=True)) for values in reader if len(values) > 0]
+    vals = [values for values in reader if len(values) > 0]
+    if len(keys) != len(vals):
+        logger.warning(
+            'parse_csv different length of keys and values'
+            f'for the following hammer output: {output}'
+        )
+    return [dict(zip_longest(keys, values, fillvalue='_excess')) for values in vals]
 
 
 def parse_help(output):


### PR DESCRIPTION
### Problem Statement

The Ruff code standard B905 requires the zip strict value to be explicitly stated, it does not require it to be True. 

### Solution

This PR sets the value to what it (implicitly) was before https://github.com/SatelliteQE/robottelo/pull/13491 thus removing the need for https://github.com/SatelliteQE/robottelo/pull/13737 https://github.com/SatelliteQE/robottelo/pull/13797 https://github.com/SatelliteQE/robottelo/pull/13999 https://github.com/SatelliteQE/robottelo/pull/13989 and additional changes discussed in the last mentioned PR

[edit]: using zip_longest to not drop any data and adding log about the mismatch