### PR TITLE
Fix flaky SyncPlans in cli_factory

### DIFF
--- a/robottelo/cli/syncplan.py
+++ b/robottelo/cli/syncplan.py
@@ -17,9 +17,20 @@ Subcommands::
     update
 """
 from robottelo.cli.base import Base
+from robottelo.exceptions import CLIError
 
 
 class SyncPlan(Base):
     """Manipulates Katello engine's sync-plan command."""
 
     command_base = 'sync-plan'
+
+    @classmethod
+    def create(cls, options=None):
+        """Create a SyncPlan"""
+        cls.command_sub = 'create'
+
+        if options.get('interval') == 'custom cron' and options.get('cron-expression') is None:
+            raise CLIError('Missing "cron-expression" option for "custom cron" interval.')
+
+        return super().create(options)

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -140,7 +140,9 @@ ENTITY_FIELDS = {
     'sync_plan': {
         'description': gen_alpha,
         'enabled': 'true',
-        'interval': lambda: random.choice(list(constants.SYNC_INTERVAL.values())),
+        'interval': lambda: random.choice(
+            [i for i in constants.SYNC_INTERVAL.values() if i != 'custom cron']
+        ),
         'name': gen_alpha,
         'sync-date': lambda: datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
     },

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -705,7 +705,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
     # Verify product has not been synced yet
     with pytest.raises(AssertionError):
         validate_task_status(target_sat, repo['id'], org.id, max_tries=1)
-    validate_repo_content(repo, ['errata', 'packages'], after_sync=False)
+    validate_repo_content(target_sat, repo, ['errata', 'packages'], after_sync=False)
     # Wait the rest of expected time
     logger.info(
         f"Waiting {(delay * 4 / 5)} seconds to check product {product['name']}"
@@ -714,7 +714,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
     sleep(delay * 4 / 5)
     # Verify product was synced successfully
     validate_task_status(target_sat, repo['id'], org.id)
-    validate_repo_content(repo, ['errata', 'packages'])
+    validate_repo_content(target_sat, repo, ['errata', 'packages'])
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
### Problem Statement
Some CLI SyncPlan tests are failing randomly. The reason is that `cli_factory` takes random `interval` (when not provided explicitly) in options and ignores that `custom cron` needs additional `cron-interval` option, so the tests fail on validation.
```
robottelo.exceptions.CLIFactoryError: Failed to create SyncPlan with data:
{ 'description': 'QpRNvtrDBf',
  'enabled': 'false',
  'interval': 'custom cron',
  'name': 'KwgvwcaNvc',
  'organization-id': 3,
  'sync-date': '2024-03-07 01:33:04'}
Command "sync-plan create" finished with status 70
stderr contains:
Could not create the sync plan:
  Cron expression is not valid!
```

Plus one small param fix forgotten in CLI refactor.


### Solution
Do not pick `custom cron` randomly from factory and check the `cron-interval` is provided when `custom cron` is used.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_syncplan.py
