### PR TITLE
[6.13.z] Add test coverage for BZ:2166466

### DIFF
--- a/tests/foreman/destructive/test_ansible.py
+++ b/tests/foreman/destructive/test_ansible.py
@@ -12,6 +12,7 @@
 
 """
 
+from fauxfactory import gen_string
 import pytest
 
 pytestmark = [pytest.mark.destructive, pytest.mark.upgrade]
@@ -69,3 +70,50 @@ def test_positive_import_all_roles(target_sat):
         # by default should work here.
         session.ansibleroles.delete('theforeman.foreman_scap_client')
         assert not session.ansibleroles.search('theforeman.foreman_scap_client')
+
+
+@pytest.mark.parametrize('setting_update', ['entries_per_page=12'], indirect=True)
+def test_positive_hostgroup_ansible_roles_tab_pagination(target_sat, setting_update):
+    """Import all Ansible roles available by default.
+
+    :id: 53fe3857-a08f-493d-93c7-3fed331ed392
+
+    :steps:
+        1. Navigate to the Configure > Roles page, and click the `Import from [hostname]` button
+        2. Get total number of importable roles from pagination.
+        3. Fill the `Select All` checkbox and click the `Submit` button
+        4. Verify that number of imported roles == number of importable roles from step 2
+        5. Navigate to Administer > Settings > General tab and update the entries_per_page setting
+        6. Navigate to `Ansible Roles` tab in Hostgroup create and edit page
+        7. Verify the new per page entry is updated in pagination list
+
+    :expectedresults: All imported roles should be available on the webUI and properly paginated
+        as per entries_per_page setting on create and edit hostgroup page.
+
+    :BZ: 2166466, 2242915
+
+    :customerscenario: true
+    """
+    setting_value = str(
+        target_sat.api.Setting().search(query={'search': 'name=entries_per_page'})[0].value
+    )
+    with target_sat.ui_session() as session:
+        imported_roles = session.ansibleroles.import_all_roles()
+        total_role_count = str(session.ansibleroles.imported_roles_count)
+        assert imported_roles == int(total_role_count)
+        assert total_role_count > setting_value
+
+        create_page = session.hostgroup.helper.read_filled_view(
+            'New', read_widget_names=['ansible_roles.pagination']
+        )
+        assert create_page['ansible_roles']['pagination']['_items'].split()[2] == setting_value
+        assert create_page['ansible_roles']['pagination']['_items'].split()[-2] == total_role_count
+
+        hg = target_sat.api.HostGroup(name=gen_string('alpha')).create()
+        edit_page = session.hostgroup.helper.read_filled_view(
+            'Edit',
+            navigation_kwargs={'entity_name': hg.name},
+            read_widget_names=['ansible_roles.pagination'],
+        )
+        assert edit_page['ansible_roles']['pagination']['_items'].split()[2] == setting_value
+        assert edit_page['ansible_roles']['pagination']['_items'].split()[-2] == total_role_count


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14914

### Problem Statement
Missing coverage for BZ:2166466/BZ:2242915, where we verified pagination on hostgroup edit page as per entries_per_page setting

### Solution
Add coverage for BZ:2166466/BZ:2242915 to verify pagination on hostgroup create and edit page as per entries_per_page setting

### Related Issues
Airgun PR https://github.com/SatelliteQE/airgun/pull/1372