### PR TITLE
[6.15.z] Coverage of BZ#2245081 ansible callback on capsule

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -251,6 +251,18 @@ def module_lb_capsule(retry_limit=3, delay=300, **broker_args):
 
 
 @pytest.fixture(scope='module')
+def module_capsule_configured_ansible(module_capsule_configured):
+    """Configure the capsule instance with Ansible feature enabled"""
+    result = module_capsule_configured.install(
+        cmd_args=[
+            'enable-foreman-proxy-plugin-ansible',
+        ]
+    )
+    assert result.status == 0, 'Installer failed to enable ansible plugin.'
+    return module_capsule_configured
+
+
+@pytest.fixture(scope='module')
 def module_capsule_configured_async_ssh(module_capsule_configured):
     """Configure the capsule instance with the satellite from settings.server.hostname,
     enable MQTT broker"""

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1777,6 +1777,37 @@ def test_installer_cap_pub_directory_accessibility(capsule_configured):
     assert 'Success!' in command_output.stdout
 
 
+def test_installer_capsule_with_enabled_ansible(module_capsule_configured_ansible):
+    """Enables Ansible feature on external Capsule and checks the callback is set correctly
+
+    :id: d60c475e-f4e7-11ee-af8a-98fa9b11ac24
+
+    :steps:
+        1. Have a Satellite with external Capsule integrated
+        2. Enable Ansible feature on external Capsule
+        3. Check the ansible callback plugin on external Capsule
+
+    :expectedresults:
+        Ansible callback plugin is overridden to "redhat.satellite.foreman"
+
+    :CaseImportance: High
+
+    :BZ: 2245081
+
+    :customerscenario: true
+    """
+    ansible_env = '/etc/foreman-proxy/ansible.env'
+    downstream_callback = 'redhat.satellite.foreman'
+    callback_whitelist = module_capsule_configured_ansible.execute(
+        f"awk -F= '/ANSIBLE_CALLBACK_WHITELIST/{{print$2}}' {ansible_env}"
+    )
+    assert callback_whitelist.stdout.strip('" \n') == downstream_callback
+    callbacks_enabled = module_capsule_configured_ansible.execute(
+        f"awk -F= '/ANSIBLE_CALLBACKS_ENABLED/{{print$2}}' {ansible_env}"
+    )
+    assert callbacks_enabled.stdout.strip('" \n') == downstream_callback
+
+
 @pytest.mark.tier1
 @pytest.mark.build_sanity
 @pytest.mark.first_sanity


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14658

### Problem Statement


### Solution
Adding coverage of BZ#2245081 ansible callback on capsule that was delivered in `6.15.0`

### Related Issues
Merge #14692 and #14693 first please
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
SAT-24477
