### PR TITLE
[6.15.z] Make test parametrization more readable

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -485,14 +485,13 @@ class TestRepository:
     @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options',
-        **datafactory.parametrized(
-            [
-                {'content_type': content_type, 'download_policy': 'on_demand'}
-                for content_type in constants.REPO_TYPE
-                if content_type not in ['yum', 'docker']
-            ]
-        ),
+        [
+            {'content_type': content_type, 'download_policy': 'on_demand'}
+            for content_type in constants.REPO_TYPE
+            if content_type not in ['yum', 'docker']
+        ],
         indirect=True,
+        ids=lambda x: x['content_type'],
     )
     def test_negative_create_non_yum_with_download_policy(self, repo_options, target_sat):
         """Verify that non-YUM repositories cannot be created with


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14569

[yum] [docker]
vs
[2] [1]




<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->