### PR TITLE
Docker repos now support on demand policy

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -489,7 +489,7 @@ class TestRepository:
             [
                 {'content_type': content_type, 'download_policy': 'on_demand'}
                 for content_type in constants.REPO_TYPE
-                if content_type != 'yum'
+                if content_type not in ['yum', 'docker']
             ]
         ),
         indirect=True,


### PR DESCRIPTION

### Problem Statement

for katello >= 4.4  (should be part of 6.15.z) docker supports on demand policy
https://github.com/Katello/katello/commit/d2c20af6911adb02ca9005350a9f2c1ad1f8140b

### Solution

add exception for docker repos

### test

tests/foreman/api/test_repository.py::TestRepository::test_negative_create_non_yum_with_download_policy

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->