### PR TITLE
cu-case-verify-worker-hosts-queue-1-service-has-proceed

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -12,6 +12,7 @@
 """
 from datetime import date, datetime, timedelta
 from operator import itemgetter
+import re
 
 from broker import Broker
 import pytest
@@ -1534,3 +1535,44 @@ def test_errata_list_by_contentview_filter(module_sca_manifest_org, module_targe
         )
     )
     assert errata_count != errata_count_cvf
+
+
+@pytest.mark.rhel_ver_match('8')
+def test_positive_verify_errata_recalculate_tasks(target_sat, errata_host):
+    """Verify 'Actions::Katello::Applicability::Hosts::BulkGenerate' tasks proceed on 'worker-hosts-queue-1.service'
+
+    :id: d5f89df2-b8fb-4aec-839d-b548b0aadc0c
+
+    :setup: Register host which has applicable errata with satellite
+
+    :steps:
+        1. Run 'hammer host errata recalculate --host-id NUMBER' (will trigger inside errata_host fixture)
+        2. Check systemctl or journalctl or /var/log/messages for 'dynflow-sidekiq@worker-hosts-queue-1.service'
+
+    :expectedresults: worker-hosts-queue-1 should proceed with task and this can be cross verify using unique PID
+
+    :customerscenario: true
+
+    :BZ: 2249736
+    """
+    # Recalculate errata command has triggered inside errata_host fixture
+
+    # get PID of 'worker-hosts-queue-1' from /var/log/messages
+    message_log = target_sat.execute(
+        'grep "dynflow-sidekiq@worker-hosts-queue-1" /var/log/messages | tail -1'
+    )
+    assert message_log.status == 0
+    pattern_1 = r'\[(.*?)\]'  # pattern to capture PID of 'worker-hosts-queue-1'
+    match = re.search(pattern_1, message_log.stdout)
+    pid_log_message = match.group(1)
+
+    # get PID of 'worker-hosts-queue-1' from systemctl command output
+    systemctl_log = target_sat.execute(
+        'systemctl status dynflow-sidekiq@worker-hosts-queue-1.service | grep -i "Main PID:"'
+    )
+    assert systemctl_log.status == 0
+    pattern_2 = r'\: (.*?) \('  # pattern to capture PID of 'worker-hosts-queue-1'
+    match = re.search(pattern_2, systemctl_log.stdout)
+    pid_systemctl_cmd = match.group(1)
+
+    assert pid_log_message == pid_systemctl_cmd


### PR DESCRIPTION
### Problem Statement
cc automation coverage
https://bugzilla.redhat.com/show_bug.cgi?id=2249736
`"Actions::Katello::Applicability::Hosts::BulkGenerate"` tasks are processed in the default queue instead of hosts_queue causing congestion.

### Solution
As per verification steps, we are looking into (`systemctl` or `journalctl` log or `/var/log/messages`) and conclude that `worker-hosts-queue-1.service` proceed when errata recalculate command runs.

### Related Issues
N/A

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py -k 'test_positive_verify_errata_recalculate_tasks'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->