### PR TITLE
Enabling Robottelo for IPv6 Testing

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -17,3 +17,4 @@ CAPSULE:
     OS: deploy-rhel  # workflow to deploy OS that is ready to run the product
   # Dictionary of arguments which should be passed along to the deploy workflow
   DEPLOY_ARGUMENTS:
+  #  deploy_network_type: '@jinja {{"ipv6" if this.server.is_ipv6 else "ipv4"}}'

--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -7,7 +7,7 @@ from box import Box
 
 from robottelo.logging import logger
 from robottelo.utils.ohsnap import dogfood_repository
-from robottelo.utils.url import is_url
+from robottelo.utils.url import ipv6_hostname_translation, is_url
 
 
 def post(settings):
@@ -26,6 +26,7 @@ def post(settings):
             )
             data = get_repos_config(settings)
             write_cache(settings_cache_path, data)
+    ipv6_hostname_translation(settings, data)
     config_migrations(settings, data)
     data['dynaconf_merge'] = True
     return data

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -36,6 +36,7 @@ SERVER:
     OS: deploy-rhel  # workflow to deploy OS that is ready to run the product
   # Dictionary of arguments which should be passed along to the deploy workflow
   # DEPLOY_ARGUMENTS:
+  #  deploy_network_type: '@jinja {{"ipv6" if this.server.is_ipv6 else "ipv4"}}'
   # HTTP scheme when building the server URL
   # Suggested values for "scheme" are "http" and "https".
   SCHEME: https

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -13,6 +13,10 @@ SERVER:
     SOURCE: "internal"
     # The RHEL Base OS Version(x.y) where the Satellite is installed
     RHEL_VERSION: '7'
+  # If the the satellite server is IPv6 server
+  # IS_IPV6:
+  # HTTP Proxy url for IPv6 satellite to connect for outer world access
+  # HTTP_PROXY_IPv6_URL:
   # run-on-one - All xdist runners default to the first satellite
   # balance - xdist runners will be split between available satellites
   # on-demand - any xdist runner without a satellite will have a new one provisioned.

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -14,9 +14,9 @@ SERVER:
     # The RHEL Base OS Version(x.y) where the Satellite is installed
     RHEL_VERSION: '7'
   # If the the satellite server is IPv6 server
-  # IS_IPV6:
+  IS_IPV6: False
   # HTTP Proxy url for IPv6 satellite to connect for outer world access
-  # HTTP_PROXY_IPv6_URL:
+  HTTP_PROXY_IPv6_URL:
   # run-on-one - All xdist runners default to the first satellite
   # balance - xdist runners will be split between available satellites
   # on-demand - any xdist runner without a satellite will have a new one provisioned.

--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -24,7 +24,10 @@ def module_stash(request):
 @pytest.fixture(scope='module')
 def sat_maintain(request, module_target_sat, module_capsule_configured):
     if settings.remotedb.server:
-        yield Satellite(settings.remotedb.server)
+        sat = Satellite(settings.remotedb.server)
+        http_proxy = sat.enable_ipv6_http_proxy()
+        yield sat
+        sat.disable_ipv6_http_proxy(http_proxy)
     else:
         module_target_sat.register_to_cdn(pool_ids=settings.subscription.fm_rhn_poolid.split())
         hosts = {'satellite': module_target_sat, 'capsule': module_capsule_configured}

--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -25,9 +25,8 @@ def module_stash(request):
 def sat_maintain(request, module_target_sat, module_capsule_configured):
     if settings.remotedb.server:
         sat = Satellite(settings.remotedb.server)
-        http_proxy = sat.enable_ipv6_http_proxy()
+        sat.enable_ipv6_http_proxy()
         yield sat
-        sat.disable_ipv6_http_proxy(http_proxy)
     else:
         module_target_sat.register_to_cdn(pool_ids=settings.subscription.fm_rhn_poolid.split())
         hosts = {'satellite': module_target_sat, 'capsule': module_capsule_configured}

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -24,7 +24,7 @@ def _target_sat_imp(request, _default_sat, satellite_factory):
     """This is the actual working part of the following target_sat fixtures"""
     if request.node.get_closest_marker(name='destructive'):
         new_sat = satellite_factory()
-        new_sat.sat.enable_ipv6_http_proxy()
+        new_sat.enable_ipv6_http_proxy()
         yield new_sat
         new_sat.teardown()
         Broker(hosts=[new_sat]).checkin()
@@ -33,7 +33,8 @@ def _target_sat_imp(request, _default_sat, satellite_factory):
         settings.set('server.hostname', installer_sat.hostname)
         yield installer_sat
     else:
-        _default_sat.enable_ipv6_http_proxy()
+        if _default_sat:
+            _default_sat.enable_ipv6_http_proxy()
         yield _default_sat
 
 

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -24,10 +24,9 @@ def _target_sat_imp(request, _default_sat, satellite_factory):
     """This is the actual working part of the following target_sat fixtures"""
     if request.node.get_closest_marker(name='destructive'):
         new_sat = satellite_factory()
-        http_proxy = new_sat.sat.enable_ipv6_http_proxy()
+        new_sat.sat.enable_ipv6_http_proxy()
         yield new_sat
         new_sat.teardown()
-        new_sat.disable_ipv6_http_proxy(http_proxy)
         Broker(hosts=[new_sat]).checkin()
     elif 'sanity' in request.config.option.markexpr:
         installer_sat = lru_sat_ready_rhel(settings.server.version.rhel_version)
@@ -36,7 +35,6 @@ def _target_sat_imp(request, _default_sat, satellite_factory):
     else:
         _default_sat.enable_ipv6_http_proxy()
         yield _default_sat
-        _default_sat.disable_ipv6_http_proxy()
 
 
 @pytest.fixture

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -13,10 +13,7 @@ def _default_sat(align_to_satellite):
     """Returns a Satellite object for settings.server.hostname"""
     if settings.server.hostname:
         try:
-            sat = Satellite.get_host_by_hostname(settings.server.hostname)
-            http_proxy = sat.enable_ipv6_http_proxy()
-            yield sat
-            sat.disable_ipv6_http_proxy(http_proxy)
+            return Satellite.get_host_by_hostname(settings.server.hostname)
         except ContentHostError:
             return Satellite()
     return None
@@ -37,7 +34,9 @@ def _target_sat_imp(request, _default_sat, satellite_factory):
         settings.set('server.hostname', installer_sat.hostname)
         yield installer_sat
     else:
+        _default_sat.enable_ipv6_http_proxy()
         yield _default_sat
+        _default_sat.disable_ipv6_http_proxy()
 
 
 @pytest.fixture

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -307,6 +307,7 @@ def get_deploy_args(request):
     rhel_version = get_sat_rhel_version()
     deploy_args = {
         'deploy_rhel_version': rhel_version.base_version,
+        'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
         'deploy_flavor': settings.flavors.default,
         'promtail_config_template_file': 'config_sat.j2',
         'workflow': settings.server.deploy_workflows.os,
@@ -338,6 +339,7 @@ def cap_ready_rhel():
     rhel_version = Version(settings.capsule.version.rhel_version)
     deploy_args = {
         'deploy_rhel_version': rhel_version.base_version,
+        'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
         'deploy_flavor': settings.flavors.default,
         'promtail_config_template_file': 'config_sat.j2',
         'workflow': settings.capsule.deploy_workflows.os,

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -31,8 +31,10 @@ def resolve_deploy_args(args_dict):
 def _target_satellite_host(request, satellite_factory):
     if 'sanity' not in request.config.option.markexpr:
         new_sat = satellite_factory()
+        http_proxy = new_sat.enable_ipv6_http_proxy()
         yield new_sat
         new_sat.teardown()
+        new_sat.disable_ipv6_http_proxy(http_proxy)
         Broker(hosts=[new_sat]).checkin()
     else:
         yield
@@ -48,8 +50,10 @@ def cached_capsule_cdn_register(hostname=None):
 def _target_capsule_host(request, capsule_factory):
     if 'sanity' not in request.config.option.markexpr and not request.config.option.n_minus:
         new_cap = capsule_factory()
+        new_cap.enable_ipv6_http_proxy()
         yield new_cap
         new_cap.teardown()
+        new_cap.disable_ipv6_http_proxy()
         Broker(hosts=[new_cap]).checkin()
     elif request.config.option.n_minus:
         if not settings.capsule.hostname:
@@ -94,8 +98,10 @@ def satellite_factory():
 def large_capsule_host(capsule_factory):
     """A fixture that provides a Capsule based on config settings"""
     new_cap = capsule_factory(deploy_flavor=settings.flavors.custom_db)
+    new_cap.enable_ipv6_http_proxy()
     yield new_cap
     new_cap.teardown()
+    new_cap.disable_ipv6_http_proxy()
     Broker(hosts=[new_cap]).checkin()
 
 
@@ -244,9 +250,11 @@ def module_lb_capsule(retry_limit=3, delay=300, **broker_args):
         )
         cap_hosts = wait_for(hosts.checkout, timeout=timeout, delay=delay)
 
+    [cap.enable_ipv6_http_proxy() for cap in cap_hosts.out]
     yield cap_hosts.out
 
     [cap.teardown() for cap in cap_hosts.out]
+    [cap.disable_ipv6_http_proxy() for cap in cap_hosts.out]
     Broker(hosts=cap_hosts.out).checkin()
 
 
@@ -278,6 +286,7 @@ def parametrized_enrolled_sat(
 ):
     """Yields a Satellite enrolled into [IDM, AD] as parameter."""
     new_sat = satellite_factory()
+    http_proxy = new_sat.enable_ipv6_http_proxy()
     ipa_host = IPAHost(new_sat)
     new_sat.register_to_cdn()
     if 'IDM' in request.param:
@@ -289,6 +298,7 @@ def parametrized_enrolled_sat(
         yield new_sat
     new_sat.unregister()
     new_sat.teardown()
+    new_sat.disable_ipv6_http_proxy(http_proxy)
     Broker(hosts=[new_sat]).checkin()
 
 
@@ -333,7 +343,9 @@ def cap_ready_rhel():
         'workflow': settings.capsule.deploy_workflows.os,
     }
     with Broker(**deploy_args, host_class=Capsule) as host:
+        host.enable_ipv6_http_proxy()
         yield host
+        host.disable_ipv6_http_proxy()
 
 
 @pytest.fixture(scope='session')
@@ -351,6 +363,7 @@ def installer_satellite(request):
     else:
         sat = lru_sat_ready_rhel(getattr(request, 'param', None))
     sat.setup_firewall()
+    http_proxy = sat.enable_ipv6_http_proxy()
     # # Register for RHEL8 repos, get Ohsnap repofile, and enable and download satellite
     sat.register_to_cdn()
     sat.download_repofile(
@@ -376,7 +389,9 @@ def installer_satellite(request):
         configure_airgun()
     yield sat
     if 'sanity' not in request.config.option.markexpr:
-        sanity_sat = Satellite(sat.hostname)
-        sanity_sat.unregister()
-        broker_sat = Satellite.get_host_by_hostname(sanity_sat.hostname)
-        Broker(hosts=[broker_sat]).checkin()
+        sat = Satellite.get_host_by_hostname(sat.hostname)
+        sat.unregister()
+        sat.disable_ipv6_http_proxy(http_proxy)
+        Broker(hosts=[sat]).checkin()
+    else:
+        sat.disable_ipv6_http_proxy(http_proxy)

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -365,9 +365,8 @@ def installer_satellite(request):
     else:
         sat = lru_sat_ready_rhel(getattr(request, 'param', None))
     sat.setup_firewall()
-    http_proxy = sat.enable_ipv6_http_proxy()
     # # Register for RHEL8 repos, get Ohsnap repofile, and enable and download satellite
-    sat.register_to_cdn()
+    sat.register_to_cdn(enable_proxy=True)
     sat.download_repofile(
         product='satellite',
         release=settings.server.version.release,
@@ -386,6 +385,7 @@ def installer_satellite(request):
         ).get_command(),
         timeout='30m',
     )
+    sat.enable_ipv6_http_proxy()
     if 'sanity' in request.config.option.markexpr:
         configure_nailgun()
         configure_airgun()
@@ -393,7 +393,4 @@ def installer_satellite(request):
     if 'sanity' not in request.config.option.markexpr:
         sat = Satellite.get_host_by_hostname(sat.hostname)
         sat.unregister()
-        sat.disable_ipv6_http_proxy(http_proxy)
         Broker(hosts=[sat]).checkin()
-    else:
-        sat.disable_ipv6_http_proxy(http_proxy)

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -31,10 +31,9 @@ def resolve_deploy_args(args_dict):
 def _target_satellite_host(request, satellite_factory):
     if 'sanity' not in request.config.option.markexpr:
         new_sat = satellite_factory()
-        http_proxy = new_sat.enable_ipv6_http_proxy()
+        new_sat.enable_ipv6_http_proxy()
         yield new_sat
         new_sat.teardown()
-        new_sat.disable_ipv6_http_proxy(http_proxy)
         Broker(hosts=[new_sat]).checkin()
     else:
         yield
@@ -53,7 +52,6 @@ def _target_capsule_host(request, capsule_factory):
         new_cap.enable_ipv6_http_proxy()
         yield new_cap
         new_cap.teardown()
-        new_cap.disable_ipv6_http_proxy()
         Broker(hosts=[new_cap]).checkin()
     elif request.config.option.n_minus:
         if not settings.capsule.hostname:
@@ -101,7 +99,6 @@ def large_capsule_host(capsule_factory):
     new_cap.enable_ipv6_http_proxy()
     yield new_cap
     new_cap.teardown()
-    new_cap.disable_ipv6_http_proxy()
     Broker(hosts=[new_cap]).checkin()
 
 
@@ -254,7 +251,6 @@ def module_lb_capsule(retry_limit=3, delay=300, **broker_args):
     yield cap_hosts.out
 
     [cap.teardown() for cap in cap_hosts.out]
-    [cap.disable_ipv6_http_proxy() for cap in cap_hosts.out]
     Broker(hosts=cap_hosts.out).checkin()
 
 
@@ -286,7 +282,7 @@ def parametrized_enrolled_sat(
 ):
     """Yields a Satellite enrolled into [IDM, AD] as parameter."""
     new_sat = satellite_factory()
-    http_proxy = new_sat.enable_ipv6_http_proxy()
+    new_sat.enable_ipv6_http_proxy()
     ipa_host = IPAHost(new_sat)
     new_sat.register_to_cdn()
     if 'IDM' in request.param:
@@ -298,7 +294,6 @@ def parametrized_enrolled_sat(
         yield new_sat
     new_sat.unregister()
     new_sat.teardown()
-    new_sat.disable_ipv6_http_proxy(http_proxy)
     Broker(hosts=[new_sat]).checkin()
 
 
@@ -347,7 +342,6 @@ def cap_ready_rhel():
     with Broker(**deploy_args, host_class=Capsule) as host:
         host.enable_ipv6_http_proxy()
         yield host
-        host.disable_ipv6_http_proxy()
 
 
 @pytest.fixture(scope='session')

--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -25,6 +25,7 @@ def align_to_satellite(request, worker_id, satellite_factory):
         # clear any hostname that may have been previously set
         settings.set("server.hostname", None)
         on_demand_sat = None
+        http_proxy = None
 
         worker_pos = 0 if worker_id in ["master", "local"] else int(worker_id.replace("gw", ""))
 
@@ -51,6 +52,7 @@ def align_to_satellite(request, worker_id, satellite_factory):
         # get current satellite information
         elif settings.server.xdist_behavior == 'on-demand':
             on_demand_sat = satellite_factory()
+            http_proxy = on_demand_sat.enable_ipv6_http_proxy()
             if on_demand_sat.hostname:
                 settings.set("server.hostname", on_demand_sat.hostname)
             # if no satellite was received, fallback to balance
@@ -70,4 +72,5 @@ def align_to_satellite(request, worker_id, satellite_factory):
                 f'{worker_id=}: Checking in on-demand Satellite ' f'{on_demand_sat.hostname}'
             )
             on_demand_sat.teardown()
+            on_demand_sat.disable_ipv6_http_proxy(http_proxy)
             Broker(hosts=[on_demand_sat]).checkin()

--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -26,7 +26,6 @@ def align_to_satellite(request, worker_id, satellite_factory):
         # clear any hostname that may have been previously set
         settings.set("server.hostname", None)
         on_demand_sat = None
-        http_proxy = None
 
         worker_pos = 0 if worker_id in ["master", "local"] else int(worker_id.replace("gw", ""))
 
@@ -53,7 +52,6 @@ def align_to_satellite(request, worker_id, satellite_factory):
         # get current satellite information
         elif settings.server.xdist_behavior == 'on-demand':
             on_demand_sat = satellite_factory()
-            http_proxy = on_demand_sat.enable_ipv6_http_proxy()
             if on_demand_sat.hostname:
                 settings.set("server.hostname", on_demand_sat.hostname)
             # if no satellite was received, fallback to balance
@@ -73,5 +71,4 @@ def align_to_satellite(request, worker_id, satellite_factory):
                 f'{worker_id=}: Checking in on-demand Satellite ' f'{on_demand_sat.hostname}'
             )
             on_demand_sat.teardown()
-            on_demand_sat.disable_ipv6_http_proxy(http_proxy)
             Broker(hosts=[on_demand_sat]).checkin()

--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -19,8 +19,9 @@ def align_to_satellite(request, worker_id, satellite_factory):
         if settings.server.hostname:
             sanity_sat = Satellite(settings.server.hostname)
             sanity_sat.unregister()
-            broker_sat = Satellite.get_host_by_hostname(sanity_sat.hostname)
-            Broker(hosts=[broker_sat]).checkin()
+            if settings.server.auto_checkin:
+                broker_sat = Satellite.get_host_by_hostname(sanity_sat.hostname)
+                Broker(hosts=[broker_sat]).checkin()
     else:
         # clear any hostname that may have been previously set
         settings.set("server.hostname", None)

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -10,7 +10,6 @@ from nailgun.config import ServerConfig
 
 from robottelo.config.validators import VALIDATORS
 from robottelo.logging import logger, robottelo_root_dir
-from robottelo.utils.url import ipv6_hostname_translation
 
 if not os.getenv('ROBOTTELO_DIR'):
     # dynaconf robottelo file uses ROBOTELLO_DIR for screenshots
@@ -44,8 +43,6 @@ def get_settings():
             logger.warning(
                 f'Dynaconf validation failed, continuing for the sake of unit tests\n{err}'
             )
-
-        ipv6_hostname_translation(settings)
 
         return settings
 

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -10,6 +10,7 @@ from nailgun.config import ServerConfig
 
 from robottelo.config.validators import VALIDATORS
 from robottelo.logging import logger, robottelo_root_dir
+from robottelo.utils.url import ipv6_hostname_translation
 
 if not os.getenv('ROBOTTELO_DIR'):
     # dynaconf robottelo file uses ROBOTELLO_DIR for screenshots
@@ -43,6 +44,8 @@ def get_settings():
             logger.warning(
                 f'Dynaconf validation failed, continuing for the sake of unit tests\n{err}'
             )
+
+        ipv6_hostname_translation(settings)
 
         return settings
 

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -36,7 +36,7 @@ VALIDATORS = dict(
         Validator('server.ssh_password', default=None),
         Validator('server.verify_ca', default=False),
         Validator('server.is_ipv6', is_type_of=bool, default=False),
-        Validator('server.http_proxy_ipv6_url', is_type_of=str),
+        Validator('server.http_proxy_ipv6_url', is_type_of=str, default=None),
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -35,6 +35,8 @@ VALIDATORS = dict(
         Validator('server.ssh_username', default='root'),
         Validator('server.ssh_password', default=None),
         Validator('server.verify_ca', default=False),
+        Validator('server.is_ipv6', is_type_of=bool, default=False),
+        Validator('server.http_proxy_ipv6_url', is_type_of=str),
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -90,11 +90,16 @@ class VersionedContent:
             )
         return product, release, v_major, repo
 
-    def download_repofile(self, product=None, release=None, snap=''):
+    def download_repofile(self, product=None, release=None, snap='', proxy=None):
         """Downloads the tools/client, capsule, or satellite repos on the machine"""
         product, release, v_major, _ = self._dogfood_helper(product, release)
-        url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap)
-        self.execute(f'curl -o /etc/yum.repos.d/dogfood.repo -L {url}')
+        if not proxy and settings.server.is_ipv6:
+            proxy = settings.server.http_proxy_ipv6_url
+        url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap, proxy=proxy)
+        command = f'curl -o /etc/yum.repos.d/dogfood.repo -L {url}'
+        if settings.server.is_ipv6:
+            command += f' -x {settings.server.http_proxy_ipv6_url}'
+        self.execute(command)
 
     def dogfood_repository(self, repo=None, product=None, release=None, snap=''):
         """Returns a repository definition based on the arguments provided"""

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1633,6 +1633,17 @@ class Capsule(ContentHost, CapsuleMixins):
             snap=settings.capsule.version.snap,
         )
 
+    def enable_ipv6_http_proxy(self):
+        if all([settings.server.is_ipv6, settings.server.http_proxy_ipv6_url]):
+            url = urlparse(settings.server.http_proxy_ipv6_url)
+            self.execute(
+                f'subscription-manager config --server.proxy_hostname={url.hostname} --server.proxy_port={url.port}'
+            )
+
+    def disable_ipv6_http_proxy(self):
+        if settings.server.is_ipv6:
+            self.execute('subscription-manager remove server.proxy_hostname server.proxy_port')
+
     def capsule_setup(self, sat_host=None, capsule_cert_opts=None, **installer_kwargs):
         """Prepare the host and run the capsule installer"""
         self._satellite = sat_host or Satellite()
@@ -1797,6 +1808,59 @@ class Satellite(Capsule, SatelliteMixins):
         self._api = type('api', (), {'_configured': False})
         to_clear = [k for k in sys.modules if 'nailgun' in k]
         [sys.modules.pop(k) for k in to_clear]
+
+    def enable_ipv6_http_proxy(self):
+        # Execute procedures for enabling IPv6 HTTP Proxy
+        if all([settings.server.is_ipv6, settings.server.http_proxy_ipv6_url]):
+            proxy_name = 'Robottelo IPv6 Automation Proxy'
+            if not self.cli.HttpProxy.exists(search=('name', proxy_name)):
+                http_proxy = self.api.HTTPProxy(
+                    name=proxy_name, url=settings.server.http_proxy_ipv6_url
+                ).create()
+            else:
+                logger.info(
+                    'The IPv6 HTTP Proxy is already enabled. Skipping the IPv6 HTTP Proxy setup.'
+                )
+                http_proxy = self.api.HTTPProxy().search(query={'search': f'name={proxy_name}'})
+                if http_proxy:
+                    http_proxy = http_proxy[0]
+            # Setting HTTP Proxy as default in the settings
+            self.cli.Settings.set(
+                {
+                    'name': 'content_default_http_proxy',
+                    'value': proxy_name,
+                }
+            )
+            self.cli.Settings.set(
+                {
+                    'name': 'http_proxy',
+                    'value': proxy_name,
+                }
+            )
+            return http_proxy
+        logger.warning(
+            'The IPv6 HTTP Proxy setting is not enabled. Skipping the IPv6 HTTP Proxy setup.'
+        )
+        return None
+
+    def disable_ipv6_http_proxy(self, http_proxy):
+        """
+        Execute procedures for disabling IPv6 HTTP Proxy
+        """
+        if http_proxy:
+            http_proxy.delete()
+            self.cli.Settings.set(
+                {
+                    'name': 'content_default_http_proxy',
+                    'value': '',
+                }
+            )
+            self.cli.Settings.set(
+                {
+                    'name': 'http_proxy',
+                    'value': '',
+                }
+            )
 
     @property
     def api(self):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2410,7 +2410,7 @@ class Satellite(Capsule, SatelliteMixins):
         enable_proxy=False,
     ):
         """Satellite Registration to CDN"""
-        # Enabling proxy for Ipv6
+        # Enabling proxy for IPv6
         if enable_proxy and all([settings.server.is_ipv6, settings.server.http_proxy_ipv6_url]):
             url = urlparse(settings.server.http_proxy_ipv6_url)
             self.enable_rhsm_proxy(url.hostname, url.port)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -73,6 +73,7 @@ def lru_sat_ready_rhel(rhel_ver):
     rhel_version = rhel_ver or settings.server.version.rhel_version
     deploy_args = {
         'deploy_rhel_version': rhel_version,
+        'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
         'deploy_flavor': settings.flavors.default,
         'promtail_config_template_file': 'config_sat.j2',
         'workflow': settings.server.deploy_workflows.os,
@@ -1834,7 +1835,7 @@ class Satellite(Capsule, SatelliteMixins):
             self.cli.Settings.set(
                 {
                     'name': 'http_proxy',
-                    'value': proxy_name,
+                    'value': settings.server.http_proxy_ipv6_url,
                 }
             )
             return http_proxy

--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -21,7 +21,7 @@ def ohsnap_response_hook(r, *args, **kwargs):
     r.raise_for_status()
 
 
-def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap=''):
+def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap='', proxy=None):
     """Returns a URL pointing to Ohsnap "repo_file" or "repositories" API endpoint"""
     if request_type not in ['repo_file', 'repositories']:
         raise InvalidArgumentError('Type must be one of "repo_file" or "repositories"')
@@ -42,11 +42,14 @@ def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap='')
                 f'.z version component not provided in the release ({release}),'
                 f' fetching the recent z-stream from ohsnap'
             )
+            request_query = {
+                'url': f'{ohsnap.host}/api/streams',
+                'hooks': {'response': ohsnap_response_hook},
+            }
+            if proxy:
+                request_query['proxies'] = {'http': proxy}
             res, _ = wait_for(
-                lambda: requests.get(
-                    f'{ohsnap.host}/api/streams',
-                    hooks={'response': ohsnap_response_hook},
-                ),
+                lambda: requests.get(**request_query),
                 handle_exception=True,
                 raise_original=True,
                 timeout=ohsnap.request_retry.timeout,
@@ -69,8 +72,8 @@ def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap='')
     )
 
 
-def dogfood_repofile_url(ohsnap, product, release, os_release, snap=''):
-    return ohsnap_repo_url(ohsnap, 'repo_file', product, release, os_release, snap)
+def dogfood_repofile_url(ohsnap, product, release, os_release, snap='', proxy=None):
+    return ohsnap_repo_url(ohsnap, 'repo_file', product, release, os_release, snap, proxy)
 
 
 def dogfood_repository(

--- a/robottelo/utils/url.py
+++ b/robottelo/utils/url.py
@@ -12,11 +12,8 @@ def is_url(url):
 
 
 def is_ipv4_url(text):
-    # Did not find the better way to filter only URLs so skipping it simple
-    # and open for reviewers suggestions
-    if isinstance(text, str) and '-ipv4' in text:
-        return True
-    return False
+    """Verify if the URL is IPv4 url"""
+    return isinstance(text, str) and 'ipv4' in text and 'redhat.com' in text
 
 
 def ipv6_translator(settings_list, setting_major, settings, data):

--- a/robottelo/utils/url.py
+++ b/robottelo/utils/url.py
@@ -1,5 +1,7 @@
 from urllib.parse import urlparse
 
+from robottelo.logging import logger
+
 
 def is_url(url):
     try:
@@ -7,3 +9,45 @@ def is_url(url):
         return all([result.scheme, result.netloc])
     except (ValueError, AttributeError):
         return False
+
+
+def is_ipv4_url(text):
+    # Did not find the better way to filter only URLs so skipping it simple
+    # and open for reviewers suggestions
+    if isinstance(text, str) and 'ipv4' in text and 'redhat.com' in text:
+        return True
+    return False
+
+
+def ipv6_translator(settings_list, setting_major, settings):
+    """Translates the hostname containing ipv4 to ipv6 and updates the settings object"""
+    dotted_settings = '.'.join(setting_major)
+    for _key, _val in settings_list.items():
+        if is_ipv4_url(_val):
+            settings.set(f'{dotted_settings}.{_key}', str(_val).replace('ipv4', 'ipv6'))
+            logger.debug(f'Setting translated to IPv6, Path: {dotted_settings}.{_key}')
+        elif isinstance(_val, list):
+            updated = False
+            new_list = _val
+            for i in range(len(new_list)):
+                if is_ipv4_url(new_list[i]):
+                    new_list[i] = new_list[i].replace('ipv4', 'ipv6')
+                    updated = True
+            if updated:
+                settings.set(f'{dotted_settings}.{_key}', new_list)
+                logger.debug(f'Setting translated to IPv6, Path: {dotted_settings}.{_key}')
+        elif isinstance(_val, dict):
+            new_setting_major = setting_major + [_key]
+            ipv6_translator(settings_list=_val, setting_major=new_setting_major, settings=settings)
+
+
+def ipv6_hostname_translation(settings):
+    """Migrates any ipv4 containing hostname in conf to ipv6 hostname"""
+    settings_path = []
+    if settings.server.is_ipv6:
+        all_settings = settings.loaded_by_loaders.items()
+        for loader_name, loader_settings in tuple(all_settings):
+            if loader_name.loader == 'yaml':
+                ipv6_translator(loader_settings, settings_path, settings)
+    else:
+        logger.debug('Ipv6 Hostname dynaconf migration hook is skipped for ipv4 testing')

--- a/robottelo/utils/url.py
+++ b/robottelo/utils/url.py
@@ -14,17 +14,17 @@ def is_url(url):
 def is_ipv4_url(text):
     # Did not find the better way to filter only URLs so skipping it simple
     # and open for reviewers suggestions
-    if isinstance(text, str) and 'ipv4' in text and 'redhat.com' in text:
+    if isinstance(text, str) and '-ipv4' in text:
         return True
     return False
 
 
-def ipv6_translator(settings_list, setting_major, settings):
+def ipv6_translator(settings_list, setting_major, settings, data):
     """Translates the hostname containing ipv4 to ipv6 and updates the settings object"""
     dotted_settings = '.'.join(setting_major)
     for _key, _val in settings_list.items():
         if is_ipv4_url(_val):
-            settings.set(f'{dotted_settings}.{_key}', str(_val).replace('ipv4', 'ipv6'))
+            data[f'{dotted_settings}.{_key}'] = str(_val).replace('ipv4', 'ipv6')
             logger.debug(f'Setting translated to IPv6, Path: {dotted_settings}.{_key}')
         elif isinstance(_val, list):
             updated = False
@@ -34,20 +34,22 @@ def ipv6_translator(settings_list, setting_major, settings):
                     new_list[i] = new_list[i].replace('ipv4', 'ipv6')
                     updated = True
             if updated:
-                settings.set(f'{dotted_settings}.{_key}', new_list)
+                data[f'{dotted_settings}.{_key}'] = new_list
                 logger.debug(f'Setting translated to IPv6, Path: {dotted_settings}.{_key}')
         elif isinstance(_val, dict):
             new_setting_major = setting_major + [_key]
-            ipv6_translator(settings_list=_val, setting_major=new_setting_major, settings=settings)
+            ipv6_translator(
+                settings_list=_val, setting_major=new_setting_major, settings=settings, data=data
+            )
 
 
-def ipv6_hostname_translation(settings):
+def ipv6_hostname_translation(settings, data):
     """Migrates any ipv4 containing hostname in conf to ipv6 hostname"""
     settings_path = []
     if settings.server.is_ipv6:
         all_settings = settings.loaded_by_loaders.items()
         for loader_name, loader_settings in tuple(all_settings):
             if loader_name.loader == 'yaml':
-                ipv6_translator(loader_settings, settings_path, settings)
+                ipv6_translator(loader_settings, settings_path, settings, data)
     else:
         logger.debug('Ipv6 Hostname dynaconf migration hook is skipped for ipv4 testing')

--- a/robottelo/utils/url.py
+++ b/robottelo/utils/url.py
@@ -16,8 +16,8 @@ def is_ipv4_url(text):
     return isinstance(text, str) and 'ipv4' in text and 'redhat.com' in text
 
 
-def ipv6_translator(settings_list, setting_major, settings, data):
-    """Translates the hostname containing ipv4 to ipv6 and updates the settings object"""
+def ipv6_translator(settings_list, setting_major, data):
+    """Translates the hostname containing IPv4 to IPv6 and updates the settings object"""
     dotted_settings = '.'.join(setting_major)
     for _key, _val in settings_list.items():
         if is_ipv4_url(_val):
@@ -35,18 +35,16 @@ def ipv6_translator(settings_list, setting_major, settings, data):
                 logger.debug(f'Setting translated to IPv6, Path: {dotted_settings}.{_key}')
         elif isinstance(_val, dict):
             new_setting_major = setting_major + [_key]
-            ipv6_translator(
-                settings_list=_val, setting_major=new_setting_major, settings=settings, data=data
-            )
+            ipv6_translator(settings_list=_val, setting_major=new_setting_major, data=data)
 
 
 def ipv6_hostname_translation(settings, data):
-    """Migrates any ipv4 containing hostname in conf to ipv6 hostname"""
+    """Migrates any IPv4 containing hostname in conf to IPv6 hostname"""
     settings_path = []
     if settings.server.is_ipv6:
         all_settings = settings.loaded_by_loaders.items()
         for loader_name, loader_settings in tuple(all_settings):
             if loader_name.loader == 'yaml':
-                ipv6_translator(loader_settings, settings_path, settings, data)
+                ipv6_translator(loader_settings, settings_path, data)
     else:
-        logger.debug('Ipv6 Hostname dynaconf migration hook is skipped for ipv4 testing')
+        logger.debug('IPv6 Hostname dynaconf migration hook is skipped for IPv4 testing')

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -162,7 +162,7 @@ def sat_default_install(module_sat_ready_rhels):
     install_satellite(module_sat_ready_rhels[0], installer_args)
     sat = module_sat_ready_rhels[0]
     http_proxy = sat.enable_ipv6_http_proxy()
-    yield
+    yield sat
     sat.disable_ipv6_http_proxy(http_proxy)
 
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -180,9 +180,7 @@ def sat_non_default_install(module_sat_ready_rhels):
     install_satellite(module_sat_ready_rhels[1], installer_args, enable_fapolicyd=True)
     sat = module_sat_ready_rhels[1]
     http_proxy = sat.enable_ipv6_http_proxy()
-    sat.execute(
-        'dnf -y --disableplugin=foreman-protector install foreman-discovery-image'
-    )
+    sat.execute('dnf -y --disableplugin=foreman-protector install foreman-discovery-image')
     yield sat
     sat.disable_ipv6_http_proxy(http_proxy)
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -161,9 +161,8 @@ def sat_default_install(module_sat_ready_rhels):
     ]
     install_satellite(module_sat_ready_rhels[0], installer_args)
     sat = module_sat_ready_rhels[0]
-    http_proxy = sat.enable_ipv6_http_proxy()
-    yield sat
-    sat.disable_ipv6_http_proxy(http_proxy)
+    sat.enable_ipv6_http_proxy()
+    return sat
 
 
 @pytest.fixture(scope='module')
@@ -179,10 +178,9 @@ def sat_non_default_install(module_sat_ready_rhels):
     ]
     install_satellite(module_sat_ready_rhels[1], installer_args, enable_fapolicyd=True)
     sat = module_sat_ready_rhels[1]
-    http_proxy = sat.enable_ipv6_http_proxy()
+    sat.enable_ipv6_http_proxy()
     sat.execute('dnf -y --disableplugin=foreman-protector install foreman-discovery-image')
-    yield sat
-    sat.disable_ipv6_http_proxy(http_proxy)
+    return sat
 
 
 @pytest.mark.e2e

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -160,7 +160,10 @@ def sat_default_install(module_sat_ready_rhels):
         f'foreman-initial-admin-password {settings.server.admin_password}',
     ]
     install_satellite(module_sat_ready_rhels[0], installer_args)
-    return module_sat_ready_rhels[0]
+    sat = module_sat_ready_rhels[0]
+    http_proxy = sat.enable_ipv6_http_proxy()
+    yield
+    sat.disable_ipv6_http_proxy(http_proxy)
 
 
 @pytest.fixture(scope='module')
@@ -175,10 +178,13 @@ def sat_non_default_install(module_sat_ready_rhels):
         'foreman-proxy-plugin-discovery-install-images true',
     ]
     install_satellite(module_sat_ready_rhels[1], installer_args, enable_fapolicyd=True)
-    module_sat_ready_rhels[1].execute(
+    sat = module_sat_ready_rhels[1]
+    http_proxy = sat.enable_ipv6_http_proxy()
+    sat.execute(
         'dnf -y --disableplugin=foreman-protector install foreman-discovery-image'
     )
-    return module_sat_ready_rhels[1]
+    yield sat
+    sat.disable_ipv6_http_proxy(http_proxy)
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### Problem Statement
Enabling IPv6 switching in Robottelo Automation 

### Solution
- Added the IPV6 switch and IPV6 proxy config that would switch ON and OFF the IPv6 Testing for robottelo tests via CI or local
- Added setup of Satellite HTTP Proxy by default to all satellite spinned as/by broker workers, factory, directly from Broker context manager
- Adder teardown of Satellite HTTP Proxy by default to all satellite spinned as/by broker workers, factory, directly from Broker context manager
- Added setup of Capsule HTTP Proxy by default to all capsules spinned by factory, directly from Broker context manager to speak to CDN for content access
- Adder teardown of Capsule HTTP Proxy by default to all capsules spinned by factory, directly from Broker context manager
- Deploy Arguments switches satellite / capsule spin up to use Ipv6 sat/cap/host

**Followup PRs, coming next:**
- [DEVs are yet to decide, Out of scope of the PR] Hosts spins up to use ipv6/ipv4 network (based on strategy of host testing in IPv6 is yet to decide)
- HTTP Proxy specific tests uses its own non-default-http-proxy setup 

### Broker Pending(Not blocking this PR from merge):
- Adding support to deploy container as content host in Ipv6 network


### Related Issues
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->