### PR TITLE
Add case for special chars in HTTP proxy password

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -1,6 +1,13 @@
 import pytest
 
 from robottelo.config import settings
+from robottelo.hosts import ProxyHost
+
+
+@pytest.fixture(scope='session')
+def session_auth_proxy(session_target_sat):
+    """Instantiates authenticated HTTP proxy as a session-scoped fixture"""
+    return ProxyHost(settings.http_proxy.auth_proxy_url)
 
 
 @pytest.fixture


### PR DESCRIPTION
### Problem Statement
We are missing coverage for a [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1844840) where the HTTP proxy is created with a user containing special characters in his password.


### Solution
Not only we need to create the proxy at the Satellite side, we also need to create the user at the proxy side to verify the content operations actually work. In the end I decided to create such users dynamically during the test run, so I needed to add a new `ProxyHost` class with a few functions to handle that. The class is instantiated in a session-scoped fixture and used in test and other fixture.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_http_proxy.py -k special
