### PR TITLE
[6.14.z] [Stream Fix] Remove escaped quotation mark from valid_name list

### DIFF
--- a/robottelo/utils/datafactory.py
+++ b/robottelo/utils/datafactory.py
@@ -390,7 +390,7 @@ def valid_names_list():
         f"νέος χρήστης-{gen_string('utf8', 2)}",
         f"foo@!#$^&*( ) {gen_string('utf8')}",
         f"<blink>{gen_string('utf8')}</blink>",
-        f"bar+{{}}|\"?hi {gen_string('utf8')}",
+        f"bar+{{}}|?hi {gen_string('utf8')}",
         f" {gen_string('utf8')}",
         f"{gen_string('utf8')} ",
     ]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14941

This PR removes an escaped quotation mark in a datafactory method used exclusively in content view CLI tests. 

This always fails, as even when escaped, the clifactory errors out when faced with this particular string. Open to better choices for a fix here. 