### PR TITLE
Fix number of imported templates

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1791,6 +1791,14 @@ SATELLITE_MAINTAIN_YML = "/etc/foreman-maintain/foreman_maintain.yml"
 FOREMAN_SETTINGS_YML = '/etc/foreman/settings.yaml'
 
 FOREMAN_TEMPLATE_IMPORT_URL = 'https://github.com/SatelliteQE/foreman_templates.git'
+FOREMAN_TEMPLATES_IMPORT_COUNT = {
+    'PUPPET_ENABLED': 18,
+    'PUPPET_DISABLED': 17,
+}
+FOREMAN_TEMPLATES_NOT_IMPORTED_COUNT = {
+    'PUPPET_ENABLED': 8,
+    'PUPPET_DISABLED': 9,
+}
 FOREMAN_TEMPLATE_IMPORT_API_URL = 'http://api.github.com/repos/SatelliteQE/foreman_templates'
 
 FOREMAN_TEMPLATE_TEST_TEMPLATE = (

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -23,6 +23,8 @@ from robottelo.constants import (
     FOREMAN_TEMPLATE_IMPORT_URL,
     FOREMAN_TEMPLATE_ROOT_DIR,
     FOREMAN_TEMPLATE_TEST_TEMPLATE,
+    FOREMAN_TEMPLATES_IMPORT_COUNT,
+    FOREMAN_TEMPLATES_NOT_IMPORTED_COUNT,
 )
 from robottelo.logging import logger
 
@@ -168,7 +170,12 @@ class TestTemplateSyncTestCase:
         not_imported_count = [
             template['imported'] for template in filtered_imported_templates['message']['templates']
         ].count(False)
-        assert not_imported_count == 9
+        exp_not_imported_count = (
+            FOREMAN_TEMPLATES_NOT_IMPORTED_COUNT["PUPPET_ENABLED"]
+            if "puppet" in module_target_sat.get_features()
+            else FOREMAN_TEMPLATES_NOT_IMPORTED_COUNT["PUPPET_DISABLED"]
+        )
+        assert not_imported_count == exp_not_imported_count
         ptemplates = module_target_sat.api.ProvisioningTemplate().search(
             query={'per_page': '100', 'search': 'name~jenkins', 'organization_id': module_org.id}
         )
@@ -955,7 +962,12 @@ class TestTemplateSyncTestCase:
         imported_count = [
             template['imported'] for template in imported_templates['message']['templates']
         ].count(True)
-        assert imported_count == 17  # Total Count
+        exp_count = (
+            FOREMAN_TEMPLATES_IMPORT_COUNT["PUPPET_ENABLED"]
+            if "puppet" in target_sat.get_features()
+            else FOREMAN_TEMPLATES_IMPORT_COUNT["PUPPET_DISABLED"]
+        )
+        assert imported_count == exp_count  # Total Count
         # Export some filtered templates to local dir
         _, dir_path = create_import_export_local_dir
         exported_templates = target_sat.api.Template().exports(
@@ -964,7 +976,7 @@ class TestTemplateSyncTestCase:
         exported_count = [
             template['exported'] for template in exported_templates['message']['templates']
         ].count(True)
-        assert exported_count == 17
+        assert exported_count == exp_count
         assert 'name' in exported_templates['message']['templates'][0]
         assert (
             target_sat.execute(


### PR DESCRIPTION
The number of total templates and templates
containing robottelo should match this repo and branch https://github.com/SatelliteQE/foreman_templates/tree/automation

I have no idea why it was once changed to a wrong number without further explanation:
https://github.com/SatelliteQE/robottelo/commit/95434f5e3b184732fe963874d19b747a02241edb





<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->