### PR TITLE
[6.14.z] Eval CapsuleContent::API Assertion Errors, time delta/format in 'wait_for_sync()'

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -12,7 +12,8 @@ interactions and use capsule.
 :CaseImportance: High
 
 """
-from datetime import datetime
+
+from datetime import datetime, timedelta
 import re
 from time import sleep
 
@@ -20,9 +21,24 @@ from nailgun import client
 from nailgun.entity_mixins import call_entity_method_with_timeout
 import pytest
 
-from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import DataFile
+from robottelo.constants import (
+    CONTAINER_CLIENTS,
+    ENVIRONMENT,
+    FAKE_1_YUM_REPOS_COUNT,
+    FAKE_3_YUM_REPO_RPMS,
+    FAKE_3_YUM_REPOS_COUNT,
+    FAKE_FILE_LARGE_COUNT,
+    FAKE_FILE_LARGE_URL,
+    FAKE_FILE_NEW_NAME,
+    KICKSTART_CONTENT,
+    PRDS,
+    REPOS,
+    REPOSET,
+    RH_CONTAINER_REGISTRY_HUB,
+    RPM_TO_UPLOAD,
+    DataFile,
+)
 from robottelo.constants.repos import ANSIBLE_GALAXY
 from robottelo.content_info import (
     get_repo_files_by_url,
@@ -79,13 +95,13 @@ class TestCapsuleContentManagement:
 
         assert repo.read().content_counts['rpm'] == 1
 
+        timestamp = datetime.utcnow().replace(microsecond=0)
         # Publish new version of the content view
         cv.publish()
+        # query sync status as publish invokes sync, task succeeds
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cv = cv.read()
-
         assert len(cv.version) == 1
-
-        module_capsule_configured.wait_for_sync()
 
         # Verify the RPM published on Capsule
         caps_repo_url = module_capsule_configured.get_published_repo_url(
@@ -97,7 +113,7 @@ class TestCapsuleContentManagement:
         )
         caps_files = get_repo_files_by_url(caps_repo_url)
         assert len(caps_files) == 1
-        assert caps_files[0] == constants.RPM_TO_UPLOAD
+        assert caps_files[0] == RPM_TO_UPLOAD
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients', 'fake_manifest')
@@ -141,16 +157,16 @@ class TestCapsuleContentManagement:
         repo = repo.read()
         cv.publish()
         cv = cv.read()
-
         assert len(cv.version) == 1
 
         cvv = cv.version[-1].read()
+        timestamp = datetime.utcnow()
+        # promote to capsule lce, invoking sync tasks
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
-
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Verify repodata's checksum type is sha256, not sha1 on capsule
         repo_url = module_capsule_configured.get_published_repo_url(
@@ -173,17 +189,16 @@ class TestCapsuleContentManagement:
         repo.sync()
         cv.publish()
         cv = cv.read()
-
         assert len(cv.version) == 2
 
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
-
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Verify repodata's checksum type has updated to sha1 on capsule
         repomd = get_repomd(repo_url)
@@ -253,11 +268,12 @@ class TestCapsuleContentManagement:
         assert len(cv.version) == 1
 
         cvv = cv.version[-1].read()
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Upload more content to the repository
         with open(DataFile.SRPM_TO_UPLOAD, 'rb') as handle:
@@ -272,11 +288,12 @@ class TestCapsuleContentManagement:
 
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Check the content is synced on the Capsule side properly
         sat_repo_url = target_sat.get_published_repo_url(
@@ -349,22 +366,28 @@ class TestCapsuleContentManagement:
         # Publish new version of the content view
         cv.publish()
         cv = cv.read()
-
         assert len(cv.version) == 1
-
         cvv = cv.version[-1].read()
-        # Promote content view to lifecycle environment
-        cvv.promote(data={'environment_ids': function_lce.id})
-        cvv = cvv.read()
 
+        # prior to trigger (promoting), assert no active sync tasks
+        active_tasks = module_capsule_configured.nailgun_capsule.content_get_sync(
+            synchronous=False, timeout=600
+        )['active_sync_tasks']
+        assert len(active_tasks) == 0
+
+        # Promote content view to lifecycle environment,
+        # invoking capsule sync task(s)
+        timestamp = datetime.utcnow()
+        cvv.promote(data={'environment_ids': function_lce.id})
+        # wait for and validate the invoked task(s)
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
+        cvv = cvv.read()
         assert len(cvv.environment) == 2
 
         # Content of the published content view in
         # lifecycle environment should equal content of the
         # repository
         assert repo.content_counts['rpm'] == cvv.package_count
-
-        module_capsule_configured.wait_for_sync()
 
         # Assert that the content published on the capsule is exactly the
         # same as in repository on satellite
@@ -400,14 +423,14 @@ class TestCapsuleContentManagement:
         cv = cv.read()
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
-        # Promote new content view version to lifecycle environment
+        # Promote new content view version to lifecycle environment,
+        # capsule sync task(s) invoked and succeed
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
-
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
-
         # Assert that the value of repomd revision of repository in
         # lifecycle environment on the capsule has not changed
         new_lce_revision_capsule = get_repomd_revision(caps_repo_url)
@@ -423,20 +446,21 @@ class TestCapsuleContentManagement:
         cv = cv.read()
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
-        cvv.promote(data={'environment_ids': function_lce.id})
-        cvv = cvv.read()
 
+        timestamp = datetime.utcnow()
+        cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
+        cvv = cvv.read()
         assert len(cvv.environment) == 2
 
         # Assert that packages count in the repository is updated
-        assert repo.content_counts['rpm'] == (constants.FAKE_1_YUM_REPOS_COUNT + 1)
+        assert repo.content_counts['rpm'] == (FAKE_1_YUM_REPOS_COUNT + 1)
 
         # Assert that the content of the published content view in
         # lifecycle environment is exactly the same as content of the
         # repository
         assert repo.content_counts['rpm'] == cvv.package_count
-
-        module_capsule_configured.wait_for_sync()
 
         # Assert that the content published on the capsule is exactly the
         # same as in the repository
@@ -447,7 +471,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'clients')
     def test_positive_iso_library_sync(
-        self, module_capsule_configured, module_entitlement_manifest_org, module_target_sat
+        self, module_capsule_configured, module_sca_manifest_org, module_target_sat
     ):
         """Ensure RH repo with ISOs after publishing to Library is synchronized
         to capsule automatically
@@ -463,18 +487,18 @@ class TestCapsuleContentManagement:
         # Enable & sync RH repository with ISOs
         rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_entitlement_manifest_org.id,
-            product=constants.PRDS['rhsc'],
-            repo=constants.REPOS['rhsc7_iso']['name'],
-            reposet=constants.REPOSET['rhsc7_iso'],
+            org_id=module_sca_manifest_org.id,
+            product=PRDS['rhsc'],
+            repo=REPOS['rhsc7_iso']['name'],
+            reposet=REPOSET['rhsc7_iso'],
             releasever=None,
         )
         rh_repo = module_target_sat.api.Repository(id=rh_repo_id).read()
         call_entity_method_with_timeout(rh_repo.sync, timeout=2500)
         # Find "Library" lifecycle env for specific organization
         lce = module_target_sat.api.LifecycleEnvironment(
-            organization=module_entitlement_manifest_org
-        ).search(query={'search': f'name={constants.ENVIRONMENT}'})[0]
+            organization=module_sca_manifest_org
+        ).search(query={'search': f'name={ENVIRONMENT}'})[0]
 
         # Associate the lifecycle environment with the capsule
         module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
@@ -487,23 +511,23 @@ class TestCapsuleContentManagement:
 
         # Create a content view with the repository
         cv = module_target_sat.api.ContentView(
-            organization=module_entitlement_manifest_org, repository=[rh_repo]
+            organization=module_sca_manifest_org, repository=[rh_repo]
         ).create()
         # Publish new version of the content view
+        timestamp = datetime.utcnow()
         cv.publish()
-        cv = cv.read()
 
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
+        cv = cv.read()
         assert len(cv.version) == 1
 
         # Verify ISOs are present on satellite
         sat_isos = get_repo_files_by_url(rh_repo.full_path, extension='iso')
         assert len(sat_isos) == 4
 
-        module_capsule_configured.wait_for_sync()
-
         # Verify all the ISOs are present on capsule
         caps_path = (
-            f'{module_capsule_configured.url}/pulp/content/{module_entitlement_manifest_org.label}'
+            f'{module_capsule_configured.url}/pulp/content/{module_sca_manifest_org.label}'
             f'/{lce.label}/{cv.label}/content/dist/rhel/server/7/7Server/x86_64/sat-capsule/6.4/'
             'iso/'
         )
@@ -536,8 +560,8 @@ class TestCapsuleContentManagement:
                the original package from the upstream repo
         """
         repo_url = settings.repos.yum_3.url
-        packages_count = constants.FAKE_3_YUM_REPOS_COUNT
-        package = constants.FAKE_3_YUM_REPO_RPMS[0]
+        packages_count = FAKE_3_YUM_REPOS_COUNT
+        package = FAKE_3_YUM_REPO_RPMS[0]
         repo = target_sat.api.Repository(
             download_policy='on_demand',
             mirroring_policy='mirror_complete',
@@ -569,12 +593,12 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
-
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Verify packages on Capsule match the source
         caps_repo_url = module_capsule_configured.get_published_repo_url(
@@ -620,7 +644,7 @@ class TestCapsuleContentManagement:
             filesystem contains valid links to packages
         """
         repo_url = settings.repos.yum_1.url
-        packages_count = constants.FAKE_1_YUM_REPOS_COUNT
+        packages_count = FAKE_1_YUM_REPOS_COUNT
         repo = target_sat.api.Repository(
             download_policy='on_demand',
             mirroring_policy='mirror_complete',
@@ -651,12 +675,12 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
-
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Update download policy to 'immediate'
         repo.download_policy = 'immediate'
@@ -679,12 +703,12 @@ class TestCapsuleContentManagement:
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
-
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Verify the count of RPMs published on Capsule
         caps_repo_url = module_capsule_configured.get_published_repo_url(
@@ -726,7 +750,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.skip_if_not_set('capsule', 'clients')
     @pytest.mark.parametrize('distro', ['rhel7', 'rhel8_bos', 'rhel9_bos'])
     def test_positive_sync_kickstart_repo(
-        self, target_sat, module_capsule_configured, function_entitlement_manifest_org, distro
+        self, target_sat, module_capsule_configured, function_sca_manifest_org, distro
     ):
         """Sync kickstart repository to the capsule.
 
@@ -747,16 +771,14 @@ class TestCapsuleContentManagement:
         """
         repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=function_entitlement_manifest_org.id,
-            product=constants.REPOS['kickstart'][distro]['product'],
-            reposet=constants.REPOS['kickstart'][distro]['reposet'],
-            repo=constants.REPOS['kickstart'][distro]['name'],
-            releasever=constants.REPOS['kickstart'][distro]['version'],
+            org_id=function_sca_manifest_org.id,
+            product=REPOS['kickstart'][distro]['product'],
+            reposet=REPOS['kickstart'][distro]['reposet'],
+            repo=REPOS['kickstart'][distro]['name'],
+            releasever=REPOS['kickstart'][distro]['version'],
         )
         repo = target_sat.api.Repository(id=repo_id).read()
-        lce = target_sat.api.LifecycleEnvironment(
-            organization=function_entitlement_manifest_org
-        ).create()
+        lce = target_sat.api.LifecycleEnvironment(organization=function_sca_manifest_org).create()
         # Associate the lifecycle environment with the capsule
         module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
             data={'environment_id': lce.id}
@@ -771,7 +793,7 @@ class TestCapsuleContentManagement:
 
         # Create a content view with the repository
         cv = target_sat.api.ContentView(
-            organization=function_entitlement_manifest_org, repository=[repo]
+            organization=function_sca_manifest_org, repository=[repo]
         ).create()
         # Sync repository
         repo.sync(timeout='10m')
@@ -784,26 +806,26 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
-
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Check for kickstart content on SAT and CAPS
         tail = (
-            f'rhel/server/7/{constants.REPOS["kickstart"][distro]["version"]}/x86_64/kickstart'
+            f'rhel/server/7/{REPOS["kickstart"][distro]["version"]}/x86_64/kickstart'
             if distro == 'rhel7'
-            else f'{distro.split("_")[0]}/{constants.REPOS["kickstart"][distro]["version"]}/x86_64/baseos/kickstart'  # noqa:E501
+            else f'{distro.split("_")[0]}/{REPOS["kickstart"][distro]["version"]}/x86_64/baseos/kickstart'  # noqa:E501
         )
         url_base = (
-            f'pulp/content/{function_entitlement_manifest_org.label}/{lce.label}/{cv.label}/'
+            f'pulp/content/{function_sca_manifest_org.label}/{lce.label}/{cv.label}/'
             f'content/dist/{tail}'
         )
 
         # Check kickstart specific files
-        for file in constants.KICKSTART_CONTENT:
+        for file in KICKSTART_CONTENT:
             sat_file = target_sat.md5_by_url(f'{target_sat.url}/{url_base}/{file}')
             caps_file = target_sat.md5_by_url(f'{module_capsule_configured.url}/{url_base}/{file}')
             assert sat_file == caps_file
@@ -883,11 +905,12 @@ class TestCapsuleContentManagement:
 
         # Promote the latest CV version into capsule's LCE
         cvv = cv.version[-1].read()
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Pull the images from capsule to the content host
         repo_paths = [
@@ -898,7 +921,7 @@ class TestCapsuleContentManagement:
             for repo in repos
         ]
 
-        for con_client in constants.CONTAINER_CLIENTS:
+        for con_client in CONTAINER_CLIENTS:
             result = container_contenthost.execute(
                 f'{con_client} login -u {settings.server.admin_username}'
                 f' -p {settings.server.admin_password} {module_capsule_configured.hostname}'
@@ -1001,10 +1024,12 @@ class TestCapsuleContentManagement:
         assert function_lce_library.id in [capsule_lce['id'] for capsule_lce in result['results']]
 
         # Sync the repo
+        timestamp = datetime.utcnow()
         repo.sync(timeout=600)
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         repo = repo.read()
         assert repo.content_counts['ansible_collection'] == 2
-        module_capsule_configured.wait_for_sync()
 
         repo_path = repo.full_path.replace(target_sat.hostname, module_capsule_configured.hostname)
         coll_path = './collections'
@@ -1059,7 +1084,7 @@ class TestCapsuleContentManagement:
         repo = target_sat.api.Repository(
             content_type='file',
             product=function_product,
-            url=constants.FAKE_FILE_LARGE_URL,
+            url=FAKE_FILE_LARGE_URL,
         ).create()
         repo.sync()
 
@@ -1083,11 +1108,12 @@ class TestCapsuleContentManagement:
 
         # Promote the latest CV version into capsule's LCE
         cvv = cv.version[-1].read()
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()
 
         # Run one more sync, check for status (BZ#1985122)
         sync_status = module_capsule_configured.nailgun_capsule.content_sync()
@@ -1110,8 +1136,8 @@ class TestCapsuleContentManagement:
         )
         sat_files = get_repo_files_by_url(sat_repo_url, extension='iso')
         caps_files = get_repo_files_by_url(caps_repo_url, extension='iso')
-        assert len(sat_files) == len(caps_files) == constants.FAKE_FILE_LARGE_COUNT + 1
-        assert constants.FAKE_FILE_NEW_NAME in caps_files
+        assert len(sat_files) == len(caps_files) == FAKE_FILE_LARGE_COUNT + 1
+        assert FAKE_FILE_NEW_NAME in caps_files
         assert sat_files == caps_files
 
         for file in sat_files:
@@ -1122,7 +1148,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_CV_to_multiple_LCEs(
-        self, target_sat, module_capsule_configured, module_manifest_org
+        self, target_sat, module_capsule_configured, module_sca_manifest_org
     ):
         """Synchronize a CV to multiple LCEs at the same time.
         All sync tasks should succeed.
@@ -1147,19 +1173,19 @@ class TestCapsuleContentManagement:
         # Sync a repository to the Satellite.
         repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_manifest_org.id,
-            product=constants.PRDS['rhel'],
-            repo=constants.REPOS['rhel7_extra']['name'],
-            reposet=constants.REPOSET['rhel7_extra'],
+            org_id=module_sca_manifest_org.id,
+            product=PRDS['rhel'],
+            repo=REPOS['rhel7_extra']['name'],
+            reposet=REPOSET['rhel7_extra'],
             releasever=None,
         )
         repo = target_sat.api.Repository(id=repo_id).read()
         repo.sync()
 
         # Create two LCEs, assign them to the Capsule.
-        lce1 = target_sat.api.LifecycleEnvironment(organization=module_manifest_org).create()
+        lce1 = target_sat.api.LifecycleEnvironment(organization=module_sca_manifest_org).create()
         lce2 = target_sat.api.LifecycleEnvironment(
-            organization=module_manifest_org, prior=lce1
+            organization=module_sca_manifest_org, prior=lce1
         ).create()
         module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
             data={'environment_id': [lce1.id, lce2.id]}
@@ -1171,7 +1197,7 @@ class TestCapsuleContentManagement:
 
         # Create a Content View, add the repository and publish it.
         cv = target_sat.api.ContentView(
-            organization=module_manifest_org, repository=[repo]
+            organization=module_sca_manifest_org, repository=[repo]
         ).create()
         cv.publish()
         cv = cv.read()
@@ -1179,15 +1205,19 @@ class TestCapsuleContentManagement:
 
         # Promote the CV to both Capsule's LCEs without waiting for Capsule sync task completion.
         cvv = cv.version[-1].read()
+        assert len(cvv.environment) == 1
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': lce1.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': lce2.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 3
-
-        # Check all sync tasks finished without errors.
-        module_capsule_configured.wait_for_sync()
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')
@@ -1231,7 +1261,8 @@ class TestCapsuleContentManagement:
         cvv = cv.version[-1].read()
         timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
-        module_capsule_configured.wait_for_sync()
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
 
         # Delete all capsule sync tasks so that we fall back for audits.
         task_result = target_sat.execute(
@@ -1261,7 +1292,7 @@ class TestCapsuleContentManagement:
         target_sat,
         pytestconfig,
         capsule_configured,
-        function_entitlement_manifest_org,
+        function_sca_manifest_org,
         function_lce_library,
     ):
         """Synchronize RPM content to the capsule, disassociate the capsule form the content
@@ -1294,10 +1325,10 @@ class TestCapsuleContentManagement:
         # Enable RHST repo and sync it to the Library LCE.
         repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=function_entitlement_manifest_org.id,
-            product=constants.REPOS['rhst8']['product'],
-            repo=constants.REPOS['rhst8']['name'],
-            reposet=constants.REPOSET['rhst8'],
+            org_id=function_sca_manifest_org.id,
+            product=REPOS['rhst8']['product'],
+            repo=REPOS['rhst8']['name'],
+            reposet=REPOSET['rhst8'],
         )
         repo = target_sat.api.Repository(id=repo_id).read()
         repo.sync()
@@ -1330,13 +1361,20 @@ class TestCapsuleContentManagement:
         sync_status = capsule_configured.nailgun_capsule.content_sync()
         assert sync_status['result'] == 'success', 'Capsule sync task failed.'
 
+        # datetime string (local time) to search for proper task.
+        timestamp = (datetime.now().replace(microsecond=0) - timedelta(seconds=1)).strftime(
+            '%B %d, %Y at %I:%M:%S %p'
+        )
         # Run orphan cleanup for the capsule.
         target_sat.execute(
             'foreman-rake katello:delete_orphaned_content RAILS_ENV=production '
             f'SMART_PROXY_ID={capsule_configured.nailgun_capsule.id}'
         )
         target_sat.wait_for_tasks(
-            search_query=('label = Actions::Katello::OrphanCleanup::RemoveOrphans'),
+            search_query=(
+                'label = Actions::Katello::OrphanCleanup::RemoveOrphans'
+                f' and started_at >= "{timestamp}"'
+            ),
             search_rate=5,
             max_tries=10,
         )
@@ -1387,7 +1425,7 @@ class TestCapsuleContentManagement:
                 content_type='docker',
                 docker_upstream_name=ups_name,
                 product=function_product,
-                url=constants.RH_CONTAINER_REGISTRY_HUB,
+                url=RH_CONTAINER_REGISTRY_HUB,
                 upstream_username=settings.subscription.rhn_username,
                 upstream_password=settings.subscription.rhn_password,
             ).create()
@@ -1410,8 +1448,9 @@ class TestCapsuleContentManagement:
 
         # Promote the latest CV version into capsule's LCE
         cvv = cv.version[-1].read()
+        timestamp = datetime.utcnow()
         cvv.promote(data={'environment_ids': function_lce.id})
+
+        module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
-
-        module_capsule_configured.wait_for_sync()


### PR DESCRIPTION
Parent pull request: #14066 
Fixes to `capsule_mixins` method `wait_for_sync`, adjust conditionals and assertions to 
verify any recently invoked sync task(s). Record and pass a start timestamp in the tests calling this method.

#### Specific modifications for 6.14.z-
- `capsule_mixins.py::118-124` ([link](https://github.com/SatelliteQE/robottelo/blob/dc2203f432979e907f0d88fb31731f03ca8d94c8/robottelo/host_helpers/capsule_mixins.py#L118)): 
After polling, when checking that the final active sync task's `end_time` is the same as capsule's `last_sync_time`, 
in 6.14.z, `capsule.content_get_sync()` does not return `['last_sync_task']` info, yields `keyError`.
I instead now save the `ended_at` time from reading the final active task by `:id`. Then assert the times match.

#### PRT Case:
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py::TestCapsuleContentManagement
```

### Demonstration (local):
```
(venvrobottelo) rh-ee-damoore-mac:robottelo damoore$ pytest tests/foreman/api/test_capsulecontent.py::TestCapsuleContentManagement
============================================================ test session starts ============================================================
platform darwin -- Python 3.11.5, pytest-7.4.4, pluggy-1.3.0
Mandatory Requirements Mismatch: pytest==8.0.2 betelgeuse==1.11.0 pytest-mock==3.12.0 jinja2==3.1.3 deepdiff==6.7.1 tenacity==8.2.3 manifester==0.0.14 pytest-xdist==3.5.0 dynaconf[vault]==3.2.4 pytest-fixturecollection==0.1.2 python-box==7.1.1 wrapanapi==3.6.0 cryptography==42.0.5 pytest-reportportal==5.4.0 docker==7.0.0  # Temporary until Broker is back on PyPi productmd==1.38 paramiko==3.4.0  # Temporary until Broker is back on PyPi navmazing==1.2.2
Optional Requirements Mismatch: flake8==7.0.0 redis==5.0.3 sphinx==7.2.6 manage==0.1.15 sphinx-autoapi==3.0.0 pytest-cov==4.1.0
To update mismatched requirements, run the pytest command with '--update-required-reqs' OR '--update-all-reqs' option.
shared_function enabled - OFF - scope:  - storage: file
rootdir: /Users/damoore/projects/robottelo
configfile: pyproject.toml
plugins: ibutsu-2.2.4, order-1.2.0, cov-4.1.0, cases-3.8.1, services-2.2.1, reportportal-5.3.1, mock-3.12.0, fixturecollection-0.1.1, xdist-3.5.0
collected 18 items   

tests/foreman/api/test_capsulecontent.py ..................          [100%]
============================================== 18 passed, 1139 warnings in 5439.30s (1:30:39) ===============================================
(venvrobottelo) rh-ee-damoore-mac:robottelo damoore$ 
```