### PR TITLE
Add test case to trigger the reclaim_space task

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Version updates managed by dependabot
 
+apypie==0.4.0
 betelgeuse==1.11.0
 # broker[docker]==0.4.1 - Temporarily disabled, see below
 cryptography==42.0.5

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1826,7 +1826,7 @@ class Satellite(Capsule, SatelliteMixins):
                 username=settings.server.admin_username,
                 password=settings.server.admin_password,
                 api_version=2,
-                verify_ssl=False,
+                verify_ssl=settings.server.verify_ca,
             ).apidoc
         return self._apidoc
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -14,6 +14,7 @@ import time
 from urllib.parse import urljoin, urlparse, urlunsplit
 import warnings
 
+import apypie
 from box import Box
 from broker import Broker
 from broker.hosts import Host
@@ -1762,6 +1763,7 @@ class Satellite(Capsule, SatelliteMixins):
         # create dummy classes for later population
         self._api = type('api', (), {'_configured': False})
         self._cli = type('cli', (), {'_configured': False})
+        self._apidoc = None
         self.record_property = None
 
     def _swap_nailgun(self, new_version):
@@ -1814,6 +1816,19 @@ class Satellite(Capsule, SatelliteMixins):
                 pass
         self._api._configured = True
         return self._api
+
+    @property
+    def apidoc(self):
+        """Provide Satellite's apidoc via apypie"""
+        if not self._apidoc:
+            self._apidoc = apypie.Api(
+                uri=self.url,
+                username=settings.server.admin_username,
+                password=settings.server.admin_password,
+                api_version=2,
+                verify_ssl=False,
+            ).apidoc
+        return self._apidoc
 
     @property
     def cli(self):

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1752,11 +1752,16 @@ class TestCapsuleContentManagement:
         assert 'success' in task['result'], 'Reclaim task did not succeed'
 
         # Check the apidoc references the correct endpoint
-        reclaim_doc = next(
-            method
-            for method in target_sat.apidoc['docs']['resources']['capsule_content']['methods']
-            if '/apidoc/v2/capsule_content/reclaim_space' in method['doc_url']
-        )
+        try:
+            reclaim_doc = next(
+                method
+                for method in target_sat.apidoc['docs']['resources']['capsule_content']['methods']
+                if '/apidoc/v2/capsule_content/reclaim_space' in method['doc_url']
+            )
+        except StopIteration:
+            raise AssertionError(
+                'Could not find the reclaim_space apidoc at the expected path.'
+            ) from None
         assert len(reclaim_doc['apis']) == 1
         assert reclaim_doc['apis'][0]['http_method'] == 'POST', 'POST method was expected.'
         assert (


### PR DESCRIPTION
### Problem Statement
A test case (and nailgun support) to trigger the Reclaim space task was missing. Also a BZ complained about wrong endpoint being referenced in apidoc.


### Solution
This PR adds one.


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k 'reclaim_space'
nailgun: 1111