### PR TITLE
[6.13.z] Remove RHEL6 supportability from robottelo

### DIFF
--- a/conf/supportability.yaml
+++ b/conf/supportability.yaml
@@ -1,4 +1,4 @@
 supportability:
   content_hosts:
     rhel:
-      versions: [6, 7,'7_fips', 8, '8_fips', 9, '9_fips']
+      versions: [7,'7_fips', 8, '8_fips', 9, '9_fips']


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15012

### Problem Statement
RHEL6 client checkout fails and hence test fails for rhel6. Also, June,2024 will be end of extended support for RHEL6

### Solution
Remove support for RHEL6 from supporting rhel versions

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->