### PR TITLE
[6.13.z] Bump pytest from 8.1.0 to 8.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ navmazing==1.2.2
 productmd==1.38
 pyotp==2.9.0
 python-box==7.1.1
-pytest==8.0.2
+pytest==8.1.1
+pytest-order==1.2.0
 pytest-services==2.2.1
 pytest-mock==3.14.0
 pytest-reportportal==5.4.0


### PR DESCRIPTION
### Problem Statement
Need to solve https://github.com/SatelliteQE/robottelo/issues/14328

### Solution
This PR will solve that.  

### Related Issues
https://github.com/SatelliteQE/robottelo/issues/14328

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->