### PR TITLE
[6.13.z] Verify a variable created and added to the host

### DIFF
--- a/pytest_fixtures/component/activationkey.py
+++ b/pytest_fixtures/component/activationkey.py
@@ -8,7 +8,7 @@ from robottelo.utils.manifest import clone
 @pytest.fixture(scope='module')
 def module_activation_key(module_entitlement_manifest_org, module_target_sat):
     """Create activation key using default CV and library environment."""
-    module_target_sat.api.ActivationKey(
+    return module_target_sat.api.ActivationKey(
         content_view=module_entitlement_manifest_org.default_content_view.id,
         environment=module_entitlement_manifest_org.library.id,
         organization=module_entitlement_manifest_org,

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -275,6 +275,81 @@ def test_positive_host_role_information(target_sat, function_host):
         assert all_assigned_roles_table[0]["Name"] == SELECTED_ROLE
 
 
+@pytest.mark.rhel_ver_match('8')
+def test_positive_assign_ansible_role_variable_on_host(
+    target_sat, rhel_contenthost, module_activation_key, module_org, module_location, request
+):
+    """Verify ansible variable is added to the role and attached to the host.
+
+    :id: 7ec4fe19-5a08-4b10-bb4e-7327dd68699a
+
+    :BZ: 2170727
+
+    :customerscenario: true
+
+    :steps:
+
+        1. Create an Ansible variable with array type and set the default value.
+        2. Enable both 'Merge Overrides' and 'Merge Default'.
+        3. Add the variable to a role and attach the role to the host.
+        4. Verify that ansible role and variable is added to the host.
+
+    :expectedresults: The role and variable is successfully added to the host.
+    """
+
+    @request.addfinalizer
+    def _finalize():
+        result = target_sat.cli.Ansible.roles_delete({'name': SELECTED_ROLE})
+        assert f'Ansible role [{SELECTED_ROLE}] was deleted.' in result[0]['message']
+
+    key = gen_string('alpha')
+    SELECTED_ROLE = 'redhat.satellite.activation_keys'
+    proxy_id = target_sat.nailgun_smart_proxy.id
+    target_sat.api.AnsibleRoles().sync(data={'proxy_id': proxy_id, 'role_names': [SELECTED_ROLE]})
+    command = target_sat.api.RegistrationCommand(
+        organization=module_org,
+        location=module_location,
+        activation_keys=[module_activation_key.name],
+    ).create()
+    result = rhel_contenthost.execute(command)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    target_host = rhel_contenthost.nailgun_host
+    default_value = '[\"test\"]'
+    parameter_type = 'array'
+    with target_sat.ui_session() as session:
+        session.organization.select(org_name=module_org.name)
+        session.location.select(loc_name=module_location.name)
+        session.ansiblevariables.create_with_overrides(
+            {
+                'key': key,
+                'ansible_role': SELECTED_ROLE,
+                'override': 'true',
+                'parameter_type': parameter_type,
+                'default_value': default_value,
+                'validator_type': None,
+                'attribute_order': 'domain \n fqdn \n hostgroup \n os',
+                'merge_default': 'true',
+                'merge_overrides': 'true',
+                'matcher_section.params': [
+                    {
+                        'attribute_type': {'matcher_key': 'os', 'matcher_value': 'fedora'},
+                        'value': '[\'13\']',
+                    }
+                ],
+            }
+        )
+        result = target_sat.cli.Host.ansible_roles_assign(
+            {'id': target_host.id, 'ansible-roles': SELECTED_ROLE}
+        )
+        assert 'Ansible roles were assigned' in result[0]['message']
+        values = session.host_new.get_details(rhel_contenthost.hostname, 'ansible')['ansible'][
+            'variables'
+        ]['table']
+        assert (key, SELECTED_ROLE, default_value, parameter_type) in [
+            (var['Name'], var['Ansible role'], var['Value'], var['Type']) for var in values
+        ]
+
+
 @pytest.mark.stubbed
 @pytest.mark.tier2
 def test_positive_role_variable_information(self):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14477

### Problem Statement
We are missing scenario for creating and adding variable to the host.
Automated BZ: 2170727

### Solution
Added the scenario

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->