### PR TITLE
Make default_os name and major versions configurable

### DIFF
--- a/conf/supportability.yaml
+++ b/conf/supportability.yaml
@@ -1,4 +1,5 @@
 supportability:
   content_hosts:
+    default_os_name: "RedHat"
     rhel:
       versions: [6, 7,'7_fips', 8, '8_fips', 9, '9_fips']

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -4,7 +4,10 @@ from robottelo.constants import AZURERM_VALID_REGIONS, VALID_GCE_ZONES
 
 VALIDATORS = dict(
     supportability=[
-        Validator('supportability.content_hosts.rhel.versions', must_exist=True, is_type_of=list)
+        Validator('supportability.content_hosts.rhel.versions', must_exist=True, is_type_of=list),
+        Validator(
+            'supportability.content_hosts.default_os_name', must_exist=True, default='RedHat'
+        ),
     ],
     server=[
         Validator('server.hostname', default=''),


### PR DESCRIPTION
### Problem Statement

default os is hardcoded in fixture

### Solution

* make default os configurable

### Related Question

Why is a new instance of `OperatingSystem` created [here](https://github.com/ATIX-AG/robottelo/blob/master/pytest_fixtures/component/os.py#L29) instead of returning the one create above?

### Related test

tests/foreman/ui/test_registration.py::test_global_registration_form_populate

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->