### PR TITLE
Fix pit marker in installer

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1401,7 +1401,7 @@ def sat_non_default_install(module_sat_ready_rhels):
 
 @pytest.mark.e2e
 @pytest.mark.tier1
-@pytest.mark.pit_client
+@pytest.mark.pit_server
 @pytest.mark.parametrize(
     'setting_update', [f'http_proxy={settings.http_proxy.un_auth_proxy_url}'], indirect=True
 )
@@ -1782,7 +1782,7 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
 @pytest.mark.tier1
 @pytest.mark.build_sanity
 @pytest.mark.first_sanity
-@pytest.mark.pit_client
+@pytest.mark.pit_server
 def test_satellite_installation(installer_satellite):
     """Run a basic Satellite installation
 


### PR DESCRIPTION
Previously we had to use a workaround to run the installation on specified RHEL version. We had to use the _pit_client_ marker and test the satellite installation on a client (content_host).
Thanks to #13177 we no longer need to do that. 