### PR TITLE
remove log check causing false negatives

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1381,8 +1381,7 @@ def sat_default_install(module_sat_ready_rhels):
         f'foreman-initial-admin-password {settings.server.admin_password}',
     ]
     install_satellite(module_sat_ready_rhels[0], installer_args)
-    yield module_sat_ready_rhels[0]
-    common_sat_install_assertions(module_sat_ready_rhels[0])
+    return module_sat_ready_rhels[0]
 
 
 @pytest.fixture(scope='module')
@@ -1395,8 +1394,7 @@ def sat_non_default_install(module_sat_ready_rhels):
         'foreman-proxy-content-pulpcore-hide-guarded-distributions false',
     ]
     install_satellite(module_sat_ready_rhels[1], installer_args, enable_fapolicyd=True)
-    yield module_sat_ready_rhels[1]
-    common_sat_install_assertions(module_sat_ready_rhels[1])
+    return module_sat_ready_rhels[1]
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Removing the common assertions from fixture teardown. Current setup lead to an error in last test of a test module, when some error appeared in logs during testing.

Example:
```
test_a
...
test_n PASSED or FAILED but creates error entries in logs
...
test_z PASSED or FAILED but throws an ERROR due to error entries in logs
```