### PR TITLE
[6.15.z]Leapp client upgrade from non-admin user

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -438,7 +438,10 @@ class ContentHost(Host, ContentHostMixins):
         if ensure and state in [VmState.RUNNING, 'reboot']:
             try:
                 wait_for(
-                    self.connect, fail_condition=lambda res: res is not None, handle_exception=True
+                    self.connect,
+                    fail_condition=lambda res: res is not None,
+                    timeout=300,
+                    handle_exception=True,
                 )
             # really broad diaper here, but connection exceptions could be a ton of types
             except TimedOutError as toe:

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -12,6 +12,7 @@
 
 """
 from broker import Broker
+from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
@@ -190,7 +191,7 @@ def custom_leapp_host(upgrade_path, module_target_sat, module_sca_manifest_org, 
 @pytest.fixture
 def precondition_check_upgrade_and_install_leapp_tool(custom_leapp_host):
     """Clean-up directory if in-place upgrade already performed,
-    set rhel release version, update system and install leapp-upgrade"""
+    set rhel release version, update system and install leapp-upgrade and fix known inhibitors before upgrade"""
     source_rhel = custom_leapp_host.os_version.base_version
     custom_leapp_host.run('rm -rf /root/tmp_leapp_py3')
     custom_leapp_host.run('yum repolist')
@@ -199,6 +200,20 @@ def precondition_check_upgrade_and_install_leapp_tool(custom_leapp_host):
     assert custom_leapp_host.run('yum install leapp-upgrade -y').status == 0
     if custom_leapp_host.run('needs-restarting -r').status == 1:
         custom_leapp_host.power_control(state='reboot', ensure=True)
+    if custom_leapp_host.os_version.major == 8:
+        # Inhibitor - Firewalld Configuration AllowZoneDrifting Is Unsupported
+        assert (
+            custom_leapp_host.run(
+                'sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf'
+            ).status
+            == 0
+        )
+        assert (
+            custom_leapp_host.run(
+                'echo -e "\nPermitRootLogin yes" >> /etc/ssh/sshd_config; systemctl restart sshd'
+            ).status
+            == 0
+        )
 
 
 @pytest.mark.parametrize(
@@ -233,12 +248,6 @@ def test_leapp_upgrade_rhel(
     :expectedresults:
         1. Update RHEL OS major version to another major version
     """
-    # Fixing known inhibitors for source rhel version 8
-    if custom_leapp_host.os_version.major == 8:
-        # Inhibitor - Firewalld Configuration AllowZoneDrifting Is Unsupported
-        custom_leapp_host.run(
-            'sed -i "s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/" /etc/firewalld/firewalld.conf'
-        )
     # Run LEAPP-PREUPGRADE Job Template-
     template_id = (
         module_target_sat.api.JobTemplate()
@@ -285,3 +294,86 @@ def test_leapp_upgrade_rhel(
     custom_leapp_host.clean_cached_properties()
     new_ver = str(custom_leapp_host.os_version)
     assert new_ver == upgrade_path['target_version']
+
+
+@pytest.mark.parametrize(
+    'upgrade_path',
+    [
+        {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
+    ],
+    ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
+    f'_to_{upgrade_path["target_version"]}',
+)
+def test_leapp_upgrade_rhel_non_admin(
+    module_target_sat,
+    module_sca_manifest_org,
+    default_location,
+    custom_leapp_host,
+    upgrade_path,
+    verify_target_repo_on_satellite,
+    precondition_check_upgrade_and_install_leapp_tool,
+):
+    """Test to upgrade RHEL host to next major RHEL release using leapp preupgrade and leapp upgrade
+    job templates
+
+    :id: afd295ca-4b0e-439f-b880-ae92c300fd9f
+
+    :BZ: 2257302
+
+    :customerscenario: true
+
+    :steps:
+        1. Import a subscription manifest and enable, sync source & target repositories
+        2. Create LCE, Create CV, add repositories to it, publish and promote CV, Create AK, etc.
+        3. Register content host with AK
+        4. Verify that target rhel repositories are enabled on Satellite
+        5. Update all packages, install leapp tool and fix inhibitors
+        6. Create a non-admin user with "Organization admin", "Remote Execution Manager" and "Remote Execution User" role assigned to it.
+        7. Run Leapp Preupgrade and Leapp Upgrade job template from the user created in step 6.
+
+    :expectedresults:
+        1. Update RHEL OS major version to another major version from non-admin user role.
+    """
+    login = gen_string('alpha')
+    password = gen_string('alpha')
+    roles = ['Organization admin', 'Remote Execution Manager', 'Remote Execution User']
+    org = module_sca_manifest_org
+    user = module_target_sat.cli_factory.user(
+        {
+            'admin': False,
+            'login': login,
+            'password': password,
+            'organization-ids': org.id,
+            'location-ids': default_location.id,
+        }
+    )
+    for role in roles:
+        module_target_sat.cli.User.add_role({'id': user['id'], 'login': login, 'role': role})
+
+    # Run leapp preupgrade job
+    invocation_command = module_target_sat.cli_factory.job_invocation_with_credentials(
+        {
+            'job-template': 'Run preupgrade via Leapp',
+            'search-query': f'name = {custom_leapp_host.hostname}',
+            'organization-id': org.id,
+            'location-id': default_location.id,
+        },
+        (login, password),
+    )
+    result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
+    assert result['success'] == '1'
+
+    # Run leapp upgrade job
+    invocation_command = module_target_sat.cli_factory.job_invocation_with_credentials(
+        {
+            'job-template': 'Run upgrade via Leapp',
+            'search-query': f'name = {custom_leapp_host.hostname}',
+            'organization-id': org.id,
+            'location-id': default_location.id,
+            'inputs': 'Reboot=false',
+        },
+        (login, password),
+    )
+    custom_leapp_host.power_control(state='reboot')
+    result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
+    assert result['success'] == '1'


### PR DESCRIPTION
### Problem Statement
Missing scenario of Leapp client upgrade from non-admin user
We need sca enabled manifest because test is failing with VDC subscription we use from manifest.yaml.

### Solution
Added test scenario to test BZ#2257302

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->