### PR TITLE
[6.13.z] Fix discovery rule test

### DIFF
--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -21,6 +21,7 @@ from robottelo.utils.datafactory import valid_data_list
 @pytest.fixture(scope='module')
 def module_hostgroup(module_org, module_target_sat):
     module_hostgroup = module_target_sat.api.HostGroup(organization=[module_org]).create()
+    yield module_hostgroup
     module_hostgroup.delete()
 
 


### PR DESCRIPTION
### Problem Statement
[test_positive_end_to_end_crud](https://github.com/SatelliteQE/robottelo/blob/96b7d330097b138e1f850a725c0c088124d509e5/tests/foreman/api/test_discoveryrule.py#L41) is failing during creation of discoveryrule due to not returning the hostgroup required from the fixture.

### Solution
Fix the module_hostgroup fixture to yield hostgroup as it was missing.