### PR TITLE
[Comp Eval] Change CV CLI/API tests to use SCA Org

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -911,14 +911,12 @@ class TestContentViewRedHatContent:
     """Tests for publishing and promoting content views."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def initiate_testclass(
-        self, request, module_cv, module_entitlement_manifest_org, class_target_sat
-    ):
+    def initiate_testclass(self, request, module_cv, module_sca_manifest_org, class_target_sat):
         """Set up organization, product and repositories for tests."""
 
         repo_id = class_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch='x86_64',
-            org_id=module_entitlement_manifest_org.id,
+            org_id=module_sca_manifest_org.id,
             product=PRDS['rhel'],
             repo=REPOS['rhst7']['name'],
             reposet=REPOSET['rhst7'],
@@ -1322,12 +1320,12 @@ class TestContentViewRedHatOstreeContent:
     """Tests for publishing and promoting cv with RH ostree contents."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def initiate_testclass(self, request, module_entitlement_manifest_org, class_target_sat):
+    def initiate_testclass(self, request, module_sca_manifest_org, class_target_sat):
         """Set up organization, product and repositories for tests."""
 
         repo_id = class_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=None,
-            org_id=module_entitlement_manifest_org.id,
+            org_id=module_sca_manifest_org.id,
             product=PRDS['rhah'],
             repo=REPOS['rhaht']['name'],
             reposet=REPOSET['rhaht'],

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -36,10 +36,10 @@ from robottelo.utils.datafactory import (
 
 
 @pytest.fixture(scope='module')
-def module_rhel_content(module_entitlement_manifest_org, module_target_sat):
+def module_rhel_content(module_sca_manifest_org, module_target_sat):
     """Returns RH repo after syncing it"""
     product = entities.Product(
-        name=constants.PRDS['rhel'], organization=module_entitlement_manifest_org
+        name=constants.PRDS['rhel'], organization=module_sca_manifest_org
     ).search()[0]
     reposet = entities.RepositorySet(name=constants.REPOSET['rhva6'], product=product).search()[0]
     data = {'basearch': 'x86_64', 'releasever': '6Server', 'product_id': product.id}
@@ -48,14 +48,14 @@ def module_rhel_content(module_entitlement_manifest_org, module_target_sat):
     repo = module_target_sat.cli.Repository.info(
         {
             'name': constants.REPOS['rhva6']['name'],
-            'organization-id': module_entitlement_manifest_org.id,
+            'organization-id': module_sca_manifest_org.id,
             'product': product.name,
         }
     )
     module_target_sat.cli.Repository.synchronize(
         {
             'name': constants.REPOS['rhva6']['name'],
-            'organization-id': module_entitlement_manifest_org.id,
+            'organization-id': module_sca_manifest_org.id,
             'product': product.name,
         }
     )
@@ -837,7 +837,7 @@ class TestContentView:
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_add_rh_repo_by_id_and_create_filter(
-        self, module_entitlement_manifest_org, module_rhel_content, module_target_sat
+        self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
         """Associate Red Hat content to a content view and create filter
 
@@ -856,13 +856,13 @@ class TestContentView:
         """
         # Create CV
         new_cv = module_target_sat.cli_factory.make_content_view(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         # Associate repo to CV
         module_target_sat.cli.ContentView.add_repository(
             {
                 'id': new_cv['id'],
-                'organization-id': module_entitlement_manifest_org.id,
+                'organization-id': module_sca_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -997,7 +997,7 @@ class TestContentView:
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier2
     def test_positive_promote_rh_content(
-        self, module_entitlement_manifest_org, module_rhel_content, module_target_sat
+        self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
         """attempt to promote a content view containing RH content
 
@@ -1012,7 +1012,7 @@ class TestContentView:
         """
         # Create CV
         new_cv = module_target_sat.cli_factory.make_content_view(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         # Associate repo to CV
         module_target_sat.cli.ContentView.add_repository(
@@ -1022,7 +1022,7 @@ class TestContentView:
         module_target_sat.cli.ContentView.publish({'id': new_cv['id']})
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         env1 = module_target_sat.cli_factory.make_lifecycle_environment(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         # Promote the Published version of CV to the next env
         module_target_sat.cli.ContentView.version_promote(
@@ -1035,7 +1035,7 @@ class TestContentView:
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier3
     def test_positive_promote_rh_and_custom_content(
-        self, module_entitlement_manifest_org, module_rhel_content, module_target_sat
+        self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
         """attempt to promote a content view containing RH content and
         custom content using filters
@@ -1054,7 +1054,7 @@ class TestContentView:
             {
                 'content-type': 'yum',
                 'product-id': module_target_sat.cli_factory.make_product(
-                    {'organization-id': module_entitlement_manifest_org.id}
+                    {'organization-id': module_sca_manifest_org.id}
                 )['id'],
             }
         )
@@ -1062,7 +1062,7 @@ class TestContentView:
         module_target_sat.cli.Repository.synchronize({'id': new_repo['id']})
         # Create CV
         new_cv = module_target_sat.cli_factory.make_content_view(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         # Associate repos with CV
         module_target_sat.cli.ContentView.add_repository(
@@ -1085,7 +1085,7 @@ class TestContentView:
         module_target_sat.cli.ContentView.publish({'id': new_cv['id']})
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         env1 = module_target_sat.cli_factory.make_lifecycle_environment(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         # Promote the Published version of CV to the next env
         module_target_sat.cli.ContentView.version_promote(
@@ -1272,7 +1272,7 @@ class TestContentView:
     @pytest.mark.pit_server
     @pytest.mark.tier3
     def test_positive_publish_rh_and_custom_content(
-        self, module_entitlement_manifest_org, module_rhel_content, module_target_sat
+        self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
         """attempt to publish  a content view containing a RH and custom
         repos and has filters
@@ -1291,7 +1291,7 @@ class TestContentView:
             {
                 'content-type': 'yum',
                 'product-id': module_target_sat.cli_factory.make_product(
-                    {'organization-id': module_entitlement_manifest_org.id}
+                    {'organization-id': module_sca_manifest_org.id}
                 )['id'],
             }
         )
@@ -1299,7 +1299,7 @@ class TestContentView:
         module_target_sat.cli.Repository.synchronize({'id': new_repo['id']})
         # Create CV
         new_cv = module_target_sat.cli_factory.make_content_view(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         # Associate repos with CV
         module_target_sat.cli.ContentView.add_repository(
@@ -1499,7 +1499,7 @@ class TestContentView:
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier2
     def test_positive_republish_after_rh_content_removed(
-        self, module_entitlement_manifest_org, module_rhel_content, module_target_sat
+        self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
         """Attempt to re-publish content view after all RH associated content
         was removed from that CV
@@ -1518,13 +1518,13 @@ class TestContentView:
         :CaseImportance: Medium
         """
         new_cv = module_target_sat.cli_factory.make_content_view(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         # Associate repo to CV
         module_target_sat.cli.ContentView.add_repository(
             {
                 'id': new_cv['id'],
-                'organization-id': module_entitlement_manifest_org.id,
+                'organization-id': module_sca_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -1668,7 +1668,7 @@ class TestContentView:
     @pytest.mark.run_in_one_thread
     @pytest.mark.tier3
     def test_positive_subscribe_chost_by_id_using_rh_content(
-        self, module_entitlement_manifest_org, module_rhel_content, module_target_sat
+        self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
         """Attempt to subscribe content host to content view that has
         Red Hat repository assigned to it
@@ -1681,15 +1681,15 @@ class TestContentView:
         :CaseImportance: Medium
         """
         env = module_target_sat.cli_factory.make_lifecycle_environment(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         content_view = module_target_sat.cli_factory.make_content_view(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         module_target_sat.cli.ContentView.add_repository(
             {
                 'id': content_view['id'],
-                'organization-id': module_entitlement_manifest_org.id,
+                'organization-id': module_sca_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -1708,7 +1708,7 @@ class TestContentView:
                 'content-view-id': content_view['id'],
                 'lifecycle-environment-id': env['id'],
                 'name': gen_alphanumeric(),
-                'organization-id': module_entitlement_manifest_org.id,
+                'organization-id': module_sca_manifest_org.id,
             }
         )
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
@@ -1718,7 +1718,7 @@ class TestContentView:
     @pytest.mark.tier3
     @pytest.mark.upgrade
     def test_positive_subscribe_chost_by_id_using_rh_content_and_filters(
-        self, module_entitlement_manifest_org, module_rhel_content, module_target_sat
+        self, module_sca_manifest_org, module_rhel_content, module_target_sat
     ):
         """Attempt to subscribe content host to filtered content view
         that has Red Hat repository assigned to it
@@ -1733,15 +1733,15 @@ class TestContentView:
         :CaseImportance: Low
         """
         env = module_target_sat.cli_factory.make_lifecycle_environment(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         content_view = module_target_sat.cli_factory.make_content_view(
-            {'organization-id': module_entitlement_manifest_org.id}
+            {'organization-id': module_sca_manifest_org.id}
         )
         module_target_sat.cli.ContentView.add_repository(
             {
                 'id': content_view['id'],
-                'organization-id': module_entitlement_manifest_org.id,
+                'organization-id': module_sca_manifest_org.id,
                 'repository-id': module_rhel_content['id'],
             }
         )
@@ -1781,7 +1781,7 @@ class TestContentView:
                 'content-view-id': content_view['id'],
                 'lifecycle-environment-id': env['id'],
                 'name': gen_alphanumeric(),
-                'organization-id': module_entitlement_manifest_org.id,
+                'organization-id': module_sca_manifest_org.id,
             }
         )
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})


### PR DESCRIPTION
### Problem Statement
CV API/CLI tests still contained old manifest org usage

### Solution
Change all usages of entitlement manifest orgs to sca manifest orgs