### PR TITLE
[6.15.z] Move RHCloud tests to team Phoenix-subscriptions

### DIFF
--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: RHCloud
 
-:Team: Platform
+:Team: Phoenix-subscriptions
 
 :CaseImportance: High
 

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: RHCloud
 
-:Team: Platform
+:Team: Phoenix-subscriptions
 
 :CaseImportance: High
 

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: RHCloud
 
-:Team: Platform
+:Team: Phoenix-subscriptions
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: RHCloud
 
-:Team: Platform
+:Team: Phoenix-subscriptions
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: RHCloud
 
-:Team: Platform
+:Team: Phoenix-subscriptions
 
 :CaseImportance: High
 

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -6,7 +6,7 @@
 
 :CaseComponent: RHCloud
 
-:Team: Platform
+:Team: Phoenix-subscriptions
 
 :CaseImportance: High
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14567

### Problem Statement
- RHCloud component is now owned by team Phoenix

### Solution
- Update team docstring for RHCloud tests.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->