### PR TITLE
[RFE] [ActivationKeys] Update tests to be SCA-compliant 

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1509,7 +1509,7 @@ def test_positive_ak_with_custom_product_on_rhel6(
     :steps:
         1. Create a custom repo
         2. Create ak and add custom repo to ak
-        4. Register a rhel6 chost with the ak
+        3. Register a rhel6 chost with the ak
 
     :expectedresults: Host is registered successfully
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -11,12 +11,6 @@
 :CaseImportance: High
 
 """
-<<<<<<< HEAD
-
-from random import choice
-import re
-=======
->>>>>>> 9676a29d5 (Updating AK to SCA Only)
 
 from broker import Broker
 from fauxfactory import gen_alphanumeric, gen_string

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1439,8 +1439,8 @@ def test_positive_view_content_by_non_admin_user(function_sca_manifest_org, modu
     )
     result = module_target_sat.cli_factory.setup_org_for_a_rh_repo(
         {
-            'product': PRDS['rhel'],
-            'repository-set': REPOSET['rhst7'],
+            'product': REPOS['rhst7']['product'],
+            'repository-set': REPOS['rhst7']['reposet'],
             'repository': REPOS['rhst7']['name'],
             'organization-id': org.id,
         },

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -11,9 +11,12 @@
 :CaseImportance: High
 
 """
+<<<<<<< HEAD
 
 from random import choice
 import re
+=======
+>>>>>>> 9676a29d5 (Updating AK to SCA Only)
 
 from broker import Broker
 from fauxfactory import gen_alphanumeric, gen_string
@@ -41,7 +44,7 @@ def get_default_env(module_org, module_target_sat):
 
 @pytest.mark.tier1
 @pytest.mark.parametrize('name', **parametrized(valid_data_list()))
-def test_positive_create_with_name(module_target_sat, module_entitlement_manifest_org, name):
+def test_positive_create_with_name(module_target_sat, module_sca_manifest_org, name):
     """Create Activation key for all variations of Activation key
     name
 
@@ -54,7 +57,7 @@ def test_positive_create_with_name(module_target_sat, module_entitlement_manifes
     :parametrized: yes
     """
     new_ak = module_target_sat.cli_factory.make_activation_key(
-        {'organization-id': module_entitlement_manifest_org.id, 'name': name}
+        {'organization-id': module_sca_manifest_org.id, 'name': name}
     )
     assert new_ak['name'] == name
 
@@ -169,7 +172,7 @@ def test_positive_create_with_usage_limit_default(module_org, module_target_sat)
     :CaseImportance: Critical
     """
     new_ak = module_target_sat.cli_factory.make_activation_key({'organization-id': module_org.id})
-    assert new_ak['host-limit'] == 'Unlimited'
+    assert new_ak['host-limit'] == '0 of Unlimited'
 
 
 @pytest.mark.tier1
@@ -185,7 +188,7 @@ def test_positive_create_with_usage_limit_finite(module_org, module_target_sat):
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id, 'max-hosts': '10'}
     )
-    assert new_ak['host-limit'] == '10'
+    assert new_ak['host-limit'] == '0 of 10'
 
 
 @pytest.mark.tier2
@@ -206,7 +209,7 @@ def test_positive_create_content_and_check_enabled(module_org, module_target_sat
     content = module_target_sat.cli.ActivationKey.product_content(
         {'id': result['activationkey-id'], 'organization-id': module_org.id}
     )
-    assert content[0]['default-enabled?'] == 'true'
+    assert content[0]['default-enabled?'] == 'false'
 
 
 @pytest.mark.tier2
@@ -519,12 +522,12 @@ def test_positive_update_usage_limit_to_finite_number(module_org, module_target_
     :CaseImportance: Critical
     """
     new_ak = module_target_sat.cli_factory.make_activation_key({'organization-id': module_org.id})
-    assert new_ak['host-limit'] == 'Unlimited'
+    assert new_ak['host-limit'] == '0 of Unlimited'
     module_target_sat.cli.ActivationKey.update(
         {'max-hosts': '2147483647', 'name': new_ak['name'], 'organization-id': module_org.id}
     )
     updated_ak = module_target_sat.cli.ActivationKey.info({'id': new_ak['id']})
-    assert updated_ak['host-limit'] == '2147483647'
+    assert updated_ak['host-limit'] == '0 of 2147483647'
 
 
 @pytest.mark.tier1
@@ -540,12 +543,12 @@ def test_positive_update_usage_limit_to_unlimited(module_org, module_target_sat)
     new_ak = module_target_sat.cli_factory.make_activation_key(
         {'organization-id': module_org.id, 'max-hosts': '10'}
     )
-    assert new_ak['host-limit'] == '10'
+    assert new_ak['host-limit'] == '0 of 10'
     module_target_sat.cli.ActivationKey.update(
         {'unlimited-hosts': True, 'name': new_ak['name'], 'organization-id': module_org.id}
     )
     updated_ak = module_target_sat.cli.ActivationKey.info({'id': new_ak['id']})
-    assert updated_ak['host-limit'] == 'Unlimited'
+    assert updated_ak['host-limit'] == '0 of Unlimited'
 
 
 @pytest.mark.tier2
@@ -699,7 +702,7 @@ def test_positive_update_host_collection_with_default_org(module_org, module_tar
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_add_redhat_product(function_entitlement_manifest_org, target_sat):
+def test_positive_add_redhat_product(function_sca_manifest_org, target_sat):
     """Test that RH product can be associated to Activation Keys
 
     :id: 7b15de8e-edde-41aa-937b-ad6aa529891a
@@ -707,7 +710,7 @@ def test_positive_add_redhat_product(function_entitlement_manifest_org, target_s
     :expectedresults: RH products are successfully associated to Activation
         key
     """
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
 
     # Using CDN as we need this repo to be RH one no matter are we in
     # downstream or cdn
@@ -752,9 +755,7 @@ def test_positive_add_custom_product(module_org, module_target_sat):
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_add_redhat_and_custom_products(
-    module_target_sat, function_entitlement_manifest_org
-):
+def test_positive_add_redhat_and_custom_products(module_target_sat, function_sca_manifest_org):
     """Test if RH/Custom product can be associated to Activation key
 
     :id: 74c77426-18f5-4abb-bca9-a2135f7fcc1f
@@ -770,7 +771,7 @@ def test_positive_add_redhat_and_custom_products(
 
     :BZ: 1426386
     """
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     # Using CDN as we need this repo to be RH one no matter are we in
     # downstream or cdn
     result = module_target_sat.cli_factory.setup_org_for_a_rh_repo(
@@ -799,77 +800,7 @@ def test_positive_add_redhat_and_custom_products(
     assert {REPOSET['rhst7'], repo['name']} == {pc['name'] for pc in content}
 
 
-@pytest.mark.tier2
-def test_positive_delete_manifest(function_entitlement_manifest_org, target_sat):
-    """Check if deleting a manifest removes it from Activation key
-
-    :id: 8256ac6d-3f60-4668-897d-2e88d29532d3
-
-    :steps:
-        1. Upload manifest
-        2. Create activation key - attach some subscriptions
-        3. Delete manifest
-        4. See if the activation key automatically removed the
-           subscriptions.
-
-    :expectedresults: Deleting a manifest removes it from the Activation
-        key
-
-    :CaseAutomation: Automated
-    """
-    org = function_entitlement_manifest_org
-    new_ak = target_sat.cli_factory.make_activation_key({'organization-id': org.id})
-    ak_subs = target_sat.cli.ActivationKey.subscriptions(
-        {'id': new_ak['id'], 'organization-id': org.id}
-    )
-    subscription_result = target_sat.cli.Subscription.list(
-        {'organization-id': org.id, 'order': 'id desc'}, per_page=False
-    )
-    result = target_sat.cli.ActivationKey.add_subscription(
-        {'id': new_ak['id'], 'subscription-id': subscription_result[-1]['id']}
-    )
-    assert 'Subscription added to activation key.' in result
-    target_sat.cli.Subscription.delete_manifest({'organization-id': org.id})
-    ak_subs_info = target_sat.cli.ActivationKey.subscriptions(
-        {'id': new_ak['id'], 'organization-id': org.id}
-    )
-    assert len(ak_subs) == len(ak_subs_info)
-
-
-@pytest.mark.run_in_one_thread
-@pytest.mark.skip_if_not_set('fake_manifest')
-@pytest.mark.tier2
-def test_positive_delete_subscription(function_entitlement_manifest_org, module_target_sat):
-    """Check if deleting a subscription removes it from Activation key
-
-    :id: bbbe4641-bfb0-48d6-acfc-de4294b18c15
-
-    :expectedresults: Deleting subscription removes it from the Activation
-        key
-    """
-    org = function_entitlement_manifest_org
-    new_ak = module_target_sat.cli_factory.make_activation_key({'organization-id': org.id})
-    subscription_result = module_target_sat.cli.Subscription.list(
-        {'organization-id': org.id, 'order': 'id desc'}, per_page=False
-    )
-    result = module_target_sat.cli.ActivationKey.add_subscription(
-        {'id': new_ak['id'], 'subscription-id': subscription_result[-1]['id']}
-    )
-    assert 'Subscription added to activation key.' in result
-    ak_subs_info = module_target_sat.cli.ActivationKey.subscriptions(
-        {'id': new_ak['id'], 'organization-id': org.id}
-    )
-    assert subscription_result[-1]['name'] in ak_subs_info
-    result = module_target_sat.cli.ActivationKey.remove_subscription(
-        {'id': new_ak['id'], 'subscription-id': subscription_result[-1]['id']}
-    )
-    assert 'Subscription removed from activation key.' in result
-    ak_subs_info = module_target_sat.cli.ActivationKey.subscriptions(
-        {'id': new_ak['id'], 'organization-id': org.id}
-    )
-    assert subscription_result[-1]['name'] not in ak_subs_info
-
-
+@pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.rhel_ver_match('[^6]')
@@ -1110,7 +1041,7 @@ def test_positive_remove_host_collection_by_name(module_org, host_col, module_ta
 
 
 @pytest.mark.tier2
-def test_create_ak_with_syspurpose_set(module_entitlement_manifest_org, module_target_sat):
+def test_create_ak_with_syspurpose_set(module_sca_manifest_org, module_target_sat):
     """Test that an activation key can be created with system purpose values set.
 
     :id: ac8931e5-7089-494a-adac-cee2a8ab57ee
@@ -1132,7 +1063,7 @@ def test_create_ak_with_syspurpose_set(module_entitlement_manifest_org, module_t
             'purpose-role': "test-role",
             'purpose-usage': "test-usage",
             'service-level': "Self-Support",
-            'organization-id': module_entitlement_manifest_org.id,
+            'organization-id': module_sca_manifest_org.id,
         }
     )
     assert new_ak['system-purpose']['purpose-addons'] == "test-addon1, test-addon2"
@@ -1147,11 +1078,11 @@ def test_create_ak_with_syspurpose_set(module_entitlement_manifest_org, module_t
             'purpose-role': '',
             'purpose-usage': '',
             'service-level': '',
-            'organization-id': module_entitlement_manifest_org.id,
+            'organization-id': module_sca_manifest_org.id,
         }
     )
     updated_ak = module_target_sat.cli.ActivationKey.info(
-        {'id': new_ak['id'], 'organization-id': module_entitlement_manifest_org.id}
+        {'id': new_ak['id'], 'organization-id': module_sca_manifest_org.id}
     )
     assert updated_ak['system-purpose']['purpose-addons'] == ''
     assert updated_ak['system-purpose']['purpose-role'] == ''
@@ -1159,7 +1090,7 @@ def test_create_ak_with_syspurpose_set(module_entitlement_manifest_org, module_t
 
 
 @pytest.mark.tier2
-def test_update_ak_with_syspurpose_values(module_entitlement_manifest_org, module_target_sat):
+def test_update_ak_with_syspurpose_values(module_sca_manifest_org, module_target_sat):
     """Test that system purpose values can be added to an existing activation key
     and can then be changed.
 
@@ -1180,7 +1111,7 @@ def test_update_ak_with_syspurpose_values(module_entitlement_manifest_org, modul
     """
     # Requires Cls org and manifest. Manifest is for self-support values.
     # Create an AK with no system purpose values set
-    org = module_entitlement_manifest_org
+    org = module_sca_manifest_org
     new_ak = module_target_sat.cli_factory.make_activation_key({'organization-id': org.id})
     # Assert system purpose values are null after creating the AK and adding the manifest.
     assert new_ak['system-purpose']['purpose-addons'] == ''
@@ -1223,35 +1154,6 @@ def test_update_ak_with_syspurpose_values(module_entitlement_manifest_org, modul
     assert updated_ak['system-purpose']['purpose-role'] == "test-role2"
     assert updated_ak['system-purpose']['purpose-usage'] == "test-usage2"
     assert updated_ak['system-purpose']['service-level'] == "Premium"
-
-
-@pytest.mark.run_in_one_thread
-@pytest.mark.skip_if_not_set('fake_manifest')
-@pytest.mark.tier2
-def test_positive_add_subscription_by_id(module_entitlement_manifest_org, module_target_sat):
-    """Test that subscription can be added to activation key
-
-    :id: b884be1c-b35d-440a-9a9d-c854c83e10a7
-
-    :steps:
-
-        1. Create Activation key
-        2. Upload manifest and add subscription
-        3. Associate the activation key to subscription
-
-    :expectedresults: Subscription successfully added to activation key
-
-    :BZ: 1463685
-
-    :BZ: 1463685
-    """
-    org_id = module_entitlement_manifest_org.id
-    ackey_id = module_target_sat.cli_factory.make_activation_key({'organization-id': org_id})['id']
-    subs_id = module_target_sat.cli.Subscription.list({'organization-id': org_id}, per_page=False)
-    result = module_target_sat.cli.ActivationKey.add_subscription(
-        {'id': ackey_id, 'subscription-id': subs_id[0]['id']}
-    )
-    assert 'Subscription added to activation key.' in result
 
 
 @pytest.mark.tier1
@@ -1327,7 +1229,7 @@ def test_negative_copy_with_same_name(module_org, module_target_sat):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_copy_subscription(module_entitlement_manifest_org, module_target_sat):
+def test_positive_copy_activationkey_and_check_content(module_sca_manifest_org, module_target_sat):
     """Copy Activation key and verify contents
 
     :id: f4ee8096-4120-4d06-8c9a-57ac1eaa8f68
@@ -1341,25 +1243,30 @@ def test_positive_copy_subscription(module_entitlement_manifest_org, module_targ
     :expectedresults: Activation key is successfully copied
     """
     # Begin test setup
-    org = module_entitlement_manifest_org
-    parent_ak = module_target_sat.cli_factory.make_activation_key({'organization-id': org.id})
-    subscription_result = module_target_sat.cli.Subscription.list(
-        {'organization-id': org.id}, per_page=False
+    org = module_sca_manifest_org
+    result = module_target_sat.cli_factory.setup_org_for_a_rh_repo(
+        {
+            'product': PRDS['rhel'],
+            'repository-set': REPOSET['rhst7'],
+            'repository': REPOS['rhst7']['name'],
+            'organization-id': org.id,
+        },
+        force_use_cdn=True,
     )
-    module_target_sat.cli.ActivationKey.add_subscription(
-        {'id': parent_ak['id'], 'subscription-id': subscription_result[0]['id']}
+    content = module_target_sat.cli.ActivationKey.product_content(
+        {'id': result['activationkey-id'], 'organization-id': org.id}
     )
+    assert content[0]['name'] == REPOSET['rhst7']
     # End test setup
     new_name = gen_string('utf8')
-    result = module_target_sat.cli.ActivationKey.copy(
-        {'id': parent_ak['id'], 'new-name': new_name, 'organization-id': org.id}
+    copy_ak = module_target_sat.cli.ActivationKey.copy(
+        {'id': result['activationkey-id'], 'new-name': new_name, 'organization-id': org.id}
     )
-    assert 'Activation key copied.' in result
-    result = module_target_sat.cli.ActivationKey.subscriptions(
-        {'name': new_name, 'organization-id': org.id}
+    assert 'Activation key copied.' in copy_ak
+    new_content = module_target_sat.cli.ActivationKey.product_content(
+        {'id': result['activationkey-id'], 'organization-id': org.id}
     )
-    # Verify that the subscription copied over
-    assert subscription_result[0]['name'] in result  # subscription name  # subscription list
+    assert new_content[0]['name'] == REPOSET['rhst7']
 
 
 @pytest.mark.tier1
@@ -1498,10 +1405,8 @@ def test_positive_remove_user(module_org, module_target_sat):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_view_subscriptions_by_non_admin_user(
-    module_entitlement_manifest_org, module_target_sat
-):
-    """Attempt to read activation key subscriptions by non admin user
+def test_positive_view_content_by_non_admin_user(module_sca_manifest_org, module_target_sat):
+    """Attempt to read activation key content by non admin user
 
     :id: af75b640-97be-431b-8ac0-a6367f8f1996
 
@@ -1510,7 +1415,7 @@ def test_positive_view_subscriptions_by_non_admin_user(
     :steps:
 
         1. As admin user create an activation
-        2. As admin user add a subscription to activation key
+        2. As admin user enable a repository on an activation key
         3. Setup a non admin User with the following permissions
             Katello::ActivationKey:
                 view_activation_keys, create_activation_keys,
@@ -1521,42 +1426,37 @@ def test_positive_view_subscriptions_by_non_admin_user(
                 Search: "name ~ "Test_*_Dev" || name ~ "Test_*_QA"
             Organization:
                 view_organizations, assign_organizations,
-            Katello::Subscription:
-                view_subscriptions, attach_subscriptions,
-                unattach_subscriptions
+            Katello::Product:
+                view_products, edit_products, sync_products,
+                create_products, destroy_products
 
 
     :expectedresults: The non admin user can view the activation key
-        subscription
+        repository sets
 
     :BZ: 1406076
     """
-    org = module_entitlement_manifest_org
+    org = module_sca_manifest_org
     user_name = gen_alphanumeric()
     user_password = gen_alphanumeric()
-    ak_name_like = f'ak_{gen_string("alpha")}'
     hc_names_like = (
         f'Test_*_{gen_string("alpha")}',
         f'Test_*_{gen_string("alpha")}',
     )
-    ak_name = f'{ak_name_like}_{gen_string("alpha")}'
-    available_subscriptions = module_target_sat.cli.Subscription.list(
-        {'organization-id': org.id}, per_page=False
+    result = module_target_sat.cli_factory.setup_org_for_a_rh_repo(
+        {
+            'product': PRDS['rhel'],
+            'repository-set': REPOSET['rhst7'],
+            'repository': REPOS['rhst7']['name'],
+            'organization-id': org.id,
+        },
+        force_use_cdn=True,
     )
-    assert len(available_subscriptions) > 0
-    available_subscription_ids = [subscription['id'] for subscription in available_subscriptions]
-    subscription_id = choice(available_subscription_ids)
-    activation_key = module_target_sat.cli_factory.make_activation_key(
-        {'name': ak_name, 'organization-id': org.id}
+    content = module_target_sat.cli.ActivationKey.product_content(
+        {'id': result['activationkey-id'], 'organization-id': org.id}
     )
-    module_target_sat.cli.ActivationKey.add_subscription(
-        {'id': activation_key['id'], 'subscription-id': subscription_id}
-    )
-    subscriptions = module_target_sat.cli.ActivationKey.subscriptions(
-        {'organization-id': org.id, 'id': activation_key['id']},
-        output_format='csv',
-    )
-    assert len(subscriptions) == 1
+    assert content[0]['name'] == REPOSET['rhst7']
+    ak_name = module_target_sat.cli.ActivationKey.info({'id': result['activationkey-id']})['name']
     role = module_target_sat.cli_factory.make_role({'organization-id': org.id})
     resource_permissions = {
         'Katello::ActivationKey': {
@@ -1566,18 +1466,20 @@ def test_positive_view_subscriptions_by_non_admin_user(
                 'edit_activation_keys',
                 'destroy_activation_keys',
             ],
-            'search': f"name ~ {ak_name_like}",
+            'search': f"name ~ {ak_name}",
         },
         'Katello::HostCollection': {
             'permissions': ['view_host_collections', 'edit_host_collections'],
             'search': f'name ~ {hc_names_like[0]} || name ~ {hc_names_like[1]}',
         },
         'Organization': {'permissions': ['view_organizations', 'assign_organizations']},
-        'Katello::Subscription': {
+        'Katello::Product': {
             'permissions': [
-                'view_subscriptions',
-                'attach_subscriptions',
-                'unattach_subscriptions',
+                'view_products',
+                'edit_products',
+                'sync_products',
+                'create_products',
+                'destroy_products',
             ]
         },
     }
@@ -1593,69 +1495,11 @@ def test_positive_view_subscriptions_by_non_admin_user(
     )
     module_target_sat.cli.User.add_role({'id': user['id'], 'role-id': role['id']})
     ak_user_cli_session = module_target_sat.cli.ActivationKey.with_user(user_name, user_password)
-    subscriptions = ak_user_cli_session.subscriptions(
-        {'organization-id': org.id, 'id': activation_key['id']},
-        output_format='csv',
+    reposet = ak_user_cli_session.product_content(
+        {'id': result['activationkey-id'], 'organization-id': org.id}
     )
-    assert len(subscriptions) == 1
-    assert subscriptions[0]['id'] == subscription_id
-
-
-@pytest.mark.tier3
-def test_positive_subscription_quantity_attached(function_org, rhel7_contenthost, target_sat):
-    """Check the Quantity and Attached fields of 'hammer activation-key subscriptions'
-
-    see https://bugzilla.redhat.com/show_bug.cgi?id=1633094
-
-    :id: 6aee3be3-9b23-4de5-a942-897d6c811ba3
-
-    :customerscenario: true
-
-    :steps:
-        1. Create activation key
-        2. add subscriptions to activation key
-        3. Attach a content host to the activation key.
-        4. Verify 'ATTACHED' & 'QUANTITY' columns of 'hammer activation-key subscriptions'
-
-    :parametrized: yes
-
-    :BZ: 1633094
-    """
-    org = function_org
-    result = target_sat.cli_factory.setup_org_for_a_rh_repo(
-        {
-            'product': PRDS['rhel'],
-            'repository-set': REPOSET['rhst7'],
-            'repository': REPOS['rhst7']['name'],
-            'organization-id': org.id,
-        },
-        force_use_cdn=True,
-    )
-    ak = target_sat.cli.ActivationKey.info({'id': result['activationkey-id']})
-    target_sat.cli_factory.setup_org_for_a_custom_repo(
-        {
-            'url': settings.repos.yum_0.url,
-            'organization-id': org.id,
-            'activationkey-id': result['activationkey-id'],
-            'content-view-id': result['content-view-id'],
-            'lifecycle-environment-id': result['lifecycle-environment-id'],
-        }
-    )
-    subs = target_sat.cli.Subscription.list({'organization-id': org.id}, per_page=False)
-    subs_lookup = {s['id']: s for s in subs}
-    rhel7_contenthost.register(org, None, ak['name'], target_sat)
-    assert rhel7_contenthost.subscribed
-
-    ak_subs = target_sat.cli.ActivationKey.subscriptions(
-        {'activation-key': ak['name'], 'organization-id': org.id}, output_format='json'
-    )
-    assert len(ak_subs) == 2  # one for #rh product, one for custom product
-    for ak_sub in ak_subs:
-        assert ak_sub['id'] in subs_lookup
-        assert ak_sub['quantity'] == '1'
-        amount = subs_lookup[ak_sub['id']]['quantity']
-        regex = re.compile(f'1 out of {amount}')
-        assert regex.match(ak_sub['attached'])
+    assert len(reposet) == 1
+    assert reposet[0]['id'] == content[0]['id']
 
 
 @pytest.mark.tier3
@@ -1671,7 +1515,6 @@ def test_positive_ak_with_custom_product_on_rhel6(
     :steps:
         1. Create a custom repo
         2. Create ak and add custom repo to ak
-        3. Add subscriptions to the ak
         4. Register a rhel6 chost with the ak
 
     :expectedresults: Host is registered successfully

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -725,7 +725,7 @@ def test_positive_add_redhat_product(function_sca_manifest_org, target_sat):
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_add_custom_product(module_org, module_target_sat):
+def test_positive_add_custom_product(module_org, function_target_sat):
     """Test that custom product can be associated to Activation Keys
 
     :id: 96ace967-e165-4069-8ff7-f54c4c822de0
@@ -735,11 +735,11 @@ def test_positive_add_custom_product(module_org, module_target_sat):
 
     :BZ: 1426386
     """
-    result = module_target_sat.cli_factory.setup_org_for_a_custom_repo(
+    result = function_target_sat.cli_factory.setup_org_for_a_custom_repo(
         {'url': settings.repos.yum_0.url, 'organization-id': module_org.id}
     )
-    repo = module_target_sat.cli.Repository.info({'id': result['repository-id']})
-    content = module_target_sat.cli.ActivationKey.product_content(
+    repo = function_target_sat.cli.Repository.info({'id': result['repository-id']})
+    content = function_target_sat.cli.ActivationKey.product_content(
         {'id': result['activationkey-id'], 'organization-id': module_org.id}
     )
     assert content[0]['name'] == repo['name']
@@ -1223,7 +1223,7 @@ def test_negative_copy_with_same_name(module_org, module_target_sat):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_copy_activationkey_and_check_content(module_sca_manifest_org, module_target_sat):
+def test_positive_copy_activationkey_and_check_content(function_sca_manifest_org, module_target_sat):
     """Copy Activation key and verify contents
 
     :id: f4ee8096-4120-4d06-8c9a-57ac1eaa8f68
@@ -1237,7 +1237,7 @@ def test_positive_copy_activationkey_and_check_content(module_sca_manifest_org, 
     :expectedresults: Activation key is successfully copied
     """
     # Begin test setup
-    org = module_sca_manifest_org
+    org = function_sca_manifest_org
     result = module_target_sat.cli_factory.setup_org_for_a_rh_repo(
         {
             'product': PRDS['rhel'],
@@ -1399,7 +1399,7 @@ def test_positive_remove_user(module_org, module_target_sat):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
-def test_positive_view_content_by_non_admin_user(module_sca_manifest_org, module_target_sat):
+def test_positive_view_content_by_non_admin_user(function_sca_manifest_org, module_target_sat):
     """Attempt to read activation key content by non admin user
 
     :id: af75b640-97be-431b-8ac0-a6367f8f1996
@@ -1430,7 +1430,7 @@ def test_positive_view_content_by_non_admin_user(module_sca_manifest_org, module
 
     :BZ: 1406076
     """
-    org = module_sca_manifest_org
+    org = function_sca_manifest_org
     user_name = gen_alphanumeric()
     user_password = gen_alphanumeric()
     hc_names_like = (

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1223,7 +1223,9 @@ def test_negative_copy_with_same_name(module_org, module_target_sat):
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_copy_activationkey_and_check_content(function_sca_manifest_org, module_target_sat):
+def test_positive_copy_activationkey_and_check_content(
+    function_sca_manifest_org, module_target_sat
+):
     """Copy Activation key and verify contents
 
     :id: f4ee8096-4120-4d06-8c9a-57ac1eaa8f68

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -725,7 +725,7 @@ def test_positive_add_redhat_product(function_sca_manifest_org, target_sat):
 
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_add_custom_product(module_org, function_target_sat):
+def test_positive_add_custom_product(module_org, target_sat):
     """Test that custom product can be associated to Activation Keys
 
     :id: 96ace967-e165-4069-8ff7-f54c4c822de0
@@ -735,11 +735,11 @@ def test_positive_add_custom_product(module_org, function_target_sat):
 
     :BZ: 1426386
     """
-    result = function_target_sat.cli_factory.setup_org_for_a_custom_repo(
+    result = target_sat.cli_factory.setup_org_for_a_custom_repo(
         {'url': settings.repos.yum_0.url, 'organization-id': module_org.id}
     )
-    repo = function_target_sat.cli.Repository.info({'id': result['repository-id']})
-    content = function_target_sat.cli.ActivationKey.product_content(
+    repo = target_sat.cli.Repository.info({'id': result['repository-id']})
+    content = target_sat.cli.ActivationKey.product_content(
         {'id': result['activationkey-id'], 'organization-id': module_org.id}
     )
     assert content[0]['name'] == repo['name']

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -60,6 +60,7 @@ def test_positive_end_to_end_crud(session, module_org, module_target_sat):
         assert session.activationkey.search(new_name)[0]['Name'] != new_name
 
 
+@pytest.mark.no_containers
 @pytest.mark.e2e
 @pytest.mark.tier3
 @pytest.mark.upgrade
@@ -916,6 +917,8 @@ def test_negative_usage_limit(session, module_org, target_sat):
         assert f'Max Hosts ({hosts_limit}) reached for activation key' in str(result.stderr)
 
 
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_match('^6')
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
@@ -1016,6 +1019,7 @@ def test_positive_host_associations(session, target_sat):
             assert ak2['content_hosts']['table'][0]['Name'] == vm2.hostname
 
 
+@pytest.mark.no_containers
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_service_level_subscription_with_custom_product(
@@ -1032,9 +1036,9 @@ def test_positive_service_level_subscription_with_custom_product(
         1. Create a product with custom repository synchronized
         2. Create and Publish a content view with the created repository
         3. Create an activation key and assign the created content view
-        5. Set the activation service_level to Premium
-        6. Register a host to activation key
-        8. Assert product is listed under repository sets on the content host
+        4. Set the activation service_level to Premium
+        5. Register a host to activation key
+        6. Assert product is listed under repository sets on the content host
 
     :expectedresults:
         1. The product is listed under repository sets on the content host

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1032,17 +1032,12 @@ def test_positive_service_level_subscription_with_custom_product(
         1. Create a product with custom repository synchronized
         2. Create and Publish a content view with the created repository
         3. Create an activation key and assign the created content view
-        4. Add a RedHat subscription to activation key (The product
-           subscription should be added automatically)
         5. Set the activation service_level to Premium
         6. Register a host to activation key
-        7. List consumed subscriptions on host
-        8. List the subscription in Content Host UI
+        8. Assert product is listed under repository sets on the content host
 
     :expectedresults:
-        1. The product subscription is listed in consumed subscriptions on host
-        2. The product subscription is listed in the contenthost subscriptions
-           UI
+        1. The product is listed under repository sets on the content host
 
     :BZ: 1394357
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -70,7 +70,7 @@ def test_positive_end_to_end_crud(session, module_org, module_target_sat):
 )
 def test_positive_end_to_end_register(
     session,
-    function_entitlement_manifest_org,
+    function_sca_manifest_org,
     default_location,
     repos_collection,
     rhel7_contenthost,
@@ -87,7 +87,7 @@ def test_positive_end_to_end_register(
 
     :CaseImportance: High
     """
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     repos_collection.setup_content(org.id, lce.id, upload_manifest=False)
     ak_name = repos_collection.setup_content_data['activation_key']['name']
@@ -399,7 +399,7 @@ def test_positive_update_cv(session, module_org, cv2_name, target_sat):
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
-def test_positive_update_rh_product(function_entitlement_manifest_org, session, target_sat):
+def test_positive_update_rh_product(function_sca_manifest_org, session, target_sat):
     """Update Content View in an Activation key
 
     :id: 9b0ac209-45de-4cc4-97e8-e191f3f37239
@@ -431,7 +431,7 @@ def test_positive_update_rh_product(function_entitlement_manifest_org, session, 
         'basearch': 'i386',
         'releasever': constants.DEFAULT_RELEASE_VERSION,
     }
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     repo1_id = target_sat.api_factory.enable_sync_redhat_repo(rh_repo1, org.id)
     target_sat.api_factory.cv_publish_promote(cv1_name, env1_name, repo1_id, org.id)
     repo2_id = target_sat.api_factory.enable_sync_redhat_repo(rh_repo2, org.id)
@@ -453,7 +453,7 @@ def test_positive_update_rh_product(function_entitlement_manifest_org, session, 
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
-def test_positive_add_rh_product(function_entitlement_manifest_org, session, target_sat):
+def test_positive_add_rh_product(function_sca_manifest_org, session, target_sat):
     """Test that RH product can be associated to Activation Keys
 
     :id: d805341b-6d2f-4e16-8cb4-902de00b9a6c
@@ -470,7 +470,7 @@ def test_positive_add_rh_product(function_entitlement_manifest_org, session, tar
         'basearch': constants.DEFAULT_ARCHITECTURE,
         'releasever': constants.DEFAULT_RELEASE_VERSION,
     }
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     # Helper function to create and promote CV to next environment
     repo_id = target_sat.api_factory.enable_sync_redhat_repo(rh_repo, org.id)
     target_sat.api_factory.cv_publish_promote(cv_name, env_name, repo_id, org.id)
@@ -480,10 +480,10 @@ def test_positive_add_rh_product(function_entitlement_manifest_org, session, tar
             {'name': name, 'lce': {env_name: True}, 'content_view': cv_name}
         )
         assert session.activationkey.search(name)[0]['Name'] == name
-        session.activationkey.add_subscription(name, constants.DEFAULT_SUBSCRIPTION_NAME)
-        ak = session.activationkey.read(name, widget_names='subscriptions')
-        subs_name = ak['subscriptions']['resources']['assigned'][0]['Repository Name']
-        assert subs_name == constants.DEFAULT_SUBSCRIPTION_NAME
+        ak = session.activationkey.read(name, widget_names='repository sets')['repository sets'][
+            'table'
+        ][0]
+        assert rh_repo['reposet'] == ak['Repository Name']
 
 
 @pytest.mark.tier2
@@ -509,18 +509,16 @@ def test_positive_add_custom_product(session, module_org, target_sat):
             {'name': name, 'lce': {env_name: True}, 'content_view': cv_name}
         )
         assert session.activationkey.search(name)[0]['Name'] == name
-        session.activationkey.add_subscription(name, product_name)
-        ak = session.activationkey.read(name, widget_names='subscriptions')
-        assigned_prod = ak['subscriptions']['resources']['assigned'][0]['Repository Name']
-        assert assigned_prod == product_name
+        ak = session.activationkey.read(name, widget_names='repository sets')['repository sets'][
+            'table'
+        ][0]
+        assert product_name == ak['Product Name']
 
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_add_rh_and_custom_products(
-    target_sat, function_entitlement_manifest_org, session
-):
+def test_positive_add_rh_and_custom_products(target_sat, function_sca_manifest_org, session):
     """Test that RH/Custom product can be associated to Activation keys
 
     :id: 3d8876fa-1412-47ca-a7a4-bce2e8baf3bc
@@ -543,7 +541,7 @@ def test_positive_add_rh_and_custom_products(
     }
     custom_product_name = gen_string('alpha')
     repo_name = gen_string('alpha')
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     product = target_sat.api.Product(name=custom_product_name, organization=org).create()
     repo = target_sat.api.Repository(name=repo_name, product=product).create()
     rhel_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
@@ -566,20 +564,15 @@ def test_positive_add_rh_and_custom_products(
             }
         )
         assert session.activationkey.search(name)[0]['Name'] == name
-        for subscription in (constants.DEFAULT_SUBSCRIPTION_NAME, custom_product_name):
-            session.activationkey.add_subscription(name, subscription)
-        ak = session.activationkey.read(name, widget_names='subscriptions')
-        subscriptions = [
-            subscription['Repository Name']
-            for subscription in ak['subscriptions']['resources']['assigned']
-        ]
-        assert {constants.DEFAULT_SUBSCRIPTION_NAME, custom_product_name} == set(subscriptions)
+        ak = session.activationkey.read(name, widget_names='repository sets')
+        reposets = [reposet['Repository Name'] for reposet in ak['repository sets']['table']]
+        assert {repo_name, constants.REPOSET['rhva6']} == set(reposets)
 
 
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_fetch_product_content(target_sat, function_entitlement_manifest_org, session):
+def test_positive_fetch_product_content(target_sat, function_sca_manifest_org, session):
     """Associate RH & custom product with AK and fetch AK's product content
 
     :id: 4c37fb12-ea2a-404e-b7cc-a2735e8dedb6
@@ -589,7 +582,8 @@ def test_positive_fetch_product_content(target_sat, function_entitlement_manifes
 
     :BZ: 1426386, 1432285
     """
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
+    lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
@@ -612,11 +606,11 @@ def test_positive_fetch_product_content(target_sat, function_entitlement_manifes
         organization=org, repository=[rh_repo_id, custom_repo.id]
     ).create()
     cv.publish()
-    ak = target_sat.api.ActivationKey(content_view=cv, organization=org).create()
+    cvv = cv.read().version[0].read()
+    cvv.promote(data={'environment_ids': lce.id, 'force': True})
+    ak = target_sat.api.ActivationKey(content_view=cv, organization=org, environment=lce).create()
     with session:
         session.organization.select(org.name)
-        for subscription in (constants.DEFAULT_SUBSCRIPTION_NAME, custom_product.name):
-            session.activationkey.add_subscription(ak.name, subscription)
         ak = session.activationkey.read(ak.name, widget_names='repository_sets')
         reposets = [reposet['Repository Name'] for reposet in ak['repository_sets']['table']]
         assert {custom_repo.name, constants.REPOSET['rhst7']} == set(reposets)
@@ -881,7 +875,6 @@ def test_positive_delete_with_system(session, rhel_contenthost, target_sat):
             {'name': name, 'lce': {env_name: True}, 'content_view': cv_name}
         )
         assert session.activationkey.search(name)[0]['Name'] == name
-        session.activationkey.add_subscription(name, product_name)
         result = rhel_contenthost.register(org, None, name, target_sat)
         assert result.status == 0, f'Failed to register host: {result.stderr}'
         assert rhel_contenthost.subscribed
@@ -962,13 +955,10 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel_contentho
                 {'name': key_name, 'lce': {env_name: True}, 'content_view': cv_name}
             )
             assert session.activationkey.search(key_name)[0]['Name'] == key_name
-            session.activationkey.add_subscription(key_name, product_name)
-            ak = session.activationkey.read(key_name, widget_names='subscriptions')
-            subscriptions = [
-                subscription['Repository Name']
-                for subscription in ak['subscriptions']['resources']['assigned']
-            ]
-            assert product_name in subscriptions
+            ak = session.activationkey.read(key_name, widget_names='repository sets')[
+                'repository sets'
+            ]['table'][0]
+            assert product_name == ak['Product Name']
         # Create VM
         result = rhel_contenthost.register(module_org, None, [key_1_name, key_2_name], target_sat)
         assert result.status == 0, f'Failed to register host: {result.stderr}'
@@ -1029,7 +1019,7 @@ def test_positive_host_associations(session, target_sat):
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
 def test_positive_service_level_subscription_with_custom_product(
-    session, function_entitlement_manifest_org, rhel7_contenthost, target_sat
+    session, function_sca_manifest_org, rhel7_contenthost, target_sat
 ):
     """Subscribe a host to activation key with Premium service level and with
     custom product
@@ -1058,81 +1048,25 @@ def test_positive_service_level_subscription_with_custom_product(
 
     :parametrized: yes
     """
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     entities_ids = target_sat.cli_factory.setup_org_for_a_custom_repo(
         {'url': settings.repos.yum_1.url, 'organization-id': org.id}
     )
     product = target_sat.api.Product(id=entities_ids['product-id']).read()
     activation_key = target_sat.api.ActivationKey(id=entities_ids['activationkey-id']).read()
-    # add the default RH subscription
-    subscription = target_sat.api.Subscription(organization=org).search(
-        query={'search': f'name="{constants.DEFAULT_SUBSCRIPTION_NAME}"'}
-    )[0]
-    activation_key.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
-    # ensure all the needed subscriptions are attached to activation key
-    results = activation_key.subscriptions()['results']
-    assert {product.name, constants.DEFAULT_SUBSCRIPTION_NAME} == {
-        ak_subscription['name'] for ak_subscription in results
-    }
-    # Set the activation service_level to Premium
     activation_key.service_level = 'Premium'
     activation_key = activation_key.update(['service_level'])
 
     result = rhel7_contenthost.register(org, None, activation_key.name, target_sat)
     assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert rhel7_contenthost.subscribed
-    result = rhel7_contenthost.run('subscription-manager list --consumed')
-    assert result.status == 0
-    assert f'Subscription Name:   {product.name}' in result.stdout
     with session:
         session.organization.select(org.name)
-        chost = session.contenthost.read(rhel7_contenthost.hostname, widget_names='subscriptions')
-        subscriptions = {
-            subs['Repository Name'] for subs in chost['subscriptions']['resources']['assigned']
-        }
-        assert product.name in subscriptions
-
-
-@pytest.mark.run_in_one_thread
-@pytest.mark.tier2
-def test_positive_delete_manifest(session, function_entitlement_manifest_org, target_sat):
-    """Check if deleting a manifest removes it from Activation key
-
-    :id: 512d8e41-b937-451e-a9c6-840457d3d7d4
-
-    :steps:
-        1. Create Activation key
-        2. Associate a manifest to the Activation Key
-        3. Delete the manifest
-
-    :expectedresults: Deleting a manifest removes it from the Activation
-        key
-    """
-    org = function_entitlement_manifest_org
-    # Create activation key
-    activation_key = target_sat.api.ActivationKey(organization=org).create()
-    # Associate a manifest to the activation key
-    subscription = target_sat.api.Subscription(organization=org).search(
-        query={'search': f'name="{constants.DEFAULT_SUBSCRIPTION_NAME}"'}
-    )[0]
-    activation_key.add_subscriptions(data={'quantity': 1, 'subscription_id': subscription.id})
-    with session:
-        session.organization.select(org.name)
-        # Verify subscription is assigned to activation key
-        ak = session.activationkey.read(activation_key.name, widget_names='subscriptions')
-        assert (
-            ak['subscriptions']['resources']['assigned'][0]['Repository Name']
-            == constants.DEFAULT_SUBSCRIPTION_NAME
+        session.location.select(constants.DEFAULT_LOC)
+        chost = session.host_new.get_details(
+            rhel7_contenthost.hostname, widget_names='content.repository_sets'
         )
-        # Delete the manifest
-        # Ignore "404 Not Found" as server will connect to upstream subscription service to verify
-        # the consumer uuid, that will be displayed in flash error messages
-        # Note: this happen only when using clone manifest.
-        session.subscription.delete_manifest(ignore_error_messages='404 Not Found')
-        assert not session.subscription.has_manifest
-        # Verify subscription is not assigned to activation key anymore
-        ak = session.activationkey.read(activation_key.name, widget_names='subscriptions')
-        assert not ak['subscriptions']['resources']['assigned']
+        assert product.name == chost['content']['repository_sets']['table'][0]['Product']
 
 
 @pytest.mark.rhel_ver_list([6])
@@ -1170,22 +1104,3 @@ def test_positive_ak_with_custom_product_on_rhel6(rhel_contenthost, target_sat):
         ak = session.activationkey.read(ak.name, widget_names='content_hosts')
         assert len(ak['content_hosts']['table']) == 1
         assert ak['content_hosts']['table'][0]['Name'] == rhel_contenthost.hostname
-
-
-def test_positive_prepare_for_sca_only_ak(target_sat, function_entitlement_manifest_org):
-    """Verify that the ActivationKey details page notifies users that Simple Content Access
-        will be required for all organizations in Satellite 6.16
-
-    :id: 417a8331-3c66-473f-938c-bbf01deb6031
-
-    :expectedresults: The ActivationKey page notifies users that Simple Content Access will
-        be required for all organizations in Satellite 6.16
-    """
-    ak = target_sat.api.ActivationKey(organization=function_entitlement_manifest_org).create()
-    with target_sat.ui_session() as session:
-        session.organization.select(function_entitlement_manifest_org.name)
-        ak = session.activationkey.read(ak.name)
-        assert (
-            'This organization is not using Simple Content Access. Entitlement-based subscription '
-            'management is deprecated and will be removed in Satellite 6.16.' in ak['sca_alert']
-        )


### PR DESCRIPTION
SCA is now the default in 6.16. This PR is for updating all tests under the Activation Key Component
SAT-24352


