### PR TITLE
[6.14.z] fixes in rex infrahost tests

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -501,12 +501,17 @@ class TestRexUsers:
     """Tests related to remote execution users"""
 
     @pytest.fixture(scope='class')
-    def class_rexmanager_user(self, module_org, class_target_sat):
+    def class_rexmanager_user(self, module_org, default_location, class_target_sat):
         """Creates a user with Remote Execution Manager role"""
         password = gen_string('alpha')
         rexmanager = gen_string('alpha')
         class_target_sat.cli_factory.user(
-            {'login': rexmanager, 'password': password, 'organization-ids': module_org.id}
+            {
+                'login': rexmanager,
+                'password': password,
+                'organization-ids': module_org.id,
+                'location-ids': default_location.id,
+            }
         )
         class_target_sat.cli.User.add_role(
             {'login': rexmanager, 'role': 'Remote Execution Manager'}
@@ -514,12 +519,17 @@ class TestRexUsers:
         return (rexmanager, password)
 
     @pytest.fixture(scope='class')
-    def class_rexinfra_user(self, module_org, class_target_sat):
+    def class_rexinfra_user(self, module_org, default_location, class_target_sat):
         """Creates a user with all Remote Execution related permissions"""
         password = gen_string('alpha')
         rexinfra = gen_string('alpha')
         class_target_sat.cli_factory.user(
-            {'login': rexinfra, 'password': password, 'organization-ids': module_org.id}
+            {
+                'login': rexinfra,
+                'password': password,
+                'organization-ids': module_org.id,
+                'location-ids': default_location.id,
+            }
         )
         role = class_target_sat.cli_factory.make_role({'organization-ids': module_org.id})
         invocation_permissions = [


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14874

### Problem Statement
location mismatch prevented users from finding the target hosts

