### PR TITLE
Add negative test case for ipv6 enabled in boot options

### DIFF
--- a/robottelo/cli/sm_update.py
+++ b/robottelo/cli/sm_update.py
@@ -13,6 +13,7 @@ Subcommands:
 Options:
     -h, --help    print help
 """
+
 from robottelo.cli.base import Base
 
 

--- a/tests/foreman/destructive/test_fm_upgrade.py
+++ b/tests/foreman/destructive/test_fm_upgrade.py
@@ -1,0 +1,55 @@
+"""Destructive test module for satellite-maintain upgrade functionality
+
+:Requirement: foreman-maintain
+
+:CaseAutomation: Automated
+
+:CaseComponent: SatelliteMaintain
+
+:Team: Platform
+
+:CaseImportance: Critical
+
+"""
+
+import pytest
+
+pytestmark = pytest.mark.destructive
+
+
+@pytest.mark.include_capsule
+def test_negative_ipv6_update_check(sat_maintain):
+    """Ensure update check fails when ipv6.disable=1 in boot options
+
+    :id: 7b3e017f-443a-4204-99be-e39fa04c89f6
+
+    :parametrized: yes
+
+    :steps:
+        1. Add ipv6.disable to grub boot options
+        2. Reboot
+        3. Run update check
+
+    :customerscenario: true
+
+    :BZ: 2277393
+
+    :expectedresults: Update check fails due to ipv6.disable=1 in boot options
+    """
+    result = sat_maintain.execute('grubby --args="ipv6.disable=1" --update-kernel=ALL')
+    assert result.status == 0
+
+    sat_maintain.power_control(state='reboot')
+
+    result = sat_maintain.cli.Update.check(
+        options={
+            'assumeyes': True,
+            'disable-self-update': True,
+            'whitelist': 'check-non-redhat-repository, repositories-validate',
+        }
+    )
+    assert result.status != 0
+    assert (
+        'The kernel contains ipv6.disable=1 which is known to break installation and upgrade, remove and reboot before continuining.'
+        in result.stdout
+    )


### PR DESCRIPTION
### Problem Statement
Customers are hitting an upgrade issue when ipv6.disable=1 is present in boot options. https://github.com/theforeman/foreman_maintain/pull/847 adds an upgrade check for ipv6.disable.

### Solution
Add a destructive test to check if this upgrade check is working.

### Related Issues
Requires changes from https://github.com/SatelliteQE/robottelo/pull/14883

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->