### PR TITLE
[6.14.z] Bump Pytest to 8.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ paramiko==3.4.0  # Temporary until Broker is back on PyPi
 productmd==1.38
 pyotp==2.9.0
 python-box==7.1.1
-pytest==7.4.4
+pytest==8.0.2
 pytest-services==2.2.1
 pytest-mock==3.12.0
 pytest-reportportal==5.3.1


### PR DESCRIPTION
Closes #14190 #14124 