### PR TITLE
Make tests SCA-Compliant

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -227,7 +227,7 @@ def test_negative_capsule_without_registration_enabled(
     module_target_sat,
     module_capsule_configured,
     module_ak_with_cv,
-    module_entitlement_manifest_org,
+    module_sca_manifest_org,
     module_location,
 ):
     """Verify registration with Capsule, when registration isn't configured in installer
@@ -241,7 +241,7 @@ def test_negative_capsule_without_registration_enabled(
 
     :expectedresults: Registration fails with HTTP error code 422 and an error message.
     """
-    org = module_entitlement_manifest_org
+    org = module_sca_manifest_org
 
     nc = module_capsule_configured.nailgun_smart_proxy
     module_target_sat.api.SmartProxy(id=nc.id, organization=[org]).update(['organization'])

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -14,7 +14,6 @@
 import re
 
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -130,7 +129,7 @@ def test_positive_logging_from_foreman_proxy(target_sat):
 
 
 @pytest.mark.tier4
-def test_positive_logging_from_candlepin(module_org, module_entitlement_manifest, target_sat):
+def test_positive_logging_from_candlepin(module_org, module_sca_manifest, target_sat):
     """Check logging after manifest upload.
 
     :id: 8c06e501-52d7-4baf-903e-7de9caffb066
@@ -148,7 +147,7 @@ def test_positive_logging_from_candlepin(module_org, module_entitlement_manifest
     # get the number of lines in the source log before the test
     line_count_start = target_sat.execute(f'wc -l < {source_log}').stdout.strip('\n')
     # command for this test
-    with module_entitlement_manifest as manifest:
+    with module_sca_manifest as manifest:
         target_sat.upload_manifest(module_org.id, manifest, interface='CLI')
     # get the number of lines in the source log after the test
     line_count_end = target_sat.execute(f'wc -l < {source_log}').stdout.strip('\n')
@@ -185,12 +184,12 @@ def test_positive_logging_from_dynflow(module_org, target_sat):
     POST_line_found = False
     source_log = '/var/log/foreman/production.log'
     test_logfile = '/var/tmp/logfile_dynflow'
-    product = entities.Product(organization=module_org).create()
+    product = target_sat.api.Product(organization=module_org).create()
     repo_name = gen_string('alpha')
     # get the number of lines in the source log before the test
     line_count_start = target_sat.execute(f'wc -l < {source_log}').stdout.strip('\n')
     # command for this test
-    new_repo = entities.Repository(name=repo_name, product=product).create()
+    new_repo = target_sat.api.Repository(name=repo_name, product=product).create()
     logger.info(f'Created Repo {new_repo.name} for dynflow log test')
     # get the number of lines in the source log after the test
     line_count_end = target_sat.execute(f'wc -l < {source_log}').stdout.strip('\n')


### PR DESCRIPTION
### Problem Statement
Satellite is in SCA mode by default with 6.16. Few tests are not adhering SCA-compliance.

### Solution
Updated the tests for Logging and Registration Component

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->