### PR TITLE
validate that cv warning to force promote

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4101,7 +4101,7 @@ class TestContentView:
         cv = target_sat.cli_factory.make_content_view({'organization-id': function_org.id})
         target_sat.cli.ContentView.publish({'id': cv['id']})
 
-        # Promote version 1.0 to Preprod, skip Library, this should fail with warning
+        # Promote version 1.0 to Preprod, skip Test, this should fail with warning
         cv_version = target_sat.cli.ContentView.info({'id': cv['id']})['versions'][0]
         with pytest.raises(CLIReturnCodeError) as error:
             target_sat.cli.ContentView.version_promote(

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4124,6 +4124,7 @@ class TestContentView:
             -1
         ]
         assert lce_preprod['id'] == promoted_lce['id']
+
         # Try to promote version 1.0 from Preprod to Prod, this should success without warning
         target_sat.cli.ContentView.version_promote(
             {'id': cv_version['id'], 'to-lifecycle-environment-id': lce_prod['id']}

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4073,7 +4073,7 @@ class TestContentView:
         :steps:
             1. Create an environment path ex- Library >> Test >> Preprod >> Prod
             2. Create a CV and publish into the Library
-            3. Promote version 1.0 to Preprod, skip Library, this should fail with warning
+            3. Promote version 1.0 to Preprod, skip Test, this should fail with warning
             4. Promote version 1.0 to Preprod using force, this should success
             5. Try to promote version 1.0 from Preprod to Prod, this should success without warning
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -4065,6 +4065,74 @@ class TestContentView:
         )
         assert content_view['version'] == '1.0'
 
+    def test_positive_validate_force_promote_warning(self, target_sat, function_org):
+        """Test cv promote shows warning of 'force promotion' for out of sequence LCE
+
+        :id: 1bfb76be-ab40-48b4-b5a3-428a2a9ab99b
+
+        :steps:
+            1. Create an environment path ex- Library >> Test >> Preprod >> Prod
+            2. Create a CV and publish into the Library
+            3. Promote version 1.0 to Preprod, skip Library, this should fail with warning
+            4. Promote version 1.0 to Preprod using force, this should success
+            5. Try to promote version 1.0 from Preprod to Prod, this should success without warning
+
+        :expectedresults:
+            1. CV version 1.0 should be present on Prod LCE
+
+        :CaseImportance: High
+
+        :BZ: 2125728
+
+        :customerscenario: true
+        """
+        # Create an environment path ex- Library >> Test >> Preprod >> Prod
+        lce_test = target_sat.cli_factory.make_lifecycle_environment(
+            {'organization-id': function_org.id}
+        )
+        lce_preprod = target_sat.cli_factory.make_lifecycle_environment(
+            {'organization-id': function_org.id, 'prior': lce_test['name']}
+        )
+        lce_prod = target_sat.cli_factory.make_lifecycle_environment(
+            {'organization-id': function_org.id, 'prior': lce_preprod['name']}
+        )
+
+        # Create a CV and publish into the Library
+        cv = target_sat.cli_factory.make_content_view({'organization-id': function_org.id})
+        target_sat.cli.ContentView.publish({'id': cv['id']})
+
+        # Promote version 1.0 to Preprod, skip Library, this should fail with warning
+        cv_version = target_sat.cli.ContentView.info({'id': cv['id']})['versions'][0]
+        with pytest.raises(CLIReturnCodeError) as error:
+            target_sat.cli.ContentView.version_promote(
+                {'id': cv_version['id'], 'to-lifecycle-environment-id': lce_preprod['id']}
+            )
+        assert (
+            'Cannot promote environment out of sequence. Use force to bypass restriction'
+            in error.value.stderr
+        )
+
+        # Promote version 1.0 to Preprod using force, this should success
+        target_sat.cli.ContentView.version_promote(
+            {
+                'id': cv_version['id'],
+                'to-lifecycle-environment-id': lce_preprod['id'],
+                'force': True,
+            }
+        )
+        promoted_lce = target_sat.cli.ContentView.info({'id': cv['id']})['lifecycle-environments'][
+            -1
+        ]
+        assert lce_preprod['id'] == promoted_lce['id']
+        # Try to promote version 1.0 from Preprod to Prod, this should success without warning
+        target_sat.cli.ContentView.version_promote(
+            {'id': cv_version['id'], 'to-lifecycle-environment-id': lce_prod['id']}
+        )
+        promoted_lce = target_sat.cli.ContentView.info({'id': cv['id']})['lifecycle-environments'][
+            -1
+        ]
+        assert lce_prod['id'] == promoted_lce['id']
+
 
 class TestContentViewFileRepo:
     """Specific tests for Content Views with File Repositories containing


### PR DESCRIPTION
### Problem Statement
CU Case - Test cv promote shows warning of 'force promotion' for out of sequence LCE
BZ 2125728

### Solution
Added automation coverage

### Related Issues
NA

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py.py -k 'test_positive_validate_force_promote_warning'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->