### PR TITLE
Extend search in *_default_os fixtures for EL9 as default OS

### DIFF
--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -17,7 +17,7 @@ def default_os(
     """
     os = getattr(request, 'param', None)
     if os is None:
-        search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
+        search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
     else:
         version = os.split(' ')[1].split('.')
         search_string = f'family="Redhat" AND major="{version[0]}" AND minor="{version[1]}"'

--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -2,6 +2,8 @@
 from nailgun import entities
 import pytest
 
+from robottelo import constants
+
 
 @pytest.fixture(scope='session')
 def default_os(
@@ -17,7 +19,7 @@ def default_os(
     """
     os = getattr(request, 'param', None)
     if os is None:
-        search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
+        search_string = constants.DEFAULT_OS_SEARCH_QUERY
     else:
         version = os.split(' ')[1].split('.')
         search_string = f'family="Redhat" AND major="{version[0]}" AND minor="{version[1]}"'

--- a/pytest_fixtures/component/provision_azure.py
+++ b/pytest_fixtures/component/provision_azure.py
@@ -11,6 +11,7 @@ from robottelo.constants import (
     AZURERM_RHEL7_FT_IMG_URN,
     AZURERM_RHEL7_UD_IMG_URN,
     DEFAULT_ARCHITECTURE,
+    DEFAULT_OS_SEARCH_QUERY,
 )
 
 
@@ -38,8 +39,9 @@ def sat_azure_domain(sat_azure, sat_azure_loc, sat_azure_org):
 @pytest.fixture(scope='module')
 def sat_azure_default_os(sat_azure):
     """Default OS on the Satellite"""
-    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
-    return sat_azure.api.OperatingSystem().search(query={'search': search_string})[0].read()
+    return (
+        sat_azure.api.OperatingSystem().search(query={'search': DEFAULT_OS_SEARCH_QUERY})[0].read()
+    )
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -9,6 +9,7 @@ from wrapanapi.systems.google import GoogleCloudSystem
 from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
+    DEFAULT_OS_SEARCH_QUERY,
     DEFAULT_PTABLE,
     FOREMAN_PROVIDERS,
     GCE_RHEL_CLOUD_PROJECTS,
@@ -41,8 +42,7 @@ def sat_gce_domain(sat_gce, sat_gce_loc, sat_gce_org):
 @pytest.fixture(scope='module')
 def sat_gce_default_os(sat_gce):
     """Default OS on the Satellite"""
-    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
-    return sat_gce.api.OperatingSystem().search(query={'search': search_string})[0].read()
+    return sat_gce.api.OperatingSystem().search(query={'search': DEFAULT_OS_SEARCH_QUERY})[0].read()
 
 
 @pytest.fixture(scope='session')
@@ -101,15 +101,6 @@ def gce_latest_rhel_uuid(googleclient):
 @pytest.fixture(scope='session')
 def gce_custom_cloudinit_uuid(googleclient, gce_cert):
     return googleclient.get_template('customcinit', project=gce_cert['project_id']).uuid
-
-
-@pytest.fixture(scope='session')
-def session_default_os(session_target_sat):
-    """Default OS on the Satellite"""
-    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
-    return (
-        session_target_sat.api.OperatingSystem().search(query={'search': search_string})[0].read()
-    )
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/provision_gce.py
+++ b/pytest_fixtures/component/provision_gce.py
@@ -106,7 +106,7 @@ def gce_custom_cloudinit_uuid(googleclient, gce_cert):
 @pytest.fixture(scope='session')
 def session_default_os(session_target_sat):
     """Default OS on the Satellite"""
-    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
+    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
     return (
         session_target_sat.api.OperatingSystem().search(query={'search': search_string})[0].read()
     )

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -1,7 +1,7 @@
 # Puppet Environment fixtures
 import pytest
 
-from robottelo.constants import ENVIRONMENT
+from robottelo import constants
 
 
 @pytest.fixture(scope='session')
@@ -119,10 +119,9 @@ def session_puppet_enabled_proxy(session_puppet_enabled_sat):
 @pytest.fixture(scope='session')
 def session_puppet_default_os(session_puppet_enabled_sat):
     """Default OS on the puppet-enabled Satellite"""
-    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
     return (
         session_puppet_enabled_sat.api.OperatingSystem()
-        .search(query={'search': search_string})[0]
+        .search(query={'search': constants.DEFAULT_OS_SEARCH_QUERY})[0]
         .read()
     )
 
@@ -141,9 +140,11 @@ def module_puppet_lce_library(session_puppet_enabled_sat, module_puppet_org):
     """Returns the Library lifecycle environment from chosen organization"""
     return (
         session_puppet_enabled_sat.api.LifecycleEnvironment()
-        .search(query={'search': f'name={ENVIRONMENT} and organization_id={module_puppet_org.id}'})[
-            0
-        ]
+        .search(
+            query={
+                'search': f'name={constants.ENVIRONMENT} and organization_id={module_puppet_org.id}'
+            }
+        )[0]
         .read()
     )
 

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -119,7 +119,7 @@ def session_puppet_enabled_proxy(session_puppet_enabled_sat):
 @pytest.fixture(scope='session')
 def session_puppet_default_os(session_puppet_enabled_sat):
     """Default OS on the puppet-enabled Satellite"""
-    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
+    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
     return (
         session_puppet_enabled_sat.api.OperatingSystem()
         .search(query={'search': search_string})[0]

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -680,6 +680,7 @@ DEFAULT_SUBSCRIPTION_NAME = 'Red Hat Enterprise Linux Server, Premium (Physical 
 DEFAULT_ARCHITECTURE = 'x86_64'
 DEFAULT_RELEASE_VERSION = '6Server'
 DEFAULT_ROLE = 'Default role'
+DEFAULT_OS_SEARCH_QUERY = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
 
 VDC_SUBSCRIPTION_NAME = 'Red Hat Enterprise Linux for Virtual Datacenters, Premium'
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -15,6 +15,7 @@ from requests import HTTPError
 from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
+    DEFAULT_OS_SEARCH_QUERY,
     DEFAULT_PTABLE,
     DEFAULT_PXE_TEMPLATE,
     DEFAULT_TEMPLATE,
@@ -336,7 +337,7 @@ class APIFactory:
         if os is None:
             os = (
                 self._satellite.api.OperatingSystem()
-                .search(query={'search': 'name="RedHat" AND (major="6" OR major="7")'})[0]
+                .search(query={'search': DEFAULT_OS_SEARCH_QUERY})[0]
                 .read()
             )
         else:

--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -31,6 +31,7 @@ from robottelo.constants import (
     CONTAINER_UPSTREAM_NAME,
     DEFAULT_ARCHITECTURE,
     DEFAULT_CV,
+    DEFAULT_OS_SEARCH_QUERY,
     DEFAULT_PTABLE,
     ENVIRONMENT,
     FAKE_0_CUSTOM_PACKAGE,
@@ -2675,9 +2676,7 @@ def test_positive_delete_with_kickstart_repo_and_host_group(
         .read()
     )
     # Get the OS ID
-    os = target_sat.api.OperatingSystem().search(
-        query={'search': 'name="RedHat" AND (major="6" OR major="7")'}
-    )[0]
+    os = target_sat.api.OperatingSystem().search(query={'search': DEFAULT_OS_SEARCH_QUERY})[0]
     # Update the OS to associate arch and ptable
     os.architecture = [arch]
     os.ptable = [ptable]


### PR DESCRIPTION
### Problem Statement
When EL9 is default OS for Foreman, *_default_os fixtures returns below error 
```
pytest_fixtures/component/os.py:24: in default_os
    os = entities.OperatingSystem().search(query={'search': search_string})[0].read()
E   IndexError: list index out of range
```
### Solution
Add  EL9 in search_string for *_default_os fixtures
Move default os search query to constants and delete unused session_default_os fixture (from review)

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->