### PR TITLE
[6.14.z] Update Ansible tests to reflect the new split Ansible components

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -15,7 +15,8 @@ CaseComponent:
     # No spaces allowed
     - ActivationKeys
     - AlternateContentSources
-    - Ansible
+    - Ansible-ConfigurationManagement
+    - Ansible-RemoteExecution
     - AnsibleCollection
     - API
     - AuditLog

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Ansible
+:CaseComponent: Ansible-ConfigurationManagement
 
 :Team: Rocket
 
@@ -41,8 +41,6 @@ def test_positive_ansible_e2e(target_sat, module_org, rhel_contenthost):
         2. Job execution must be successful.
         3. Operations performed with hammer must be successful.
 
-    :CaseAutomation: Automated
-
     :BZ: 2154184
 
     :customerscenario: true
@@ -53,7 +51,7 @@ def test_positive_ansible_e2e(target_sat, module_org, rhel_contenthost):
     SELECTED_ROLE_1 = 'theforeman.foreman_scap_client'
     SELECTED_VAR = gen_string('alpha')
     # disable batch tasks to test BZ#2154184
-    target_sat.cli.Settings.set({'name': "foreman_tasks_proxy_batch_trigger", 'value': "false"})
+    target_sat.cli.Settings.set({'name': 'foreman_tasks_proxy_batch_trigger', 'value': 'false'})
     if rhel_contenthost.os_version.major <= 7:
         rhel_contenthost.create_custom_repos(rhel7=settings.repos.rhel7_os)
         assert rhel_contenthost.execute('yum install -y insights-client').status == 0
@@ -121,7 +119,7 @@ def test_positive_ansible_e2e(target_sat, module_org, rhel_contenthost):
 @pytest.mark.tier2
 def test_add_and_remove_ansible_role_hostgroup(target_sat):
     """
-    Test add and remove functionality for ansible roles in hostgroup via cli
+    Test add and remove functionality for ansible roles in hostgroup via CLI
 
     :id: 2c6fda14-4cd2-490a-b7ef-7a08f8164fad
 
@@ -135,11 +133,9 @@ def test_add_and_remove_ansible_role_hostgroup(target_sat):
         5. Remove the added ansible roles from the host group
 
     :expectedresults:
-        1. Ansible role assign/add/remove functionality should work as expected in cli
+        1. Ansible role assign/add/remove functionality should work as expected in CLI
 
     :BZ: 2029402
-
-    :CaseAutomation: Automated
     """
     ROLES = [
         'theforeman.foreman_scap_client',

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -854,7 +854,7 @@ class TestAnsibleREX:
 
         :id: ad25aee5-4ea3-4743-a301-1c6271856f79
 
-        :CaseComponent: Ansible
+        :CaseComponent: Ansible-RemoteExecution
 
         :Team: Rocket
         """

--- a/tests/foreman/destructive/test_ansible.py
+++ b/tests/foreman/destructive/test_ansible.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Ansible
+:CaseComponent: Ansible-ConfigurationManagement
 
 :Team: Rocket
 
@@ -21,10 +21,6 @@ def test_positive_persistent_ansible_cfg_change(target_sat):
 
     :id: c22fcd47-8627-4230-aa1f-7d4fc8517a0e
 
-    :BZ: 1786358
-
-    :customerscenario: true
-
     :steps:
         1. Update value in ansible.cfg.
         2. Verify value is updated in the file.
@@ -33,6 +29,10 @@ def test_positive_persistent_ansible_cfg_change(target_sat):
 
     :expectedresults: Changes in ansible.cfg are persistent after running
         "satellite-installer".
+
+    :BZ: 1786358
+
+    :customerscenario: true
     """
     ansible_cfg = '/etc/ansible/ansible.cfg'
     param = 'local_tmp = /tmp'
@@ -49,7 +49,6 @@ def test_positive_import_all_roles(target_sat):
     :id: 53fe3857-a08f-493d-93c7-3fed331ed391
 
     :steps:
-
         1. Navigate to the Configure > Roles page.
         2. Click the `Import from [hostname]` button.
         3. Get total number of importable roles from pagination.

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -4,11 +4,11 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Ansible
+:CaseComponent: Ansible-ConfigurationManagement
 
 :Team: Rocket
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 """
 from fauxfactory import gen_string
@@ -111,7 +111,7 @@ def test_positive_config_report_ansible(session, target_sat, module_org, rhel_co
         1. Host should be assigned the proper role.
         2. Job report should be created.
 
-    :CaseImportance: Critical
+    :CaseComponent: Ansible-RemoteExecution
     """
     SELECTED_ROLE = 'RedHatInsights.insights-client'
     if rhel_contenthost.os_version.major <= 7:
@@ -176,7 +176,7 @@ def test_positive_ansible_custom_role(target_sat, session, module_org, rhel_cont
 
     :BZ: 2155392
 
-    :CaseAutomation: Automated
+    :CaseComponent: Ansible-RemoteExecution
     """
     SELECTED_ROLE = 'custom_role'
     playbook = f'{robottelo_tmp_dir}/playbook.yml'

--- a/tests/foreman/ui/test_jobinvocation.py
+++ b/tests/foreman/ui/test_jobinvocation.py
@@ -126,7 +126,7 @@ def test_positive_schedule_recurring_host_job(self):
 
     :id: 5052be04-28ab-4349-8bee-851ef76e4ffa
 
-    :caseComponent: Ansible
+    :caseComponent: Ansible-RemoteExecution
 
     :Team: Rocket
 
@@ -152,7 +152,7 @@ def test_positive_schedule_recurring_hostgroup_job(self):
 
     :id: c65db99b-11fe-4a32-89d0-0a4692b07efe
 
-    :caseComponent: Ansible
+    :caseComponent: Ansible-RemoteExecution
 
     :Team: Rocket
 

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -288,7 +288,7 @@ def test_positive_ansible_job_check_mode(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-RemoteExecution
 
     :Team: Rocket
     """
@@ -311,7 +311,7 @@ def test_positive_ansible_config_report_failed_tasks_errors(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """
@@ -335,7 +335,7 @@ def test_positive_ansible_config_report_changes_notice(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """
@@ -356,7 +356,7 @@ def test_positive_ansible_variables_imported_with_roles(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """
@@ -377,7 +377,7 @@ def test_positive_roles_import_in_background(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """
@@ -399,7 +399,7 @@ def test_positive_ansible_roles_ignore_list(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """
@@ -423,7 +423,7 @@ def test_positive_ansible_variables_installed_with_collection(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """
@@ -449,7 +449,7 @@ def test_positive_install_ansible_collection_via_job_invocation(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-RemoteExecution
 
     :Team: Rocket
     """
@@ -474,7 +474,7 @@ def test_positive_set_ansible_role_order_per_host(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """
@@ -501,7 +501,7 @@ def test_positive_set_ansible_role_order_per_hostgroup(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """
@@ -527,7 +527,7 @@ def test_positive_matcher_field_highlight(session):
 
     :CaseAutomation: NotAutomated
 
-    :CaseComponent: Ansible
+    :CaseComponent: Ansible-ConfigurationManagement
 
     :Team: Rocket
     """


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14302

### Problem Statement
Ansible component name is going to be split in ohsnap into "Ansible - Configuration Management " and "Ansible - Remote Execution" components
Pytest collection of updated components would be broken based on those updated names as CI will have all those components in unaligned pipelines.

### Solution
The docstrings and tokens for those components needs to be updated to match with the ohsnap tokens.

### Related Issues
1. https://github.com/SatelliteQE/robottelo/pull/14268
2. GitlabURL/satellite/ohsnap/-/merge_requests/1066
Please dont merge this PR until that is merged!