### PR TITLE
[6.15.z] Workaround for some ext auth tests for PR13737 which broke CSV handling

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -456,10 +456,10 @@ def configure_hammer_no_negotiate(parametrized_enrolled_sat):
 def hammer_logout(parametrized_enrolled_sat):
     """Logout in Hammer."""
     result = parametrized_enrolled_sat.cli.Auth.logout()
-    assert result[0]['message'] == LOGGEDOUT
+    assert result.split("\n")[1] == LOGGEDOUT
     yield
     result = parametrized_enrolled_sat.cli.Auth.logout()
-    assert result[0]['message'] == LOGGEDOUT
+    assert result.split("\n")[1] == LOGGEDOUT
 
 
 @pytest.fixture

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -134,7 +134,7 @@ class TestADAuthSource:
         result = module_target_sat.cli.Auth.with_user(
             username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
         ).status()
-        assert LOGEDIN_MSG.format(ad_data['ldap_user_name']) in result[0]['message']
+        assert LOGEDIN_MSG.format(ad_data['ldap_user_name']) in result.split("\n")[1]
         module_target_sat.cli.UserGroupExternal.refresh(
             {'user-group-id': user_group['id'], 'name': member_group}
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14423

Workaround for some ext auth tests for [PR13737](https://github.com/SatelliteQE/robottelo/pull/13737) which broke CSV handling