### PR TITLE
Bump Manifester to v0.0.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ docker==7.0.0  # Temporary until Broker is back on PyPi
 dynaconf[vault]==3.2.4
 fauxfactory==3.1.0
 jinja2==3.1.3
-manifester==0.0.14
+manifester==0.0.15
 navmazing==1.2.2
 paramiko==3.4.0  # Temporary until Broker is back on PyPi
 productmd==1.38


### PR DESCRIPTION
Dependabot does not appear to have created a PR bumping the required manifester version to the latest release. This PR does so manually.