### PR TITLE
Fix module_hostgroup fixture

### DIFF
--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -21,6 +21,7 @@ from robottelo.utils.datafactory import valid_data_list
 @pytest.fixture(scope='module')
 def module_hostgroup(module_org, module_target_sat):
     module_hostgroup = module_target_sat.api.HostGroup(organization=[module_org]).create()
+    yield module_hostgroup
     module_hostgroup.delete()
 
 


### PR DESCRIPTION
### Problem Statement
Hostgroup fixture doesn't return anything.

### Solution
Fixed hostgroup fixture .

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->