### PR TITLE
[6.13.z] Skip orphan cleanup case for n_minus scenario

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1291,7 +1291,7 @@ class TestCapsuleContentManagement:
         :BZ: 22043089, 2211962
 
         """
-        if not pytestconfig.option.n_minus:
+        if pytestconfig.option.n_minus:
             pytest.skip('Test cannot be run on n-minus setups session-scoped capsule')
         # Enable RHST repo and sync it to the Library LCE.
         repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14371

### Problem Statement
Orphan cleanup test case should be skipped for n_minus scenario but run in normal runs.


### Solution
Flip the logic.

