### PR TITLE
Add coverage for clone from el8 to el9

### DIFF
--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -15,13 +15,18 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.hosts import Satellite
+from robottelo.hosts import Satellite, get_sat_rhel_version
 
 SSH_PASS = settings.server.ssh_password
 pytestmark = pytest.mark.destructive
 
 
 @pytest.mark.e2e
+@pytest.mark.parametrize(
+    "sat_ready_rhel",
+    [8, 9] if get_sat_rhel_version().major < 9 else [9],
+    indirect=True,
+)
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
 @pytest.mark.parametrize('skip_pulp', [False, True], ids=['include_pulp', 'skip_pulp'])
 def test_positive_clone_backup(


### PR DESCRIPTION
### Problem Statement
Stream/6.16 supports both el8 and el9 versions. We need to ensure that customers are able to upgrade underlying OS using `satellite-clone` tool

### Solution
If we are running for el8 then parametrize target `sat_ready_rhel`  to be both 8 and 9 extending matrix of testing datapoints. 

### Related Issues
SAT-24714

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->