### PR TITLE
[6.15.z] Force keyscan to use ipv4

### DIFF
--- a/pytest_fixtures/component/templatesync.py
+++ b/pytest_fixtures/component/templatesync.py
@@ -66,7 +66,7 @@ def git_pub_key(session_target_sat, git_port):
     id = res.json()['id']
     # add ssh key to known host
     session_target_sat.execute(
-        f'ssh-keyscan -t rsa -p {git.ssh_port} {git.hostname} > {key_path}/known_hosts'
+        f'ssh-keyscan -4 -t rsa -p {git.ssh_port} {git.hostname} > {key_path}/known_hosts'
     )
     yield
     res = requests.delete(

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -161,7 +161,7 @@ class TestTemplateSyncTestCase:
                 'repo': url,
                 'branch': git_branch,
                 'organization-id': module_org.id,
-                'filter': 'Atomic Kickstart default',
+                'filter': 'User - Registered Users',
                 'dirname': dirname,
             }
         ).split('\n')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14017

### Problem Statement
a bunch or templatesync tests failing with `Host key verification failed` when exporting templates to gitea. Turns out that ssh-keyscan opts for ipv6 connenction, where it gets no response

### Solution
Force ssh-keyscan to go via ipv6. Also updated filter to use existing template