### PR TITLE
Add marker for case insensitive test collection by component and importance

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -163,8 +163,8 @@ def pytest_collection_modifyitems(items, config):
 
     # split the option string and handle no option, single option, multiple
     # config.getoption(default) doesn't work like you think it does, hence or ''
-    importance = [i for i in (config.getoption('importance') or '').split(',') if i != '']
-    component = [c for c in (config.getoption('component') or '').split(',') if c != '']
+    importance = [i.lower() for i in (config.getoption('importance') or '').split(',') if i != '']
+    component = [c.lower() for c in (config.getoption('component') or '').split(',') if c != '']
     team = [a.lower() for a in (config.getoption('team') or '').split(',') if a != '']
     verifies_issues = config.getoption('verifies_issues')
     blocked_by = config.getoption('blocked_by')
@@ -192,10 +192,10 @@ def pytest_collection_modifyitems(items, config):
             # only add the mark if it hasn't already been applied at a lower scope
             doc_component = component_regex.findall(docstring)
             if doc_component and 'component' not in item_mark_names:
-                item.add_marker(pytest.mark.component(doc_component[0]))
+                item.add_marker(pytest.mark.component(doc_component[0].lower()))
             doc_importance = importance_regex.findall(docstring)
             if doc_importance and 'importance' not in item_mark_names:
-                item.add_marker(pytest.mark.importance(doc_importance[0]))
+                item.add_marker(pytest.mark.importance(doc_importance[0].lower()))
             doc_team = team_regex.findall(docstring)
             if doc_team and 'team' not in item_mark_names:
                 item.add_marker(pytest.mark.team(doc_team[0].lower()))


### PR DESCRIPTION
### Problem Statement
We need case insensitive test collection component-wise

### Solution
Added marker for component-wise test collection
result:
pytest tests/foreman/ --component auditlog
collected 5434 items / 5426 deselected / 8 selected                                                                                              

```
tests/foreman/api/test_audit.py ✓✓✓                                                                                                38% ███▊      
 tests/foreman/ui/test_audit.py ✓✓✓✓✓                                                                                              100% ██████████
```
=======================================================


### Related Issues



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->