### PR TITLE
Bump Broker to 0.4.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,6 @@ wait-for==1.2.0
 wrapanapi==3.6.0
 
 # Get airgun, nailgun and upgrade from master
-git+https://github.com/SatelliteQE/airgun.git@master#egg=airgun
-git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun
+airgun @ git+https://github.com/SatelliteQE/airgun.git@master#egg=airgun
+nailgun @ git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun
 --editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Version updates managed by dependabot
 
 betelgeuse==1.11.0
-broker[docker]==0.4.8
+broker[docker]==0.4.9
 cryptography==42.0.5
 deepdiff==6.7.1
 dynaconf[vault]==3.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,14 @@
 # Version updates managed by dependabot
 
 betelgeuse==1.11.0
-# broker[docker]==0.4.1 - Temporarily disabled, see below
+broker[docker]==0.4.8
 cryptography==42.0.5
 deepdiff==6.7.1
-docker==7.0.0  # Temporary until Broker is back on PyPi
 dynaconf[vault]==3.2.4
 fauxfactory==3.1.0
 jinja2==3.1.3
 manifester==0.0.14
 navmazing==1.2.2
-paramiko==3.4.0  # Temporary until Broker is back on PyPi
 productmd==1.38
 pyotp==2.9.0
 python-box==7.1.1
@@ -32,9 +30,4 @@ wrapanapi==3.6.0
 # Get airgun, nailgun and upgrade from master
 git+https://github.com/SatelliteQE/airgun.git@master#egg=airgun
 git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun
-# Broker currently is unable to push to PyPi due to [1] and [2]
-# In the meantime, we install directly from the repo
-# [1] - https://github.com/ParallelSSH/ssh2-python/issues/193
-# [2] - https://github.com/pypi/warehouse/issues/7136
-git+https://github.com/SatelliteQE/broker.git@0.4.7#egg=broker
 --editable .


### PR DESCRIPTION
Now that Broker is back on PyPI, let's clean up the requirements

trigger: test-robottelo
pytest: tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'