### PR TITLE
os fixtures updated for rhel9

### DIFF
--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -17,7 +17,7 @@ def default_os(
     """
     os = getattr(request, 'param', None)
     if os is None:
-        search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
+        search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
     else:
         version = os.split(' ')[1].split('.')
         search_string = f'family="Redhat" AND major="{version[0]}" AND minor="{version[1]}"'

--- a/pytest_fixtures/component/puppet.py
+++ b/pytest_fixtures/component/puppet.py
@@ -119,7 +119,7 @@ def session_puppet_enabled_proxy(session_puppet_enabled_sat):
 @pytest.fixture(scope='session')
 def session_puppet_default_os(session_puppet_enabled_sat):
     """Default OS on the puppet-enabled Satellite"""
-    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
+    search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8" OR major="9")'
     return (
         session_puppet_enabled_sat.api.OperatingSystem()
         .search(query={'search': search_string})[0]


### PR DESCRIPTION
### Problem Statement
default os was not found on rhel9 backend sat

### Solution
extended search
