### PR TITLE
[6.15.z] addFinalizer in test body

### DIFF
--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -113,9 +113,9 @@ def test_positive_create_with_name_description(
         location=[module_location],
         url=LIBVIRT_URL,
     ).create()
+    request.addfinalizer(compresource.delete)
     assert compresource.name == name
     assert compresource.description == name
-    request.addfinalizer(compresource.delete)
 
 
 @pytest.mark.tier2
@@ -134,9 +134,9 @@ def test_positive_create_with_orgs_and_locs(request, module_target_sat):
     compresource = module_target_sat.api.LibvirtComputeResource(
         location=locs, organization=orgs, url=LIBVIRT_URL
     ).create()
+    request.addfinalizer(compresource.delete)
     assert {org.name for org in orgs} == {org.read().name for org in compresource.organization}
     assert {loc.name for loc in locs} == {loc.read().name for loc in compresource.location}
-    request.addfinalizer(compresource.delete)
 
 
 @pytest.mark.tier2
@@ -175,8 +175,8 @@ def test_negative_create_with_same_name(request, module_target_sat, module_org, 
     cr = module_target_sat.api.LibvirtComputeResource(
         location=[module_location], name=name, organization=[module_org], url=LIBVIRT_URL
     ).create()
-    assert cr.name == name
     request.addfinalizer(cr.delete)
+    assert cr.name == name
     with pytest.raises(HTTPError):
         module_target_sat.api.LibvirtComputeResource(
             name=name,
@@ -245,18 +245,15 @@ def test_negative_update_same_name(request, module_target_sat, module_org, modul
     compresource = module_target_sat.api.LibvirtComputeResource(
         location=[module_location], name=name, organization=[module_org], url=LIBVIRT_URL
     ).create()
+    request.addfinalizer(compresource.delete)
     new_compresource = module_target_sat.api.LibvirtComputeResource(
         location=[module_location], organization=[module_org], url=LIBVIRT_URL
     ).create()
+    request.addfinalizer(new_compresource.delete)
     new_compresource.name = name
     with pytest.raises(HTTPError):
         new_compresource.update(['name'])
     assert new_compresource.read().name != name
-
-    @request.addfinalizer
-    def _finalize():
-        compresource.delete()
-        new_compresource.delete()
 
 
 @pytest.mark.tier2

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -171,8 +171,11 @@ def test_positive_multi_provision_with_rule_limit(
 
     :CaseImportance: High
     """
+
     discovered_host1 = module_target_sat.api_factory.create_discovered_host()
+    request.addfinalizer(module_target_sat.api.Host(id=discovered_host1['id']).delete)
     discovered_host2 = module_target_sat.api_factory.create_discovered_host()
+    request.addfinalizer(module_target_sat.api.DiscoveredHost(id=discovered_host2['id']).delete)
     rule = module_target_sat.api.DiscoveryRule(
         max_count=1,
         hostgroup=module_discovery_hostgroup,
@@ -181,14 +184,6 @@ def test_positive_multi_provision_with_rule_limit(
         organization=[discovery_org],
         priority=1000,
     ).create()
+    request.addfinalizer(rule.delete)
     result = module_target_sat.api.DiscoveredHost().auto_provision_all()
     assert '1 discovered hosts were provisioned' in result['message']
-
-    # Delete discovery rule
-    @request.addfinalizer
-    def _finalize():
-        rule.delete()
-        module_target_sat.api.Host(id=discovered_host1['id']).delete()
-        module_target_sat.api.DiscoveredHost(id=discovered_host2['id']).delete()
-        with pytest.raises(HTTPError):
-            rule.read()

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -295,6 +295,11 @@ def test_positive_sync_proxy_with_certificate(request, target_sat, module_org, m
 
     :customerscenario: true
     """
+
+    @request.addfinalizer
+    def _finalize():
+        target_sat.custom_certs_cleanup()
+
     # Cleanup any existing certs that may conflict
     target_sat.custom_certs_cleanup()
     proxy_host = settings.http_proxy.auth_proxy_url.replace('http://', '').replace(':3128', '')

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -86,8 +86,8 @@ class TestSmartClassParameters:
             location=module_puppet_loc.id,
             environment=module_puppet['env'].name,
         ).create()
-        host.add_puppetclass(data={'puppetclass_id': module_puppet['class']['id']})
         request.addfinalizer(host.delete)
+        host.add_puppetclass(data={'puppetclass_id': module_puppet['class']['id']})
         hostgroup = session_puppet_enabled_sat.cli_factory.hostgroup(
             {
                 'puppet-environment-id': module_puppet['env'].id,

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -76,6 +76,7 @@ class TestOSPComputeResourceTestCase:
                 'url': osp_version,
             }
         )
+        request.addfinalizer(lambda: self.cr_cleanup(compute_resource['id'], id_type, target_sat))
         assert compute_resource['name'] == name
         assert target_sat.cli.ComputeResource.exists(search=(id_type, compute_resource[id_type]))
 
@@ -102,7 +103,6 @@ class TestOSPComputeResourceTestCase:
         else:
             compute_resource = target_sat.cli.ComputeResource.info({'id': compute_resource['id']})
         assert new_name == compute_resource['name']
-        request.addfinalizer(lambda: self.cr_cleanup(compute_resource['id'], id_type, target_sat))
 
     @pytest.mark.tier3
     def test_negative_create_osp_with_url(self, target_sat):

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -70,10 +70,8 @@ def test_rhel_pxe_discovery_provisioning(
 
     assert 'Host created' in result[0]['message']
     host = sat.api.Host().search(query={"search": f'id={discovered_host.id}'})[0]
-    assert host
-
-    # teardown
     request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+    assert host
 
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
@@ -131,10 +129,8 @@ def test_rhel_pxeless_discovery_provisioning(
     )
     assert 'Host created' in result[0]['message']
     host = sat.api.Host().search(query={"search": f'id={discovered_host.id}'})[0]
-    assert host
-
-    # teardown
     request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
+    assert host
 
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -688,16 +688,11 @@ def test_positive_list_affected_chosts_by_erratum_restrict_flag(
             'inclusion': 'false',
         }
     )
-
-    @request.addfinalizer
-    def cleanup():
-        cv_filter_cleanup(
-            target_sat,
-            cv_filter['filter-id'],
-            module_cv,
-            module_sca_manifest_org,
-            module_lce,
+    request.addfinalizer(
+        lambda: cv_filter_cleanup(
+            target_sat, cv_filter['filter-id'], module_cv, module_sca_manifest_org, module_lce
         )
+    )
 
     # Make rule to hide the RPM that creates the need for the installable erratum
     target_sat.cli_factory.content_view_filter_rule(
@@ -861,17 +856,11 @@ def test_host_errata_search_commands(
             'inclusion': 'false',
         }
     )
-
-    @request.addfinalizer
-    def cleanup():
-        cv_filter_cleanup(
-            target_sat,
-            cv_filter['filter-id'],
-            module_cv,
-            module_sca_manifest_org,
-            module_lce,
+    request.addfinalizer(
+        lambda: cv_filter_cleanup(
+            target_sat, cv_filter['filter-id'], module_cv, module_sca_manifest_org, module_lce
         )
-
+    )
     # Make rule to exclude the specified bugfix package
     target_sat.cli_factory.content_view_filter_rule(
         {

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -136,6 +136,13 @@ def test_positive_disable_hammer_defaults(request, function_product, target_sat)
 
     :BZ: 1640644, 1368173
     """
+
+    @request.addfinalizer
+    def _finalize():
+        target_sat.cli.Defaults.delete({'param-name': 'organization_id'})
+        result = target_sat.execute('hammer defaults list')
+        assert str(function_product.organization.id) not in result.stdout
+
     target_sat.cli.Defaults.add(
         {'param-name': 'organization_id', 'param-value': function_product.organization.id}
     )
@@ -153,12 +160,6 @@ def test_positive_disable_hammer_defaults(request, function_product, target_sat)
     result = target_sat.execute('hammer --use-defaults product list')
     assert result.status == 0
     assert function_product.name in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        target_sat.cli.Defaults.delete({'param-name': 'organization_id'})
-        result = target_sat.execute('hammer defaults list')
-        assert str(function_product.organization.id) not in result.stdout
 
 
 @pytest.mark.upgrade

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -2272,6 +2272,7 @@ class TestInterSatelliteSync:
         meta_file = 'metadata.json'
         crt_file = 'source.crt'
         pub_dir = '/var/www/html/pub/repos'
+        request.addfinalizer(lambda: target_sat.execute(f'rm -rf {pub_dir}'))
 
         # Export the repository in syncable format and move it
         # to /var/www/html/pub/repos to mimic custom CDN.
@@ -2288,7 +2289,6 @@ class TestInterSatelliteSync:
         exp_dir = exp_dir[0].replace(meta_file, '')
 
         assert target_sat.execute(f'mv {exp_dir} {pub_dir}').status == 0
-        request.addfinalizer(lambda: target_sat.execute(f'rm -rf {pub_dir}'))
         target_sat.execute(f'semanage fcontext -a -t httpd_sys_content_t "{pub_dir}(/.*)?"')
         target_sat.execute(f'restorecon -R {pub_dir}')
 

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -199,8 +199,8 @@ def test_negative_update_attributes(request, options, module_target_sat):
     :CaseImportance: Medium
     """
     subnet = module_target_sat.cli_factory.make_subnet()
-    options['id'] = subnet['id']
     request.addfinalizer(lambda: module_target_sat.cli.Subnet.delete({'id': subnet['id']}))
+    options['id'] = subnet['id']
     with pytest.raises(CLIReturnCodeError, match='Could not update the subnet:'):
         module_target_sat.cli.Subnet.update(options)
     # check - subnet is not updated
@@ -223,8 +223,8 @@ def test_negative_update_address_pool(request, options, module_target_sat):
     :CaseImportance: Medium
     """
     subnet = module_target_sat.cli_factory.make_subnet()
-    opts = {'id': subnet['id']}
     request.addfinalizer(lambda: module_target_sat.cli.Subnet.delete({'id': subnet['id']}))
+    opts = {'id': subnet['id']}
     # generate pool range from network address
     for key, val in options.items():
         opts[key] = re.sub(r'\d+$', str(val), subnet['network-addr'])

--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -191,6 +191,7 @@ def test_loadbalancer_install_package(
         registration.
 
         """
+
     # Register content host
     result = rhel7_contenthost.register(
         org=module_org,
@@ -219,6 +220,9 @@ def test_loadbalancer_install_package(
         if loadbalancer_setup['setup_capsules']['capsule_1'].hostname in result.stdout
         else loadbalancer_setup['setup_capsules']['capsule_2']
     )
+    request.addfinalizer(
+        lambda: registered_to_capsule.power_control(state=VmState.RUNNING, ensure=True)
+    )
 
     # Remove the packages from the client
     result = rhel7_contenthost.execute('yum remove -y tree')
@@ -230,10 +234,6 @@ def test_loadbalancer_install_package(
     # Try package installation again
     result = rhel7_contenthost.execute('yum install -y tree')
     assert result.status == 0
-
-    @request.addfinalizer
-    def _finalize():
-        registered_to_capsule.power_control(state=VmState.RUNNING, ensure=True)
 
 
 @pytest.mark.rhel_ver_match('[^6]')

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -201,6 +201,13 @@ def test_negative_health_check_upstream_repository(sat_maintain, request):
 
     :expectedresults: check-upstream-repository health check should fail.
     """
+
+    @request.addfinalizer
+    def _finalize():
+        for name in upstream_url:
+            sat_maintain.execute(f'rm -fr /etc/yum.repos.d/{name}.repo')
+        sat_maintain.execute('dnf clean all')
+
     for name, url in upstream_url.items():
         sat_maintain.create_custom_repos(**{name: url})
     result = sat_maintain.cli.Health.check(
@@ -215,12 +222,6 @@ def test_negative_health_check_upstream_repository(sat_maintain, request):
             assert 'enabled=1' in result.stdout
         elif name in ['foreman_repo', 'puppet_repo']:
             assert 'enabled=0' in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        for name in upstream_url:
-            sat_maintain.execute(f'rm -fr /etc/yum.repos.d/{name}.repo')
-        sat_maintain.execute('dnf clean all')
 
 
 def test_positive_health_check_available_space(sat_maintain):
@@ -260,14 +261,15 @@ def test_positive_hammer_defaults_set(sat_maintain, request):
 
     :customerscenario: true
     """
-    sat_maintain.cli.Defaults.add({'param-name': 'organization_id', 'param-value': 1})
-    result = sat_maintain.cli.Health.check(options={'assumeyes': True})
-    assert result.status == 0
-    assert 'FAIL' not in result.stdout
 
     @request.addfinalizer
     def _finalize():
         sat_maintain.cli.Defaults.delete({'param-name': 'organization_id'})
+
+    sat_maintain.cli.Defaults.add({'param-name': 'organization_id', 'param-value': 1})
+    result = sat_maintain.cli.Health.check(options={'assumeyes': True})
+    assert result.status == 0
+    assert 'FAIL' not in result.stdout
 
 
 @pytest.mark.include_capsule
@@ -288,6 +290,13 @@ def test_positive_health_check_hotfix_installed(sat_maintain, request):
     :expectedresults: check-hotfix-installed check should detect modified file
         and installed hotfix.
     """
+
+    @request.addfinalizer
+    def _finalize():
+        sat_maintain.execute('rm -fr /etc/yum.repos.d/custom_repo.repo')
+        sat_maintain.execute('dnf remove -y hotfix-package')
+        assert sat_maintain.execute(f'sed -i "/#modifying_file/d" {fpath.stdout}').status == 0
+
     # Verify check-hotfix-installed without hotfix package.
     result = sat_maintain.cli.Health.check(options={'label': 'check-hotfix-installed'})
     assert result.status == 0
@@ -306,12 +315,6 @@ def test_positive_health_check_hotfix_installed(sat_maintain, request):
     assert result.status == 78
     assert 'WARNING' in result.stdout
     assert 'hotfix-package' in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        sat_maintain.execute('rm -fr /etc/yum.repos.d/custom_repo.repo')
-        sat_maintain.execute('dnf remove -y hotfix-package')
-        assert sat_maintain.execute(f'sed -i "/#modifying_file/d" {fpath.stdout}').status == 0
 
 
 @pytest.mark.include_capsule
@@ -365,16 +368,17 @@ def test_negative_health_check_epel_repository(request, sat_maintain):
 
     :expectedresults: check-non-redhat-repository health check should fail.
     """
+
+    @request.addfinalizer
+    def _finalize():
+        assert sat_maintain.execute('dnf remove -y epel-release').status == 0
+
     epel_repo = 'https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm'
     sat_maintain.execute(f'dnf install -y {epel_repo}')
     result = sat_maintain.cli.Health.check(options={'label': 'check-non-redhat-repository'})
     assert 'System is subscribed to non Red Hat repositories' in result.stdout
     assert result.status == 1
     assert 'FAIL' in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        assert sat_maintain.execute('dnf remove -y epel-release').status == 0
 
 
 def test_positive_health_check_old_foreman_tasks(sat_maintain):
@@ -471,6 +475,14 @@ def test_positive_health_check_tftp_storage(sat_maintain, request):
 
     :expectedresults: check-tftp-storage health check should pass.
     """
+
+    @request.addfinalizer
+    def _finalize():
+        sat_maintain.cli.Settings.set({'name': 'token_duration', 'value': '360'})
+        assert (
+            sat_maintain.cli.Settings.list({'search': 'name=token_duration'})[0]['value'] == '360'
+        )
+
     sat_maintain.cli.Settings.set({'name': 'token_duration', 'value': '2'})
     assert sat_maintain.cli.Settings.list({'search': 'name=token_duration'})[0]['value'] == '2'
     files_to_delete = [
@@ -503,13 +515,6 @@ def test_positive_health_check_tftp_storage(sat_maintain, request):
     result = sat_maintain.cli.Health.check({'label': 'check-tftp-storage'})
     assert result.status == 0
     assert 'FAIL' not in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        sat_maintain.cli.Settings.set({'name': 'token_duration', 'value': '360'})
-        assert (
-            sat_maintain.cli.Settings.list({'search': 'name=token_duration'})[0]['value'] == '360'
-        )
 
 
 @pytest.mark.include_capsule
@@ -661,10 +666,20 @@ def test_positive_health_check_corrupted_roles(sat_maintain, request):
 
     :BZ: 1703041, 1908846
     """
-    # Check the filter created to verify the role, resource type, and permissions assigned.
     role_name = 'test_role'
     resource_type = gen_string("alpha")
     sat_maintain.cli.Role.create(options={'name': role_name})
+
+    @request.addfinalizer
+    def _finalize():
+        resource_type = r"'\''Host'\''"
+        sat_maintain.execute(
+            f'''sudo su - postgres -c "psql -d foreman -c 'UPDATE permissions SET
+                        resource_type = {resource_type} WHERE name = {permission_name};'"'''
+        )
+        sat_maintain.cli.Role.delete(options={'name': role_name})
+
+    # Check the filter created to verify the role, resource type, and permissions assigned.
     sat_maintain.cli.Filter.create(
         options={'role': role_name, 'permissions': ['view_hosts', 'console_hosts']}
     )
@@ -685,15 +700,6 @@ def test_positive_health_check_corrupted_roles(sat_maintain, request):
     # Verify corrupted roles are fixed and new filter is created for updated resource_type.
     result = sat_maintain.cli.Filter.list(options={'search': role_name}, output_format='yaml')
     assert result.count('Id') == 4
-
-    @request.addfinalizer
-    def _finalize():
-        resource_type = r"'\''Host'\''"
-        sat_maintain.execute(
-            f'''sudo su - postgres -c "psql -d foreman -c 'UPDATE permissions SET
-                        resource_type = {resource_type} WHERE name = {permission_name};'"'''
-        )
-        sat_maintain.cli.Role.delete(options={'name': role_name})
 
 
 @pytest.mark.include_capsule
@@ -719,6 +725,12 @@ def test_positive_health_check_non_rh_packages(sat_maintain, request):
 
     :CaseImportance: High
     """
+
+    @request.addfinalizer
+    def _finalize():
+        assert sat_maintain.execute('dnf remove -y  walrus').status == 0
+        assert sat_maintain.execute('rm -fr /etc/yum.repos.d/custom_repo.repo').status == 0
+
     sat_maintain.create_custom_repos(custom_repo=settings.repos.yum_0.url)
     assert (
         sat_maintain.cli.Packages.install(packages='walrus', options={'assumeyes': True}).status
@@ -729,11 +741,6 @@ def test_positive_health_check_non_rh_packages(sat_maintain, request):
     assert 'walrus-5.21-1.noarch' in result.stdout
     assert result.status == 78
     assert 'WARNING' in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        assert sat_maintain.execute('dnf remove -y  walrus').status == 0
-        assert sat_maintain.execute('rm -fr /etc/yum.repos.d/custom_repo.repo').status == 0
 
 
 def test_positive_health_check_duplicate_permissions(sat_maintain):

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -47,6 +47,11 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
         to disable/enable sync-plan, stop/start crond.service and is able to add
         FOREMAN_MAINTAIN_TABLE rule in nftables.
     """
+
+    @request.addfinalizer
+    def _finalize():
+        assert sat_maintain.cli.MaintenanceMode.stop().status == 0
+
     enable_sync_ids = setup_sync_plan
     data_yml_path = '/var/lib/foreman-maintain/data.yml'
     local_data_yml_path = f'{robottelo_tmp_dir}/data.yml'
@@ -142,7 +147,3 @@ def test_positive_maintenance_mode(request, sat_maintain, setup_sync_plan):
     assert 'OK' in result.stdout
     assert result.status == 1
     assert 'Maintenance mode is Off' in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        assert sat_maintain.cli.MaintenanceMode.stop().status == 0

--- a/tests/foreman/maintain/test_packages.py
+++ b/tests/foreman/maintain/test_packages.py
@@ -160,6 +160,15 @@ def test_positive_fm_packages_install(request, sat_maintain):
 
     :expectedresults: Packages get install/update when lock/unlocked.
     """
+
+    @request.addfinalizer
+    def _finalize():
+        assert sat_maintain.execute('dnf remove -y zsh').status == 0
+        if sat_maintain.__class__.__name__ == 'Satellite':
+            result = sat_maintain.install(InstallerCommand('lock-package-versions'))
+            assert result.status == 0
+            assert 'Success!' in result.stdout
+
     # Test whether packages are locked or not
     result = sat_maintain.install(InstallerCommand('lock-package-versions'))
     assert result.status == 0
@@ -216,14 +225,6 @@ def test_positive_fm_packages_install(request, sat_maintain):
     assert result.status == 0
     assert 'Use foreman-maintain packages install/update <package>' not in result.stdout
 
-    @request.addfinalizer
-    def _finalize():
-        assert sat_maintain.execute('dnf remove -y zsh').status == 0
-        if sat_maintain.__class__.__name__ == 'Satellite':
-            result = sat_maintain.install(InstallerCommand('lock-package-versions'))
-            assert result.status == 0
-            assert 'Success!' in result.stdout
-
 
 @pytest.mark.include_capsule
 def test_positive_fm_packages_update(request, sat_maintain):
@@ -244,6 +245,12 @@ def test_positive_fm_packages_update(request, sat_maintain):
 
     :customerscenario: true
     """
+
+    @request.addfinalizer
+    def _finalize():
+        assert sat_maintain.execute('dnf remove -y walrus').status == 0
+        sat_maintain.execute('rm -rf /etc/yum.repos.d/custom_repo.repo')
+
     # Setup custom_repo and packages update
     sat_maintain.create_custom_repos(custom_repo=settings.repos.yum_0.url)
     disableplugin = '--disableplugin=foreman-protector'
@@ -263,8 +270,3 @@ def test_positive_fm_packages_update(request, sat_maintain):
     result = sat_maintain.execute('rpm -qa walrus')
     assert result.status == 0
     assert 'walrus-5.21-1' in result.stdout
-
-    @request.addfinalizer
-    def _finalize():
-        assert sat_maintain.execute('dnf remove -y walrus').status == 0
-        sat_maintain.execute('rm -rf /etc/yum.repos.d/custom_repo.repo')

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -178,6 +178,13 @@ def test_positive_ansible_custom_role(target_sat, session, module_org, rhel_cont
 
     :CaseComponent: Ansible-RemoteExecution
     """
+
+    @request.addfinalizer
+    def _finalize():
+        result = target_sat.cli.Ansible.roles_delete({'name': SELECTED_ROLE})
+        assert f'Ansible role [{SELECTED_ROLE}] was deleted.' in result[0]['message']
+        target_sat.execute('rm -rvf /etc/ansible/roles/custom_role')
+
     SELECTED_ROLE = 'custom_role'
     playbook = f'{robottelo_tmp_dir}/playbook.yml'
     data = {
@@ -230,12 +237,6 @@ def test_positive_ansible_custom_role(target_sat, session, module_org, rhel_cont
         session.configreport.search(rhel_contenthost.hostname)
         session.configreport.delete(rhel_contenthost.hostname)
         assert len(session.configreport.read()['table']) == 0
-
-    @request.addfinalizer
-    def _finalize():
-        result = target_sat.cli.Ansible.roles_delete({'name': SELECTED_ROLE})
-        assert f'Ansible role [{SELECTED_ROLE}] was deleted.' in result[0]['message']
-        target_sat.execute('rm -rvf /etc/ansible/roles/custom_role')
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -161,8 +161,17 @@ def test_positive_gce_provision_end_to_end(
 
     :expectedresults: Host is provisioned successfully
     """
+
     name = f'test{gen_string("alpha", 4).lower()}'
     hostname = f'{name}.{gce_domain.name}'
+
+    @request.addfinalizer
+    def _finalize():
+        gcehost = sat_gce.api.Host().search(query={'search': f'name={hostname}'})
+        if gcehost:
+            gcehost[0].delete()
+        googleclient.disconnect()
+
     gceapi_vmname = hostname.replace('.', '-')
     root_pwd = gen_string('alpha', 15)
     storage = [{'size': 20}]
@@ -214,13 +223,6 @@ def test_positive_gce_provision_end_to_end(
             # 2.2 GCE Backend Assertions
             assert gceapi_vm.is_stopping or gceapi_vm.is_stopped
 
-    @request.addfinalizer
-    def _finalize():
-        gcehost = sat_gce.api.Host().search(query={'search': f'name={hostname}'})
-        if gcehost:
-            gcehost[0].delete()
-        googleclient.disconnect()
-
 
 @pytest.mark.tier4
 @pytest.mark.upgrade
@@ -247,6 +249,14 @@ def test_positive_gce_cloudinit_provision_end_to_end(
     """
     name = f'test{gen_string("alpha", 4).lower()}'
     hostname = f'{name}.{gce_domain.name}'
+
+    @request.addfinalizer
+    def _finalize():
+        gcehost = sat_gce.api.Host().search(query={'search': f'name={hostname}'})
+        if gcehost:
+            gcehost[0].delete()
+        googleclient.disconnect()
+
     gceapi_vmname = hostname.replace('.', '-')
     storage = [{'size': 20}]
     root_pwd = gen_string('alpha', random.choice([8, 15]))
@@ -290,10 +300,3 @@ def test_positive_gce_cloudinit_provision_end_to_end(
             assert not sat_gce.api.Host().search(query={'search': f'name="{hostname}"'})
             # 2.2 GCE Backend Assertions
             assert gceapi_vm.is_stopping or gceapi_vm.is_stopped
-
-    @request.addfinalizer
-    def _finalize():
-        gcehost = sat_gce.api.Host().search(query={'search': f'name={hostname}'})
-        if gcehost:
-            gcehost[0].delete()
-        googleclient.disconnect()

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -171,10 +171,8 @@ def test_positive_provision_end_to_end(
             }
         )
         name = f'{hostname}.{module_libvirt_provisioning_sat.domain.name}'
-        assert session.host.search(name)[0]['Name'] == name
-
-        # teardown
         request.addfinalizer(lambda: sat.provisioning_cleanup(name))
+        assert session.host.search(name)[0]['Name'] == name
 
         # Check on Libvirt, if VM exists
         result = sat.execute(

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -87,6 +87,7 @@ class TestContentView:
         cv = target_sat.api.ContentView(organization=org.id).search(
             query={'search': f'name="{cv_name}"'}
         )[0]
+        request.addfinalizer(cv.delete)
         yum_repo = target_sat.api.Repository(organization=org.id).search(
             query={'search': f'name="{pre_test_name}_yum_repo"'}
         )[0]
@@ -95,7 +96,6 @@ class TestContentView:
             query={'search': f'name="{pre_test_name}_file_repo"'}
         )[0]
         request.addfinalizer(file_repo.delete)
-        request.addfinalizer(cv.delete)
         cv.repository = []
         cv.update(['repository'])
         assert len(cv.read_json()['repositories']) == 0

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -161,6 +161,7 @@ class TestScenarioPositiveGCEHostComputeResource:
         pre_upgrade_host = sat_gce.api.Host().search(
             query={'search': f'name={pre_upgrade_data.provision_host_name}'}
         )[0]
+        request.addfinalizer(pre_upgrade_host.delete)
         org = sat_gce.api.Organization(id=pre_upgrade_host.organization.id).read()
         loc = sat_gce.api.Location(id=pre_upgrade_host.location.id).read()
         domain = sat_gce.api.Domain(id=pre_upgrade_host.domain.id).read()
@@ -185,7 +186,6 @@ class TestScenarioPositiveGCEHostComputeResource:
             image=image,
             root_pass=gen_string('alphanumeric'),
         ).create()
-        request.addfinalizer(pre_upgrade_host.delete)
         request.addfinalizer(host.delete)
         assert host.name == f"{self.hostname.lower()}.{domain.name}"
         assert host.build_status_label == 'Installed'

--- a/tests/upgrades/test_provisioningtemplate.py
+++ b/tests/upgrades/test_provisioningtemplate.py
@@ -105,6 +105,7 @@ class TestScenarioPositiveProvisioningTemplates:
         pre_upgrade_host = module_target_sat.api.Host().search(
             query={'search': f'id={pre_upgrade_data.provision_host_id}'}
         )[0]
+        request.addfinalizer(pre_upgrade_host.delete)
         org = module_target_sat.api.Organization(id=pre_upgrade_host.organization.id).read()
         loc = module_target_sat.api.Location(id=pre_upgrade_host.location.id).read()
         domain = module_target_sat.api.Domain(id=pre_upgrade_host.domain.id).read()
@@ -129,7 +130,6 @@ class TestScenarioPositiveProvisioningTemplates:
             root_pass=settings.provisioning.host_root_password,
             pxe_loader=pxe_loader,
         ).create()
-        request.addfinalizer(pre_upgrade_host.delete)
         request.addfinalizer(new_host.delete)
 
         for kind in provisioning_template_kinds:

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -173,5 +173,5 @@ class TestSubscriptionAutoAttach:
         sub.delete_manifest(data={'organization_id': org.id})
         assert len(sub.search()) == 0
         manifester = Manifester(manifest_category=settings.manifest.entitlement)
-        manifester.allocation_uuid = pre_upgrade_data.allocation_uuid
         request.addfinalizer(manifester.delete_subscription_allocation)
+        manifester.allocation_uuid = pre_upgrade_data.allocation_uuid

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -102,16 +102,16 @@ class TestUserGroupMembership:
         user_group = target_sat.api.UserGroup().search(
             query={'search': f'name={pre_upgrade_data["user_group_name"]}'}
         )
+        request.addfinalizer(user_group[0].delete)
         auth_source = target_sat.api.AuthSourceLDAP().search(
             query={'search': f'name={pre_upgrade_data["auth_source_name"]}'}
         )[0]
         request.addfinalizer(auth_source.delete)
-        request.addfinalizer(user_group[0].delete)
         user = target_sat.api.User().search(query={'search': f'login={ad_data["ldap_user_name"]}'})[
             0
         ]
-        assert user.read().id == user_group[0].read().user[0].id
         request.addfinalizer(user.delete)
+        assert user.read().id == user_group[0].read().user[0].id
         role_list = target_sat.cli.Role.with_user(
             username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
         ).list()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14036

### Problem Statement
Turns out that `@request.addFinalizer` when used in test body (not in fixture) is dependent on the execution order, so basically when some assertion defined in the test before the finalizer part fails, finalizer is not added and so not executed.

This exactly happened in `test_positive_disable_hammer_defaults` in upgrades, breaking a lot of other tests in the same run. Big kudos to @lpramuk for isolating the issue there.

### Solution

Moving the addFinalizer part to the start of the test, fixes the problem. Prt run won't reveal much in this case, but running the previous version of the test with induced assertion error leaves satellite with:

```
~]# hammer defaults list
----------------|------
PARAMETER       | VALUE
----------------|------
organization_id | 41   
----------------|------
```

...which means that the finalizer didn't run. With this pr, the defaults are properly cleaned up:

```
~]# hammer defaults list
----------|------
PARAMETER | VALUE
----------|------
```

### Related Issues

I did a quick search for this pattern across robottelo and I found quite a bit of cases where `@request.addfinalizer` is added towards the end of the test body, with some preceding assertions that could possibly break it:

- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/cli/test_errata.py#L692
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/api/test_discoveryrule.py#L188
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/api/test_computeresource_libvirt.py#L256
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/api/test_parameters.py#L58
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/maintain/test_maintenance_mode.py#L146
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/api/test_http_proxy.py#L316
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/maintain/test_packages.py#L219
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/ui/test_computeresource_gce.py#L217
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/maintain/test_advanced.py#L104
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/destructive/test_capsule_loadbalancer.py#L234
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/maintain/test_health.py#L219
- [x] https://github.com/SatelliteQE/robottelo/blob/d9c5ea85cf4c12c9a0b8e0cde269fc26c0814378/tests/foreman/ui/test_ansible.py#L233


This doesn't include `request.addFinalizer(...)` calls that likely suffer from the same problem. Now, I could go and reorder all those occurrences, but I feel we should discuss this team wide and maybe abolish this practice all together