### PR TITLE
[6.14.z] virt-who config SCA-compliant

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -57,7 +57,7 @@ class TestScenarioPositiveVirtWho:
 
     @pytest.mark.pre_upgrade
     def test_pre_create_virt_who_configuration(
-        self, form_data, save_test_data, target_sat, function_entitlement_manifest
+        self, form_data, save_test_data, target_sat, module_sca_manifest_org
     ):
         """Create and deploy virt-who configuration.
 
@@ -69,57 +69,27 @@ class TestScenarioPositiveVirtWho:
             1. Config can be created and deployed by command.
             2. No error msg in /var/log/rhsm/rhsm.log.
             3. Report is sent to satellite.
-            4. Virtual sku can be generated and attached.
         """
-        org = target_sat.api.Organization(name=ORG_DATA['name']).create()
-        target_sat.api.Location(organization=[org]).create()
-        org.sca_disable()
-        target_sat.upload_manifest(org.id, function_entitlement_manifest.content)
-        form_data.update({'organization_id': org.id})
+        form_data.update({'organization_id': module_sca_manifest_org.id})
         vhd = target_sat.api.VirtWhoConfig(**form_data).create()
         assert vhd.status == 'unknown'
-        command = get_configure_command(vhd.id, org=org.name)
+        command = get_configure_command(vhd.id, org=module_sca_manifest_org.name)
         hypervisor_name, guest_name = deploy_configure_by_command(
-            command, form_data['hypervisor_type'], debug=True, org=org.label
+            command, form_data['hypervisor_type'], debug=True, org=module_sca_manifest_org.label
         )
         virt_who_instance = (
-            target_sat.api.VirtWhoConfig(organization_id=org.id)
+            target_sat.api.VirtWhoConfig(organization_id=module_sca_manifest_org.id)
             .search(query={'search': f'name={form_data["name"]}'})[0]
             .status
         )
         assert virt_who_instance == 'ok'
-        hosts = [
-            (hypervisor_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=NORMAL'),
-            (guest_name, f'product_id={settings.virtwho.sku.vdc_physical} and type=STACK_DERIVED'),
-        ]
-        for hostname, sku in hosts:
-            host = target_sat.cli.Host.list({'search': hostname})[0]
-            subscriptions = target_sat.cli.Subscription.list(
-                {'organization-id': org.id, 'search': sku}
-            )
-            vdc_id = subscriptions[0]['id']
-            if 'type=STACK_DERIVED' in sku:
-                for item in subscriptions:
-                    if hypervisor_name.lower() in item['type']:
-                        vdc_id = item['id']
-                        break
-            target_sat.api.HostSubscription(host=host['id']).add_subscriptions(
-                data={'subscriptions': [{'id': vdc_id, 'quantity': 'Automatic'}]}
-            )
-            result = (
-                target_sat.api.Host(organization=org.id)
-                .search(query={'search': hostname})[0]
-                .read_json()
-            )
-            assert result['subscription_status_label'] == 'Fully entitled'
-
         save_test_data(
             {
                 'hypervisor_name': hypervisor_name,
                 'guest_name': guest_name,
-                'org_id': org.id,
-                'org_name': org.name,
-                'org_label': org.label,
+                'org_id': module_sca_manifest_org.id,
+                'org_name': module_sca_manifest_org.name,
+                'org_label': module_sca_manifest_org.label,
                 'name': vhd.name,
             }
         )
@@ -174,7 +144,7 @@ class TestScenarioPositiveVirtWho:
                 .search(query={'search': hostname})[0]
                 .read_json()
             )
-            assert result['subscription_status_label'] == 'Fully entitled'
+            assert result['subscription_status_label'] == 'Simple Content Access'
 
         # Verify the virt-who config-file exists.
         config_file = get_configure_file(vhd.id)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14775

### Problem Statement
virt-who config SCA-compliant


### Solution
update the org to module_sca_manifest_org
remove virtual sku attache check step
update check status to "Simple Content Access"

Cases : PASS
```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/upgrades/test_virtwho.py  -m pre_upgrade --disable-pytest-warnings -q
.                                                                                                                                          [100%]
1 passed, 1 deselected, 3 warnings in 164.29s (0:02:44)
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/upgrades/test_virtwho.py  -m post_upgrade --disable-pytest-warnings -q.                                                                                                                                          [100%]
1 passed, 1 deselected, 3 warnings in 145.22s (0:02:25)

```
