### PR TITLE
make oscap tests run on rhel9 backend

### DIFF
--- a/conf/oscap.yaml.template
+++ b/conf/oscap.yaml.template
@@ -1,4 +1,6 @@
 OSCAP:
-  CONTENT_PATH: /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+  RHEL_MAJOR_VERSION: "@jinja {{this.server.version.rhel_version | int }}"
+  CONTENT_PATH: '@format /usr/share/xml/scap/ssg/content/ssg-rhel{this.oscap.rhel_major_version}-ds.xml'
   # see: robottelo/constants/__init__.py OSCAP_PROFILE
-  PROFILE: security7
+  PROFILE: '@format security{this.oscap.rhel_major_version}'
+  CONTENT_DIR: /usr/share/xml/scap/ssg/content

--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -38,7 +38,7 @@ def scap_content(import_ansible_roles, module_target_sat):
     scap_profile_id = [
         profile['id']
         for profile in scap_info.scap_content_profiles
-        if OSCAP_PROFILE[f'dsrhel{module_target_sat.os_version.major}'] in profile['title']
+        if module_target_sat.OSCAP['dsrhel'] in profile['title']
     ][0]
     return {
         "title": title,

--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -35,11 +35,10 @@ def scap_content(import_ansible_roles, module_target_sat):
     )
     scap_id = scap_info['id']
     scap_info = entities.ScapContents(id=scap_id).read()
-
     scap_profile_id = [
         profile['id']
         for profile in scap_info.scap_content_profiles
-        if OSCAP_PROFILE[settings.oscap.profile] in profile['title']
+        if OSCAP_PROFILE[f'dsrhel{module_target_sat.os_version.major}'] in profile['title']
     ][0]
     return {
         "title": title,

--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -5,7 +5,7 @@ from nailgun import entities
 import pytest
 
 from robottelo.config import robottelo_tmp_dir, settings
-from robottelo.constants import OSCAP_PROFILE, OSCAP_TAILORING_FILE, DataFile
+from robottelo.constants import OSCAP_TAILORING_FILE, DataFile
 
 
 @pytest.fixture(scope="session")

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1585,6 +1585,7 @@ OSCAP_DEFAULT_CONTENT = {
     'rhel6_content': 'Red Hat rhel6 default content',
     'rhel7_content': 'Red Hat rhel7 default content',
     'rhel8_content': 'Red Hat rhel8 default content',
+    'rhel9_content': 'Red Hat rhel9 default content',
     'rhel_firefox': 'Red Hat firefox default content',
 }
 
@@ -1592,7 +1593,8 @@ OSCAP_PROFILE = {
     'c2s_rhel6': 'C2S for Red Hat Enterprise Linux 6',
     'dsrhel6': 'DISA STIG for Red Hat Enterprise Linux 6',
     'dsrhel7': 'DISA STIG for Red Hat Enterprise Linux 7',
-    'dsrhel8': '[DRAFT] DISA STIG for Red Hat Enterprise Linux 8',
+    'dsrhel8': 'DISA STIG for Red Hat Enterprise Linux 8',
+    'dsrhel9': 'DISA STIG for Red Hat Enterprise Linux 9',
     'esp': 'Example Server Profile',
     'rhccp': 'Red Hat Corporate Profile for Certified Cloud Providers (RH CCP)',
     'firefox': 'Mozilla Firefox STIG',

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -67,8 +67,7 @@ class TestOpenScap:
         :CaseImportance: Medium
         """
         scap_contents = [content['title'] for content in module_target_sat.cli.Scapcontent.list()]
-        for title in OSCAP_DEFAULT_CONTENT.values():
-            assert title in scap_contents
+        assert f'Red Hat rhel{module_target_sat.os_version.major} default content' in scap_contents
 
     @pytest.mark.tier1
     def test_negative_list_default_content_with_viewer_role(
@@ -295,7 +294,9 @@ class TestOpenScap:
     @pytest.mark.parametrize('name', **parametrized(invalid_names_list()))
     @pytest.mark.tier1
     def test_negative_create_scap_content_with_invalid_originalfile_name(
-        self, name, module_target_sat
+        self,
+        name,
+        module_target_sat,
     ):
         """Create scap-content with invalid original file name
 
@@ -354,7 +355,10 @@ class TestOpenScap:
             module_target_sat.cli_factory.scapcontent({'title': title})
 
     @pytest.mark.tier1
-    def test_positive_update_scap_content_with_newtitle(self, module_target_sat):
+    def test_positive_update_scap_content_with_newtitle(
+        self,
+        module_target_sat,
+    ):
         """Update scap content title
 
         :id: 2c32e94a-237d-40b9-8a3b-fca2ef26fe79
@@ -920,7 +924,8 @@ class TestOpenScap:
         )
         assert scap_policy['scap-content-id'] == scap_content["scap_id"]
         scap_id, scap_profile_id = self.fetch_scap_and_profile_id(
-            OSCAP_DEFAULT_CONTENT['rhel_firefox'], module_target_sat
+            OSCAP_DEFAULT_CONTENT[f'rhel{module_target_sat.os_version.major}_content'],
+            module_target_sat,
         )
         module_target_sat.cli.Scappolicy.update(
             {'name': name, 'scap-content-id': scap_id, 'scap-content-profile-id': scap_profile_id}

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -11,22 +11,11 @@
 :CaseImportance: High
 
 """
-import os
 
 import pytest
 
-from robottelo.config import robottelo_tmp_dir, settings
 from robottelo.constants import DataFile
 from robottelo.utils.datafactory import gen_string
-
-
-@pytest.fixture(scope='module')
-def oscap_content_path(module_target_sat):
-    _, file_name = os.path.split(settings.oscap.content_path)
-
-    local_file = robottelo_tmp_dir.joinpath(file_name)
-    module_target_sat.get(remote_path=settings.oscap.content_path, local_path=str(local_file))
-    return local_file
 
 
 @pytest.mark.skip_if_open("BZ:2167937")


### PR DESCRIPTION
### Problem Statement
Part of the oscap tests were too rhel8 backend specific and didn't run on rhel9 sat

### Solution
Making the tests more flexible

### Related Issues
Requires satelliteqe-jenkins mr 1300

Results form local rhel9 sat run:
```
pytest tests/foreman/cli/test_oscap.py 
...
============ 68 passed, 3 deselected, 35 warnings in 971.49s (0:16:11) =============

```
