### PR TITLE
[6.12.z] Fix pit marker in installer (#14180)

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1411,6 +1411,7 @@ def test_installer_options_and_sections(filter):
 @pytest.mark.tier1
 @pytest.mark.build_sanity
 @pytest.mark.first_sanity
+@pytest.mark.pit_server
 @pytest.mark.parametrize(
     "installer_satellite", [settings.server.version.rhel_version], indirect=True
 )
@@ -1444,6 +1445,7 @@ def test_satellite_installation(installer_satellite):
 
 @pytest.mark.e2e
 @pytest.mark.tier1
+@pytest.mark.pit_server
 @pytest.mark.parametrize(
     "installer_satellite", [settings.server.version.rhel_version], indirect=True
 )


### PR DESCRIPTION
(cherry picked from commit b5bbc224c88a164c3be2cab906645518d9dbc84d)

backport #14180
closes #14187