### PR TITLE
Update tests for satellite-maintain update command

### DIFF
--- a/robottelo/cli/sm_update.py
+++ b/robottelo/cli/sm_update.py
@@ -1,0 +1,36 @@
+"""
+Usage:
+    satellite-maintain update [OPTIONS] SUBCOMMAND [ARG] ...
+
+Parameters:
+    SUBCOMMAND    subcommand
+    [ARG] ...     subcommand arguments
+
+Subcommands:
+    check         Run pre-update checks before updating
+    run           Run an update
+
+Options:
+    -h, --help    print help
+"""
+from robottelo.cli.base import Base
+
+
+class Update(Base):
+    """Manipulates Satellite-maintain's update command"""
+
+    command_base = 'update'
+
+    @classmethod
+    def check(cls, options=None, env_var=None):
+        """Build satellite-maintain update check"""
+        cls.command_sub = 'check'
+        options = options or {}
+        return cls.sm_execute(cls._construct_command(options), env_var=env_var)
+
+    @classmethod
+    def run(cls, options=None, env_var=None):
+        """Build satellite-maintain update run"""
+        cls.command_sub = 'run'
+        options = options or {}
+        return cls.sm_execute(cls._construct_command(options), env_var=env_var)


### PR DESCRIPTION
### Problem Statement
https://github.com/theforeman/foreman_maintain/pull/802 introduces the `update` command which will replace z stream upgrades.

### Solution
Update robottelo tests that do a z stream upgrade.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/maintain/test_upgrade.py::test_negative_pre_update_tuning_profile_check tests/foreman/maintain/test_upgrade.py::test_positive_repositories_validate
theforeman:
    foreman_maintain: 802
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->