### PR TITLE
[6.15.z] Add preconversion check for convert2rhel

### DIFF
--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -16,7 +16,7 @@ import pytest
 import requests
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ARCHITECTURE, DEFAULT_SUBSCRIPTION_NAME, REPOS
+from robottelo.constants import DEFAULT_ARCHITECTURE, REPOS
 
 
 def create_repo(sat, org, repo_url, ssl_cert=None):
@@ -35,23 +35,6 @@ def create_repo(sat, org, repo_url, ssl_cert=None):
     repo.product = product
     repo.sync()
     return repo
-
-
-def create_activation_key(sat, org, lce, cv, subscription_id):
-    """Create activation key with subscription"""
-    act_key = sat.api.ActivationKey(
-        organization=org,
-        content_view=cv,
-        environment=lce,
-    ).create()
-    act_key.add_subscriptions(data={'subscription_id': subscription_id})
-    content = sat.cli.ActivationKey.product_content({'id': act_key.id, 'organization-id': org.id})
-    act_key.content_override(
-        data={'content_overrides': [{'content_label': content[0]['label'], 'value': '1'}]}
-    )
-    ak_subscriptions = act_key.product_content()['results']
-    ak_subscriptions[0]['enabled'] = True
-    return act_key
 
 
 def update_cv(sat, cv, lce, repos):
@@ -79,24 +62,18 @@ def activation_key_rhel(
     module_target_sat, module_entitlement_manifest_org, module_lce, module_promoted_cv, version
 ):
     """Create activation key that will be used after conversion for registration"""
-    subs = module_target_sat.api.Subscription(
-        organization=module_entitlement_manifest_org.id
-    ).search(query={'search': f'{DEFAULT_SUBSCRIPTION_NAME}'})
-    assert subs
-    return create_activation_key(
-        module_target_sat,
-        module_entitlement_manifest_org,
-        module_lce,
-        module_promoted_cv,
-        subs[0].id,
-    )
+    return module_target_sat.api.ActivationKey(
+        organization=module_entitlement_manifest_org,
+        content_view=module_promoted_cv,
+        environment=module_lce,
+    ).create()
 
 
 @pytest.fixture(scope='module')
 def enable_rhel_subscriptions(module_target_sat, module_entitlement_manifest_org, version):
     """Enable and sync RHEL rpms repos"""
     major = version.split('.')[0]
-    minor = ""
+    minor = ''
     if major == '8':
         repo_names = ['rhel8_bos', 'rhel8_aps']
         minor = version[1:]
@@ -150,12 +127,16 @@ def centos(
     cv = update_cv(
         module_target_sat, module_promoted_cv, module_lce, enable_rhel_subscriptions + [repo]
     )
-    c2r_sub = module_target_sat.api.Subscription(
-        organization=module_entitlement_manifest_org.id, name=repo.product.name
-    ).search()[0]
-    ak = create_activation_key(
-        module_target_sat, module_entitlement_manifest_org, module_lce, cv, c2r_sub.id
-    )
+    ak = module_target_sat.api.ActivationKey(
+        organization=module_entitlement_manifest_org,
+        content_view=cv,
+        environment=module_lce,
+    ).create()
+
+    # Ensure C2R repo is enabled in the activation key
+    all_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
+    repo_label = [content['label'] for content in all_content if content['name'] == repo.name][0]
+    ak.content_override(data={'content_overrides': [{'content_label': repo_label, 'value': '1'}]})
 
     # Register CentOS host with Satellite
     result = centos_host.api_register(
@@ -193,12 +174,14 @@ def oracle(
     oracle_host.execute('echo "exclude=rhn-client-tools" >> /etc/yum.conf')
 
     # Install and set correct RHEL compatible kernel and using non-UEK kernel, based on C2R docs
-    result = oracle_host.execute(
-        'yum install -y kernel && '
-        'grubby --set-default /boot/vmlinuz-'
-        '`rpm -q --qf "%{BUILDTIME}\t%{EVR}.%{ARCH}\n" kernel | sort -nr | head -1 | cut -f2`'
+    assert (
+        oracle_host.execute(
+            'yum install -y kernel* && '
+            'grubby --set-default /boot/vmlinuz-'
+            '`rpm -q --qf "%{BUILDTIME}\t%{EVR}.%{ARCH}\n" kernel | sort -nr | head -1 | cut -f2`'
+        ).status
+        == 0
     )
-    assert result.status == 0
 
     if major == '8':
         # needs-restarting missing in OEL8
@@ -219,12 +202,17 @@ def oracle(
     cv = update_cv(
         module_target_sat, module_promoted_cv, module_lce, enable_rhel_subscriptions + [repo]
     )
-    c2r_sub = module_target_sat.api.Subscription(
-        organization=module_entitlement_manifest_org, name=repo.product.name
-    ).search()[0]
-    ak = create_activation_key(
-        module_target_sat, module_entitlement_manifest_org, module_lce, cv, c2r_sub.id
-    )
+    ak = module_target_sat.api.ActivationKey(
+        organization=module_entitlement_manifest_org,
+        content_view=cv,
+        environment=module_lce,
+    ).create()
+
+    # Ensure C2R repo is enabled in the activation key
+    all_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
+    repo_label = [content['label'] for content in all_content if content['name'] == repo.name][0]
+    ak.content_override(data={'content_overrides': [{'content_label': repo_label, 'value': '1'}]})
+
     # UBI repo required for subscription-manager packages on Oracle
     ubi_url = settings.repos.convert2rhel.ubi7 if major == '7' else settings.repos.convert2rhel.ubi8
 
@@ -251,7 +239,9 @@ def version(request):
 
 @pytest.mark.e2e
 @pytest.mark.parametrize('version', ['oracle7', 'oracle8'], indirect=True)
-def test_convert2rhel_oracle(module_target_sat, oracle, activation_key_rhel, version):
+def test_convert2rhel_oracle_with_pre_conversion_template_check(
+    module_target_sat, oracle, activation_key_rhel, version
+):
     """Convert Oracle linux to RHEL
 
     :id: 7fd393f0-551a-4de0-acdd-7f026b485f79
@@ -278,6 +268,29 @@ def test_convert2rhel_oracle(module_target_sat, oracle, activation_key_rhel, ver
     host_content = module_target_sat.api.Host(id=oracle.hostname).read_json()
     assert host_content['operatingsystem_name'] == f"OracleLinux {version}"
 
+    # Pre-conversion template job
+    template_id = (
+        module_target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Convert2RHEL analyze"'})[0]
+        .id
+    )
+    job = module_target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'targeting_type': 'static_query',
+            'search_query': f'name = {oracle.hostname}',
+        },
+    )
+
+    # wait for job to complete
+    module_target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}',
+        poll_timeout=5500,
+        search_rate=20,
+    )
+    result = module_target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 1
     # execute job 'Convert 2 RHEL' on host
     template_id = (
         module_target_sat.api.JobTemplate().search(query={'search': 'name="Convert to RHEL"'})[0].id
@@ -289,7 +302,6 @@ def test_convert2rhel_oracle(module_target_sat, oracle, activation_key_rhel, ver
             'inputs': {
                 'Activation Key': activation_key_rhel.id,
                 'Restart': 'yes',
-                'Data telemetry': 'yes',
             },
             'targeting_type': 'static_query',
             'search_query': f'name = {oracle.hostname}',
@@ -315,7 +327,9 @@ def test_convert2rhel_oracle(module_target_sat, oracle, activation_key_rhel, ver
 
 @pytest.mark.e2e
 @pytest.mark.parametrize('version', ['centos7', 'centos8'], indirect=True)
-def test_convert2rhel_centos(module_target_sat, centos, activation_key_rhel, version):
+def test_convert2rhel_centos_with_pre_conversion_template_check(
+    module_target_sat, centos, activation_key_rhel, version
+):
     """Convert CentOS linux to RHEL
 
     :id: 6f698440-7d85-4deb-8dd9-363ea9003b92
@@ -333,6 +347,30 @@ def test_convert2rhel_centos(module_target_sat, centos, activation_key_rhel, ver
     host_content = module_target_sat.api.Host(id=centos.hostname).read_json()
     major = version.split('.')[0]
     assert host_content['operatingsystem_name'] == f'CentOS {major}'
+
+    # Pre-conversion template job
+    template_id = (
+        module_target_sat.api.JobTemplate()
+        .search(query={'search': 'name="Convert2RHEL analyze"'})[0]
+        .id
+    )
+    job = module_target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'targeting_type': 'static_query',
+            'search_query': f'name = {centos.hostname}',
+        },
+    )
+    # wait for job to complete
+    module_target_sat.wait_for_tasks(
+        f'resource_type = JobInvocation and resource_id = {job["id"]}',
+        poll_timeout=5500,
+        search_rate=20,
+    )
+    result = module_target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 1
+
     # execute job 'Convert 2 RHEL' on host
     template_id = (
         module_target_sat.api.JobTemplate().search(query={'search': 'name="Convert to RHEL"'})[0].id
@@ -344,7 +382,6 @@ def test_convert2rhel_centos(module_target_sat, centos, activation_key_rhel, ver
             'inputs': {
                 'Activation Key': activation_key_rhel.id,
                 'Restart': 'yes',
-                'Data telemetry': 'yes',
             },
             'targeting_type': 'static_query',
             'search_query': f'name = {centos.hostname}',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15044

### Problem Statement
We have pre-conversion check for convert2rhel but missing automation for it.

### Solution
Added pre-convesion check.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->