### PR TITLE
fixed sanity suite, AttributeError due to not matching scope

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -145,10 +145,8 @@ class ContentInfo:
         :returns: the manifest upload result
 
         """
-        if (
-            not isinstance(manifest, bytes | io.BytesIO)
-            and not hasattr(manifest, 'content')
-            or manifest.content is None
+        if not isinstance(manifest, bytes | io.BytesIO) and (
+            not hasattr(manifest, 'content') or manifest.content is None
         ):
             manifest = clone()
         if timeout is None:


### PR DESCRIPTION
### Problem Statement
```
pytest_fixtures/component/taxonomy.py:102: in module_sca_manifest_org
    module_target_sat.upload_manifest(module_org.id, module_sca_manifest.content)
robottelo/host_helpers/satellite_mixins.py:151: in upload_manifest
    or manifest.content is None
E   AttributeError: 'bytes' object has no attribute 'content'
```

### Solution
After applying valid bracket scope it will run the test successfully 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->