### PR TITLE
[6.15.z] updated hammer commands tree

### DIFF
--- a/tests/foreman/data/hammer_commands.json
+++ b/tests/foreman/data/hammer_commands.json
@@ -746,7 +746,13 @@
               "value": null
             },
             {
-              "help": "Print help --------------------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | limit                      | x   | x       | attach                     | x   | x       | version                 | x   | x       | environment           | x   | x       | view                    | x   | x       | collections/id             | x   | x       | collections/name           | x   | x       | overrides/content label | x   | x       | overrides/name          | x   | x       | overrides/value         | x   | x       | purpose/service level    | x   | x       | purpose/purpose usage    | x   | x       | purpose/purpose role     | x   | x       | purpose/purpose addons   | x   | x       | --------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Show hosts associated to an activation key",
+              "name": "show-hosts",
+              "shortname": null,
+              "value": "BOOLEAN"
+            },
+            {
+              "help": "Print help --------------------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | limit                      | x   | x       | attach                     | x   | x       | version                 | x   | x       | environment           | x   | x       | view                    | x   | x       | hosts/id             | x   | x       | hosts/name           | x   | x       | collections/id             | x   | x       | collections/name           | x   | x       | overrides/content label | x   | x       | overrides/name          | x   | x       | overrides/value         | x   | x       | purpose/service level    | x   | x       | purpose/purpose usage    | x   | x       | purpose/purpose role     | x   | x       | purpose/purpose addons   | x   | x       | --------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -1450,6 +1456,71 @@
       ],
       "subcommands": [
         {
+          "description": "Modify alternate content sources in bulk",
+          "name": "bulk",
+          "options": [
+            {
+              "help": "Print help",
+              "name": "help",
+              "shortname": "h",
+              "value": null
+            }
+          ],
+          "subcommands": [
+            {
+              "description": "Destroy alternate content sources",
+              "name": "destroy",
+              "options": [
+                {
+                  "help": "List of alternate content source ids",
+                  "name": "ids",
+                  "shortname": null,
+                  "value": "LIST"
+                },
+                {
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Refresh alternate content sources",
+              "name": "refresh",
+              "options": [
+                {
+                  "help": "List of alternate content source ids",
+                  "name": "ids",
+                  "shortname": null,
+                  "value": "LIST"
+                },
+                {
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Refresh all alternate content sources",
+              "name": "refresh-all",
+              "options": [
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            }
+          ]
+        },
+        {
           "description": "Create an alternate content source to download content from during repository syncing.  Note: alternate content sources are global and affect ALL sync actions on their capsules regardless of organization.",
           "name": "create",
           "options": [
@@ -1612,7 +1683,7 @@
               "value": "VALUE"
             },
             {
-              "help": "Print help ------------------------------|-----|---------|----- | ALL | DEFAULT | THIN ------------------------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | url                      | x   | x       | type                  | x   | x       | content source type | x   | x       | username             | x   | x       | Subpaths/                     | x   | x       | Products/id                   | x   | x       | Products/organization id      | x   | x       | Products/name                 | x   | x       | Products/label                | x   | x       | proxies/id              | x   | x       | proxies/name            | x   | x       | proxies/url             | x   | x       | proxies/download policy | x   | x       | ------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help ------------------------------|-----|---------|----- | ALL | DEFAULT | THIN ------------------------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | url                      | x   | x       | type                  | x   | x       | content source type | x   | x       | username             | x   | x       | ssl                    | x   | x       | ca cert/id                | x   | x       | ca cert/name              | x   | x       | client cert/id            | x   | x       | client cert/name          | x   | x       | client key/id             | x   | x       | client key/name           | x   | x       | Subpaths/                     | x   | x       | Products/id                   | x   | x       | Products/organization id      | x   | x       | Products/name                 | x   | x       | Products/label                | x   | x       | proxies/id              | x   | x       | proxies/name            | x   | x       | proxies/url             | x   | x       | proxies/download policy | x   | x       | ------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -4108,7 +4179,7 @@
               "value": "VALUE"
             },
             {
-              "help": "Print help --------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------|-----|---------|----- | x   | x       | x at         | x   | x       | name           | x   | x       | x proxy name | x   | x       | name         | x   | x       | | x   | x       | | x   | x       | | x   | x       | --------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string Values: compliant, incompliant, inconclusive string Values: true, false string string integer integer string string string integer string Values: host, policy datetime string string integer text string string string integer string string datetime text string text string string",
+              "help": "Print help --------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------|-----|---------|----- | x   | x       | x at         | x   | x       | name           | x   | x       | x proxy name | x   | x       | name         | x   | x       | | x   | x       | | x   | x       | | x   | x       | --------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string Values: compliant, incompliant, inconclusive string Values: true, false string string integer integer string string string integer string Values: host, policy datetime lifecycle_environment string integer text string string string integer string string datetime text string text string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -4299,6 +4370,31 @@
             {
               "description": "Provide username and password",
               "name": "basic",
+              "options": [
+                {
+                  "help": "Print help",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                },
+                {
+                  "help": "Password to access the remote system",
+                  "name": "password",
+                  "shortname": "p",
+                  "value": "VALUE"
+                },
+                {
+                  "help": "Username to access the remote system you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "name": "username",
+                  "shortname": "u",
+                  "value": "VALUE"
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Authenticate against external source (IPA/PAM) with credentials",
+              "name": "basic-external",
               "options": [
                 {
                   "help": "Print help",
@@ -6230,7 +6326,7 @@
                   "value": null
                 },
                 {
-                  "help": "Print help -------------------------------------------------------------------|-----|-------- | ALL | DEFAULT -------------------------------------------------------------------|-----|-------- environments/name                                        | x   | x environments/organization                                | x   | x environments/content views/name                          | x   | x environments/content views/composite                     | x   | x environments/content views/last published                | x   | x environments/content views/content/hosts                 | x   | x environments/content views/content/products              | x   | x environments/content views/content/yum repos             | x   | x environments/content views/content/container image repos | x   | x environments/content views/content/packages              | x   | x environments/content views/content/package groups        | x   | x environments/content views/content/errata                | x   | x -------------------------------------------------------------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help ---------------------------------------------------------------------------------|-----|-------- | ALL | DEFAULT ---------------------------------------------------------------------------------|-----|-------- environments/name                                                      | x   | x environments/organization                                              | x   | x environments/content views/name                                        | x   | x environments/content views/composite                                   | x   | x environments/content views/last published                              | x   | x environments/content views/repositories/repository id                  | x   | x environments/content views/repositories/repository name                | x   | x environments/content views/repositories/content counts/warning         | x   | x environments/content views/repositories/content counts/packages        | x   | x environments/content views/repositories/content counts/srpms           | x   | x environments/content views/repositories/content counts/module streams  | x   | x environments/content views/repositories/content counts/package groups  | x   | x environments/content views/repositories/content counts/errata          | x   | x environments/content views/repositories/content counts/debian packages | x   | x environments/content views/repositories/content counts/container tags  | x   | x environments/content views/repositories/content counts/container ma... | x   | x environments/content views/repositories/content counts/container ma... | x   | x environments/content views/repositories/content counts/files           | x   | x environments/content views/repositories/content counts/ansible coll... | x   | x environments/content views/repositories/content counts/ostree refs     | x   | x environments/content views/repositories/content counts/python packages | x   | x ---------------------------------------------------------------------------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -6286,6 +6382,37 @@
                 },
                 {
                   "help": "Print help -------------|-----|---------|----- | ALL | DEFAULT | THIN -------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | -------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Reclaim space from all On Demand repositories on a capsule",
+              "name": "reclaim-space",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "NUMBER"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "VALUE"
+                },
+                {
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -6496,6 +6623,49 @@
                   "name": "skip-metadata-check",
                   "shortname": null,
                   "value": "BOOLEAN"
+                },
+                {
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update content counts for the capsule",
+              "name": "update-counts",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "NUMBER"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "VALUE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "VALUE"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "VALUE"
                 },
                 {
                   "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
@@ -6816,7 +6986,7 @@
               "value": null
             },
             {
-              "help": "Print help -----------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | | x   | x       | | x   | x       | | x   | x       | Features/name    | x   | x       | Features/version | x   | x       | Locations/       | x   | x       | Organizations/   | x   | x       | at       | x   | x       | at       | x   | x       | -----------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help -----------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | | x   | x       | | x   | x       | count       | x   | x       | Features/name    | x   | x       | Features/version | x   | x       | Locations/       | x   | x       | Organizations/   | x   | x       | at       | x   | x       | at       | x   | x       | -----------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -7523,7 +7693,7 @@
                   "value": null
                 },
                 {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --interface: Libvirt: --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default OpenStack: --interface: oVirt: --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile Rackspace: --interface: VMware: --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware AzureRM: --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) GCE: --interface:",
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --interface: Libvirt: --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default OpenStack: --interface: oVirt: --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile VMware: --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware AzureRM: --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) GCE: --interface:",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -7602,7 +7772,7 @@
                   "value": "KEY_VALUE_LIST"
                 },
                 {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 OpenStack: --volume: oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virto or virto_scsi Rackspace: --volume: VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) GCE: --volume: size_gb             Volume size in GB, integer value",
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 OpenStack: --volume: oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virtio or virtio_scsi VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) GCE: --volume: size_gb             Volume size in GB, integer value",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -7693,7 +7863,7 @@
                   "value": "KEY_VALUE_LIST"
                 },
                 {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: --interface: --compute-attributes: availability_zone flavor_id groups security_group_ids managed_ip Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default --compute-attributes: \u001b[1mcpus\u001b[0m                Number of CPUs \u001b[1mmemory\u001b[0m              String, amount of memory, value in bytes cpu_mode            Possible values: default, host-model, host-passthrough boot_order          Device names to specify the boot order OpenStack: --volume: --interface: --compute-attributes: availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virto or virto_scsi --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile --compute-attributes: cluster             ID or name of cluster to use template            Hardware profile to use cores               Integer value, number of cores sockets             Integer value, number of sockets memory              Amount of memory, integer value in bytes ha                  Boolean, set 1 to high availability display_type        Possible values: VNC, SPICE keyboard_layout     Possible values: ar, de-ch, es, fo, fr-ca, hu, ja, mk, no, pt-br, sv, da, en-gb, et, fr, fr-ch, is, lt, nl, pl, ru, th, de, en-us, fi, fr-be, hr, it, lv, nl-be, pt, sl, tr. Not usable if display type is SPICE. Rackspace: --volume: --interface: --compute-attributes: flavor_id VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware --compute-attributes: \u001b[1mcluster\u001b[0m              Cluster ID from VMware \u001b[1mcorespersocket\u001b[0m       Number of cores per socket (applicable to hardware versions < 10 only) \u001b[1mcpus\u001b[0m                 CPU count \u001b[1mmemory_mb\u001b[0m            Integer number, amount of memory in MB \u001b[1mpath\u001b[0m                 Path to folder \u001b[1mresource_pool\u001b[0m        Resource Pool ID from VMware firmware             automatic/bios/efi guest_id             Guest OS ID form VMware hardware_version     Hardware version ID from VMware memoryHotAddEnabled  Must be a 1 or 0, lets you add memory resources while the machine is on cpuHotAddEnabled     Must be a 1 or 0, lets you add CPU resources while the machine is on add_cdrom            Must be a 1 or 0, Add a CD-ROM drive to the virtual machine annotation           Annotation Notes scsi_controllers     List with SCSI controllers definitions type - ID of the controller from VMware key  - Key of the controller (e.g. 1000) boot_order           Device names to specify the boot order AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) --compute-attributes: resource_group      Existing Azure Resource Group of user vm_size             VM Size, eg. Standard_A0 etc. username            The Admin username password            The Admin password platform            OS type eg. Linux ssh_key_data        SSH key for passwordless authentication os_disk_caching     OS disk caching premium_os_disk     Premium OS Disk, Boolean as 0 or 1 script_command      Custom Script Command script_uris         Comma seperated file URIs GCE: --volume: size_gb             Volume size in GB, integer value --interface: --compute-attributes: machine_type network associate_external_ip",
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: --interface: --compute-attributes: availability_zone flavor_id groups security_group_ids managed_ip Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default --compute-attributes: \u001b[1mcpus\u001b[0m                Number of CPUs \u001b[1mmemory\u001b[0m              String, amount of memory, value in bytes cpu_mode            Possible values: default, host-model, host-passthrough boot_order          Device names to specify the boot order OpenStack: --volume: --interface: --compute-attributes: availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virtio or virtio_scsi --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile --compute-attributes: cluster             ID or name of cluster to use template            Hardware profile to use cores               Integer value, number of cores sockets             Integer value, number of sockets memory              Amount of memory, integer value in bytes ha                  Boolean, set 1 to high availability display_type        Possible values: VNC, SPICE keyboard_layout     Possible values: ar, de-ch, es, fo, fr-ca, hu, ja, mk, no, pt-br, sv, da, en-gb, et, fr, fr-ch, is, lt, nl, pl, ru, th, de, en-us, fi, fr-be, hr, it, lv, nl-be, pt, sl, tr. Not usable if display type is SPICE. VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware --compute-attributes: \u001b[1mcluster\u001b[0m              Cluster ID from VMware \u001b[1mcorespersocket\u001b[0m       Number of cores per socket (applicable to hardware versions < 10 only) \u001b[1mcpus\u001b[0m                 CPU count \u001b[1mmemory_mb\u001b[0m            Integer number, amount of memory in MB \u001b[1mpath\u001b[0m                 Path to folder \u001b[1mresource_pool\u001b[0m        Resource Pool ID from VMware firmware             automatic/bios/efi guest_id             Guest OS ID form VMware hardware_version     Hardware version ID from VMware memoryHotAddEnabled  Must be a 1 or 0, lets you add memory resources while the machine is on cpuHotAddEnabled     Must be a 1 or 0, lets you add CPU resources while the machine is on add_cdrom            Must be a 1 or 0, Add a CD-ROM drive to the virtual machine annotation           Annotation Notes scsi_controllers     List with SCSI controllers definitions type - ID of the controller from VMware key  - Key of the controller (e.g. 1000) boot_order           Device names to specify the boot order AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) --compute-attributes: resource_group      Existing Azure Resource Group of user vm_size             VM Size, eg. Standard_A0 etc. username            The Admin username password            The Admin password platform            OS type eg. Linux ssh_key_data        SSH key for passwordless authentication os_disk_caching     OS disk caching premium_os_disk     Premium OS Disk, Boolean as 0 or 1 script_command      Custom Script Command script_uris         Comma seperated file URIs GCE: --volume: size_gb             Volume size in GB, integer value --interface: --compute-attributes: machine_type network associate_external_ip",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -7942,7 +8112,7 @@
                   "value": "KEY_VALUE_LIST"
                 },
                 {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: --interface: --compute-attributes: availability_zone flavor_id groups security_group_ids managed_ip Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default --compute-attributes: \u001b[1mcpus\u001b[0m                Number of CPUs \u001b[1mmemory\u001b[0m              String, amount of memory, value in bytes cpu_mode            Possible values: default, host-model, host-passthrough boot_order          Device names to specify the boot order OpenStack: --volume: --interface: --compute-attributes: availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virto or virto_scsi --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile --compute-attributes: cluster             ID or name of cluster to use template            Hardware profile to use cores               Integer value, number of cores sockets             Integer value, number of sockets memory              Amount of memory, integer value in bytes ha                  Boolean, set 1 to high availability display_type        Possible values: VNC, SPICE keyboard_layout     Possible values: ar, de-ch, es, fo, fr-ca, hu, ja, mk, no, pt-br, sv, da, en-gb, et, fr, fr-ch, is, lt, nl, pl, ru, th, de, en-us, fi, fr-be, hr, it, lv, nl-be, pt, sl, tr. Not usable if display type is SPICE. Rackspace: --volume: --interface: --compute-attributes: flavor_id VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware --compute-attributes: \u001b[1mcluster\u001b[0m              Cluster ID from VMware \u001b[1mcorespersocket\u001b[0m       Number of cores per socket (applicable to hardware versions < 10 only) \u001b[1mcpus\u001b[0m                 CPU count \u001b[1mmemory_mb\u001b[0m            Integer number, amount of memory in MB \u001b[1mpath\u001b[0m                 Path to folder \u001b[1mresource_pool\u001b[0m        Resource Pool ID from VMware firmware             automatic/bios/efi guest_id             Guest OS ID form VMware hardware_version     Hardware version ID from VMware memoryHotAddEnabled  Must be a 1 or 0, lets you add memory resources while the machine is on cpuHotAddEnabled     Must be a 1 or 0, lets you add CPU resources while the machine is on add_cdrom            Must be a 1 or 0, Add a CD-ROM drive to the virtual machine annotation           Annotation Notes scsi_controllers     List with SCSI controllers definitions type - ID of the controller from VMware key  - Key of the controller (e.g. 1000) boot_order           Device names to specify the boot order AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) --compute-attributes: resource_group      Existing Azure Resource Group of user vm_size             VM Size, eg. Standard_A0 etc. username            The Admin username password            The Admin password platform            OS type eg. Linux ssh_key_data        SSH key for passwordless authentication os_disk_caching     OS disk caching premium_os_disk     Premium OS Disk, Boolean as 0 or 1 script_command      Custom Script Command script_uris         Comma seperated file URIs GCE: --volume: size_gb             Volume size in GB, integer value --interface: --compute-attributes: machine_type network associate_external_ip",
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: --interface: --compute-attributes: availability_zone flavor_id groups security_group_ids managed_ip Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default --compute-attributes: \u001b[1mcpus\u001b[0m                Number of CPUs \u001b[1mmemory\u001b[0m              String, amount of memory, value in bytes cpu_mode            Possible values: default, host-model, host-passthrough boot_order          Device names to specify the boot order OpenStack: --volume: --interface: --compute-attributes: availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virtio or virtio_scsi --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile --compute-attributes: cluster             ID or name of cluster to use template            Hardware profile to use cores               Integer value, number of cores sockets             Integer value, number of sockets memory              Amount of memory, integer value in bytes ha                  Boolean, set 1 to high availability display_type        Possible values: VNC, SPICE keyboard_layout     Possible values: ar, de-ch, es, fo, fr-ca, hu, ja, mk, no, pt-br, sv, da, en-gb, et, fr, fr-ch, is, lt, nl, pl, ru, th, de, en-us, fi, fr-be, hr, it, lv, nl-be, pt, sl, tr. Not usable if display type is SPICE. VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware --compute-attributes: \u001b[1mcluster\u001b[0m              Cluster ID from VMware \u001b[1mcorespersocket\u001b[0m       Number of cores per socket (applicable to hardware versions < 10 only) \u001b[1mcpus\u001b[0m                 CPU count \u001b[1mmemory_mb\u001b[0m            Integer number, amount of memory in MB \u001b[1mpath\u001b[0m                 Path to folder \u001b[1mresource_pool\u001b[0m        Resource Pool ID from VMware firmware             automatic/bios/efi guest_id             Guest OS ID form VMware hardware_version     Hardware version ID from VMware memoryHotAddEnabled  Must be a 1 or 0, lets you add memory resources while the machine is on cpuHotAddEnabled     Must be a 1 or 0, lets you add CPU resources while the machine is on add_cdrom            Must be a 1 or 0, Add a CD-ROM drive to the virtual machine annotation           Annotation Notes scsi_controllers     List with SCSI controllers definitions type - ID of the controller from VMware key  - Key of the controller (e.g. 1000) boot_order           Device names to specify the boot order AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) --compute-attributes: resource_group      Existing Azure Resource Group of user vm_size             VM Size, eg. Standard_A0 etc. username            The Admin username password            The Admin password platform            OS type eg. Linux ssh_key_data        SSH key for passwordless authentication os_disk_caching     OS disk caching premium_os_disk     Premium OS Disk, Boolean as 0 or 1 script_command      Custom Script Command script_uris         Comma seperated file URIs GCE: --volume: size_gb             Volume size in GB, integer value --interface: --compute-attributes: machine_type network associate_external_ip",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -8027,7 +8197,7 @@
                   "value": null
                 },
                 {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --interface: Libvirt: --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default OpenStack: --interface: oVirt: --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile Rackspace: --interface: VMware: --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware AzureRM: --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) GCE: --interface:",
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --interface: Libvirt: --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default OpenStack: --interface: oVirt: --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile VMware: --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware AzureRM: --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) GCE: --interface:",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -8112,7 +8282,7 @@
                   "value": "NUMBER"
                 },
                 {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 OpenStack: --volume: oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virto or virto_scsi Rackspace: --volume: VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) GCE: --volume: size_gb             Volume size in GB, integer value",
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 OpenStack: --volume: oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virtio or virtio_scsi VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) GCE: --volume: size_gb             Volume size in GB, integer value",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -10749,7 +10919,7 @@
               "value": null
             },
             {
-              "help": "Print help --------------------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------------------|-----|---------|----- | x   | x       | x | x   | x       | at                     | x   | x       | | x   | x       | status/applied           | x   | x       | status/restarted         | x   | x       | status/failed            | x   | x       | status/restart failures  | x   | x       | status/skipped           | x   | x       | status/pending           | x   | x       | metrics/config_retrieval | x   | x       | metrics/exec             | x   | x       | metrics/file             | x   | x       | metrics/package          | x   | x       | metrics/service          | x   | x       | metrics/user             | x   | x       | metrics/yumrepo          | x   | x       | metrics/filebucket       | x   | x       | metrics/cron             | x   | x       | metrics/total            | x   | x       | Logs/resource                   | x   | x       | Logs/message                    | x   | x       | --------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help --------------------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------------------|-----|---------|----- | x   | x       | x | x   | x       | at                     | x   | x       | | x   | x       | status/applied           | x   | x       | status/restarted         | x   | x       | status/failed            | x   | x       | status/restart failures  | x   | x       | status/skipped           | x   | x       | status/pending           | x   | x       | metrics/config retrieval | x   | x       | metrics/exec             | x   | x       | metrics/file             | x   | x       | metrics/package          | x   | x       | metrics/service          | x   | x       | metrics/user             | x   | x       | metrics/yumrepo          | x   | x       | metrics/filebucket       | x   | x       | metrics/cron             | x   | x       | metrics/total            | x   | x       | Logs/resource                   | x   | x       | Logs/message                    | x   | x       | --------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -11216,7 +11386,7 @@
                   "value": null
                 },
                 {
-                  "help": "Export formats. Choose syncable if content is to be imported via repository sync. Choose importable if content is to be imported via hammer content-import. Defaults to importable. Possible value(s): 'syncable', 'importable'",
+                  "help": "Export formats.Choose syncable if the exported content needs to be in a yum format. This option is only available for yum, file repositories. Choose importable if the importing server uses the same version  and exported content needs to be one of yum, file, ansible_collection, docker repositories. Possible value(s): 'syncable', 'importable'",
                   "name": "format",
                   "shortname": null,
                   "value": "ENUM"
@@ -11271,7 +11441,7 @@
                   "value": "NUMBER"
                 },
                 {
-                  "help": "Export formats. Choose syncable if content is to be imported via repository sync. Choose importable if content is to be imported via hammer content-import. Defaults to importable. Possible value(s): 'syncable', 'importable'",
+                  "help": "Export formats.Choose syncable if the exported content needs to be in a yum format. This option is only available for yum, file repositories. Choose importable if the importing server uses the same version  and exported content needs to be one of yum, file, ansible_collection, docker repositories. Possible value(s): 'syncable', 'importable'",
                   "name": "format",
                   "shortname": null,
                   "value": "ENUM"
@@ -11374,7 +11544,7 @@
                   "value": null
                 },
                 {
-                  "help": "Export formats. Choose syncable if content is to be imported via repository sync. Choose importable if content is to be imported via hammer content-import. Defaults to importable. Possible value(s): 'syncable', 'importable'",
+                  "help": "Export formats.Choose syncable if the exported content needs to be in a yum format. This option is only available for yum, file repositories. Choose importable if the importing server uses the same version  and exported content needs to be one of yum, file, ansible_collection, docker repositories. Possible value(s): 'syncable', 'importable'",
                   "name": "format",
                   "shortname": null,
                   "value": "ENUM"
@@ -11529,6 +11699,12 @@
                   "value": null
                 },
                 {
+                  "help": "Export formats.Choose syncable if the exported content needs to be in a yum format. This option is only available for yum, file repositories. Choose importable if the importing server uses the same version  and exported content needs to be one of yum, file, ansible_collection, docker repositories. Possible value(s): 'syncable', 'importable'",
+                  "name": "format",
+                  "shortname": null,
+                  "value": "ENUM"
+                },
+                {
                   "help": "Export history id used for incremental export. If not provided the most recent export history will be used.",
                   "name": "from-history-id",
                   "shortname": null,
@@ -11582,6 +11758,12 @@
                   "name": "chunk-size-gb",
                   "shortname": null,
                   "value": "NUMBER"
+                },
+                {
+                  "help": "Export formats.Choose syncable if the exported content needs to be in a yum format. This option is only available for yum, file repositories. Choose importable if the importing server uses the same version  and exported content needs to be one of yum, file, ansible_collection, docker repositories. Possible value(s): 'syncable', 'importable'",
+                  "name": "format",
+                  "shortname": null,
+                  "value": "ENUM"
                 },
                 {
                   "help": "Export history id used for incremental export. If not provided the most recent export history will be used.",
@@ -11685,6 +11867,12 @@
                   "name": "fail-on-missing-content",
                   "shortname": null,
                   "value": null
+                },
+                {
+                  "help": "Export formats.Choose syncable if the exported content needs to be in a yum format. This option is only available for yum, file repositories. Choose importable if the importing server uses the same version  and exported content needs to be one of yum, file, ansible_collection, docker repositories. Possible value(s): 'syncable', 'importable'",
+                  "name": "format",
+                  "shortname": null,
+                  "value": "ENUM"
                 },
                 {
                   "help": "Export history id used for incremental export. If not provided the most recent export history will be used.",
@@ -14335,7 +14523,7 @@
               "value": "LIST"
             },
             {
-              "help": "Print help ----------------|-----|---------|----- | ALL | DEFAULT | THIN ----------------|-----|---------|----- view id | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | published  | x   | x       | ids  | x   | x       | ----------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string boolean boolean integer string string integer",
+              "help": "Print help ----------------|-----|---------|----- | ALL | DEFAULT | THIN ----------------|-----|---------|----- view id | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | published  | x   | x       | ids  | x   | x       | ----------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string boolean string boolean integer string string integer",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -14418,6 +14606,12 @@
               "name": "organization-label",
               "shortname": null,
               "value": "VALUE"
+            },
+            {
+              "help": "Check audited changes and proceed only if content or filters have changed since last publish",
+              "name": "publish-only-if-needed",
+              "shortname": null,
+              "value": "BOOLEAN"
             },
             {
               "help": "Specify the list of units in each repo",
@@ -15149,6 +15343,12 @@
                   "value": "NUMBER"
                 },
                 {
+                  "help": "Whether or not to return filters applied to the content view version",
+                  "name": "include-applied-filters",
+                  "shortname": null,
+                  "value": "BOOLEAN"
+                },
+                {
                   "help": "VALUE/NUMBER      Name/Id of associated lifecycle environment",
                   "name": "lifecycle-environment",
                   "shortname": null,
@@ -15191,7 +15391,7 @@
                   "value": "VALUE"
                 },
                 {
-                  "help": "Print help -----------------------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------------------|-----|---------|----- | x   | x       | x | x   | x       | | x   | x       | x | x   | x       | view id              | x   | x       | view name            | x   | x       | view label           | x   | x       | environments/id    | x   | x       | environments/name  | x   | x       | environments/label | x   | x       | Repositories/id              | x   | x       | Repositories/name            | x   | x       | Repositories/label           | x   | x       | -----------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help ---------------------------------------------|-----|---------|----- | ALL | DEFAULT | THIN ---------------------------------------------|-----|---------|----- | x   | x       | x | x   | x       | | x   | x       | x | x   | x       | view id                              | x   | x       | view name                            | x   | x       | view label                           | x   | x       | environments/id                    | x   | x       | environments/name                  | x   | x       | environments/label                 | x   | x       | Repositories/id                              | x   | x       | Repositories/name                            | x   | x       | Repositories/label                           | x   | x       | applied filters                          | x   | x       | filters/id                           | x   | x       | filters/name                         | x   | x       | filters/type                         | x   | x       | filters/inclusion                    | x   | x       | filters/original packages            | x   | x       | filters/original module streams      | x   | x       | filters/rules/id                     | x   | x       | filters/rules/name                   | x   | x       | filters/rules/uuid                   | x   | x       | filters/rules/module stream id       | x   | x       | filters/rules/types/                 | x   | x       | filters/rules/architecture           | x   | x       | filters/rules/content view filter id | x   | x       | filters/rules/errata id              | x   | x       | filters/rules/date type              | x   | x       | filters/rules/start date             | x   | x       | filters/rules/end date               | x   | x       | solving                           | x   | x       | ---------------------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -15240,8 +15440,20 @@
                   "value": "LIST"
                 },
                 {
+                  "help": "Filter content view versions that contain the file",
+                  "name": "file-id",
+                  "shortname": null,
+                  "value": "NUMBER"
+                },
+                {
                   "help": "Whether or not to show all results",
                   "name": "full-result",
+                  "shortname": null,
+                  "value": "BOOLEAN"
+                },
+                {
+                  "help": "Whether or not to return filters applied to the content view version",
+                  "name": "include-applied-filters",
                   "shortname": null,
                   "value": "BOOLEAN"
                 },
@@ -15256,6 +15468,12 @@
                   "name": "lifecycle-environment-id",
                   "shortname": null,
                   "value": null
+                },
+                {
+                  "help": "Filter out default content views",
+                  "name": "nondefault",
+                  "shortname": null,
+                  "value": "BOOLEAN"
                 },
                 {
                   "help": "Sort field and order, eg. 'id DESC'",
@@ -15452,7 +15670,7 @@
                   "value": null
                 },
                 {
-                  "help": "Force metadata regeneration to proceed.  Dangerous when repositories use the 'Complete Mirroring' mirroring policy",
+                  "help": "Force metadata regeneration to proceed. Dangerous operation when version has repositories with the 'Complete Mirroring' mirroring policy",
                   "name": "force",
                   "shortname": null,
                   "value": "BOOLEAN"
@@ -18487,6 +18705,18 @@
               "value": "VALUE"
             },
             {
+              "help": "VALUE/NUMBER                (--environment-id is deprecated: Use --lifecycle-environment-id instead)",
+              "name": "environment",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "VALUE/NUMBER                (--environment-id is deprecated: Use --lifecycle-environment-id instead)",
+              "name": "environment-id",
+              "shortname": null,
+              "value": null
+            },
+            {
               "help": "Return errata that are applicable to one or more hosts (defaults to true if host_id is specified)",
               "name": "errata-restrict-applicable",
               "shortname": null,
@@ -18523,10 +18753,16 @@
               "value": null
             },
             {
-              "help": "Environment id",
+              "help": "VALUE/NUMBER      Environment name/id",
+              "name": "lifecycle-environment",
+              "shortname": null,
+              "value": null
+            },
+            {
+              "help": "VALUE/NUMBER      Environment name/id",
               "name": "lifecycle-environment-id",
               "shortname": null,
-              "value": "NUMBER"
+              "value": null
             },
             {
               "help": "Sort field and order, eg. 'id DESC'",
@@ -21265,7 +21501,7 @@
               "value": "KEY_VALUE_LIST"
             },
             {
-              "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string parameters accept format defined by its schema (bold are required; <> contains acceptable type; [] contains acceptable value): \"\u001b[1mname\u001b[0m=<string>\\,\u001b[1mvalue\u001b[0m=<string>\\,parameter_type=[string|boolean|integer|real|array|hash|yaml|json]\\,hidden_value=[true|false|1|0], ... \" \"product_id=<string>\\,product_name=<string>\\,arch=<string>\\,version=<string>, ... \" mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: --interface: --compute-attributes: availability_zone flavor_id groups security_group_ids managed_ip Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default --compute-attributes: \u001b[1mcpus\u001b[0m                Number of CPUs \u001b[1mmemory\u001b[0m              String, amount of memory, value in bytes cpu_mode            Possible values: default, host-model, host-passthrough boot_order          Device names to specify the boot order start               Boolean (expressed as 0 or 1), whether to start the machine or not OpenStack: --volume: --interface: --compute-attributes: availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virto or virto_scsi --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile --compute-attributes: cluster             ID or name of cluster to use template            Hardware profile to use cores               Integer value, number of cores sockets             Integer value, number of sockets memory              Amount of memory, integer value in bytes ha                  Boolean, set 1 to high availability display_type        Possible values: VNC, SPICE keyboard_layout     Possible values: ar, de-ch, es, fo, fr-ca, hu, ja, mk, no, pt-br, sv, da, en-gb, et, fr, fr-ch, is, lt, nl, pl, ru, th, de, en-us, fi, fr-be, hr, it, lv, nl-be, pt, sl, tr. Not usable if display type is SPICE. start               Boolean, set 1 to start the vm Rackspace: --volume: --interface: --compute-attributes: flavor_id VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware --compute-attributes: \u001b[1mcluster\u001b[0m              Cluster ID from VMware \u001b[1mcorespersocket\u001b[0m       Number of cores per socket (applicable to hardware versions < 10 only) \u001b[1mcpus\u001b[0m                 CPU count \u001b[1mmemory_mb\u001b[0m            Integer number, amount of memory in MB \u001b[1mpath\u001b[0m                 Path to folder \u001b[1mresource_pool\u001b[0m        Resource Pool ID from VMware firmware             automatic/bios/efi guest_id             Guest OS ID form VMware hardware_version     Hardware version ID from VMware memoryHotAddEnabled  Must be a 1 or 0, lets you add memory resources while the machine is on cpuHotAddEnabled     Must be a 1 or 0, lets you add CPU resources while the machine is on add_cdrom            Must be a 1 or 0, Add a CD-ROM drive to the virtual machine annotation           Annotation Notes scsi_controllers     List with SCSI controllers definitions type - ID of the controller from VMware key  - Key of the controller (e.g. 1000) boot_order           Device names to specify the boot order start                Must be a 1 or 0, whether to start the machine or not AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) --compute-attributes: resource_group      Existing Azure Resource Group of user vm_size             VM Size, eg. Standard_A0 etc. username            The Admin username password            The Admin password platform            OS type eg. Linux ssh_key_data        SSH key for passwordless authentication os_disk_caching     OS disk caching premium_os_disk     Premium OS Disk, Boolean as 0 or 1 script_command      Custom Script Command script_uris         Comma seperated file URIs GCE: --volume: size_gb             Volume size in GB, integer value --interface: --compute-attributes: machine_type network associate_external_ip",
+              "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string parameters accept format defined by its schema (bold are required; <> contains acceptable type; [] contains acceptable value): \"\u001b[1mname\u001b[0m=<string>\\,\u001b[1mvalue\u001b[0m=<string>\\,parameter_type=[string|boolean|integer|real|array|hash|yaml|json]\\,hidden_value=[true|false|1|0], ... \" \"product_id=<string>\\,product_name=<string>\\,arch=<string>\\,version=<string>, ... \" mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: --interface: --compute-attributes: availability_zone flavor_id groups security_group_ids managed_ip Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default --compute-attributes: \u001b[1mcpus\u001b[0m                Number of CPUs \u001b[1mmemory\u001b[0m              String, amount of memory, value in bytes cpu_mode            Possible values: default, host-model, host-passthrough boot_order          Device names to specify the boot order start               Boolean (expressed as 0 or 1), whether to start the machine or not OpenStack: --volume: --interface: --compute-attributes: availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virtio or virtio_scsi --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile --compute-attributes: cluster             ID or name of cluster to use template            Hardware profile to use cores               Integer value, number of cores sockets             Integer value, number of sockets memory              Amount of memory, integer value in bytes ha                  Boolean, set 1 to high availability display_type        Possible values: VNC, SPICE keyboard_layout     Possible values: ar, de-ch, es, fo, fr-ca, hu, ja, mk, no, pt-br, sv, da, en-gb, et, fr, fr-ch, is, lt, nl, pl, ru, th, de, en-us, fi, fr-be, hr, it, lv, nl-be, pt, sl, tr. Not usable if display type is SPICE. start               Boolean, set 1 to start the vm VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware --compute-attributes: \u001b[1mcluster\u001b[0m              Cluster ID from VMware \u001b[1mcorespersocket\u001b[0m       Number of cores per socket (applicable to hardware versions < 10 only) \u001b[1mcpus\u001b[0m                 CPU count \u001b[1mmemory_mb\u001b[0m            Integer number, amount of memory in MB \u001b[1mpath\u001b[0m                 Path to folder \u001b[1mresource_pool\u001b[0m        Resource Pool ID from VMware firmware             automatic/bios/efi guest_id             Guest OS ID form VMware hardware_version     Hardware version ID from VMware memoryHotAddEnabled  Must be a 1 or 0, lets you add memory resources while the machine is on cpuHotAddEnabled     Must be a 1 or 0, lets you add CPU resources while the machine is on add_cdrom            Must be a 1 or 0, Add a CD-ROM drive to the virtual machine annotation           Annotation Notes scsi_controllers     List with SCSI controllers definitions type - ID of the controller from VMware key  - Key of the controller (e.g. 1000) boot_order           Device names to specify the boot order start                Must be a 1 or 0, whether to start the machine or not AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) --compute-attributes: resource_group      Existing Azure Resource Group of user vm_size             VM Size, eg. Standard_A0 etc. username            The Admin username password            The Admin password platform            OS type eg. Linux ssh_key_data        SSH key for passwordless authentication os_disk_caching     OS disk caching premium_os_disk     Premium OS Disk, Boolean as 0 or 1 script_command      Custom Script Command script_uris         Comma seperated file URIs GCE: --volume: size_gb             Volume size in GB, integer value --interface: --compute-attributes: machine_type network associate_external_ip",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -21575,77 +21811,11 @@
           ],
           "subcommands": [
             {
-              "description": "Schedule errata for installation using katello-agent. NOTE: Katello-agent is deprecated and will be removed in a future release. Consider using remote execution instead.",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_errata_install`.",
               "name": "apply",
               "options": [
                 {
-                  "help": "Do not wait for the task",
-                  "name": "async",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "List of Errata ids to install. Will be removed in a future release",
-                  "name": "errata-ids",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Whether or not to show all results",
-                  "name": "full-result",
-                  "shortname": null,
-                  "value": "BOOLEAN"
-                },
-                {
-                  "help": "VALUE/NUMBER      Host name/id",
-                  "name": "host",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Host name/id",
-                  "name": "host-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Sort field and order, eg. 'id DESC'",
-                  "name": "order",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Page number, starting at 1",
-                  "name": "page",
-                  "shortname": null,
-                  "value": "NUMBER"
-                },
-                {
-                  "help": "Number of results per page to return",
-                  "name": "per-page",
-                  "shortname": null,
-                  "value": "NUMBER"
-                },
-                {
-                  "help": "Search string for erratum to perform an action on",
-                  "name": "search",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Field to sort the results on",
-                  "name": "sort-by",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "How to order the sorted results (e.g. ASC for ascending)",
-                  "name": "sort-order",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -22012,7 +22182,7 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "Print help --------------------------------------------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------------------------------------------|-----|---------|----- | x   | x       | x | x   | x       | | x   | x       | x | x   | x       | | x   | x       | group                                              | x   | x       | resource                                        | x   | x       | profile                                         | x   | x       | name                                               | x   | x       | | x   | x       | | x   | x       | at                                            | x   | x       | report                                             | x   | x       | (seconds)                                        | x   | x       | Status/global status                                    | x   | x       | Status/build status                                     | x   | x       | Network/ipv4 address                                    | x   | x       | Network/ipv6 address                                    | x   | x       | Network/mac                                             | x   | x       | Network/subnet ipv4                                     | x   | x       | Network/subnet ipv6                                     | x   | x       | Network/domain                                          | x   | x       | Network/service provider/sp name                        | x   | x       | Network/service provider/sp ip                          | x   | x       | Network/service provider/sp mac                         | x   | x       | Network/service provider/sp subnet                      | x   | x       | interfaces/id                                   | x   | x       | interfaces/identifier                           | x   | x       | interfaces/type                                 | x   | x       | interfaces/mac address                          | x   | x       | interfaces/ipv4 address                         | x   | x       | interfaces/ipv6 address                         | x   | x       | interfaces/fqdn                                 | x   | x       | system/architecture                           | x   | x       | system/operating system                       | x   | x       | system/build                                  | x   | x       | system/medium                                 | x   | x       | system/partition table                        | x   | x       | system/pxe loader                             | x   | x       | system/custom partition table                 | x   | x       | system/image                                  | x   | x       | system/image file                             | x   | x       | system/use image                              | x   | x       | Parameters/                                             | x   | x       | parameters/                                         | x   | x       | info/owner                                   | x   | x       | info/owner id                                | x   | x       | info/owner type                              | x   | x       | info/enabled                                 | x   | x       | info/model                                   | x   | x       | info/comment                                 | x   | x       | proxy                                          | x   | x       | information/content view/id                     | x   | x       | information/content view/name                   | x   | x       | information/lifecycle environment/id            | x   | x       | information/lifecycle environment/name          | x   | x       | information/content source/id                   | x   | x       | information/content source/name                 | x   | x       | information/kickstart repository/id             | x   | x       | information/kickstart repository/name           | x   | x       | information/applicable packages                 | x   | x       | information/upgradable packages                 | x   | x       | information/applicable errata/enhancement       | x   | x       | information/applicable errata/bug fix           | x   | x       | information/applicable errata/security          | x   | x       | information/uuid                           | x   | x       | information/last checkin                   | x   | x       | information/release version                | x   | x       | information/autoheal                       | x   | x       | information/registered to                  | x   | x       | information/registered at                  | x   | x       | information/registered by activation keys/ | x   | x       | information/system purpose/service level   | x   | x       | information/system purpose/purpose usage   | x   | x       | information/system purpose/purpose role    | x   | x       | information/system purpose/purpose addons  | x   | x       | status                                            | x   | x       | collections/id                                     | x   | x       | collections/name                                   | x   | x       | --------------------------------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help -------------------------------------------------------------------------|-----|---------|----- | ALL | DEFAULT | THIN -------------------------------------------------------------------------|-----|---------|----- | x   | x       | x | x   | x       | | x   | x       | x | x   | x       | | x   | x       | group                                                               | x   | x       | resource                                                         | x   | x       | profile                                                          | x   | x       | name                                                                | x   | x       | | x   | x       | | x   | x       | at                                                             | x   | x       | report                                                              | x   | x       | (seconds)                                                         | x   | x       | Status/global status                                                     | x   | x       | Status/build status                                                      | x   | x       | Network/ipv4 address                                                     | x   | x       | Network/ipv6 address                                                     | x   | x       | Network/mac                                                              | x   | x       | Network/subnet ipv4                                                      | x   | x       | Network/subnet ipv6                                                      | x   | x       | Network/domain                                                           | x   | x       | Network/service provider/sp name                                         | x   | x       | Network/service provider/sp ip                                           | x   | x       | Network/service provider/sp mac                                          | x   | x       | Network/service provider/sp subnet                                       | x   | x       | interfaces/id                                                    | x   | x       | interfaces/identifier                                            | x   | x       | interfaces/type                                                  | x   | x       | interfaces/mac address                                           | x   | x       | interfaces/ipv4 address                                          | x   | x       | interfaces/ipv6 address                                          | x   | x       | interfaces/fqdn                                                  | x   | x       | system/architecture                                            | x   | x       | system/operating system                                        | x   | x       | system/build                                                   | x   | x       | system/medium                                                  | x   | x       | system/partition table                                         | x   | x       | system/pxe loader                                              | x   | x       | system/custom partition table                                  | x   | x       | system/image                                                   | x   | x       | system/image file                                              | x   | x       | system/use image                                               | x   | x       | Parameters/                                                              | x   | x       | parameters/                                                          | x   | x       | info/owner                                                    | x   | x       | info/owner id                                                 | x   | x       | info/owner type                                               | x   | x       | info/enabled                                                  | x   | x       | info/model                                                    | x   | x       | info/comment                                                  | x   | x       | proxy                                                           | x   | x       | information/content view environments/content view/id            | x   | x       | information/content view environments/content view/name          | x   | x       | information/content view environments/content view/composite     | x   | x       | information/content view environments/lifecycle environment/id   | x   | x       | information/content view environments/lifecycle environment/name | x   | x       | information/content source/id                                    | x   | x       | information/content source/name                                  | x   | x       | information/kickstart repository/id                              | x   | x       | information/kickstart repository/name                            | x   | x       | information/applicable packages                                  | x   | x       | information/upgradable packages                                  | x   | x       | information/applicable errata/enhancement                        | x   | x       | information/applicable errata/bug fix                            | x   | x       | information/applicable errata/security                           | x   | x       | information/uuid                                            | x   | x       | information/last checkin                                    | x   | x       | information/release version                                 | x   | x       | information/autoheal                                        | x   | x       | information/registered to                                   | x   | x       | information/registered at                                   | x   | x       | information/registered by activation keys/                  | x   | x       | information/system purpose/service level                    | x   | x       | information/system purpose/purpose usage                    | x   | x       | information/system purpose/purpose role                     | x   | x       | information/system purpose/purpose addons                   | x   | x       | status                                                             | x   | x       | collections/id                                                      | x   | x       | collections/name                                                    | x   | x       | -------------------------------------------------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -22812,7 +22982,7 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "Print help -----------------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------------|-----|---------|----- | x   | x       | x | x   | x       | x system       | x   | x       | group             | x   | x       | | x   | x       | | x   | x       | status          | x   | x       | | x   |         | | x   |         | information | x   |         | view           | x   | x       | environment  | x   | x       | | x   |         | | x   |         | | x   |         | status           | x   | x       | -----------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string string Values: mismatched, matched, not_specified string string string date string string boolean boot_time Values: true, false Values: built, pending, token_expired, build_failed text string integer string string integer datetime integer string integer Values: security_needed, errata_needed, updated, unknown Values: ok, error string Values: ok, warning, error string string string string string integer string string boolean string integer string infrastructure_facet.foreman infrastructure_facet.smart_proxy_id Values: reporting, no_report Values: disconnect, sync integer string datetime string string job_invocation.id                    string job_invocation.result                Values: cancelled, failed, pending, success datetime datetime string integer string integer string Values: true, false string string string integer string string string integer string string string string integer string string string string string integer string Values: mismatched, matched, not_specified string integer datetime string string reported.boot_time reported.cores reported.disks_total reported.kernel_version reported.ram reported.sockets reported.virtual                     Values: true, false string string text Values: mismatched, matched, not_specified string Values: mismatched, matched, not_specified string status.applied                       integer status.enabled                       Values: true, false status.failed                        integer status.failed_restarts               integer status.interesting                   Values: true, false status.pending                       integer status.restarted                     integer status.skipped                       integer string subnet.name                          text string subnet6.name                         text string string Values: valid, partial, invalid, unknown, disabled, unsubscribed_hypervisor string Values: reboot_needed, process_restart_needed, updated string string text Values: mismatched, matched, not_specified user.firstname                       string user.lastname                        string user.login                           string user.mail                            string string usergroup.name                       string string",
+              "help": "Print help -----------------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------------|-----|---------|----- | x   | x       | x | x   | x       | x system       | x   | x       | group             | x   | x       | | x   | x       | | x   | x       | status          | x   | x       | | x   |         | | x   |         | information | x   |         | view           | x   | x       | environment  | x   | x       | | x   |         | | x   |         | | x   |         | status           | x   | x       | -----------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string string Values: mismatched, matched, not_specified string string date string string boolean boot_time Values: true, false Values: built, pending, token_expired, build_failed text string integer configuration_status.applied          integer configuration_status.enabled          Values: true, false configuration_status.failed           integer configuration_status.failed_restarts  integer configuration_status.interesting      Values: true, false configuration_status.pending          integer configuration_status.restarted        integer configuration_status.skipped          integer string string datetime integer string integer Values: security_needed, errata_needed, updated, unknown Values: ok, error string Values: ok, warning, error string string string string string integer string string boolean string integer string infrastructure_facet.foreman          Values: true, false infrastructure_facet.smart_proxy_id Values: reporting, no_report Values: disconnect, sync integer string datetime string string job_invocation.id                     string job_invocation.result                 Values: cancelled, failed, pending, success datetime datetime string string integer string Values: true, false string string string integer string string string integer string string string string integer string string string string string integer string Values: mismatched, matched, not_specified Values: PXELinux_BIOS, PXELinux_UEFI, Grub_UEFI, Grub2_BIOS, Grub2_ELF, Grub2_UEFI, Grub2_UEFI_SecureBoot, Grub2_UEFI_HTTP, Grub2_UEFI_HTTPS, Grub2_UEFI_HTTPS_SecureBoot, iPXE_Embedded, iPXE_UEFI_HTTP, iPXE_Chain_BIOS, iPXE_Chain_UEFI string integer datetime string string reported.bios_release_date reported.bios_vendor reported.bios_version reported.boot_time reported.cores reported.disks_total reported.kernel_version reported.ram reported.sockets reported.virtual                      Values: true, false string string Values: full_support, maintenance_support, approaching_end_of_maintenance, extended_support, approaching_end_of_support, support_ended text Values: mismatched, matched, not_specified string Values: mismatched, matched, not_specified string status.applied                        integer status.enabled                        Values: true, false status.failed                         integer status.failed_restarts                integer status.interesting                    Values: true, false status.pending                        integer status.restarted                      integer status.skipped                        integer string subnet.name                           text string subnet6.name                          text string string Values: valid, partial, invalid, unknown, disabled, unsubscribed_hypervisor string Values: reboot_needed, process_restart_needed, updated string string text Values: mismatched, matched, not_specified user.firstname                        string user.lastname                         string user.login                            string user.mail                             string string usergroup.name                        string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -22833,35 +23003,11 @@
           ],
           "subcommands": [
             {
-              "description": "Install packages remotely using katello-agent. NOTE: Katello-agent is deprecated and will be removed in a future release. Consider using remote execution instead.",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_package_install`.",
               "name": "install",
               "options": [
                 {
-                  "help": "Do not wait for the task",
-                  "name": "async",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "List of package names",
-                  "name": "packages",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -22943,35 +23089,11 @@
               "subcommands": []
             },
             {
-              "description": "Uninstall packages remotely using katello-agent. NOTE: Katello-agent is deprecated and will be removed in a future release. Consider using remote execution instead.",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_package_remove`.",
               "name": "remove",
               "options": [
                 {
-                  "help": "Do not wait for the task",
-                  "name": "async",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "List of package names",
-                  "name": "packages",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -22980,35 +23102,11 @@
               "subcommands": []
             },
             {
-              "description": "Update packages remotely using katello-agent. NOTE: Katello-agent is deprecated and will be removed in a future release. Consider using remote execution instead.",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_package_update`.",
               "name": "upgrade",
               "options": [
                 {
-                  "help": "Do not wait for the task",
-                  "name": "async",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "List of packages names",
-                  "name": "packages",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -23017,29 +23115,11 @@
               "subcommands": []
             },
             {
-              "description": "Update packages remotely using katello-agent. NOTE: Katello-agent is deprecated and will be removed in a future release. Consider using remote execution instead.",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_package_update`.",
               "name": "upgrade-all",
               "options": [
                 {
-                  "help": "Do not wait for the task",
-                  "name": "async",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -23050,7 +23130,7 @@
           ]
         },
         {
-          "description": "Manage package-groups on your hosts",
+          "description": "Manage package-groups on your hosts. These commands are no longer available Use the remote execution equivalent",
           "name": "package-group",
           "options": [
             {
@@ -23062,35 +23142,11 @@
           ],
           "subcommands": [
             {
-              "description": "Install packages remotely using katello-agent. NOTE: Katello-agent is deprecated and will be removed in a future release. Consider using remote execution instead.",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_group_install`.",
               "name": "install",
               "options": [
                 {
-                  "help": "Do not wait for the task",
-                  "name": "async",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "List of package group names (Deprecated)",
-                  "name": "groups",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -23099,35 +23155,11 @@
               "subcommands": []
             },
             {
-              "description": "Uninstall packages remotely using katello-agent. NOTE: Katello-agent is deprecated and will be removed in a future release. Consider using remote execution instead.",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_group_remove`.",
               "name": "remove",
               "options": [
                 {
-                  "help": "Do not wait for the task",
-                  "name": "async",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "List of package group names (Deprecated)",
-                  "name": "groups",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER      Name/id of the host",
-                  "name": "host-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -24749,7 +24781,7 @@
               "value": "KEY_VALUE_LIST"
             },
             {
-              "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string parameters accept format defined by its schema (bold are required; <> contains acceptable type; [] contains acceptable value): \"name=<string>\\,value=<string>\\,parameter_type=[string|boolean|integer|real|array|hash|yaml|json]\\,hidden_value=[true|false|1|0], ... \" \"product_id=<string>\\,product_name=<string>\\,arch=<string>\\,version=<string>, ... \" mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: --interface: --compute-attributes: availability_zone flavor_id groups security_group_ids managed_ip Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default --compute-attributes: \u001b[1mcpus\u001b[0m                Number of CPUs \u001b[1mmemory\u001b[0m              String, amount of memory, value in bytes cpu_mode            Possible values: default, host-model, host-passthrough boot_order          Device names to specify the boot order start               Boolean (expressed as 0 or 1), whether to start the machine or not OpenStack: --volume: --interface: --compute-attributes: availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virto or virto_scsi --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile --compute-attributes: cluster             ID or name of cluster to use template            Hardware profile to use cores               Integer value, number of cores sockets             Integer value, number of sockets memory              Amount of memory, integer value in bytes ha                  Boolean, set 1 to high availability display_type        Possible values: VNC, SPICE keyboard_layout     Possible values: ar, de-ch, es, fo, fr-ca, hu, ja, mk, no, pt-br, sv, da, en-gb, et, fr, fr-ch, is, lt, nl, pl, ru, th, de, en-us, fi, fr-be, hr, it, lv, nl-be, pt, sl, tr. Not usable if display type is SPICE. start               Boolean, set 1 to start the vm Rackspace: --volume: --interface: --compute-attributes: flavor_id VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware --compute-attributes: \u001b[1mcluster\u001b[0m              Cluster ID from VMware \u001b[1mcorespersocket\u001b[0m       Number of cores per socket (applicable to hardware versions < 10 only) \u001b[1mcpus\u001b[0m                 CPU count \u001b[1mmemory_mb\u001b[0m            Integer number, amount of memory in MB \u001b[1mpath\u001b[0m                 Path to folder \u001b[1mresource_pool\u001b[0m        Resource Pool ID from VMware firmware             automatic/bios/efi guest_id             Guest OS ID form VMware hardware_version     Hardware version ID from VMware memoryHotAddEnabled  Must be a 1 or 0, lets you add memory resources while the machine is on cpuHotAddEnabled     Must be a 1 or 0, lets you add CPU resources while the machine is on add_cdrom            Must be a 1 or 0, Add a CD-ROM drive to the virtual machine annotation           Annotation Notes scsi_controllers     List with SCSI controllers definitions type - ID of the controller from VMware key  - Key of the controller (e.g. 1000) boot_order           Device names to specify the boot order start                Must be a 1 or 0, whether to start the machine or not AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) --compute-attributes: resource_group      Existing Azure Resource Group of user vm_size             VM Size, eg. Standard_A0 etc. username            The Admin username password            The Admin password platform            OS type eg. Linux ssh_key_data        SSH key for passwordless authentication os_disk_caching     OS disk caching premium_os_disk     Premium OS Disk, Boolean as 0 or 1 script_command      Custom Script Command script_uris         Comma seperated file URIs GCE: --volume: size_gb             Volume size in GB, integer value --interface: --compute-attributes: machine_type network associate_external_ip",
+              "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string parameters accept format defined by its schema (bold are required; <> contains acceptable type; [] contains acceptable value): \"name=<string>\\,value=<string>\\,parameter_type=[string|boolean|integer|real|array|hash|yaml|json]\\,hidden_value=[true|false|1|0], ... \" \"product_id=<string>\\,product_name=<string>\\,arch=<string>\\,version=<string>, ... \" mac ip Possible values: interface, bmc, bond, bridge name subnet_id domain_id identifier true/false true/false, each managed hosts needs to have one primary interface. true/false true/false virtual=true: tag                 VLAN tag, this attribute has precedence over the subnet VLAN ID. Only for virtual interfaces. attached_to         Identifier of the interface to which this interface belongs, e.g. eth1. type=bond: mode                Possible values: balance-rr, active-backup, balance-xor, broadcast, 802.3ad, balance-tlb, balance-alb attached_devices    Identifiers of slave interfaces, e.g. [eth1,eth2] bond_options type=bmc: provider            always IPMI username password \u001b[1mNOTE:\u001b[0m Bold attributes are required. EC2: --volume: --interface: --compute-attributes: availability_zone flavor_id groups security_group_ids managed_ip Libvirt: --volume: \u001b[1mpool_name\u001b[0m                    One of available storage pools \u001b[1mcapacity\u001b[0m                     String value, e.g. 10G allocation Initial allocation, e.g. 0G format_type                  Possible values: raw, qcow2 --interface: compute_type                            Possible values: bridge, network compute_bridge                          Name of interface according to type compute_model                           Possible values: virtio, rtl8139, ne2k_pci, pcnet, e1000 compute_network Libvirt instance network, e.g. default --compute-attributes: \u001b[1mcpus\u001b[0m                Number of CPUs \u001b[1mmemory\u001b[0m              String, amount of memory, value in bytes cpu_mode            Possible values: default, host-model, host-passthrough boot_order          Device names to specify the boot order start               Boolean (expressed as 0 or 1), whether to start the machine or not OpenStack: --volume: --interface: --compute-attributes: availability_zone boot_from_volume flavor_ref image_ref tenant_id security_groups network oVirt: --volume: size_gb             Volume size in GB, integer value storage_domain      ID or name of storage domain bootable            Boolean, set 1 for bootable, only one volume can be bootable preallocate         Boolean, set 1 to preallocate wipe_after_delete   Boolean, set 1 to wipe disk after delete interface           Disk interface name, must be ide, virtio or virtio_scsi --interface: compute_name          Compute name, e.g. eth0 compute_network       Select one of available networks for a cluster, must be an ID or a name compute_interface     Interface type compute_vnic_profile  Vnic Profile --compute-attributes: cluster             ID or name of cluster to use template            Hardware profile to use cores               Integer value, number of cores sockets             Integer value, number of sockets memory              Amount of memory, integer value in bytes ha                  Boolean, set 1 to high availability display_type        Possible values: VNC, SPICE keyboard_layout     Possible values: ar, de-ch, es, fo, fr-ca, hu, ja, mk, no, pt-br, sv, da, en-gb, et, fr, fr-ch, is, lt, nl, pl, ru, th, de, en-us, fi, fr-be, hr, it, lv, nl-be, pt, sl, tr. Not usable if display type is SPICE. start               Boolean, set 1 to start the vm VMware: --volume: name storage_pod         Storage Pod ID from VMware datastore           Datastore ID from VMware mode                persistent/independent_persistent/independent_nonpersistent size_gb             Integer number, volume size in GB thin                true/false eager_zero          true/false controller_key      Associated SCSI controller key --interface: compute_type        Type of the network adapter, for example one of: VirtualVmxnet3 VirtualE1000 See documentation center for your version of vSphere to find more details about available adapter types: https://www.vmware.com/support/pubs/ compute_network     Network ID or Network Name from VMware --compute-attributes: \u001b[1mcluster\u001b[0m              Cluster ID from VMware \u001b[1mcorespersocket\u001b[0m       Number of cores per socket (applicable to hardware versions < 10 only) \u001b[1mcpus\u001b[0m                 CPU count \u001b[1mmemory_mb\u001b[0m            Integer number, amount of memory in MB \u001b[1mpath\u001b[0m                 Path to folder \u001b[1mresource_pool\u001b[0m        Resource Pool ID from VMware firmware             automatic/bios/efi guest_id             Guest OS ID form VMware hardware_version     Hardware version ID from VMware memoryHotAddEnabled  Must be a 1 or 0, lets you add memory resources while the machine is on cpuHotAddEnabled     Must be a 1 or 0, lets you add CPU resources while the machine is on add_cdrom            Must be a 1 or 0, Add a CD-ROM drive to the virtual machine annotation           Annotation Notes scsi_controllers     List with SCSI controllers definitions type - ID of the controller from VMware key  - Key of the controller (e.g. 1000) boot_order           Device names to specify the boot order start                Must be a 1 or 0, whether to start the machine or not AzureRM: --volume: disk_size_gb        Volume Size in GB (integer value) data_disk_caching   Data Disk Caching (None, ReadOnly, ReadWrite) --interface: compute_network     Select one of available Azure Subnets, must be an ID compute_public_ip   Public IP (None, Static, Dynamic) compute_private_ip  Static Private IP (expressed as true or false) --compute-attributes: resource_group      Existing Azure Resource Group of user vm_size             VM Size, eg. Standard_A0 etc. username            The Admin username password            The Admin password platform            OS type eg. Linux ssh_key_data        SSH key for passwordless authentication os_disk_caching     OS disk caching premium_os_disk     Premium OS Disk, Boolean as 0 or 1 script_command      Custom Script Command script_uris         Comma seperated file URIs GCE: --volume: size_gb             Volume size in GB, integer value --interface: --compute-attributes: machine_type network associate_external_ip",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -25010,7 +25042,7 @@
           "subcommands": []
         },
         {
-          "description": "Manipulate errata for a host collection",
+          "description": "Manage errata on your host collections. These commands are no longer available. Use the remote execution equivalent",
           "name": "erratum",
           "options": [
             {
@@ -25022,53 +25054,11 @@
           ],
           "subcommands": [
             {
-              "description": "Install errata on content hosts contained within a host collection",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_errata_install`. Specify the host collection with the --search-query parameter, e.g. `--search-query \"host_collection = MyCollection\"` or `--search-query \"host_collection_id=6\"`",
               "name": "install",
               "options": [
                 {
-                  "help": "List of Errata to install",
-                  "name": "errata",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Host Collection ID",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Host Collection Name",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-label",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -25197,7 +25187,7 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "Print help ------------|-----|---------|----- | ALL | DEFAULT | THIN ------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   |         | | x   |         | | x   |         | ------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string string Values: mismatched, matched, not_specified string string string date string string boolean boot_time Values: true, false Values: built, pending, token_expired, build_failed text string integer string string integer datetime integer string integer Values: security_needed, errata_needed, updated, unknown Values: ok, error string Values: ok, warning, error string string string string string integer string string boolean string integer string infrastructure_facet.foreman infrastructure_facet.smart_proxy_id Values: reporting, no_report Values: disconnect, sync integer string datetime string string job_invocation.id                    string job_invocation.result                Values: cancelled, failed, pending, success datetime datetime string integer string integer string Values: true, false string string string integer string string string integer string string string string integer string string string string string integer string Values: mismatched, matched, not_specified string integer datetime string string reported.boot_time reported.cores reported.disks_total reported.kernel_version reported.ram reported.sockets reported.virtual                     Values: true, false string string text Values: mismatched, matched, not_specified string Values: mismatched, matched, not_specified string status.applied                       integer status.enabled                       Values: true, false status.failed                        integer status.failed_restarts               integer status.interesting                   Values: true, false status.pending                       integer status.restarted                     integer status.skipped                       integer string subnet.name                          text string subnet6.name                         text string string Values: valid, partial, invalid, unknown, disabled, unsubscribed_hypervisor string Values: reboot_needed, process_restart_needed, updated string string text Values: mismatched, matched, not_specified user.firstname                       string user.lastname                        string user.login                           string user.mail                            string string usergroup.name                       string string",
+              "help": "Print help ------------|-----|---------|----- | ALL | DEFAULT | THIN ------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   |         | | x   |         | | x   |         | ------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string string Values: mismatched, matched, not_specified string string date string string boolean boot_time Values: true, false Values: built, pending, token_expired, build_failed text string integer configuration_status.applied          integer configuration_status.enabled          Values: true, false configuration_status.failed           integer configuration_status.failed_restarts  integer configuration_status.interesting      Values: true, false configuration_status.pending          integer configuration_status.restarted        integer configuration_status.skipped          integer string string datetime integer string integer Values: security_needed, errata_needed, updated, unknown Values: ok, error string Values: ok, warning, error string string string string string integer string string boolean string integer string infrastructure_facet.foreman          Values: true, false infrastructure_facet.smart_proxy_id Values: reporting, no_report Values: disconnect, sync integer string datetime string string job_invocation.id                     string job_invocation.result                 Values: cancelled, failed, pending, success datetime datetime string string integer string Values: true, false string string string integer string string string integer string string string string integer string string string string string integer string Values: mismatched, matched, not_specified Values: PXELinux_BIOS, PXELinux_UEFI, Grub_UEFI, Grub2_BIOS, Grub2_ELF, Grub2_UEFI, Grub2_UEFI_SecureBoot, Grub2_UEFI_HTTP, Grub2_UEFI_HTTPS, Grub2_UEFI_HTTPS_SecureBoot, iPXE_Embedded, iPXE_UEFI_HTTP, iPXE_Chain_BIOS, iPXE_Chain_UEFI string integer datetime string string reported.bios_release_date reported.bios_vendor reported.bios_version reported.boot_time reported.cores reported.disks_total reported.kernel_version reported.ram reported.sockets reported.virtual                      Values: true, false string string Values: full_support, maintenance_support, approaching_end_of_maintenance, extended_support, approaching_end_of_support, support_ended text Values: mismatched, matched, not_specified string Values: mismatched, matched, not_specified string status.applied                        integer status.enabled                        Values: true, false status.failed                         integer status.failed_restarts                integer status.interesting                    Values: true, false status.pending                        integer status.restarted                      integer status.skipped                        integer string subnet.name                           text string subnet6.name                          text string string Values: valid, partial, invalid, unknown, disabled, unsubscribed_hypervisor string Values: reboot_needed, process_restart_needed, updated string string text Values: mismatched, matched, not_specified user.firstname                        string user.lastname                         string user.login                            string user.mail                             string string usergroup.name                        string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -25370,7 +25360,7 @@
           "subcommands": []
         },
         {
-          "description": "Manipulate packages for a host collection",
+          "description": "Manage packages on your host collections. These commands are no longer available. Use the remote execution equivalent",
           "name": "package",
           "options": [
             {
@@ -25382,53 +25372,11 @@
           ],
           "subcommands": [
             {
-              "description": "Install packages on content hosts contained within a host collection",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_package_install`. Specify the host collection with the --search-query parameter, e.g. `--search-query \"host_collection = MyCollection\"` or `--search-query \"host_collection_id=6\"`",
               "name": "install",
               "options": [
                 {
-                  "help": "Host Collection ID",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Host Collection Name",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-label",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Comma-separated list of packages to install",
-                  "name": "packages",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -25437,53 +25385,11 @@
               "subcommands": []
             },
             {
-              "description": "Remove packages on content hosts contained within a host collection",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_package_remove`. Specify the host collection with the --search-query parameter, e.g. `--search-query \"host_collection = MyCollection\"` or `--search-query \"host_collection_id=6\"`",
               "name": "remove",
               "options": [
                 {
-                  "help": "Host Collection ID",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Host Collection Name",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-label",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Comma-separated list of packages to install",
-                  "name": "packages",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -25492,53 +25398,11 @@
               "subcommands": []
             },
             {
-              "description": "Update packages on content hosts contained within a host collection",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_package_update`. Specify the host collection with the --search-query parameter, e.g. `--search-query \"host_collection = MyCollection\"` or `--search-query \"host_collection_id=6\"`",
               "name": "update",
               "options": [
                 {
-                  "help": "Host Collection ID",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Host Collection Name",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-label",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Comma-separated list of packages to install",
-                  "name": "packages",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -25549,7 +25413,7 @@
           ]
         },
         {
-          "description": "Manipulate package-groups for a host collection",
+          "description": "Manage package-groups on your host collections. These commands are no longer available. Use the remote execution equivalent",
           "name": "package-group",
           "options": [
             {
@@ -25561,53 +25425,11 @@
           ],
           "subcommands": [
             {
-              "description": "Install package-groups on content hosts contained within a host collection",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_group_install`. Specify the host collection with the --search-query parameter, e.g. `--search-query \"host_collection = MyCollection\"` or `--search-query \"host_collection_id=6\"`",
               "name": "install",
               "options": [
                 {
-                  "help": "Host Collection ID",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Host Collection Name",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-label",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Comma-separated list of package-groups to install",
-                  "name": "package-groups",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -25616,53 +25438,11 @@
               "subcommands": []
             },
             {
-              "description": "Remove package-groups on content hosts contained within a host collection",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_group_remove`. Specify the host collection with the --search-query parameter, e.g. `--search-query \"host_collection = MyCollection\"` or `--search-query \"host_collection_id=6\"`",
               "name": "remove",
               "options": [
                 {
-                  "help": "Host Collection ID",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Host Collection Name",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-label",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Comma-separated list of package-groups to install",
-                  "name": "package-groups",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -25671,53 +25451,11 @@
               "subcommands": []
             },
             {
-              "description": "Update package-groups on content hosts contained within a host collection",
+              "description": "Not supported. Use the remote execution equivalent `hammer job-invocation create --feature katello_group_update`. Specify the host collection with the --search-query parameter, e.g. `--search-query \"host_collection = MyCollection\"` or `--search-query \"host_collection_id=6\"`",
               "name": "update",
               "options": [
                 {
-                  "help": "Host Collection ID",
-                  "name": "id",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "Host Collection Name",
-                  "name": "name",
-                  "shortname": null,
-                  "value": "VALUE"
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-id",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-title",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "VALUE/NUMBER Name/Title/Label/Id of associated organization",
-                  "name": "organization-label",
-                  "shortname": null,
-                  "value": null
-                },
-                {
-                  "help": "Comma-separated list of package-groups to install",
-                  "name": "package-groups",
-                  "shortname": null,
-                  "value": "LIST"
-                },
-                {
-                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -25910,19 +25648,19 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "VALUE/NUMBER      Name/title/id of the Host group to register the host in",
+              "help": "VALUE/NUMBER    Name/title/id of the Host group to register the host in",
               "name": "hostgroup",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER      Name/title/id of the Host group to register the host in",
+              "help": "VALUE/NUMBER    Name/title/id of the Host group to register the host in",
               "name": "hostgroup-id",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER      Name/title/id of the Host group to register the host in",
+              "help": "VALUE/NUMBER    Name/title/id of the Host group to register the host in",
               "name": "hostgroup-title",
               "shortname": null,
               "value": null
@@ -25940,67 +25678,55 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "Expiration of the authorization token (in hours)",
+              "help": "Expiration of the authorization token (in hours), 0 means 'unlimited'.",
               "name": "jwt-expiration",
               "shortname": null,
               "value": "NUMBER"
             },
             {
-              "help": "VALUE/NUMBER Lifecycle environment for the host.",
-              "name": "lifecycle-environment",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "VALUE/NUMBER Lifecycle environment for the host.",
-              "name": "lifecycle-environment-id",
-              "shortname": null,
-              "value": null
-            },
-            {
-              "help": "VALUE/NUMBER       Set the current location context for the request",
+              "help": "VALUE/NUMBER     Set the current location context for the request",
               "name": "location",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER       Set the current location context for the request",
+              "help": "VALUE/NUMBER     Set the current location context for the request",
               "name": "location-id",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER       Set the current location context for the request",
+              "help": "VALUE/NUMBER     Set the current location context for the request",
               "name": "location-title",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER       Title/id of the Operating System to register the host in. Operating system must have a `host_init_config` template assigned",
+              "help": "VALUE/NUMBER     Title/id of the Operating System to register the host in. Operating system must have a `host_init_config` template assigned",
               "name": "operatingsystem",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER       Title/id of the Operating System to register the host in. Operating system must have a `host_init_config` template assigned",
+              "help": "VALUE/NUMBER     Title/id of the Operating System to register the host in. Operating system must have a `host_init_config` template assigned",
               "name": "operatingsystem-id",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER   Set the current organization context for the request",
+              "help": "VALUE/NUMBER Set the current organization context for the request",
               "name": "organization",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER   Set the current organization context for the request",
+              "help": "VALUE/NUMBER Set the current organization context for the request",
               "name": "organization-id",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER   Set the current organization context for the request",
+              "help": "VALUE/NUMBER Set the current organization context for the request",
               "name": "organization-title",
               "shortname": null,
               "value": null
@@ -26048,13 +25774,13 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "VALUE/NUMBER           Name/id of the Capsule. This Capsule must have enabled both the 'Templates' and 'Registration' features",
+              "help": "VALUE/NUMBER         Name/id of the Capsule. This Capsule must have enabled both the 'Templates' and 'Registration' features",
               "name": "smart-proxy",
               "shortname": null,
               "value": null
             },
             {
-              "help": "VALUE/NUMBER           Name/id of the Capsule. This Capsule must have enabled both the 'Templates' and 'Registration' features",
+              "help": "VALUE/NUMBER         Name/id of the Capsule. This Capsule must have enabled both the 'Templates' and 'Registration' features",
               "name": "smart-proxy-id",
               "shortname": null,
               "value": null
@@ -28387,8 +28113,8 @@
               "value": "ENUM"
             },
             {
-              "help": "Distribute tasks over N seconds",
-              "name": "time-span",
+              "help": "Override the global time to pickup interval for this invocation only",
+              "name": "time-to-pickup",
               "shortname": null,
               "value": "NUMBER"
             },
@@ -28442,7 +28168,7 @@
               "value": null
             },
             {
-              "help": "Print help --------------------|-----|-------- | ALL | DEFAULT --------------------|-----|-------- | x   | x | x   | x | x   | x | x   | x | x   | x | x   | x | x   | x | x   | x | x   | x ordering | x   | x | x   | x category        | x   | x | x   | x line           | x   | x logic id  | x   | x | x   | x --------------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help --------------------|-----|-------- | ALL | DEFAULT --------------------|-----|-------- | x   | x | x   | x | x   | x | x   | x | x   | x | x   | x | x   | x | x   | x | x   | x ordering | x   | x | x   | x category        | x   | x | x   | x line           | x   | x logic id  | x   | x to pickup      | x   | x | x   | x --------------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -28663,6 +28389,12 @@
           "description": "Create a job template",
           "name": "create",
           "options": [
+            {
+              "help": "Enable the callback plugin for this template",
+              "name": "ansible-callback-enabled",
+              "shortname": null,
+              "value": "BOOLEAN"
+            },
             {
               "help": "",
               "name": "audit-comment",
@@ -29131,7 +28863,7 @@
               "value": null
             },
             {
-              "help": "Print help ---------------|-----|---------|----- | ALL | DEFAULT | THIN ---------------|-----|---------|----- | x   | x       | x | x   | x       | x category   | x   | x       | | x   | x       | | x   | x       | | x   | x       | | x   | x       | Locations/     | x   | x       | Organizations/ | x   | x       | ---------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help -------------------------|-----|---------|----- | ALL | DEFAULT | THIN -------------------------|-----|---------|----- | x   | x       | x | x   | x       | x category             | x   | x       | | x   | x       | | x   | x       | callback enabled | x   | x       | | x   | x       | | x   | x       | Locations/               | x   | x       | Organizations/           | x   | x       | -------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -29222,6 +28954,12 @@
           "description": "Update a job template",
           "name": "update",
           "options": [
+            {
+              "help": "Enable the callback plugin for this template",
+              "name": "ansible-callback-enabled",
+              "shortname": null,
+              "value": "BOOLEAN"
+            },
             {
               "help": "",
               "name": "audit-comment",
@@ -29607,10 +29345,10 @@
               "value": "VALUE"
             },
             {
-              "help": "Set true if you want to see only library environments Possible value(s): 'true', 'false'",
+              "help": "Set true if you want to see only library environments",
               "name": "library",
               "shortname": null,
-              "value": "ENUM"
+              "value": "BOOLEAN"
             },
             {
               "help": "Filter only environments containing this name",
@@ -29679,6 +29417,12 @@
           "description": "List environment paths",
           "name": "paths",
           "options": [
+            {
+              "help": "Show whether each lifecycle environment is associated with the given Capsule id.",
+              "name": "content-source-id",
+              "shortname": null,
+              "value": "NUMBER"
+            },
             {
               "help": "Show specified fields or predefined field sets only. (See below)",
               "name": "fields",
@@ -33221,7 +32965,7 @@
               "help": "If product certificates should be used to authenticate to a custom CDN.",
               "name": "custom-cdn-auth-enabled",
               "shortname": null,
-              "value": "VALUE"
+              "value": "BOOLEAN"
             },
             {
               "help": "Id of the Organization",
@@ -34528,6 +34272,12 @@
               "name": "redhat-repository-url",
               "shortname": null,
               "value": "VALUE"
+            },
+            {
+              "help": "Whether Simple Content Access should be enabled for the organization.",
+              "name": "simple-content-access",
+              "shortname": null,
+              "value": "BOOLEAN"
             },
             {
               "help": "Capsule names/ids",
@@ -37384,7 +37134,7 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "Print help -----------------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------------|-----|---------|----- | x   | x       | x | x   | x       | x system       | x   | x       | group             | x   | x       | | x   | x       | | x   | x       | status          | x   | x       | | x   |         | | x   |         | information | x   |         | view           | x   | x       | environment  | x   | x       | | x   |         | | x   |         | | x   |         | status           | x   | x       | -----------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string string Values: mismatched, matched, not_specified string string string date string string boolean boot_time Values: true, false Values: built, pending, token_expired, build_failed text string integer string string integer datetime integer string integer Values: security_needed, errata_needed, updated, unknown Values: ok, error string Values: ok, warning, error string string string string string integer string string boolean string integer string infrastructure_facet.foreman infrastructure_facet.smart_proxy_id Values: reporting, no_report Values: disconnect, sync integer string datetime string string job_invocation.id                    string job_invocation.result                Values: cancelled, failed, pending, success datetime datetime string integer string integer string Values: true, false string string string integer string string string integer string string string string integer string string string string string integer string Values: mismatched, matched, not_specified string integer datetime string string reported.boot_time reported.cores reported.disks_total reported.kernel_version reported.ram reported.sockets reported.virtual                     Values: true, false string string text Values: mismatched, matched, not_specified string Values: mismatched, matched, not_specified string status.applied                       integer status.enabled                       Values: true, false status.failed                        integer status.failed_restarts               integer status.interesting                   Values: true, false status.pending                       integer status.restarted                     integer status.skipped                       integer string subnet.name                          text string subnet6.name                         text string string Values: valid, partial, invalid, unknown, disabled, unsubscribed_hypervisor string Values: reboot_needed, process_restart_needed, updated string string text Values: mismatched, matched, not_specified user.firstname                       string user.lastname                        string user.login                           string user.mail                            string string usergroup.name                       string string",
+              "help": "Print help -----------------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------------|-----|---------|----- | x   | x       | x | x   | x       | x system       | x   | x       | group             | x   | x       | | x   | x       | | x   | x       | status          | x   | x       | | x   |         | | x   |         | information | x   |         | view           | x   | x       | environment  | x   | x       | | x   |         | | x   |         | | x   |         | status           | x   | x       | -----------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string string Values: mismatched, matched, not_specified string string date string string boolean boot_time Values: true, false Values: built, pending, token_expired, build_failed text string integer configuration_status.applied          integer configuration_status.enabled          Values: true, false configuration_status.failed           integer configuration_status.failed_restarts  integer configuration_status.interesting      Values: true, false configuration_status.pending          integer configuration_status.restarted        integer configuration_status.skipped          integer string string datetime integer string integer Values: security_needed, errata_needed, updated, unknown Values: ok, error string Values: ok, warning, error string string string string string integer string string boolean string integer string infrastructure_facet.foreman          Values: true, false infrastructure_facet.smart_proxy_id Values: reporting, no_report Values: disconnect, sync integer string datetime string string job_invocation.id                     string job_invocation.result                 Values: cancelled, failed, pending, success datetime datetime string string integer string Values: true, false string string string integer string string string integer string string string string integer string string string string string integer string Values: mismatched, matched, not_specified Values: PXELinux_BIOS, PXELinux_UEFI, Grub_UEFI, Grub2_BIOS, Grub2_ELF, Grub2_UEFI, Grub2_UEFI_SecureBoot, Grub2_UEFI_HTTP, Grub2_UEFI_HTTPS, Grub2_UEFI_HTTPS_SecureBoot, iPXE_Embedded, iPXE_UEFI_HTTP, iPXE_Chain_BIOS, iPXE_Chain_UEFI string integer datetime string string reported.bios_release_date reported.bios_vendor reported.bios_version reported.boot_time reported.cores reported.disks_total reported.kernel_version reported.ram reported.sockets reported.virtual                      Values: true, false string string Values: full_support, maintenance_support, approaching_end_of_maintenance, extended_support, approaching_end_of_support, support_ended text Values: mismatched, matched, not_specified string Values: mismatched, matched, not_specified string status.applied                        integer status.enabled                        Values: true, false status.failed                         integer status.failed_restarts                integer status.interesting                    Values: true, false status.pending                        integer status.restarted                      integer status.skipped                        integer string subnet.name                           text string subnet6.name                          text string string Values: valid, partial, invalid, unknown, disabled, unsubscribed_hypervisor string Values: reboot_needed, process_restart_needed, updated string string text Values: mismatched, matched, not_specified user.firstname                        string user.lastname                         string user.login                            string user.mail                             string string usergroup.name                        string string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -38647,7 +38397,7 @@
                   "value": null
                 },
                 {
-                  "help": "Print help -------------------------------------------------------------------|-----|-------- | ALL | DEFAULT -------------------------------------------------------------------|-----|-------- environments/name                                        | x   | x environments/organization                                | x   | x environments/content views/name                          | x   | x environments/content views/composite                     | x   | x environments/content views/last published                | x   | x environments/content views/content/hosts                 | x   | x environments/content views/content/products              | x   | x environments/content views/content/yum repos             | x   | x environments/content views/content/container image repos | x   | x environments/content views/content/packages              | x   | x environments/content views/content/package groups        | x   | x environments/content views/content/errata                | x   | x -------------------------------------------------------------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "help": "Print help ---------------------------------------------------------------------------------|-----|-------- | ALL | DEFAULT ---------------------------------------------------------------------------------|-----|-------- environments/name                                                      | x   | x environments/organization                                              | x   | x environments/content views/name                                        | x   | x environments/content views/composite                                   | x   | x environments/content views/last published                              | x   | x environments/content views/repositories/repository id                  | x   | x environments/content views/repositories/repository name                | x   | x environments/content views/repositories/content counts/warning         | x   | x environments/content views/repositories/content counts/packages        | x   | x environments/content views/repositories/content counts/srpms           | x   | x environments/content views/repositories/content counts/module streams  | x   | x environments/content views/repositories/content counts/package groups  | x   | x environments/content views/repositories/content counts/errata          | x   | x environments/content views/repositories/content counts/debian packages | x   | x environments/content views/repositories/content counts/container tags  | x   | x environments/content views/repositories/content counts/container ma... | x   | x environments/content views/repositories/content counts/container ma... | x   | x environments/content views/repositories/content counts/files           | x   | x environments/content views/repositories/content counts/ansible coll... | x   | x environments/content views/repositories/content counts/ostree refs     | x   | x environments/content views/repositories/content counts/python packages | x   | x ---------------------------------------------------------------------------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -38703,6 +38453,37 @@
                 },
                 {
                   "help": "Print help -------------|-----|---------|----- | ALL | DEFAULT | THIN -------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | -------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Reclaim space from all On Demand repositories on a capsule",
+              "name": "reclaim-space",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "NUMBER"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "VALUE"
+                },
+                {
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
                   "name": "help",
                   "shortname": "h",
                   "value": null
@@ -38913,6 +38694,49 @@
                   "name": "skip-metadata-check",
                   "shortname": null,
                   "value": "BOOLEAN"
+                },
+                {
+                  "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+                  "name": "help",
+                  "shortname": "h",
+                  "value": null
+                }
+              ],
+              "subcommands": []
+            },
+            {
+              "description": "Update content counts for the capsule",
+              "name": "update-counts",
+              "options": [
+                {
+                  "help": "Do not wait for the task",
+                  "name": "async",
+                  "shortname": null,
+                  "value": null
+                },
+                {
+                  "help": "Id of the capsule",
+                  "name": "id",
+                  "shortname": null,
+                  "value": "NUMBER"
+                },
+                {
+                  "help": "Name to search by",
+                  "name": "name",
+                  "shortname": null,
+                  "value": "VALUE"
+                },
+                {
+                  "help": "Organization name",
+                  "name": "organization",
+                  "shortname": null,
+                  "value": "VALUE"
+                },
+                {
+                  "help": "Organization ID",
+                  "name": "organization-id",
+                  "shortname": null,
+                  "value": "VALUE"
                 },
                 {
                   "help": "Print help you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
@@ -39233,7 +39057,7 @@
               "value": null
             },
             {
-              "help": "Print help -----------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | | x   | x       | | x   | x       | | x   | x       | Features/name    | x   | x       | Features/version | x   | x       | Locations/       | x   | x       | Organizations/   | x   | x       | at       | x   | x       | at       | x   | x       | -----------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help -----------------|-----|---------|----- | ALL | DEFAULT | THIN -----------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | | x   | x       | | x   | x       | count       | x   | x       | Features/name    | x   | x       | Features/version | x   | x       | Locations/       | x   | x       | Organizations/   | x   | x       | at       | x   | x       | at       | x   | x       | -----------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -40112,7 +39936,7 @@
               "value": null
             },
             {
-              "help": "Print help ----------------|-----|-------- | ALL | DEFAULT ----------------|-----|-------- | x   | x line       | x   | x | x   | x occurrence | x   | x occurrence | x   | x | x   | x limit | x   | x until    | x   | x | x   | x ----------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help ----------------|-----|-------- | ALL | DEFAULT ----------------|-----|-------- | x   | x line       | x   | x | x   | x occurrence | x   | x occurrence | x   | x count      | x   | x | x   | x occurrence | x   | x occurrence | x   | x | x   | x limit | x   | x limit | x   | x until    | x   | x | x   | x | x   | x ----------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -40191,7 +40015,7 @@
               "value": "VALUE"
             },
             {
-              "help": "Print help ----------|-----|-------- | ALL | DEFAULT ----------|-----|-------- | x   | x line | x   | x | x   | x time  | x   | x | x   | x ----------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help ----------------|-----|-------- | ALL | DEFAULT ----------------|-----|-------- | x   | x line       | x   | x count      | x   | x | x   | x occurrence | x   | x occurrence | x   | x | x   | x limit | x   | x time        | x   | x | x   | x | x   | x ----------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -40536,7 +40360,7 @@
               "value": null
             },
             {
-              "help": "Print help --------------------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------------------|-----|---------|----- | x   | x       | x | x   | x       | at                     | x   | x       | | x   | x       | status/applied           | x   | x       | status/restarted         | x   | x       | status/failed            | x   | x       | status/restart failures  | x   | x       | status/skipped           | x   | x       | status/pending           | x   | x       | metrics/config_retrieval | x   | x       | metrics/exec             | x   | x       | metrics/file             | x   | x       | metrics/package          | x   | x       | metrics/service          | x   | x       | metrics/user             | x   | x       | metrics/yumrepo          | x   | x       | metrics/filebucket       | x   | x       | metrics/cron             | x   | x       | metrics/total            | x   | x       | Logs/resource                   | x   | x       | Logs/message                    | x   | x       | --------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help --------------------------------|-----|---------|----- | ALL | DEFAULT | THIN --------------------------------|-----|---------|----- | x   | x       | x | x   | x       | at                     | x   | x       | | x   | x       | status/applied           | x   | x       | status/restarted         | x   | x       | status/failed            | x   | x       | status/restart failures  | x   | x       | status/skipped           | x   | x       | status/pending           | x   | x       | metrics/config retrieval | x   | x       | metrics/exec             | x   | x       | metrics/file             | x   | x       | metrics/package          | x   | x       | metrics/service          | x   | x       | metrics/user             | x   | x       | metrics/yumrepo          | x   | x       | metrics/filebucket       | x   | x       | metrics/cron             | x   | x       | metrics/total            | x   | x       | Logs/resource                   | x   | x       | Logs/message                    | x   | x       | --------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -41790,12 +41614,6 @@
               "value": "VALUE"
             },
             {
-              "help": "Comma-separated list of tags to sync for Container Image repository (Deprecated)",
-              "name": "docker-tags-whitelist",
-              "shortname": null,
-              "value": "LIST"
-            },
-            {
               "help": "Name of the upstream docker repository",
               "name": "docker-upstream-name",
               "shortname": null,
@@ -41850,7 +41668,7 @@
               "value": "ENUM"
             },
             {
-              "help": "List of content units to ignore while syncing a yum repository. Must be subset of srpm",
+              "help": "List of content units to ignore while syncing a yum repository. Must be subset of srpm,treeinfo",
               "name": "ignorable-content",
               "shortname": null,
               "value": "LIST"
@@ -41874,10 +41692,10 @@
               "value": "VALUE"
             },
             {
-              "help": "True if this repository when synced has to be mirrored from the source and stale rpms removed (Deprecated)",
-              "name": "mirror-on-sync",
+              "help": "Time to expire yum metadata in seconds. Only relevant for custom yum repositories.",
+              "name": "metadata-expire",
               "shortname": null,
-              "value": "BOOLEAN"
+              "value": "NUMBER"
             },
             {
               "help": "Policy to set for mirroring content.  Must be one of additive. Possible value(s): 'additive', 'mirror_complete', 'mirror_content_only'",
@@ -41916,7 +41734,7 @@
               "value": null
             },
             {
-              "help": "Versionsentifies whether the repository should be disabled on a client with a non-matching OS version. Pass [] to enable regardless of OS version. Maximum length 1; allowed tags are: rhel-6, rhel-7, rhel-8, rhel-9",
+              "help": "Versionsentifies whether the repository should be unavailable on a client with a non-matching OS version. Pass [] to make repo available for clients regardless of OS version. Maximum length 1; allowed tags are: rhel-6, rhel-7, rhel-8, rhel-9",
               "name": "os-versions",
               "shortname": null,
               "value": "LIST"
@@ -42012,6 +41830,12 @@
           "description": "Destroy a custom repository",
           "name": "delete",
           "options": [
+            {
+              "help": "Delete content view filters that have this repository as the last associated repository. Defaults to true. If false, such filters will now apply to all repositories in the content view.",
+              "name": "delete-empty-repo-filters",
+              "shortname": null,
+              "value": "BOOLEAN"
+            },
             {
               "help": "",
               "name": "id",
@@ -42128,7 +41952,7 @@
               "value": null
             },
             {
-              "help": "Print help ----------------------------------------------|-----|---------|----- | ALL | DEFAULT | THIN ----------------------------------------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | | x   | x       | hat repository                            | x   | x       | type                                  | x   | x       | type                                 | x   | x       | policy                              | x   | x       | | x   | x       | via http                              | x   | x       | at                                  | x   | x       | path                                 | x   | x       | policy                               | x   | x       | repository name                      | x   | x       | image tags filter                   | x   | x       | repository name                     | x   | x       | content units                       | x   | x       | proxy/id                                 | x   | x       | proxy/name                               | x   | x       | proxy/http proxy policy                  | x   | x       | Product/id                                    | x   | x       | Product/name                                  | x   | x       | key/id                                    | x   | x       | key/name                                  | x   | x       | Sync/status                                   | x   | x       | Sync/last sync date                           | x   | x       | | x   | x       | | x   | x       | counts/packages                       | x   | x       | counts/source rpms                    | x   | x       | counts/package groups                 | x   | x       | counts/errata                         | x   | x       | counts/container image manifest lists | x   | x       | counts/container image manifests      | x   | x       | counts/container image tags           | x   | x       | counts/files                          | x   | x       | counts/module streams                 | x   | x       | ----------------------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help ----------------------------------------|-----|---------|----- | ALL | DEFAULT | THIN ----------------------------------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | | x   | x       | | x   | x       | hat repository                      | x   | x       | type                            | x   | x       | label                           | x   | x       | type                           | x   | x       | policy                        | x   | x       | | x   | x       | via http                        | x   | x       | at                            | x   | x       | path                           | x   | x       | policy                         | x   | x       | expiration                     | x   | x       | repository name                | x   | x       | image tags filter             | x   | x       | repository name               | x   | x       | content units                 | x   | x       | proxy/id                           | x   | x       | proxy/name                         | x   | x       | proxy/http proxy policy            | x   | x       | Product/id                              | x   | x       | Product/name                            | x   | x       | key/id                              | x   | x       | key/name                            | x   | x       | Sync/status                             | x   | x       | Sync/last sync date                     | x   | x       | | x   | x       | | x   | x       | counts/packages                 | x   | x       | counts/srpms                    | x   | x       | counts/module streams           | x   | x       | counts/package groups           | x   | x       | counts/errata                   | x   | x       | counts/debian packages          | x   | x       | counts/container tags           | x   | x       | counts/container manifests      | x   | x       | counts/container manifest lists | x   | x       | counts/files                    | x   | x       | counts/ansible collections      | x   | x       | counts/ostree refs              | x   | x       | counts/python packages          | x   | x       | ----------------------------------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -42363,7 +42187,7 @@
               "value": "VALUE"
             },
             {
-              "help": "Print help -------------|-----|---------|----- | ALL | DEFAULT | THIN -------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | type | x   | x       | | x   | x       | -------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string string integer text string boolean string string string string string string string integer string Values: true, false",
+              "help": "Print help --------------|-----|---------|----- | ALL | DEFAULT | THIN --------------|-----|---------|----- | x   | x       | x | x   | x       | x | x   | x       | type  | x   | x       | label | x   | x       | | x   | x       | --------------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string string integer text string boolean string string string string string string string integer string Values: true, false",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -42516,7 +42340,7 @@
               "value": null
             },
             {
-              "help": "Force metadata regeneration to proceed.  Dangerous when repositories use the 'Complete Mirroring' mirroring policy.",
+              "help": "Force metadata regeneration to proceed. Dangerous when repositories use the 'Complete Mirroring' mirroring policy",
               "name": "force",
               "shortname": null,
               "value": "BOOLEAN"
@@ -42668,6 +42492,12 @@
           "name": "types",
           "options": [
             {
+              "help": "When set to 'True' repository types that are creatable will be returned",
+              "name": "creatable",
+              "shortname": null,
+              "value": "BOOLEAN"
+            },
+            {
               "help": "Show specified fields or predefined field sets only. (See below)",
               "name": "fields",
               "shortname": null,
@@ -42759,12 +42589,6 @@
               "value": "VALUE"
             },
             {
-              "help": "Comma-separated list of tags to sync for Container Image repository (Deprecated)",
-              "name": "docker-tags-whitelist",
-              "shortname": null,
-              "value": "LIST"
-            },
-            {
               "help": "Name of the upstream docker repository",
               "name": "docker-upstream-name",
               "shortname": null,
@@ -42825,7 +42649,7 @@
               "value": "NUMBER"
             },
             {
-              "help": "List of content units to ignore while syncing a yum repository. Must be subset of srpm",
+              "help": "List of content units to ignore while syncing a yum repository. Must be subset of srpm,treeinfo",
               "name": "ignorable-content",
               "shortname": null,
               "value": "LIST"
@@ -42843,10 +42667,10 @@
               "value": "LIST"
             },
             {
-              "help": "True if this repository when synced has to be mirrored from the source and stale rpms removed (Deprecated)",
-              "name": "mirror-on-sync",
+              "help": "Time to expire yum metadata in seconds. Only relevant for custom yum repositories.",
+              "name": "metadata-expire",
               "shortname": null,
-              "value": "BOOLEAN"
+              "value": "NUMBER"
             },
             {
               "help": "Policy to set for mirroring content.  Must be one of additive. Possible value(s): 'additive', 'mirror_complete', 'mirror_content_only'",
@@ -42885,7 +42709,7 @@
               "value": "VALUE"
             },
             {
-              "help": "Versionsentifies whether the repository should be disabled on a client with a non-matching OS version. Pass [] to enable regardless of OS version. Maximum length 1; allowed tags are: rhel-6, rhel-7, rhel-8, rhel-9",
+              "help": "Versionsentifies whether the repository should be unavailable on a client with a non-matching OS version. Pass [] to make repo available for clients regardless of OS version. Maximum length 1; allowed tags are: rhel-6, rhel-7, rhel-8, rhel-9",
               "name": "os-versions",
               "shortname": null,
               "value": "LIST"
@@ -43493,6 +43317,12 @@
               "value": null
             },
             {
+              "help": "Limit content to Red Hat / custom Possible value(s): 'redhat', 'custom'",
+              "name": "repository-type",
+              "shortname": null,
+              "value": "ENUM"
+            },
+            {
               "help": "Search string",
               "name": "search",
               "shortname": null,
@@ -43511,13 +43341,13 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "If true, return custom repository sets along with redhat repos",
+              "help": "If true, return custom repository sets along with redhat repos. Will be ignored if repository_type is supplied.",
               "name": "with-custom",
               "shortname": null,
               "value": "BOOLEAN"
             },
             {
-              "help": "Print help -------|-----|---------|----- | ALL | DEFAULT | THIN -------|-----|---------|----- | x   | x       | x | x   | x       | | x   | x       | x -------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string Values: true, false string string string string integer string",
+              "help": "Print help -------|-----|---------|----- | ALL | DEFAULT | THIN -------|-----|---------|----- | x   | x       | x | x   | x       | | x   | x       | x -------|-----|---------|----- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string string string Values: true, false string string string string integer string Values: true, false",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -44977,7 +44807,7 @@
       ],
       "subcommands": [
         {
-          "description": "Disable simple content access for a manifest",
+          "description": "Disable simple content access for a manifest. WARNING: Simple Content Access will be required for all organizations in Satellite 6.16.",
           "name": "disable",
           "options": [
             {
@@ -45063,7 +44893,7 @@
           "subcommands": []
         },
         {
-          "description": "Check if the specified organization has Simple Content Access enabled",
+          "description": "Check if the specified organization has Simple Content Access enabled. WARNING: Simple Content Access will be required for all organizations in Satellite 6.16.",
           "name": "status",
           "options": [
             {
@@ -49085,7 +48915,7 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "For values of type search, this is the resource the value searches in Possible value(s): 'AnsibleRole', 'AnsibleVariable', 'Architecture', 'Audit', 'AuthSource', 'Bookmark', 'ComputeProfile', 'ComputeResource', 'ConfigReport', 'DiscoveryRule', 'Domain', 'ExternalUsergroup', 'FactValue', 'Filter', 'ForemanOpenscap::ArfReport', 'ForemanOpenscap::OvalContent', 'ForemanOpenscap::OvalPolicy', 'ForemanOpenscap::Policy', 'ForemanOpenscap::ScapContent', 'ForemanOpenscap::TailoringFile', 'ForemanTasks::RecurringLogic', 'ForemanTasks::Task', 'ForemanVirtWhoConfigure::Config', 'Host', 'Hostgroup', 'HttpProxy', 'Image', 'InsightsHit', 'JobInvocation', 'JobTemplate', 'Katello::ActivationKey', 'Katello::AlternateContentSource', 'Katello::ContentCredential', 'Katello::ContentView', 'Katello::HostCollection', 'Katello::KTEnvironment', 'Katello::Product', 'Katello::Subscription', 'Katello::SyncPlan', 'KeyPair', 'Location', 'MailNotification', 'Medium', 'Model', 'Operatingsystem', 'Organization', 'Parameter', 'PersonalAccessToken', 'ProvisioningTemplate', 'Ptable', 'Realm', 'RemoteExecutionFeature', 'ReportTemplate', 'Role', 'Setting', 'SmartProxy', 'SshKey', 'Subnet', 'Template', 'TemplateInvocation', 'User', 'Usergroup', 'Webhook', 'WebhookTemplate'",
+              "help": "For values of type search, this is the resource the value searches in Possible value(s): 'AnsibleRole', 'AnsibleVariable', 'Architecture', 'Audit', 'AuthSource', 'Bookmark', 'ComputeProfile', 'ComputeResource', 'ConfigReport', 'DiscoveryRule', 'Domain', 'ExternalUsergroup', 'FactValue', 'Filter', 'ForemanOpenscap::ArfReport', 'ForemanOpenscap::OvalContent', 'ForemanOpenscap::OvalPolicy', 'ForemanOpenscap::Policy', 'ForemanOpenscap::ScapContent', 'ForemanOpenscap::TailoringFile', 'ForemanTasks::RecurringLogic', 'ForemanTasks::Task', 'ForemanVirtWhoConfigure::Config', 'Host', 'Hostgroup', 'HttpProxy', 'Image', 'InsightsHit', 'JobInvocation', 'JobTemplate', 'Katello::ActivationKey', 'Katello::AlternateContentSource', 'Katello::ContentCredential', 'Katello::ContentView', 'Katello::HostCollection', 'Katello::KTEnvironment', 'Katello::Product', 'Katello::Subscription', 'Katello::SyncPlan', 'KeyPair', 'Location', 'LookupValue', 'MailNotification', 'Medium', 'Model', 'Operatingsystem', 'Organization', 'Parameter', 'PersonalAccessToken', 'ProvisioningTemplate', 'Ptable', 'Realm', 'RemoteExecutionFeature', 'ReportTemplate', 'Role', 'Setting', 'SmartProxy', 'SshKey', 'Subnet', 'Template', 'TemplateInvocation', 'User', 'Usergroup', 'Webhook', 'WebhookTemplate'",
               "name": "resource-type",
               "shortname": null,
               "value": "ENUM"
@@ -49449,7 +49279,7 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "For values of type search, this is the resource the value searches in Possible value(s): 'AnsibleRole', 'AnsibleVariable', 'Architecture', 'Audit', 'AuthSource', 'Bookmark', 'ComputeProfile', 'ComputeResource', 'ConfigReport', 'DiscoveryRule', 'Domain', 'ExternalUsergroup', 'FactValue', 'Filter', 'ForemanOpenscap::ArfReport', 'ForemanOpenscap::OvalContent', 'ForemanOpenscap::OvalPolicy', 'ForemanOpenscap::Policy', 'ForemanOpenscap::ScapContent', 'ForemanOpenscap::TailoringFile', 'ForemanTasks::RecurringLogic', 'ForemanTasks::Task', 'ForemanVirtWhoConfigure::Config', 'Host', 'Hostgroup', 'HttpProxy', 'Image', 'InsightsHit', 'JobInvocation', 'JobTemplate', 'Katello::ActivationKey', 'Katello::AlternateContentSource', 'Katello::ContentCredential', 'Katello::ContentView', 'Katello::HostCollection', 'Katello::KTEnvironment', 'Katello::Product', 'Katello::Subscription', 'Katello::SyncPlan', 'KeyPair', 'Location', 'MailNotification', 'Medium', 'Model', 'Operatingsystem', 'Organization', 'Parameter', 'PersonalAccessToken', 'ProvisioningTemplate', 'Ptable', 'Realm', 'RemoteExecutionFeature', 'ReportTemplate', 'Role', 'Setting', 'SmartProxy', 'SshKey', 'Subnet', 'Template', 'TemplateInvocation', 'User', 'Usergroup', 'Webhook', 'WebhookTemplate'",
+              "help": "For values of type search, this is the resource the value searches in Possible value(s): 'AnsibleRole', 'AnsibleVariable', 'Architecture', 'Audit', 'AuthSource', 'Bookmark', 'ComputeProfile', 'ComputeResource', 'ConfigReport', 'DiscoveryRule', 'Domain', 'ExternalUsergroup', 'FactValue', 'Filter', 'ForemanOpenscap::ArfReport', 'ForemanOpenscap::OvalContent', 'ForemanOpenscap::OvalPolicy', 'ForemanOpenscap::Policy', 'ForemanOpenscap::ScapContent', 'ForemanOpenscap::TailoringFile', 'ForemanTasks::RecurringLogic', 'ForemanTasks::Task', 'ForemanVirtWhoConfigure::Config', 'Host', 'Hostgroup', 'HttpProxy', 'Image', 'InsightsHit', 'JobInvocation', 'JobTemplate', 'Katello::ActivationKey', 'Katello::AlternateContentSource', 'Katello::ContentCredential', 'Katello::ContentView', 'Katello::HostCollection', 'Katello::KTEnvironment', 'Katello::Product', 'Katello::Subscription', 'Katello::SyncPlan', 'KeyPair', 'Location', 'LookupValue', 'MailNotification', 'Medium', 'Model', 'Operatingsystem', 'Organization', 'Parameter', 'PersonalAccessToken', 'ProvisioningTemplate', 'Ptable', 'Realm', 'RemoteExecutionFeature', 'ReportTemplate', 'Role', 'Setting', 'SmartProxy', 'SshKey', 'Subnet', 'Template', 'TemplateInvocation', 'User', 'Usergroup', 'Webhook', 'WebhookTemplate'",
               "name": "resource-type",
               "shortname": null,
               "value": "ENUM"
@@ -50053,7 +49883,7 @@
               "value": "LIST"
             },
             {
-              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US & Canada)', 'Tijuana', 'Arizona', 'Mazatlan', 'Mountain Time (US & Canada)', 'Central America', 'Central Time (US & Canada)', 'Chihuahua', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US & Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Casablanca', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Volgograd', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku'alofa', 'Samoa', 'Tokelau Is.'",
+              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US & Canada)', 'Tijuana', 'Arizona', 'Mazatlan', 'Mountain Time (US & Canada)', 'Central America', 'Central Time (US & Canada)', 'Chihuahua', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US & Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Montevideo', 'Greenland', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Casablanca', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Volgograd', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Yerevan', 'Kabul', 'Almaty', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku'alofa', 'Samoa', 'Tokelau Is.'",
               "name": "timezone",
               "shortname": null,
               "value": "ENUM"
@@ -51625,7 +51455,7 @@
               "value": "LIST"
             },
             {
-              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US & Canada)', 'Tijuana', 'Arizona', 'Mazatlan', 'Mountain Time (US & Canada)', 'Central America', 'Central Time (US & Canada)', 'Chihuahua', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US & Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Greenland', 'Montevideo', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Casablanca', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Volgograd', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Yerevan', 'Kabul', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Almaty', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku'alofa', 'Samoa', 'Tokelau Is.'",
+              "help": "User's timezone Possible value(s): 'International Date Line West', 'American Samoa', 'Midway Island', 'Hawaii', 'Alaska', 'Pacific Time (US & Canada)', 'Tijuana', 'Arizona', 'Mazatlan', 'Mountain Time (US & Canada)', 'Central America', 'Central Time (US & Canada)', 'Chihuahua', 'Guadalajara', 'Mexico City', 'Monterrey', 'Saskatchewan', 'Bogota', 'Eastern Time (US & Canada)', 'Indiana (East)', 'Lima', 'Quito', 'Atlantic Time (Canada)', 'Caracas', 'Georgetown', 'La Paz', 'Puerto Rico', 'Santiago', 'Newfoundland', 'Brasilia', 'Buenos Aires', 'Montevideo', 'Greenland', 'Mid-Atlantic', 'Azores', 'Cape Verde Is.', 'Casablanca', 'Dublin', 'Edinburgh', 'Lisbon', 'London', 'Monrovia', 'UTC', 'Amsterdam', 'Belgrade', 'Berlin', 'Bern', 'Bratislava', 'Brussels', 'Budapest', 'Copenhagen', 'Ljubljana', 'Madrid', 'Paris', 'Prague', 'Rome', 'Sarajevo', 'Skopje', 'Stockholm', 'Vienna', 'Warsaw', 'West Central Africa', 'Zagreb', 'Zurich', 'Athens', 'Bucharest', 'Cairo', 'Harare', 'Helsinki', 'Jerusalem', 'Kaliningrad', 'Kyiv', 'Pretoria', 'Riga', 'Sofia', 'Tallinn', 'Vilnius', 'Baghdad', 'Istanbul', 'Kuwait', 'Minsk', 'Moscow', 'Nairobi', 'Riyadh', 'St. Petersburg', 'Volgograd', 'Tehran', 'Abu Dhabi', 'Baku', 'Muscat', 'Samara', 'Tbilisi', 'Yerevan', 'Kabul', 'Almaty', 'Ekaterinburg', 'Islamabad', 'Karachi', 'Tashkent', 'Chennai', 'Kolkata', 'Mumbai', 'New Delhi', 'Sri Jayawardenepura', 'Kathmandu', 'Astana', 'Dhaka', 'Urumqi', 'Rangoon', 'Bangkok', 'Hanoi', 'Jakarta', 'Krasnoyarsk', 'Novosibirsk', 'Beijing', 'Chongqing', 'Hong Kong', 'Irkutsk', 'Kuala Lumpur', 'Perth', 'Singapore', 'Taipei', 'Ulaanbaatar', 'Osaka', 'Sapporo', 'Seoul', 'Tokyo', 'Yakutsk', 'Adelaide', 'Darwin', 'Brisbane', 'Canberra', 'Guam', 'Hobart', 'Melbourne', 'Port Moresby', 'Sydney', 'Vladivostok', 'Magadan', 'New Caledonia', 'Solomon Is.', 'Srednekolymsk', 'Auckland', 'Fiji', 'Kamchatka', 'Marshall Is.', 'Wellington', 'Chatham Is.', 'Nuku'alofa', 'Samoa', 'Tokelau Is.'",
               "name": "timezone",
               "shortname": null,
               "value": "ENUM"
@@ -52795,12 +52625,6 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "The frequency of VM-to-host mapping updates for AHV(in seconds)",
-              "name": "ahv-update-interval",
-              "shortname": null,
-              "value": "NUMBER"
-            },
-            {
               "help": "Hypervisor blacklist, applicable only when filtering mode is set to 2. Wildcards and regular expressions are supported, multiple records must be separated by comma.",
               "name": "blacklist",
               "shortname": null,
@@ -53207,7 +53031,7 @@
               "value": null
             },
             {
-              "help": "Print help -----------------------------------------|-----|-------- | ALL | DEFAULT -----------------------------------------|-----|-------- information/id                   | x   | x information/name                 | x   | x information/hypervisor type      | x   | x information/hypervisor server    | x   | x information/hypervisor username  | x   | x information/configuration file   | x   | x information/ahv prism flavor     | x   | x information/ahv update frequency | x   | x information/enable ahv debug     | x   | x information/status               | x   | x Schedule/interval                        | x   | x Schedule/last report at                  | x   | x Connection/satellite server              | x   | x Connection/hypervisor id                 | x   | x Connection/filtering                     | x   | x Connection/excluded hosts                | x   | x Connection/filtered hosts                | x   | x Connection/filter host parents           | x   | x Connection/exclude host parents          | x   | x Connection/debug mode                    | x   | x Connection/ignore proxy                  | x   | x proxy/http proxy id                 | x   | x proxy/http proxy name               | x   | x proxy/http proxy url                | x   | x Locations/                               | x   | x Organizations/                           | x   | x -----------------------------------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
+              "help": "Print help ----------------------------------------|-----|-------- | ALL | DEFAULT ----------------------------------------|-----|-------- information/id                  | x   | x information/name                | x   | x information/hypervisor type     | x   | x information/hypervisor server   | x   | x information/hypervisor username | x   | x information/configuration file  | x   | x information/ahv prism flavor    | x   | x information/enable ahv debug    | x   | x information/status              | x   | x Schedule/interval                       | x   | x Schedule/last report at                 | x   | x Connection/satellite server             | x   | x Connection/hypervisor id                | x   | x Connection/filtering                    | x   | x Connection/excluded hosts               | x   | x Connection/filtered hosts               | x   | x Connection/filter host parents          | x   | x Connection/exclude host parents         | x   | x Connection/debug mode                   | x   | x Connection/ignore proxy                 | x   | x proxy/http proxy id                | x   | x proxy/http proxy name              | x   | x proxy/http proxy url               | x   | x Locations/                              | x   | x Organizations/                          | x   | x ----------------------------------------|-----|-------- you can find option types and the value an option can accept: One of true/false, yes/no, 1/0 Date and time in YYYY-MM-DD HH:MM:SS or ISO 8601 format Possible values are described in the option's description Path to a file Comma-separated list of key=value. JSON is acceptable and preferred way for such parameters Comma separated list of values. Values containing comma should be quoted or escaped with backslash. JSON is acceptable and preferred way for such parameters Any combination of possible values described in the option's description Numeric value. Integer Comma separated list of values defined by a schema. JSON is acceptable and preferred way for such parameters Value described in the option's description. Mostly simple string",
               "name": "help",
               "shortname": "h",
               "value": null
@@ -53303,12 +53127,6 @@
               "name": "ahv-internal-debug",
               "shortname": null,
               "value": "BOOLEAN"
-            },
-            {
-              "help": "The frequency of VM-to-host mapping updates for AHV(in seconds)",
-              "name": "ahv-update-interval",
-              "shortname": null,
-              "value": "NUMBER"
             },
             {
               "help": "Hypervisor blacklist, applicable only when filtering mode is set to 2. Wildcards and regular expressions are supported, multiple records must be separated by comma.",
@@ -53506,7 +53324,7 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "Possible value(s): 'actions.katello.content_view.promote_succeeded', 'actions.katello.content_view.publish_succeeded', 'actions.katello.repository.sync_succeeded', 'actions.remote_execution.run_host_job_ansible_configure_cloud_connector_succeeded', 'actions.remote_execution.run_host_job_ansible_enable_web_console_succeeded', 'actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_succeeded', 'actions.remote_execution.run_host_job_ansible_run_host_succeeded', 'actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded', 'actions.remote_execution.run_host_job_ansible_run_playbook_succeeded', 'actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_succeeded', 'actions.remote_execution.run_host_job_foreman_openscap_run_scans_succeeded', 'actions.remote_execution.run_host_job_katello_errata_install_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_errata_install_succeeded', 'actions.remote_execution.run_host_job_katello_group_install_succeeded', 'actions.remote_execution.run_host_job_katello_group_remove_succeeded', 'actions.remote_execution.run_host_job_katello_group_update_succeeded', 'actions.remote_execution.run_host_job_katello_host_tracer_resolve_succeeded', 'actions.remote_execution.run_host_job_katello_module_stream_action_succeeded', 'actions.remote_execution.run_host_job_katello_package_install_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_package_install_succeeded', 'actions.remote_execution.run_host_job_katello_package_remove_succeeded', 'actions.remote_execution.run_host_job_katello_package_update_succeeded', 'actions.remote_execution.run_host_job_katello_packages_remove_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_packages_update_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_service_restart_succeeded', 'actions.remote_execution.run_host_job_leapp_preupgrade_succeeded', 'actions.remote_execution.run_host_job_leapp_remediation_plan_succeeded', 'actions.remote_execution.run_host_job_leapp_upgrade_succeeded', 'actions.remote_execution.run_host_job_puppet_run_host_succeeded', 'actions.remote_execution.run_host_job_rh_cloud_connector_run_playbook_succeeded', 'actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_succeeded', 'actions.remote_execution.run_host_job_succeeded', 'build_entered', 'build_exited', 'content_view_created', 'content_view_destroyed', 'content_view_updated', 'domain_created', 'domain_destroyed', 'domain_updated', 'host_created', 'host_destroyed', 'host_updated', 'hostgroup_created', 'hostgroup_destroyed', 'hostgroup_updated', 'model_created', 'model_destroyed', 'model_updated', 'status_changed', 'subnet_created', 'subnet_destroyed', 'subnet_updated', 'user_created', 'user_destroyed', 'user_updated'",
+              "help": "Possible value(s): 'actions.katello.capsule_content.sync_failed', 'actions.katello.capsule_content.sync_succeeded', 'actions.katello.content_view.promote_failed', 'actions.katello.content_view.promote_succeeded', 'actions.katello.content_view.publish_failed', 'actions.katello.content_view.publish_succeeded', 'actions.katello.repository.sync_failed', 'actions.katello.repository.sync_succeeded', 'actions.remote_execution.run_host_job_ansible_configure_cloud_connector_failed', 'actions.remote_execution.run_host_job_ansible_configure_cloud_connector_succeeded', 'actions.remote_execution.run_host_job_ansible_enable_web_console_failed', 'actions.remote_execution.run_host_job_ansible_enable_web_console_succeeded', 'actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_failed', 'actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_succeeded', 'actions.remote_execution.run_host_job_ansible_run_host_failed', 'actions.remote_execution.run_host_job_ansible_run_host_succeeded', 'actions.remote_execution.run_host_job_ansible_run_insights_plan_failed', 'actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded', 'actions.remote_execution.run_host_job_ansible_run_playbook_failed', 'actions.remote_execution.run_host_job_ansible_run_playbook_succeeded', 'actions.remote_execution.run_host_job_failed', 'actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_failed', 'actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_succeeded', 'actions.remote_execution.run_host_job_foreman_openscap_run_scans_failed', 'actions.remote_execution.run_host_job_foreman_openscap_run_scans_succeeded', 'actions.remote_execution.run_host_job_katello_errata_install_by_search_failed', 'actions.remote_execution.run_host_job_katello_errata_install_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_errata_install_failed', 'actions.remote_execution.run_host_job_katello_errata_install_succeeded', 'actions.remote_execution.run_host_job_katello_group_install_failed', 'actions.remote_execution.run_host_job_katello_group_install_succeeded', 'actions.remote_execution.run_host_job_katello_group_remove_failed', 'actions.remote_execution.run_host_job_katello_group_remove_succeeded', 'actions.remote_execution.run_host_job_katello_group_update_failed', 'actions.remote_execution.run_host_job_katello_group_update_succeeded', 'actions.remote_execution.run_host_job_katello_host_tracer_resolve_failed', 'actions.remote_execution.run_host_job_katello_host_tracer_resolve_succeeded', 'actions.remote_execution.run_host_job_katello_module_stream_action_failed', 'actions.remote_execution.run_host_job_katello_module_stream_action_succeeded', 'actions.remote_execution.run_host_job_katello_package_install_by_search_failed', 'actions.remote_execution.run_host_job_katello_package_install_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_package_install_failed', 'actions.remote_execution.run_host_job_katello_package_install_succeeded', 'actions.remote_execution.run_host_job_katello_package_remove_failed', 'actions.remote_execution.run_host_job_katello_package_remove_succeeded', 'actions.remote_execution.run_host_job_katello_package_update_failed', 'actions.remote_execution.run_host_job_katello_package_update_succeeded', 'actions.remote_execution.run_host_job_katello_packages_remove_by_search_failed', 'actions.remote_execution.run_host_job_katello_packages_remove_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_packages_update_by_search_failed', 'actions.remote_execution.run_host_job_katello_packages_update_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_service_restart_failed', 'actions.remote_execution.run_host_job_katello_service_restart_succeeded', 'actions.remote_execution.run_host_job_leapp_preupgrade_failed', 'actions.remote_execution.run_host_job_leapp_preupgrade_succeeded', 'actions.remote_execution.run_host_job_leapp_remediation_plan_failed', 'actions.remote_execution.run_host_job_leapp_remediation_plan_succeeded', 'actions.remote_execution.run_host_job_leapp_upgrade_failed', 'actions.remote_execution.run_host_job_leapp_upgrade_succeeded', 'actions.remote_execution.run_host_job_puppet_run_host_failed', 'actions.remote_execution.run_host_job_puppet_run_host_succeeded', 'actions.remote_execution.run_host_job_rh_cloud_connector_run_playbook_failed', 'actions.remote_execution.run_host_job_rh_cloud_connector_run_playbook_succeeded', 'actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_failed', 'actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_succeeded', 'actions.remote_execution.run_host_job_run_script_failed', 'actions.remote_execution.run_host_job_run_script_succeeded', 'actions.remote_execution.run_host_job_succeeded', 'actions.remote_execution.run_hosts_job_ansible_configure_cloud_connector_failed', 'actions.remote_execution.run_hosts_job_ansible_configure_cloud_connector_running', 'actions.remote_execution.run_hosts_job_ansible_configure_cloud_connector_succeeded', 'actions.remote_execution.run_hosts_job_ansible_enable_web_console_failed', 'actions.remote_execution.run_hosts_job_ansible_enable_web_console_running', 'actions.remote_execution.run_hosts_job_ansible_enable_web_console_succeeded', 'actions.remote_execution.run_hosts_job_ansible_run_capsule_upgrade_failed', 'actions.remote_execution.run_hosts_job_ansible_run_capsule_upgrade_running', 'actions.remote_execution.run_hosts_job_ansible_run_capsule_upgrade_succeeded', 'actions.remote_execution.run_hosts_job_ansible_run_host_failed', 'actions.remote_execution.run_hosts_job_ansible_run_host_running', 'actions.remote_execution.run_hosts_job_ansible_run_host_succeeded', 'actions.remote_execution.run_hosts_job_ansible_run_insights_plan_failed', 'actions.remote_execution.run_hosts_job_ansible_run_insights_plan_running', 'actions.remote_execution.run_hosts_job_ansible_run_insights_plan_succeeded', 'actions.remote_execution.run_hosts_job_ansible_run_playbook_failed', 'actions.remote_execution.run_hosts_job_ansible_run_playbook_running', 'actions.remote_execution.run_hosts_job_ansible_run_playbook_succeeded', 'actions.remote_execution.run_hosts_job_failed', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_oval_scans_failed', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_oval_scans_running', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_oval_scans_succeeded', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_scans_failed', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_scans_running', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_scans_succeeded', 'actions.remote_execution.run_hosts_job_katello_errata_install_by_search_failed', 'actions.remote_execution.run_hosts_job_katello_errata_install_by_search_running', 'actions.remote_execution.run_hosts_job_katello_errata_install_by_search_succeeded', 'actions.remote_execution.run_hosts_job_katello_errata_install_failed', 'actions.remote_execution.run_hosts_job_katello_errata_install_running', 'actions.remote_execution.run_hosts_job_katello_errata_install_succeeded', 'actions.remote_execution.run_hosts_job_katello_group_install_failed', 'actions.remote_execution.run_hosts_job_katello_group_install_running', 'actions.remote_execution.run_hosts_job_katello_group_install_succeeded', 'actions.remote_execution.run_hosts_job_katello_group_remove_failed', 'actions.remote_execution.run_hosts_job_katello_group_remove_running', 'actions.remote_execution.run_hosts_job_katello_group_remove_succeeded', 'actions.remote_execution.run_hosts_job_katello_group_update_failed', 'actions.remote_execution.run_hosts_job_katello_group_update_running', 'actions.remote_execution.run_hosts_job_katello_group_update_succeeded', 'actions.remote_execution.run_hosts_job_katello_host_tracer_resolve_failed', 'actions.remote_execution.run_hosts_job_katello_host_tracer_resolve_running', 'actions.remote_execution.run_hosts_job_katello_host_tracer_resolve_succeeded', 'actions.remote_execution.run_hosts_job_katello_module_stream_action_failed', 'actions.remote_execution.run_hosts_job_katello_module_stream_action_running', 'actions.remote_execution.run_hosts_job_katello_module_stream_action_succeeded', 'actions.remote_execution.run_hosts_job_katello_package_install_by_search_failed', 'actions.remote_execution.run_hosts_job_katello_package_install_by_search_running', 'actions.remote_execution.run_hosts_job_katello_package_install_by_search_succeeded', 'actions.remote_execution.run_hosts_job_katello_package_install_failed', 'actions.remote_execution.run_hosts_job_katello_package_install_running', 'actions.remote_execution.run_hosts_job_katello_package_install_succeeded', 'actions.remote_execution.run_hosts_job_katello_package_remove_failed', 'actions.remote_execution.run_hosts_job_katello_package_remove_running', 'actions.remote_execution.run_hosts_job_katello_package_remove_succeeded', 'actions.remote_execution.run_hosts_job_katello_package_update_failed', 'actions.remote_execution.run_hosts_job_katello_package_update_running', 'actions.remote_execution.run_hosts_job_katello_package_update_succeeded', 'actions.remote_execution.run_hosts_job_katello_packages_remove_by_search_failed', 'actions.remote_execution.run_hosts_job_katello_packages_remove_by_search_running', 'actions.remote_execution.run_hosts_job_katello_packages_remove_by_search_succeeded', 'actions.remote_execution.run_hosts_job_katello_packages_update_by_search_failed', 'actions.remote_execution.run_hosts_job_katello_packages_update_by_search_running', 'actions.remote_execution.run_hosts_job_katello_packages_update_by_search_succeeded', 'actions.remote_execution.run_hosts_job_katello_service_restart_failed', 'actions.remote_execution.run_hosts_job_katello_service_restart_running', 'actions.remote_execution.run_hosts_job_katello_service_restart_succeeded', 'actions.remote_execution.run_hosts_job_leapp_preupgrade_failed', 'actions.remote_execution.run_hosts_job_leapp_preupgrade_running', 'actions.remote_execution.run_hosts_job_leapp_preupgrade_succeeded', 'actions.remote_execution.run_hosts_job_leapp_remediation_plan_failed', 'actions.remote_execution.run_hosts_job_leapp_remediation_plan_running', 'actions.remote_execution.run_hosts_job_leapp_remediation_plan_succeeded', 'actions.remote_execution.run_hosts_job_leapp_upgrade_failed', 'actions.remote_execution.run_hosts_job_leapp_upgrade_running', 'actions.remote_execution.run_hosts_job_leapp_upgrade_succeeded', 'actions.remote_execution.run_hosts_job_puppet_run_host_failed', 'actions.remote_execution.run_hosts_job_puppet_run_host_running', 'actions.remote_execution.run_hosts_job_puppet_run_host_succeeded', 'actions.remote_execution.run_hosts_job_rh_cloud_connector_run_playbook_failed', 'actions.remote_execution.run_hosts_job_rh_cloud_connector_run_playbook_running', 'actions.remote_execution.run_hosts_job_rh_cloud_connector_run_playbook_succeeded', 'actions.remote_execution.run_hosts_job_rh_cloud_remediate_hosts_failed', 'actions.remote_execution.run_hosts_job_rh_cloud_remediate_hosts_running', 'actions.remote_execution.run_hosts_job_rh_cloud_remediate_hosts_succeeded', 'actions.remote_execution.run_hosts_job_run_script_failed', 'actions.remote_execution.run_hosts_job_run_script_running', 'actions.remote_execution.run_hosts_job_run_script_succeeded', 'actions.remote_execution.run_hosts_job_running', 'actions.remote_execution.run_hosts_job_succeeded', 'build_entered', 'build_exited', 'content_view_created', 'content_view_destroyed', 'content_view_updated', 'domain_created', 'domain_destroyed', 'domain_updated', 'host_created', 'host_destroyed', 'host_facts_updated', 'host_updated', 'hostgroup_created', 'hostgroup_destroyed', 'hostgroup_updated', 'model_created', 'model_destroyed', 'model_updated', 'status_changed', 'subnet_created', 'subnet_destroyed', 'subnet_updated', 'user_created', 'user_destroyed', 'user_updated'",
               "name": "event",
               "shortname": null,
               "value": "ENUM"
@@ -53846,7 +53664,7 @@
               "value": "BOOLEAN"
             },
             {
-              "help": "Possible value(s): 'actions.katello.content_view.promote_succeeded', 'actions.katello.content_view.publish_succeeded', 'actions.katello.repository.sync_succeeded', 'actions.remote_execution.run_host_job_ansible_configure_cloud_connector_succeeded', 'actions.remote_execution.run_host_job_ansible_enable_web_console_succeeded', 'actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_succeeded', 'actions.remote_execution.run_host_job_ansible_run_host_succeeded', 'actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded', 'actions.remote_execution.run_host_job_ansible_run_playbook_succeeded', 'actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_succeeded', 'actions.remote_execution.run_host_job_foreman_openscap_run_scans_succeeded', 'actions.remote_execution.run_host_job_katello_errata_install_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_errata_install_succeeded', 'actions.remote_execution.run_host_job_katello_group_install_succeeded', 'actions.remote_execution.run_host_job_katello_group_remove_succeeded', 'actions.remote_execution.run_host_job_katello_group_update_succeeded', 'actions.remote_execution.run_host_job_katello_host_tracer_resolve_succeeded', 'actions.remote_execution.run_host_job_katello_module_stream_action_succeeded', 'actions.remote_execution.run_host_job_katello_package_install_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_package_install_succeeded', 'actions.remote_execution.run_host_job_katello_package_remove_succeeded', 'actions.remote_execution.run_host_job_katello_package_update_succeeded', 'actions.remote_execution.run_host_job_katello_packages_remove_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_packages_update_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_service_restart_succeeded', 'actions.remote_execution.run_host_job_leapp_preupgrade_succeeded', 'actions.remote_execution.run_host_job_leapp_remediation_plan_succeeded', 'actions.remote_execution.run_host_job_leapp_upgrade_succeeded', 'actions.remote_execution.run_host_job_puppet_run_host_succeeded', 'actions.remote_execution.run_host_job_rh_cloud_connector_run_playbook_succeeded', 'actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_succeeded', 'actions.remote_execution.run_host_job_succeeded', 'build_entered', 'build_exited', 'content_view_created', 'content_view_destroyed', 'content_view_updated', 'domain_created', 'domain_destroyed', 'domain_updated', 'host_created', 'host_destroyed', 'host_updated', 'hostgroup_created', 'hostgroup_destroyed', 'hostgroup_updated', 'model_created', 'model_destroyed', 'model_updated', 'status_changed', 'subnet_created', 'subnet_destroyed', 'subnet_updated', 'user_created', 'user_destroyed', 'user_updated'",
+              "help": "Possible value(s): 'actions.katello.capsule_content.sync_failed', 'actions.katello.capsule_content.sync_succeeded', 'actions.katello.content_view.promote_failed', 'actions.katello.content_view.promote_succeeded', 'actions.katello.content_view.publish_failed', 'actions.katello.content_view.publish_succeeded', 'actions.katello.repository.sync_failed', 'actions.katello.repository.sync_succeeded', 'actions.remote_execution.run_host_job_ansible_configure_cloud_connector_failed', 'actions.remote_execution.run_host_job_ansible_configure_cloud_connector_succeeded', 'actions.remote_execution.run_host_job_ansible_enable_web_console_failed', 'actions.remote_execution.run_host_job_ansible_enable_web_console_succeeded', 'actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_failed', 'actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_succeeded', 'actions.remote_execution.run_host_job_ansible_run_host_failed', 'actions.remote_execution.run_host_job_ansible_run_host_succeeded', 'actions.remote_execution.run_host_job_ansible_run_insights_plan_failed', 'actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded', 'actions.remote_execution.run_host_job_ansible_run_playbook_failed', 'actions.remote_execution.run_host_job_ansible_run_playbook_succeeded', 'actions.remote_execution.run_host_job_failed', 'actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_failed', 'actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_succeeded', 'actions.remote_execution.run_host_job_foreman_openscap_run_scans_failed', 'actions.remote_execution.run_host_job_foreman_openscap_run_scans_succeeded', 'actions.remote_execution.run_host_job_katello_errata_install_by_search_failed', 'actions.remote_execution.run_host_job_katello_errata_install_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_errata_install_failed', 'actions.remote_execution.run_host_job_katello_errata_install_succeeded', 'actions.remote_execution.run_host_job_katello_group_install_failed', 'actions.remote_execution.run_host_job_katello_group_install_succeeded', 'actions.remote_execution.run_host_job_katello_group_remove_failed', 'actions.remote_execution.run_host_job_katello_group_remove_succeeded', 'actions.remote_execution.run_host_job_katello_group_update_failed', 'actions.remote_execution.run_host_job_katello_group_update_succeeded', 'actions.remote_execution.run_host_job_katello_host_tracer_resolve_failed', 'actions.remote_execution.run_host_job_katello_host_tracer_resolve_succeeded', 'actions.remote_execution.run_host_job_katello_module_stream_action_failed', 'actions.remote_execution.run_host_job_katello_module_stream_action_succeeded', 'actions.remote_execution.run_host_job_katello_package_install_by_search_failed', 'actions.remote_execution.run_host_job_katello_package_install_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_package_install_failed', 'actions.remote_execution.run_host_job_katello_package_install_succeeded', 'actions.remote_execution.run_host_job_katello_package_remove_failed', 'actions.remote_execution.run_host_job_katello_package_remove_succeeded', 'actions.remote_execution.run_host_job_katello_package_update_failed', 'actions.remote_execution.run_host_job_katello_package_update_succeeded', 'actions.remote_execution.run_host_job_katello_packages_remove_by_search_failed', 'actions.remote_execution.run_host_job_katello_packages_remove_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_packages_update_by_search_failed', 'actions.remote_execution.run_host_job_katello_packages_update_by_search_succeeded', 'actions.remote_execution.run_host_job_katello_service_restart_failed', 'actions.remote_execution.run_host_job_katello_service_restart_succeeded', 'actions.remote_execution.run_host_job_leapp_preupgrade_failed', 'actions.remote_execution.run_host_job_leapp_preupgrade_succeeded', 'actions.remote_execution.run_host_job_leapp_remediation_plan_failed', 'actions.remote_execution.run_host_job_leapp_remediation_plan_succeeded', 'actions.remote_execution.run_host_job_leapp_upgrade_failed', 'actions.remote_execution.run_host_job_leapp_upgrade_succeeded', 'actions.remote_execution.run_host_job_puppet_run_host_failed', 'actions.remote_execution.run_host_job_puppet_run_host_succeeded', 'actions.remote_execution.run_host_job_rh_cloud_connector_run_playbook_failed', 'actions.remote_execution.run_host_job_rh_cloud_connector_run_playbook_succeeded', 'actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_failed', 'actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_succeeded', 'actions.remote_execution.run_host_job_run_script_failed', 'actions.remote_execution.run_host_job_run_script_succeeded', 'actions.remote_execution.run_host_job_succeeded', 'actions.remote_execution.run_hosts_job_ansible_configure_cloud_connector_failed', 'actions.remote_execution.run_hosts_job_ansible_configure_cloud_connector_running', 'actions.remote_execution.run_hosts_job_ansible_configure_cloud_connector_succeeded', 'actions.remote_execution.run_hosts_job_ansible_enable_web_console_failed', 'actions.remote_execution.run_hosts_job_ansible_enable_web_console_running', 'actions.remote_execution.run_hosts_job_ansible_enable_web_console_succeeded', 'actions.remote_execution.run_hosts_job_ansible_run_capsule_upgrade_failed', 'actions.remote_execution.run_hosts_job_ansible_run_capsule_upgrade_running', 'actions.remote_execution.run_hosts_job_ansible_run_capsule_upgrade_succeeded', 'actions.remote_execution.run_hosts_job_ansible_run_host_failed', 'actions.remote_execution.run_hosts_job_ansible_run_host_running', 'actions.remote_execution.run_hosts_job_ansible_run_host_succeeded', 'actions.remote_execution.run_hosts_job_ansible_run_insights_plan_failed', 'actions.remote_execution.run_hosts_job_ansible_run_insights_plan_running', 'actions.remote_execution.run_hosts_job_ansible_run_insights_plan_succeeded', 'actions.remote_execution.run_hosts_job_ansible_run_playbook_failed', 'actions.remote_execution.run_hosts_job_ansible_run_playbook_running', 'actions.remote_execution.run_hosts_job_ansible_run_playbook_succeeded', 'actions.remote_execution.run_hosts_job_failed', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_oval_scans_failed', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_oval_scans_running', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_oval_scans_succeeded', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_scans_failed', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_scans_running', 'actions.remote_execution.run_hosts_job_foreman_openscap_run_scans_succeeded', 'actions.remote_execution.run_hosts_job_katello_errata_install_by_search_failed', 'actions.remote_execution.run_hosts_job_katello_errata_install_by_search_running', 'actions.remote_execution.run_hosts_job_katello_errata_install_by_search_succeeded', 'actions.remote_execution.run_hosts_job_katello_errata_install_failed', 'actions.remote_execution.run_hosts_job_katello_errata_install_running', 'actions.remote_execution.run_hosts_job_katello_errata_install_succeeded', 'actions.remote_execution.run_hosts_job_katello_group_install_failed', 'actions.remote_execution.run_hosts_job_katello_group_install_running', 'actions.remote_execution.run_hosts_job_katello_group_install_succeeded', 'actions.remote_execution.run_hosts_job_katello_group_remove_failed', 'actions.remote_execution.run_hosts_job_katello_group_remove_running', 'actions.remote_execution.run_hosts_job_katello_group_remove_succeeded', 'actions.remote_execution.run_hosts_job_katello_group_update_failed', 'actions.remote_execution.run_hosts_job_katello_group_update_running', 'actions.remote_execution.run_hosts_job_katello_group_update_succeeded', 'actions.remote_execution.run_hosts_job_katello_host_tracer_resolve_failed', 'actions.remote_execution.run_hosts_job_katello_host_tracer_resolve_running', 'actions.remote_execution.run_hosts_job_katello_host_tracer_resolve_succeeded', 'actions.remote_execution.run_hosts_job_katello_module_stream_action_failed', 'actions.remote_execution.run_hosts_job_katello_module_stream_action_running', 'actions.remote_execution.run_hosts_job_katello_module_stream_action_succeeded', 'actions.remote_execution.run_hosts_job_katello_package_install_by_search_failed', 'actions.remote_execution.run_hosts_job_katello_package_install_by_search_running', 'actions.remote_execution.run_hosts_job_katello_package_install_by_search_succeeded', 'actions.remote_execution.run_hosts_job_katello_package_install_failed', 'actions.remote_execution.run_hosts_job_katello_package_install_running', 'actions.remote_execution.run_hosts_job_katello_package_install_succeeded', 'actions.remote_execution.run_hosts_job_katello_package_remove_failed', 'actions.remote_execution.run_hosts_job_katello_package_remove_running', 'actions.remote_execution.run_hosts_job_katello_package_remove_succeeded', 'actions.remote_execution.run_hosts_job_katello_package_update_failed', 'actions.remote_execution.run_hosts_job_katello_package_update_running', 'actions.remote_execution.run_hosts_job_katello_package_update_succeeded', 'actions.remote_execution.run_hosts_job_katello_packages_remove_by_search_failed', 'actions.remote_execution.run_hosts_job_katello_packages_remove_by_search_running', 'actions.remote_execution.run_hosts_job_katello_packages_remove_by_search_succeeded', 'actions.remote_execution.run_hosts_job_katello_packages_update_by_search_failed', 'actions.remote_execution.run_hosts_job_katello_packages_update_by_search_running', 'actions.remote_execution.run_hosts_job_katello_packages_update_by_search_succeeded', 'actions.remote_execution.run_hosts_job_katello_service_restart_failed', 'actions.remote_execution.run_hosts_job_katello_service_restart_running', 'actions.remote_execution.run_hosts_job_katello_service_restart_succeeded', 'actions.remote_execution.run_hosts_job_leapp_preupgrade_failed', 'actions.remote_execution.run_hosts_job_leapp_preupgrade_running', 'actions.remote_execution.run_hosts_job_leapp_preupgrade_succeeded', 'actions.remote_execution.run_hosts_job_leapp_remediation_plan_failed', 'actions.remote_execution.run_hosts_job_leapp_remediation_plan_running', 'actions.remote_execution.run_hosts_job_leapp_remediation_plan_succeeded', 'actions.remote_execution.run_hosts_job_leapp_upgrade_failed', 'actions.remote_execution.run_hosts_job_leapp_upgrade_running', 'actions.remote_execution.run_hosts_job_leapp_upgrade_succeeded', 'actions.remote_execution.run_hosts_job_puppet_run_host_failed', 'actions.remote_execution.run_hosts_job_puppet_run_host_running', 'actions.remote_execution.run_hosts_job_puppet_run_host_succeeded', 'actions.remote_execution.run_hosts_job_rh_cloud_connector_run_playbook_failed', 'actions.remote_execution.run_hosts_job_rh_cloud_connector_run_playbook_running', 'actions.remote_execution.run_hosts_job_rh_cloud_connector_run_playbook_succeeded', 'actions.remote_execution.run_hosts_job_rh_cloud_remediate_hosts_failed', 'actions.remote_execution.run_hosts_job_rh_cloud_remediate_hosts_running', 'actions.remote_execution.run_hosts_job_rh_cloud_remediate_hosts_succeeded', 'actions.remote_execution.run_hosts_job_run_script_failed', 'actions.remote_execution.run_hosts_job_run_script_running', 'actions.remote_execution.run_hosts_job_run_script_succeeded', 'actions.remote_execution.run_hosts_job_running', 'actions.remote_execution.run_hosts_job_succeeded', 'build_entered', 'build_exited', 'content_view_created', 'content_view_destroyed', 'content_view_updated', 'domain_created', 'domain_destroyed', 'domain_updated', 'host_created', 'host_destroyed', 'host_facts_updated', 'host_updated', 'hostgroup_created', 'hostgroup_destroyed', 'hostgroup_updated', 'model_created', 'model_destroyed', 'model_updated', 'status_changed', 'subnet_created', 'subnet_destroyed', 'subnet_updated', 'user_created', 'user_destroyed', 'user_updated'",
               "name": "event",
               "shortname": null,
               "value": "ENUM"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14760

### Problem Statement
updated commands tree for the current state in 6.15, opening master PR first to have these changes there too

local result against 6.15:
```
pytest tests/foreman/cli/test_hammer.py -k all_options
===================================== test session starts =====================================

                    
tests/foreman/cli/test_hammer.py .                                                      [100%]
