### PR TITLE
[6.15.z] [RFE] Should not be able to publish the content-view, while repository sync in-progress

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+from datetime import datetime, timedelta
 import random
 
 from fauxfactory import gen_integer, gen_string, gen_utf8
@@ -531,6 +532,54 @@ class TestContentViewPublishPromote:
         assert composite_cv.component[0].id == content_view.version[0].id
         # composite CV → CV version → CV == CV
         assert composite_cv.component[0].read().content_view.id == content_view.id
+
+    @pytest.mark.tier2
+    def test_negative_publish_during_repo_sync(self, content_view, module_target_sat):
+        """Attempt to publish a new version of the content-view,
+        while an associated repository is being synced.
+
+        :id: c272fff7-a679-4844-a261-80830cdd5694
+
+        :BZ: 1957144
+
+        :steps:
+            1. Add repository to content-view
+            2. Perform asynchronous repository sync
+            3. Attempt to publish a version of the content-view, while repo sync ongoing.
+
+        :expectedresults:
+            1. User cannot publish during repository sync.
+            2. HTTP exception raised, assert publish task failed for expected reason,
+                repo sync task_id found in humanized error, content-view versions unchanged.
+        """
+        # add repository to content-view
+        content_view.repository = [self.yum_repo]
+        content_view.update(['repository'])
+        content_view = content_view.read()
+        existing_versions = content_view.version
+        timestamp = (datetime.utcnow() - timedelta(seconds=1)).strftime('%Y-%m-%d %H:%M')
+
+        # perform async repository sync, while still in progress-
+        # attempt to publish a new version of the content view.
+        repo_task_id = self.yum_repo.sync(synchronous=False)['id']
+        with pytest.raises(HTTPError) as InternalServerError:
+            content_view.publish()
+        assert str(content_view.id) in str(InternalServerError)
+
+        # search for failed publish task
+        task_action = 'Actions::Katello::ContentView::Publish'
+        task_search = module_target_sat.api.ForemanTask().search(
+            query={'search': f'{task_action} and started_at >= "{timestamp}"'}
+        )
+        assert len(task_search) == 1
+        task_id = task_search[0].id
+        # task failed for expected reason
+        task = module_target_sat.api.ForemanTask(id=task_id).poll(must_succeed=False)
+        assert task['result'] == 'error'
+        assert len(task['humanized']['errors']) == 1
+        assert repo_task_id in task['humanized']['errors'][0]
+        # no new versions of content view, any existing remained the same
+        assert content_view.read().version == existing_versions
 
     @pytest.mark.tier2
     def test_negative_add_components_to_composite(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14677

### Reason
API Automation coverage for [RFE] SAT-2927 and BZ# 1957144
Target Milestone is 6.15.0, no CP to 6.14.z

### Steps
- Add repository to content-view
- Perform asynchronous repository sync
- Attempt to publish a version of the content-view, while repo sync ongoing.
- _Assert:_ Raised HTTP exception, publish task failed, repo sync `task_id` found in humanized error, CV versions unchanged.

### PRT Trigger
```
trigger: test-robottelo
pytest: tests/foreman/api/test_contentview.py::TestContentViewPublishPromote::test_negative_publish_during_repo_sync
```