### PR TITLE
Mark manifester tests that do not use manifester fixtures

### DIFF
--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -226,6 +226,7 @@ def test_positive_sync_upstream_repo_with_zst_compression(
 
 
 @pytest.mark.tier1
+@pytest.mark.manifester
 def test_negative_upload_expired_manifest(module_org, target_sat):
     """Upload an expired manifest and attempt to refresh it
 

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -145,6 +145,7 @@ class TestSubscriptionAutoAttach:
 
     @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
     @pytest.mark.post_upgrade(depend_on=test_pre_subscription_scenario_auto_attach)
+    @pytest.mark.manifester
     def test_post_subscription_scenario_auto_attach(self, request, target_sat, pre_upgrade_data):
         """Run subscription auto-attach on pre-upgrade content host registered
         with Satellite.


### PR DESCRIPTION
### Problem Statement

Tests that do not use manifester fixture cannot be filtered by https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/conftest.py#L33

### Solution

Add simple pytest mark.

### Related Issues

https://github.com/SatelliteQE/robottelo/pull/14405

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->