### PR TITLE
ui_session: return airgun session as a context manager

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1919,17 +1919,15 @@ class Satellite(Capsule, SatelliteMixins):
             return None
 
         try:
-            ui_session = Session(
+            with Session(
                 session_name=testname or get_caller(),
                 user=user or settings.server.admin_username,
                 password=password or settings.server.admin_password,
                 url=url,
                 hostname=self.hostname,
                 login=login,
-            )
-            yield ui_session
-        except Exception:
-            raise
+            ) as ui_session:
+                yield ui_session
         finally:
             if self.record_property is not None and settings.ui.record_video:
                 video_url = settings.ui.grid_url.replace(


### PR DESCRIPTION
### Problem Statement

If a UI test is using the new session approach via `target_sat.ui_session()`,
the browser window is not closed at the end of the test.
Also the screenshot is not taken if the test fails.


### Solution

`Satellite.ui_session()` method needs to return the airgun `Session` as a context manager,
so the `__exit__` method is called, which handles screenshot capture and closing the browser window.
