### PR TITLE
[6.15.z] More meaningful parametrization id

### DIFF
--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -75,7 +75,7 @@ class TestWebhook:
             target_sat.api.Webhooks(event='invalid_event').create()
 
     @pytest.mark.tier2
-    @pytest.mark.parametrize('event', **parametrized(WEBHOOK_EVENTS))
+    @pytest.mark.parametrize('event', WEBHOOK_EVENTS)
     def test_positive_valid_event(self, event, target_sat):
         """Test positive webhook creation with a valid event
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14223

TestWebhook::test_positive_valid_event[user_updated] 
instead of
TestWebhook::test_positive_valid_event[1]

