### PR TITLE
Fix upstream api permission tests

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -970,13 +970,6 @@ PERMISSIONS = {
         'view_discovery_rules',
     ],
     'Domain': ['view_domains', 'create_domains', 'edit_domains', 'destroy_domains'],
-    #    'Environment': [
-    #        'view_environments',
-    #        'create_environments',
-    #        'edit_environments',
-    #        'destroy_environments',
-    #        'import_environments',
-    #    ],
     'ExternalUsergroup': [
         'view_external_usergroups',
         'create_external_usergroups',
@@ -1054,19 +1047,35 @@ PERMISSIONS = {
         'destroy_hostgroups',
         'play_roles_on_hostgroup',
     ],
-    #    'Puppetclass': [
-    #        'view_puppetclasses',
-    #        'create_puppetclasses',
-    #        'edit_puppetclasses',
-    #        'destroy_puppetclasses',
-    #        'import_puppetclasses',
-    #    ],
-    #    'PuppetclassLookupKey': [
-    #        'view_external_parameters',
-    #        'create_external_parameters',
-    #        'edit_external_parameters',
-    #        'destroy_external_parameters',
-    #    ],
+    'ForemanPuppet::ConfigGroup': [
+        'view_config_groups',
+        'create_config_groups',
+        'edit_config_groups',
+        'destroy_config_groups',
+    ],
+    'ForemanPuppet::Environment': [
+        'view_environments',
+        'create_environments',
+        'edit_environments',
+        'destroy_environments',
+        'import_environments',
+    ],
+    'ForemanPuppet::HostClass': [
+        'edit_classes',
+    ],
+    'ForemanPuppet::Puppetclass': [
+        'view_puppetclasses',
+        'create_puppetclasses',
+        'edit_puppetclasses',
+        'destroy_puppetclasses',
+        'import_puppetclasses',
+    ],
+    'ForemanPuppet::PuppetclassLookupKey': [
+        'view_external_parameters',
+        'create_external_parameters',
+        'edit_external_parameters',
+        'destroy_external_parameters',
+    ],
     'HttpProxy': [
         'view_http_proxies',
         'create_http_proxies',

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -38,28 +38,35 @@ class TestPermission:
         # workaround for setting class variables
         cls = type(self)
         cls.permissions = PERMISSIONS.copy()
-        if class_target_sat.is_upstream:
-            cls.permissions[None].extend(cls.permissions.pop('DiscoveryRule'))
-            cls.permissions[None].remove('app_root')
-            cls.permissions[None].remove('attachments')
-            cls.permissions[None].remove('configuration')
-            cls.permissions[None].remove('logs')
-            cls.permissions[None].remove('view_cases')
-            cls.permissions[None].remove('view_log_viewer')
 
-        result = class_target_sat.execute('rpm -qa | grep rubygem-foreman_openscap')
-        if result.status != 0:
+        rpm_packages = class_target_sat.execute('rpm -qa').stdout
+        if 'rubygem-foreman_rh_cloud' not in rpm_packages:
+            cls.permissions.pop('InsightsHit')
+            cls.permissions[None].remove('generate_foreman_rh_cloud')
+            cls.permissions[None].remove('view_foreman_rh_cloud')
+            cls.permissions[None].remove('dispatch_cloud_requests')
+            cls.permissions[None].remove('control_organization_insights')
+        if 'rubygem-foreman_bootdisk' not in rpm_packages:
+            cls.permissions[None].remove('download_bootdisk')
+        if 'rubygem-foreman_virt_who_configure' not in rpm_packages:
+            cls.permissions.pop('ForemanVirtWhoConfigure::Config')
+        if 'rubygem-foreman_openscap' not in rpm_packages:
             cls.permissions.pop('ForemanOpenscap::Policy')
             cls.permissions.pop('ForemanOpenscap::ScapContent')
             cls.permissions[None].remove('destroy_arf_reports')
             cls.permissions[None].remove('view_arf_reports')
             cls.permissions[None].remove('create_arf_reports')
-        result = class_target_sat.execute('rpm -qa | grep rubygem-foreman_remote_execution')
-        if result.status != 0:
+        if 'rubygem-foreman_remote_execution' not in rpm_packages:
             cls.permissions.pop('JobInvocation')
             cls.permissions.pop('JobTemplate')
             cls.permissions.pop('RemoteExecutionFeature')
             cls.permissions.pop('TemplateInvocation')
+        if 'rubygem-foreman_puppet' not in rpm_packages:
+            cls.permissions.pop('ForemanPuppet::ConfigGroup')
+            cls.permissions.pop('ForemanPuppet::Environment')
+            cls.permissions.pop('ForemanPuppet::HostClass')
+            cls.permissions.pop('ForemanPuppet::Puppetclass')
+            cls.permissions.pop('ForemanPuppet::PuppetclassLookupKey')
 
         #: e.g. ['Architecture', 'Audit', 'AuthSourceLdap', …]
         cls.permission_resource_types = list(cls.permissions.keys())


### PR DESCRIPTION
### Problem Statement

API permission tests failing for upstream

### Solution

* add more checks for installed rpm packages
* speedup by querying rpm -qa ony once
* some tests were not updated with this commit https://github.com/SatelliteQE/robottelo/commit/6651dd63b4c308b3f7f3601f0e69d76b4c602b29#diff-9a55ae74469aa91ad5efb2b9068f73174467cd0c00d45abf7d35f9f2277a7632

Relevant tests:
```
tests/foreman/cli/test_role.py
tests/foreman/api/test_role.py
tests/foreman/api/test_permission.py

```

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->