### PR TITLE
[6.15.z] [Comp Eval] Updating to test on multiple hosts and fixing test failures

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -696,7 +696,7 @@ class CLIFactory:
             'repository-id': custom_repo['id'],
         }
 
-    def _setup_org_for_a_rh_repo(self, options=None):
+    def _setup_org_for_a_rh_repo(self, options=None, force=False):
         """Sets up Org for the given Red Hat repository by:
 
         1. Checks if organization and lifecycle environment were given, otherwise
@@ -792,7 +792,12 @@ class CLIFactory:
         # Promote version1 to next env
         try:
             self._satellite.cli.ContentView.version_promote(
-                {'id': cvv['id'], 'organization-id': org_id, 'to-lifecycle-environment-id': env_id}
+                {
+                    'id': cvv['id'],
+                    'organization-id': org_id,
+                    'to-lifecycle-environment-id': env_id,
+                    'force': force,
+                }
             )
         except CLIReturnCodeError as err:
             raise CLIFactoryError(
@@ -845,7 +850,11 @@ class CLIFactory:
         }
 
     def setup_org_for_a_rh_repo(
-        self, options=None, force_manifest_upload=False, force_use_cdn=False
+        self,
+        options=None,
+        force_manifest_upload=False,
+        force_use_cdn=False,
+        force=False,
     ):
         """Wrapper above ``_setup_org_for_a_rh_repo`` to use custom downstream repo
         instead of CDN's 'Satellite Capsule', 'Satellite Tools'  and base OS repos if
@@ -874,7 +883,7 @@ class CLIFactory:
         elif 'Satellite Capsule' in options.get('repository'):
             custom_repo_url = settings.repos.capsule_repo
         if force_use_cdn or settings.robottelo.cdn or not custom_repo_url:
-            return self._setup_org_for_a_rh_repo(options)
+            return self._setup_org_for_a_rh_repo(options, force)
         options['url'] = custom_repo_url
         result = self.setup_org_for_a_custom_repo(options)
         if force_manifest_upload:

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -667,7 +667,7 @@ def test_positive_schedule_entitlements_report(setup_content, target_sat):
 
 @pytest.mark.no_containers
 @pytest.mark.tier3
-def test_positive_generate_job_report(setup_content, target_sat, rhel7_contenthost):
+def test_positive_generate_job_report(setup_content, module_target_sat, content_hosts):
     """Generate a report using the Job - Invocation Report template.
 
     :id: 946c39db-3061-43d7-b922-1be61f0c7d93
@@ -686,17 +686,17 @@ def test_positive_generate_job_report(setup_content, target_sat, rhel7_contentho
     :customerscenario: true
     """
     ak, org = setup_content
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(org.label, ak.name)
-    rhel7_contenthost.add_rex_key(target_sat)
-    assert rhel7_contenthost.subscribed
-    # Run a Job on the Host
+    for host in content_hosts:
+        host.register(org, None, ak.name, module_target_sat)
+        host.add_rex_key(module_target_sat)
+        assert host.subscribed
+        # Run a Job on the Host
     template_id = (
-        target_sat.api.JobTemplate()
+        module_target_sat.api.JobTemplate()
         .search(query={'search': 'name="Run Command - Script Default"'})[0]
         .id
     )
-    job = target_sat.api.JobInvocation().run(
+    job = module_target_sat.api.JobInvocation().run(
         synchronous=False,
         data={
             'job_template_id': template_id,
@@ -704,14 +704,14 @@ def test_positive_generate_job_report(setup_content, target_sat, rhel7_contentho
                 'command': 'pwd',
             },
             'targeting_type': 'static_query',
-            'search_query': f'name = {rhel7_contenthost.hostname}',
+            'search_query': f'name ^ ({content_hosts[0].hostname} && {content_hosts[1].hostname}',
         },
     )
-    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
-    result = target_sat.api.JobInvocation(id=job['id']).read()
-    assert result.succeeded == 1
+    module_target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = module_target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 2
     rt = (
-        target_sat.api.ReportTemplate()
+        module_target_sat.api.ReportTemplate()
         .search(query={'search': 'name="Job - Invocation Report"'})[0]
         .read()
     )
@@ -722,8 +722,10 @@ def test_positive_generate_job_report(setup_content, target_sat, rhel7_contentho
             'input_values': {"job_id": job["id"]},
         }
     )
-    assert res[0]['Host'] == rhel7_contenthost.hostname
+    assert res[0]['Host'] == content_hosts[0].hostname
+    assert res[1]['Host'] == content_hosts[1].hostname
     assert '/root' in res[0]['stdout']
+    assert '/root' in res[1]['stdout']
 
 
 @pytest.mark.tier2

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -746,9 +746,10 @@ def test_positive_generate_ansible_template(module_target_sat):
     assert host['name'] in [item.split(',')[1] for item in report_data.split('\n') if len(item) > 0]
 
 
+@pytest.mark.no_containers
 @pytest.mark.tier3
 def test_positive_generate_entitlements_report_multiple_formats(
-    module_entitlement_manifest_org, local_ak, local_subscription, rhel7_contenthost, target_sat
+    module_sca_manifest_org, local_ak, local_subscription, rhel7_contenthost, target_sat
 ):
     """Generate an report using the Subscription - Entitlement Report template
     in html, yaml, and csv format.
@@ -772,11 +773,11 @@ def test_positive_generate_entitlements_report_multiple_formats(
     """
     client = rhel7_contenthost
     client.install_katello_ca(target_sat)
-    client.register_contenthost(module_entitlement_manifest_org.label, local_ak['name'])
+    client.register_contenthost(module_sca_manifest_org.label, local_ak['name'])
     assert client.subscribed
     result_html = target_sat.cli.ReportTemplate.generate(
         {
-            'organization': module_entitlement_manifest_org.name,
+            'organization': module_sca_manifest_org.name,
             'name': 'Subscription - Entitlement Report',
             'report-format': 'html',
             'inputs': 'Days from Now=no limit',
@@ -786,7 +787,7 @@ def test_positive_generate_entitlements_report_multiple_formats(
     assert local_subscription['name'] in result_html
     result_yaml = target_sat.cli.ReportTemplate.generate(
         {
-            'organization': module_entitlement_manifest_org.name,
+            'organization': module_sca_manifest_org.name,
             'name': 'Subscription - Entitlement Report',
             'report-format': 'yaml',
             'inputs': 'Days from Now=no limit',
@@ -799,7 +800,7 @@ def test_positive_generate_entitlements_report_multiple_formats(
             assert local_subscription['name'] in entry
     result_csv = target_sat.cli.ReportTemplate.generate(
         {
-            'organization': module_entitlement_manifest_org.name,
+            'organization': module_sca_manifest_org.name,
             'name': 'Subscription - Entitlement Report',
             'report-format': 'csv',
             'inputs': 'Days from Now=no limit',
@@ -924,7 +925,8 @@ def test_positive_generate_hostpkgcompare(
             'content-view-id': local_content_view['id'],
             'lifecycle-environment-id': local_environment['id'],
             'activationkey-id': local_ak['id'],
-        }
+        },
+        force=True,
     )
     target_sat.cli_factory.setup_org_for_a_custom_repo(
         {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14704

Tests failures due to trying to promote a content view version out of sequential order. Adding functionality to test on multiple hosts, and adding pytest fixture to tests due to consuming content on containers. 

RHSAT6-45564 test_positive_generate_job_report
RHSAT6-44204 test_positive_generate_entitlements_report_multiple_formats
RHSAT6-44455 test_positive_generate_hostpkgcompare

