### PR TITLE
[6.12.z] Fix Capsule.install when used w/o kwargs

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1545,7 +1545,8 @@ class Capsule(ContentHost, CapsuleMixins):
         """General purpose installer"""
         if not installer_obj:
             command_opts = {'scenario': self.__class__.__name__.lower()}
-            command_opts.update(cmd_kwargs)
+            if cmd_kwargs:
+                command_opts.update(cmd_kwargs)
             installer_obj = InstallerCommand(*cmd_args, **command_opts)
         return self.execute(installer_obj.get_command(), timeout=0)
 


### PR DESCRIPTION
Cherrypicks #14693
(cherry picked from commit d37f76c3c9b6be2a49922f960015e70c5aa68202)

### Problem Statement


### Solution


### Related Issues
Fixes #14714 

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->