### PR TITLE
[6.14.z] Safely bump ruff-pre-commit to v0.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,29 +1,33 @@
 # configuration for pre-commit git hooks
 
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
-  hooks:
-  - id: trailing-whitespace
-    exclude: tests/foreman/data/
-  - id: check-yaml
-  - id: debug-statements
-- repo: https://github.com/psf/black
-  rev: 22.10.0
-  hooks:
-  - id: black
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.277
-  hooks:
-    - id: ruff
-      args: [--fix, --exit-non-zero-on-fix]
-- repo: local
-  hooks:
-    - id: fix-uuids
-      name: Robottelo Custom Fix UUIDs script
-      description: This hook runs the scripts/fix_uuids.sh script
-      language: script
-      entry: scripts/fix_uuids.sh
-      verbose: true
-      types: [text]
-      require_serial: true
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+    - id: trailing-whitespace
+      exclude: tests/foreman/data/
+    - id: check-yaml
+    - id: debug-statements
+  - repo: https://github.com/psf/black
+    rev: 22.10.0
+    hooks:
+    - id: black
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.0
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+  - repo: local
+    hooks:
+      - id: fix-uuids
+        name: Robottelo Custom Fix UUIDs script
+        description: This hook runs the scripts/fix_uuids.sh script
+        language: script
+        entry: scripts/fix_uuids.sh
+        verbose: true
+        types: [text]
+        require_serial: true
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Cherrypicks https://github.com/SatelliteQE/robottelo/pull/14692
(cherry picked from commit 590e1758f9cc6f8100277e49d9d7345904c0442c)

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
Fixes https://github.com/SatelliteQE/robottelo/issues/14696