### PR TITLE
[6.15.z] Bump pytest from 8.0.2 to 8.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ paramiko==3.4.0  # Temporary until Broker is back on PyPi
 productmd==1.38
 pyotp==2.9.0
 python-box==7.1.1
-pytest==8.0.2
+pytest==8.1.0
 pytest-order==1.2.0
 pytest-services==2.2.1
 pytest-mock==3.12.0


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/robottelo/issues/14292
Manual Cherrypick of https://github.com/SatelliteQE/robottelo/pull/14243