### PR TITLE
Mark fake secret as "notsecret"

### DIFF
--- a/tests/robottelo/test_dependencies.py
+++ b/tests/robottelo/test_dependencies.py
@@ -82,7 +82,7 @@ def test_productmd():
 def test_pyotp():
     import pyotp
 
-    fake_secret = 'JBSWY3DPEHPK3PXP'
+    fake_secret = 'JBSWY3DPEHPK3PXP'  # notsecret
     totp = pyotp.TOTP(fake_secret)
     assert totp.now()
 


### PR DESCRIPTION
### Problem Statement
Internal pre-commit hook complains on this line. It assumes that we are revealing a secret.

### Solution
Add a comment at the end of the line to tell the hook that it is not a secret.



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->