### PR TITLE
[6.15.z] Ensure correct finalizer order

### DIFF
--- a/tests/foreman/api/test_parameters.py
+++ b/tests/foreman/api/test_parameters.py
@@ -26,8 +26,8 @@ def test_positive_parameter_precedence_impact(
 
     :steps:
         1. Create Global Parameter
-        2. Create host and verify global parameter is assigned
-        3. Create Host Group with parameter
+        2. Create Host Group with parameter
+        3. Create host and verify global parameter is assigned
         4. Assign hostgroup to host created above and verify hostgroup parameter is assigned.
         5. Add parameter on the host directly, and verify that this should take precedence
             over Host group and Global Parameter
@@ -40,18 +40,21 @@ def test_positive_parameter_precedence_impact(
 
     cp = module_target_sat.api.CommonParameter(name=param_name, value=param_value).create()
     request.addfinalizer(cp.delete)
-    host = module_target_sat.api.Host(organization=module_org, location=module_location).create()
-    request.addfinalizer(host.delete)
-    result = [res for res in host.all_parameters if res['name'] == param_name]
-    assert result[0]['name'] == param_name
-    assert result[0]['associated_type'] == 'global'
 
     hg = module_target_sat.api.HostGroup(
         organization=[module_org],
         group_parameters_attributes=[{'name': param_name, 'value': param_value}],
     ).create()
     request.addfinalizer(hg.delete)
+
+    host = module_target_sat.api.Host(organization=module_org, location=module_location).create()
+    request.addfinalizer(host.delete)
+    result = [res for res in host.all_parameters if res['name'] == param_name]
+    assert result[0]['name'] == param_name
+    assert result[0]['associated_type'] == 'global'
+
     host.hostgroup = hg
+
     host = host.update(['hostgroup'])
     result = [res for res in host.all_parameters if res['name'] == param_name]
     assert result[0]['name'] == param_name


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14620

### Problem Statement

the host was not deleted before the hostgroup

see: https://github.com/pytest-dev/pytest/issues/10023#issuecomment-1148514756

### Solution

Execute host finalizer after hostgroup finalizer

### Note

This should replace https://github.com/SatelliteQE/robottelo/pull/14568