### PR TITLE
[6.15.z] virt-who config upgrade duplicate config issue fix

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -37,7 +37,7 @@ def form_data(target_sat):
         'satellite_url': target_sat.hostname,
         'hypervisor_username': esx.hypervisor_username,
         'hypervisor_password': esx.hypervisor_password,
-        'name': 'preupgrade_virt_who',
+        'name': f'preupgrade_virt_who_{gen_string("alpha")}',
     }
 
 
@@ -120,6 +120,7 @@ class TestScenarioPositiveVirtWho:
                 'org_id': org.id,
                 'org_name': org.name,
                 'org_label': org.label,
+                'name': vhd.name,
             }
         )
 
@@ -146,15 +147,16 @@ class TestScenarioPositiveVirtWho:
         org_id = pre_upgrade_data.get('org_id')
         org_name = pre_upgrade_data.get('org_name')
         org_label = pre_upgrade_data.get('org_label')
+        name = pre_upgrade_data.get('name')
 
         # Post upgrade, Verify virt-who exists and has same status.
         vhd = target_sat.api.VirtWhoConfig(organization_id=org_id).search(
-            query={'search': f'name={form_data["name"]}'}
+            query={'search': f'name={name}'}
         )[0]
         if not is_open('BZ:1802395'):
             assert vhd.status == 'ok'
         # Verify virt-who status via CLI as we cannot check it via API now
-        vhd_cli = target_sat.cli.VirtWhoConfig.exists(search=('name', form_data['name']))
+        vhd_cli = target_sat.cli.VirtWhoConfig.exists(search=('name', name))
         assert (
             target_sat.cli.VirtWhoConfig.info({'id': vhd_cli['id']})['general-information'][
                 'status'
@@ -185,7 +187,7 @@ class TestScenarioPositiveVirtWho:
         )
         virt_who_instance = (
             target_sat.api.VirtWhoConfig(organization_id=org_id)
-            .search(query={'search': f'name={form_data["name"]}'})[0]
+            .search(query={'search': f'name={name}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14378

when the virt-who upgrade tests failed for some issues, delete virt-who config will failed, then rerun the upgrade testing, it will create another virt-who config in other org, but when list or check info the config, it will list the first virt-who config.

Use auto name to fix it.
Test Case: PASS
```
(robottelo_vv_615) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/upgrades/test_virtwho.py  -m pre_upgrade --disable-pytest-warnings -q
.                                                                                                                                                                                                                                      [100%]
1 passed, 1 deselected, 20 warnings in 188.91s (0:03:08)
(robottelo_vv_615) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/upgrades/test_virtwho.py  -m post_upgrade --disable-pytest-warnings -q
.                                                                                                                                                                                                                                      [100%]
1 passed, 1 deselected, 12 warnings in 136.32s (0:02:16)
```