### PR TITLE
[6.14.z] Update Platform tests that have hard coded content host versions

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -45,6 +45,15 @@ def rhel_contenthost(request):
         yield host
 
 
+@pytest.fixture(scope='module')
+def module_rhel_contenthost(request):
+    """A module-level fixture that provides a content host object parametrized"""
+    # Request should be parametrized through pytest_fixtures.fixture_markers
+    # unpack params dict
+    with Broker(**host_conf(request), host_class=ContentHost) as host:
+        yield host
+
+
 @pytest.fixture(params=[{'rhel_version': '7'}])
 def rhel7_contenthost(request):
     """A function-level fixture that provides a rhel7 content host object"""
@@ -278,8 +287,10 @@ def sat_upgrade_chost():
 def custom_host(request):
     """A rhel content host that passes custom host config through request.param"""
     deploy_args = request.param
-    # if 'deploy_rhel_version' is not set, let's default to RHEL 8
-    deploy_args['deploy_rhel_version'] = deploy_args.get('deploy_rhel_version', '8')
+    # if 'deploy_rhel_version' is not set, let's default to what's in content_host.yaml
+    deploy_args['deploy_rhel_version'] = deploy_args.get(
+        'deploy_rhel_version', settings.content_host.default_rhel_version
+    )
     deploy_args['workflow'] = 'deploy-rhel'
     with Broker(**deploy_args, host_class=Satellite) as host:
         yield host

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -5,6 +5,7 @@ from robottelo.config import settings
 
 TARGET_FIXTURES = [
     'rhel_contenthost',
+    'module_rhel_contenthost',
     'content_hosts',
     'module_provisioning_rhel_content',
     'capsule_provisioning_rhel_content',

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -98,8 +98,14 @@ def test_positive_repositories_validate(sat_maintain):
 @pytest.mark.parametrize(
     'custom_host',
     [
-        {'deploy_rhel_version': '8', 'deploy_flavor': 'satqe-ssd.disk.xxxl'},
-        {'deploy_rhel_version': '8', 'deploy_flavor': 'satqe-ssd.standard.std'},
+        {
+            'deploy_rhel_version': settings.server.version.rhel_version,
+            'deploy_flavor': 'satqe-ssd.disk.xxxl',
+        },
+        {
+            'deploy_rhel_version': settings.server.version.rhel_version,
+            'deploy_flavor': 'satqe-ssd.standard.std',
+        },
     ],
     ids=['default', 'medium'],
     indirect=True,
@@ -122,15 +128,18 @@ def test_negative_pre_upgrade_tuning_profile_check(request, custom_host):
     :expectedresults: Pre-upgrade check fails.
     """
     profile = request.node.callspec.id
+    rhel_major = custom_host.os_version.major
     sat_version = ".".join(settings.server.version.release.split('.')[0:2])
-    # Register to CDN for RHEL8 repos, download and enable last y stream's ohsnap repos,
+    # Register to CDN for RHEL repos, download and enable last y stream's ohsnap repos,
     # and enable the satellite module and install it on the host
     custom_host.register_to_cdn()
     last_y_stream = last_y_stream_version(
         SATELLITE_VERSION if sat_version == 'stream' else sat_version
     )
     custom_host.download_repofile(product='satellite', release=last_y_stream)
-    custom_host.execute('dnf -y module enable satellite:el8 && dnf -y install satellite')
+    custom_host.execute(
+        f'dnf -y module enable satellite:el{rhel_major} && dnf -y install satellite'
+    )
     # Install with development tuning profile to get around installer checks
     custom_host.execute(
         'satellite-installer --scenario satellite --tuning development',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14317

### Problem Statement
PIT isn't running some of Platform's tests because they are hard coded to older rhel versions (7 or 8). 

### Solution
Update tests to be future-proof and run on whatever the test suite decides (ie: use settings file).

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->