### PR TITLE
[6.12.z] Remove enable_tools_repo and enable_rhel_repo methods

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -100,26 +100,6 @@ class VersionedContent:
         product, release, v_major, repo = self._dogfood_helper(product, release, repo)
         return dogfood_repository(settings.ohsnap, repo, product, release, v_major, snap, self.arch)
 
-    def enable_tools_repo(self, organization_id):
-        return self.satellite.api_factory.enable_rhrepo_and_fetchid(
-            basearch=constants.DEFAULT_ARCHITECTURE,
-            org_id=organization_id,
-            product=constants.PRDS['rhel'],
-            repo=self.REPOS['rhst']['name'],
-            reposet=self.REPOSET['rhst'],
-            releasever=None,
-        )
-
-    def enable_rhel_repo(self, organization_id):
-        return self.satellite.api_factory.enable_rhrepo_and_fetchid(
-            basearch=constants.DEFAULT_ARCHITECTURE,
-            org_id=organization_id,
-            product=constants.PRDS['rhel'],
-            repo=self.REPOS['rhel']['name'],
-            reposet=self.REPOSET['rhel'],
-            releasever=None,
-        )
-
     def create_custom_html_repo(self, rpm_url, repo_name=None, update=False, remove_rpm=None):
         """Creates a custom yum repository, that will be published on https
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14134

### Problem Statement

Methods `enable_tools_repo` and `enable_rhel_repo` do not have a use in our code.

Closes #12147 #12148

### Solution
Remove the methods as discussed on the call.
