### PR TITLE
[6.14.z] partition table fix

### DIFF
--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -53,7 +53,7 @@ class TestPartitionTable:
                     strict=True,
                 )
             )
-        )
+        ),
     )
     def test_positive_crud_with_name(self, name, new_name, module_target_sat):
         """Create, read, update and delete Partition Tables with different names
@@ -86,23 +86,9 @@ class TestPartitionTable:
         :CaseImportance: Critical
         """
         content = 'Fake ptable'
-        ptable = module_target_sat.cli_factory.make_partition_table({'content': content})
-        ptable_content = module_target_sat.cli.PartitionTable().dump({'id': ptable['id']})
-        assert content in ptable_content
-
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    def test_positive_create_with_content_length(self, module_target_sat):
-        """Create a Partition Table with content length more than 4096 chars
-
-        :id: 59e6f9ef-85c2-4229-8831-00edb41b19f4
-
-        :expectedresults: Partition Table is created and has correct content
-
-        :BZ: 1270181
-        """
-        content = gen_string('alpha', 5000)
-        ptable = module_target_sat.cli_factory.make_partition_table({'content': content})
+        filename = gen_string('alpha', 10)
+        module_target_sat.execute(f'echo {content} > {filename}')
+        ptable = module_target_sat.cli_factory.make_partition_table({'file': filename})
         ptable_content = module_target_sat.cli.PartitionTable().dump({'id': ptable['id']})
         assert content in ptable_content
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14808

### Problem Statement
in `hammer partition-table create` the  `--content` parameter is no longer around, one needs to supply file

### Solution
tests updated
