### PR TITLE
[6.13.z] moving to use pull_request_target for prt_label.yml GHA

### DIFF
--- a/.github/workflows/prt_labels.yml
+++ b/.github/workflows/prt_labels.yml
@@ -1,7 +1,7 @@
 name: Remove the PRT label, for the new commit
 
 on:
-  pull_request:
+  pull_request_target:
     types: ["synchronize"]
 
 jobs:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14467

### Problem Statement
https://github.com/SatelliteQE/robottelo/actions/runs/8363883965/job/22919405093?pr=14465 failing because of the github token passed related to pull request https://github.com/actions/labeler/issues/121 more details. 

### Solution
Moving prt_label.yml GHA to  use`pull request target` will solve this issue.  

### Related Issues
https://github.com/SatelliteQE/robottelo/actions/runs/8363883965/job/22919405093?pr=14465

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->