### PR TITLE
Fix test_content_access_after_stopped_foreman

### DIFF
--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -30,14 +30,13 @@ def test_content_access_after_stopped_foreman(target_sat, rhel7_contenthost):
 
     :CaseImportance: Medium
 
-    :CaseComponent: Infrastructure
+    :CaseComponent: Hosts-Content
 
-    :Team: Platform
+    :Team: Phoenix-subscriptions
 
     :parametrized: yes
     """
     org = target_sat.api.Organization().create()
-    org.sca_disable()
     lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     repos_collection = target_sat.cli_factory.RepositoryCollection(
         distro='rhel7',


### PR DESCRIPTION
### Problem Statement
- `test_content_access_after_stopped_foreman` is failing at `org.sca_disable()` for Stream. 
- Also move the test to `Hosts-Content` component.

### Solution
- Remove `org.sca_disable()` as 6.16 is SCA-only. 

### Related Issues
- SAT-23522


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->