### PR TITLE
Lint: Black -> Ruff formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,12 @@ repos:
       exclude: tests/foreman/data/
     - id: check-yaml
     - id: debug-statements
-  - repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-    - id: black
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.0
+    rev: v0.4.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
   - repo: local
     hooks:
       - id: fix-uuids

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 """Global Configurations for py.test runner"""
+
 import pytest
 
 pytest_plugins = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@ The full set of configuration options is listed on the Sphinx website:
 http://sphinx-doc.org/config.html
 
 """
+
 import builtins
 import os
 import sys

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,12 @@
-[tool.black]
-line-length = 100
-skip-string-normalization = true
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | \.hg
-  | \.mypy_cache
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-)/
-'''
-
 [tool.ruff]
 target-version = "py311"
+# Allow lines to be as long as 100.
+line-length = 100
+exclude = [".git", ".hg", ".mypy_cache", ".venv", "_build", "buck-out", "build", "dist"]
+
+[tool.ruff.format]
+# Preserve quotes
+quote-style = "preserve"  # TODO: change to "single" when flake8-quotes is enabled
 
 [tool.ruff.lint]
 fixable = ["ALL"]

--- a/pytest_fixtures/component/virtwho_config.py
+++ b/pytest_fixtures/component/virtwho_config.py
@@ -24,11 +24,7 @@ def org_module(request, default_org, module_sca_manifest_org):
 
 @pytest.fixture
 def org_session(request, session, session_sca):
-    if 'sca' in request.module.__name__.split('.')[-1]:
-        org_session = session_sca
-    else:
-        org_session = session
-    return org_session
+    return session_sca if 'sca' in request.module.__name__.split('.')[-1] else session
 
 
 @pytest.fixture

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -4,6 +4,7 @@ This module is to define pytest functions for content hosts
 The functions in this module are read in the pytest_plugins/fixture_markers.py module
 All functions in this module will be treated as fixtures that apply the contenthost mark
 """
+
 from broker import Broker
 import pytest
 

--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -25,10 +25,7 @@ def align_to_satellite(request, worker_id, satellite_factory):
         settings.set("server.hostname", None)
         on_demand_sat = None
 
-        if worker_id in ['master', 'local']:
-            worker_pos = 0
-        else:
-            worker_pos = int(worker_id.replace('gw', ''))
+        worker_pos = 0 if worker_id in ["master", "local"] else int(worker_id.replace("gw", ""))
 
         # attempt to add potential satellites from the broker inventory file
         if settings.server.inventory_filter:

--- a/pytest_plugins/capsule_n-minus.py
+++ b/pytest_plugins/capsule_n-minus.py
@@ -19,7 +19,6 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(items, config):
-
     if not config.getoption('n_minus', False):
         return
 

--- a/pytest_plugins/requirements/req_updater.py
+++ b/pytest_plugins/requirements/req_updater.py
@@ -3,7 +3,6 @@ import subprocess
 
 
 class ReqUpdater:
-
     # Installed package name as key and its counterpart in requirements file as value
     package_deviates = {
         'Betelgeuse': 'betelgeuse',

--- a/pytest_plugins/requirements/update_requirements.py
+++ b/pytest_plugins/requirements/update_requirements.py
@@ -1,4 +1,5 @@
 """Plugin enables pytest to notify and update the requirements"""
+
 from .req_updater import ReqUpdater
 
 updater = ReqUpdater()

--- a/pytest_plugins/sanity_plugin.py
+++ b/pytest_plugins/sanity_plugin.py
@@ -1,4 +1,4 @@
-""" A sanity testing plugin to assist in executing robottelo tests as sanity tests smartly
+"""A sanity testing plugin to assist in executing robottelo tests as sanity tests smartly
 
 1. Make installer test to run first which should set the hostname and all other tests then
 should run after that

--- a/robottelo/cli/acs.py
+++ b/robottelo/cli/acs.py
@@ -21,6 +21,7 @@ Subcommands::
     update          Update an alternate content source.
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/activationkey.py
+++ b/robottelo/cli/activationkey.py
@@ -25,6 +25,7 @@ Subcommands::
     subscriptions                 List associated subscriptions
     update                        Update an activation key
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/admin.py
+++ b/robottelo/cli/admin.py
@@ -12,6 +12,7 @@ Subcommands:
 Options:
  -h, --help                    Print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/ansible.py
+++ b/robottelo/cli/ansible.py
@@ -8,6 +8,7 @@ Subcommands::
      roles                         Manage ansible roles
      variables                     Manage ansible variables
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/architecture.py
+++ b/robottelo/cli/architecture.py
@@ -18,6 +18,7 @@ Subcommands::
     remove_operatingsystem        Disassociate a resource
     update                        Update an architecture.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/arfreport.py
+++ b/robottelo/cli/arfreport.py
@@ -16,6 +16,7 @@ Subcommands::
      list                          List ARF reports
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/auth.py
+++ b/robottelo/cli/auth.py
@@ -11,6 +11,7 @@ Subcommands::
     logout                        Wipe your credentials
     status                        Information about current connections
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/base.py
+++ b/robottelo/cli/base.py
@@ -1,4 +1,5 @@
 """Generic base class for cli hammer commands."""
+
 import re
 
 from wait_for import wait_for

--- a/robottelo/cli/bootdisk.py
+++ b/robottelo/cli/bootdisk.py
@@ -14,6 +14,7 @@ Subcommands::
     host                          Download host image
     subnet                        Download subnet generic image
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/capsule.py
+++ b/robottelo/cli/capsule.py
@@ -19,6 +19,7 @@ Subcommands::
     refresh-features              Refresh capsule features
     update                        Update a capsule
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/computeprofile.py
+++ b/robottelo/cli/computeprofile.py
@@ -18,6 +18,7 @@ Options:
  -h, --help                    Print help
                       Update a compute resource.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/computeresource.py
+++ b/robottelo/cli/computeresource.py
@@ -17,6 +17,7 @@ Subcommands::
     list                          List all compute resources.
     update                        Update a compute resource.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/content_credentials.py
+++ b/robottelo/cli/content_credentials.py
@@ -16,6 +16,7 @@ Subcommands::
     list                          List content credentials
     update                        Update a content credential
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/content_export.py
+++ b/robottelo/cli/content_export.py
@@ -19,6 +19,7 @@ Subcommands::
     list                          View content view export histories
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/content_import.py
+++ b/robottelo/cli/content_import.py
@@ -16,6 +16,7 @@ Subcommands::
     version                       Imports a content archive to a content view version
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -33,6 +33,7 @@ Options::
 
     -h, --help                    print help
 """
+
 from robottelo.cli import hammer
 from robottelo.cli.base import Base, CLIError
 

--- a/robottelo/cli/defaults.py
+++ b/robottelo/cli/defaults.py
@@ -15,6 +15,7 @@ Subcommands::
     list                          List all the default parameters
     providers                     List all the providers
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/discoveredhost.py
+++ b/robottelo/cli/discoveredhost.py
@@ -19,6 +19,7 @@ Subcommands::
     reboot                        Reboot a host
     refresh-facts                 Refresh the facts of a host
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/discoveryrule.py
+++ b/robottelo/cli/discoveryrule.py
@@ -16,6 +16,7 @@ Subcommands::
     list                          List all discovery rules
     update                        Update a rule
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/docker.py
+++ b/robottelo/cli/docker.py
@@ -1,4 +1,5 @@
 """Docker related hammer commands"""
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/domain.py
+++ b/robottelo/cli/domain.py
@@ -18,6 +18,7 @@ Subcommands::
     set_parameter                 Create or update parameter for a domain.
     update                        Update a domain.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/environment.py
+++ b/robottelo/cli/environment.py
@@ -17,6 +17,7 @@ Subcommands::
     sc-params                     List all smart class parameters
     update                        Update an environment
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/erratum.py
+++ b/robottelo/cli/erratum.py
@@ -13,6 +13,7 @@ Subcommands::
  info                          Show an erratum
  list                          List errata
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/fact.py
+++ b/robottelo/cli/fact.py
@@ -12,6 +12,7 @@ Subcommands::
 
     list                          List all fact values.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/file.py
+++ b/robottelo/cli/file.py
@@ -13,6 +13,7 @@ Subcommands::
     info                          Show a file
     list                          List files
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/filter.py
+++ b/robottelo/cli/filter.py
@@ -17,6 +17,7 @@ Subcommands::
  list                          List all filters
  update                        Update a filter
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/globalparam.py
+++ b/robottelo/cli/globalparam.py
@@ -14,6 +14,7 @@ Subcommands::
     list                          List all common parameters.
     set                           Set a global parameter.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/gpgkey.py
+++ b/robottelo/cli/gpgkey.py
@@ -16,6 +16,7 @@ Subcommands::
     list                          List GPG Keys
     update                        Update a GPG Key
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -1,4 +1,5 @@
 """Helpers to interact with hammer command line utility."""
+
 import csv
 import json
 import re

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -39,6 +39,7 @@ Subcommands::
      update                        Update a host
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/host_registration.py
+++ b/robottelo/cli/host_registration.py
@@ -13,6 +13,7 @@ Options:
  -h, --help                    Print help
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/hostcollection.py
+++ b/robottelo/cli/hostcollection.py
@@ -23,6 +23,7 @@ Subcommands::
  remove-host                   Remove hosts from the host collection
  update                        Update a host collection
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/hostgroup.py
+++ b/robottelo/cli/hostgroup.py
@@ -22,6 +22,7 @@ Subcommands::
     set-parameter                 Create or update parameter for a hostgroup
     update                        Update a host group
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/http_proxy.py
+++ b/robottelo/cli/http_proxy.py
@@ -16,6 +16,7 @@ Subcommands:
 Options:
  -h, --help                    Print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/job_invocation.py
+++ b/robottelo/cli/job_invocation.py
@@ -15,6 +15,7 @@ Subcommands:
  rerun                         Rerun the job
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/job_template.py
+++ b/robottelo/cli/job_template.py
@@ -16,6 +16,7 @@ Subcommands:
      list           List job templates
      update         Update a job template
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/ldapauthsource.py
+++ b/robottelo/cli/ldapauthsource.py
@@ -15,6 +15,7 @@ Subcommands::
     list                          List all LDAP authentication sources
     update                        Update an LDAP authentication source
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/lifecycleenvironment.py
+++ b/robottelo/cli/lifecycleenvironment.py
@@ -16,6 +16,7 @@ Subcommands::
     delete                        Destroy an environment
     info                          Show an environment
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/location.py
+++ b/robottelo/cli/location.py
@@ -36,6 +36,7 @@ Subcommands::
     remove-user                   Disassociate an user
     update                        Update a location
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/medium.py
+++ b/robottelo/cli/medium.py
@@ -18,6 +18,7 @@ Subcommands::
     remove_operatingsystem        Disassociate a resource
     update                        Update a medium.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/model.py
+++ b/robottelo/cli/model.py
@@ -16,6 +16,7 @@ Subcommands::
     list                          List all models.
     update                        Update a model.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/module_stream.py
+++ b/robottelo/cli/module_stream.py
@@ -13,6 +13,7 @@ Subcommands::
     info                          Show a module-stream
     list                          List module-streams
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/operatingsys.py
+++ b/robottelo/cli/operatingsys.py
@@ -27,6 +27,7 @@ Subcommands::
                                   operating system.
     update                        Update an OS.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/org.py
+++ b/robottelo/cli/org.py
@@ -40,6 +40,7 @@ Subcommands::
                                     organization.
     update                        Update an organization
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/ostreebranch.py
+++ b/robottelo/cli/ostreebranch.py
@@ -14,6 +14,7 @@ Subcommands::
     list                          List ostree_branches
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/package.py
+++ b/robottelo/cli/package.py
@@ -13,6 +13,7 @@ Subcommands::
     info                          Show a package
     list                          List packages
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/partitiontable.py
+++ b/robottelo/cli/partitiontable.py
@@ -19,6 +19,7 @@ Subcommands::
     remove_operatingsystem        Disassociate a resource
     update                        Update a ptable.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/product.py
+++ b/robottelo/cli/product.py
@@ -20,6 +20,7 @@ Subcommands::
     update                        Update a product
     update-proxy                  Updates an HTTP Proxy for a product
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/proxy.py
+++ b/robottelo/cli/proxy.py
@@ -18,6 +18,7 @@ Subcommands::
     refresh-features              Refresh smart proxy features
     update                        Update a smart proxy.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/puppet.py
+++ b/robottelo/cli/puppet.py
@@ -14,6 +14,7 @@ Subcommands::
     list                          List all puppetclasses.
     sc-params                     List all smart class parameters
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/realm.py
+++ b/robottelo/cli/realm.py
@@ -16,6 +16,7 @@ Subcommands:
 Options:
  -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/recurring_logic.py
+++ b/robottelo/cli/recurring_logic.py
@@ -11,6 +11,7 @@ Subcommands:
  info                          Show recurring logic details
  list                          List recurring logics
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/report.py
+++ b/robottelo/cli/report.py
@@ -15,6 +15,7 @@ Subcommands::
     list                          List reports.
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/report_template.py
+++ b/robottelo/cli/report_template.py
@@ -21,6 +21,7 @@ Subcommands::
     schedule                      Schedule generating of a report
     update                        Update a report template
 """
+
 from os import chmod
 from tempfile import mkstemp
 

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -19,6 +19,7 @@ Subcommands::
     update                        Update a repository
     upload-content                Upload content into the repository
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/repository_set.py
+++ b/robottelo/cli/repository_set.py
@@ -19,6 +19,7 @@ Subcommands::
     info                          Show a repository
     list                          List of repositories
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/rex_feature.py
+++ b/robottelo/cli/rex_feature.py
@@ -15,6 +15,7 @@ Subcommands::
     update          Update a job template
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/role.py
+++ b/robottelo/cli/role.py
@@ -17,6 +17,7 @@ Subcommands::
     list                          List all roles.
     update                        Update an role.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/scap_policy.py
+++ b/robottelo/cli/scap_policy.py
@@ -16,6 +16,7 @@ Subcommands::
      list                          List Policies
      update                        Update a Policy
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/scap_tailoring_files.py
+++ b/robottelo/cli/scap_tailoring_files.py
@@ -17,6 +17,7 @@ Subcommands::
      list                          List Tailoring files
      update                        Update a Tailoring file
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/scapcontent.py
+++ b/robottelo/cli/scapcontent.py
@@ -16,6 +16,7 @@ Subcommands::
      list                          List SCAP contents
      update                        Update an SCAP content
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/scparams.py
+++ b/robottelo/cli/scparams.py
@@ -18,6 +18,7 @@ Subcommands::
                                   variable
     update                        Update a smart class parameter
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/settings.py
+++ b/robottelo/cli/settings.py
@@ -13,6 +13,7 @@ Subcommands::
     list                          List all settings
     set                           Update a setting
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/simple_content_access.py
+++ b/robottelo/cli/simple_content_access.py
@@ -16,6 +16,7 @@ Subcommands::
                                   Simple Content Access enabled
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_advanced.py
+++ b/robottelo/cli/sm_advanced.py
@@ -81,6 +81,7 @@ Subcommands:
 Options:
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_advanced_by_tag.py
+++ b/robottelo/cli/sm_advanced_by_tag.py
@@ -17,6 +17,7 @@ Subcommands:
 Options:
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_backup.py
+++ b/robottelo/cli/sm_backup.py
@@ -13,6 +13,7 @@ Subcommands:
 Options:
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_health.py
+++ b/robottelo/cli/sm_health.py
@@ -14,6 +14,7 @@ Subcommands:
 Options:
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_maintenance_mode.py
+++ b/robottelo/cli/sm_maintenance_mode.py
@@ -12,6 +12,7 @@ Subcommands:
 Options:
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_packages.py
+++ b/robottelo/cli/sm_packages.py
@@ -18,6 +18,7 @@ Subcommands:
 Options:
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_restore.py
+++ b/robottelo/cli/sm_restore.py
@@ -12,6 +12,7 @@ Options:
     -i, --incremental             Restore an incremental backup
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_service.py
+++ b/robottelo/cli/sm_service.py
@@ -18,6 +18,7 @@ Subcommands:
 Options:
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/sm_upgrade.py
+++ b/robottelo/cli/sm_upgrade.py
@@ -14,6 +14,7 @@ Subcommands:
 Options:
     -h, --help                    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/srpm.py
+++ b/robottelo/cli/srpm.py
@@ -10,6 +10,7 @@ Subcommands:
  info                          Show a SRPM Details
  list                          List srpms
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/subnet.py
+++ b/robottelo/cli/subnet.py
@@ -17,6 +17,7 @@ Subcommands::
     update                        Update a subnet
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/subscription.py
+++ b/robottelo/cli/subscription.py
@@ -18,6 +18,7 @@ Subcommands::
     upload                        Upload a subscription manifest
 
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/syncplan.py
+++ b/robottelo/cli/syncplan.py
@@ -16,6 +16,7 @@ Subcommands::
     list                          List sync plans
     update
 """
+
 from robottelo.cli.base import Base
 from robottelo.exceptions import CLIError
 

--- a/robottelo/cli/task.py
+++ b/robottelo/cli/task.py
@@ -14,6 +14,7 @@ Subcommands::
     progress                      Show the progress of the task
     resume                        Resume all tasks paused in error state
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/template.py
+++ b/robottelo/cli/template.py
@@ -20,6 +20,7 @@ Subcommands::
     remove-operatingsystem        Disassociate an operating system
     update                        Update a provisioning template
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/template_input.py
+++ b/robottelo/cli/template_input.py
@@ -15,6 +15,7 @@ Subcommands::
     info                          Show template input details
     list                          List template inputs
 """
+
 from robottelo.cli.base import Base, CLIError
 
 

--- a/robottelo/cli/template_sync.py
+++ b/robottelo/cli/template_sync.py
@@ -39,6 +39,7 @@ Options::
     prefix                        The string all imported templates should begin with.
     repo                          Override the default repo from settings.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/user.py
+++ b/robottelo/cli/user.py
@@ -20,6 +20,7 @@ Subcommands::
     ssh-keys                      Managing User SSH Keys.
     update                        Update an user.
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/usergroup.py
+++ b/robottelo/cli/usergroup.py
@@ -20,6 +20,7 @@ Subcommands::
     remove-user-group             Disassociate an user group
     update                        Update a user group
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/virt_who_config.py
+++ b/robottelo/cli/virt_who_config.py
@@ -19,6 +19,7 @@ Subcommands::
     list                          List of virt-who configurations
     update                        Update a virt-who configuration
 """
+
 from robottelo.cli.base import Base
 
 

--- a/robottelo/cli/webhook.py
+++ b/robottelo/cli/webhook.py
@@ -13,12 +13,12 @@ Subcommands:
 Options:
  -h, --help                    Print help
 """
+
 from robottelo.cli.base import Base, CLIError
 from robottelo.constants import WEBHOOK_EVENTS, WEBHOOK_METHODS
 
 
 class Webhook(Base):
-
     command_base = 'webhook'
 
     @classmethod

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1,4 +1,5 @@
 """Defines various constants"""
+
 from pathlib import Path
 
 from box import Box
@@ -2078,6 +2079,7 @@ DNF_RECOMMENDATION = (
 )
 
 EXPIRED_MANIFEST = 'expired-manifest.zip'
+
 
 # Data File Paths
 class DataFile(Box):

--- a/robottelo/content_info.py
+++ b/robottelo/content_info.py
@@ -1,4 +1,5 @@
 """Miscellaneous content helper functions"""
+
 import os
 import re
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -2,6 +2,7 @@
 It is not meant to be used directly, but as part of a robottelo.hosts.Satellite instance
 example: my_satellite.api_factory.api_method()
 """
+
 from contextlib import contextmanager
 from datetime import datetime
 import time

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -3,6 +3,7 @@ This module is a more object oriented replacement for robottelo.cli.factory
 It is not meant to be used directly, but as part of a robottelo.hosts.Satellite instance
 example: my_satellite.cli_factory.make_org()
 """
+
 import datetime
 from functools import lru_cache, partial
 import inspect

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -1,4 +1,5 @@
 """A collection of mixins for robottelo.hosts classes"""
+
 from functools import cached_property
 import json
 from tempfile import NamedTemporaryFile

--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -2,6 +2,7 @@
 All the Repository classes in this module are supposed to use from sat_object.cli_factory object.
 The direct import of the repo classes in this module is prohibited !!!!!
 """
+
 import inspect
 import sys
 
@@ -509,7 +510,6 @@ class RepositoryCollection:
     satellite = None
 
     def __init__(self, distro=None, repositories=None):
-
         self._items = []
 
         if distro is not None and distro not in constants.DISTROS_SUPPORTED:

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -308,7 +308,7 @@ class SystemInfo:
     ):
         """Checks the existence of certain files in a pulp dir"""
         extension_query = ' -o '.join([f'-name "{file}"' for file in file_names])
-        result = self.execute(fr'find {dir_path}{org.name} -type f \( {extension_query} \)')
+        result = self.execute(rf'find {dir_path}{org.name} -type f \( {extension_query} \)')
         return result.stdout
 
 

--- a/robottelo/host_helpers/ui_factory.py
+++ b/robottelo/host_helpers/ui_factory.py
@@ -3,6 +3,7 @@ It is not meant to be used directly, but as part of a robottelo.hosts.Satellite 
 Need to pass the existing session object to the ui_factory method as a parameter
 example: my_satellite.ui_factory(session).ui_method()
 """
+
 from fauxfactory import gen_string
 
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -63,7 +63,7 @@ from robottelo.utils.installer import InstallerCommand
 POWER_OPERATIONS = {
     VmState.RUNNING: 'running',
     VmState.STOPPED: 'stopped',
-    'reboot': 'reboot'
+    'reboot': 'reboot',
     # TODO paused, suspended, shelved?
 }
 
@@ -837,10 +837,7 @@ class ContentHost(Host, ContentHostMixins):
             registration.
         """
 
-        if username and password:
-            userpass = f' --username {username} --password {password}'
-        else:
-            userpass = ''
+        userpass = f' --username {username} --password {password}' if username and password else ''
         # Setup the base command
         cmd = 'subscription-manager register'
         if org:

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -1,4 +1,5 @@
 """Utility module to handle the shared ssh connection."""
+
 from robottelo.cli import hammer
 
 

--- a/robottelo/utils/datafactory.py
+++ b/robottelo/utils/datafactory.py
@@ -1,4 +1,5 @@
 """Data Factory for all entities"""
+
 from functools import wraps
 import random
 import string

--- a/robottelo/utils/decorators/__init__.py
+++ b/robottelo/utils/decorators/__init__.py
@@ -1,4 +1,5 @@
 """Implements various decorators"""
+
 from functools import wraps
 
 OBJECT_CACHE = {}

--- a/robottelo/utils/decorators/func_locker.py
+++ b/robottelo/utils/decorators/func_locker.py
@@ -39,6 +39,7 @@ Usage::
             with locking_function(self.test_to_lock):
                 # do some operations that conflict with test_to_lock
 """
+
 from contextlib import contextmanager
 import functools
 import inspect
@@ -223,7 +224,6 @@ def lock_function(
     class_name = '.'.join(class_names)
 
     def main_wrapper(func):
-
         func.__class_name__ = class_name
         func.__function_locked__ = True
 

--- a/robottelo/utils/decorators/func_shared/file_storage.py
+++ b/robottelo/utils/decorators/func_shared/file_storage.py
@@ -45,7 +45,6 @@ class FileStorageHandler(BaseStorageHandler):
     """Key value file storage handler."""
 
     def __init__(self, root_dir=None, create=True, lock_timeout=LOCK_TIMEOUT):
-
         if root_dir is None:
             root_dir = _get_root_dir()
 

--- a/robottelo/utils/decorators/func_shared/redis_storage.py
+++ b/robottelo/utils/decorators/func_shared/redis_storage.py
@@ -23,7 +23,6 @@ class RedisStorageHandler(BaseStorageHandler):
         password=REDIS_PASSWORD,
         lock_timeout=LOCK_TIMEOUT,
     ):
-
         self._lock_timeout = lock_timeout
         self._client = redis.StrictRedis(host=host, port=port, db=db, password=password)
 

--- a/robottelo/utils/decorators/func_shared/shared.py
+++ b/robottelo/utils/decorators/func_shared/shared.py
@@ -84,6 +84,7 @@ Usage::
 
             return dict(org=cls.org, repo=cls.repo}
 """
+
 import datetime
 import functools
 import hashlib
@@ -213,7 +214,6 @@ class _SharedFunction:
         inject=False,
         injected_kw='_inject',
     ):
-
         if storage_handler is None:
             storage_handler = _get_default_storage_handler()
 
@@ -258,7 +258,6 @@ class _SharedFunction:
         return kwargs
 
     def _call_function(self):
-
         retries = self._max_retries
         if not retries:
             retries = 1
@@ -465,11 +464,7 @@ def _get_function_name_key(function_name, scope=None, scope_kwargs=None, scope_c
     scope_name = _get_scope_name(
         scope=scope, scope_kwargs=scope_kwargs, scope_context=scope_context
     )
-    if scope_name:
-        function_name_key = '.'.join([scope_name, function_name])
-    else:
-        function_name_key = function_name
-    return function_name_key
+    return '.'.join([scope_name, function_name]) if scope_name else function_name
 
 
 def shared(

--- a/robottelo/utils/manifest.py
+++ b/robottelo/utils/manifest.py
@@ -69,9 +69,9 @@ class ManifestCloner:
                     consumer_data['uuid'] = str(uuid.uuid1())
                     if org_environment_access:
                         consumer_data['contentAccessMode'] = 'org_environment'
-                        consumer_data['owner'][
-                            'contentAccessModeList'
-                        ] = 'entitlement,org_environment'
+                        consumer_data['owner']['contentAccessModeList'] = (
+                            'entitlement,org_environment'
+                        )
                     new_consumer_export_zip.writestr(name, json.dumps(consumer_data))
                 else:
                     new_consumer_export_zip.writestr(name, consumer_export_zip.read(name))

--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -1,4 +1,5 @@
 """Utility module to communicate with Ohsnap API"""
+
 from box import Box
 from packaging.version import Version
 import requests

--- a/robottelo/utils/shared_resource.py
+++ b/robottelo/utils/shared_resource.py
@@ -21,6 +21,7 @@ Example:
     ...     yield target_sat  # give the upgraded satellite to the test
     ...     # Do post-upgrade cleanup steps if any
 """
+
 import json
 from pathlib import Path
 import time

--- a/robottelo/utils/ssh.py
+++ b/robottelo/utils/ssh.py
@@ -1,4 +1,5 @@
 """Utility module to handle the shared ssh connection."""
+
 from robottelo.cli import hammer
 
 

--- a/robottelo/utils/vault.py
+++ b/robottelo/utils/vault.py
@@ -1,4 +1,5 @@
 """Hashicorp Vault Utils where vault CLI is wrapped to perform vault operations"""
+
 import json
 import os
 import re

--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -1,4 +1,5 @@
 """Utility module to handle the virtwho configure UI/CLI/API testing"""
+
 import json
 import re
 import uuid

--- a/scripts/config_helpers.py
+++ b/scripts/config_helpers.py
@@ -1,4 +1,5 @@
 """A series of commands to help with robottelo configuration"""
+
 from pathlib import Path
 
 import click

--- a/scripts/graph_entities.py
+++ b/scripts/graph_entities.py
@@ -7,6 +7,7 @@ this script and generate an image all in one go, use the ``graph-entities``
 command provided by the make file in the parent directory.
 
 """
+
 import inspect
 
 from nailgun import entities, entity_mixins

--- a/scripts/hammer_command_tree.py
+++ b/scripts/hammer_command_tree.py
@@ -2,6 +2,7 @@
 help.
 
 """
+
 import json
 
 from robottelo import ssh

--- a/scripts/token_editor.py
+++ b/scripts/token_editor.py
@@ -4,6 +4,7 @@
 Reads Python test modules under test/foreman and edit docstring tokens' prefix
 from ``OLD_TOKEN_PREFIX`` to ``NEW_TOKEN_PREFIX``.
 """
+
 import glob
 import os
 import re
@@ -30,6 +31,6 @@ test_modules = glob.glob(os.path.join(ROOT_PATH, 'tests', 'foreman', '*', 'test_
 for test_module in test_modules:
     with open(test_module) as handler:
         content = handler.read()
-    content = TOKEN_RE.sub(fr'{NEW_TOKEN_PREFIX}\1:', content)
+    content = TOKEN_RE.sub(rf'{NEW_TOKEN_PREFIX}\1:', content)
     with open(test_module, 'w') as handler:
         handler.write(content)

--- a/scripts/tokenize_customer_scenario.py
+++ b/scripts/tokenize_customer_scenario.py
@@ -13,6 +13,7 @@ But in this script we are doing programatically and interactivelly in Python
 On robottelo root dir run:
 $ python scripts/tokenize_customer_scenario.py
 """
+
 import codemod
 from codemod import Query, regex_suggestor, run_interactive
 from codemod.helpers import path_filter

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -1,4 +1,5 @@
 """Usage: python scripts/validate_config.py"""
+
 from dynaconf.validator import ValidationError
 
 from robottelo.config import get_settings

--- a/tests/foreman/api/test_acs.py
+++ b/tests/foreman/api/test_acs.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -12,6 +12,7 @@
 
 
 """
+
 import http
 
 from fauxfactory import gen_integer, gen_string

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for

--- a/tests/foreman/api/test_architecture.py
+++ b/tests/foreman/api/test_architecture.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_choice
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_audit.py
+++ b/tests/foreman/api/test_audit.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.utils.datafactory import gen_string

--- a/tests/foreman/api/test_bookmarks.py
+++ b/tests/foreman/api/test_bookmarks.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_string

--- a/tests/foreman/api/test_capsule.py
+++ b/tests/foreman/api/test_capsule.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from fauxfactory import gen_string, gen_url
 import pytest
 from requests import HTTPError

--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -11,6 +11,7 @@
 :Team: Rocket
 
 """
+
 import json
 from random import choice
 

--- a/tests/foreman/api/test_computeprofile.py
+++ b/tests/foreman/api/test_computeprofile.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 from requests.exceptions import HTTPError
 

--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -14,6 +14,7 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_string

--- a/tests/foreman/api/test_computeresource_libvirt.py
+++ b/tests/foreman/api/test_computeresource_libvirt.py
@@ -15,6 +15,7 @@ http://www.katello.org/docs/api/apidoc/compute_resources.html
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_contentcredentials.py
+++ b/tests/foreman/api/test_contentcredentials.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from copy import copy
 
 from fauxfactory import gen_string

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 import random
 

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -15,6 +15,7 @@ http://www.katello.org/docs/api/apidoc/content_view_filters.html
 :CaseImportance: High
 
 """
+
 import http
 from random import randint
 

--- a/tests/foreman/api/test_contentviewversion.py
+++ b/tests/foreman/api/test_contentviewversion.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -11,6 +11,7 @@
 :Team: Rocket
 
 """
+
 import pytest
 import requests
 

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -9,6 +9,7 @@
 :CaseAutomation: Automated
 
 """
+
 import re
 
 from fauxfactory import gen_choice, gen_ipaddr, gen_mac, gen_string

--- a/tests/foreman/api/test_discoveryrule.py
+++ b/tests/foreman/api/test_discoveryrule.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_choice, gen_integer, gen_string
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -7,6 +7,7 @@
 :CaseImportance: High
 
 """
+
 from random import choice, randint, shuffle
 
 from fauxfactory import gen_string, gen_url

--- a/tests/foreman/api/test_environment.py
+++ b/tests/foreman/api/test_environment.py
@@ -15,6 +15,7 @@ http://theforeman.org/api/apidoc/v2/environments.html
 :CaseImportance: Critical
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -123,7 +123,7 @@ def _validate_errata_counts(host, errata_type, expected_value, timeout=120):
         sleep(5)
     else:
         pytest.fail(
-            'Host {} contains {} {} errata, but expected to contain ' '{} of them'.format(
+            'Host {} contains {} {} errata, but expected to contain {} of them'.format(
                 host.name,
                 host.content_facet_attributes['errata_counts'][errata_type],
                 errata_type,
@@ -149,7 +149,7 @@ def _fetch_available_errata(host, expected_amount=None, timeout=120):
         errata = host.errata()
     else:
         pytest.fail(
-            'Host {} contains {} available errata, but expected to ' 'contain {} of them'.format(
+            'Host {} contains {} available errata, but expected to contain {} of them'.format(
                 host.name,
                 len(errata['results']),
                 expected_amount if not None else 'No expected_amount provided',

--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 # For ease of use hc refers to host-collection throughout this document
 from time import sleep, time
 
@@ -122,8 +123,7 @@ def _validate_errata_counts(host, errata_type, expected_value, timeout=120):
         sleep(5)
     else:
         pytest.fail(
-            'Host {} contains {} {} errata, but expected to contain '
-            '{} of them'.format(
+            'Host {} contains {} {} errata, but expected to contain ' '{} of them'.format(
                 host.name,
                 host.content_facet_attributes['errata_counts'][errata_type],
                 errata_type,
@@ -149,8 +149,7 @@ def _fetch_available_errata(host, expected_amount=None, timeout=120):
         errata = host.errata()
     else:
         pytest.fail(
-            'Host {} contains {} available errata, but expected to '
-            'contain {} of them'.format(
+            'Host {} contains {} available errata, but expected to ' 'contain {} of them'.format(
                 host.name,
                 len(errata['results']),
                 expected_amount if not None else 'No expected_amount provided',
@@ -400,7 +399,7 @@ def package_applicability_changed_as_expected(
         output = host.execute(f'rpm -q {package_basename}').stdout
         current_package = output[:-1]
         assert package_basename in current_package
-        if current_package == package_filename:
+        if current_package == package_filename:  # noqa: SIM108
             # we have already checked if applicable package count changed,
             # in case the same version as prior was installed and present.
             prior_package = None  # package must not have been present before this modification
@@ -495,13 +494,16 @@ def _publish_and_wait(sat, org, cv, search_rate=1, max_tries=10):
     task_id = sat.api.ContentView(id=cv.id).publish({'id': cv.id, 'organization': org})['id']
     assert task_id, f'No task was invoked to publish the Content-View: {cv.id}.'
     # Should take < 1 minute, check in 5s intervals
-    sat.wait_for_tasks(
-        search_query=(f'label = Actions::Katello::ContentView::Publish and id = {task_id}'),
-        search_rate=search_rate,
-        max_tries=max_tries,
-    ), (
-        f'Failed to publish the Content-View: {cv.id}, in time.'
-        f'Task: {task_id} failed, or timed out ({search_rate*max_tries}s).'
+    (
+        sat.wait_for_tasks(
+            search_query=(f'label = Actions::Katello::ContentView::Publish and id = {task_id}'),
+            search_rate=search_rate,
+            max_tries=max_tries,
+        ),
+        (
+            f'Failed to publish the Content-View: {cv.id}, in time.'
+            f'Task: {task_id} failed, or timed out ({search_rate*max_tries}s).'
+        ),
     )
 
 
@@ -623,13 +625,16 @@ def test_positive_install_in_hc(
             'organization_id': module_sca_manifest_org.id,
         },
     )['id']
-    target_sat.wait_for_tasks(
-        search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
-        search_rate=15,
-        max_tries=10,
-    ), (
-        f'Could not install erratum: {CUSTOM_REPO_ERRATA_ID}, to Host-Collection.'
-        f' Task: {task_id} failed, or timed out.'
+    (
+        target_sat.wait_for_tasks(
+            search_query=(f'label = Actions::RemoteExecution::RunHostsJob and id = {task_id}'),
+            search_rate=15,
+            max_tries=10,
+        ),
+        (
+            f'Could not install erratum: {CUSTOM_REPO_ERRATA_ID}, to Host-Collection.'
+            f' Task: {task_id} failed, or timed out.'
+        ),
     )
     for client in content_hosts:
         # No applicable errata after install on all clients
@@ -928,8 +933,8 @@ def test_positive_install_multiple_in_host(
         f' but installed {len(updated_packages)}.'
     )
     # Check sets of installed package filename(s) strings, matches expected
-    assert set(updated_packages) == set(
-        security_packages_to_install
+    assert (
+        set(updated_packages) == set(security_packages_to_install)
     ), 'Expected package version filename(s) and installed package version filenam(s) are not the same.'
 
 

--- a/tests/foreman/api/test_filter.py
+++ b/tests/foreman/api/test_filter.py
@@ -15,6 +15,7 @@ http://theforeman.org/api/apidoc/v2/filters.html
 :CaseImportance: High
 
 """
+
 import pytest
 from requests.exceptions import HTTPError
 

--- a/tests/foreman/api/test_foremantask.py
+++ b/tests/foreman/api/test_foremantask.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 from requests.exceptions import HTTPError
 

--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -15,6 +15,7 @@ http://theforeman.org/api/apidoc/v2/hosts.html
 :CaseImportance: High
 
 """
+
 import http
 
 from fauxfactory import gen_choice, gen_integer, gen_ipaddr, gen_mac, gen_string

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from random import choice, randint
 
 from broker import Broker

--- a/tests/foreman/api/test_hostgroup.py
+++ b/tests/foreman/api/test_hostgroup.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from random import randint
 
 from fauxfactory import gen_string

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -11,6 +11,7 @@
 :CaseAutomation: Automated
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/api/test_ldapauthsource.py
+++ b/tests/foreman/api/test_ldapauthsource.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 from requests.exceptions import HTTPError
 

--- a/tests/foreman/api/test_lifecycleenvironment.py
+++ b/tests/foreman/api/test_lifecycleenvironment.py
@@ -15,6 +15,7 @@ http://www.katello.org/docs/api/apidoc/lifecycle_environments.html
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_location.py
+++ b/tests/foreman/api/test_location.py
@@ -14,6 +14,7 @@ http://theforeman.org/api/apidoc/v2/locations.html
 :CaseImportance: High
 
 """
+
 from random import randint
 
 from fauxfactory import gen_integer, gen_string

--- a/tests/foreman/api/test_media.py
+++ b/tests/foreman/api/test_media.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_string, gen_url
@@ -38,7 +39,7 @@ class TestMedia:
         ('name', 'new_name'),
         **parametrized(
             list(zip(valid_data_list().values(), valid_data_list().values(), strict=True))
-        )
+        ),
     )
     def test_positive_crud_with_name(self, module_org, name, new_name, module_target_sat):
         """Create, update, delete media with valid name only

--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import http
 
 from nailgun import client, entities, entity_fields

--- a/tests/foreman/api/test_notifications.py
+++ b/tests/foreman/api/test_notifications.py
@@ -239,8 +239,8 @@ def long_running_task(target_sat):
         f"SET start_at = {sql_date_2_days_ago}, "
         f" started_at = {sql_date_2_days_ago}, "
         f" state_updated_at = {sql_date_2_days_ago} "
-        f"WHERE id='{job['task']['id']}';\nEOF\n\" "
-    )
+        f"WHERE id=\'{job['task']['id']}\';\nEOF\n\" "
+    )  # fmt: skip  # skip formatting to avoid breaking the SQL query
     assert 'UPDATE 1' in result.stdout, f'Failed to age task {job["task"]["id"]}: {result.stderr}'
 
     yield job

--- a/tests/foreman/api/test_notifications.py
+++ b/tests/foreman/api/test_notifications.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from mailbox import mbox
 from re import findall
 from tempfile import mkstemp
@@ -231,14 +232,14 @@ def long_running_task(target_sat):
             'password': settings.server.ssh_password,
         },
     )
-    sql_date_2_days_ago = "now() - INTERVAL \'2 days\'"
+    sql_date_2_days_ago = "now() - INTERVAL '2 days'"
     result = target_sat.execute(
         "su - postgres -c \"psql foreman postgres <<EOF\n"
         "UPDATE foreman_tasks_tasks "
         f"SET start_at = {sql_date_2_days_ago}, "
         f" started_at = {sql_date_2_days_ago}, "
         f" state_updated_at = {sql_date_2_days_ago} "
-        f"WHERE id=\'{job['task']['id']}\';\nEOF\n\" "
+        f"WHERE id='{job['task']['id']}';\nEOF\n\" "
     )
     assert 'UPDATE 1' in result.stdout, f'Failed to age task {job["task"]["id"]}: {result.stderr}'
 

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from http.client import NOT_FOUND
 import random
 

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -14,6 +14,7 @@ http://<satellite-host>/apidoc/v2/organizations.html
 :CaseImportance: High
 
 """
+
 import http
 import json
 from random import randint

--- a/tests/foreman/api/test_oscap_tailoringfiles.py
+++ b/tests/foreman/api/test_oscap_tailoringfiles.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.utils.datafactory import gen_string

--- a/tests/foreman/api/test_oscappolicy.py
+++ b/tests/foreman/api/test_oscappolicy.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/api/test_parameters.py
+++ b/tests/foreman/api/test_parameters.py
@@ -10,6 +10,7 @@
 
 :CaseImportance: Critical
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/api/test_partitiontable.py
+++ b/tests/foreman/api/test_partitiontable.py
@@ -15,6 +15,7 @@ http://theforeman.org/api/apidoc/v2/ptables.html
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_integer, gen_string

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -15,6 +15,7 @@ http://<satellite-host>/apidoc/v2/permissions.html
 :CaseImportance: High
 
 """
+
 from itertools import chain
 import json
 import re

--- a/tests/foreman/api/test_ping.py
+++ b/tests/foreman/api/test_ping.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 
 pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -14,6 +14,7 @@ http://<sat6>/apidoc/v2/products.html
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from requests.exceptions import HTTPError

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import re
 
 from fauxfactory import gen_string

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -11,6 +11,7 @@
 :CaseImportance: Medium
 
 """
+
 from fauxfactory import gen_string
 from packaging.version import Version
 import pytest

--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -14,6 +14,7 @@ http://theforeman.org/api/apidoc/v2/provisioning_templates.html
 :CaseImportance: High
 
 """
+
 from random import choice
 
 from fauxfactory import gen_choice, gen_integer, gen_mac, gen_string

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -11,6 +11,7 @@
 :Team: Rocket
 
 """
+
 import uuid
 
 from fauxfactory import gen_ipaddr, gen_mac, gen_string

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import re
 
 from broker import Broker

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from manifester import Manifester
 from nailgun.entity_mixins import call_entity_method_with_timeout
 import pytest

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import re
 from string import punctuation
 import tempfile
@@ -1759,7 +1760,7 @@ class TestDockerRepository:
         :BZ: 1475121, 1580510
 
         """
-        msg = "404, message=\'Not Found\'"
+        msg = "404, message='Not Found'"
         with pytest.raises(TaskFailedError, match=msg):
             repo.sync()
 

--- a/tests/foreman/api/test_repository_set.py
+++ b/tests/foreman/api/test_repository_set.py
@@ -14,6 +14,7 @@ https://theforeman.org/plugins/katello/3.16/api/apidoc/v2/repository_sets.html
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import PRDS, REPOSET

--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_alphanumeric, gen_string
 import pytest
 

--- a/tests/foreman/api/test_rhsm.py
+++ b/tests/foreman/api/test_rhsm.py
@@ -15,6 +15,7 @@ No API doc exists for the subscription manager path(s). However, bugzilla bug
 :CaseImportance: High
 
 """
+
 import http
 
 from nailgun import client

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -15,6 +15,7 @@ http://theforeman.org/api/apidoc/v2/roles.html
 :CaseImportance: High
 
 """
+
 from nailgun.config import ServerConfig
 import pytest
 from requests.exceptions import HTTPError
@@ -183,7 +184,7 @@ class TestCannedRole:
             ldap_user_passwd=ad_data['ldap_user_passwd'],
             authsource=target_sat.api.AuthSourceLDAP(
                 onthefly_register=True,
-                account=fr"{ad_data['workgroup']}\{ad_data['ldap_user_name']}",
+                account=rf"{ad_data['workgroup']}\{ad_data['ldap_user_name']}",
                 account_password=ad_data['ldap_user_passwd'],
                 base_dn=ad_data['base_dn'],
                 groups_base=ad_data['group_base_dn'],

--- a/tests/foreman/api/test_settings.py
+++ b/tests/foreman/api/test_settings.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 import pytest

--- a/tests/foreman/api/test_subnet.py
+++ b/tests/foreman/api/test_subnet.py
@@ -16,6 +16,7 @@ http://theforeman.org/api/apidoc/v2/1.15.html
 :CaseImportance: High
 
 """
+
 import re
 
 import pytest

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -15,6 +15,7 @@ https://<sat6.com>/apidoc/v2/subscriptions.html
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 from nailgun.config import ServerConfig
 from nailgun.entity_mixins import TaskFailedError

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -15,6 +15,7 @@ API reference for sync plans can be found on your Satellite:
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 from time import sleep
 

--- a/tests/foreman/api/test_template_combination.py
+++ b/tests/foreman/api/test_template_combination.py
@@ -9,6 +9,7 @@
 :Team: Rocket
 
 """
+
 import pytest
 from requests.exceptions import HTTPError
 

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -9,6 +9,7 @@
 :Team: Endeavour
 
 """
+
 import base64
 import json
 import time

--- a/tests/foreman/api/test_user.py
+++ b/tests/foreman/api/test_user.py
@@ -15,6 +15,7 @@ http://<satellite-host>/apidoc/v2/users.html
 :CaseImportance: High
 
 """
+
 import json
 import re
 
@@ -667,7 +668,7 @@ class TestActiveDirectoryUser:
             ldap_user_passwd=ad_data['ldap_user_passwd'],
             authsource=module_target_sat.api.AuthSourceLDAP(
                 onthefly_register=True,
-                account=fr"{ad_data['workgroup']}\{ad_data['ldap_user_name']}",
+                account=rf"{ad_data['workgroup']}\{ad_data['ldap_user_name']}",
                 account_password=ad_data['ldap_user_passwd'],
                 base_dn=ad_data['base_dn'],
                 groups_base=ad_data['group_base_dn'],

--- a/tests/foreman/api/test_usergroup.py
+++ b/tests/foreman/api/test_usergroup.py
@@ -14,6 +14,7 @@ https://theforeman.org/api/2.0/apidoc/v2/usergroups.html
 :CaseImportance: High
 
 """
+
 from random import randint
 
 from fauxfactory import gen_string

--- a/tests/foreman/api/test_webhook.py
+++ b/tests/foreman/api/test_webhook.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import re
 
 import pytest

--- a/tests/foreman/cli/test_abrt.py
+++ b/tests/foreman/cli/test_abrt.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 pytestmark = [pytest.mark.stubbed]

--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_alphanumeric
 import pytest
 

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from random import choice
 import re
 

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -8,6 +8,7 @@
 
 :CaseImportance: High
 """
+
 from time import sleep
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_architecture.py
+++ b/tests/foreman/cli/test_architecture.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_choice
 import pytest
 

--- a/tests/foreman/cli/test_auth.py
+++ b/tests/foreman/cli/test_auth.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from time import sleep
 
 from fauxfactory import gen_string
@@ -29,9 +30,7 @@ def configure_sessions(satellite, enable=True, add_default_creds=False):
     """Enables the `use_sessions` option in hammer config"""
     result = satellite.execute(
         '''sed -i -e '/username/d;/password/d;/use_sessions/d' {0};\
-        echo '  :use_sessions: {1}' >> {0}'''.format(
-            HAMMER_CONFIG, 'true' if enable else 'false'
-        )
+        echo '  :use_sessions: {1}' >> {0}'''.format(HAMMER_CONFIG, 'true' if enable else 'false')
     )
     if result.status == 0 and add_default_creds:
         result = satellite.execute(

--- a/tests/foreman/cli/test_bootdisk.py
+++ b/tests/foreman/cli/test_bootdisk.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_mac, gen_string
 import pytest
 

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 
 pytestmark = [pytest.mark.run_in_one_thread]

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/cli/test_classparameters.py
+++ b/tests/foreman/cli/test_classparameters.py
@@ -11,6 +11,7 @@
 :Team: Rocket
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 
@@ -343,8 +344,9 @@ class TestAzureRMFinishTemplateProvisioning:
         Provisions the host on AzureRM using Finish template
         Later in tests this host will be used to perform assertions
         """
-        with sat_azure.hammer_api_timeout(), sat_azure.skip_yum_update_during_provisioning(
-            template='Kickstart default finish'
+        with (
+            sat_azure.hammer_api_timeout(),
+            sat_azure.skip_yum_update_during_provisioning(template='Kickstart default finish'),
         ):
             host = sat_azure.cli.Host.create(
                 {
@@ -472,8 +474,9 @@ class TestAzureRMUserDataProvisioning:
         Provisions the host on AzureRM using UserData template
         Later in tests this host will be used to perform assertions
         """
-        with sat_azure.hammer_api_timeout(), sat_azure.skip_yum_update_during_provisioning(
-            template='Kickstart default user data'
+        with (
+            sat_azure.hammer_api_timeout(),
+            sat_azure.skip_yum_update_during_provisioning(template='Kickstart default user data'),
         ):
             host = sat_azure.cli.Host.create(
                 {

--- a/tests/foreman/cli/test_computeresource_ec2.py
+++ b/tests/foreman/cli/test_computeresource_ec2.py
@@ -8,6 +8,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -28,6 +28,7 @@ Subcommands::
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_string, gen_url

--- a/tests/foreman/cli/test_computeresource_osp.py
+++ b/tests/foreman/cli/test_computeresource_osp.py
@@ -10,6 +10,7 @@
 :CaseImportance: High
 
 """
+
 from box import Box
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -10,6 +10,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -10,6 +10,7 @@
 :CaseAutomation: Automated
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -9,6 +9,7 @@
 :CaseComponent: ContainerManagement-Content
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 import time
 
 from nailgun import entities

--- a/tests/foreman/cli/test_contentcredentials.py
+++ b/tests/foreman/cli/test_contentcredentials.py
@@ -13,6 +13,7 @@ Satellite 6.8
 :CaseImportance: High
 
 """
+
 from tempfile import mkstemp
 
 from fauxfactory import gen_alphanumeric, gen_choice, gen_integer, gen_string

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_alphanumeric, gen_string

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -9,6 +9,7 @@
 :Team: Rocket
 
 """
+
 import pytest
 from wait_for import wait_for
 

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from functools import partial
 import random
 

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -7,6 +7,7 @@
 :CaseImportance: High
 
 """
+
 from random import choice, randint
 
 from fauxfactory import gen_string, gen_url

--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/cli/test_environment.py
+++ b/tests/foreman/cli/test_environment.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from random import choice
 
 from fauxfactory import gen_alphanumeric, gen_string

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -10,6 +10,7 @@
 
 :CaseImportance: High
 """
+
 from datetime import date, datetime, timedelta
 from operator import itemgetter
 import re

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/cli/test_filter.py
+++ b/tests/foreman/cli/test_filter.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.exceptions import CLIReturnCodeError

--- a/tests/foreman/cli/test_foremantask.py
+++ b/tests/foreman/cli/test_foremantask.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/foreman/cli/test_globalparam.py
+++ b/tests/foreman/cli/test_globalparam.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from functools import partial
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_hammer.py
+++ b/tests/foreman/cli/test_hammer.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import io
 import json
 import re

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from random import choice
 import re
 

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from broker import Broker
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_integer
 from nailgun import entities
 import pytest

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -11,6 +11,7 @@
 :CaseAutomation: Automated
 
 """
+
 from fauxfactory import gen_integer, gen_string, gen_url
 import pytest
 

--- a/tests/foreman/cli/test_installer.py
+++ b/tests/foreman/cli/test_installer.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 pytestmark = [pytest.mark.stubbed]

--- a/tests/foreman/cli/test_jobtemplate.py
+++ b/tests/foreman/cli/test_jobtemplate.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 from nailgun import entities
 import pytest
@@ -113,7 +114,7 @@ class TestADAuthSource:
                 'attr-firstname': LDAP_ATTR['firstname'],
                 'attr-lastname': LDAP_ATTR['surname'],
                 'attr-mail': LDAP_ATTR['mail'],
-                'account': fr"{ad_data['workgroup']}\{ad_data['ldap_user_name']}",
+                'account': rf"{ad_data['workgroup']}\{ad_data['ldap_user_name']}",
                 'account-password': ad_data['ldap_user_passwd'],
                 'base-dn': ad_data['base_dn'],
             }

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -11,6 +11,7 @@
 :CaseAutomation: Automated
 
 """
+
 from broker import Broker
 import pytest
 

--- a/tests/foreman/cli/test_lifecycleenvironment.py
+++ b/tests/foreman/cli/test_lifecycleenvironment.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from math import ceil
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_location.py
+++ b/tests/foreman/cli/test_location.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/cli/test_logging.py
+++ b/tests/foreman/cli/test_logging.py
@@ -11,6 +11,7 @@
 :CaseImportance: Medium
 
 """
+
 import re
 
 from fauxfactory import gen_string
@@ -242,7 +243,7 @@ def test_positive_logging_from_pulp3(module_org, target_sat):
     target_sat.cli.Repository.synchronize({'id': repo['id']})
     # Get the id of repository sync from task
     task_out = target_sat.execute(
-        "hammer task list | grep -F \'Synchronize repository {\"text\"=>\"repository\'"
+        "hammer task list | grep -F 'Synchronize repository {\"text\"=>\"repository'"
     ).stdout.splitlines()[0][:8]
     prod_log_out = target_sat.execute(f'grep  {task_out} {source_log}').stdout.splitlines()[0]
     # Get correlation id of pulp from production logs

--- a/tests/foreman/cli/test_medium.py
+++ b/tests/foreman/cli/test_medium.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_alphanumeric
 import pytest
 

--- a/tests/foreman/cli/test_model.py
+++ b/tests/foreman/cli/test_model.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 
@@ -37,7 +38,7 @@ class TestModel:
         ('name', 'new_name'),
         **parametrized(
             list(zip(valid_data_list().values(), valid_data_list().values(), strict=True))
-        )
+        ),
     )
     def test_positive_crud_with_name(self, name, new_name, module_target_sat):
         """Successfully creates, updates and deletes a Model.

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_alphanumeric, gen_string
 import pytest
 

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -11,6 +11,7 @@
 :CaseAutomation: Automated
 
 """
+
 from fauxfactory import gen_string
 from nailgun import entities
 import pytest

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -11,6 +11,7 @@
 :CaseAutomation: Automated
 
 """
+
 from fauxfactory import gen_string
 import pytest
 
@@ -185,7 +186,6 @@ class TestTailoringFiles:
     @pytest.mark.skip_if_open("BZ:1857572")
     @pytest.mark.tier2
     def test_positive_download_tailoring_file(self, tailoring_file_path, target_sat):
-
         """Download the tailoring file from satellite
 
         :id: 75d8c810-19a7-4285-bc3a-a1fb1a0e9088

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from nailgun import entities

--- a/tests/foreman/cli/test_partitiontable.py
+++ b/tests/foreman/cli/test_partitiontable.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from random import randint
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 
 pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_alphanumeric, gen_integer, gen_string, gen_url
 import pytest
 

--- a/tests/foreman/cli/test_provisioning.py
+++ b/tests/foreman/cli/test_provisioning.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 
 

--- a/tests/foreman/cli/test_provisioningtemplate.py
+++ b/tests/foreman/cli/test_provisioningtemplate.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 from random import randint
 

--- a/tests/foreman/cli/test_puppetclass.py
+++ b/tests/foreman/cli/test_puppetclass.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/cli/test_realm.py
+++ b/tests/foreman/cli/test_realm.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -11,6 +11,7 @@
 :Team: Rocket
 
 """
+
 import json
 import re
 from tempfile import mkstemp

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from calendar import monthrange
 from datetime import datetime, timedelta
 import random

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import random
 
 import pytest

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -10,6 +10,7 @@
 :CaseImportance: High
 
 """
+
 from broker import Broker
 from fauxfactory import gen_alpha
 import pytest

--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 from requests.exceptions import HTTPError
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from random import choice
 from string import punctuation
 

--- a/tests/foreman/cli/test_repository_set.py
+++ b/tests/foreman/cli/test_repository_set.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import PRDS, REPOSET

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime
 import time
 

--- a/tests/foreman/cli/test_role.py
+++ b/tests/foreman/cli/test_role.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from math import ceil
 from random import choice
 import re

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import os
 from time import sleep
 

--- a/tests/foreman/cli/test_settings.py
+++ b/tests/foreman/cli/test_settings.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 from time import sleep
 

--- a/tests/foreman/cli/test_sso.py
+++ b/tests/foreman/cli/test_sso.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 pytestmark = [pytest.mark.stubbed, pytest.mark.upgrade]

--- a/tests/foreman/cli/test_subnet.py
+++ b/tests/foreman/cli/test_subnet.py
@@ -11,6 +11,7 @@
 :CaseImportance: Medium
 
 """
+
 import random
 import re
 

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 from manifester import Manifester
 from nailgun import entities

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 from time import sleep
 

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -9,6 +9,7 @@
 :Team: Endeavour
 
 """
+
 import base64
 
 from fauxfactory import gen_string

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -17,6 +17,7 @@ When testing email validation [1] and [2] should be taken into consideration.
 :CaseImportance: High
 
 """
+
 import datetime
 import random
 from time import sleep

--- a/tests/foreman/cli/test_usergroup.py
+++ b/tests/foreman/cli/test_usergroup.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 import pytest

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from broker import Broker
 import pytest
 

--- a/tests/foreman/cli/test_webhook.py
+++ b/tests/foreman/cli/test_webhook.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from functools import partial
 from random import choice
 

--- a/tests/foreman/destructive/test_ansible.py
+++ b/tests/foreman/destructive/test_ansible.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 pytestmark = [pytest.mark.destructive, pytest.mark.upgrade]

--- a/tests/foreman/destructive/test_auth.py
+++ b/tests/foreman/destructive/test_auth.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/destructive/test_capsule.py
+++ b/tests/foreman/destructive/test_capsule.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 from wrapanapi import VmState
 

--- a/tests/foreman/destructive/test_capsulecontent.py
+++ b/tests/foreman/destructive/test_capsulecontent.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from box import Box
 from fauxfactory import gen_alpha
 import pytest

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo import constants

--- a/tests/foreman/destructive/test_contenthost.py
+++ b/tests/foreman/destructive/test_contenthost.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/destructive/test_contentview.py
+++ b/tests/foreman/destructive/test_contentview.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 from time import sleep
 

--- a/tests/foreman/destructive/test_discoveredhost.py
+++ b/tests/foreman/destructive/test_discoveredhost.py
@@ -9,6 +9,7 @@
 :CaseAutomation: Automated
 
 """
+
 from copy import copy
 import re
 

--- a/tests/foreman/destructive/test_foreman_rake.py
+++ b/tests/foreman/destructive/test_foreman_rake.py
@@ -11,6 +11,7 @@
 :Team: Endeavour
 
 """
+
 import pytest
 
 pytestmark = pytest.mark.destructive

--- a/tests/foreman/destructive/test_foreman_service.py
+++ b/tests/foreman/destructive/test_foreman_service.py
@@ -7,6 +7,7 @@
 :CaseImportance: Medium
 
 """
+
 import pytest
 
 from robottelo.constants import DEFAULT_ORG

--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from airgun.exceptions import NoSuchElementException
 import pytest
 

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -9,6 +9,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_mac, gen_string
 import pytest
 import requests

--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import random
 
 from fauxfactory import gen_domain, gen_string

--- a/tests/foreman/destructive/test_katello_certs_check.py
+++ b/tests/foreman/destructive/test_katello_certs_check.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import re
 
 import pytest

--- a/tests/foreman/destructive/test_ldap_authentication.py
+++ b/tests/foreman/destructive/test_ldap_authentication.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import os
 from time import sleep
 
@@ -196,9 +197,12 @@ def test_positive_create_with_https(
         assert ldap_source['ldap_server']['name'] == ldap_auth_name
         assert ldap_source['ldap_server']['host'] == auth_data['ldap_hostname']
         assert ldap_source['ldap_server']['port'] == '636'
-    with module_target_sat.ui_session(
-        test_name, username, auth_data['ldap_user_passwd']
-    ) as ldapsession, pytest.raises(NavigationTriesExceeded):
+    with (
+        module_target_sat.ui_session(
+            test_name, username, auth_data['ldap_user_passwd']
+        ) as ldapsession,
+        pytest.raises(NavigationTriesExceeded),
+    ):
         ldapsession.user.search('')
     assert module_target_sat.api.User().search(query={'search': f'login="{username}"'})
 

--- a/tests/foreman/destructive/test_ldapauthsource.py
+++ b/tests/foreman/destructive/test_ldapauthsource.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from time import sleep
 
 import pytest

--- a/tests/foreman/destructive/test_leapp_satellite.py
+++ b/tests/foreman/destructive/test_leapp_satellite.py
@@ -9,6 +9,7 @@
 :CaseImportance: High
 
 """
+
 from broker import Broker
 import pytest
 

--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import re
 
 import pytest

--- a/tests/foreman/destructive/test_ping.py
+++ b/tests/foreman/destructive/test_ping.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 
 pytestmark = pytest.mark.destructive

--- a/tests/foreman/destructive/test_puppetplugin.py
+++ b/tests/foreman/destructive/test_puppetplugin.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import PUPPET_CAPSULE_INSTALLER, PUPPET_COMMON_INSTALLER_OPTS

--- a/tests/foreman/destructive/test_realm.py
+++ b/tests/foreman/destructive/test_realm.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_string

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -10,6 +10,7 @@
 
 :Team: Rocket
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/destructive/test_remoteexecution.py
+++ b/tests/foreman/destructive/test_remoteexecution.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 from nailgun import client
 from nailgun.entity_mixins import TaskFailedError

--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/destructive/test_repository.py
+++ b/tests/foreman/destructive/test_repository.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from nailgun.entity_mixins import TaskFailedError
 import pytest
 

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from collections import defaultdict
 import http
 from pprint import pformat

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_alphanumeric, gen_ipaddr
 import pytest
 

--- a/tests/foreman/installer/test_infoblox.py
+++ b/tests/foreman/installer/test_infoblox.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 import requests
 import yaml

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 
 from nailgun import entities

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from broker import Broker
 from fauxfactory import gen_string
 from nailgun import entities

--- a/tests/foreman/longrun/test_remoteexecution.py
+++ b/tests/foreman/longrun/test_remoteexecution.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 import yaml
 

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -12,6 +12,7 @@
 
 
 """
+
 import re
 
 from fauxfactory import gen_string
@@ -136,7 +137,7 @@ def test_positive_backup_split_pulp_tar(
     assert 'FAIL' not in result.stdout
 
     # Check for expected files
-    backup_dir = re.findall(fr'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
+    backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
@@ -180,7 +181,7 @@ def test_positive_backup_capsule_features(
     assert 'FAIL' not in result.stdout
 
     # Check for expected files
-    backup_dir = re.findall(fr'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
+    backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
@@ -215,7 +216,7 @@ def test_positive_backup_all(sat_maintain, setup_backup_tests, module_synced_rep
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
-    init_backup_dir = re.findall(fr'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
+    init_backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
 
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,
@@ -262,7 +263,7 @@ def test_positive_backup_offline_logical(sat_maintain, setup_backup_tests, modul
     assert 'FAIL' not in result.stdout
 
     # Check for expected files
-    backup_dir = re.findall(fr'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
+    backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
@@ -402,7 +403,7 @@ def test_positive_puppet_backup_restore(
     assert 'FAIL' not in result.stdout
 
     # Check for expected files
-    backup_dir = re.findall(fr'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
+    backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
@@ -488,7 +489,7 @@ def test_positive_backup_restore(
     assert 'FAIL' not in result.stdout
 
     # Check for expected files
-    backup_dir = re.findall(fr'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
+    backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
@@ -572,7 +573,7 @@ def test_positive_backup_restore_incremental(
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
-    init_backup_dir = re.findall(fr'{subdir}\/satellite-backup-.*-[0-5][0-9]', result.stdout)[0]
+    init_backup_dir = re.findall(rf'{subdir}\/satellite-backup-.*-[0-5][0-9]', result.stdout)[0]
 
     # create additional content
     secondary_repo = sat_maintain.api.Repository(
@@ -591,7 +592,7 @@ def test_positive_backup_restore_incremental(
     assert 'FAIL' not in result.stdout
 
     # check for expected files
-    inc_backup_dir = re.findall(fr'{subdir}\/satellite-backup-.*-[0-5][0-9]', result.stdout)[0]
+    inc_backup_dir = re.findall(rf'{subdir}\/satellite-backup-.*-[0-5][0-9]', result.stdout)[0]
     files = sat_maintain.execute(f'ls -a {inc_backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 

--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import time
 
 from fauxfactory import gen_string

--- a/tests/foreman/maintain/test_maintenance_mode.py
+++ b/tests/foreman/maintain/test_maintenance_mode.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 import yaml
 

--- a/tests/foreman/maintain/test_offload_DB.py
+++ b/tests/foreman/maintain/test_offload_DB.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/maintain/test_packages.py
+++ b/tests/foreman/maintain/test_packages.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/maintain/test_service.py
+++ b/tests/foreman/maintain/test_service.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/sanity/test_bvt.py
+++ b/tests/foreman/sanity/test_bvt.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import re
 
 import pytest

--- a/tests/foreman/sys/test_dynflow.py
+++ b/tests/foreman/sys/test_dynflow.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -11,6 +11,7 @@
 :Team: Platform
 
 """
+
 from broker import Broker
 import pytest
 

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import re
 
 import pytest

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime
 import json
 

--- a/tests/foreman/sys/test_webpack.py
+++ b/tests/foreman/sys/test_webpack.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/foreman/ui/test_acs.py
+++ b/tests/foreman/ui/test_acs.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo import constants

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from broker import Broker

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -183,7 +183,7 @@ class TestAnsibleCfgMgmt:
         result = rhel_contenthost.execute(command)
         assert result.status == 0, f'Failed to register host: {result.stderr}'
         target_host = rhel_contenthost.nailgun_host
-        default_value = '["test"]'
+        default_value = '[\"test\"]'  # fmt: skip
         parameter_type = 'array'
         with target_sat.ui_session() as session:
             session.organization.select(org_name=module_org.name)

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -8,6 +8,7 @@
 
 :CaseImportance: Critical
 """
+
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for
@@ -182,7 +183,7 @@ class TestAnsibleCfgMgmt:
         result = rhel_contenthost.execute(command)
         assert result.status == 0, f'Failed to register host: {result.stderr}'
         target_host = rhel_contenthost.nailgun_host
-        default_value = '[\"test\"]'
+        default_value = '["test"]'
         parameter_type = 'array'
         with target_sat.ui_session() as session:
             session.organization.select(org_name=module_org.name)

--- a/tests/foreman/ui/test_architecture.py
+++ b/tests/foreman/ui/test_architecture.py
@@ -11,6 +11,7 @@
 :CaseImportance: Low
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_audit.py
+++ b/tests/foreman/ui/test_audit.py
@@ -9,6 +9,7 @@
 :Team: Endeavour
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_bookmarks.py
+++ b/tests/foreman/ui/test_bookmarks.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from airgun.exceptions import DisabledWidgetError, NoSuchElementException
 from fauxfactory import gen_string
 import pytest

--- a/tests/foreman/ui/test_branding.py
+++ b/tests/foreman/ui/test_branding.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/foreman/ui/test_capsulecontent.py
+++ b/tests/foreman/ui/test_capsulecontent.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 from wait_for import wait_for
 
@@ -288,7 +289,6 @@ def test_positive_VM_import(session, module_org, module_location, rhev_data, mod
 
     name = gen_string('alpha')
     with session:
-
         session.computeresource.create(
             {
                 'name': name,

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import json
 import random
 

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from random import choice
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from math import floor, log10
 from random import choice
 

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -11,6 +11,7 @@
 :CaseImportance: Low
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import (

--- a/tests/foreman/ui/test_contentcredentials.py
+++ b/tests/foreman/ui/test_contentcredentials.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 import re
 from urllib.parse import urlparse
@@ -1773,7 +1774,7 @@ def test_pagination_multiple_hosts_multiple_pages(session, module_host_template,
             f'os = {module_host_template.operatingsystem.name}'
         )
         # Assert dump of fake hosts found includes the higest numbered host created for this test
-        match = re.search(fr'test-{host_num:0>2}', str(all_fake_hosts_found))
+        match = re.search(rf'test-{host_num:0>2}', str(all_fake_hosts_found))
         assert match, 'Highest numbered host not found.'
         # Get all the pagination values
         pagination_values = session.contenthost.read_all('Pagination')['Pagination']
@@ -1811,8 +1812,8 @@ def test_search_for_virt_who_hypervisors(session, default_location, module_targe
         hypervisor_display_name = f'virt-who-{hypervisor_name}-{org.id}'
         # Search with hypervisor=True gives the correct result.
         assert (
-            session.contenthost.search('hypervisor = true')[0]['Name']
-        ) == hypervisor_display_name
+            (session.contenthost.search('hypervisor = true')[0]['Name']) == hypervisor_display_name
+        )
         # Search with hypervisor=false gives the correct result.
         content_hosts = [host['Name'] for host in session.contenthost.search('hypervisor = false')]
         assert hypervisor_display_name not in content_hosts

--- a/tests/foreman/ui/test_contentview.py
+++ b/tests/foreman/ui/test_contentview.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -14,6 +14,7 @@ Feature details: https://fedorahosted.org/katello/wiki/ContentViews
 :CaseImportance: High
 
 """
+
 import datetime
 from random import randint
 

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from nailgun.entity_mixins import TaskFailedError
 import pytest
 
@@ -52,14 +53,14 @@ def test_positive_host_configuration_status(session, target_sat):
         'Hosts with no reports',
     ]
     search_strings_list = [
-        'last_report > \"30 minutes ago\" and (status.applied > 0 or'
+        'last_report > "30 minutes ago" and (status.applied > 0 or'
         ' status.restarted > 0) and (status.failed = 0)',
-        'last_report > \"30 minutes ago\" and (status.failed > 0 or'
+        'last_report > "30 minutes ago" and (status.failed > 0 or'
         ' status.failed_restarts > 0) and status.enabled = true',
-        'last_report > \"30 minutes ago\" and status.enabled = true and'
+        'last_report > "30 minutes ago" and status.enabled = true and'
         ' status.applied = 0 and status.failed = 0 and status.pending = 0',
-        'last_report > \"30 minutes ago\" and status.pending > 0 and status.enabled = true',
-        'last_report < \"30 minutes ago\" and status.enabled = true',
+        'last_report > "30 minutes ago" and status.pending > 0 and status.enabled = true',
+        'last_report < "30 minutes ago" and status.enabled = true',
         'status.enabled = false',
         'not has last_report and status.enabled = true',
     ]

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -9,6 +9,7 @@
 :Team: Rocket
 
 """
+
 from fauxfactory import gen_string
 import pytest
 from wait_for import wait_for

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
 import pytest
 

--- a/tests/foreman/ui/test_domain.py
+++ b/tests/foreman/ui/test_domain.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_eol_banner.py
+++ b/tests/foreman/ui/test_eol_banner.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 
 from airgun.session import Session

--- a/tests/foreman/ui/test_hardwaremodel.py
+++ b/tests/foreman/ui/test_hardwaremodel.py
@@ -9,6 +9,7 @@
 :Team: Endeavour
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import copy
 import csv
 import os

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import time
 
 from broker import Broker

--- a/tests/foreman/ui/test_hostgroup.py
+++ b/tests/foreman/ui/test_hostgroup.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -11,6 +11,7 @@
 :CaseAutomation: Automated
 
 """
+
 from box import Box
 from fauxfactory import gen_integer, gen_string, gen_url
 import pytest

--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import os
 
 from fauxfactory import gen_url
@@ -404,9 +405,12 @@ def test_positive_delete_external_roles(
         session.usergroup.update(
             ldap_usergroup_name, {'roles.resources.unassigned': [foreman_role.name]}
         )
-    with target_sat.ui_session(
-        test_name, ldap_data['ldap_user_name'], ldap_data['ldap_user_passwd']
-    ) as ldapsession, pytest.raises(NavigationTriesExceeded):
+    with (
+        target_sat.ui_session(
+            test_name, ldap_data['ldap_user_name'], ldap_data['ldap_user_passwd']
+        ) as ldapsession,
+        pytest.raises(NavigationTriesExceeded),
+    ):
         ldapsession.location.create({'name': gen_string('alpha')})
 
 
@@ -758,9 +762,12 @@ def test_positive_login_user_basic_roles(
     role = target_sat.api.Role().create()
     permissions = {'Architecture': PERMISSIONS['Architecture']}
     target_sat.api_factory.create_role_permissions(role, permissions)
-    with target_sat.ui_session(
-        test_name, ldap_data['ldap_user_name'], ldap_data['ldap_user_passwd']
-    ) as ldapsession, pytest.raises(NavigationTriesExceeded):
+    with (
+        target_sat.ui_session(
+            test_name, ldap_data['ldap_user_name'], ldap_data['ldap_user_passwd']
+        ) as ldapsession,
+        pytest.raises(NavigationTriesExceeded),
+    ):
         ldapsession.usergroup.search('')
     with session:
         session.user.update(ldap_data['ldap_user_name'], {'roles.resources.assigned': [role.name]})
@@ -792,9 +799,12 @@ def test_positive_login_user_password_otp(
     otp_pass = (
         f"{default_ipa_host.ldap_user_passwd}{generate_otp(default_ipa_host.time_based_secret)}"
     )
-    with target_sat.ui_session(
-        test_name, default_ipa_host.ipa_otp_username, otp_pass
-    ) as ldapsession, pytest.raises(NavigationTriesExceeded):
+    with (
+        target_sat.ui_session(
+            test_name, default_ipa_host.ipa_otp_username, otp_pass
+        ) as ldapsession,
+        pytest.raises(NavigationTriesExceeded),
+    ):
         ldapsession.user.search('')
     users = target_sat.api.User().search(
         query={'search': f'login="{default_ipa_host.ipa_otp_username}"'}
@@ -1210,11 +1220,14 @@ def test_userlist_with_external_admin(
         assert idm_user in ldapsession.task.read_all()['current_user']
 
     # verify the users count with local admin and remote/external admin
-    with target_sat.ui_session(
-        user=idm_admin, password=settings.server.ssh_password
-    ) as remote_admin_session, target_sat.ui_session(
-        user=settings.server.admin_username, password=settings.server.admin_password
-    ) as local_admin_session:
+    with (
+        target_sat.ui_session(
+            user=idm_admin, password=settings.server.ssh_password
+        ) as remote_admin_session,
+        target_sat.ui_session(
+            user=settings.server.admin_username, password=settings.server.admin_password
+        ) as local_admin_session,
+    ):
         assert local_admin_session.user.search(idm_user)[0]['Username'] == idm_user
         assert remote_admin_session.user.search(idm_user)[0]['Username'] == idm_user
 

--- a/tests/foreman/ui/test_lifecycleenvironment.py
+++ b/tests/foreman/ui/test_lifecycleenvironment.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from navmazing import NavigationTriesExceeded
 import pytest
 

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_ipaddr, gen_string
 import pytest
 

--- a/tests/foreman/ui/test_media.py
+++ b/tests/foreman/ui/test_media.py
@@ -11,6 +11,7 @@
 :CaseImportance: Low
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import HASH_TYPE

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import OSCAP_PROFILE

--- a/tests/foreman/ui/test_oscaptailoringfile.py
+++ b/tests/foreman/ui/test_oscaptailoringfile.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.utils.datafactory import gen_string

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_partitiontable.py
+++ b/tests/foreman/ui/test_partitiontable.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_product.py
+++ b/tests/foreman/ui/test_product.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import timedelta
 
 from fauxfactory import gen_choice

--- a/tests/foreman/ui/test_provisioningtemplate.py
+++ b/tests/foreman/ui/test_provisioningtemplate.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import DataFile

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -11,6 +11,7 @@
 :CaseImportance: Low
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -11,6 +11,7 @@
 :CaseImportance: Low
 
 """
+
 import pytest
 
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT

--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -10,6 +10,7 @@
 
 :Team: Rocket
 """
+
 from datetime import datetime
 import re
 
@@ -540,7 +541,6 @@ def test_positive_host_registration_with_non_admin_user(
     with module_target_sat.ui_session(
         test_name, user=user.login, password=user_password
     ) as session:
-
         cmd = session.host_new.get_register_command(
             {
                 'general.insecure': True,

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from collections import OrderedDict
 import datetime
 import time

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import csv
 import json
 import os

--- a/tests/foreman/ui/test_repositories.py
+++ b/tests/foreman/ui/test_repositories.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 
 

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 from random import randint, shuffle
 

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime
 
 import pytest

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 
 import pytest

--- a/tests/foreman/ui/test_role.py
+++ b/tests/foreman/ui/test_role.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from navmazing import NavigationTriesExceeded

--- a/tests/foreman/ui/test_search.py
+++ b/tests/foreman/ui/test_search.py
@@ -10,6 +10,7 @@
 
 :CaseImportance: Medium
 """
+
 from collections import namedtuple
 
 from fauxfactory import gen_string

--- a/tests/foreman/ui/test_settings.py
+++ b/tests/foreman/ui/test_settings.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import math
 
 from fauxfactory import gen_url

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from random import choice, uniform
 
 import pytest

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_ipaddr
 import pytest
 

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from tempfile import mkstemp
 import time
 

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime, timedelta
 import time
 

--- a/tests/foreman/ui/test_templatesync.py
+++ b/tests/foreman/ui/test_templatesync.py
@@ -9,6 +9,7 @@
 :Team: Endeavour
 
 """
+
 from fauxfactory import gen_string
 import pytest
 import requests

--- a/tests/foreman/ui/test_user.py
+++ b/tests/foreman/ui/test_user.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import random
 
 from fauxfactory import gen_email, gen_string

--- a/tests/foreman/ui/test_usergroup.py
+++ b/tests/foreman/ui/test_usergroup.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string, gen_utf8
 import pytest
 

--- a/tests/foreman/ui/test_webhook.py
+++ b/tests/foreman/ui/test_webhook.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string, gen_url
 import pytest
 

--- a/tests/foreman/virtwho/api/test_esx.py
+++ b/tests/foreman/virtwho/api/test_esx.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings
@@ -359,9 +360,7 @@ class TestVirtWhoConfigforEsx:
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
         option = "env"
         config_file = get_configure_file(virtwho_config_api.id)
-        env_error = (
-            f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
-        )
+        env_error = f"option {{'{option}'}} is not exist or not be enabled in {{'{config_file}'}}"
         with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
             get_configure_option({option}, {config_file})
         assert str(exc_info.value) == env_error

--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -9,6 +9,7 @@
 :Team: Phoenix
 
 """
+
 import pytest
 
 from robottelo.config import settings
@@ -407,9 +408,7 @@ class TestVirtWhoConfigforEsx:
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
         option = "env"
         config_file = get_configure_file(virtwho_config_api.id)
-        env_error = (
-            f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
-        )
+        env_error = f"option {{'{option}'}} is not exist or not be enabled in {{'{config_file}'}}"
         with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
             get_configure_option({option}, {config_file})
         assert str(exc_info.value) == env_error

--- a/tests/foreman/virtwho/api/test_hyperv.py
+++ b/tests/foreman/virtwho/api/test_hyperv.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/api/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/api/test_hyperv_sca.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/api/test_kubevirt.py
+++ b/tests/foreman/virtwho/api/test_kubevirt.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/api/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/api/test_kubevirt_sca.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/api/test_libvirt.py
+++ b/tests/foreman/virtwho/api/test_libvirt.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/api/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/api/test_libvirt_sca.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/api/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/api/test_nutanix_sca.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/cli/test_esx.py
+++ b/tests/foreman/virtwho/cli/test_esx.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import re
 
 from fauxfactory import gen_string
@@ -410,9 +411,7 @@ class TestVirtWhoConfigforEsx:
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
         option = "env"
         config_file = get_configure_file(virtwho_config_cli['id'])
-        env_error = (
-            f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
-        )
+        env_error = f"option {{'{option}'}} is not exist or not be enabled in {{'{config_file}'}}"
         with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
             get_configure_option({option}, {config_file})
         assert str(exc_info.value) == env_error

--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -9,6 +9,7 @@
 :Team: Phoenix
 
 """
+
 import re
 
 from fauxfactory import gen_string
@@ -492,9 +493,7 @@ class TestVirtWhoConfigforEsx:
         # Check the option "env=" should be removed from etc/virt-who.d/virt-who.conf
         option = "env"
         config_file = get_configure_file(virtwho_config_cli['id'])
-        env_error = (
-            f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
-        )
+        env_error = f"option {{'{option}'}} is not exist or not be enabled in {{'{config_file}'}}"
         with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
             get_configure_option({option}, {config_file})
         assert str(exc_info.value) == env_error

--- a/tests/foreman/virtwho/cli/test_hyperv.py
+++ b/tests/foreman/virtwho/cli/test_hyperv.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/cli/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/cli/test_hyperv_sca.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/cli/test_kubevirt.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/cli/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_kubevirt_sca.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/cli/test_libvirt.py
+++ b/tests/foreman/virtwho/cli/test_libvirt.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/cli/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/cli/test_libvirt_sca.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/cli/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/cli/test_nutanix_sca.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/ui/test_esx.py
+++ b/tests/foreman/virtwho/ui/test_esx.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from datetime import datetime
 
 from fauxfactory import gen_string
@@ -731,9 +732,7 @@ class TestVirtwhoConfigforEsx:
         option = "env"
         config_id = get_configure_id(name)
         config_file = get_configure_file(config_id)
-        env_error = (
-            f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
-        )
+        env_error = f"option {{'{option}'}} is not exist or not be enabled in {{'{config_file}'}}"
         with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
             get_configure_option({option}, {config_file})
         assert str(exc_info.value) == env_error

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 from datetime import datetime
 
 from airgun.session import Session
@@ -312,9 +313,7 @@ class TestVirtwhoConfigforEsx:
         option = "env"
         config_id = get_configure_id(name)
         config_file = get_configure_file(config_id)
-        env_error = (
-            f"option {{\'{option}\'}} is not exist or not be enabled in {{\'{config_file}\'}}"
-        )
+        env_error = f"option {{'{option}'}} is not exist or not be enabled in {{'{config_file}'}}"
         with pytest.raises(Exception) as exc_info:  # noqa: PT011 - TODO determine better exception
             get_configure_option({option}, {config_file})
         assert str(exc_info.value) == env_error

--- a/tests/foreman/virtwho/ui/test_hyperv.py
+++ b/tests/foreman/virtwho/ui/test_hyperv.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/ui/test_kubevirt.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/ui/test_libvirt.py
+++ b/tests/foreman/virtwho/ui/test_libvirt.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -9,6 +9,7 @@
 :team: Phoenix-subscriptions
 
 """
+
 import pytest
 
 from robottelo.utils.virtwho import (

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -9,6 +9,7 @@
 :Team: Phoenix-subscriptions
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/robottelo/test_datafactory.py
+++ b/tests/robottelo/test_datafactory.py
@@ -1,4 +1,5 @@
 """Tests for module ``robottelo.utils.datafactory``."""
+
 import itertools
 import random
 from unittest import mock

--- a/tests/robottelo/test_decorators.py
+++ b/tests/robottelo/test_decorators.py
@@ -1,4 +1,5 @@
 """Unit tests for :mod:`robottelo.utils.decorators`."""
+
 from unittest import mock
 
 import pytest

--- a/tests/robottelo/test_dependencies.py
+++ b/tests/robottelo/test_dependencies.py
@@ -1,4 +1,5 @@
 """Test important behavior in robottelo's direct dependencies"""
+
 import contextlib
 
 

--- a/tests/robottelo/test_func_locker.py
+++ b/tests/robottelo/test_func_locker.py
@@ -96,8 +96,9 @@ def simple_recursive_locking_function():
     """try to trigger the same lock from the same process, an exception
     should be expected
     """
-    with func_locker.locking_function(simple_locked_function), func_locker.locking_function(
-        simple_locked_function
+    with (
+        func_locker.locking_function(simple_locked_function),
+        func_locker.locking_function(simple_locked_function),
     ):
         pass
     return 'I should not be reached'
@@ -125,9 +126,10 @@ def simple_function_to_lock():
 def simple_with_locking_function(index=None):
     global counter_file
     time.sleep(0.05)
-    with func_locker.locking_function(simple_locked_function), open(
-        _get_function_lock_path('simple_locked_function')
-    ) as rf:
+    with (
+        func_locker.locking_function(simple_locked_function),
+        open(_get_function_lock_path('simple_locked_function')) as rf,
+    ):
         content = rf.read()
 
     if index is not None:
@@ -234,9 +236,10 @@ class TestFuncLocker:
             content = ''
         assert str(os.getpid()) != content
 
-        with func_locker.locking_function(SimpleClass.simple_function_to_lock), open(
-            file_path
-        ) as rf:
+        with (
+            func_locker.locking_function(SimpleClass.simple_function_to_lock),
+            open(file_path) as rf,
+        ):
             content = rf.read()
 
         assert str(os.getpid()) == content
@@ -249,9 +252,10 @@ class TestFuncLocker:
             content = ''
         assert str(os.getpid()) != content
 
-        with func_locker.locking_function(SimpleClass.simple_function_to_lock_cls), open(
-            file_path
-        ) as rf:
+        with (
+            func_locker.locking_function(SimpleClass.simple_function_to_lock_cls),
+            open(file_path) as rf,
+        ):
             content = rf.read()
 
         assert str(os.getpid()) == content
@@ -296,9 +300,10 @@ class TestFuncLocker:
         else:
             content = ''
         assert str(os.getpid()) != content
-        with func_locker.locking_function(SimpleClass.SubClass.simple_function_to_lock_cls), open(
-            file_path
-        ) as rf:
+        with (
+            func_locker.locking_function(SimpleClass.SubClass.simple_function_to_lock_cls),
+            open(file_path) as rf,
+        ):
             content = rf.read()
 
         assert str(os.getpid()) == content
@@ -410,7 +415,8 @@ class TestFuncLocker:
         assert os.path.exists(lock_file_path)
 
     def test_negative_with_locking_not_locked(self):
-        with pytest.raises(
-            func_locker.FunctionLockerError, match=r'.*Cannot ensure locking.*'
-        ), func_locker.locking_function(simple_function_not_locked):
+        with (
+            pytest.raises(func_locker.FunctionLockerError, match=r'.*Cannot ensure locking.*'),
+            func_locker.locking_function(simple_function_not_locked),
+        ):
             pass

--- a/tests/robottelo/test_hammer.py
+++ b/tests/robottelo/test_hammer.py
@@ -1,4 +1,5 @@
 """Tests for Robottelo's hammer helpers"""
+
 from robottelo.cli import hammer
 
 

--- a/tests/robottelo/test_helpers.py
+++ b/tests/robottelo/test_helpers.py
@@ -1,4 +1,5 @@
 """Tests for module ``robottelo.helpers``."""
+
 import pytest
 
 from robottelo.utils import slugify_component, validate_ssh_pub_key

--- a/tests/robottelo/test_issue_handlers.py
+++ b/tests/robottelo/test_issue_handlers.py
@@ -365,7 +365,6 @@ class TestBugzillaIssueHandler:
                 os.remove(DEFAULT_BZ_CACHE_FILE)
 
         try:
-
             subprocess.run(
                 [sys.executable, '-m', 'pytest', '--collect-only', 'tests/robottelo'], check=True
             )
@@ -408,7 +407,11 @@ def test_add_workaround():
     add_workaround(data, matches, 'test', foo='bar')
 
     add_workaround(
-        data, matches, 'test', validation=lambda *a, **k: False, zaz='traz'  # Should not be added
+        data,
+        matches,
+        'test',
+        validation=lambda *a, **k: False,
+        zaz='traz',  # Should not be added
     )
 
     for match in matches:

--- a/tests/robottelo/test_ssh.py
+++ b/tests/robottelo/test_ssh.py
@@ -1,4 +1,5 @@
 """Tests for module ``robottelo.utils.ssh``."""
+
 from unittest import mock
 
 from robottelo import ssh

--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -81,6 +81,7 @@ This module is intended to be used for upgrade tests, that have two run stages,
         # in post_upgrade scenario, test results should be
         #  2 passed, 6 deselected
 """
+
 import datetime
 import functools
 import json

--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 from requests.exceptions import HTTPError
 

--- a/tests/upgrades/test_bookmarks.py
+++ b/tests/upgrades/test_bookmarks.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import BOOKMARK_ENTITIES_SELECTION

--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import os
 
 import pytest

--- a/tests/upgrades/test_classparameter.py
+++ b/tests/upgrades/test_classparameter.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import json
 
 import pytest

--- a/tests/upgrades/test_client.py
+++ b/tests/upgrades/test_client.py
@@ -14,6 +14,7 @@ sat6-upgrade requires env.satellite_hostname to be set, this is required for the
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_alpha
 import pytest
 

--- a/tests/upgrades/test_discovery.py
+++ b/tests/upgrades/test_discovery.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import re
 
 from packaging.version import Version

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -11,6 +11,7 @@
 :CaseImportance: Critical
 
 """
+
 import pytest
 from wait_for import wait_for
 

--- a/tests/upgrades/test_host.py
+++ b/tests/upgrades/test_host.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/upgrades/test_hostgroup.py
+++ b/tests/upgrades/test_hostgroup.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/upgrades/test_performance_tuning.py
+++ b/tests/upgrades/test_performance_tuning.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import filecmp
 
 import pytest

--- a/tests/upgrades/test_provisioningtemplate.py
+++ b/tests/upgrades/test_provisioningtemplate.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/upgrades/test_puppet.py
+++ b/tests/upgrades/test_puppet.py
@@ -11,6 +11,7 @@
 :CaseImportance: Medium
 
 """
+
 import pytest
 
 

--- a/tests/upgrades/test_remoteexecution.py
+++ b/tests/upgrades/test_remoteexecution.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.config import settings

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/upgrades/test_satellite_maintain.py
+++ b/tests/upgrades/test_satellite_maintain.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import re
 
 import pytest

--- a/tests/upgrades/test_satellitesync.py
+++ b/tests/upgrades/test_satellitesync.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 from robottelo.constants import PULP_EXPORT_DIR

--- a/tests/upgrades/test_subnet.py
+++ b/tests/upgrades/test_subnet.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from manifester import Manifester
 import pytest
 

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_choice
 import pytest
 

--- a/tests/upgrades/test_user.py
+++ b/tests/upgrades/test_user.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 import pytest
 
 

--- a/tests/upgrades/test_usergroup.py
+++ b/tests/upgrades/test_usergroup.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -11,6 +11,7 @@
 :CaseImportance: High
 
 """
+
 from fauxfactory import gen_string
 import pytest
 
@@ -148,7 +149,7 @@ class TestScenarioPositiveVirtWho:
 
         # Verify the virt-who config-file exists.
         config_file = get_configure_file(vhd.id)
-        get_configure_option('hypervisor_id', config_file),
+        get_configure_option('hypervisor_id', config_file)
 
         # Verify Report is sent to satellite.
         command = get_configure_command(vhd.id, org=org_name)


### PR DESCRIPTION
### Problem Statement
#14781 attempts to upgrade some of our pre-commit hooks including black. The new version of [black formats](https://results.pre-commit.ci/run/github/4000279/1714059668.imtZ-VkMSyK3E5Wo_AicJw) 150+ files. Given the patch size, I propose switching to Ruff formatter as the patch size is comparable to the patch for the new version of black.

#### Reason to switch to Ruff
(copy&paste from one of the comments in this PR)
Astral's page sums it up pretty well. [astral.sh/blog/the-ruff-formatter](https://astral.sh/blog/the-ruff-formatter)

I would like us to switch to Ruff mainly because of its speed compared to black. It is incredibly fast and the compatibility with Black is 99%. Looking at the patch, it might not look like 99%, but taking into account how big our project is and what changes were made, it is not that bad.

### Solution
* Remove the black formatter and substitute it with Ruff formatter,
* bump the version of ruff pre-commit hook.

### Related Issues
Related PR: #14781

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->