### PR TITLE
test export of cloned template

### DIFF
--- a/tests/foreman/ui/test_jobtemplate.py
+++ b/tests/foreman/ui/test_jobtemplate.py
@@ -199,6 +199,8 @@ def test_positive_end_to_end(session, module_org, module_location, target_sat):
         assert target_sat.hostname in template_values['template']['template_editor']['editor']
         session.jobtemplate.clone(template_new_name, {'template.name': template_clone_name})
         assert session.jobtemplate.search(template_clone_name)[0]['Name'] == template_clone_name
+        dumped_content = target_sat.cli.JobTemplate.dump({'name': template_clone_name})
+        assert len(dumped_content) > 0
         for name in (template_new_name, template_clone_name):
             session.jobtemplate.delete(name)
             assert not session.jobtemplate.search(name)


### PR DESCRIPTION
### Problem Statement
request from the component evaluation -- to check if cloned template can be exported successfully.  

### Solution
extending the UI test as we don't have the clone functionality in hammer job-template right now

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->