### PR TITLE
[Customer Case] Test for creating a host with lce specified

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2694,3 +2694,34 @@ def test_positive_create_and_update_with_content_source(
     target_sat.cli.Capsule.content_synchronize({'name': module_capsule_configured.hostname})
     assert rhel_contenthost.execute(f'dnf -y install {package}').status == 0
     assert rhel_contenthost.execute(f'rpm -q {package}').status == 0
+
+
+@pytest.mark.cli_host_create
+@pytest.mark.tier2
+def test_positive_create_host_with_lifecycle_environment_name(
+    module_lce, module_org, module_promoted_cv, module_target_sat
+):
+    """Attempt to create a host with lifecycle-environment name specified
+
+    :id: 7445ad21-538f-4357-8bd1-9676d2478633
+
+    :BZ: 2106256
+
+    :expectedresults: Host is created with no errors
+
+    :CaseImportance: Medium
+    """
+    found_host = False
+    new_host = module_target_sat.cli_factory.make_fake_host(
+        {
+            'content-view-id': module_promoted_cv.id,
+            'lifecycle-environment': module_lce.name,
+            'organization-id': module_org.id,
+        }
+    )
+    hosts = module_target_sat.cli.Host.list({'organization-id': module_org.id})
+    for i in hosts:
+        if new_host.name in i.values():
+            found_host = True
+            break
+    assert found_host is True, 'Assertion failed: host not found'


### PR DESCRIPTION
### Problem Statement
hammer host create did not previously support --lifecycle-environment options, only --lifecycle-environment-id

Now users should be able to create a host with --lifecycle-environment ['name'] set

### Solution

Automation to create a host using the --lifecycle-environment option 
