### PR TITLE
[6.15.z] ISS fix for CVV sorting issue

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -773,7 +773,7 @@ class TestContentViewSync:
             }
         )
         exporting_cv = target_sat.cli.ContentView.info({'id': exporting_cv['id']})
-        exporting_cvv_id = exporting_cv['versions'][0]['id']
+        exporting_cvv_id = max(exporting_cv['versions'], key=lambda x: int(x['id']))['id']
         # Check presence of 1 rpm due to filter
         export_packages = target_sat.cli.Package.list({'content-view-version-id': exporting_cvv_id})
         assert len(export_packages) == 1


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14142

### Problem Statement
CVV sorting issue hits again ([BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2209758) for reference)


### Solution
Use CVV with highest id.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k export_import_filtered_cvv
