### PR TITLE
[6.13.z] Fix pytest deprecation warning

### DIFF
--- a/pytest_fixtures/component/host.py
+++ b/pytest_fixtures/component/host.py
@@ -21,7 +21,6 @@ def module_model():
     return entities.Model().create()
 
 
-@pytest.mark.skip_if_not_set('clients', 'fake_manifest')
 @pytest.fixture(scope="module")
 def setup_rhst_repo(module_target_sat):
     """Prepare Satellite tools repository for usage in specified organization"""

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -1,7 +1,6 @@
 # Puppet Environment fixtures
 import pytest
 
-from robottelo.config import settings
 from robottelo.constants import ENVIRONMENT
 
 
@@ -55,7 +54,6 @@ def module_puppet_environment(module_puppet_org, module_puppet_loc, session_pupp
     return session_puppet_enabled_sat.api.Environment(id=environment.id).read()
 
 
-@pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 @pytest.fixture(scope='module')
 def module_import_puppet_module(session_puppet_enabled_sat):
     """Returns custom puppet environment name that contains imported puppet module

--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -334,7 +334,6 @@ def enable_external_auth_rhsso(
     default_sso_host.set_the_redirect_uri()
 
 
-@pytest.mark.external_auth
 @pytest.fixture(scope='module')
 def module_enroll_idm_and_configure_external_auth(module_target_sat):
     ipa_host = IPAHost(module_target_sat)
@@ -343,7 +342,6 @@ def module_enroll_idm_and_configure_external_auth(module_target_sat):
     ipa_host.disenroll_idm()
 
 
-@pytest.mark.external_auth
 @pytest.fixture
 def func_enroll_idm_and_configure_external_auth(target_sat):
     ipa_host = IPAHost(target_sat)
@@ -410,19 +408,16 @@ def rhsso_setting_setup_with_timeout(module_target_sat, rhsso_setting_setup):
     setting_entity.update({'value'})
 
 
-@pytest.mark.external_auth
 @pytest.fixture(scope='module')
 def module_enroll_ad_and_configure_external_auth(ad_data, module_target_sat):
     module_target_sat.enroll_ad_and_configure_external_auth(ad_data)
 
 
-@pytest.mark.external_auth
 @pytest.fixture
 def func_enroll_ad_and_configure_external_auth(ad_data, target_sat):
     target_sat.enroll_ad_and_configure_external_auth(ad_data)
 
 
-@pytest.mark.external_auth
 @pytest.fixture
 def configure_hammer_no_creds(parametrized_enrolled_sat):
     """Configures hammer to use sessions and negotiate auth."""
@@ -433,7 +428,6 @@ def configure_hammer_no_creds(parametrized_enrolled_sat):
     parametrized_enrolled_sat.execute(f'mv -f {HAMMER_CONFIG}.backup {HAMMER_CONFIG}')
 
 
-@pytest.mark.external_auth
 @pytest.fixture
 def configure_hammer_negotiate(parametrized_enrolled_sat, configure_hammer_no_creds):
     """Configures hammer to use sessions and negotiate auth."""
@@ -448,7 +442,6 @@ def configure_hammer_negotiate(parametrized_enrolled_sat, configure_hammer_no_cr
     parametrized_enrolled_sat.execute(f'mv -f {HAMMER_CONFIG}.backup {HAMMER_CONFIG}')
 
 
-@pytest.mark.external_auth
 @pytest.fixture
 def configure_hammer_no_negotiate(parametrized_enrolled_sat):
     """Configures hammer not to use automatic negotiation."""
@@ -458,7 +451,6 @@ def configure_hammer_no_negotiate(parametrized_enrolled_sat):
     parametrized_enrolled_sat.execute(f'mv -f {HAMMER_CONFIG}.backup {HAMMER_CONFIG}')
 
 
-@pytest.mark.external_auth
 @pytest.fixture
 def hammer_logout(parametrized_enrolled_sat):
     """Logout in Hammer."""

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -368,9 +368,6 @@ class TestContentViewCreate:
 class TestContentViewPublishPromote:
     """Tests for publishing and promoting content views."""
 
-    @pytest.mark.skipif(
-        (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
-    )
     @pytest.fixture(scope='class', autouse=True)
     def class_setup(self, request, module_product, class_target_sat):
         """Set up organization, product and repositories for tests."""
@@ -1240,9 +1237,6 @@ def test_negative_non_readonly_user_actions(target_sat, content_view, function_r
 class TestOstreeContentView:
     """Tests for ostree contents in content views."""
 
-    @pytest.mark.skipif(
-        (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
-    )
     @pytest.fixture(scope='class', autouse=True)
     def initiate_testclass(self, request, module_product, class_target_sat):
         """Set up organization, product and repositories for tests."""
@@ -1347,7 +1341,6 @@ class TestOstreeContentView:
 class TestContentViewRedHatOstreeContent:
     """Tests for publishing and promoting cv with RH ostree contents."""
 
-    @pytest.mark.run_in_one_thread
     @pytest.fixture(scope='class', autouse=True)
     def initiate_testclass(self, request, module_entitlement_manifest_org, class_target_sat):
         """Set up organization, product and repositories for tests."""

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -101,7 +101,6 @@ def invalid_update_data():
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.skip_if_not_set('libvirt')
 def libvirt_url():
     return LIBVIRT_RESOURCE_URL % settings.libvirt.libvirt_hostname
 

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -1792,7 +1792,6 @@ def test_positive_install_package_via_rex(
 
 
 # -------------------------- HOST SUBSCRIPTION SUBCOMMAND FIXTURES --------------------------
-@pytest.mark.skip_if_not_set('clients')
 @pytest.fixture
 def host_subscription_client(rhel7_contenthost, target_sat):
     rhel7_contenthost.install_katello_ca(target_sat)

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -115,7 +115,6 @@ def rhsso_groups_teardown(module_target_sat, default_sso_host):
         default_sso_host.delete_rhsso_group(group_name)
 
 
-@pytest.mark.external_auth
 @pytest.fixture
 def configure_hammer_session(parametrized_enrolled_sat, enable=True):
     """Take backup of the hammer config file and enable use_sessions"""


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14205

Applying a mark to a fixture function never had any effect but is a common user error.

see: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
