### PR TITLE
[6.15.z] removed unnecessary line

### DIFF
--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -43,7 +43,6 @@ def test_selinux_status(target_sat):
 @pytest.mark.parametrize(
     'directory',
     [
-        '/var/lib/pulp',
         '/var/lib/pulp/assets',
         '/var/lib/pulp/media',
         '/var/lib/pulp/tmp',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15092

### Problem Statement
In parametrize section line '/var/lib/pulp' was redundant.

In remaining parametrize path it is already covering the above path.

### Solution
Removing redundant line which is no longer required.

