### PR TITLE
[6.15.z] Add negative test for ipv6 update check

### DIFF
--- a/tests/foreman/destructive/test_fm_upgrade.py
+++ b/tests/foreman/destructive/test_fm_upgrade.py
@@ -1,0 +1,56 @@
+"""Destructive test module for satellite-maintain upgrade functionality
+
+:Requirement: foreman-maintain
+
+:CaseAutomation: Automated
+
+:CaseComponent: SatelliteMaintain
+
+:Team: Platform
+
+:CaseImportance: Critical
+
+"""
+
+import pytest
+
+pytestmark = pytest.mark.destructive
+
+
+@pytest.mark.include_capsule
+def test_negative_ipv6_update_check(sat_maintain):
+    """Ensure update check fails when ipv6.disable=1 in boot options
+
+    :id: 7b3e017f-443a-4204-99be-e39fa04c89f6
+
+    :parametrized: yes
+
+    :steps:
+        1. Add ipv6.disable to grub boot options
+        2. Reboot
+        3. Run update check
+
+    :customerscenario: true
+
+    :BZ: 2277393
+
+    :expectedresults: Update check fails due to ipv6.disable=1 in boot options
+    """
+    result = sat_maintain.execute('grubby --args="ipv6.disable=1" --update-kernel=ALL')
+    assert result.status == 0
+
+    sat_maintain.power_control(state='reboot')
+
+    xy_version = '.'.join(sat_maintain.version.split('.')[:2])
+    result = sat_maintain.cli.Upgrade.check(
+        options={
+            'assumeyes': True,
+            'target-version': f'{xy_version}.z',
+            'whitelist': 'check-non-redhat-repository, repositories-validate',
+        },
+    )
+    assert result.status != 0
+    assert (
+        'The kernel contains ipv6.disable=1 which is known to break installation and upgrade, remove and reboot before continuining.'
+        in result.stdout
+    )


### PR DESCRIPTION
### Problem Statement
6.15 cherry-pick for https://github.com/SatelliteQE/robottelo/pull/15062.

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->