### PR TITLE
Fix ssh command usage

### DIFF
--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -200,7 +200,7 @@ class Base:
             command,
         )
         response = ssh.command(
-            cmd.encode('utf-8'),
+            cmd,
             hostname=hostname or cls.hostname or settings.server.hostname,
             output_format=output_format,
             timeout=timeout,

--- a/tests/robottelo/test_cli.py
+++ b/tests/robottelo/test_cli.py
@@ -258,7 +258,7 @@ class BaseCliTestCase(unittest.TestCase):
         response = Base.execute('some_cmd', return_raw_response=True)
         ssh_cmd = 'LANG=en_US  hammer -v -u admin -p password  some_cmd'
         command.assert_called_once_with(
-            ssh_cmd.encode('utf-8'),
+            ssh_cmd,
             hostname=mock.ANY,
             output_format=None,
             timeout=None,
@@ -277,7 +277,7 @@ class BaseCliTestCase(unittest.TestCase):
         response = Base.execute('some_cmd', hostname=None, output_format='json')
         ssh_cmd = 'LANG=en_US time -p hammer -v -u admin -p password --output=json some_cmd'
         command.assert_called_once_with(
-            ssh_cmd.encode('utf-8'),
+            ssh_cmd,
             hostname=mock.ANY,
             output_format='json',
             timeout=None,


### PR DESCRIPTION
### Problem Statement

The `Base.execute()` method, which is used to run hammer CLI commands via broker's ssh client, currently encodes the hammer command as a `bytes` object before sending it to broker. Broker and its current ssh library (`ssh2-python312`) expect a `str` instead, although the library silently accepts the `bytes` object and runs the command successfully.

With support for other ssh libraries being added to broker in https://github.com/SatelliteQE/broker/pull/282, passing in a `bytes` object won't work anymore:

```
09:29:43  robottelo/cli/settings.py:29: in set
09:29:43      return cls.execute(cls._construct_command(options))
09:29:43  robottelo/cli/base.py:202: in execute
09:29:43      response = ssh.command(
09:29:43  robottelo/ssh.py:51: in command
09:29:43      result = client.execute(cmd, timeout=timeout)
09:29:43  ../../lib64/python3.12/site-packages/broker/hosts.py:165: in execute
09:29:43      res = self.session.run(command, timeout=timeout)
09:29:43  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
09:29:43  
09:29:43  self = <broker.ssh_session_hussh.Session object at 0x7f87a3b33950>
09:29:43  command = b'LANG=en_US.UTF-8  hammer -v -u admin -p ****  settings set --name="failed_login_attempts_limit" --value="0" '
09:29:43  timeout = '10m'
09:29:43  
09:29:43      def run(self, command, timeout=0):
09:29:43          """Run a command on the host and return the results."""
09:29:43          # TODO support timeout parameter
09:29:43  >       return self.session.execute(command)
09:29:43  E       TypeError: argument 'command': 'bytes' object cannot be converted to 'PyString'
09:29:43  
09:29:43  ../../lib64/python3.12/site-packages/broker/ssh_session_hussh.py:97: TypeError
```

### Solution

This PR updates `Host.execute()` to pass a string-valued command instead.

PRT test runs:

- Fix without broker PR (using ssh2-python312)
  - https://github.com/SatelliteQE/robottelo/pull/14703#issuecomment-2049875320
- Fix with broker PR (using ssh2-python312)
  - https://github.com/SatelliteQE/robottelo/pull/14703#issuecomment-2050156744
- Fix with broker PR (using hussh)
  - https://github.com/SatelliteQE/robottelo/pull/14703#issuecomment-2047828826


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->