### PR TITLE
[6.14.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,14 +5,14 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
     - id: trailing-whitespace
       exclude: tests/foreman/data/
     - id: check-yaml
     - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.1
+    rev: v0.4.3
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -28,6 +28,6 @@ repos:
         types: [text]
         require_serial: true
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.0
+    rev: v8.18.2
     hooks:
       - id: gitleaks

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -162,7 +162,7 @@ def test_positive_list(libvirt_url, module_target_sat):
     )
     assert comp_res['name']
     result_list = module_target_sat.cli.ComputeResource.list(
-        {'search': 'name=%s' % comp_res['name']}
+        {'search': 'name={}'.format(comp_res['name'])}
     )
     assert len(result_list) > 0
     result = module_target_sat.cli.ComputeResource.exists(search=('name', comp_res['name']))


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14781

<!--pre-commit.ci start-->
updates:
- [github.com/pre-commit/pre-commit-hooks: v4.4.0 → v4.6.0](https://github.com/pre-commit/pre-commit-hooks/compare/v4.4.0...v4.6.0)
- [github.com/astral-sh/ruff-pre-commit: v0.4.1 → v0.4.3](https://github.com/astral-sh/ruff-pre-commit/compare/v0.4.1...v0.4.3)
- [github.com/gitleaks/gitleaks: v8.18.0 → v8.18.2](https://github.com/gitleaks/gitleaks/compare/v8.18.0...v8.18.2)
<!--pre-commit.ci end-->