### PR TITLE
Add ohsnap repos for rhel9

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -263,6 +263,11 @@ OHSNAP_RHEL8_REPOS = (
     'rhel-8-for-x86_64-appstream-rpms',
 )
 
+OHSNAP_RHEL9_REPOS = (
+    'rhel-9-for-x86_64-baseos-rpms',
+    'rhel-9-for-x86_64-appstream-rpms',
+)
+
 # On importing manifests, Red Hat repositories are listed like this:
 # Product -> RepositorySet -> Repository
 # We need to first select the Product, then the reposet and then the repos


### PR DESCRIPTION
### Problem Statement
`capsule_setup` requires a constant defined for RHEL9 that was missing. See https://github.com/SatelliteQE/robottelo/blob/64815689ecffae197b099099338324bc56931fc5/robottelo/hosts.py#L1638.

### Solution
Add RHEL9 constant

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->