### PR TITLE
Fix test_content_guarded_distributions_option

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1555,7 +1555,7 @@ def test_content_guarded_distributions_option(
     )[0]
     rh_repo.sync()
     assert (
-        "403: [('PEM routines', 'get_name', 'no start line')]"
+        "403"
         in sat_non_default_install.execute(
             f'curl https://{sat_non_default_install.hostname}/pulp/content/{org.label}'
             f'/Library/content/dist/layered/rhel8/x86_64/ansible/2.9/os/'


### PR DESCRIPTION
### Problem Statement
- Fix `test_content_guarded_distributions_option` failing with `assert "403: [('PEM routines', 'get_name', 'no start line')]" in "403: [('PEM routines', '', 'no start line')]"` on RHEL9.

### Solution
- Update assertion to only check `403` error code

### Related Issues
- SAT-24616

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->