### PR TITLE
Remove foreman-maintain snapshot backup related code

### DIFF
--- a/robottelo/cli/sm_advanced.py
+++ b/robottelo/cli/sm_advanced.py
@@ -23,13 +23,6 @@ Subcommands:
     backup-online-safety-confirmation Data consistency warning
     backup-prepare-directory      Prepare backup Directory
     backup-pulp                   Backup Pulp data
-    backup-snapshot-clean-mount   Remove the snapshot mount points
-    backup-snapshot-logical-volume-confirmation Check if backup is on different LV then the source
-    backup-snapshot-mount-candlepin-db Create and mount snapshot of Candlepin DB
-    backup-snapshot-mount-foreman-db Create and mount snapshot of Foreman DB
-    backup-snapshot-mount-pulp    Create and mount snapshot of Pulp data
-    backup-snapshot-mount-pulpcore-db Create and mount snapshot of Pulpcore DB
-    backup-snapshot-prepare-mount Prepare mount point for the snapshot
     content-migration-reset       Reset the Pulp 2 to Pulp 3 migration data (pre-switchover)
     content-migration-stats       Retrieve Pulp 2 to Pulp 3 migration statistics
     content-prepare               Prepare content for Pulp 3

--- a/robottelo/cli/sm_backup.py
+++ b/robottelo/cli/sm_backup.py
@@ -9,7 +9,6 @@ Parameters:
 Subcommands:
     online                        Keep services online during backup
     offline                       Shut down services to preserve consistent backup
-    snapshot                      Use snapshots of the databases to create backup
 
 Options:
     -h, --help                    print help
@@ -24,7 +23,7 @@ class Backup(Base):
 
     @classmethod
     def run_backup(cls, backup_dir='/tmp/', backup_type='online', options=None, timeout=None):
-        """Build satellite-maintain backup online/offline/snapshot"""
+        """Build satellite-maintain backup online/offline"""
         cls.command_sub = backup_type
         cls.command_end = backup_dir
         options = options or {}

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -327,39 +327,6 @@ def test_negative_backup_incremental_nodir(sat_maintain, setup_backup_tests, bac
 
 
 @pytest.mark.include_capsule
-def test_negative_backup_maintenance_mode(sat_maintain, setup_backup_tests):
-    """Try to take a backup which would fail and verify maintenance-mode isn't running/ON
-
-    :id: dd53c19c-4ebf-11ed-a3d2-932dbdabb055
-
-    :parametrized: yes
-
-    :steps:
-        1. try to create a snapshot backup which would fail
-
-    :expectedresults:
-        1. Verify maintenance-mode isn't running if backup fails
-
-    :BZ: 1908478, 1962842
-
-    :customerscenario: true
-    """
-    subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
-    result = sat_maintain.cli.Backup.run_backup(
-        backup_dir=subdir,
-        backup_type='snapshot',
-        options={'assumeyes': True, 'plaintext': True},
-    )
-    assert result.status != 0
-    assert "Backup didn't finish. Incomplete backup was removed." in result.stdout
-
-    result = sat_maintain.cli.MaintenanceMode.status()
-    assert result.status == 0
-    assert 'Status of maintenance-mode: Off' in result.stdout
-    assert 'Nftables table: absent' in result.stdout
-
-
-@pytest.mark.include_capsule
 def test_negative_restore_baddir_nodir(sat_maintain, setup_backup_tests):
     """Try to run restore with non-existing source dir provided
 


### PR DESCRIPTION
### Problem Statement
- Snapshot backup has been removed from foreman-maintain in 6.16

### Solution
- Remove foreman-maintain snapshot backup-related code

### Related Issues
- SAT-20641

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->