### PR TITLE
[6.15.z] Remove broken cached parameter

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3798,7 +3798,7 @@ class TestContentView:
         password = gen_alphanumeric()
         no_rights_user = module_target_sat.cli_factory.user({'password': password})
         no_rights_user['password'] = password
-        org_id = module_target_sat.cli_factory.make_org(cached=True)['id']
+        org_id = module_target_sat.cli_factory.make_org()['id']
         for name in generate_strings_list(exclude_types=['cjk']):
             # test that user can't create
             with pytest.raises(CLIReturnCodeError):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14807

### Problem Statement

```
TypeError: create_object() got an unexpected keyword argument 'cached'
```

### Solution

remove `cached` parameter

### Related tests

```
tests/foreman/cli/test_contentview.py::TestContentView::test_negative_user_with_no_create_view_cv_permissions
```


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->