### PR TITLE
Test fixes for the Endeavour team

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -162,6 +162,16 @@ def rex_contenthost(request, module_org, target_sat, module_ak_with_cv):
 
 
 @pytest.fixture
+def rex_contenthosts(request, module_org, target_sat, module_ak_with_cv):
+    request.param['no_containers'] = True
+    with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
+        for host in hosts:
+            repo = settings.repos['SATCLIENT_REPO'][f'RHEL{host.os_version.major}']
+            host.register(module_org, None, module_ak_with_cv.name, target_sat, repo=repo)
+        yield hosts
+
+
+@pytest.fixture
 def katello_host_tools_tracer_host(rex_contenthost, target_sat):
     """Install katello-host-tools-tracer, create custom
     repositories on the host"""

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -10,6 +10,7 @@ TARGET_FIXTURES = [
     'capsule_provisioning_rhel_content',
     'module_sync_kickstart_content',
     'rex_contenthost',
+    'rex_contenthosts',
 ]
 
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1093,43 +1093,6 @@ def test_positive_read_details_page_from_new_ui(session, host_ui_options):
 
 
 @pytest.mark.tier4
-@pytest.mark.rhel_ver_match('8')
-def test_rex_new_ui(session, target_sat, rex_contenthost):
-    """Run remote execution using the new host details page
-
-    :id: ee625595-4995-43b2-9e6d-633c9b33ff93
-
-    :steps:
-        1. Navigate to Overview tab
-        2. Schedule a job
-        3. Wait for the job to finish
-        4. Job is visible in Recent jobs card
-
-    :expectedresults: Remote execution succeeded and the job is visible on Recent jobs card on
-        Overview tab
-    """
-    hostname = rex_contenthost.hostname
-    job_args = {
-        'job_category': 'Commands',
-        'job_template': 'Run Command - Script Default',
-        'template_content.command': 'ls',
-    }
-    with session:
-        session.location.select(loc_name=DEFAULT_LOC)
-        session.host_new.schedule_job(hostname, job_args)
-        task_result = target_sat.wait_for_tasks(
-            search_query=(f'Remote action: Run ls on {hostname}'),
-            search_rate=2,
-            max_tries=30,
-        )
-        task_status = target_sat.api.ForemanTask(id=task_result[0].id).poll()
-        assert task_status['result'] == 'success'
-        recent_jobs = session.host_new.get_details(hostname, "overview.recent_jobs")['overview']
-        assert recent_jobs['recent_jobs']['finished']['table'][0]['column0'] == "Run ls"
-        assert recent_jobs['recent_jobs']['finished']['table'][0]['column2'] == "succeeded"
-
-
-@pytest.mark.tier4
 def test_positive_manage_table_columns(
     target_sat, test_name, ui_hosts_columns_user, current_sat_org, current_sat_location
 ):

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -165,7 +165,6 @@ def test_positive_run_job_template_multiple_hosts_by_ip(
         vm.configure_rex(satellite=target_sat, org=module_org)
     with target_sat.ui_session() as session:
         session.organization.select(module_org.name)
-        # session.location.select('Default Location')
         for host in host_names:
             assert session.host.search(host)[0]['Name'] == host
         session.host.reset_search()

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -161,7 +161,6 @@ def test_positive_run_job_template_multiple_hosts_by_ip(
 
     host_names = []
     for vm in rex_contenthosts:
-        # for vm in rex_contenthost:
         host_names.append(vm.hostname)
         vm.configure_rex(satellite=target_sat, org=module_org)
     with target_sat.ui_session() as session:

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -140,7 +140,7 @@ def test_positive_run_custom_job_template_by_ip(
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_list([8])
 def test_positive_run_job_template_multiple_hosts_by_ip(
-    session, module_org, target_sat, registered_hosts
+    session, module_org, target_sat, rex_contenthosts
 ):
     """Run a job template against multiple hosts by ip
 
@@ -158,22 +158,24 @@ def test_positive_run_job_template_multiple_hosts_by_ip(
 
     :expectedresults: Verify the job was successfully ran against the hosts
     """
+
     host_names = []
-    for vm in registered_hosts:
+    for vm in rex_contenthosts:
+        # for vm in rex_contenthost:
         host_names.append(vm.hostname)
         vm.configure_rex(satellite=target_sat, org=module_org)
-    with session:
+    with target_sat.ui_session() as session:
         session.organization.select(module_org.name)
-        session.location.select('Default Location')
-        hosts = session.host.search(' or '.join([f'name="{hostname}"' for hostname in host_names]))
-        assert {host['Name'] for host in hosts} == set(host_names)
+        # session.location.select('Default Location')
+        for host in host_names:
+            assert session.host.search(host)[0]['Name'] == host
+        session.host.reset_search()
         job_status = session.host.schedule_remote_job(
             host_names,
             {
                 'category_and_template.job_category': 'Commands',
                 'category_and_template.job_template': 'Run Command - Script Default',
-                'target_hosts_and_inputs.command': 'ls',
-                'schedule.immediate': True,
+                'target_hosts_and_inputs.command': 'sleep 5',
             },
         )
         assert job_status['overview']['job_status'] == 'Success'
@@ -211,19 +213,20 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
 
     :parametrized: yes
     """
-    job_time = 10 * 60
+    job_time = 6 * 60
     hostname = rex_contenthost.hostname
     with session:
         session.organization.select(module_org.name)
         session.location.select('Default Location')
         assert session.host.search(hostname)[0]['Name'] == hostname
         plan_time = session.browser.get_client_datetime() + datetime.timedelta(seconds=job_time)
+        command_to_run = 'sleep 10'
         job_status = session.host.schedule_remote_job(
             [hostname],
             {
                 'category_and_template.job_category': 'Commands',
                 'category_and_template.job_template': 'Run Command - Script Default',
-                'target_hosts_and_inputs.command': 'ls',
+                'target_hosts_and_inputs.command': command_to_run,
                 'schedule.future': True,
                 'schedule_future_execution.start_at_date': plan_time.strftime("%Y/%m/%d"),
                 'schedule_future_execution.start_at_time': plan_time.strftime("%H:%M"),
@@ -237,34 +240,36 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
         # the job_time must be significantly greater than job creation time.
         assert job_left_time > 0
         assert job_status['overview']['hosts_table'][0]['Host'] == hostname
-        assert job_status['overview']['hosts_table'][0]['Status'] == 'N/A'
+        assert job_status['overview']['hosts_table'][0]['Status'] in ('Awaiting start', 'N/A')
         # sleep 3/4 of the left time
         time.sleep(job_left_time * 3 / 4)
-        job_status = session.jobinvocation.read('Run ls', hostname, 'overview.hosts_table')
+        job_status = session.jobinvocation.read(
+            f'Run {command_to_run}', hostname, 'overview.hosts_table'
+        )
         assert job_status['overview']['hosts_table'][0]['Host'] == hostname
-        assert job_status['overview']['hosts_table'][0]['Status'] == 'N/A'
+        assert job_status['overview']['hosts_table'][0]['Status'] in ('Awaiting start', 'N/A')
         # recalculate the job left time to be more accurate
         job_left_time = (plan_time - session.browser.get_client_datetime()).total_seconds()
         # the last read time should not take more than 1/4 of the last left time
         assert job_left_time > 0
         wait_for(
-            lambda: session.jobinvocation.read('Run ls', hostname, 'overview.hosts_table')[
-                'overview'
-            ]['hosts_table'][0]['Status']
+            lambda: session.jobinvocation.read(
+                f'Run {command_to_run}', hostname, 'overview.hosts_table'
+            )['overview']['hosts_table'][0]['Status']
             == 'running',
             timeout=(job_left_time + 30),
             delay=1,
         )
         # wait the job to change status to "success"
         wait_for(
-            lambda: session.jobinvocation.read('Run ls', hostname, 'overview.hosts_table')[
-                'overview'
-            ]['hosts_table'][0]['Status']
+            lambda: session.jobinvocation.read(
+                f'Run {command_to_run}', hostname, 'overview.hosts_table'
+            )['overview']['hosts_table'][0]['Status']
             == 'success',
             timeout=30,
             delay=1,
         )
-        job_status = session.jobinvocation.read('Run ls', hostname, 'overview')
+        job_status = session.jobinvocation.read(f'Run {command_to_run}', hostname, 'overview')
         assert job_status['overview']['job_status'] == 'Success'
         assert job_status['overview']['hosts_table'][0]['Host'] == hostname
         assert job_status['overview']['hosts_table'][0]['Status'] == 'success'


### PR DESCRIPTION
### Problem Statement
SAT-20041
Some endeavor tests were failing. 
Investigation and finding fixes were needed.
### Solution
I fixed those issues, via refactoring, refreshing fixtures used in the test, or via some airgun changes.

`test_rex_new_ui` moved and renamed  from test_hosts to test_jobinvocation after discussion with @pondrejk .

Needs: https://github.com/SatelliteQE/airgun/pull/1295

![image](https://github.com/SatelliteQE/robottelo/assets/62888716/4969f79e-adde-428b-a741-2bf282bdc701)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->