### PR TITLE
[6.15.z] - remove the all nailgun imports from UI folder

### DIFF
--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -12,13 +12,12 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session):
+def test_positive_end_to_end(session, target_sat):
     """Perform end to end testing for architecture component
 
     :id: eef14b29-9f5a-41aa-805e-73398ed2b112
@@ -29,7 +28,7 @@ def test_positive_end_to_end(session):
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
-    os = entities.OperatingSystem().create()
+    os = target_sat.api.OperatingSystem().create()
     os_name = f'{os.name} {os.major}'
     with session:
         # Create new architecture with assigned operating system

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -10,15 +10,14 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.constants import ENVIRONMENT
 
 
 @pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
+def module_org(module_target_sat):
+    return module_target_sat.api.Organization().create()
 
 
 pytestmark = [pytest.mark.run_in_one_thread]
@@ -26,7 +25,7 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_create_event(session, module_org, module_location):
+def test_positive_create_event(session, module_org, module_location, module_target_sat):
     """When new host is created, corresponding audit entry appear in the application
 
     :id: d0595705-f4b2-4f06-888b-ee93edd4acf8
@@ -39,7 +38,7 @@ def test_positive_create_event(session, module_org, module_location):
 
     :BZ: 1730360
     """
-    host = entities.Host(organization=module_org, location=module_location).create()
+    host = module_target_sat.api.Host(organization=module_org, location=module_location).create()
     with session:
         session.organization.select(org_name=module_org.name)
         session.location.select(loc_name=module_location.name)
@@ -103,7 +102,7 @@ def test_positive_audit_comment(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_update_event(session, module_org):
+def test_positive_update_event(session, module_org, module_target_sat):
     """When existing content view is updated, corresponding audit entry appear
     in the application
 
@@ -119,7 +118,7 @@ def test_positive_update_event(session, module_org):
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
-    cv = entities.ContentView(name=name, organization=module_org).create()
+    cv = module_target_sat.api.ContentView(name=name, organization=module_org).create()
     cv.name = new_name
     cv.update(['name'])
     with session:
@@ -135,7 +134,7 @@ def test_positive_update_event(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_delete_event(session, module_org):
+def test_positive_delete_event(session, module_org, module_target_sat):
     """When existing architecture is deleted, corresponding audit entry appear
     in the application
 
@@ -147,7 +146,7 @@ def test_positive_delete_event(session, module_org):
 
     :CaseImportance: Medium
     """
-    architecture = entities.Architecture().create()
+    architecture = module_target_sat.api.Architecture().create()
     architecture.delete()
     with session:
         values = session.audit.search('type=architecture and action=destroy')
@@ -160,7 +159,7 @@ def test_positive_delete_event(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_add_event(session, module_org):
+def test_positive_add_event(session, module_org, module_target_sat):
     """When content view is published and proper lifecycle environment added to it,
     corresponding audit entry appear in the application
 
@@ -172,7 +171,7 @@ def test_positive_add_event(session, module_org):
 
     :CaseImportance: Medium
     """
-    cv = entities.ContentView(organization=module_org).create()
+    cv = module_target_sat.api.ContentView(organization=module_org).create()
     cv.publish()
     with session:
         values = session.audit.search(

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -12,13 +12,12 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, module_location, module_org):
+def test_positive_end_to_end(session, module_location, module_org, module_target_sat):
     """Perform end to end testing for compute profile component
 
     :id: 5445fc7e-7b3f-472f-8a94-93f89aca6c22
@@ -29,13 +28,13 @@ def test_positive_end_to_end(session, module_location, module_org):
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
-    compute_resource = entities.LibvirtComputeResource(
+    compute_resource = module_target_sat.api.LibvirtComputeResource(
         location=[module_location], organization=[module_org], url='qemu+ssh://root@test/system'
     ).create()
     with session:
         session.computeprofile.create({'name': name})
 
-        assert entities.ComputeProfile().search(query={'search': f'name={name}'}), (
+        assert module_target_sat.api.ComputeProfile().search(query={'search': f'name={name}'}), (
             'Compute profile {} expected to exist, but is not included in the search '
             'results'.format(name)
         )
@@ -44,12 +43,16 @@ def test_positive_end_to_end(session, module_location, module_org):
             resource['Compute Resource'] for resource in compute_resource_list
         ]
         session.computeprofile.rename(name, {'name': new_name})
-        assert entities.ComputeProfile().search(query={'search': f'name={new_name}'}), (
+        assert module_target_sat.api.ComputeProfile().search(
+            query={'search': f'name={new_name}'}
+        ), (
             'Compute profile {} expected to exist, but is not included in the search '
             'results'.format(new_name)
         )
         session.computeprofile.delete(new_name)
-        assert not entities.ComputeProfile().search(query={'search': f'name={new_name}'}), (
+        assert not module_target_sat.api.ComputeProfile().search(
+            query={'search': f'name={new_name}'}
+        ), (
             'Compute profile {} expected to be deleted, but is included in the search '
             'results'.format(new_name)
         )

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -12,7 +12,6 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -44,7 +43,7 @@ def module_ec2_settings():
 @pytest.mark.skip_if_not_set('http_proxy')
 @pytest.mark.skip_if_open("BZ:2032530")
 def test_positive_default_end_to_end_with_custom_profile(
-    session, module_org, module_location, module_ec2_settings
+    session, module_org, module_location, module_ec2_settings, module_target_sat
 ):
     """Create EC2 compute resource with default properties and apply it's basic functionality.
 
@@ -67,9 +66,9 @@ def test_positive_default_end_to_end_with_custom_profile(
     cr_name = gen_string('alpha')
     new_cr_name = gen_string('alpha')
     cr_description = gen_string('alpha')
-    new_org = entities.Organization().create()
-    new_loc = entities.Location().create()
-    http_proxy = entities.HTTPProxy(
+    new_org = module_target_sat.api.Organization().create()
+    new_loc = module_target_sat.api.Location().create()
+    http_proxy = module_target_sat.api.HTTPProxy(
         name=gen_string('alpha', 15),
         url=settings.http_proxy.auth_proxy_url,
         username=settings.http_proxy.username,

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -14,7 +14,6 @@
 from math import floor, log10
 from random import choice
 
-from nailgun import entities
 import pytest
 from wait_for import TimedOutError, wait_for
 from wrapanapi.systems.virtualcenter import VMWareSystem, vim
@@ -83,8 +82,8 @@ def _get_vmware_datastore_summary_string(data_store_name=settings.vmware.datasto
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
-def test_positive_end_to_end(session, module_org, module_location, vmware):
-    """Perform end to end testing for compute resource VMware component.
+def test_positive_end_to_end(session, module_org, module_location, vmware, module_target_sat):
+    """Perform end-to-end testing for compute resource VMware component.
 
     :id: 47fc9e77-5b22-46b4-a76c-3217434fde2f
 
@@ -96,8 +95,8 @@ def test_positive_end_to_end(session, module_org, module_location, vmware):
     display_type = choice(('VNC', 'VMRC'))
     vnc_console_passwords = choice((False, True))
     enable_caching = choice((False, True))
-    new_org = entities.Organization().create()
-    new_loc = entities.Location().create()
+    new_org = module_target_sat.api.Organization().create()
+    new_loc = module_target_sat.api.Location().create()
     with session:
         session.computeresource.create(
             {

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -11,7 +11,6 @@
 :CaseImportance: High
 
 """
-from nailgun import entities
 import pytest
 
 from robottelo.constants import (
@@ -25,18 +24,18 @@ from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope="module")
-def module_org():
-    return entities.Organization().create()
+def module_org(module_target_sat):
+    return module_target_sat.api.Organization().create()
 
 
 @pytest.fixture(scope="module")
-def module_product(module_org):
-    return entities.Product(organization=module_org).create()
+def module_product(module_org, module_target_sat):
+    return module_target_sat.api.Product(organization=module_org).create()
 
 
 @pytest.fixture(scope="module")
-def module_repository(module_product):
-    repo = entities.Repository(
+def module_repository(module_product, module_target_sat):
+    repo = module_target_sat.api.Repository(
         content_type=REPO_TYPE['docker'],
         docker_upstream_name=CONTAINER_UPSTREAM_NAME,
         product=module_product,

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -12,7 +12,6 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.utils.datafactory import valid_domain_names
@@ -113,7 +112,9 @@ def test_positive_remove_parameter(session, valid_domain_name):
 @pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, module_org, module_location, valid_domain_name):
+def test_positive_end_to_end(
+    session, module_org, module_location, valid_domain_name, module_target_sat
+):
     """Perform end to end testing for domain component
 
     :id: ce90fd87-3e63-4298-a771-38f4aacce091
@@ -148,4 +149,4 @@ def test_positive_end_to_end(session, module_org, module_location, valid_domain_
         assert session.domain.search(new_name)[0]['Description'] == new_name
         # Delete domain
         session.domain.delete(new_name)
-        assert not entities.Domain().search(query={'search': f'name={new_name}'})
+        assert not module_target_sat.api.Domain().search(query={'search': f'name={new_name}'})

--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -10,14 +10,13 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 
 @pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, host_ui_options):
+def test_positive_end_to_end(session, host_ui_options, module_target_sat):
     """Perform end to end testing for hardware model component
 
     :id: 93663cc9-7c8f-4f43-8050-444be1313bed
@@ -62,4 +61,4 @@ def test_positive_end_to_end(session, host_ui_options):
         session.host.update(host_name, {'additional_information.hardware_model': ''})
         # Delete hardware model
         session.hardwaremodel.delete(new_name)
-        assert not entities.Host().search(query={'search': f'name="{new_name}"'})
+        assert not module_target_sat.api.Host().search(query={'search': f'name="{new_name}"'})

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -12,7 +12,6 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -21,7 +20,7 @@ from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 
 @pytest.mark.e2e
 @pytest.mark.tier2
-def test_positive_end_to_end(session, module_org, module_location):
+def test_positive_end_to_end(session, module_org, module_location, module_target_sat):
     """Perform end to end testing for host group component
 
     :id: 537d95f2-fe32-4e06-a2cb-21c80fe8e2e2
@@ -33,10 +32,12 @@ def test_positive_end_to_end(session, module_org, module_location):
     name = gen_string('alpha')
     new_name = gen_string('alpha')
     description = gen_string('alpha')
-    architecture = entities.Architecture().create()
-    os = entities.OperatingSystem(architecture=[architecture]).create()
+    architecture = module_target_sat.api.Architecture().create()
+    os = module_target_sat.api.OperatingSystem(architecture=[architecture]).create()
     os_name = f'{os.name} {os.major}'
-    domain = entities.Domain(organization=[module_org], location=[module_location]).create()
+    domain = module_target_sat.api.Domain(
+        organization=[module_org], location=[module_location]
+    ).create()
     with session:
         # Create host group with some data
         session.hostgroup.create(
@@ -62,11 +63,13 @@ def test_positive_end_to_end(session, module_org, module_location):
         assert session.hostgroup.search(new_name)[0]['Name'] == new_name
         # Delete host group
         session.hostgroup.delete(new_name)
-        assert not entities.HostGroup().search(query={'search': f'name={new_name}'})
+        assert not module_target_sat.api.HostGroup().search(query={'search': f'name={new_name}'})
 
 
 @pytest.mark.tier2
-def test_negative_delete_with_discovery_rule(session, module_org, module_location):
+def test_negative_delete_with_discovery_rule(
+    session, module_org, module_location, module_target_sat
+):
     """Attempt to delete hostgroup which has dependent discovery rule
 
     :id: bd046e9a-f0d0-4110-8f94-fd04193cb3af
@@ -80,8 +83,10 @@ def test_negative_delete_with_discovery_rule(session, module_org, module_locatio
 
     :CaseImportance: High
     """
-    hostgroup = entities.HostGroup(organization=[module_org], location=[module_location]).create()
-    entities.DiscoveryRule(
+    hostgroup = module_target_sat.api.HostGroup(
+        organization=[module_org], location=[module_location]
+    ).create()
+    module_target_sat.api.DiscoveryRule(
         hostgroup=hostgroup, organization=[module_org], location=[module_location]
     ).create()
     with session:

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -12,7 +12,6 @@
 
 """
 from fauxfactory import gen_ipaddr, gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -22,7 +21,7 @@ from robottelo.constants import ANY_CONTEXT, INSTALL_MEDIUM_URL, LIBVIRT_RESOURC
 @pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session):
+def test_positive_end_to_end(session, target_sat):
     """Perform end to end testing for location component
 
     :id: dba5d94d-0c18-4db0-a9e8-66599bffc5d9
@@ -31,18 +30,18 @@ def test_positive_end_to_end(session):
 
     :CaseImportance: Critical
     """
-    loc_parent = entities.Location().create()
+    loc_parent = target_sat.api.Location().create()
     loc_child_name = gen_string('alpha')
     description = gen_string('alpha')
     updated_name = gen_string('alphanumeric')
 
     # create entities
     ip_addres = gen_ipaddr(ip3=True)
-    subnet = entities.Subnet(network=ip_addres, mask='255.255.255.0').create()
+    subnet = target_sat.api.Subnet(network=ip_addres, mask='255.255.255.0').create()
     subnet_name = f'{subnet.name} ({subnet.network}/{subnet.cidr})'
-    domain = entities.Domain().create()
-    user = entities.User().create()
-    media = entities.Media(
+    domain = target_sat.api.Domain().create()
+    user = target_sat.api.User().create()
+    media = target_sat.api.Media(
         path_=INSTALL_MEDIUM_URL % gen_string('alpha', 6), os_family='Redhat'
     ).create()
 
@@ -105,7 +104,7 @@ def test_positive_end_to_end(session):
 
 @pytest.mark.skip_if_open("BZ:1321543")
 @pytest.mark.tier2
-def test_positive_update_with_all_users(session):
+def test_positive_update_with_all_users(session, target_sat):
     """Create location and do not add user to it. Check and uncheck
     'all users' setting. Verify that for both operation expected location
     is assigned to user. Then add user to location and retry.
@@ -119,8 +118,8 @@ def test_positive_update_with_all_users(session):
 
     :BZ: 1321543, 1479736, 1479736
     """
-    user = entities.User().create()
-    loc = entities.Location().create()
+    user = target_sat.api.User().create()
+    loc = target_sat.api.Location().create()
     with session:
         session.organization.select(org_name=ANY_CONTEXT['org'])
         session.location.select(loc_name=loc.name)
@@ -144,7 +143,7 @@ def test_positive_update_with_all_users(session):
 
 
 @pytest.mark.tier2
-def test_positive_add_org_hostgroup_template(session):
+def test_positive_add_org_hostgroup_template(session, target_sat):
     """Add a organization, hostgroup, provisioning template by using
        the location name
 
@@ -153,10 +152,10 @@ def test_positive_add_org_hostgroup_template(session):
     :expectedresults: organization, hostgroup, provisioning template are
         added to location
     """
-    org = entities.Organization().create()
-    loc = entities.Location().create()
-    hostgroup = entities.HostGroup().create()
-    template = entities.ProvisioningTemplate().create()
+    org = target_sat.api.Organization().create()
+    loc = target_sat.api.Location().create()
+    hostgroup = target_sat.api.HostGroup().create()
+    template = target_sat.api.ProvisioningTemplate().create()
     with session:
         session.location.update(
             loc.name,
@@ -186,7 +185,7 @@ def test_positive_add_org_hostgroup_template(session):
 
 @pytest.mark.skip_if_not_set('libvirt')
 @pytest.mark.tier2
-def test_positive_update_compresource(session):
+def test_positive_update_compresource(session, target_sat):
     """Add/Remove compute resource from/to location
 
     :id: 1d24414a-666d-490d-89b9-cd0704684cdd
@@ -194,9 +193,9 @@ def test_positive_update_compresource(session):
     :expectedresults: compute resource is added and removed from the location
     """
     url = LIBVIRT_RESOURCE_URL % settings.libvirt.libvirt_hostname
-    resource = entities.LibvirtComputeResource(url=url).create()
+    resource = target_sat.api.LibvirtComputeResource(url=url).create()
     resource_name = resource.name + ' (Libvirt)'
-    loc = entities.Location().create()
+    loc = target_sat.api.Location().create()
     with session:
         session.location.update(loc.name, {'compute_resources.resources.assigned': [resource_name]})
         loc_values = session.location.read(loc.name)

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -12,25 +12,24 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
 
 
 @pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
+def module_org(module_target_sat):
+    return module_target_sat.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
-def module_product(module_org):
-    return entities.Product(organization=module_org).create()
+def module_product(module_org, module_target_sat):
+    return module_target_sat.api.Product(organization=module_org).create()
 
 
 @pytest.fixture(scope='module')
-def module_yum_repo(module_product):
-    yum_repo = entities.Repository(
+def module_yum_repo(module_product, module_target_sat):
+    yum_repo = module_target_sat.api.Repository(
         name=gen_string('alpha'),
         product=module_product,
         content_type='yum',

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -11,7 +11,6 @@
 :CaseImportance: High
 
 """
-from nailgun import entities
 import pytest
 
 from robottelo.constants import OSCAP_PROFILE
@@ -19,8 +18,10 @@ from robottelo.utils.datafactory import gen_string
 
 
 @pytest.fixture(scope='module')
-def module_host_group(default_location, default_org):
-    return entities.HostGroup(location=[default_location], organization=[default_org]).create()
+def module_host_group(default_location, default_org, module_target_sat):
+    return module_target_sat.api.HostGroup(
+        location=[default_location], organization=[default_org]
+    ).create()
 
 
 @pytest.mark.skip_if_open("BZ:2167937")
@@ -33,6 +34,7 @@ def test_positive_check_dashboard(
     default_org,
     oscap_content_path,
     import_ansible_roles,
+    module_target_sat,
 ):
     """Create OpenScap Policy which is connected to the host. That policy
     dashboard should be rendered and correctly display information about
@@ -56,12 +58,12 @@ def test_positive_check_dashboard(
     """
     name = gen_string('alpha')
     oscap_content_title = gen_string('alpha')
-    lce = entities.LifecycleEnvironment(organization=default_org).create()
-    content_view = entities.ContentView(organization=default_org).create()
+    lce = module_target_sat.api.LifecycleEnvironment(organization=default_org).create()
+    content_view = module_target_sat.api.ContentView(organization=default_org).create()
     content_view.publish()
     content_view = content_view.read()
     content_view.version[0].promote(data={'environment_ids': lce.id})
-    entities.Host(
+    module_target_sat.api.Host(
         hostgroup=module_host_group,
         location=default_location,
         organization=default_org,
@@ -70,7 +72,7 @@ def test_positive_check_dashboard(
             'lifecycle_environment_id': lce.id,
         },
     ).create()
-    entities.ScapContents(
+    module_target_sat.api.ScapContents(
         title=oscap_content_title,
         scap_file=oscap_content_path,
         organization=[default_org],
@@ -110,6 +112,7 @@ def test_positive_end_to_end(
     oscap_content_path,
     tailoring_file_path,
     import_ansible_roles,
+    module_target_sat,
 ):
     """Perform end to end testing for oscap policy component
 
@@ -127,14 +130,14 @@ def test_positive_end_to_end(
     profile_type = OSCAP_PROFILE['security7']
     tailoring_type = OSCAP_PROFILE['tailoring_rhel7']
     # Upload oscap content file
-    entities.ScapContents(
+    module_target_sat.api.ScapContents(
         title=oscap_content_title,
         scap_file=oscap_content_path,
         organization=[default_org],
         location=[default_location],
     ).create()
     # Upload tailoring file
-    entities.TailoringFile(
+    module_target_sat.api.TailoringFile(
         name=tailoring_name,
         scap_file=tailoring_file_path['local'],
         organization=[default_org],

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -11,7 +11,6 @@
 :CaseImportance: High
 
 """
-from nailgun import entities
 import pytest
 
 from robottelo.utils.datafactory import gen_string
@@ -19,7 +18,9 @@ from robottelo.utils.datafactory import gen_string
 
 @pytest.mark.tier1
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, tailoring_file_path, default_org, default_location):
+def test_positive_end_to_end(
+    session, tailoring_file_path, default_org, default_location, module_target_sat
+):
     """Perform end to end testing for tailoring file component
 
     :id: 9aebccb8-6837-4583-8a8a-8883480ab688
@@ -52,7 +53,9 @@ def test_positive_end_to_end(session, tailoring_file_path, default_org, default_
         assert session.oscaptailoringfile.search(new_name)[0]['Name'] == new_name
         assert not session.oscaptailoringfile.search(name)
         session.oscaptailoringfile.delete(new_name)
-        assert not entities.TailoringFile().search(query={'search': f'name={new_name}'})
+        assert not module_target_sat.api.TailoringFile().search(
+            query={'search': f'name={new_name}'}
+        )
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -12,7 +12,6 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -20,18 +19,18 @@ from robottelo.constants import RPM_TO_UPLOAD, DataFile
 
 
 @pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
+def module_org(module_target_sat):
+    return module_target_sat.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
-def module_product(module_org):
-    return entities.Product(organization=module_org).create()
+def module_product(module_org, module_target_sat):
+    return module_target_sat.api.Product(organization=module_org).create()
 
 
 @pytest.fixture(scope='module')
-def module_yum_repo(module_product):
-    yum_repo = entities.Repository(
+def module_yum_repo(module_product, module_target_sat):
+    yum_repo = module_target_sat.api.Repository(
         name=gen_string('alpha'),
         product=module_product,
         content_type='yum',
@@ -42,8 +41,8 @@ def module_yum_repo(module_product):
 
 
 @pytest.fixture(scope='module')
-def module_yum_repo2(module_product):
-    yum_repo = entities.Repository(
+def module_yum_repo2(module_product, module_target_sat):
+    yum_repo = module_target_sat.api.Repository(
         name=gen_string('alpha'),
         product=module_product,
         content_type='yum',
@@ -64,8 +63,8 @@ def module_rh_repo(module_entitlement_manifest_org, module_target_sat):
         reposet=rhst.data['repository-set'],
         releasever=rhst.data['releasever'],
     )
-    entities.Repository(id=repo_id).sync()
-    return entities.Repository(id=repo_id).read()
+    module_target_sat.api.Repository(id=repo_id).sync()
+    return module_target_sat.api.Repository(id=repo_id).read()
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -14,7 +14,6 @@
 from datetime import timedelta
 
 from fauxfactory import gen_choice
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -28,13 +27,13 @@ from robottelo.utils.datafactory import (
 
 
 @pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
+def module_org(module_target_sat):
+    return module_target_sat.api.Organization().create()
 
 
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_end_to_end(session, module_org):
+def test_positive_end_to_end(session, module_org, module_target_sat):
     """Perform end to end testing for product component
 
     :id: d0e1f0d1-2380-4508-b270-62c1d8b3e2ff
@@ -47,11 +46,11 @@ def test_positive_end_to_end(session, module_org):
     new_product_name = gen_string('alpha')
     product_label = gen_string('alpha')
     product_description = gen_string('alpha')
-    gpg_key = entities.GPGKey(
+    gpg_key = module_target_sat.api.GPGKey(
         content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         organization=module_org,
     ).create()
-    sync_plan = entities.SyncPlan(organization=module_org).create()
+    sync_plan = module_target_sat.api.SyncPlan(organization=module_org).create()
     with session:
         # Create new product using different parameters
         session.product.create(
@@ -97,7 +96,7 @@ def test_positive_end_to_end(session, module_org):
 
 @pytest.mark.parametrize('product_name', **parametrized(valid_data_list('ui')))
 @pytest.mark.tier2
-def test_positive_create_in_different_orgs(session, product_name):
+def test_positive_create_in_different_orgs(session, product_name, module_target_sat):
     """Create Product with same name but in different organizations
 
     :id: 469fc036-a48a-4c0a-9da9-33e73f903479
@@ -107,7 +106,7 @@ def test_positive_create_in_different_orgs(session, product_name):
     :expectedresults: Product is created successfully in both
         organizations.
     """
-    orgs = [entities.Organization().create() for _ in range(2)]
+    orgs = [module_target_sat.api.Organization().create() for _ in range(2)]
     with session:
         for org in orgs:
             session.organization.select(org_name=org.name)
@@ -118,7 +117,7 @@ def test_positive_create_in_different_orgs(session, product_name):
 
 
 @pytest.mark.tier2
-def test_positive_product_create_with_create_sync_plan(session, module_org):
+def test_positive_product_create_with_create_sync_plan(session, module_org, module_target_sat):
     """Perform Sync Plan Create from Product Create Page
 
     :id: 4a87b533-12b6-4d4e-8a99-4bb95efc4321
@@ -129,7 +128,7 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
     """
     product_name = gen_string('alpha')
     product_description = gen_string('alpha')
-    gpg_key = entities.GPGKey(
+    gpg_key = module_target_sat.api.GPGKey(
         content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         organization=module_org,
     ).create()
@@ -162,7 +161,7 @@ def test_positive_product_create_with_create_sync_plan(session, module_org):
 
 
 @pytest.mark.tier2
-def test_positive_bulk_action_advanced_sync(session, module_org):
+def test_positive_bulk_action_advanced_sync(session, module_org, module_target_sat):
     """Advanced sync is available as a bulk action in the product.
 
     :id: 7e9bb306-452d-43b8-8725-604b4aebb222
@@ -177,7 +176,7 @@ def test_positive_bulk_action_advanced_sync(session, module_org):
     :expectedresults: Advanced sync for repositories can be run as a bulk action from the product.
     """
     repo_name = gen_string('alpha')
-    product = entities.Product(organization=module_org).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
     with session:
         session.repository.create(
             product.name,

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -17,7 +17,6 @@ import os
 from pathlib import Path, PurePath
 
 from lxml import etree
-from nailgun import entities
 import pytest
 import yaml
 
@@ -44,25 +43,25 @@ def setup_content(module_entitlement_manifest_org, module_target_sat):
         reposet=REPOSET['rhst7'],
         releasever=None,
     )
-    rh_repo = entities.Repository(id=rh_repo_id).read()
+    rh_repo = module_target_sat.api.Repository(id=rh_repo_id).read()
     rh_repo.sync()
-    custom_product = entities.Product(organization=org).create()
-    custom_repo = entities.Repository(
+    custom_product = module_target_sat.api.Product(organization=org).create()
+    custom_repo = module_target_sat.api.Repository(
         name=gen_string('alphanumeric').upper(), product=custom_product
     ).create()
     custom_repo.sync()
-    lce = entities.LifecycleEnvironment(organization=org).create()
-    cv = entities.ContentView(
+    lce = module_target_sat.api.LifecycleEnvironment(organization=org).create()
+    cv = module_target_sat.api.ContentView(
         organization=org,
         repository=[rh_repo_id, custom_repo.id],
     ).create()
     cv.publish()
     cvv = cv.read().version[0].read()
     cvv.promote(data={'environment_ids': lce.id})
-    ak = entities.ActivationKey(
+    ak = module_target_sat.api.ActivationKey(
         content_view=cv, organization=org, environment=lce, auto_attach=True
     ).create()
-    subscription = entities.Subscription(organization=org).search(
+    subscription = module_target_sat.api.Subscription(organization=org).search(
         query={'search': f'name="{DEFAULT_SUBSCRIPTION_NAME}"'}
     )[0]
     ak.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
@@ -283,7 +282,7 @@ def test_positive_generate_registered_hosts_report(target_sat, module_org, modul
 @pytest.mark.upgrade
 @pytest.mark.tier2
 def test_positive_generate_subscriptions_report_json(
-    session, module_org, module_location, setup_content
+    session, module_org, setup_content, module_target_sat
 ):
     """Use provided Subscriptions report, generate JSON
 
@@ -300,7 +299,7 @@ def test_positive_generate_subscriptions_report_json(
         )
     with open(file_path) as json_file:
         data = json.load(json_file)
-    subscription_cnt = len(entities.Subscription(organization=module_org).search())
+    subscription_cnt = len(module_target_sat.api.Subscription(organization=module_org).search())
     assert subscription_cnt > 0
     assert len(data) >= subscription_cnt
     keys_expected = [

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -12,7 +12,6 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -28,13 +27,13 @@ from robottelo.constants.repos import FEDORA_OSTREE_REPO
 
 
 @pytest.fixture(scope='module')
-def module_org():
-    return entities.Organization().create()
+def module_org(module_target_sat):
+    return module_target_sat.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
-def module_custom_product(module_org):
-    return entities.Product(organization=module_org).create()
+def module_custom_product(module_org, module_target_sat):
+    return module_target_sat.api.Product(organization=module_org).create()
 
 
 @pytest.mark.run_in_one_thread
@@ -79,7 +78,7 @@ def test_positive_sync_rh_repos(session, target_sat, module_entitlement_manifest
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_sync_custom_ostree_repo(session, module_custom_product):
+def test_positive_sync_custom_ostree_repo(session, module_custom_product, module_target_sat):
     """Create custom ostree repository and sync it.
 
     :id: e4119b9b-0356-4661-a3ec-e5807224f7d2
@@ -90,7 +89,7 @@ def test_positive_sync_custom_ostree_repo(session, module_custom_product):
 
     :BZ: 1625783
     """
-    repo = entities.Repository(
+    repo = module_target_sat.api.Repository(
         content_type='ostree',
         url=FEDORA_OSTREE_REPO,
         product=module_custom_product,
@@ -139,7 +138,7 @@ def test_positive_sync_rh_ostree_repo(session, target_sat, module_entitlement_ma
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_sync_docker_via_sync_status(session, module_org):
+def test_positive_sync_docker_via_sync_status(session, module_org, module_target_sat):
     """Create custom docker repo and sync it via the sync status page.
 
     :id: 00b700f4-7e52-48ed-98b2-e49b3be102f2
@@ -147,7 +146,7 @@ def test_positive_sync_docker_via_sync_status(session, module_org):
     :expectedresults: Sync procedure for specific docker repository is
         successful
     """
-    product = entities.Product(organization=module_org).create()
+    product = module_target_sat.api.Product(organization=module_org).create()
     repo_name = gen_string('alphanumeric')
     with session:
         session.repository.create(

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -15,7 +15,6 @@ from datetime import datetime, timedelta
 import time
 
 from fauxfactory import gen_choice
-from nailgun import entities
 import pytest
 
 from robottelo.constants import SYNC_INTERVAL
@@ -162,15 +161,15 @@ def test_positive_search_scoped(session, request, target_sat):
     """
     name = gen_string('alpha')
     start_date = datetime.utcnow() + timedelta(days=10)
-    org = entities.Organization().create()
-    sync_plan = entities.SyncPlan(
+    org = target_sat.api.Organization().create()
+    sync_plan = target_sat.api.SyncPlan(
         name=name,
         interval=SYNC_INTERVAL['day'],
         organization=org,
         enabled=True,
         sync_date=start_date,
     ).create()
-    sync_plan = entities.SyncPlan(organization=org.id, id=sync_plan.id).read()
+    sync_plan = target_sat.api.SyncPlan(organization=org.id, id=sync_plan.id).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     with session:
         session.organization.select(org.name)
@@ -191,8 +190,8 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
     :expectedresults: Product is synchronized successfully.
     """
     plan_name = gen_string('alpha')
-    product = entities.Product(organization=module_org).create()
-    repo = entities.Repository(product=product).create()
+    product = target_sat.api.Product(organization=module_org).create()
+    repo = target_sat.api.Repository(product=product).create()
     with session:
         # workaround: force session.browser to point to browser object on next line
         session.contenthost.read_all('current_user')
@@ -257,8 +256,8 @@ def test_positive_synchronize_custom_product_custom_cron_past_sync_date(
     :expectedresults: Product is synchronized successfully.
     """
     plan_name = gen_string('alpha')
-    product = entities.Product(organization=module_org).create()
-    repo = entities.Repository(product=product).create()
+    product = target_sat.api.Product(organization=module_org).create()
+    repo = target_sat.api.Repository(product=product).create()
     with session:
         # workaround: force session.browser to point to browser object on next line
         session.contenthost.read_all('current_user')

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -10,7 +10,6 @@
 
 """
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 import requests
 
@@ -19,13 +18,13 @@ from robottelo.constants import FOREMAN_TEMPLATE_IMPORT_URL, FOREMAN_TEMPLATE_RO
 
 
 @pytest.fixture(scope='module')
-def templates_org():
-    return entities.Organization().create()
+def templates_org(module_target_sat):
+    return module_target_sat.api.Organization().create()
 
 
 @pytest.fixture(scope='module')
-def templates_loc(templates_org):
-    return entities.Location(organization=[templates_org]).create()
+def templates_loc(templates_org, module_target_sat):
+    return module_target_sat.api.Location(organization=[templates_org]).create()
 
 
 git = settings.git

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -12,13 +12,12 @@
 
 """
 from fauxfactory import gen_string, gen_utf8
-from nailgun import entities
 import pytest
 
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_delete_with_user(session, module_org, module_location):
+def test_positive_delete_with_user(session, module_org, module_location, module_target_sat):
     """Delete a Usergroup that contains a user
 
     :id: 2bda3db5-f54f-412f-831f-8e005631f271
@@ -28,7 +27,7 @@ def test_positive_delete_with_user(session, module_org, module_location):
     user_name = gen_string('alpha')
     group_name = gen_utf8(smp=False)
     # Create a new user
-    entities.User(
+    module_target_sat.api.User(
         login=user_name,
         password=gen_string('alpha'),
         organization=[module_org],
@@ -46,7 +45,7 @@ def test_positive_delete_with_user(session, module_org, module_location):
 @pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(session, module_org, module_location):
+def test_positive_end_to_end(session, module_org, module_location, module_target_sat):
     """Perform end to end testing for usergroup component
 
     :id: c1c7c383-b118-4caf-a5ef-4e75fdbbacdc
@@ -57,10 +56,10 @@ def test_positive_end_to_end(session, module_org, module_location):
     """
     name = gen_string('alpha')
     new_name = gen_string('alpha')
-    user = entities.User(
+    user = module_target_sat.api.User(
         password=gen_string('alpha'), organization=[module_org], location=[module_location]
     ).create()
-    user_group = entities.UserGroup().create()
+    user_group = module_target_sat.api.UserGroup().create()
     with session:
         # Create new user group with assigned entities
         session.usergroup.create(


### PR DESCRIPTION

Problem Statement

We are using the direct imports from the nailgun rather than directly using from target_sat
Solution

Direct Imports Removed: We've cleaned up our codebase by eliminating direct imports from the Nailgun package.

Using target_sat, module_target_sat, class_target_sat: Modified the API calls and using the target_sat.api. pattern for all API calls.
