### PR TITLE
Remove the sub-man status

### DIFF
--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -291,8 +291,6 @@ def test_convert2rhel_oracle(module_target_sat, oracle, activation_key_rhel, ver
         or host_content['operatingsystem_name'].startswith(f'RedHat {version}')
         or host_content['operatingsystem_name'].startswith(f'RHEL {version}')
     )
-    assert host_content['subscription_status_label'] == 'Simple Content Access'
-    assert host_content['subscription_status'] == 5
 
 
 @pytest.mark.e2e
@@ -349,5 +347,3 @@ def test_convert2rhel_centos(module_target_sat, centos, activation_key_rhel, ver
         or host_content['operatingsystem_name'].startswith(f'RedHat {version}')
         or host_content['operatingsystem_name'].startswith(f'RHEL {version}')
     )
-    assert host_content['subscription_status_label'] == 'Simple Content Access'
-    assert host_content['subscription_status'] == 5

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -203,9 +203,9 @@ def test_positive_force_register_twice(module_ak_with_cv, module_org, rhel_conte
     assert f'The system has been registered with ID: {reg_id_new}' in str(result.stdout)
     assert reg_id_new != reg_id_old
     assert (
-        target_sat.cli.Host.info({'name': rhel_contenthost.hostname})['subscription-information'][
-            'uuid'
-        ]
+        target_sat.cli.Host.info({'name': rhel_contenthost.hostname}, output_format='json')[
+            'subscription-information'
+        ]['uuid']
         == reg_id_new
     )
 


### PR DESCRIPTION
### Problem Statement
We had subscription status code for 6.15 and older versions, with 6.16, SCA is enabled by default and subscription status code are no more valid. This PR removes the assertion to check the subscription code and subscription_status_label.

The second issue was with the registration test where I have updated the output format to json.

### Solution
Fixes the tests failing with the above issues.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->