### PR TITLE
[6.14.z] Fix useless asserts in installer tests

### DIFF
--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -64,7 +64,10 @@ def test_installer_sat_pub_directory_accessibility(target_sat):
     https_curl_command = f'curl -i {target_sat.url}/pub/ -k'
     for command in [http_curl_command, https_curl_command]:
         accessibility_check = target_sat.execute(command)
-        assert 'HTTP/1.1 200 OK' or 'HTTP/2 200 ' in accessibility_check.stdout.split('\r\n')
+        assert (
+            'HTTP/1.1 200 OK' in accessibility_check.stdout
+            or 'HTTP/2 200' in accessibility_check.stdout
+        )
     target_sat.get(
         local_path='custom-hiera-satellite.yaml',
         remote_path=f'{custom_hiera_location}',
@@ -74,7 +77,8 @@ def test_installer_sat_pub_directory_accessibility(target_sat):
     assert 'Success!' in command_output.stdout
     for command in [http_curl_command, https_curl_command]:
         accessibility_check = target_sat.execute(command)
-        assert 'HTTP/1.1 200 OK' or 'HTTP/2 200 ' not in accessibility_check.stdout.split('\r\n')
+        assert 'HTTP/1.1 200 OK' not in accessibility_check.stdout
+        assert 'HTTP/2 200' not in accessibility_check.stdout
     target_sat.put(
         local_path='custom-hiera-satellite.yaml',
         remote_path=f'{custom_hiera_location}',

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1743,7 +1743,10 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
     https_curl_command = f'curl -i {capsule_configured.url}/pub/ -k'
     for command in [http_curl_command, https_curl_command]:
         accessibility_check = capsule_configured.execute(command)
-        assert 'HTTP/1.1 200 OK' or 'HTTP/2 200 ' in accessibility_check.stdout.split('\r\n')
+        assert (
+            'HTTP/1.1 200 OK' in accessibility_check.stdout
+            or 'HTTP/2 200' in accessibility_check.stdout
+        )
     capsule_configured.get(
         local_path='custom-hiera-capsule.yaml',
         remote_path=f'{custom_hiera_location}',
@@ -1753,7 +1756,8 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
     assert 'Success!' in command_output.stdout
     for command in [http_curl_command, https_curl_command]:
         accessibility_check = capsule_configured.execute(command)
-        assert 'HTTP/1.1 200 OK' or 'HTTP/2 200 ' not in accessibility_check.stdout.split('\r\n')
+        assert 'HTTP/1.1 200 OK' not in accessibility_check.stdout
+        assert 'HTTP/2 200' not in accessibility_check.stdout
     capsule_configured.put(
         local_path='custom-hiera-capsule.yaml',
         remote_path=f'{custom_hiera_location}',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14099

Fixing assertions that were always True and therefore useless.

Note: `bool("any string with non-zero length")` is True, `True or False` is True