### PR TITLE
Call function parameters by key-value

### DIFF
--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -1195,7 +1195,7 @@ class TestCannedRole:
         # Creating resource
         dom_name = gen_string('alpha')
         dom = target_sat.api.Domain(
-            sc,
+            server_config=sc,
             name=dom_name,
             organization=[role_taxonomies['org']],
             location=[role_taxonomies['loc']],
@@ -1239,7 +1239,7 @@ class TestCannedRole:
         # Creating resource
         dom_name = gen_string('alpha')
         dom = target_sat.api.Domain(
-            sc,
+            server_config=sc,
             name=dom_name,
             organization=[role_taxonomies['org']],
             location=[role_taxonomies['loc']],


### PR DESCRIPTION
affected tests:

tests/foreman/api/test_role.py::TestCannedRole::test_positive_taxonomies_control_to_superadmin_without_org_admin 
tests/foreman/api/test_role.py::TestCannedRole::test_positive_taxonomies_control_to_superadmin_with_org_admin 

### Problem Statement

```
TypeError: Domain.__init__() got multiple values for argument 'server_config'
```

### Solution

see PR

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->