### PR TITLE
[6.15.z] code coverage bug2063218

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -209,10 +209,7 @@ def check_message_in_rhsm_log(message):
         delay=2,
     )
     logs = get_rhsm_log()
-    for line in logs.split('\n'):
-        if message in line:
-            return message
-    return False
+    return any(message in line for line in logs.split('\n'))
 
 
 def _get_hypervisor_mapping(hypervisor_type):

--- a/tests/foreman/virtwho/api/test_nutanix.py
+++ b/tests/foreman/virtwho/api/test_nutanix.py
@@ -242,7 +242,7 @@ class TestVirtWhoConfigforNutanix:
         assert str(exc_info.value) == env_error
         # check message exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert check_message_in_rhsm_log(message) == message
+        assert check_message_in_rhsm_log(message)
 
         # Update ahv_internal_debug option to true
         value = 'true'
@@ -266,4 +266,4 @@ class TestVirtWhoConfigforNutanix:
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert str(check_message_in_rhsm_log(message)) == 'False'
+        assert not check_message_in_rhsm_log(message)

--- a/tests/foreman/virtwho/cli/test_nutanix.py
+++ b/tests/foreman/virtwho/cli/test_nutanix.py
@@ -217,7 +217,7 @@ class TestVirtWhoConfigforNutanix:
         assert str(exc_info.value) == env_error
         # check message exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert check_message_in_rhsm_log(message) == message
+        assert check_message_in_rhsm_log(message)
 
         # Update ahv_internal_debug option to true
         value = 'true'
@@ -241,4 +241,4 @@ class TestVirtWhoConfigforNutanix:
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert str(check_message_in_rhsm_log(message)) == 'False'
+        assert not check_message_in_rhsm_log(message)

--- a/tests/foreman/virtwho/ui/test_nutanix.py
+++ b/tests/foreman/virtwho/ui/test_nutanix.py
@@ -228,7 +228,7 @@ class TestVirtwhoConfigforNutanix:
         assert str(exc_info.value) == env_error
         # check message exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert check_message_in_rhsm_log(message) == message
+        assert check_message_in_rhsm_log(message)
 
         # Update ahv_internal_debug option to true
         org_session.virtwho_configure.edit(name, {'ahv_internal_debug': True})
@@ -246,4 +246,4 @@ class TestVirtwhoConfigforNutanix:
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert str(check_message_in_rhsm_log(message)) == 'False'
+        assert not check_message_in_rhsm_log(message)

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -196,7 +196,7 @@ class TestVirtwhoConfigforNutanix:
         assert str(exc_info.value) == env_error
         # check message exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert check_message_in_rhsm_log(message) == message
+        assert check_message_in_rhsm_log(message)
 
         # Update ahv_internal_debug option to true
         org_session.virtwho_configure.edit(name, {'ahv_internal_debug': True})
@@ -214,4 +214,4 @@ class TestVirtwhoConfigforNutanix:
         assert get_configure_option("ahv_internal_debug", config_file) == 'true'
         # check message does not exist in log file /var/log/rhsm/rhsm.log
         message = 'Value for "ahv_internal_debug" not set, using default: False'
-        assert str(check_message_in_rhsm_log(message)) == 'False'
+        assert not check_message_in_rhsm_log(message)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14308

Code coverage bug2063218, it is a new [RFE]
Test case : PASS
```
(robottelo_vv_615) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/cli/test_esx_sca.py -k test_positive_rhsm_username_option --disable-pytest-warnings -q
.                                                                                                                                                                                                                                      [100%]
1 passed, 39 deselected, 23 warnings in 450.60s (0:07:30)
```