### PR TITLE
[6.13.z] Fix foreman service test

### DIFF
--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -225,7 +225,9 @@ def test_positive_foreman_service(sat_maintain):
     assert 'foreman' in result.stdout
     result = sat_maintain.cli.Service.status(options={'only': 'httpd'})
     assert result.status == 0
-    result = sat_maintain.cli.Health.check(options={'assumeyes': True})
+    result = sat_maintain.cli.Health.check(
+        options={'assumeyes': True, 'whitelist': 'check-tftp-storage'}
+    )
     assert result.status == 0
     assert 'foreman' in result.stdout
     assert sat_maintain.cli.Service.start(options={'only': 'foreman'}).status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14583

### Problem Statement
After turning off the foreman service, the `check-tftp-storage` requires the user to input the admin password since the foreman service isn't running. This causes the command to time out while waiting for input.

### Solution
Let's whitelist the tftp storage check since it's not necessary for the test.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->