### PR TITLE
Fix tests failing on enabling satellite/capsule module

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -358,7 +358,7 @@ def installer_satellite(request):
         release=settings.server.version.release,
         snap=settings.server.version.snap,
     )
-    sat.execute('dnf -y module enable satellite:el8 && dnf -y install satellite')
+    sat.install_satellite_or_capsule_package()
     installed_version = sat.execute('rpm --query satellite').stdout
     assert sat_version in installed_version
     # Install Satellite

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1739,6 +1739,19 @@ class Capsule(ContentHost, CapsuleMixins):
         self._cli._configured = True
         return self._cli
 
+    def install_satellite_or_capsule_package(self):
+        """Install Satellite/Capsule package.
+        Note: Make sure required repos are enabled before using this.
+        """
+        if self.os_version.major == 8:
+            assert (
+                self.execute(
+                    f'dnf -y module enable {self.product_rpm_name}:el{self.os_version.major}'
+                ).status
+                == 0
+            )
+        assert self.execute(f'dnf -y install {self.product_rpm_name}').status == 0
+
 
 class Satellite(Capsule, SatelliteMixins):
     product_rpm_name = 'satellite'

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -90,7 +90,7 @@ def test_positive_clone_backup(
     for repo in getattr(constants, f"OHSNAP_RHEL{rhel_version}_REPOS"):
         sat_ready_rhel.enable_repo(repo, force=True)
     # Enabling satellite module
-    assert sat_ready_rhel.execute(f'dnf module enable -y satellite:el{rhel_version}').status == 0
+    sat_ready_rhel.install_satellite_or_capsule_package()
     # Install satellite-clone
     assert sat_ready_rhel.execute('yum install satellite-clone -y').status == 0
     # Disabling CDN repos as we install from dogfdood

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1358,7 +1358,7 @@ def install_satellite(satellite, installer_args, enable_fapolicyd=False):
             satellite.execute('dnf -y install fapolicyd && systemctl enable --now fapolicyd').status
             == 0
         )
-    satellite.execute('dnf -y module enable satellite:el8 && dnf -y install satellite')
+    satellite.install_satellite_or_capsule_package()
     if enable_fapolicyd:
         assert satellite.execute('rpm -q foreman-fapolicyd').status == 0
         assert satellite.execute('rpm -q foreman-proxy-fapolicyd').status == 0
@@ -1441,9 +1441,7 @@ def test_capsule_installation(sat_non_default_install, cap_ready_rhel, setting_u
         ).status
         == 0
     )
-    cap_ready_rhel.execute(
-        'dnf -y module enable satellite-capsule:el8 && dnf -y install satellite-capsule'
-    )
+    cap_ready_rhel.install_satellite_or_capsule_package()
     assert cap_ready_rhel.execute('rpm -q foreman-proxy-fapolicyd').status == 0
     # Setup Capsule
     setup_capsule(sat_non_default_install, cap_ready_rhel, org)

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -44,10 +44,7 @@ def test_positive_install_sat_with_katello_certs(certs_data, sat_ready_rhel):
     )
     sat_ready_rhel.register_to_cdn()
     sat_ready_rhel.execute('dnf -y update')
-    result = sat_ready_rhel.execute(
-        'dnf -y module enable satellite:el8 && dnf -y install satellite'
-    )
-    assert result.status == 0
+    sat_ready_rhel.install_satellite_or_capsule_package()
     command = InstallerCommand(
         scenario='satellite',
         certs_server_cert=f'/root/{certs_data["cert_file_name"]}',


### PR DESCRIPTION
### Problem Statement
- Robottelo tests that enable satellite/capsule modules are failing on RHEL9. We're not using modules for RHEL9 atm but this may change in the future. 

### Solution
- Don't try to enable satellite/capsule modules on RHEL9

### Related Issues
- SAT-24336

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->