### PR TITLE
Preparations for ruff 0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ exclude = '''
 
 [tool.ruff]
 target-version = "py311"
+
+[tool.ruff.lint]
 fixable = ["ALL"]
 
 select = [
@@ -40,21 +42,21 @@ ignore = [
     "PT005", # pytest no underscrore prefix for return fixtures
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 force-sort-within-sections = true
 known-first-party = [
     "robottelo",
 ]
 combine-as-imports = true
 
-[tool.ruff.flake8-pytest-style]
+[tool.ruff.lint.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "single"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 20
 
 [tool.pytest.ini_options]

--- a/robottelo/exceptions.py
+++ b/robottelo/exceptions.py
@@ -107,9 +107,7 @@ class CLIBaseError(Exception):
 
     def __repr__(self):
         """Include class name status, stderr and msg to improve logging"""
-        return '{}(status={!r}, stderr={!r}, msg={!r}'.format(
-            type(self).__name__, self.status, self.stderr, self.msg
-        )
+        return f'{type(self).__name__}(status={self.status!r}, stderr={self.stderr!r}, msg={self.msg!r}'
 
 
 class CLIReturnCodeError(CLIBaseError):

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -56,9 +56,7 @@ def create_object(cli_object, options, values=None, credentials=None, timeout=No
     except CLIReturnCodeError as err:
         # If the object is not created, raise exception, stop the show.
         raise CLIFactoryError(
-            'Failed to create {} with data:\n{}\n{}'.format(
-                cli_object.__name__, pprint.pformat(options, indent=2), err.msg
-            )
+            f'Failed to create {cli_object.__name__} with data:\n{pprint.pformat(options, indent=2)}\n{err.msg}'
         ) from err
     # Sometimes we get a list with a dictionary and not a dictionary.
     if isinstance(result, list) and len(result) > 0:
@@ -999,9 +997,7 @@ class CLIFactory:
             missing_permissions = set(permission_names).difference(set(available_permission_names))
             if missing_permissions:
                 raise CLIFactoryError(
-                    'Permissions "{}" are not available in Resource "{}"'.format(
-                        list(missing_permissions), resource_type
-                    )
+                    f'Permissions "{list(missing_permissions)}" are not available in Resource "{resource_type}"'
                 )
             # Create the current resource type role permissions
             options = {'role-id': role_id}

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -932,11 +932,7 @@ class ContentHost(Host, ContentHostMixins):
         # ensure ssh directory exists
         self.execute(f'mkdir -p {ssh_path}')
         # append the key if doesn't exists
-        self.execute(
-            "grep -q '{key}' {dest} || echo '{key}' >> {dest}".format(
-                key=key_content, dest=auth_file
-            )
-        )
+        self.execute(f"grep -q '{key_content}' {auth_file} || echo '{key_content}' >> {auth_file}")
         # set proper permissions
         self.execute(f'chmod 700 {ssh_path}')
         self.execute(f'chmod 600 {auth_file}')

--- a/robottelo/utils/decorators/func_locker.py
+++ b/robottelo/utils/decorators/func_locker.py
@@ -240,9 +240,7 @@ def lock_function(
 
             with file_lock(lock_file_path, remove=False, timeout=timeout) as handler:
                 logger.info(
-                    'process id: {} lock function using file path: {}'.format(
-                        process_id, lock_file_path
-                    )
+                    f'process id: {process_id} lock function using file path: {lock_file_path}'
                 )
                 # write the process id that locked this function
                 _write_content(handler, process_id)
@@ -303,9 +301,7 @@ def locking_function(
 
     with file_lock(lock_file_path, remove=False, timeout=timeout) as handler:
         logger.info(
-            'process id: {} - lock function name:{}  - using file path: {}'.format(
-                process_id, function_name, lock_file_path
-            )
+            f'process id: {process_id} - lock function name:{function_name}  - using file path: {lock_file_path}'
         )
         # write the process id that locked this function
         _write_content(handler, process_id)

--- a/robottelo/utils/decorators/func_shared/shared.py
+++ b/robottelo/utils/decorators/func_shared/shared.py
@@ -271,9 +271,7 @@ class _SharedFunction:
             traceback_text = None
             try:
                 logger.info(
-                    'calling shared function: {} - retry index: {}'.format(
-                        self._function_key, retry_index
-                    )
+                    f'calling shared function: {self._function_key} - retry index: {retry_index}'
                 )
                 result = self._function(*self._function_args, **self._function_kwargs)
                 break
@@ -334,9 +332,7 @@ class _SharedFunction:
                 creation_datetime = datetime.datetime.utcnow().strftime(_DATETIME_FORMAT)
                 if exp:
                     error = str(exp) or 'error occurred'
-                    error_class_name = '{}.{}'.format(
-                        exp.__class__.__module__, exp.__class__.__name__
-                    )
+                    error_class_name = f'{exp.__class__.__module__}.{exp.__class__.__name__}'
                     value = dict(
                         state=_STATE_FAILED,
                         id=self.transaction,

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -99,18 +99,14 @@ def register_system(system, activation_key=None, org='Default_Organization', env
     runcmd('subscription-manager clean', system)
     runcmd('rpm -qa | grep katello-ca-consumer | xargs rpm -e |sort', system)
     runcmd(
-        'rpm -ihv http://{}/pub/katello-ca-consumer-latest.noarch.rpm'.format(
-            settings.server.hostname
-        ),
+        f'rpm -ihv http://{settings.server.hostname}/pub/katello-ca-consumer-latest.noarch.rpm',
         system,
     )
     cmd = f'subscription-manager register --org={org} --environment={env} '
     if activation_key is not None:
         cmd += f'--activationkey={activation_key}'
     else:
-        cmd += '--username={} --password={}'.format(
-            settings.server.admin_username, settings.server.admin_password
-        )
+        cmd += f'--username={settings.server.admin_username} --password={settings.server.admin_password}'
     ret, stdout = runcmd(cmd, system)
     if ret == 0 or "system has been registered" in stdout:
         return True
@@ -170,9 +166,7 @@ def get_configure_command(config_id, org=DEFAULT_ORG):
     :param str org: the satellite organization name.
     """
     username, password = Base._get_username_password()
-    return "hammer -u {} -p {} virt-who-config deploy --id {} --organization '{}' ".format(
-        username, password, config_id, org
-    )
+    return f"hammer -u {username} -p {password} virt-who-config deploy --id {config_id} --organization '{org}' "
 
 
 def get_configure_file(config_id):

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -181,6 +181,6 @@ def test_positive_add_event(session, module_org, module_target_sat):
         assert values['resource_type'] == 'KATELLO/CONTENT VIEW ENVIRONMENT'
         assert values['resource_name'] == f'{ENVIRONMENT}/{cv.name} / {cv.name}'
         assert len(values['action_summary']) == 1
-        assert values['action_summary'][0]['column0'] == 'Added {}/{} to {}'.format(
-            ENVIRONMENT, cv.name, cv.name
+        assert (
+            values['action_summary'][0]['column0'] == f'Added {ENVIRONMENT}/{cv.name} to {cv.name}'
         )

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -35,8 +35,8 @@ def test_positive_end_to_end(session, module_location, module_org, module_target
         session.computeprofile.create({'name': name})
 
         assert module_target_sat.api.ComputeProfile().search(query={'search': f'name={name}'}), (
-            'Compute profile {} expected to exist, but is not included in the search '
-            'results'.format(name)
+            f'Compute profile {name} expected to exist, but is not included in the search '
+            'results'
         )
         compute_resource_list = session.computeprofile.list_resources(name)
         assert f'{compute_resource.name} (Libvirt)' in [
@@ -46,13 +46,13 @@ def test_positive_end_to_end(session, module_location, module_org, module_target
         assert module_target_sat.api.ComputeProfile().search(
             query={'search': f'name={new_name}'}
         ), (
-            'Compute profile {} expected to exist, but is not included in the search '
-            'results'.format(new_name)
+            f'Compute profile {new_name} expected to exist, but is not included in the search '
+            'results'
         )
         session.computeprofile.delete(new_name)
         assert not module_target_sat.api.ComputeProfile().search(
             query={'search': f'name={new_name}'}
         ), (
-            'Compute profile {} expected to be deleted, but is included in the search '
-            'results'.format(new_name)
+            f'Compute profile {new_name} expected to be deleted, but is included in the search '
+            'results'
         )

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -159,9 +159,7 @@ def test_positive_task_status(session, target_sat):
         tasks = session.task.read_all()
         total_items = session.task.total_items()
         assert total_items == int(tasks['StoppedChart']['table'][1]['Total'])
-        task_name = "Synchronize repository '{}'; product '{}'; organization '{}'".format(
-            repo.name, product.name, org.name
-        )
+        task_name = f"Synchronize repository '{repo.name}'; product '{product.name}'; organization '{org.name}'"
         assert tasks['table'][0]['Action'] == task_name
         assert tasks['table'][0]['State'] == 'stopped'
         assert tasks['table'][0]['Result'] == 'warning'

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -756,8 +756,8 @@ def test_positive_install_modular_errata(
     """
     stream = "0"
     version = "20180704111719"
-    _module_install_command = 'dnf -y module install {}:{}:{}'.format(
-        constants.FAKE_4_CUSTOM_PACKAGE_NAME, stream, version
+    _module_install_command = (
+        f'dnf -y module install {constants.FAKE_4_CUSTOM_PACKAGE_NAME}:{stream}:{version}'
     )
     _run_remote_command_on_content_hosts(_module_install_command, vm_content_hosts_module_stream)
     _run_remote_command_on_content_hosts('dnf -y upload-profile', vm_content_hosts_module_stream)

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -583,8 +583,9 @@ def test_positive_upstream_with_credentials(session, module_prod):
         )
         assert session.repository.search(module_prod.name, repo_name)[0]['Name'] == repo_name
         repo_values = session.repository.read(module_prod.name, repo_name)
-        assert repo_values['repo_content']['upstream_authorization'] == '{} / {}'.format(
-            upstream_username, hidden_password
+        assert (
+            repo_values['repo_content']['upstream_authorization']
+            == f'{upstream_username} / {hidden_password}'
         )
         session.repository.update(
             module_prod.name,
@@ -596,8 +597,9 @@ def test_positive_upstream_with_credentials(session, module_prod):
             },
         )
         repo_values = session.repository.read(module_prod.name, repo_name)
-        assert repo_values['repo_content']['upstream_authorization'] == '{} / {}'.format(
-            new_upstream_username, hidden_password
+        assert (
+            repo_values['repo_content']['upstream_authorization']
+            == f'{new_upstream_username} / {hidden_password}'
         )
         session.repository.update(
             module_prod.name, repo_name, {'repo_content.upstream_authorization': {}}


### PR DESCRIPTION
### Problem Statement
#14781 attempts to update ruff to a newer version, but it fails because there are some fixes required before the bump can be made. Also, new version of ruff requires different paths in the config. 

### Solution
Fix linter failures, make sure that ruff 0.4.1 does not complain. Modify the config to silence ruff's warnings.

### Related Issues
none