### PR TITLE
Add fixture to cut Satellite off nameservers

### DIFF
--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -189,7 +189,7 @@ def test_positive_environment_variable_unset_set():
 @pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
+def test_positive_assign_http_proxy_to_products(module_org, module_target_sat, satellite_cut_off):
     """Assign http_proxy to Products and perform product sync.
 
     :id: 6af7b2b8-15d5-4d9f-9f87-e76b404a966f


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->