### PR TITLE
Add pit marker to ansible test

### DIFF
--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -91,6 +91,7 @@ def test_positive_create_variable_with_overrides(target_sat):
         assert session.ansiblevariables.search(key)[0]['Name'] == key
 
 
+@pytest.mark.pit_server
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('[^6]')
 def test_positive_config_report_ansible(session, target_sat, module_org, rhel_contenthost):


### PR DESCRIPTION
### Problem Statement
Ansible test is missing pit marker which will be useful for interop testing.

### Solution
Added pit marker to the test.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->