### PR TITLE
[6.13.z] comp audit - use global registration method

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1974,8 +1974,7 @@ class TestRepository:
 
         :CaseImportance: Critical
         """
-        rhel7_contenthost.install_katello_ca(target_sat)
-        rhel7_contenthost.register_contenthost(module_org.label, module_ak_with_synced_repo['name'])
+        rhel7_contenthost.register(module_org, None, module_ak_with_synced_repo['name'], target_sat)
         assert rhel7_contenthost.subscribed
         rhel7_contenthost.run('yum repolist')
         access_log = target_sat.execute(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14738

### Problem Statement
Component Audit: SAT-23364
Test `test_positive_accessible_content_status` were using deprecated consumer CA cert RPM, 

### Solution
change content host registration method to global registration template/method

### Related Issues
No

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py -k 'test_positive_accessible_content_status'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->