### PR TITLE
[6.15.z] Update HTTP Proxy e2e test cases

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -16,6 +16,11 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
+from robottelo.constants import (
+    CONTAINER_REGISTRY_HUB,
+    CONTAINER_UPSTREAM_NAME,
+)
+from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
 
 
 @pytest.mark.tier2
@@ -24,27 +29,58 @@ from robottelo.config import settings
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize(
     'setup_http_proxy',
-    [None, True, False],
+    [True, False],
     indirect=True,
-    ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
+    ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
-def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifest_org):
+@pytest.mark.parametrize(
+    'module_repos_collection_with_manifest',
+    [
+        {
+            'distro': 'rhel7',
+            'RHELAnsibleEngineRepository': {'cdn': True},
+            'YumRepository': {'url': settings.repos.module_stream_1.url},
+            'FileRepository': {'url': CUSTOM_FILE_REPO},
+            'DockerRepository': {
+                'url': CONTAINER_REGISTRY_HUB,
+                'upstream_name': CONTAINER_UPSTREAM_NAME,
+            },
+            'AnsibleRepository': {
+                'url': ANSIBLE_GALAXY,
+                'requirements': [
+                    {'name': 'theforeman.foreman', 'version': '2.1.0'},
+                    {'name': 'theforeman.operations', 'version': '0.1.0'},
+                ],
+            },
+        }
+    ],
+    indirect=True,
+)
+def test_positive_end_to_end(
+    setup_http_proxy, module_target_sat, module_org, module_repos_collection_with_manifest
+):
     """End-to-end test for HTTP Proxy related scenarios.
 
     :id: 38df5479-9127-49f3-a30e-26b33655971a
 
     :customerscenario: true
 
+    :setup:
+        1. Create HTTP proxy entity at the Satellite.
+        2. Create RH yum repository.
+        3. Create custom repo of each content type (yum, file, docker, ansible collection).
+
     :steps:
-        1. Set Http proxy settings for Satellite.
-        2. Enable and sync redhat repository.
-        3. Assign Http Proxy to custom repository and perform repo sync.
-        4. Discover yum type repo.
-        5. Discover docker type repo.
+        1. Set immediate download policy where applicable for complete sync testing.
+        2. For each repo set global default HTTP proxy and sync it.
+        3. For each repo set specific HTTP proxy and sync it.
+        4. For each repo set no HTTP proxy and sync it.
+        5. Discover yum type repo through HTTP proxy.
+        6. Discover docker type repo through HTTP proxy.
 
-    :expectedresults: HTTP Proxy works with other satellite components.
-
-    :Team: Phoenix-content
+    :expectedresults:
+        1. All repository updates and syncs succeed.
+        2. Yum and docker repos can be discovered through HTTP proxy.
 
     :BZ: 2011303, 2042473, 2046337
 
@@ -52,59 +88,36 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
 
     :CaseImportance: Critical
     """
-    http_proxy, http_proxy_type = setup_http_proxy
-    http_proxy_id = http_proxy.id if http_proxy_type is not None else None
-    http_proxy_policy = 'use_selected_http_proxy' if http_proxy_type is not None else 'none'
-    # Assign http_proxy to Redhat repository and perform repository sync.
-    rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
-        basearch=constants.DEFAULT_ARCHITECTURE,
-        org_id=module_manifest_org.id,
-        product=constants.PRDS['rhae'],
-        repo=constants.REPOS['rhae2']['name'],
-        reposet=constants.REPOSET['rhae2'],
-        releasever=None,
-    )
-    module_target_sat.api.Repository(id=rh_repo_id).sync()
-    rh_repo = module_target_sat.api.Repository(
-        id=rh_repo_id,
-        http_proxy_policy=http_proxy_policy,
-        http_proxy_id=http_proxy_id,
-        download_policy='immediate',
-    ).update()
-    assert rh_repo.http_proxy_policy == http_proxy_policy
-    assert rh_repo.http_proxy_id == http_proxy_id
-    assert rh_repo.download_policy == 'immediate'
-    rh_repo.sync()
-    assert rh_repo.read().content_counts['rpm'] >= 1
+    # Set immediate download policy where applicable for complete sync testing
+    for repo in module_repos_collection_with_manifest.repos_info:
+        if repo['content-type'] in ['yum', 'docker']:
+            module_target_sat.api.Repository(id=repo['id'], download_policy='immediate').update()
 
-    # Assign http_proxy to Repositories and perform repository sync.
-    repo_options = {
-        'http_proxy_policy': http_proxy_policy,
-        'http_proxy_id': http_proxy_id,
-    }
-    repo = module_target_sat.api.Repository(**repo_options).create()
+    # For each repo set global/specific/no HTTP proxy and sync it
+    for policy in ['global_default_http_proxy', 'use_selected_http_proxy', 'none']:
+        for repo in module_repos_collection_with_manifest.repos_info:
+            repo = module_target_sat.api.Repository(
+                id=repo['id'],
+                http_proxy_policy=policy,
+                http_proxy_id=setup_http_proxy[0].id if 'selected' in policy else None,
+            ).update()
+            assert (
+                repo.http_proxy_policy == policy
+            ), f'Policy update failed for {repo.content_type} repo with {policy} HTTP policy'
+            assert (
+                repo.http_proxy_id == setup_http_proxy[0].id
+                if 'selected' in policy
+                else repo.http_proxy_id is None
+            ), f'Proxy id update failed for {repo.content_type} repo with {policy} HTTP policy'
+            assert (
+                'success' in module_target_sat.api.Repository(id=repo.id).sync()['result']
+            ), f'Sync of a {repo.content_type} repo with {policy} HTTP policy failed'
 
-    assert repo.http_proxy_policy == http_proxy_policy
-    assert repo.http_proxy_id == http_proxy_id
-    repo.sync()
-    assert repo.read().content_counts['rpm'] >= 1
-
-    # Use global_default_http_proxy
-    repo_options['http_proxy_policy'] = 'global_default_http_proxy'
-    repo_2 = module_target_sat.api.Repository(**repo_options).create()
-    repo_2.sync()
-    assert repo_2.http_proxy_policy == 'global_default_http_proxy'
-
-    # Update to selected_http_proxy
-    repo_2.http_proxy_policy = 'none'
-    repo_2.update(['http_proxy_policy'])
-    assert repo_2.read().http_proxy_policy == 'none'
-
-    # test scenario for yum type repo discovery.
+    # Discover yum type repo through HTTP proxy
     repo_name = 'fakerepo01'
-    yum_repo = module_target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
+    yum_repo = module_target_sat.api.Organization(id=module_org.id).repo_discover(
         data={
-            "id": module_manifest_org.id,
+            "id": module_org.id,
             "url": settings.repos.repo_discovery.url,
             "content_type": "yum",
         }
@@ -112,10 +125,10 @@ def test_positive_end_to_end(setup_http_proxy, module_target_sat, module_manifes
     assert len(yum_repo['output']) == 1
     assert yum_repo['output'][0] == f'{settings.repos.repo_discovery.url}/{repo_name}/'
 
-    # test scenario for docker type repo discovery.
-    docker_repo = module_target_sat.api.Organization(id=module_manifest_org.id).repo_discover(
+    # Discover docker type repo through HTTP proxy
+    docker_repo = module_target_sat.api.Organization(id=module_org.id).repo_discover(
         data={
-            "id": module_manifest_org.id,
+            "id": module_org.id,
             "url": 'quay.io',
             "content_type": "docker",
             "search": 'foreman/foreman',
@@ -200,38 +213,42 @@ def test_positive_auto_attach_with_http_proxy(
 
 @pytest.mark.e2e
 @pytest.mark.tier2
-def test_positive_assign_http_proxy_to_products(target_sat):
+def test_positive_assign_http_proxy_to_products(target_sat, function_org):
     """Assign http_proxy to Products and check whether http-proxy is
      used during sync.
 
     :id: c9d23aa1-3325-4abd-a1a6-d5e75c12b08a
 
-    :expectedresults: HTTP Proxy is assigned to all repos present
-        in Products and sync operation uses assigned http-proxy.
+    :setup:
+        1. Create an Organization.
 
-    :Team: Phoenix-content
+    :steps:
+        1. Create two HTTP proxies.
+        2. Create two products and two repos in each product with various HTTP proxy policies.
+        3. Set the HTTP proxy through bulk action for both products.
+        4. Bulk sync one product.
 
-    :CaseImportance: Critical
+    :expectedresults:
+        1. HTTP Proxy is assigned to all repos present in Products
+           and sync operation uses assigned http-proxy and pass.
     """
-    org = target_sat.api.Organization().create()
-    # create HTTP proxies
+    # Create two HTTP proxies
     http_proxy_a = target_sat.api.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.un_auth_proxy_url,
-        organization=[org],
+        organization=[function_org],
     ).create()
-
     http_proxy_b = target_sat.api.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.auth_proxy_url,
         username=settings.http_proxy.username,
         password=settings.http_proxy.password,
-        organization=[org],
+        organization=[function_org],
     ).create()
 
-    # Create products and repositories
-    product_a = target_sat.api.Product(organization=org).create()
-    product_b = target_sat.api.Product(organization=org).create()
+    # Create two products and two repos in each product with various HTTP proxy policies
+    product_a = target_sat.api.Product(organization=function_org).create()
+    product_b = target_sat.api.Product(organization=function_org).create()
     repo_a1 = target_sat.api.Repository(product=product_a, http_proxy_policy='none').create()
     repo_a2 = target_sat.api.Repository(
         product=product_a,
@@ -242,7 +259,8 @@ def test_positive_assign_http_proxy_to_products(target_sat):
     repo_b2 = target_sat.api.Repository(
         product=product_b, http_proxy_policy='global_default_http_proxy'
     ).create()
-    # Add http_proxy to products
+
+    # Set the HTTP proxy through bulk action for both products
     target_sat.api.ProductBulkAction().http_proxy(
         data={
             "ids": [product_a.id, product_b.id],
@@ -250,13 +268,11 @@ def test_positive_assign_http_proxy_to_products(target_sat):
             "http_proxy_id": http_proxy_b.id,
         }
     )
-
     for repo in repo_a1, repo_a2, repo_b1, repo_b2:
         r = repo.read()
         assert r.http_proxy_policy == "use_selected_http_proxy"
         assert r.http_proxy_id == http_proxy_b.id
-
-    product_a.sync({'async': True})
+    assert 'success' in product_a.sync()['result'], 'Product sync failed'
 
 
 @pytest.mark.tier2
@@ -286,6 +302,11 @@ def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, m
 
     # Create and fetch new cerfiticate
     target_sat.custom_cert_generate(proxy_host)
+
+    @request.addfinalizer
+    def _finalize():
+        target_sat.custom_certs_cleanup()
+
     cacert = target_sat.execute(f'cat {cacert_path}').stdout
     assert 'END CERTIFICATE' in cacert
 
@@ -312,7 +333,3 @@ def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, m
     assert response.get('errors') is None
     assert repo.read().last_sync is not None
     assert repo.read().content_counts['rpm'] >= 1
-
-    @request.addfinalizer
-    def _finalize():
-        target_sat.custom_certs_cleanup()

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -111,8 +111,6 @@ def test_insights_client_registration_with_http_proxy():
             works with http proxy set.
 
     :CaseAutomation: NotAutomated
-
-    :CaseImportance: High
     """
 
 
@@ -132,8 +130,6 @@ def test_positive_set_content_default_http_proxy(block_fake_repo_access, target_
             4. Sync a repo.
 
     :expectedresults:  Repo is synced
-
-    :CaseImportance: High
     """
     org = target_sat.api.Organization().create()
     proxy_name = gen_string('alpha', 15)
@@ -186,8 +182,6 @@ def test_positive_environment_variable_unset_set():
     :expectedresults: satellite-installer unsets system proxy and SSL environment variables
                       only for the duration of install and sets back those in the end.
 
-    :CaseImportance: High
-
     :CaseAutomation: NotAutomated
     """
 
@@ -200,12 +194,22 @@ def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
 
     :id: 6af7b2b8-15d5-4d9f-9f87-e76b404a966f
 
-    :expectedresults: HTTP Proxy is assigned to all repos present
-        in Products and sync operation performed successfully.
+    :steps:
+        1. Create two HTTP proxies.
+        2. Create two products and two repos in each product with various HTTP proxy policies.
+        3. Set the HTTP proxy through bulk action for both products to the selected proxy.
+        4. Bulk sync both products and verify packages counts.
+        5. Set the HTTP proxy through bulk action for both products to None.
 
-    :CaseImportance: High
+    :expectedresults:
+        1. HTTP Proxy is assigned to all repos present in Products
+           and sync operation uses assigned http-proxy and pass.
+
+    :expectedresults:
+        1. HTTP Proxy is assigned to all repos present in Products
+           and sync operation performed successfully.
     """
-    # create HTTP proxies
+    # Create two HTTP proxies
     http_proxy_a = module_target_sat.cli.HttpProxy.create(
         {
             'name': gen_string('alpha', 15),
@@ -222,7 +226,8 @@ def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
             'organization-id': module_org.id,
         },
     )
-    # Create products and repositories
+
+    # Create two products and two repos in each product with various HTTP proxy policies
     product_a = module_target_sat.cli_factory.make_product({'organization-id': module_org.id})
     product_b = module_target_sat.cli_factory.make_product({'organization-id': module_org.id})
     repo_a1 = module_target_sat.cli_factory.make_repository(
@@ -257,31 +262,37 @@ def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
             'url': settings.repos.yum_0.url,
         },
     )
-    # Add http_proxy to products
-    module_target_sat.cli.Product.update_proxy(
+
+    # Set the HTTP proxy through bulk action for both products to the selected proxy
+    res = module_target_sat.cli.Product.update_proxy(
         {
             'ids': f"{product_a['id']},{product_b['id']}",
             'http-proxy-policy': 'use_selected_http_proxy',
             'http-proxy-id': http_proxy_b['id'],
         }
     )
+    assert 'Product proxy updated' in res
     for repo in repo_a1, repo_a2, repo_b1, repo_b2:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['http-proxy']['http-proxy-policy'] == 'use_selected_http_proxy'
         assert result['http-proxy']['id'] == http_proxy_b['id']
-    # Perform sync and verify packages count
+
+    # Bulk sync both products and verify packages counts
     module_target_sat.cli.Product.synchronize(
         {'id': product_a['id'], 'organization-id': module_org.id}
     )
     module_target_sat.cli.Product.synchronize(
         {'id': product_b['id'], 'organization-id': module_org.id}
     )
+    for repo in repo_a1, repo_a2, repo_b1, repo_b2:
+        info = module_target_sat.cli.Repository.info({'id': repo['id']})
+        assert int(info['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
 
-    module_target_sat.cli.Product.update_proxy(
+    # Set the HTTP proxy through bulk action for both products to None
+    res = module_target_sat.cli.Product.update_proxy(
         {'ids': f"{product_a['id']},{product_b['id']}", 'http-proxy-policy': 'none'}
     )
-
+    assert 'Product proxy updated' in res
     for repo in repo_a1, repo_a2, repo_b1, repo_b2:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['http-proxy']['http-proxy-policy'] == 'none'
-        assert int(result['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -73,12 +73,18 @@ def test_positive_assign_http_proxy_to_products_repositories(
 
     :id: 2b803f9c-8d5d-4467-8eba-18244ebc0201
 
-    :expectedresults: HTTP Proxy is assigned to all repos present
-        in Products.
+    :setup:
+        1. Create an Organization and Location.
 
-    :CaseImportance: Critical
+    :steps:
+        1. Create two HTTP proxies.
+        2. Create two products and two repos in each product with various HTTP proxy policies.
+        3. Set the HTTP proxy through bulk action for both products.
+
+    :expectedresults:
+        1. HTTP Proxy is assigned to all repos present in Products.
     """
-    # create HTTP proxies
+    # Create two HTTP proxies
     http_proxy_a = target_sat.api.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.un_auth_proxy_url,
@@ -93,14 +99,14 @@ def test_positive_assign_http_proxy_to_products_repositories(
         organization=[module_org.id],
         location=[module_location.id],
     ).create()
-    # Create products
+    # Create two products
     product_a = target_sat.api.Product(
         organization=module_org.id,
     ).create()
     product_b = target_sat.api.Product(
         organization=module_org.id,
     ).create()
-    # Create repositories from UI.
+    # Create two repositories in each product from UI
     with target_sat.ui_session() as session:
         repo_a1_name = gen_string('alpha')
         session.organization.select(org_name=module_org.name)
@@ -152,7 +158,7 @@ def test_positive_assign_http_proxy_to_products_repositories(
                 'repo_content.http_proxy_policy': 'No HTTP Proxy',
             },
         )
-        # Add http_proxy to products
+        # Set the HTTP proxy through bulk action for both products
         session.product.search('')
         session.product.manage_http_proxy(
             [product_a.name, product_b.name],
@@ -337,8 +343,6 @@ def test_positive_repo_discovery(setup_http_proxy, module_target_sat, module_org
     :id: fd385552-8cbb-49f7-8557-cc4e6ac7e79a
 
     :expectedresults: Repository is discovered and created.
-
-    :team: Phoenix-content
 
     :BZ: 2011303, 2042473
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14215

### Problem Statement
During the HTTP proxy component evaluation PX/SD/QE agreed to make several changes. This PR addresses those related to the E2E tests, in particular:
- extends `test_positive_end_to_end` to sync other content type repos via HTTP proxy
- decreases CaseImportance of some 

Some other changes improve docstings - remove redundant fields and adds more information.


### Related Issues
SAT-23276
