### PR TITLE
6.15.z Cherrypick Test_Fixes_and_SCA_enbaled_manifest 

### DIFF
--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -203,9 +203,9 @@ def test_positive_force_register_twice(module_ak_with_cv, module_org, rhel_conte
     assert f'The system has been registered with ID: {reg_id_new}' in str(result.stdout)
     assert reg_id_new != reg_id_old
     assert (
-        target_sat.cli.Host.info({'name': rhel_contenthost.hostname})['subscription-information'][
-            'uuid'
-        ]
+        target_sat.cli.Host.info({'name': rhel_contenthost.hostname}, output_format='json')[
+            'subscription-information'
+        ]['uuid']
         == reg_id_new
     )
 


### PR DESCRIPTION
### Problem Statement
Manual cherrypick of https://github.com/SatelliteQE/robottelo/pull/14783 

### Solution


### Related Issues

trigger: test-robottelo
pytest: tests/foreman/cli/test_registration.py -k 'test_positive_force_register_twice'
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->