### PR TITLE
[6.14.z] Add case for special chars in HTTP proxy password

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -1,6 +1,13 @@
 import pytest
 
 from robottelo.config import settings
+from robottelo.hosts import ProxyHost
+
+
+@pytest.fixture(scope='session')
+def session_auth_proxy(session_target_sat):
+    """Instantiates authenticated HTTP proxy as a session-scoped fixture"""
+    return ProxyHost(settings.http_proxy.auth_proxy_url)
 
 
 @pytest.fixture

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -145,7 +145,7 @@ class APIFactory:
         """Enable the RedHat repo, sync it and returns repo_id"""
         # Enable RH repo and fetch repository_id
         repo_id = self.enable_rhrepo_and_fetchid(
-            basearch=rh_repo['basearch'],
+            basearch=rh_repo.get('basearch', rh_repo.get('arch', DEFAULT_ARCHITECTURE)),
             org_id=org_id,
             product=rh_repo['product'],
             repo=rh_repo['name'],

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -169,6 +169,10 @@ class IPAHostError(Exception):
     pass
 
 
+class ProxyHostError(Exception):
+    pass
+
+
 class ContentHost(Host, ContentHostMixins):
     run = Host.execute
     default_timeout = settings.server.ssh_client.command_timeout
@@ -2558,3 +2562,42 @@ class IPAHost(Host):
         )
         if result.status != 0:
             raise IPAHostError('Failed to remove the user from user group')
+
+
+class ProxyHost(Host):
+    """Class representing HTTP Proxy host"""
+
+    def __init__(self, url, **kwargs):
+        self._conf_dir = '/etc/squid/'
+        self._access_log = '/var/log/squid/access.log'
+        kwargs['hostname'] = urlparse(url).hostname
+        super().__init__(**kwargs)
+
+    def add_user(self, name, passwd):
+        """Adds new user to the HTTP Proxy"""
+        res = self.execute(f"htpasswd -b {self._conf_dir}passwd {name} '{passwd}'")
+        assert res.status == 0, f'User addition failed on the proxy side: {res.stderr}'
+        return res
+
+    def remove_user(self, name):
+        """Removes a user from HTTP Proxy"""
+        res = self.execute(f'htpasswd -D {self._conf_dir}passwd {name}')
+        assert res.status == 0, f'User deletion failed on the proxy side: {res.stderr}'
+        return res
+
+    def get_log(self, which=None, tail=None, grep=None):
+        """Returns log content from the HTTP Proxy instance
+
+        :param which: Which log file should be read. Defaults to access.log.
+        :param tail: Use when only the tail of a long log file is needed.
+        :param grep: Grep for some expression.
+        :return: Log content found or None
+        """
+        log_file = which or self._access_log
+        cmd = f'tail -n {tail} {log_file}' if tail else f'cat {log_file}'
+        if grep:
+            cmd = f'{cmd} | grep "{grep}"'
+        res = self.execute(cmd)
+        if res.status != 0:
+            raise ProxyHostError(f'Proxy log read failed: {res.stderr}')
+        return None if res.stdout == '' else res.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14538

### Problem Statement
We are missing coverage for a [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1844840) where the HTTP proxy is created with a user containing special characters in his password.


### Solution
Not only we need to create the proxy at the Satellite side, we also need to create the user at the proxy side to verify the content operations actually work. In the end I decided to create such users dynamically during the test run, so I needed to add a new `ProxyHost` class with a few functions to handle that. The class is instantiated in a session-scoped fixture and used in test and other fixture.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_http_proxy.py -k special
