### PR TITLE
[6.13.z] Remove nailgun.entities imports in tests/foreman/endtoend

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -18,7 +18,7 @@ from pprint import pformat
 
 from deepdiff import DeepDiff
 from fauxfactory import gen_string
-from nailgun import client, entities
+from nailgun import client
 import pytest
 
 from robottelo import constants
@@ -1006,39 +1006,41 @@ class TestEndToEnd:
     def fake_manifest_is_set(self):
         return setting_is_set('fake_manifest')
 
-    def test_positive_find_default_org(self):
+    def test_positive_find_default_org(self, class_target_sat):
         """Check if 'Default Organization' is present
 
         :id: c6e45b36-d8b6-4507-8dcd-0645668496b9
 
         :expectedresults: 'Default Organization' is found
         """
-        results = entities.Organization().search(
+        results = class_target_sat.api.Organization().search(
             query={'search': f'name="{constants.DEFAULT_ORG}"'}
         )
         assert len(results) == 1
         assert results[0].name == constants.DEFAULT_ORG
 
-    def test_positive_find_default_loc(self):
+    def test_positive_find_default_loc(self, class_target_sat):
         """Check if 'Default Location' is present
 
         :id: 1f40b3c6-488d-4037-a7ab-250a02bf919a
 
         :expectedresults: 'Default Location' is found
         """
-        results = entities.Location().search(query={'search': f'name="{constants.DEFAULT_LOC}"'})
+        results = class_target_sat.api.Location().search(
+            query={'search': f'name="{constants.DEFAULT_LOC}"'}
+        )
         assert len(results) == 1
         assert results[0].name == constants.DEFAULT_LOC
 
     @pytest.mark.build_sanity
-    def test_positive_find_admin_user(self):
+    def test_positive_find_admin_user(self, class_target_sat):
         """Check if Admin User is present
 
         :id: 892fdfcd-18c0-42ef-988b-f13a04097f5c
 
         :expectedresults: Admin User is found and has Admin role
         """
-        results = entities.User().search(query={'search': 'login=admin'})
+        results = class_target_sat.api.User().search(query={'search': 'login=admin'})
         assert len(results) == 1
         assert results[0].login == 'admin'
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15083

### Problem Statement

SAT-22502

Uses of `nailgun.entities.${ENTITY}` should be replaced with `${SATELLITE_INSTANCE}.api.${ENTITY}`.


### Solution

All tests under `tests/foreman/endtoend/` now use nailgun through the satellite instance's `api` attribute, and imports of `nailgun.entities` have been removed.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->