### PR TITLE
changes in test_positive_run_job_on_host_converted_to_pull_provider

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -1302,15 +1302,11 @@ class TestPullProviderRex:
         assert_job_invocation_result(
             module_target_sat, invocation_command['id'], rhel_contenthost.hostname
         )
-        # check katello-agent runs along ygdrassil (SAT-1671)
-        result = rhel_contenthost.execute('systemctl status goferd')
-        assert result.status == 0, 'Failed to start goferd on client'
-
         # run Ansible rex command to prove ssh provider works, remove katello-agent
         invocation_command = module_target_sat.cli_factory.job_invocation(
             {
-                'job-template': 'Package Action - Ansible Default',
-                'inputs': 'state=absent, name=katello-agent',
+                'job-template': 'Remove Package - Katello Script Default',
+                'inputs': 'package=katello-agent',
                 'search-query': f"name ~ {rhel_contenthost.hostname}",
             }
         )


### PR DESCRIPTION
### Problem Statement

Katello-agent is long deprecated, though as per my discussion with team phoenix it still makes sense to test module_capsule_configured_mqtt conversion as it might be used to convert hosts re-registered from older versions.

The context is now different from the time this test was created, so I'm making some changes. Insisting on deprecated goferd running is a source of potential flakiness in the future. I also stopped using ansible rex here as it clashes with the `remote_execution_global_proxy=False` setting -- the setting takes priority as it ensures that we don't get false positive result in case of any mqtt capsule issue.



