### PR TITLE
[6.15.z] Use manifester from fixture

### DIFF
--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -11,7 +11,6 @@
 :CaseImportance: Critical
 
 """
-from manifester import Manifester
 from nailgun.entity_mixins import call_entity_method_with_timeout
 import pytest
 from requests.exceptions import HTTPError
@@ -187,7 +186,7 @@ def test_positive_sync_kickstart_repo(module_sca_manifest_org, target_sat):
 
 
 @pytest.mark.tier1
-def test_negative_upload_expired_manifest(module_org, target_sat):
+def test_negative_upload_expired_manifest(module_org, target_sat, function_entitlement_manifest):
     """Upload an expired manifest and attempt to refresh it
 
     :id: d6e652d8-5f46-4d15-9191-d842466d45d0
@@ -199,10 +198,9 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
 
     :expectedresults: Manifest refresh should fail and return error message
     """
-    manifester = Manifester(manifest_category=settings.manifest.entitlement)
-    manifest = manifester.get_manifest()
+    manifest = function_entitlement_manifest.get_manifest()
     target_sat.upload_manifest(module_org.id, manifest.content)
-    manifester.delete_subscription_allocation()
+    function_entitlement_manifest.delete_subscription_allocation()
     with pytest.raises(CLIReturnCodeError) as error:
         target_sat.cli.Subscription.refresh_manifest({'organization-id': module_org.id})
     assert (

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -11,11 +11,9 @@
 :CaseImportance: High
 
 """
-from manifester import Manifester
 import pytest
 
 from robottelo import constants
-from robottelo.config import settings
 from robottelo.hosts import ContentHost
 
 
@@ -144,7 +142,9 @@ class TestSubscriptionAutoAttach:
 
     @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
     @pytest.mark.post_upgrade(depend_on=test_pre_subscription_scenario_auto_attach)
-    def test_post_subscription_scenario_auto_attach(self, request, target_sat, pre_upgrade_data):
+    def test_post_subscription_scenario_auto_attach(
+        self, request, target_sat, pre_upgrade_data, function_entitlement_manifest
+    ):
         """Run subscription auto-attach on pre-upgrade content host registered
         with Satellite.
 
@@ -172,6 +172,6 @@ class TestSubscriptionAutoAttach:
         sub = target_sat.api.Subscription(organization=org)
         sub.delete_manifest(data={'organization_id': org.id})
         assert len(sub.search()) == 0
-        manifester = Manifester(manifest_category=settings.manifest.entitlement)
+        manifester = function_entitlement_manifest
         manifester.allocation_uuid = pre_upgrade_data.allocation_uuid
         request.addfinalizer(manifester.delete_subscription_allocation)


### PR DESCRIPTION
https://github.com/SatelliteQE/robottelo/pull/14377



We should check with the authors of these tests, but I believe it was by design that they did not use Manifester via fixtures in these cases. function_entitlement_manifest returns a Request object, not a Manifester object, so the Manifester instance methods are not available to it or the other Manifester fixtures. If a test requires Manifester instance methods, it's currently necessary to instantiate Manifester locally in order to access those methods.

@omkarkhatavkar @ColeHiggins2 can you confirm that these tests are intentionally instantiating Manifester objects?



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->