### PR TITLE
[6.13.z] Test capsule without registration module

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -15,6 +15,7 @@ import uuid
 
 from fauxfactory import gen_ipaddr, gen_mac
 import pytest
+from requests import HTTPError
 
 from robottelo import constants
 from robottelo.config import settings
@@ -205,3 +206,60 @@ def test_positive_rex_interface_for_global_registration(
             assert interface['execution'] is True
             assert interface['ip'] == ip
             assert interface['mac'] == mac_address
+
+
+@pytest.mark.tier1
+def test_negative_global_registration_without_ak(module_target_sat):
+    """Attempt to register a host without ActivationKey
+
+    :id: e48a6260-97e0-4234-a69c-77bbbcde85de
+
+    :expectedresults: Generate command is disabled without ActivationKey
+    """
+    with pytest.raises(HTTPError) as context:
+        module_target_sat.api.RegistrationCommand().create()
+    assert 'Missing activation key!' in context.value.response.text
+
+
+def test_negative_capsule_without_registration_enabled(
+    module_target_sat,
+    module_capsule_configured,
+    module_ak_with_cv,
+    module_entitlement_manifest_org,
+    module_location,
+):
+    """Verify registration with Capsule, when registration isn't configured in installer
+
+    :id: a2f23e42-648d-4428-a961-6e0b933c6dff
+
+    :steps:
+            1. Get a configured capsule
+            2. The registration is set to False on capsule by default
+            3. Try to register host with that capsule
+
+    :expectedresults: Registration fails with HTTP error code 422 and an error message.
+    """
+    org = module_entitlement_manifest_org
+
+    nc = module_capsule_configured.nailgun_smart_proxy
+    module_target_sat.api.SmartProxy(id=nc.id, organization=[org]).update(['organization'])
+    module_target_sat.api.SmartProxy(id=nc.id, location=[module_location]).update(['location'])
+
+    res = module_capsule_configured.install(
+        cmd_args={},
+        cmd_kwargs={'foreman-proxy-registration': 'false', 'foreman-proxy-templates': 'true'},
+    )
+    assert res.status == 0
+    error_message = '422 Client Error'
+    with pytest.raises(HTTPError, match=f'{error_message}') as context:
+        module_target_sat.api.RegistrationCommand(
+            smart_proxy=nc,
+            organization=org,
+            location=module_location,
+            activation_keys=[module_ak_with_cv.name],
+            insecure=True,
+        ).create()
+    assert (
+        "Proxy lacks one of the following features: 'Registration', 'Templates'"
+        in context.value.response.text
+    )


### PR DESCRIPTION
### Problem Statement
Manual cherrypick of  https://github.com/SatelliteQE/robottelo/pull/13583

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->