### PR TITLE
code coverage bug2063218

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -214,10 +214,7 @@ def check_message_in_rhsm_log(message):
         delay=2,
     )
     logs = get_rhsm_log()
-    for line in logs.split('\n'):
-        if message in line:
-            return message
-    return False
+    return any(message in line for line in logs.split("\n"))
 
 
 def _get_hypervisor_mapping(hypervisor_type):

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -214,7 +214,7 @@ def check_message_in_rhsm_log(message):
         delay=2,
     )
     logs = get_rhsm_log()
-    return any(message in line for line in logs.split("\n"))
+    return any(message in line for line in logs.split('\n'))
 
 
 def _get_hypervisor_mapping(hypervisor_type):

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -241,7 +241,7 @@ class TestVirtWhoConfigforNutanix:
         assert str(exc_info.value) == env_error
         # check message exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert check_message_in_rhsm_log(message) == message
+        assert check_message_in_rhsm_log(message)
 
         # Update ahv_internal_debug option to true
         value = 'true'
@@ -265,4 +265,4 @@ class TestVirtWhoConfigforNutanix:
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert str(check_message_in_rhsm_log(message)) == 'False'
+        assert not check_message_in_rhsm_log(message)

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -518,8 +518,8 @@ class TestVirtWhoConfigforEsx:
             1. virt-who config belong to a same org with the same rhsm_username
             2. virt-who config belong to a different org with the different rhsm_username
             3. hypervisors and guest mapping info send by group of org and service account exist in rhsm.log
-            4. not delete all virt-who config service account virt_who_reporter_X exist
-            5. delete all virt-who config service account virt_who_reporter_X will be deleted
+            4. verify delete virt-who config and remain only one virt-who config, service account virt_who_reporter_X exist
+            5. verify delete all virt-who config, service account virt_who_reporter_X has be deleted
 
 
 

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -565,7 +565,7 @@ class TestVirtWhoConfigforEsx:
         rhsm_username.append(get_configure_option('rhsm_username', config_file))
         vc_id.append(virtwho_config_cli['id'])
 
-        # verify the two service account belong to the different org are different
+        # verify the two service accounts belonging to different orgs are different
         assert rhsm_username[2] != rhsm_username[0]
 
         # Verify virt-who config with the same service account send hypervisors and guest mapping info in the same organization section, and service account exist in rhsm.log

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -520,9 +520,6 @@ class TestVirtWhoConfigforEsx:
             3. rhsm.log contains the correct orgs where hypervisors-guest mapping is sent to
             4. rhsm.log contains the correct account
             5. After deleting all virt-who config belong to the same org, verify that the rhsm user belong to this org has been deleted
-
-
-
         :customerscenario: true
 
         :CaseImportance: Medium

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -548,7 +548,7 @@ class TestVirtWhoConfigforEsx:
         # verify the two service accounts belonging to the same org are the same
         assert rhsm_username[0] == rhsm_username[1]
 
-        # Create a different org virtwho_fake_XXXX and then create virt-who config, get the service account rhsm_username
+        # Create a different org virtwho_fake_XXXX and then create virt-who config in that org, get the service account rhsm_username
         ORG_DATA = {'name': f'virtwho_fake_{gen_string("alpha")}'}
         org = target_sat.api.Organization(name=ORG_DATA['name']).create()
         target_sat.api.Location(organization=[org]).create()

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -529,7 +529,7 @@ class TestVirtWhoConfigforEsx:
 
         :BZ: 2063218
         """
-        # create two virt-who config in the same organization, get the service account rhsm_username
+        # create two virt-who configs in the same organization, get the service account rhsm_username
         vc_id = []
         rhsm_username = []
         for _i in range(2):

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -545,7 +545,7 @@ class TestVirtWhoConfigforEsx:
             config_file = get_configure_file(virtwho_config_cli['id'])
             rhsm_username.append(get_configure_option('rhsm_username', config_file))
 
-        # verify the two service account belong to the same org are the same
+        # verify the two service accounts belonging to the same org are the same
         assert rhsm_username[0] == rhsm_username[1]
 
         # Create a different org virtwho_fake_XXXX and then create virt-who config, get the service account rhsm_username

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -580,8 +580,8 @@ class TestVirtWhoConfigforEsx:
         for item in service_account_message:
             assert check_message_in_rhsm_log(item)
 
-        # delete one of the virt-who config belong to module_sca_manifest_org, verify service account rhsm_username_1 exist
-        # delete all the virt-who config belong to module_sca_manifest_org, verify service account  rhsm_username_1 does not exist
+        # delete one of the virt-who configs belonging to module_sca_manifest_org, verify the other service account for that org still exists
+        # delete the other config in that org, verify the service account doesn't exist anymore
         vd_ids = [vc_id[0], vc_id[1]]
         messages = [
             f"Authenticating with RHSM username {rhsm_username[0]}",

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -529,7 +529,7 @@ class TestVirtWhoConfigforEsx:
         # create two virt-who configs in the same organization, get the service account rhsm_username
         vc_id = []
         rhsm_username = []
-        for _i in range(2):
+        for _ in range(2):
             form_data_cli['name'] = gen_string('alpha')
             virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)[
                 'general-information'

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -588,7 +588,7 @@ class TestVirtWhoConfigforEsx:
         message = f"Authenticating with RHSM username {rhsm_username[0]}"
         assert check_message_in_rhsm_log(message)
 
-        # delete all the virt-who config belong to module_sca_manifest_org, verify service account  rhsm_username_1 does not exist
+        # delete the other config in that org, verify the service account doesn't exist anymore
         target_sat.cli.VirtWhoConfig.delete({'id': vc_id[1]})
         config_file = get_configure_file(vc_id[1])
         runcmd(f"rm -f {config_file}")

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -580,7 +580,7 @@ class TestVirtWhoConfigforEsx:
         for item in service_account_message:
             assert check_message_in_rhsm_log(item)
 
-        # delete one of the virt-who config belong to module_sca_manifest_org, verify service account rhsm_username_1 exist
+        # delete one of the virt-who configs belonging to module_sca_manifest_org, verify the other service account for that org still exists
         target_sat.cli.VirtWhoConfig.delete({'id': vc_id[0]})
         config_file = get_configure_file(vc_id[0])
         runcmd(f"rm -f {config_file}")

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -515,11 +515,11 @@ class TestVirtWhoConfigforEsx:
         :id: 2d0d3126-859f-4092-9196-a553bc1d3bd9
 
         :expectedresults:
-            1. virt-who config belong to a same org with the same rhsm_username
-            2. virt-who config belong to a different org with the different rhsm_username
-            3. hypervisors and guest mapping info send by group of org and service account exist in rhsm.log
-            4. verify delete virt-who config and remain only one virt-who config, service account virt_who_reporter_X exist
-            5. verify delete all virt-who config, service account virt_who_reporter_X has be deleted
+            1. virt-who config belongs to the same org with the same rhsm_username
+            2. virt-who config belongs to a different org with the different rhsm_username
+            3. rhsm.log contains the correct orgs where hypervisors-guest mapping is sent to
+            4. rhsm.log contains the correct account
+            5. After deleting all virt-who config belong to the same org, verify that the rhsm user belong to this org has been deleted
 
 
 

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -568,7 +568,7 @@ class TestVirtWhoConfigforEsx:
         # verify the two service accounts belonging to different orgs are different
         assert rhsm_username[2] != rhsm_username[0]
 
-        # Verify virt-who config with the same service account send hypervisors and guest mapping info in the same organization section, and service account exist in rhsm.log
+        # Verify rhsm.log contains correct orgs to which hypervisor-guest mapping is sent to, and rhsm.log contains the correct user names.
         runcmd(get_configure_command(vc_id[0], module_sca_manifest_org.name))
         runcmd(get_configure_command(vc_id[1], module_sca_manifest_org.name))
         service_account_message = [

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -216,7 +216,7 @@ class TestVirtWhoConfigforNutanix:
         assert str(exc_info.value) == env_error
         # check message exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert check_message_in_rhsm_log(message) == message
+        assert check_message_in_rhsm_log(message)
 
         # Update ahv_internal_debug option to true
         value = 'true'
@@ -240,4 +240,4 @@ class TestVirtWhoConfigforNutanix:
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert str(check_message_in_rhsm_log(message)) == 'False'
+        assert not check_message_in_rhsm_log(message)

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -227,7 +227,7 @@ class TestVirtwhoConfigforNutanix:
         assert str(exc_info.value) == env_error
         # check message exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert check_message_in_rhsm_log(message) == message
+        assert check_message_in_rhsm_log(message)
 
         # Update ahv_internal_debug option to true
         org_session.virtwho_configure.edit(name, {'ahv_internal_debug': True})
@@ -245,4 +245,4 @@ class TestVirtwhoConfigforNutanix:
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert str(check_message_in_rhsm_log(message)) == 'False'
+        assert not check_message_in_rhsm_log(message)

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -195,7 +195,7 @@ class TestVirtwhoConfigforNutanix:
         assert str(exc_info.value) == env_error
         # check message exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert check_message_in_rhsm_log(message) == message
+        assert check_message_in_rhsm_log(message)
 
         # Update ahv_internal_debug option to true
         org_session.virtwho_configure.edit(name, {'ahv_internal_debug': True})
@@ -213,4 +213,4 @@ class TestVirtwhoConfigforNutanix:
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert str(check_message_in_rhsm_log(message)) == 'False'
+        assert not check_message_in_rhsm_log(message)


### PR DESCRIPTION
Code coverage bug2063218, it is a new [RFE]
Test case : PASS
```
(robottelo_vv_615) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/cli/test_esx_sca.py -k test_positive_rhsm_username_option --disable-pytest-warnings -q
.                                                                                                                                                                                                                                      [100%]
1 passed, 39 deselected, 23 warnings in 450.60s (0:07:30)
```