### PR TITLE
[6.15.z] Remove pre-commit GitHub Action from our CI/CQ (#14717)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,9 +41,6 @@ jobs:
           cp broker_settings.yaml.example broker_settings.yaml
           cp .env.example .env
 
-      - name: Pre Commit Checks
-        uses: pre-commit/action@v3.0.0
-
       - name: Collect Tests
         run: |
           # To skip vault login in pull request checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # configuration for pre-commit git hooks
 
+ci:
+  autofix_prs: false  # disable autofixing PRs
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0


### PR DESCRIPTION
(cherry picked from commit 4f5c857c73f5815d83f178f1f18a28bcce8de60d)

This PR backports #14717