### PR TITLE
[6.14.z & 6.13.z] add test steps, refresh uploaded manifest file

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1557,14 +1557,22 @@ class TestRepositorySync:
         ),
         indirect=True,
     )
-    def test_missing_content_id(self, repo):
+    def test_missing_content_id(self, repo, function_entitlement_manifest_org, target_sat):
         """Handle several cases of missing content ID correctly
 
         :id: f507790a-933b-4b3f-ac93-cade6967fbd2
 
         :parametrized: yes
 
-        :expectedresults: Repository URL can be set to something new and the repo can be deleted
+        :setup:
+            1. Create product and repo, sync repo
+
+        :steps:
+            1. Try to update repo URL
+            2. Attempt to delete repo
+            3. Refresh manifest file
+
+        :expectedresults: Repo URL can be updated, repo can be deleted and manifest refresh works after repo delete
 
         :BZ:2032040
         """
@@ -1582,6 +1590,10 @@ class TestRepositorySync:
         repo.delete()
         with pytest.raises(HTTPError):
             repo.read()
+        output = target_sat.cli.Subscription.refresh_manifest(
+            {'organization-id': function_entitlement_manifest_org.id}
+        )
+        assert 'Candlepin job status: SUCCESS' in output, 'Failed to refresh manifest'
 
 
 class TestDockerRepository:


### PR DESCRIPTION
### Problem Statement
As per comment on original PR https://github.com/SatelliteQE/robottelo/pull/14195#discussion_r1503974136 from @shweta83 we are suppose to use sca-disable org for 6.14.z and lower version.

### Solution
I talked with Phoenix team and we decided to use function scope fixture instead of module scope just to avoid any future failure with module scope org

CC: @vsedmik @synkd 

### Related Issues
NA

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k test_missing_content_id
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->