### PR TITLE
Remove pre-commit GitHub Action from our CI/CQ

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,9 +41,6 @@ jobs:
           cp broker_settings.yaml.example broker_settings.yaml
           cp .env.example .env
 
-      - name: Pre Commit Checks
-        uses: pre-commit/action@v3.0.1
-
       - name: Collect Tests
         run: |
           # To skip vault login in pull request checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # configuration for pre-commit git hooks
 
+ci:
+  autofix_prs: false  # disable autofixing PRs
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
### Problem Statement
pre-commit.ci [is enabled](https://results.pre-commit.ci/repo/github/4000279) for robottelo repository, the GH Action that runs pre-commit is now redundant.

### Solution
Remove the pre-commit GitHub Action from our CI/CQ workflow. Also [disable PR autofix](https://pre-commit.ci/#configuration-autofix_prs) if pre-commit auto fixes files.