### PR TITLE
[6.15.z] extend the timeout for poor network

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -210,7 +210,7 @@ def check_message_in_rhsm_log(message):
     """Check the message exist in /var/log/rhsm/rhsm.log"""
     wait_for(
         lambda: 'Host-to-guest mapping being sent to' in get_rhsm_log(),
-        timeout=10,
+        timeout=20,
         delay=2,
     )
     logs = get_rhsm_log()
@@ -230,7 +230,7 @@ def _get_hypervisor_mapping(hypervisor_type):
     """
     wait_for(
         lambda: 'Host-to-guest mapping being sent to' in get_rhsm_log(),
-        timeout=10,
+        timeout=20,
         delay=2,
     )
     logs = get_rhsm_log()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14573

### Problem Statement
when the network is poor, it will not enough time to get the correct message and mapping info. so extend the timeout
