### PR TITLE
[6.14.z] component name changes

### DIFF
--- a/testimony.yaml
+++ b/testimony.yaml
@@ -47,8 +47,6 @@ CaseComponent:
     - DiscoveryImage
     - DiscoveryPlugin
     - Documentation
-    - Dynflow
-    - Email
     - Entitlements
     - ErrataManagement
     - Fact
@@ -68,7 +66,6 @@ CaseComponent:
     - InterSatelliteSync
     - katello-agent
     - katello-tracer
-    - LDAP
     - Leappintegration
     - LifecycleEnvironments
     - LocalizationInternationalization

--- a/tests/foreman/api/test_ldapauthsource.py
+++ b/tests/foreman/api/test_ldapauthsource.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: LDAP
+:CaseComponent: Authentication
 
 :Team: Endeavour
 

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: LDAP
+:CaseComponent: Authentication
 
 :Team: Endeavour
 

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: LDAP
+:CaseComponent: Authentication
 
 :Team: Endeavour
 

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: LDAP
+:CaseComponent: Authentication
 
 :Team: Endeavour
 

--- a/tests/foreman/destructive/test_ldapauthsource.py
+++ b/tests/foreman/destructive/test_ldapauthsource.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: LDAP
+:CaseComponent: Authentication
 
 :Team: Endeavour
 

--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -2,11 +2,11 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: Dynflow
+:CaseComponent: TasksPlugin
 
 :Team: Endeavour
 
-:Requirement: Dynflow
+:Requirement: TasksPlugin
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -4,7 +4,7 @@
 
 :CaseAutomation: Automated
 
-:CaseComponent: LDAP
+:CaseComponent: Authentication
 
 :Team: Endeavour
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14380

Updated component names as needed