### PR TITLE
[6.14.z] Modify VMware compute profile test

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1782,7 +1782,6 @@ STRING_TYPES = ['alpha', 'numeric', 'alphanumeric', 'latin1', 'utf8', 'cjk', 'ht
 
 VMWARE_CONSTANTS = {
     'folder': 'vm',
-    'guest_os': 'Red Hat Enterprise Linux 8 (64 bit)',
     'scsicontroller': 'LSI Logic Parallel',
     'virtualhw_version': 'Default',
     'pool': 'Resources',

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -27,6 +27,7 @@ from robottelo.constants import (
     VMWARE_CONSTANTS,
 )
 from robottelo.utils.datafactory import gen_string
+from robottelo.utils.issue_handlers import is_open
 
 pytestmark = [pytest.mark.skip_if_not_set('vmware')]
 
@@ -290,129 +291,64 @@ def test_positive_resource_vm_power_management(session, vmware):
             raise AssertionError('Timed out waiting for VM to toggle power state') from err
 
 
+@pytest.mark.e2e
+@pytest.mark.upgrade
 @pytest.mark.tier2
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
-def test_positive_select_vmware_custom_profile_guest_os_rhel7(session, vmware):
-    """Select custom default (3-Large) compute profile guest OS RHEL7.
+def test_positive_vmware_custom_profile_end_to_end(session, vmware, request, target_sat):
+    """Perform end to end testing for VMware compute profile.
 
     :id: 24f7bb5f-2aaf-48cb-9a56-d2d0713dfe3d
 
     :customerscenario: true
 
-    :setup: vmware hostname and credentials.
-
     :steps:
 
         1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Select the created vmware CR.
-        4. Click Compute Profile tab.
-        5. Select 3-Large profile
-        6. Set Guest OS field to RHEL7 OS.
+        2. Update a compute profile with all values
 
-    :expectedresults: Guest OS RHEL7 is selected successfully.
+    :expectedresults: Compute profiles are updated successfully with all the values.
 
-    :BZ: 1315277
+    :BZ: 1315277, 2266672
     """
     cr_name = gen_string('alpha')
-    guest_os_name = 'Red Hat Enterprise Linux 7 (64-bit)'
-    with session:
-        session.computeresource.create(
-            {
-                'name': cr_name,
-                'provider': FOREMAN_PROVIDERS['vmware'],
-                'provider_content.vcenter': vmware.hostname,
-                'provider_content.user': settings.vmware.username,
-                'provider_content.password': settings.vmware.password,
-                'provider_content.datacenter.value': settings.vmware.datacenter,
-            }
-        )
-        assert session.computeresource.search(cr_name)[0]['Name'] == cr_name
-        session.computeresource.update_computeprofile(
-            cr_name, COMPUTE_PROFILE_LARGE, {'provider_content.guest_os': guest_os_name}
-        )
-        values = session.computeresource.read_computeprofile(cr_name, COMPUTE_PROFILE_LARGE)
-        assert values['provider_content']['guest_os'] == guest_os_name
-
-
-@pytest.mark.tier2
-@pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
-def test_positive_access_vmware_with_custom_profile(session, vmware):
-    """Associate custom default (3-Large) compute profile
-
-    :id: 751ef765-5091-4322-a0d9-0c9c73009cc4
-
-    :setup: vmware hostname and credentials.
-
-    :steps:
-
-        1. Create a compute resource of type vmware.
-        2. Provide valid hostname, username and password.
-        3. Select the created vmware CR.
-        4. Click Compute Profile tab.
-        5. Edit (3-Large) with valid configurations and submit.
-
-    :expectedresults: The Compute Resource created and associated to compute profile (3-Large)
-        with provided values.
-    """
-    cr_name = gen_string('alpha')
+    guest_os_names = [
+        'Red Hat Enterprise Linux 7 (64-bit)',
+        'Red Hat Enterprise Linux 8 (64 bit)',
+        'Red Hat Enterprise Linux 9 (64 bit)',
+    ]
+    compute_profile = ['1-Small', '2-Medium', '3-Large']
+    cpus = ['2', '4', '6']
+    vm_memory = ['4000', '6000', '8000']
+    annotation_notes = gen_string('alpha')
+    firmware_type = ['Automatic', 'BIOS', 'EFI']
+    resource_pool = VMWARE_CONSTANTS['pool']
+    folder = VMWARE_CONSTANTS['folder']
+    virtual_hw_version = VMWARE_CONSTANTS['virtualhw_version']
+    memory_hot_add = True
+    cpu_hot_add = True
+    cdrom_drive = True
+    disk_size = '10 GB'
+    network = 'VLAN 1001'  # hardcoding network here as this test won't be doing actual provisioning
     data_store_summary_string = _get_vmware_datastore_summary_string(vmware=vmware)
-    cr_profile_data = dict(
-        cpus='2',
-        cores_per_socket='2',
-        memory='1024',
-        firmware='EFI',
-        cluster=settings.vmware.cluster,
-        resource_pool=VMWARE_CONSTANTS.get('pool'),
-        folder=VMWARE_CONSTANTS.get('folder'),
-        guest_os=VMWARE_CONSTANTS.get('guest_os'),
-        virtual_hw_version=VMWARE_CONSTANTS.get('virtualhw_version'),
-        memory_hot_add=True,
-        cpu_hot_add=True,
-        cdrom_drive=True,
-        annotation_notes=gen_string('alpha'),
-        network_interfaces=[]
-        if not settings.provisioning.vlan_id
-        else [
-            dict(
-                nic_type=VMWARE_CONSTANTS.get('network_interface_name'),
-                network='VLAN 1001',  # hardcoding network here as these test won't be doing actual provisioning
-            ),
-            dict(
-                nic_type=VMWARE_CONSTANTS.get('network_interface_name'),
-                network='VLAN 1001',
-            ),
-        ],
-        storage=[
-            dict(
-                controller=VMWARE_CONSTANTS.get('scsicontroller'),
-                disks=[
-                    dict(
-                        data_store=data_store_summary_string,
-                        size='10 GB',
-                        thin_provision=True,
-                    ),
-                    dict(
-                        data_store=data_store_summary_string,
-                        size='20 GB',
-                        thin_provision=False,
-                        eager_zero=False,
-                    ),
-                ],
-            ),
-            dict(
-                controller=VMWARE_CONSTANTS.get('scsicontroller'),
-                disks=[
-                    dict(
-                        data_store=data_store_summary_string,
-                        size='30 GB',
-                        thin_provision=False,
-                        eager_zero=True,
-                    )
-                ],
-            ),
-        ],
-    )
+    storage_data = {
+        'storage': {
+            'controller': VMWARE_CONSTANTS['scsicontroller'],
+            'disks': [
+                {
+                    'data_store': data_store_summary_string,
+                    'size': disk_size,
+                    'thin_provision': True,
+                }
+            ],
+        }
+    }
+    network_data = {
+        'network_interfaces': {
+            'nic_type': VMWARE_CONSTANTS['network_interface_name'],
+            'network': network,
+        }
+    }
     with session:
         session.computeresource.create(
             {
@@ -424,46 +360,65 @@ def test_positive_access_vmware_with_custom_profile(session, vmware):
                 'provider_content.datacenter.value': settings.vmware.datacenter,
             }
         )
+
+        @request.addfinalizer
+        def _finalize():
+            cr = target_sat.api.VMWareComputeResource().search(query={'search': f'name={cr_name}'})
+            if cr:
+                target_sat.api.VMWareComputeResource(id=cr[0].id).delete()
+
         assert session.computeresource.search(cr_name)[0]['Name'] == cr_name
-        session.computeresource.update_computeprofile(
-            cr_name,
-            COMPUTE_PROFILE_LARGE,
-            {f'provider_content.{key}': value for key, value in cr_profile_data.items()},
-        )
-        values = session.computeresource.read_computeprofile(cr_name, COMPUTE_PROFILE_LARGE)
-        provider_content = values['provider_content']
-        # assert main compute resource profile data updated successfully.
-        excluded_keys = ['network_interfaces', 'storage']
-        expected_value = {
-            key: value for key, value in cr_profile_data.items() if key not in excluded_keys
-        }
-        provided_value = {
-            key: value for key, value in provider_content.items() if key in expected_value
-        }
-        assert provided_value == expected_value
-        # assert compute resource profile network data updated successfully.
-        for network_index, expected_network_value in enumerate(
-            cr_profile_data['network_interfaces']
+        for guest_os_name, cprofile, cpu, memory, firmware in zip(
+            guest_os_names, compute_profile, cpus, vm_memory, firmware_type, strict=True
         ):
-            provided_network_value = {
-                key: value
-                for key, value in provider_content['network_interfaces'][network_index].items()
-                if key in expected_network_value
-            }
-            assert provided_network_value == expected_network_value
-        # assert compute resource profile storage data updated successfully.
-        for controller_index, expected_controller_value in enumerate(cr_profile_data['storage']):
-            provided_controller_value = provider_content['storage'][controller_index]
-            assert (
-                provided_controller_value['controller'] == expected_controller_value['controller']
+            session.computeresource.update_computeprofile(
+                cr_name,
+                cprofile,
+                {
+                    'provider_content.guest_os': guest_os_name,
+                    'provider_content.cpus': cpu,
+                    'provider_content.memory': memory,
+                    'provider_content.cluster': settings.vmware.cluster,
+                    'provider_content.annotation_notes': annotation_notes,
+                    'provider_content.virtual_hw_version': virtual_hw_version,
+                    'provider_content.firmware': firmware,
+                    'provider_content.resource_pool': resource_pool,
+                    'provider_content.folder': folder,
+                    'provider_content.memory_hot_add': memory_hot_add,
+                    'provider_content.cpu_hot_add': cpu_hot_add,
+                    'provider_content.cdrom_drive': cdrom_drive,
+                    'provider_content.storage': [value for value in storage_data.values()],
+                    'provider_content.network_interfaces': [
+                        value for value in network_data.values()
+                    ],
+                },
             )
-            for disk_index, expected_disk_value in enumerate(expected_controller_value['disks']):
-                provided_disk_value = {
-                    key: value
-                    for key, value in provided_controller_value['disks'][disk_index].items()
-                    if key in expected_disk_value
-                }
-                assert provided_disk_value == expected_disk_value
+            values = session.computeresource.read_computeprofile(cr_name, cprofile)
+            provider_content = values['provider_content']
+            assert provider_content['guest_os'] == guest_os_name
+            assert provider_content['cpus'] == cpu
+            assert provider_content['memory'] == memory
+            assert provider_content['cluster'] == settings.vmware.cluster
+            assert provider_content['annotation_notes'] == annotation_notes
+            assert provider_content['virtual_hw_version'] == virtual_hw_version
+            if not is_open('BZ:2266672'):
+                assert values['provider_content']['firmware'] == firmware
+            assert provider_content['resource_pool'] == resource_pool
+            assert provider_content['folder'] == folder
+            assert provider_content['memory_hot_add'] == memory_hot_add
+            assert provider_content['cpu_hot_add'] == cpu_hot_add
+            assert provider_content['cdrom_drive'] == cdrom_drive
+            assert (
+                provider_content['storage'][0]['controller'] == VMWARE_CONSTANTS['scsicontroller']
+            )
+            assert provider_content['storage'][0]['disks'][0]['size'] == disk_size
+            assert (
+                provider_content['network_interfaces'][0]['nic_type']
+                == VMWARE_CONSTANTS['network_interface_name']
+            )
+            assert provider_content['network_interfaces'][0]['network'] == network
+        session.computeresource.delete(cr_name)
+        assert not session.computeresource.search(cr_name)
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14202

Modifying the VMware compute profile test by making it end-to-end and removing redundant test as a part of Component Audit