### PR TITLE
Add proper teardown of VMware client

### DIFF
--- a/pytest_fixtures/component/provision_vmware.py
+++ b/pytest_fixtures/component/provision_vmware.py
@@ -1,5 +1,6 @@
 from fauxfactory import gen_string
 import pytest
+from wrapanapi import VMWareSystem
 
 from robottelo.config import settings
 
@@ -11,6 +12,17 @@ def vmware(request):
         'vmware8': settings.vmware.vcenter8,
     }
     return versions[getattr(request, 'param', 'vmware8')]
+
+
+@pytest.fixture
+def vmwareclient(vmware):
+    vmwareclient = VMWareSystem(
+        hostname=vmware.hostname,
+        username=settings.vmware.username,
+        password=settings.vmware.password,
+    )
+    yield vmwareclient
+    vmwareclient.disconnect()
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -13,7 +13,6 @@
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for
-from wrapanapi import VMWareSystem
 
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
@@ -93,6 +92,7 @@ def test_positive_provision_end_to_end(
     module_vmware_hostgroup,
     provision_method,
     vmware,
+    vmwareclient,
 ):
     """Provision a host on vmware compute resource with
     the help of hostgroup.
@@ -139,12 +139,7 @@ def test_positive_provision_end_to_end(
     hostname = f'{hostname}.{module_provisioning_sat.domain.name}'
     assert hostname == host['name']
     # check if vm is created on vmware
-    vmware = VMWareSystem(
-        hostname=vmware.hostname,
-        username=settings.vmware.username,
-        password=settings.vmware.password,
-    )
-    assert vmware.does_vm_exist(hostname) is True
+    assert vmwareclient.does_vm_exist(hostname) is True
     wait_for(
         lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
         != 'Pending installation',

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -16,7 +16,7 @@ from random import choice
 
 import pytest
 from wait_for import TimedOutError, wait_for
-from wrapanapi.systems.virtualcenter import VMWareSystem, vim
+from wrapanapi.systems.virtualcenter import vim
 
 from robottelo.config import settings
 from robottelo.constants import (
@@ -56,20 +56,18 @@ def _get_normalized_size(size):
     return f'{size} {suffixes[suffix_index]}'
 
 
-def _get_vmware_datastore_summary_string(data_store_name=settings.vmware.datastore, vmware=None):
+@pytest.fixture
+def get_vmware_datastore_summary_string(vmware, vmwareclient):
     """Return the datastore string summary for data_store_name
 
     For "Local-Ironforge" datastore the string looks Like:
 
         "Local-Ironforge (free: 1.66 TB, prov: 2.29 TB, total: 2.72 TB)"
     """
-    system = VMWareSystem(
-        hostname=vmware.hostname,
-        username=settings.vmware.username,
-        password=settings.vmware.password,
-    )
     data_store_summary = [
-        h for h in system.get_obj_list(vim.Datastore) if h.host and h.name == data_store_name
+        h
+        for h in vmwareclient.get_obj_list(vim.Datastore)
+        if h.host and h.name == settings.vmware.datastore
     ][0].summary
     uncommitted = data_store_summary.uncommitted or 0
     capacity = _get_normalized_size(data_store_summary.capacity)
@@ -77,7 +75,7 @@ def _get_vmware_datastore_summary_string(data_store_name=settings.vmware.datasto
     prov = _get_normalized_size(
         data_store_summary.capacity + uncommitted - data_store_summary.freeSpace
     )
-    return f'{data_store_name} (free: {free_space}, prov: {prov}, total: {capacity})'
+    return f'{settings.vmware.datastore} (free: {free_space}, prov: {prov}, total: {capacity})'
 
 
 @pytest.mark.e2e
@@ -295,7 +293,9 @@ def test_positive_resource_vm_power_management(session, vmware):
 @pytest.mark.upgrade
 @pytest.mark.tier2
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
-def test_positive_vmware_custom_profile_end_to_end(session, vmware, request, target_sat):
+def test_positive_vmware_custom_profile_end_to_end(
+    session, vmware, request, target_sat, get_vmware_datastore_summary_string
+):
     """Perform end to end testing for VMware compute profile.
 
     :id: 24f7bb5f-2aaf-48cb-9a56-d2d0713dfe3d
@@ -330,13 +330,12 @@ def test_positive_vmware_custom_profile_end_to_end(session, vmware, request, tar
     cdrom_drive = True
     disk_size = '10 GB'
     network = 'VLAN 1001'  # hardcoding network here as this test won't be doing actual provisioning
-    data_store_summary_string = _get_vmware_datastore_summary_string(vmware=vmware)
     storage_data = {
         'storage': {
             'controller': VMWARE_CONSTANTS['scsicontroller'],
             'disks': [
                 {
-                    'data_store': data_store_summary_string,
+                    'data_store': get_vmware_datastore_summary_string,
                     'size': disk_size,
                     'thin_provision': True,
                 }


### PR DESCRIPTION
### Problem Statement
There wasn't any proper teardown of vmwareclient. we see `DEBUG - vCenter keep-alive: 2024-04-14 07:51:45.515419+00:00`  in the logs

### Solution
Add a fixture which handles the proper teardown