### PR TITLE
6.15.z update scope of fixtures from hosts-content longrun test_inc_updates

### DIFF
--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -228,7 +228,7 @@ def test_positive_noapply_api(
 
 
 @pytest.mark.tier3
-def test_positive_incremental_update_time(module_target_sat, module_sca_manifest_org):
+def test_positive_incremental_update_time(target_sat, function_sca_manifest_org):
     """Incremental update should not take a long time.
 
     :id: a9cdcc58-2d10-42cf-8e24-f7bec3b79d6b
@@ -253,33 +253,31 @@ def test_positive_incremental_update_time(module_target_sat, module_sca_manifest
 
     """
     # create content view
-    cv = module_target_sat.cli_factory.make_content_view(
-        {'organization-id': module_sca_manifest_org.id}
-    )
+    cv = target_sat.cli_factory.make_content_view({'organization-id': function_sca_manifest_org.id})
     repo_sync_timestamp = (
         datetime.utcnow().replace(microsecond=0) - timedelta(seconds=1)
     ).strftime('%Y-%m-%d %H:%M')
     # setup rh repositories, add to cv, begin sync
     for _repo in ['rhel8_bos', 'rhst8', 'rhsclient8']:
-        rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
+        rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=DEFAULT_ARCHITECTURE,
-            org_id=module_sca_manifest_org.id,
+            org_id=function_sca_manifest_org.id,
             product=PRDS['rhel8'],
             repo=REPOS[_repo]['name'],
             reposet=REPOSET[_repo],
             releasever=REPOS[_repo]['releasever'],
         )
-        module_target_sat.cli.ContentView.add_repository(
+        target_sat.cli.ContentView.add_repository(
             {
                 'id': cv['id'],
-                'organization-id': module_sca_manifest_org.id,
+                'organization-id': function_sca_manifest_org.id,
                 'repository-id': rh_repo_id,
             }
         )
-        module_target_sat.api.Repository(id=rh_repo_id).sync(synchronous=False)
+        target_sat.api.Repository(id=rh_repo_id).sync(synchronous=False)
 
     # wait for all repo sync tasks
-    sync_tasks = module_target_sat.wait_for_tasks(
+    sync_tasks = target_sat.wait_for_tasks(
         search_query=(
             'label = Actions::Katello::Repository::Sync'
             f' and started_at >= "{repo_sync_timestamp}"'
@@ -289,14 +287,14 @@ def test_positive_incremental_update_time(module_target_sat, module_sca_manifest
     )
     assert all(task.poll()['result'] == 'success' for task in sync_tasks)
     # publish and fetch new CVV
-    module_target_sat.cli.ContentView.publish({'id': cv['id']})
-    content_view = module_target_sat.cli.ContentView.info({'id': cv['id']})
+    target_sat.cli.ContentView.publish({'id': cv['id']})
+    content_view = target_sat.cli.ContentView.info({'id': cv['id']})
     cvv = content_view['versions'][0]
 
     # update incremental version via hammer, using one errata.
     # expect: incr. "version-1.1" is created
     update_start_time = datetime.utcnow()
-    result = module_target_sat.cli.ContentView.version_incremental_update(
+    result = target_sat.cli.ContentView.version_incremental_update(
         {'content-view-version-id': cvv['id'], 'errata-ids': REAL_RHEL8_1_ERRATA_ID}
     )
     assert 'version-1.1' in str(result[0].keys())
@@ -307,7 +305,7 @@ def test_positive_incremental_update_time(module_target_sat, module_sca_manifest
     )
     # publish the full CV, containing the added version-1.1
     publish_start_time = datetime.utcnow()
-    result = module_target_sat.cli.ContentView.publish({'id': cv['id']})
+    result = target_sat.cli.ContentView.publish({'id': cv['id']})
     publish_duration = (datetime.utcnow() - publish_start_time).total_seconds()
     logger.info(f'Publish for CV id: {content_view["id"]}, took {publish_duration} seconds.')
     # Per BZs: expect update duration was quicker than publish duration,

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -55,9 +55,9 @@ def dev_lce(module_entitlement_manifest_org):
 
 
 @pytest.fixture(scope='module')
-def qe_lce(module_sca_manifest_org, dev_lce):
+def qe_lce(module_entitlement_manifest_org, dev_lce):
     return entities.LifecycleEnvironment(
-        name='QE', prior=dev_lce, organization=module_sca_manifest_org
+        name='QE', prior=dev_lce, organization=module_entitlement_manifest_org
     ).create()
 
 
@@ -228,7 +228,7 @@ def test_positive_noapply_api(
 
 
 @pytest.mark.tier3
-def test_positive_incremental_update_time(target_sat, function_sca_manifest_org):
+def test_positive_incremental_update_time(module_target_sat, module_entitlement_manifest_org):
     """Incremental update should not take a long time.
 
     :id: a9cdcc58-2d10-42cf-8e24-f7bec3b79d6b
@@ -253,31 +253,33 @@ def test_positive_incremental_update_time(target_sat, function_sca_manifest_org)
 
     """
     # create content view
-    cv = target_sat.cli_factory.make_content_view({'organization-id': function_sca_manifest_org.id})
+    cv = module_target_sat.cli_factory.make_content_view(
+        {'organization-id': module_entitlement_manifest_org.id}
+    )
     repo_sync_timestamp = (
         datetime.utcnow().replace(microsecond=0) - timedelta(seconds=1)
     ).strftime('%Y-%m-%d %H:%M')
     # setup rh repositories, add to cv, begin sync
     for _repo in ['rhel8_bos', 'rhst8', 'rhsclient8']:
-        rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
+        rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=DEFAULT_ARCHITECTURE,
-            org_id=function_sca_manifest_org.id,
+            org_id=module_entitlement_manifest_org.id,
             product=PRDS['rhel8'],
             repo=REPOS[_repo]['name'],
             reposet=REPOSET[_repo],
             releasever=REPOS[_repo]['releasever'],
         )
-        target_sat.cli.ContentView.add_repository(
+        module_target_sat.cli.ContentView.add_repository(
             {
                 'id': cv['id'],
-                'organization-id': function_sca_manifest_org.id,
+                'organization-id': module_entitlement_manifest_org.id,
                 'repository-id': rh_repo_id,
             }
         )
-        target_sat.api.Repository(id=rh_repo_id).sync(synchronous=False)
+        module_target_sat.api.Repository(id=rh_repo_id).sync(synchronous=False)
 
     # wait for all repo sync tasks
-    sync_tasks = target_sat.wait_for_tasks(
+    sync_tasks = module_target_sat.wait_for_tasks(
         search_query=(
             'label = Actions::Katello::Repository::Sync'
             f' and started_at >= "{repo_sync_timestamp}"'
@@ -287,14 +289,14 @@ def test_positive_incremental_update_time(target_sat, function_sca_manifest_org)
     )
     assert all(task.poll()['result'] == 'success' for task in sync_tasks)
     # publish and fetch new CVV
-    target_sat.cli.ContentView.publish({'id': cv['id']})
-    content_view = target_sat.cli.ContentView.info({'id': cv['id']})
+    module_target_sat.cli.ContentView.publish({'id': cv['id']})
+    content_view = module_target_sat.cli.ContentView.info({'id': cv['id']})
     cvv = content_view['versions'][0]
 
     # update incremental version via hammer, using one errata.
     # expect: incr. "version-1.1" is created
     update_start_time = datetime.utcnow()
-    result = target_sat.cli.ContentView.version_incremental_update(
+    result = module_target_sat.cli.ContentView.version_incremental_update(
         {'content-view-version-id': cvv['id'], 'errata-ids': REAL_RHEL8_1_ERRATA_ID}
     )
     assert 'version-1.1' in str(result[0].keys())
@@ -305,7 +307,7 @@ def test_positive_incremental_update_time(target_sat, function_sca_manifest_org)
     )
     # publish the full CV, containing the added version-1.1
     publish_start_time = datetime.utcnow()
-    result = target_sat.cli.ContentView.publish({'id': cv['id']})
+    result = module_target_sat.cli.ContentView.publish({'id': cv['id']})
     publish_duration = (datetime.utcnow() - publish_start_time).total_seconds()
     logger.info(f'Publish for CV id: {content_view["id"]}, took {publish_duration} seconds.')
     # Per BZs: expect update duration was quicker than publish duration,


### PR DESCRIPTION
### Problem Statement
`longrun/test_inc_updates.py` has 2 tests, module scope fixture creates one organization and same organization has been used in two test cases, after uploading manifest second time test was failing due to below error message

**test name:** test_positive_incremental_update_time
**Error:**
`['Owner has already imported from another subscription management application. The following conflicts were found: [ DISTRIBUTOR_CONFLICT ]']
`
### Solution
changed scope of fixture of one test case so it will not use previously created organization from same test session.


### Related Issues
6.14.z PR https://github.com/SatelliteQE/robottelo/pull/14842

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/longrun/test_inc_updates.py

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->