### PR TITLE
Flip SyncPlan tests to SCA

### DIFF
--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -783,7 +783,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier4
 def test_positive_synchronize_rh_product_past_sync_date(
-    request, function_entitlement_manifest_org, target_sat
+    request, function_sca_manifest_org, target_sat
 ):
     """Create a sync plan with past datetime as a sync date, add a
     RH product and verify the product gets synchronized on the next sync
@@ -799,7 +799,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
     """
     interval = 60 * 60  # 'hourly' sync interval in seconds
     delay = 2 * 60
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
@@ -851,7 +851,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
 @pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_rh_product_future_sync_date(
-    request, function_entitlement_manifest_org, target_sat
+    request, function_sca_manifest_org, target_sat
 ):
     """Create a sync plan with sync date in a future and sync one RH
     product with it automatically.
@@ -861,7 +861,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
     :expectedresults: Product is synchronized successfully.
     """
     delay = 2 * 60  # delay for sync date in seconds
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -580,7 +580,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
 @pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_rh_product_past_sync_date(
-    target_sat, function_entitlement_manifest_org, request
+    target_sat, function_sca_manifest_org, request
 ):
     """Create a sync plan with past datetime as a sync date, add a
     RH product and verify the product gets synchronized on the next sync
@@ -594,7 +594,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
     """
     interval = 60 * 60  # 'hourly' sync interval in seconds
     delay = 2 * 60
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     target_sat.cli.RepositorySet.enable(
         {
             'name': REPOSET['rhva6'],
@@ -647,7 +647,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
 @pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_synchronize_rh_product_future_sync_date(
-    target_sat, function_entitlement_manifest_org, request
+    target_sat, function_sca_manifest_org, request
 ):
     """Create a sync plan with sync date in a future and sync one RH
     product with it automatically.
@@ -661,7 +661,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
     cron_multiple = 5  # sync event is on every multiple of this value, starting from 00 mins
     delay = (cron_multiple) * 60  # delay for sync date in seconds
     guardtime = 180  # do not start test less than 2 mins before the next sync event
-    org = function_entitlement_manifest_org
+    org = function_sca_manifest_org
     target_sat.cli.RepositorySet.enable(
         {
             'name': REPOSET['rhva6'],


### PR DESCRIPTION
### Problem Statement
Four SyncPlans tests are still using `entitlement` mode, which was deprecated and removed in 6.16. They need to be flipped to SCA mode.


### Solution
This PR.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_syncplan.py tests/foreman/cli/test_syncplan.py -k 'synchronize_rh_product_past_sync_date or synchronize_rh_product_future_sync_date'
