### PR TITLE
[6.12.z] host package_list fix

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -49,8 +49,9 @@ def parse_csv(output):
     # ignore warning about puppet and ostree deprecation
     output.replace('Puppet and OSTree will no longer be supported in Katello 3.16\n', '')
     is_rex = True if 'Job invocation' in output else False
+    is_pkg_list = True if 'Nvra' in output else False
     # Validate if the output is eligible for CSV conversions else return as it is
-    if not is_csv(output) and not is_rex:
+    if not is_csv(output) and not is_rex and not is_pkg_list:
         return output
     output = output.splitlines()[0:2] if is_rex else output.splitlines()
     reader = csv.reader(output)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13989

### Problem Statement
similar problem to  https://github.com/SatelliteQE/robottelo/pull/13797 -- the output of the cli package search won't qualify as csv but otherwise can be processed  all right by the parse_csv function

This pr adds an exception, fixes around 6 tests
