### PR TITLE
[6.13.z] Add logging to Satellite-xdist worker assignment process

### DIFF
--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -1,4 +1,5 @@
 """Fixtures specific to or relating to pytest's xdist plugin"""
+
 import random
 
 from broker import Broker
@@ -31,9 +32,17 @@ def align_to_satellite(request, worker_id, satellite_factory):
 
         # attempt to add potential satellites from the broker inventory file
         if settings.server.inventory_filter:
+            logger.info(
+                f'{worker_id=}: Attempting to add Satellite hosts using inventory filter: '
+                f'{settings.server.inventory_filter}'
+            )
             hosts = Satellite.get_hosts_from_inventory(filter=settings.server.inventory_filter)
             settings.server.hostnames += [host.hostname for host in hosts]
 
+        logger.debug(
+            f'{worker_id=}: {settings.server.xdist_behavior=}, '
+            f'{settings.server.hostnames=}, {settings.server.auto_checkin=}'
+        )
         # attempt to align a worker to a satellite
         if settings.server.xdist_behavior == 'run-on-one' and settings.server.hostnames:
             settings.set("server.hostname", settings.server.hostnames[0])
@@ -48,14 +57,19 @@ def align_to_satellite(request, worker_id, satellite_factory):
                 settings.set("server.hostname", on_demand_sat.hostname)
             # if no satellite was received, fallback to balance
             if not settings.server.hostname:
+                logger.info(
+                    f'{worker_id=}: No Satellite hostnames were available, '
+                    'falling back to balance behavior'
+                )
                 settings.set("server.hostname", random.choice(settings.server.hostnames))
         if settings.server.hostname:
-            logger.info(
-                f'xdist worker {worker_id} was assigned hostname {settings.server.hostname}'
-            )
+            logger.info(f'{worker_id=}: Worker was assigned hostname {settings.server.hostname}')
             configure_airgun()
             configure_nailgun()
         yield
         if on_demand_sat and settings.server.auto_checkin:
+            logger.info(
+                f'{worker_id=}: Checking in on-demand Satellite ' f'{on_demand_sat.hostname}'
+            )
             on_demand_sat.teardown()
             Broker(hosts=[on_demand_sat]).checkin()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14539

### Problem Statement
There were situations in the past where I would be more than grateful for a context of what is happening in `align_to_satellite` fixture.

### Solution
This PR adds logging to the fixture. That should help during the log investigation.

### Related Issues
none

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->