### PR TITLE
Fix manifest file transer for fam

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -49,7 +49,7 @@ def setup_fam(module_target_sat, module_sca_manifest):
     module_target_sat.execute(f"sed -i '/^live/ s/$(MANIFEST)//' {FAM_ROOT_DIR}/Makefile")
 
     # Upload manifest to test playbooks directory
-    module_target_sat.put(module_sca_manifest.path, module_sca_manifest.name)
+    module_target_sat.put(str(module_sca_manifest.path), str(module_sca_manifest.name))
     module_target_sat.execute(
         f'mv {module_sca_manifest.name} {FAM_ROOT_DIR}/tests/test_playbooks/data'
     )


### PR DESCRIPTION
### Problem Statement
The file transfer in `setup_fam` was failing in CI. This came from an untested change on my last PR.

### Solution
Convert PosixPath objects to strings.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->