### PR TITLE
[6.13.z] Fix CaseAutomation for tests and delete Certificates related tests as part of component audit.

### DIFF
--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -313,7 +313,7 @@ class TestDiscoveredHost:
         :expectedresults: All discovered hosts should be auto-provisioned
             successfully
 
-        :CaseAutomation: NotAutomated
+        :CaseAutomation: Automated
 
         :CaseImportance: High
         """

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -2,7 +2,7 @@
 
 :Requirement: Provisioning
 
-:CaseAutomation: NotAutomated
+:CaseAutomation: Automated
 
 :CaseComponent: Provisioning
 

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -2,7 +2,7 @@
 
 :Requirement: Provisioning
 
-:CaseAutomation: NotAutomated
+:CaseAutomation: Automated
 
 :CaseComponent: Provisioning
 
@@ -728,4 +728,6 @@ def test_rhel_provisioning_using_realm():
         3. Host installs right version of RHEL
         4. Satellite is able to run REX job on the host
         5. Host is registered to Satellite and subscription status is 'Success'
+
+    :CaseAutomation: NotAutomated
     """

--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -160,28 +160,6 @@ class TestKatelloCertsCheck:
         result = target_sat.execute(command)
         self.validate_output(result, cert_data)
 
-    @pytest.mark.tier1
-    def test_katello_certs_check_output_wildcard_inputs(self, cert_setup_teardown):
-        """Validate that katello-certs-check generates correct output with wildcard certs.
-
-        :id: 7f9da806-5b23-11eb-b7ea-d46d6dd3b5b2
-
-        :steps:
-
-            1. Get valid wildcard certs from generate_certs
-            2. Run katello-certs-check with the required valid arguments
-               katello-certs-check -c CERT_FILE -k KEY_FILE -r REQ_FILE
-               -b CA_BUNDLE_FILE
-            3. Assert the output has correct commands with options
-
-        :expectedresults: katello-certs-check should generate correct commands
-         with options.
-        """
-        cert_data, target_sat = cert_setup_teardown
-        command = 'katello-certs-check -c certs/wildcard.crt -k certs/wildcard.key -b certs/ca.crt'
-        result = target_sat.execute(command)
-        self.validate_output(result, cert_data)
-
     @pytest.mark.parametrize(('error', 'cert_file', 'key_file', 'ca_file'), invalid_inputs)
     @pytest.mark.tier1
     def test_katello_certs_check_output_invalid_input(
@@ -237,7 +215,7 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Checking expiration of certificate check should fail.
 
-        :CaseAutomation: NotAutomated
+        :CaseAutomation: Automated
         """
         cert_data, target_sat = cert_setup_teardown
         hostname = target_sat.hostname
@@ -275,23 +253,6 @@ class TestKatelloCertsCheck:
 
         :expectedresults: Check for validating the certificate subject should
             fail.
-
-        :CaseAutomation: NotAutomated
-        """
-
-    @pytest.mark.stubbed
-    @pytest.mark.tier1
-    def test_negative_check_private_key_match(self):
-        """Validate private key match with certificate.
-
-        :id: 358edbb3-08b0-47d7-856b-ce0d5ea95979
-
-        :steps:
-
-            1. Have KEY_FILE with invalid private key
-            2. Run katello-certs-check with the required arguments
-
-        :expectedresults: Private key match with the certificate should fail.
 
         :CaseAutomation: NotAutomated
         """

--- a/tests/upgrades/test_role.py
+++ b/tests/upgrades/test_role.py
@@ -2,7 +2,7 @@
 
 :Requirement: UpgradedSatellite
 
-:CaseAutomation: NotAutomated
+:CaseAutomation: Automated
 
 :CaseComponent: UsersRoles
 
@@ -31,6 +31,8 @@ class TestOverriddenFilter:
         1. The Filter should be have set override flag postupgrade
         2. The locations and organizations of filter should be unchanged
             postupgrade
+
+    :CaseAutomation: NotAutomated
     """
 
     @pytest.mark.pre_upgrade
@@ -82,6 +84,8 @@ class TestBuiltInRolesLocked:
 
         1. Builtin roles of satellite should be locked and non-editable
         2. Built in roles of satellite should be allowed to clone
+
+    :CaseAutomation: NotAutomated
     """
 
     @pytest.mark.post_upgrade
@@ -117,6 +121,8 @@ class TestNewOrganizationAdminRole:
             non-editable
         4. Organization Admin role of satellite should be allowed to clone
         5. Taxonomies should be assigned to cloned org admin role
+
+    :CaseAutomation: NotAutomated
     """
 
     @pytest.mark.post_upgrade
@@ -164,7 +170,6 @@ class TestRoleAddPermission:
         :steps: New permission is added to existing 'Default role'
 
         :expectedresults: Permission is added to existing 'Default role'.
-
         """
         default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
         subnet_filter = target_sat.api.Filter(
@@ -219,7 +224,6 @@ class TestRoleAddPermissionWithFilter:
 
         :expectedresults: Permission with filter is added to existing
             'Default role'
-
         """
         default_role = target_sat.api.Role().search(query={'search': 'name="Default role"'})[0]
         domain_filter = target_sat.api.Filter(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14873

### This PR
- Deletes certificate-related tests as part of the component audit.
- Fixes `CaseAutomation`, as some of the tests are marked as `NotAutomated` even though they are automated and should be run in automation.

### Related Issues
- SAT-23021

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->