### PR TITLE
[6.15.z] codecoverage bug2173870

### DIFF
--- a/tests/foreman/virtwho/cli/test_esx_sca.py
+++ b/tests/foreman/virtwho/cli/test_esx_sca.py
@@ -10,6 +10,8 @@
 
 """
 
+import json
+from pathlib import Path
 import re
 
 from fauxfactory import gen_string
@@ -26,10 +28,13 @@ from robottelo.utils.virtwho import (
     get_configure_command,
     get_configure_file,
     get_configure_option,
+    hypervisor_fake_json_create,
     hypervisor_json_create,
     restart_virtwho_service,
     runcmd,
     virtwho_package_locked,
+    vw_fake_conf_create,
+    vw_run_option,
 )
 
 
@@ -593,3 +598,88 @@ class TestVirtWhoConfigforEsx:
             elif index == 1:
                 restart_virtwho_service()
                 assert not check_message_in_rhsm_log(messages[1])
+
+    @pytest.mark.tier2
+    def test_positive_post_hypervisors_with_fake_different_org_simultaneous(
+        self, module_sca_manifest_org, form_data_cli, target_sat
+    ):
+        """create many fake conf files in two orgs with specific service account rhsm_username=virt_who_reporter_X post to satellite without task errors"
+
+        :id: ee2ec178-01e0-48b9-8c2f-5c3279eef796
+
+        :expectedresults:
+            hypervisor/guest json can be posted and the task is success status
+
+        :customerscenario: true
+
+        :CaseImportance: Medium
+
+        :BZ: 2173870
+        """
+
+        # create json file for 3 hyperviors, each with 3 guests
+        json_file = Path("/tmp/fake.json")
+        data = hypervisor_fake_json_create(hypervisors=3, guests=3)
+        json_file.write_text(json.dumps(data))
+        # create 10 fake files in module_sca_manifest_org
+        virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)[
+            'general-information'
+        ]
+        command = get_configure_command(virtwho_config_cli['id'], module_sca_manifest_org.name)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], org=module_sca_manifest_org.label
+        )
+        config_file_1 = get_configure_file(virtwho_config_cli['id'])
+        owner_1 = get_configure_option('owner', config_file_1)
+        rhsm_hostname_1 = get_configure_option('rhsm_hostname', config_file_1)
+        rhsm_username_1 = get_configure_option('rhsm_username', config_file_1)
+        rhsm_encrypted_password_1 = get_configure_option('rhsm_encrypted_password', config_file_1)
+        # create another org and create fake conf files in this org
+        ORG_DATA = {'name': f'virtwho_fake_{gen_string("alpha")}'}
+        org = target_sat.api.Organization(name=ORG_DATA['name']).create()
+        target_sat.api.Location(organization=[org]).create()
+        form_data_cli['organization-id'] = org.id
+        virtwho_config_cli = target_sat.cli.VirtWhoConfig.create(form_data_cli)[
+            'general-information'
+        ]
+        command = get_configure_command(virtwho_config_cli['id'], org.name)
+        deploy_configure_by_command(
+            command, form_data_cli['hypervisor-type'], debug=True, org=org.label
+        )
+        config_file_2 = get_configure_file(virtwho_config_cli['id'])
+        owner_2 = get_configure_option('owner', config_file_2)
+        rhsm_hostname_2 = get_configure_option('rhsm_hostname', config_file_2)
+        rhsm_username_2 = get_configure_option('rhsm_username', config_file_2)
+        rhsm_encrypted_password_2 = get_configure_option('rhsm_encrypted_password', config_file_2)
+        for i in range(5):
+            fake_conf_file = f"/etc/virt-who.d/virt-who-config-fake{i}.conf"
+            vw_fake_conf_create(
+                owner_1,
+                rhsm_hostname_1,
+                rhsm_username_1,
+                rhsm_encrypted_password_1,
+                fake_conf_file,
+                json_file,
+            )
+        for i in range(5, 10):
+            fake_conf_file = f"/etc/virt-who.d/virt-who-config-fake{i}.conf"
+            vw_fake_conf_create(
+                owner_2,
+                rhsm_hostname_2,
+                rhsm_username_2,
+                rhsm_encrypted_password_2,
+                fake_conf_file,
+                json_file,
+            )
+        # run virt-who with option -d, --debug and -o, --one-shot
+        vw_run_option("od")
+        for i in range(10):
+            fake_conf_file = f"/etc/virt-who.d/virt-who-config-fake{i}.conf"
+            conf_name = fake_conf_file.split("/")[-1].split(".")[0]
+            config_str = f'Using configuration "{conf_name}" ("fake" mode)'
+            check_message_in_rhsm_log(config_str)
+        check_message_in_rhsm_log(f"Host-to-guest mapping being sent to '{org}'")
+        task = target_sat.cli.Task.list_tasks({'search': 'label ~ Hyper'})
+        for item in task:
+            assert "Job blocked by the following existing jobs" not in item['task-errors']
+            assert "success" in item['result']


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14273

Code coverage Bug2173870
Test Case : PASS
```
(robottelo_vv_615) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/cli/test_esx_sca.py -k test_positive_post_hypervisors_with_fake_different_org_simultaneous --disable-pytest-warnings -q
.                                                                                                                                                                                                                                      [100%]
1 passed, 39 deselected, 23 warnings in 421.21s (0:07:01)
2024-03-06 23:04:35 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

```