### PR TITLE
SCA refactor of Subscription HTTP proxy test

### DIFF
--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -144,7 +144,7 @@ class APIFactory:
         """Enable the RedHat repo, sync it and returns repo_id"""
         # Enable RH repo and fetch repository_id
         repo_id = self.enable_rhrepo_and_fetchid(
-            basearch=rh_repo['basearch'],
+            basearch=rh_repo.get('basearch', rh_repo.get('arch', DEFAULT_ARCHITECTURE)),
             org_id=org_id,
             product=rh_repo['product'],
             repo=rh_repo['name'],


### PR DESCRIPTION
### Problem Statement
As 6.16 is SCA-only we need to get rid of entitlements and subscriptions related logic in our tests but keep the approach user take for this or similar scenario.


### Solution
Get rid of entitlements/subscriptions. Also I propose to change this test case to `e2e` since it syncs a RH repo, publishes and promotes it to an LCE, registers a content host via AK and consumes the content in it. Case remain parametrized to run with authenticated, unauthenticated and without (this param could be probably omited) HTTP proxy.

One minor update in `enable_sync_redhat_repo` so that we can use repos from constants which define `arch` key instead of `basearch` or even no arch at all.

**Open question:** Should the test id be changed since it doesn't cover the subscription manipulation at all?


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_http_proxy.py -k install_content_with_http_proxy
