### PR TITLE
[6.15.z] Add test case to trigger the reclaim_space task

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # Version updates managed by dependabot
 
+apypie==0.4.0
 betelgeuse==1.11.0
 broker[docker]==0.4.9
 cryptography==42.0.5

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -14,6 +14,7 @@ import time
 from urllib.parse import urljoin, urlparse, urlunsplit
 import warnings
 
+import apypie
 from box import Box
 from broker import Broker
 from broker.hosts import Host
@@ -1762,6 +1763,7 @@ class Satellite(Capsule, SatelliteMixins):
         # create dummy classes for later population
         self._api = type('api', (), {'_configured': False})
         self._cli = type('cli', (), {'_configured': False})
+        self._apidoc = None
         self.record_property = None
 
     def _swap_nailgun(self, new_version):
@@ -1814,6 +1816,19 @@ class Satellite(Capsule, SatelliteMixins):
                 pass
         self._api._configured = True
         return self._api
+
+    @property
+    def apidoc(self):
+        """Provide Satellite's apidoc via apypie"""
+        if not self._apidoc:
+            self._apidoc = apypie.Api(
+                uri=self.url,
+                username=settings.server.admin_username,
+                password=settings.server.admin_password,
+                api_version=2,
+                verify_ssl=settings.server.verify_ca,
+            ).apidoc
+        return self._apidoc
 
     @property
     def cli(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14397

### Problem Statement
A test case (and nailgun support) to trigger the Reclaim space task was missing. Also a BZ complained about wrong endpoint being referenced in apidoc.


### Solution
This PR adds one.


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k 'reclaim_space'
nailgun: 1111