### PR TITLE
[6.13.z] removed the non-used Colored box object

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -5,17 +5,6 @@ from pathlib import Path
 from box import Box
 from nailgun import entities
 
-
-# String Color codes
-class Colored(Box):
-    YELLOW = '\033[1;33m'
-    REDLIGHT = '\033[3;31m'
-    REDDARK = '\033[1;31m'
-    GREEN = '\033[1;32m'
-    WHITELIGHT = '\033[1;30m'
-    RESET = '\033[0m'
-
-
 # This should be updated after each version branch
 SATELLITE_VERSION = "6.13"
 SATELLITE_OS_VERSION = "8"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14991

### Problem Statement
We are seeing an error here https://github.com/SatelliteQE/robottelo/actions/runs/8990989538/job/24697560722?pr=14702
this could be because of the how Sphinx render the html code

### Solution
This object in the constant was not used hence I tried to removed that.  

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->