### PR TITLE
[6.13.z] Fix teardown of bootdisk tests with request.addfinalizer

### DIFF
--- a/tests/foreman/cli/test_bootdisk.py
+++ b/tests/foreman/cli/test_bootdisk.py
@@ -20,6 +20,7 @@ from robottelo.constants import HTTPS_MEDIUM_URL
 
 @pytest.mark.parametrize('module_sync_kickstart_content', [7, 8, 9], indirect=True)
 def test_positive_bootdisk_download_https(
+    request,
     module_location,
     module_sync_kickstart_content,
     module_provisioning_capsule,
@@ -79,8 +80,12 @@ def test_positive_bootdisk_download_https(
             'lifecycle-environment-id': module_lce_library.id,
         }
     )
+
+    @request.addfinalizer
+    def _finalize():
+        module_target_sat.api.Host(id=host.id).delete()
+        module_target_sat.api.Media(id=media['id']).delete()
+
     # Check if full-host bootdisk can be downloaded.
     bootdisk = module_target_sat.cli.Bootdisk.host({'host-id': host['id'], 'full': 'true'})
     assert 'Successfully downloaded host disk image' in bootdisk['message']
-    module_target_sat.api.Host(id=host.id).delete()
-    module_target_sat.api.Media(id=media['id']).delete()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14701

### Problem Statement
If first test for rhel7 fails, rhel8 and rhel9 fails as well with error as media path is already taken

### Solution
Use request.addfinalizer for teardown to delete media and hosts in bootdisk tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->