### PR TITLE
[6.14.z] change a way to upload content into satellite

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2331,13 +2331,14 @@ class TestFileRepository:
 
         :CaseAutomation: Automated
         """
-        repo.upload_content(files={'content': DataFile.RPM_TO_UPLOAD.read_bytes()})
+        with open(DataFile.FAKE_FILE_NEW_NAME, 'rb') as handle:
+            repo.upload_content(files={'content': handle})
         assert repo.read().content_counts['file'] == 1
 
         filesearch = target_sat.api.File().search(
-            query={"search": f"name={constants.RPM_TO_UPLOAD}"}
+            query={"search": f"name={constants.FAKE_FILE_NEW_NAME}"}
         )
-        assert filesearch[0].name == constants.RPM_TO_UPLOAD
+        assert filesearch[0].name == constants.FAKE_FILE_NEW_NAME
 
     @pytest.mark.tier1
     @pytest.mark.upgrade


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14393

### Problem Statement
**Regression-** In repository api tests, content was uploaded as a file named `content` (can see on web ui) but unabled to search uploaded file content using api call.

**Error-**
```
tests/foreman/api/test_repository.py:2304: in test_positive_upload_file_to_file_repo
    assert filesearch[0].name == constants.RPM_TO_UPLOAD
E   IndexError: list index out of range
```

### Solution
By using open context manager able to upload content and search using api call.

### Related Issues
N/A

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k 'test_positive_upload_file_to_file_repo'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->