### PR TITLE
[6.15.z] Gracious message when vault is not reachable

### DIFF
--- a/robottelo/utils/vault.py
+++ b/robottelo/utils/vault.py
@@ -64,7 +64,10 @@ class Vault:
                 logger.error(f"Error! {self.HELP_TEXT}")
                 sys.exit(1)
             if vcommand.stderr:
-                if 'Error revoking token' in verror:
+                if 'no such host' in verror:
+                    logger.error("The Vault host is not reachable, check network availability.")
+                    sys.exit()
+                elif 'Error revoking token' in verror:
                     logger.info("Token is alredy revoked!")
                 elif 'Error looking up token' in verror:
                     logger.info("Vault is not logged in!")


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14942

### Problem Statement

When the VPN is not connected today, an unclear/lengthy traceback:
```
# make vault-login                                  
2024-05-03 15:16:29 - robottelo - ERROR - Error! b'Error authenticating: Put "https://vault.example.com:8200/v1/auth/oidc/oidc/auth_url": dial tcp: lookup vault.example.com: no such host\n'
Traceback (most recent call last):
  File "/Users/jyejare/gitrepos/robottelo/scripts/vault_login.py", line 10, in <module>
    vclient.login()
  File "/Users/jyejare/gitrepos/robottelo/robottelo/utils/vault.py", line 94, in login
    token = json.loads(str(token.decode('UTF-8')))['data']['id']
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.3/Frameworks/Python.framework/Versions/3.12/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
make: *** [vault-login] Error 1
```

### Solution

When the VPN is not connected with this PR, a nice message:
```
# make vault-login                                            
2024-05-03 15:11:07 - robottelo - INFO - The Vault host is not reachable, check network availability
```


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->