### PR TITLE
[6.12.z] remove the PRT labels for new commits

### DIFF
--- a/.github/workflows/prt_labels.yml
+++ b/.github/workflows/prt_labels.yml
@@ -1,0 +1,49 @@
+name: Remove the PRT label, for the new commit
+
+on:
+  pull_request:
+    types: ["synchronize"]
+
+jobs:
+    prt_labels_remover:
+      name: remove the PRT label when amendments or new commits added to PR
+      runs-on: ubuntu-latest
+      if: "(contains(github.event.pull_request.labels.*.name, 'PRT-Passed') || contains(github.event.pull_request.labels.*.name, 'PRT-Failed'))"
+      steps:
+        - name: Avoid the race condition as PRT result will be cleaned
+          run: |
+            echo "Avoiding the race condition if prt result will be cleaned" && sleep 60
+
+        - name: Fetch the PRT status
+          id: prt
+          uses: omkarkhatavkar/wait-for-status-checks@main
+          with:
+            ref: ${{ github.head_ref }}
+            context: 'Robottelo-Runner'
+            wait-interval: 2
+            count: 5
+
+        - name: remove the PRT Passed/Failed label, for new commit
+          if: always() && ${{steps.prt.outputs.result}} == 'not_found'
+          uses: actions/github-script@v7
+          with:
+            github-token: ${{ secrets.CHERRYPICK_PAT }}
+            script: |
+              const prNumber = '${{ github.event.number }}';
+              const issue = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+              });
+              const labelsToRemove = ['PRT-Failed', 'PRT-Passed'];
+              const labelsToRemoveFiltered = labelsToRemove.filter(label => issue.data.labels.some(({ name }) => name === label));
+              if (labelsToRemoveFiltered.length > 0) {
+                await Promise.all(labelsToRemoveFiltered.map(async label => {
+                  await github.rest.issues.removeLabel({
+                    issue_number: prNumber,
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    name: label
+                  });
+                }));
+              }


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14093

### Problem Statement
Currently, the labels `PRT-Passed` and `PRT-Failed` are added based on the results of the Pull Request Testing (PRT). However, when contributors update the pull request with new commits, these labels might remain, leading to potential confusion. There is a need to automatically remove these labels when new commits are added to the pull request.

### Solution
To address this issue, we propose implementing a solution using GitHub Actions (GHA). The solution involves periodically checking the GitHub status API to monitor for new commits on the pull request. Upon detecting a new commit, the workflow will automatically remove the `PRT-Passed` and `PRT-Failed` labels from the pull request. This ensures that the labels accurately reflect the current status of the pull request, reducing confusion and maintaining clarity for reviewers and contributors.


### Test Result 
https://github.com/omkarkhatavkar/robottelo/actions/runs/7916581527/job/21610780591?pr=216