### PR TITLE
[6.15.z] Fix getting exit code on capsule tunnel error

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -288,10 +288,10 @@ class SystemInfo:
             post_ncat_procs = self.execute('pgrep ncat').stdout.splitlines()
             ncat_pid = set(post_ncat_procs).difference(set(pre_ncat_procs))
             if not len(ncat_pid):
-                stderr = channel.get_exit_status()[1]
-                logger.debug(f'Tunnel failed: {stderr}')
+                err = channel.get_exit_signal()
+                logger.debug(f'Tunnel failed: {err}')
                 # Something failed, so raise an exception.
-                raise CapsuleTunnelError(f'Starting ncat failed: {stderr}')
+                raise CapsuleTunnelError(f'Starting ncat failed: {err}')
             forward_url = f'https://{self.hostname}:{newport}'
             logger.debug(f'Yielding capsule forward port url: {forward_url}')
             try:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14821

### Problem Statement
There is a problem with capsule tunnel error handling. It throws `TypeError: 'int' object is not subscriptable`.  By checking [ssh2.channel.Channel.get_exit_status](https://ssh2-python.readthedocs.io/en/latest/channel.html#ssh2.channel.Channel.get_exit_status) documentation it is obvious that `channel.get_exit_status()[1]` could never work since it was added. 

### Solution
Replace `channel.get_exit_status()` by `channel.get_exit_signal()` which is way more verbose providing not only return code but also error message and exit signal.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->