### PR TITLE
Fix Capsule.install when used w/o kwargs

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1597,7 +1597,8 @@ class Capsule(ContentHost, CapsuleMixins):
         """General purpose installer"""
         if not installer_obj:
             command_opts = {'scenario': self.__class__.__name__.lower()}
-            command_opts.update(cmd_kwargs)
+            if cmd_kwargs:
+                command_opts.update(cmd_kwargs)
             installer_obj = InstallerCommand(*cmd_args, **command_opts)
         return self.execute(installer_obj.get_command(), timeout=0)
 
@@ -1695,22 +1696,6 @@ class Capsule(ContentHost, CapsuleMixins):
         )
         if result.status != 0:
             raise SatelliteHostError(f'Failed to enable pull provider: {result.stdout}')
-
-    def run_installer_arg(self, *args, timeout='20m'):
-        """Run an installer argument on capsule"""
-        installer_args = list(args)
-        installer_command = InstallerCommand(
-            installer_args=installer_args,
-        )
-        result = self.execute(
-            installer_command.get_command(),
-            timeout=timeout,
-        )
-        if result.status != 0:
-            raise SatelliteHostError(
-                f'Failed to execute with arguments: {installer_args} and,'
-                f' the stderr is {result.stderr}'
-            )
 
     def set_mqtt_resend_interval(self, value):
         """Set the time interval in seconds at which the notification should be

--- a/tests/foreman/api/test_capsule.py
+++ b/tests/foreman/api/test_capsule.py
@@ -46,7 +46,7 @@ def test_positive_update_capsule(request, pytestconfig, target_sat, module_capsu
 
     # refresh features
     features = capsule.refresh()
-    module_capsule_configured.run_installer_arg('enable-foreman-proxy-plugin-openscap')
+    module_capsule_configured.install(cmd_args=['enable-foreman-proxy-plugin-openscap'])
     features_new = capsule.refresh()
     assert len(features_new["features"]) == len(features["features"]) + 1
     assert 'Openscap' in [feature["name"] for feature in features_new["features"]]


### PR DESCRIPTION
### Problem Statement
`Capsule.install()` fails with ` TypeError: 'NoneType' object is not iterable` when used w/o kwargs
Some contributors already introduced misplaced workaround for this `Capsule.run_installer_arg()`

### Solution
Fix `Capsule.install()` instead of implementing yet another installer method `Capsule.run_installer_arg()`

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->