### PR TITLE
Testing Upstream PRT DO NOT MERGE

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -132,3 +132,10 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
     )
     assert 'PASSED' in result.stdout
     assert result.status == 0
+
+
+def test_prt(target_sat):
+    result = target_sat.execute('rpm -q foreman')
+    assert 'pr10126' in result.stdout
+    result = target_sat.execute('rpm -q rubygem-katello')
+    assert 'pr10960' in result.stdout


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->