### PR TITLE
[6.14.z] Add upgrade marker on ansible destructive tests

### DIFF
--- a/tests/foreman/destructive/test_ansible.py
+++ b/tests/foreman/destructive/test_ansible.py
@@ -13,7 +13,7 @@
 """
 import pytest
 
-pytestmark = pytest.mark.destructive
+pytestmark = [pytest.mark.destructive, pytest.mark.upgrade]
 
 
 def test_positive_persistent_ansible_cfg_change(target_sat):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14488

### Problem Statement
Missing upgrade marker on ansible destructive tests which run installer, suggested by SD in audit

### Solution
Add upgrade marker on ansible destructive tests to run these in upgrade job
