### PR TITLE
[6.15.z] Bump cryptography from 42.0.2 to 42.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 betelgeuse==1.11.0
 broker[docker]==0.4.1
-cryptography==42.0.2
+cryptography==42.0.5
 deepdiff==6.7.1
 docker==7.0.0  # Temporary until Broker is back on PyPi
 dynaconf[vault]==3.2.4


### PR DESCRIPTION
Closes #14115 #14151 #14173 