### PR TITLE
[6.14.z] content host set location to Default Location

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -243,7 +243,12 @@ class TestVirtwhoConfigforEsx:
 
     @pytest.mark.tier2
     def test_positive_last_checkin_status(
-        self, module_sca_manifest_org, virtwho_config_ui, form_data_ui, org_session
+        self,
+        module_sca_manifest_org,
+        virtwho_config_ui,
+        form_data_ui,
+        org_session,
+        default_location,
     ):
         """Verify the Last Checkin status on Content Hosts Page.
 
@@ -265,6 +270,7 @@ class TestVirtwhoConfigforEsx:
         )
         time_now = org_session.browser.get_client_datetime()
         assert org_session.virtwho_configure.search(name)[0]['Status'] == 'ok'
+        org_session.location.select(default_location.name)
         checkin_time = org_session.contenthost.search(hypervisor_name)[0]['Last Checkin']
         # 10 mins margin to check the Last Checkin time
         assert (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14497

### Problem Statement
hypervisor guest register to satellite server,  the guest is in the Default Location, so locate to Default Location then can list in the content host page
Case :  PASS
```
(robottelo_615) [virtwho@dell-per740-68-vm-04 robottelo]$ pytest ./tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_last_checkin_status --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 35 deselected, 5 warnings in 282.19s (0:04:42)
```