### PR TITLE
[6.15.z] [Component Refresh] Component Names are updated

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -25,9 +25,8 @@ CaseComponent:
     - Branding
     - BVT
     - Candlepin
-    - Capsule
+    - ForemanProxy
     - Capsule-Content
-    - Certificates
     - ComputeResources
     - ComputeResources-Azure
     - ComputeResources-CNV
@@ -53,7 +52,7 @@ CaseComponent:
     - ErrataManagement
     - Fact
     - ForemanDebug
-    - ForemanMaintain
+    - SatelliteMaintain
     - Hammer
     - Hammer-Content
     - HTTPProxy
@@ -64,7 +63,7 @@ CaseComponent:
     - Hosts-Content
     - Infobloxintegration
     - Infrastructure
-    - Installer
+    - Installation
     - InterSatelliteSync
     - katello-tracer
     - LDAP
@@ -76,7 +75,6 @@ CaseComponent:
     - Networking
     - Notifications
     - OrganizationsandLocations
-    - Packaging
     - Parameters
     - Provisioning
     - ProvisioningTemplates
@@ -89,16 +87,12 @@ CaseComponent:
     - RemoteExecution
     - Reporting
     - Repositories
-    - RHCloud-CloudConnector
-    - RHCloud-Insights
-    - RHCloud-Inventory
+    - RHCloud
     - rubygem-foreman-redhat_access
-    - satellite-change-hostname
     - SatelliteClone
     - SCAPPlugin
     - Search
     - Security
-    - SELinux
     - Settings
     - SubscriptionManagement
     - Subscriptions-virt-who

--- a/tests/foreman/api/test_capsule.py
+++ b/tests/foreman/api/test_capsule.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Capsule
+:CaseComponent: ForemanProxy
 
 :Team: Platform
 

--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud-CloudConnector
+:CaseComponent: RHCloud
 
 :Team: Platform
 

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -1,10 +1,10 @@
 """API tests for RH Cloud - Inventory, also known as Insights Inventory Upload
 
-:Requirement: RH Cloud - Inventory
+:Requirement: RHCloud
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud-Inventory
+:CaseComponent: RHCloud
 
 :Team: Platform
 

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -1,10 +1,10 @@
 """Test class for the capsule CLI.
 
-:Requirement: Capsule
+:Requirement: ForemanProxy
 
 :CaseAutomation: Automated
 
-:CaseComponent: Capsule
+:CaseComponent: ForemanProxy
 
 :Team: Platform
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -1,10 +1,10 @@
 """Tests For Disconnected Satellite Installation
 
-:Requirement: Installer (disconnected satellite installation)
+:Requirement: Installation (disconnected satellite installation)
 
 :CaseAutomation: Automated
 
-:CaseComponent: Installer
+:CaseComponent: Installation
 
 :Team: Platform
 

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -1,10 +1,10 @@
 """CLI tests for RH Cloud - Inventory, aka Insights Inventory Upload
 
-:Requirement: RH Cloud - Inventory
+:Requirement: RHCloud
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud-Inventory
+:CaseComponent: RHCloud
 
 :Team: Platform
 

--- a/tests/foreman/destructive/test_capsule.py
+++ b/tests/foreman/destructive/test_capsule.py
@@ -1,10 +1,10 @@
 """Test class for the capsule CLI.
 
-:Requirement: Capsule
+:Requirement: ForemanProxy
 
 :CaseAutomation: Automated
 
-:CaseComponent: Capsule
+:CaseComponent: ForemanProxy
 
 :Team: Platform
 

--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Capsule
+:CaseComponent: ForemanProxy
 
 :Team: Platform
 

--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -1,10 +1,10 @@
 """Smoke tests to check installation health
 
-:Requirement: Installer
+:Requirement: Installation
 
 :CaseAutomation: Automated
 
-:CaseComponent: Installer
+:CaseComponent: Installation
 
 :Team: Platform
 

--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Certificates
+:CaseComponent: Installation
 
 :Team: Platform
 

--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 

--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: satellite-change-hostname
+:CaseComponent: Installation
 
 :Team: Platform
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1,10 +1,10 @@
 """Smoke tests to check installation health
 
-:Requirement: Installer
+:Requirement: Installation
 
 :CaseAutomation: Automated
 
-:CaseComponent: Installer
+:CaseComponent: Installation
 
 :Team: Platform
 

--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 

--- a/tests/foreman/maintain/test_offload_DB.py
+++ b/tests/foreman/maintain/test_offload_DB.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: ManualOnly
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 
@@ -28,5 +28,5 @@ def test_offload_internal_db_to_external_db_host():
 
     :expectedresults: Installed successful, all services running
 
-    :CaseComponent: Installer
+    :CaseComponent: Installation
     """

--- a/tests/foreman/maintain/test_packages.py
+++ b/tests/foreman/maintain/test_packages.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Certificates
+:CaseComponent: Installation
 
 :Team: Platform
 

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud-CloudConnector
+:CaseComponent: RHCloud
 
 :Team: Platform
 

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -1,10 +1,10 @@
 """Tests for RH Cloud - Inventory
 
-:Requirement: RH Cloud - Inventory
+:Requirement: RHCloud
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud-Inventory
+:CaseComponent: RHCloud
 
 :Team: Platform
 

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -1,10 +1,10 @@
 """Tests for RH Cloud - Inventory, also known as Insights Inventory Upload
 
-:Requirement: RH Cloud - Inventory
+:Requirement: RHCloud
 
 :CaseAutomation: Automated
 
-:CaseComponent: RHCloud-Inventory
+:CaseComponent: RHCloud
 
 :Team: Platform
 

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Capsule
+:CaseComponent: ForemanProxy
 
 :Team: Platform
 

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Installer
+:CaseComponent: Installation
 
 :Team: Platform
 

--- a/tests/upgrades/test_satellite_maintain.py
+++ b/tests/upgrades/test_satellite_maintain.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: ForemanMaintain
+:CaseComponent: SatelliteMaintain
 
 :Team: Platform
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14268

### Problem Statement
The component names are updated, split and removed in ohsnap. Collection of updated components would be broken based on those updated names as CI will have all those components in unaligned pipelines.


### Solution
The docstrings and tokens for those components needs to be updated to match with the ohsnap tokens.

### Related Issues
GitlabURL/satellite/ohsnap/-/merge_requests/1066
Please dont merge this PR until that is merged!

