### PR TITLE
Flip repos_collection fixture to SCA

### DIFF
--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -227,7 +227,7 @@ def module_repos_collection_with_setup(request, module_target_sat, module_org, m
 
 @pytest.fixture(scope='module')
 def module_repos_collection_with_manifest(
-    request, module_target_sat, module_entitlement_manifest_org, module_lce
+    request, module_target_sat, module_sca_manifest_org, module_lce
 ):
     """This fixture and its usage is very similar to repos_collection fixture above with extra
     setup_content and uploaded manifest capabilities using module_org and module_lce fixtures
@@ -246,7 +246,7 @@ def module_repos_collection_with_manifest(
             for repo_name, repo_params in repo.items()
         ],
     )
-    _repos_collection.setup_content(module_entitlement_manifest_org.id, module_lce.id)
+    _repos_collection.setup_content(module_sca_manifest_org.id, module_lce.id)
     return _repos_collection
 
 


### PR DESCRIPTION
### Problem Statement
As 6.16 is SCA-only we need to flip from `entitlement` to `SCA` mode. This fixture is still using entitlement, breaking all tests that use it in setup.


### Solution
Flip it to SCA.


