### PR TITLE
Add test coverage for BZ:1931489

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -532,3 +532,72 @@ class TestAnsibleREX:
         result = target_sat.api.JobInvocation(id=job['id']).outputs()['outputs'][0]['output']
         assert [i['output'] for i in result if '"msg": "Hello, localhost!"' in i['output']]
         assert [i['output'] for i in result if i['output'] == 'Exit status: 0']
+
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_list('8')
+    def test_negative_ansible_job_timeout_to_kill(
+        self, target_sat, module_org, module_location, module_ak_with_synced_repo, rhel_contenthost
+    ):
+        """when running ansible-playbook, timeout to kill/execution_timeout_interval setting
+            is honored for registered host
+
+        :id: a082f599-fbf7-4779-aa18-5139e2bce777
+
+        :steps:
+            1. Register a content host with satellite
+            2. Run Ansible playbook to pause execution for a while, along with
+                timeout to kill/execution_timeout_interval setting on the registered host
+            3. Verify job is terminated honoring timeout to kill setting and verify job output.
+
+        :expectedresults: Timeout to kill terminates the job if playbook doesn't finish in time
+
+        :BZ: 1931489
+
+        :customerscenario: true
+        """
+        playbook = '''
+            ---
+            - name: Sample Ansible Playbook to pause
+              hosts: all
+              gather_facts: no
+              tasks:
+              - name: Pause for 5 minutes
+                pause:
+                  minutes: 5
+        '''
+        result = rhel_contenthost.register(
+            module_org, module_location, module_ak_with_synced_repo.name, target_sat
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+        template_id = (
+            target_sat.api.JobTemplate()
+            .search(query={'search': 'name="Ansible - Run playbook"'})[0]
+            .id
+        )
+        # run ansible-playbook with execution_timeout_interval/timeout_to_kill
+        job = target_sat.api.JobInvocation().run(
+            synchronous=False,
+            data={
+                'job_template_id': template_id,
+                'targeting_type': 'static_query',
+                'search_query': f'name = {rhel_contenthost.hostname}',
+                'inputs': {'playbook': playbook},
+                'execution_timeout_interval': '30',
+            },
+        )
+        target_sat.wait_for_tasks(
+            f'resource_type = JobInvocation and resource_id = {job["id"]}',
+            poll_timeout=1000,
+            must_succeed=False,
+        )
+        result = target_sat.api.JobInvocation(id=job['id']).read()
+        assert result.pending == 0
+        assert result.failed == 1
+        assert result.status_label == 'failed'
+
+        result = target_sat.api.JobInvocation(id=job['id']).outputs()['outputs'][0]['output']
+        termination_msg = 'Timeout for execution passed, stopping the job'
+        assert [i['output'] for i in result if i['output'] == termination_msg]
+        assert [i['output'] for i in result if i['output'] == 'StandardError: Job execution failed']
+        assert [i['output'] for i in result if i['output'] == 'Exit status: 120']


### PR DESCRIPTION
### Problem Statement
Missing coverage for BZ:1931489, where we verified timeout to kill/execution_timeout_interval setting is honored by long running ansible-playbook job

### Solution
Add test coverage for BZ:1931489, to verify long running ansible-playbook job along with timeout to kill/execution_timeout_interval setting

### Dependent PRs:
https://github.com/SatelliteQE/nailgun/pull/1139