### PR TITLE
[6.14.z] Wait for product HTTP Proxy update to finish

### DIFF
--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -272,6 +272,13 @@ def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
         }
     )
     assert 'Product proxy updated' in res
+    module_target_sat.wait_for_tasks(
+        search_query=(
+            f'Actions::Katello::Repository::Update and organization_id = {module_org.id}'
+        ),
+        max_tries=5,
+        poll_rate=10,
+    )
     for repo in repo_a1, repo_a2, repo_b1, repo_b2:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['http-proxy']['http-proxy-policy'] == 'use_selected_http_proxy'
@@ -293,6 +300,13 @@ def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
         {'ids': f"{product_a['id']},{product_b['id']}", 'http-proxy-policy': 'none'}
     )
     assert 'Product proxy updated' in res
+    module_target_sat.wait_for_tasks(
+        search_query=(
+            f'Actions::Katello::Repository::Update and organization_id = {module_org.id}'
+        ),
+        max_tries=5,
+        poll_rate=10,
+    )
     for repo in repo_a1, repo_a2, repo_b1, repo_b2:
         result = module_target_sat.cli.Repository.info({'id': repo['id']})
         assert result['http-proxy']['http-proxy-policy'] == 'none'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14269

### Problem Statement
CLI `test_positive_assign_http_proxy_to_products` is flaky, it looks like the repo properties were not set in time (of assertion).


### Solution
Wait for the Update repo tasks to finish.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_http_proxy.py -k test_positive_assign_http_proxy_to_products
