### PR TITLE
[6.14.z] Broker dependency updated to resolve ssh2-python limitation/packagever issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,5 +35,5 @@ git+https://github.com/SatelliteQE/nailgun.git@6.14.z#egg=nailgun
 # In the meantime, we install directly from the repo
 # [1] - https://github.com/ParallelSSH/ssh2-python/issues/193
 # [2] - https://github.com/pypi/warehouse/issues/7136
-git+https://github.com/SatelliteQE/broker.git@0.4.5#egg=broker
+git+https://github.com/SatelliteQE/broker.git@0.4.7#egg=broker
 --editable .


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14275

### Problem Statement
Checks in Robottelo PRs failing due to last broker version 0.4.5 where we have seen rate limit issue as well as packageName issue for new repo ssh2-python312


### Solution
The issue  is resolved in latest 0.4.7 version.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->