### PR TITLE
[6.15.z] bookmark entities reduced parametrization

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1656,77 +1656,20 @@ ROLES_LOCKED = [
     'Viewer',
 ]
 
-BOOKMARK_ENTITIES = [
+BOOKMARK_ENTITIES_SELECTION = [
     {
         'name': 'ActivationKey',
         'controller': 'katello_activation_keys',
         'session_name': 'activationkey',
         'old_ui': True,
     },
-    {'name': 'Dashboard', 'controller': 'dashboard', 'session_name': 'dashboard'},
-    {'name': 'Audit', 'controller': 'audits', 'session_name': 'audit'},
-    {
-        'name': 'Report',
-        'controller': 'config_reports',
-        'setup': entities.Report,
-        'session_name': 'configreport',
-    },
-    {'name': 'Task', 'controller': 'foreman_tasks_tasks', 'session_name': 'task'},
-    # TODO Load manifest for the test_positive_end_to_end from the ui/test_bookmarks.py
-    # {'name': 'Subscriptions', 'controller': 'subscriptions','session_name': 'subscription' },
-    {
-        'name': 'Product',
-        'controller': 'katello_products',
-        'session_name': 'product',
-        'old_ui': True,
-    },
-    {'name': 'Repository', 'controller': 'katello_repositories', 'session_name': 'repository'},
-    {
-        'name': 'ContentCredential',
-        'controller': 'katello_content_credentials',
-        'session_name': 'contentcredential',
-        'old_ui': True,
-    },
-    {
-        'name': 'SyncPlan',
-        'controller': 'katello_sync_plans',
-        'session_name': 'syncplan',
-        'old_ui': True,
-    },
-    {'name': 'ContentView', 'controller': 'katello_content_views', 'session_name': 'contentview'},
     {'name': 'Errata', 'controller': 'katello_errata', 'session_name': 'errata', 'old_ui': True},
-    {'name': 'Package', 'controller': 'katello_erratum_packages', 'session_name': 'package'},
-    {
-        'name': 'ContainerImageTag',
-        'controller': 'katello_docker_tags',
-        'session_name': 'containerimagetag',
-        'old_ui': True,
-    },
     {'name': 'Host', 'controller': 'hosts', 'setup': entities.Host, 'session_name': 'host_new'},
-    {'name': 'ContentHost', 'controller': 'hosts', 'session_name': 'contenthost', 'old_ui': True},
     {
-        'name': 'HostCollection',
-        'controller': 'katello_host_collections',
-        'session_name': 'hostcollection',
-        'old_ui': True,
-    },
-    {'name': 'Architecture', 'controller': 'architectures', 'session_name': 'architecture'},
-    {
-        'name': 'HardwareModel',
-        'controller': 'models',
-        'setup': entities.Model,
-        'session_name': 'hardwaremodel',
-    },
-    {
-        'name': 'InstallationMedia',
-        'controller': 'media',
-        'session_name': 'media',
-        'setup': entities.Media,
-    },
-    {
-        'name': 'OperatingSystem',
-        'controller': 'operatingsystems',
-        'session_name': 'operatingsystem',
+        'name': 'UserGroup',
+        'controller': 'usergroups',
+        'setup': entities.UserGroup,
+        'session_name': 'usergroup',
     },
     {
         'name': 'PartitionTable',
@@ -1735,57 +1678,17 @@ BOOKMARK_ENTITIES = [
         'session_name': 'partitiontable',
     },
     {
+        'name': 'Product',
+        'controller': 'katello_products',
+        'session_name': 'product',
+        'old_ui': True,
+    },
+    {
         'name': 'ProvisioningTemplate',
         'controller': 'provisioning_templates',
         'session_name': 'provisioningtemplate',
     },
-    {
-        'name': 'HostGroup',
-        'controller': 'hostgroups',
-        'setup': entities.HostGroup,
-        'session_name': 'hostgroup',
-    },
-    {
-        'name': 'DiscoveryRule',
-        'controller': 'discovery_rules',
-        'setup': entities.DiscoveryRule,
-        'session_name': 'discoveryrule',
-    },
-    {
-        'name': 'GlobalParameter',
-        'controller': 'common_parameters',
-        'setup': entities.CommonParameter,
-        'skip_for_ui': True,
-    },
-    {'name': 'Role', 'controller': 'ansible_roles', 'setup': entities.Role, 'session_name': 'role'},
-    {'name': 'Variables', 'controller': 'ansible_variables', 'session_name': 'ansiblevariables'},
-    {'name': 'Capsules', 'controller': 'smart_proxies', 'session_name': 'capsule'},
-    {
-        'name': 'ComputeResource',
-        'controller': 'compute_resources',
-        'setup': entities.LibvirtComputeResource,
-        'session_name': 'computeresource',
-    },
-    {
-        'name': 'ComputeProfile',
-        'controller': 'compute_profiles',
-        'setup': entities.ComputeProfile,
-        'session_name': 'computeprofile',
-    },
-    {'name': 'Subnet', 'controller': 'subnets', 'setup': entities.Subnet, 'session_name': 'subnet'},
-    {'name': 'Domain', 'controller': 'domains', 'setup': entities.Domain, 'session_name': 'domain'},
-    {'name': 'Realm', 'controller': 'realms', 'setup': entities.Realm, 'session_name': 'realm'},
-    {'name': 'Location', 'controller': 'locations', 'session_name': 'location'},
-    {'name': 'Organization', 'controller': 'organizations', 'session_name': 'organization'},
-    {'name': 'User', 'controller': 'users', 'session_name': 'user'},
-    {
-        'name': 'UserGroup',
-        'controller': 'usergroups',
-        'setup': entities.UserGroup,
-        'session_name': 'usergroup',
-    },
-    {'name': 'Role', 'controller': 'roles', 'session_name': 'role'},
-    {'name': 'Settings', 'controller': 'settings', 'session_name': 'settings'},
+    {'name': 'Repository', 'controller': 'katello_repositories', 'session_name': 'repository'},
 ]
 
 STRING_TYPES = ['alpha', 'numeric', 'alphanumeric', 'latin1', 'utf8', 'cjk', 'html']

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -17,11 +17,11 @@ from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError
 
-from robottelo.constants import BOOKMARK_ENTITIES
+from robottelo.constants import BOOKMARK_ENTITIES_SELECTION
 from robottelo.utils.datafactory import invalid_values_list, valid_data_list
 
 # List of unique bookmark controller values, preserving order
-CONTROLLERS = list(dict.fromkeys(entity['controller'] for entity in BOOKMARK_ENTITIES))
+CONTROLLERS = list(dict.fromkeys(entity['controller'] for entity in BOOKMARK_ENTITIES_SELECTION))
 
 
 @pytest.mark.tier1

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -16,11 +16,13 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import user_nailgun_config
-from robottelo.constants import BOOKMARK_ENTITIES
+from robottelo.constants import BOOKMARK_ENTITIES_SELECTION
 
 
 @pytest.fixture(
-    scope='module', params=BOOKMARK_ENTITIES, ids=(i['name'] for i in BOOKMARK_ENTITIES)
+    scope='module',
+    params=BOOKMARK_ENTITIES_SELECTION,
+    ids=(i['name'] for i in BOOKMARK_ENTITIES_SELECTION),
 )
 def ui_entity(module_org, module_location, request):
     """Collects the list of all applicable UI entities for testing and does all

--- a/tests/upgrades/test_bookmarks.py
+++ b/tests/upgrades/test_bookmarks.py
@@ -13,7 +13,7 @@
 """
 import pytest
 
-from robottelo.constants import BOOKMARK_ENTITIES
+from robottelo.constants import BOOKMARK_ENTITIES_SELECTION
 
 
 class TestPublicDisableBookmark:
@@ -45,7 +45,7 @@ class TestPublicDisableBookmark:
         :CaseImportance: Critical
         """
 
-        for entity in BOOKMARK_ENTITIES:
+        for entity in BOOKMARK_ENTITIES_SELECTION:
             book_mark_name = entity["name"] + request.node.name
             bm = target_sat.api.Bookmark(
                 controller=entity['controller'],
@@ -77,7 +77,7 @@ class TestPublicDisableBookmark:
         :CaseImportance: Critical
         """
         pre_test_name = dependent_scenario_name
-        for entity in BOOKMARK_ENTITIES:
+        for entity in BOOKMARK_ENTITIES_SELECTION:
             book_mark_name = entity["name"] + pre_test_name
             bm = target_sat.api.Bookmark().search(query={'search': f'name="{book_mark_name}"'})[0]
             assert bm.controller == entity['controller']
@@ -115,7 +115,7 @@ class TestPublicEnableBookmark:
         :customerscenario: true
         """
 
-        for entity in BOOKMARK_ENTITIES:
+        for entity in BOOKMARK_ENTITIES_SELECTION:
             book_mark_name = entity["name"] + request.node.name
             bm = target_sat.api.Bookmark(
                 controller=entity['controller'],
@@ -145,7 +145,7 @@ class TestPublicEnableBookmark:
         :CaseImportance: Critical
         """
         pre_test_name = dependent_scenario_name
-        for entity in BOOKMARK_ENTITIES:
+        for entity in BOOKMARK_ENTITIES_SELECTION:
             book_mark_name = entity["name"] + pre_test_name
             bm = target_sat.api.Bookmark().search(query={'search': f'name="{book_mark_name}"'})[0]
             assert bm.controller == entity['controller']


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14542

### Problem Statement
Let's face it, running 730 tests on a component like this didn't bring us that much value. I'd say we don't need to parametrize with everything that exists.

This pr attemps on a representative selection (old ui, new ui, required setup, session name vs controller mismatch) taking entity traffic into consideration

