### PR TITLE
[6.15.z] Make oscap profile configurable in settings file

### DIFF
--- a/conf/oscap.yaml.template
+++ b/conf/oscap.yaml.template
@@ -1,2 +1,4 @@
 OSCAP:
   CONTENT_PATH: /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+  # see: robottelo/constants/__init__.py OSCAP_PROFILE
+  PROFILE: security7

--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -39,7 +39,7 @@ def scap_content(import_ansible_roles, module_target_sat):
     scap_profile_id = [
         profile['id']
         for profile in scap_info.scap_content_profiles
-        if OSCAP_PROFILE['security7'] in profile['title']
+        if OSCAP_PROFILE[settings.oscap.profile] in profile['title']
     ][0]
     return {
         "title": title,

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -225,7 +225,12 @@ VALIDATORS = dict(
         Validator(
             'oscap.content_path',
             must_exist=True,
-        )
+        ),
+        Validator(
+            'oscap.profile',
+            default='security7',
+            must_exist=True,
+        ),
     ],
     osp=[
         Validator(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14535

### Problem Statement

oscap profile is hardcoded for rhel operating systems

### Solution

make it configurable in settings

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->