### PR TITLE
Assert installer status when enabling OpenSCAP

### DIFF
--- a/tests/foreman/api/test_capsule.py
+++ b/tests/foreman/api/test_capsule.py
@@ -46,7 +46,8 @@ def test_positive_update_capsule(request, pytestconfig, target_sat, module_capsu
 
     # refresh features
     features = capsule.refresh()
-    module_capsule_configured.install(cmd_args=['enable-foreman-proxy-plugin-openscap'])
+    result = module_capsule_configured.install(cmd_args=['enable-foreman-proxy-plugin-openscap'])
+    assert result.status == 0, 'Installer failed when enabling OpenSCAP plugin.'
     features_new = capsule.refresh()
     assert len(features_new["features"]) == len(features["features"]) + 1
     assert 'Openscap' in [feature["name"] for feature in features_new["features"]]


### PR DESCRIPTION
### Problem Statement
#14693 missed to address changes in installer status check

### Solution
Add installer status check in a form of an assertion.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->