### PR TITLE
Add posibility to filter tests that require manifester

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -24,6 +24,7 @@ def pytest_configure(config):
         "no_containers: Disable container hosts from being used in favor of VMs",
         "include_capsule: For satellite-maintain tests to run on Satellite and Capsule both",
         "capsule_only: For satellite-maintain tests to run only on Capsules",
+        "manifester: Tests that require manifester",
     ]
     markers.extend(module_markers())
     for marker in markers:

--- a/tests/foreman/conftest.py
+++ b/tests/foreman/conftest.py
@@ -30,6 +30,8 @@ def pytest_collection_modifyitems(session, items, config):
     deselected_items = []
 
     for item in items:
+        if any("manifest" in f for f in getattr(item, "fixturenames", ())):
+            item.add_marker("manifester")
         # 1. Deselect tests marked with @pytest.mark.deselect
         # WONTFIX BZs makes test to be dynamically marked as deselect.
         deselect = item.get_closest_marker('deselect')


### PR DESCRIPTION
### Problem Statement
We cannot run tests that require manifester

### Solution

Add pytest marker to filter these tests if required

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->