### PR TITLE
Fix test_positive_clone_backup

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1739,8 +1739,8 @@ class Capsule(ContentHost, CapsuleMixins):
         self._cli._configured = True
         return self._cli
 
-    def install_satellite_or_capsule_package(self):
-        """Install Satellite/Capsule package.
+    def enable_satellite_or_capsule_module_for_rhel8(self):
+        """Enable Satellite/Capsule module for RHEL8.
         Note: Make sure required repos are enabled before using this.
         """
         if self.os_version.major == 8:
@@ -1750,6 +1750,12 @@ class Capsule(ContentHost, CapsuleMixins):
                 ).status
                 == 0
             )
+
+    def install_satellite_or_capsule_package(self):
+        """Install Satellite/Capsule package. Also handles module enablement for RHEL8.
+        Note: Make sure required repos are enabled before using this.
+        """
+        self.enable_satellite_or_capsule_module_for_rhel8()
         assert self.execute(f'dnf -y install {self.product_rpm_name}').status == 0
 
 

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -89,8 +89,8 @@ def test_positive_clone_backup(
     # Enabling repositories
     for repo in getattr(constants, f"OHSNAP_RHEL{rhel_version}_REPOS"):
         sat_ready_rhel.enable_repo(repo, force=True)
-    # Enabling satellite module
-    sat_ready_rhel.install_satellite_or_capsule_package()
+    # Enabling satellite module for RHEL8
+    sat_ready_rhel.enable_satellite_or_capsule_module_for_rhel8()
     # Install satellite-clone
     assert sat_ready_rhel.execute('yum install satellite-clone -y').status == 0
     # Disabling CDN repos as we install from dogfdood


### PR DESCRIPTION
### Problem Statement
- `test_positive_clone_backup` is failing with `Satellite is already installed. Satellite-clone should be run on a clean RHEL machine.` error.

### Solution
- Only enable the Satellite module but do not install the package.

### Related Issues
- SAT-24576


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->