### PR TITLE
[6.15.z] Fix server_config in subscription test

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -203,11 +203,11 @@ def test_positive_delete_manifest_as_another_user(
     )
     # use the first admin to upload a manifest
     with function_entitlement_manifest as manifest:
-        target_sat.api.Subscription(sc1, organization=function_org).upload(
+        target_sat.api.Subscription(server_config=sc1, organization=function_org).upload(
             data={'organization_id': function_org.id}, files={'content': manifest.content}
         )
     # try to search and delete the manifest with another admin
-    target_sat.api.Subscription(sc2, organization=function_org).delete_manifest(
+    target_sat.api.Subscription(server_config=sc2, organization=function_org).delete_manifest(
         data={'organization_id': function_org.id}
     )
     assert len(target_sat.cli.Subscription.list({'organization-id': function_org.id})) == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14226

### Problem Statement
During z-stream sign-off I noticed that `api/test_subscription.py/test_positive_delete_manifest_as_another_user` is failing with
```
E   TypeError: Subscription.init() got multiple values for argument 'server_config'
```
since [this entities refactor](https://github.com/SatelliteQE/robottelo/pull/13067/files#diff-d2c6c44eb9940dcd63eac12c534c75d8785ede8592528e64f0c927582cdcd2d5R212).


### Solution
Pass the `server_config` as named parameter.


 ### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_subscription.py -k delete_manifest_as_another_user
```