### PR TITLE
[6.15.z] update fixture name as per expected feature

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -442,7 +442,7 @@ def test_positive_os_restriction_on_repos():
     """
 
 
-def test_positive_async_endpoint_for_manifest_refresh(target_sat, module_entitlement_manifest_org):
+def test_positive_async_endpoint_for_manifest_refresh(target_sat, function_sca_manifest_org):
     """Verify that manifest refresh is using an async endpoint. Previously this was a single,
     synchronous endpoint. The endpoint to retrieve manifests is now split into two: an async
     endpoint to start "exporting" the manifest, and a second endpoint to download the
@@ -461,12 +461,12 @@ def test_positive_async_endpoint_for_manifest_refresh(target_sat, module_entitle
 
     :BZ: 2066323
     """
-    sub = target_sat.api.Subscription(organization=module_entitlement_manifest_org)
+    sub = target_sat.api.Subscription(organization=function_sca_manifest_org)
     # set log level to 'debug' and restart services
     target_sat.cli.Admin.logging({'all': True, 'level-debug': True})
     target_sat.cli.Service.restart()
     # refresh manifest and assert new log message to confirm async endpoint
-    sub.refresh_manifest(data={'organization_id': module_entitlement_manifest_org.id})
+    sub.refresh_manifest(data={'organization_id': function_sca_manifest_org.id})
     results = target_sat.execute(
         'grep "Sending GET request to upstream Candlepin" /var/log/foreman/production.log'
     )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14375

### Problem Statement
test `test_positive_async_endpoint_for_manifest_refresh` was failing due to manifest issue inside `module_entitlement_manifest_org > upload_manifest`
Basically unable to upload manifest and return org, as per current feature we are supposed to use sca enabled organization

### Solution
This PR would fix the issue

### Related Issues
N/A

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_subscription.py -k 'test_positive_async_endpoint_for_manifest_refresh'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->