### PR TITLE
[6.15.z] Add proper teardown of VMware client

### DIFF
--- a/pytest_fixtures/component/provision_vmware.py
+++ b/pytest_fixtures/component/provision_vmware.py
@@ -1,5 +1,6 @@
 from fauxfactory import gen_string
 import pytest
+from wrapanapi import VMWareSystem
 
 from robottelo.config import settings
 
@@ -11,6 +12,17 @@ def vmware(request):
         'vmware8': settings.vmware.vcenter8,
     }
     return versions[getattr(request, 'param', 'vmware8')]
+
+
+@pytest.fixture
+def vmwareclient(vmware):
+    vmwareclient = VMWareSystem(
+        hostname=vmware.hostname,
+        username=settings.vmware.username,
+        password=settings.vmware.password,
+    )
+    yield vmwareclient
+    vmwareclient.disconnect()
 
 
 @pytest.fixture(scope='module')

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -13,7 +13,6 @@
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for
-from wrapanapi import VMWareSystem
 
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS
@@ -93,6 +92,7 @@ def test_positive_provision_end_to_end(
     module_vmware_hostgroup,
     provision_method,
     vmware,
+    vmwareclient,
 ):
     """Provision a host on vmware compute resource with
     the help of hostgroup.
@@ -139,12 +139,7 @@ def test_positive_provision_end_to_end(
     hostname = f'{hostname}.{module_provisioning_sat.domain.name}'
     assert hostname == host['name']
     # check if vm is created on vmware
-    vmware = VMWareSystem(
-        hostname=vmware.hostname,
-        username=settings.vmware.username,
-        password=settings.vmware.password,
-    )
-    assert vmware.does_vm_exist(hostname) is True
+    assert vmwareclient.does_vm_exist(hostname) is True
     wait_for(
         lambda: sat.cli.Host.info({'name': hostname})['status']['build-status']
         != 'Pending installation',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14799

### Problem Statement
There wasn't any proper teardown of vmwareclient. we see `DEBUG - vCenter keep-alive: 2024-04-14 07:51:45.515419+00:00`  in the logs

### Solution
Add a fixture which handles the proper teardown