### PR TITLE
[6.14.z] Copy config files for FAM to server

### DIFF
--- a/conf/fam.yaml.template
+++ b/conf/fam.yaml.template
@@ -1,0 +1,101 @@
+FAM:
+  SERVER:
+    # Parameter for all tests
+    foreman_username: admin
+    foreman_password: "changeme"
+    foreman_server_url: "https://foreman.example.com"
+    foreman_validate_certs: false
+
+    foreman_proxy: "foreman.example.com"
+
+    # Parameter for snapshot test
+    snapshot_host_name: "test_host"
+
+    # Parameter for job invocation  test
+    foreman_host: "foreman.example.com"
+
+    # Parameter for subscription_manifest test
+    subscription_manifest_path: "data/manifest_foreman-ansible-modules.zip"
+
+    # Parameter for redhat_manifest test
+    manifest_name: "katello.example.com"
+    rhsm_username: "john-smith"
+    rhsm_password: "changeme"
+    rhsm_pool_id: 8a85f99a7db4827d017dc512fcad00b0
+    rhsm_validate_certs: false
+
+    # Parameter for scc_product test
+    scc_account_name_for_scc_product: testaccount
+    scc_account_login_for_scc_product: testuser
+    scc_account_password_for_scc_product: testpass
+
+    # Parameter for external_usergroup testing
+    auth_source_ldap_host: ldap.example.com
+    auth_source_ldap_account: ansible
+    auth_source_ldap_account_password: pass
+    auth_source_ldap_base_dn: dc=example,dc=com
+    auth_source_ldap_attr_login: uid
+    auth_source_ldap_groups_base: cn=groups,cn=accounts,dc=example,dc=com
+    external_usergroup_name: "admins"
+
+  COMPUTE_PROFILE:
+    libvirt:
+      compute_resource:
+        name: libvirt-cr01
+        organizations:
+          - Test Organization
+        locations:
+          - Test Location
+        params:
+          url: qemu+ssh://libvirtuser@localhost/system
+        compute_profile:
+          name: app-small
+          attrs:
+            cpus: 1
+            memory: 2147483648
+            nics_attributes:
+              0:
+                type: bridge
+                bridge: ""
+                model: virtio
+            volumes_attributes:
+              0:
+                pool_name: default
+                capacity: 10G
+                allocation: 0G
+                format_type: raw
+    ovirt:
+      compute_resource:
+        name: ovirt-cr01
+        organizations:
+          - Test Organization
+        locations:
+          - Test Location
+        params:
+          url: "https://ovirt.example.com/ovirt-engine/api"
+          user: compute-user@internal
+          password: ovirtcompute123
+          use_v4: true
+          datacenter: c1479626-99a2-44eb-8401-14b5630f417f
+          ovirt_quota: 502a76bb-a3fe-42f1-aed6-2a7c892a6786
+        compute_profile:
+          name: app-small
+          attrs:
+            cluster: Devel-Infra
+            cores: 2
+            sockets: 1
+            memory: 1073741824
+            ha: 0
+            interfaces_attributes:
+              0:
+                name: ""
+                network: ovirtmgmt
+                interface: virtio
+            volumes_attributes:
+              0:
+                size_gb: '16'
+                storage_domain: 'Local-IBM'
+                preallocate: '1'
+                wipe_after_delete: '0'
+                interface: 'virtio_scsi'
+                bootable: 'true'

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1872,7 +1872,6 @@ FAM_TEST_PLAYBOOKS = [
     "content_export_repository",
     "content_export_version",
     "content_rhel_role",
-    "content_upload_ostree",
     "content_upload",
     "content_view_filter_info",
     "content_view_filter_rule_info",
@@ -1933,9 +1932,9 @@ FAM_TEST_PLAYBOOKS = [
     "puppet_environment",
     "realm",
     "redhat_manifest",
+    "registration_command",
     "repositories_role",
     "repository_info",
-    "repository_ostree",
     "repository_set_info",
     "repository_set",
     "repository_sync",
@@ -1962,6 +1961,7 @@ FAM_TEST_PLAYBOOKS = [
     "usergroup",
     "user",
     "wait_for_task",
+    "webhook",
 ]
 
 FAM_ROOT_DIR = '/usr/share/ansible/collections/ansible_collections/redhat/satellite'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -892,12 +892,17 @@ class ContentHost(Host, ContentHostMixins):
         """Get a remote file from the broker virtual machine."""
         self.session.sftp_read(source=remote_path, destination=local_path)
 
-    def put(self, local_path, remote_path=None):
+    def put(self, local_path, remote_path=None, temp_file=False):
         """Put a local file to the broker virtual machine.
         If local_path is a manifest object, write its contents to a temporary file
         then continue with the upload.
         """
-        if 'utils.manifest' in str(local_path):
+        if temp_file:
+            with NamedTemporaryFile(dir=robottelo_tmp_dir) as content_file:
+                content_file.write(str.encode(local_path))
+                content_file.flush()
+                self.session.sftp_write(source=content_file.name, destination=remote_path)
+        elif 'utils.manifest' in str(local_path):
             with NamedTemporaryFile(dir=robottelo_tmp_dir) as content_file:
                 content_file.write(local_path.content.read())
                 content_file.flush()

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -46,6 +46,19 @@ def setup_fam(module_target_sat, module_sca_manifest):
     # Execute AAP WF for FAM setup
     Broker().execute(workflow='fam-test-setup', source_vm=module_target_sat.name)
 
+    # Setup provisioning resources and copy config files to the Satellite
+    module_target_sat.configure_libvirt_cr()
+    module_target_sat.put(
+        settings.fam.server.to_yaml(),
+        f'{FAM_ROOT_DIR}/tests/test_playbooks/vars/server.yml',
+        temp_file=True,
+    )
+    module_target_sat.put(
+        settings.fam.compute_profile.to_yaml(),
+        f'{FAM_ROOT_DIR}/tests/test_playbooks/vars/compute_profile.yml',
+        temp_file=True,
+    )
+
     # Edit Makefile to not try to rebuild the collection when tests run
     module_target_sat.execute(f"sed -i '/^live/ s/$(MANIFEST)//' {FAM_ROOT_DIR}/Makefile")
 
@@ -54,26 +67,9 @@ def setup_fam(module_target_sat, module_sca_manifest):
     module_target_sat.execute(
         f'mv {module_sca_manifest.name} {FAM_ROOT_DIR}/tests/test_playbooks/data'
     )
-
-    # Edit config file
     config_file = f'{FAM_ROOT_DIR}/tests/test_playbooks/vars/server.yml'
     module_target_sat.execute(
-        f'cp {FAM_ROOT_DIR}/tests/test_playbooks/vars/server.yml.example {config_file}'
-    )
-    module_target_sat.execute(
-        f'sed -i "s/foreman.example.com/{module_target_sat.hostname}/g" {config_file}'
-    )
-    module_target_sat.execute(
-        f'sed -i "s/rhsm_pool_id:.*/rhsm_pool_id: {settings.subscription.rhn_poolid}/g" {config_file}'
-    )
-    module_target_sat.execute(
-        f'''sed -i 's/rhsm_username:.*/rhsm_username: "{settings.subscription.rhn_username}"/g' {config_file}'''
-    )
-    module_target_sat.execute(
         f'''sed -i 's|subscription_manifest_path:.*|subscription_manifest_path: "data/{module_sca_manifest.name}"|g' {config_file}'''
-    )
-    module_target_sat.execute(
-        f'''sed -i 's/rhsm_password:.*/rhsm_password: "{settings.subscription.rhn_password}"/g' {config_file}'''
     )
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14866

### Problem Statement
Some tests are failing in production because we are missing live config settings for them. We also created some tech debt on the last PR, because we were doing inline config replacement with `sed`.

### Solution
Host the config files ourselves and evaluate them with dynaconf before sending them to the server.

I won't be able to test this in PRT at the moment, but will open a jenkins PR for the right config settings. The current templates I copied into here are directly from https://github.com/theforeman/foreman-ansible-modules/tree/develop/tests/test_playbooks/vars

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->