### PR TITLE
[6.13.z] Remove nailgun.entities imports in pytest_fixtures

### DIFF
--- a/pytest_fixtures/component/computeprofile.py
+++ b/pytest_fixtures/component/computeprofile.py
@@ -1,8 +1,7 @@
 # Compute Profile Fixtures
-from nailgun import entities
 import pytest
 
 
 @pytest.fixture(scope='module')
-def module_compute_profile():
-    return entities.ComputeProfile().create()
+def module_compute_profile(module_target_sat):
+    return module_target_sat.api.ComputeProfile().create()

--- a/pytest_fixtures/component/host.py
+++ b/pytest_fixtures/component/host.py
@@ -1,6 +1,5 @@
 # Host Specific Fixtures
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.constants import DEFAULT_CV, ENVIRONMENT, PRDS, REPOS, REPOSET
@@ -12,22 +11,22 @@ def function_host(target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_host():
-    return entities.Host().create()
+def module_host(module_target_sat):
+    return module_target_sat.api.Host().create()
 
 
 @pytest.fixture(scope='module')
-def module_model():
-    return entities.Model().create()
+def module_model(module_target_sat):
+    return module_target_sat.api.Model().create()
 
 
 @pytest.fixture(scope="module")
 def setup_rhst_repo(module_target_sat):
     """Prepare Satellite tools repository for usage in specified organization"""
-    org = entities.Organization().create()
-    cv = entities.ContentView(organization=org).create()
-    lce = entities.LifecycleEnvironment(organization=org).create()
-    ak = entities.ActivationKey(
+    org = module_target_sat.api.Organization().create()
+    cv = module_target_sat.api.ContentView(organization=org).create()
+    lce = module_target_sat.api.LifecycleEnvironment(organization=org).create()
+    ak = module_target_sat.api.ActivationKey(
         environment=lce,
         organization=org,
     ).create()

--- a/pytest_fixtures/component/hostgroup.py
+++ b/pytest_fixtures/component/hostgroup.py
@@ -1,5 +1,4 @@
 # Hostgroup Fixtures
-from nailgun import entities
 import pytest
 from requests.exceptions import HTTPError
 
@@ -7,14 +6,16 @@ from robottelo.logging import logger
 
 
 @pytest.fixture(scope='module')
-def module_hostgroup():
-    return entities.HostGroup().create()
+def module_hostgroup(module_target_sat):
+    return module_target_sat.api.HostGroup().create()
 
 
 @pytest.fixture(scope='class')
-def class_hostgroup(class_org, class_location):
+def class_hostgroup(class_target_sat, class_org, class_location):
     """Create a hostgroup linked to specific org and location created at the class scope"""
-    hostgroup = entities.HostGroup(organization=[class_org], location=[class_location]).create()
+    hostgroup = class_target_sat.api.HostGroup(
+        organization=[class_org], location=[class_location]
+    ).create()
     yield hostgroup
     try:
         hostgroup.delete()

--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -1,5 +1,4 @@
 # Operating System Fixtures
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -33,8 +32,8 @@ def default_os(
 
 
 @pytest.fixture(scope='module')
-def module_os():
-    return entities.OperatingSystem().create()
+def module_os(module_target_sat):
+    return module_target_sat.api.OperatingSystem().create()
 
 
 @pytest.fixture(scope='module')

--- a/pytest_fixtures/component/oscap.py
+++ b/pytest_fixtures/component/oscap.py
@@ -1,7 +1,6 @@
 from pathlib import PurePath
 
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import robottelo_tmp_dir, settings
@@ -34,7 +33,7 @@ def scap_content(import_ansible_roles, module_target_sat):
         {'title': title, 'scap-file': f'{settings.oscap.content_path}'}
     )
     scap_id = scap_info['id']
-    scap_info = entities.ScapContents(id=scap_id).read()
+    scap_info = module_target_sat.api.ScapContents(id=scap_id).read()
     scap_profile_id = [
         profile['id']
         for profile in scap_info.scap_content_profiles
@@ -48,10 +47,10 @@ def scap_content(import_ansible_roles, module_target_sat):
 
 
 @pytest.fixture(scope="module")
-def tailoring_file(module_org, module_location, tailoring_file_path):
+def tailoring_file(module_target_sat, module_org, module_location, tailoring_file_path):
     """Create Tailoring file."""
     tailoring_file_name = f"tailoring-file-{gen_string('alpha')}"
-    tf_info = entities.TailoringFile(
+    tf_info = module_target_sat.api.TailoringFile(
         name=f"{tailoring_file_name}",
         scap_file=f"{tailoring_file_path['local']}",
         organization=[module_org],

--- a/pytest_fixtures/component/provisioning_template.py
+++ b/pytest_fixtures/component/provisioning_template.py
@@ -1,6 +1,5 @@
 # Provisioning Template Fixtures
 from box import Box
-from nailgun import entities
 from packaging.version import Version
 import pytest
 
@@ -9,45 +8,49 @@ from robottelo.constants import DEFAULT_PTABLE, DEFAULT_PXE_TEMPLATE, DEFAULT_TE
 
 
 @pytest.fixture(scope='module')
-def module_provisioningtemplate_default(module_org, module_location):
-    provisioning_template = entities.ProvisioningTemplate().search(
+def module_provisioningtemplate_default(module_target_sat, module_org, module_location):
+    provisioning_template = module_target_sat.api.ProvisioningTemplate().search(
         query={'search': f'name="{DEFAULT_TEMPLATE}"'}
     )
     provisioning_template = provisioning_template[0].read()
     provisioning_template.organization.append(module_org)
     provisioning_template.location.append(module_location)
     provisioning_template.update(['organization', 'location'])
-    return entities.ProvisioningTemplate(id=provisioning_template.id).read()
+    return module_target_sat.api.ProvisioningTemplate(id=provisioning_template.id).read()
 
 
 @pytest.fixture(scope='module')
-def module_provisioningtemplate_pxe(module_org, module_location):
-    pxe_template = entities.ProvisioningTemplate().search(
+def module_provisioningtemplate_pxe(module_target_sat, module_org, module_location):
+    pxe_template = module_target_sat.api.ProvisioningTemplate().search(
         query={'search': f'name="{DEFAULT_PXE_TEMPLATE}"'}
     )
     pxe_template = pxe_template[0].read()
     pxe_template.organization.append(module_org)
     pxe_template.location.append(module_location)
     pxe_template.update(['organization', 'location'])
-    return entities.ProvisioningTemplate(id=pxe_template.id).read()
+    return module_target_sat.api.ProvisioningTemplate(id=pxe_template.id).read()
 
 
 @pytest.fixture(scope='session')
-def default_partitiontable():
-    ptables = entities.PartitionTable().search(query={'search': f'name="{DEFAULT_PTABLE}"'})
+def default_partitiontable(session_target_sat):
+    ptables = session_target_sat.api.PartitionTable().search(
+        query={'search': f'name="{DEFAULT_PTABLE}"'}
+    )
     if ptables:
         return ptables[0].read()
     return None
 
 
 @pytest.fixture(scope='module')
-def module_env():
-    return entities.Environment().create()
+def module_env(module_target_sat):
+    return module_target_sat.api.Environment().create()
 
 
 @pytest.fixture(scope='session')
-def default_pxetemplate():
-    pxe_template = entities.ProvisioningTemplate().search(query={'search': DEFAULT_PXE_TEMPLATE})
+def default_pxetemplate(session_target_sat):
+    pxe_template = session_target_sat.api.ProvisioningTemplate().search(
+        query={'search': DEFAULT_PXE_TEMPLATE}
+    )
     return pxe_template[0].read()
 
 

--- a/pytest_fixtures/component/repository.py
+++ b/pytest_fixtures/component/repository.py
@@ -1,6 +1,5 @@
 # Repository Fixtures
 from fauxfactory import gen_string
-from nailgun import entities
 from nailgun.entity_mixins import call_entity_method_with_timeout
 import pytest
 
@@ -24,8 +23,8 @@ def module_repo(module_repo_options, module_target_sat):
 
 
 @pytest.fixture
-def function_product(function_org):
-    return entities.Product(organization=function_org).create()
+def function_product(target_sat, function_org):
+    return target_sat.api.Product(organization=function_org).create()
 
 
 @pytest.fixture(scope='module')
@@ -57,38 +56,38 @@ def module_rhst_repo(module_target_sat, module_org_with_manifest, module_promote
 
 
 @pytest.fixture
-def repo_setup():
+def repo_setup(target_sat):
     """
     This fixture is used to create an organization, product, repository, and lifecycle environment
     and once the test case gets completed then it performs the teardown of that.
     """
     repo_name = gen_string('alpha')
-    org = entities.Organization().create()
-    product = entities.Product(organization=org).create()
-    repo = entities.Repository(name=repo_name, product=product).create()
-    lce = entities.LifecycleEnvironment(organization=org).create()
+    org = target_sat.api.Organization().create()
+    product = target_sat.api.Product(organization=org).create()
+    repo = target_sat.api.Repository(name=repo_name, product=product).create()
+    lce = target_sat.api.LifecycleEnvironment(organization=org).create()
     return {'org': org, 'product': product, 'repo': repo, 'lce': lce}
 
 
 @pytest.fixture(scope='module')
-def setup_content(module_org):
+def setup_content(module_target_sat, module_org):
     """This fixture is used to setup an activation key with a custom product attached. Used for
     registering a host
     """
     org = module_org
-    custom_repo = entities.Repository(
-        product=entities.Product(organization=org).create(),
+    custom_repo = module_target_sat.api.Repository(
+        product=module_target_sat.api.Product(organization=org).create(),
     ).create()
     custom_repo.sync()
-    lce = entities.LifecycleEnvironment(organization=org).create()
-    cv = entities.ContentView(
+    lce = module_target_sat.api.LifecycleEnvironment(organization=org).create()
+    cv = module_target_sat.api.ContentView(
         organization=org,
         repository=[custom_repo.id],
     ).create()
     cv.publish()
     cvv = cv.read().version[0].read()
     cvv.promote(data={'environment_ids': lce.id, 'force': False})
-    ak = entities.ActivationKey(
+    ak = module_target_sat.api.ActivationKey(
         content_view=cv, max_hosts=100, organization=org, environment=lce, auto_attach=True
     ).create()
     return ak, org, custom_repo

--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -2,7 +2,6 @@ import copy
 import socket
 
 from box import Box
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -36,11 +35,11 @@ def default_ipa_host(module_target_sat):
 
 
 @pytest.fixture
-def ldap_cleanup():
+def ldap_cleanup(target_sat):
     """this is an extra step taken to clean any existing ldap source"""
-    ldap_auth_sources = entities.AuthSourceLDAP().search()
+    ldap_auth_sources = target_sat.api.AuthSourceLDAP().search()
     for ldap_auth in ldap_auth_sources:
-        users = entities.User(auth_source=ldap_auth).search()
+        users = target_sat.api.User(auth_source=ldap_auth).search()
         for user in users:
             user.delete()
         ldap_auth.delete()
@@ -105,9 +104,9 @@ def open_ldap_data():
 
 
 @pytest.fixture
-def auth_source(ldap_cleanup, module_org, module_location, ad_data):
+def auth_source(ldap_cleanup, module_target_sat, module_org, module_location, ad_data):
     ad_data = ad_data()
-    return entities.AuthSourceLDAP(
+    return module_target_sat.api.AuthSourceLDAP(
         onthefly_register=True,
         account=ad_data['ldap_user_name'],
         account_password=ad_data['ldap_user_passwd'],
@@ -128,8 +127,8 @@ def auth_source(ldap_cleanup, module_org, module_location, ad_data):
 
 
 @pytest.fixture
-def auth_source_ipa(ldap_cleanup, default_ipa_host, module_org, module_location):
-    return entities.AuthSourceLDAP(
+def auth_source_ipa(ldap_cleanup, default_ipa_host, module_target_sat, module_org, module_location):
+    return module_target_sat.api.AuthSourceLDAP(
         onthefly_register=True,
         account=default_ipa_host.ldap_user_cn,
         account_password=default_ipa_host.ldap_user_passwd,
@@ -150,8 +149,14 @@ def auth_source_ipa(ldap_cleanup, default_ipa_host, module_org, module_location)
 
 
 @pytest.fixture
-def auth_source_open_ldap(ldap_cleanup, module_org, module_location, open_ldap_data):
-    return entities.AuthSourceLDAP(
+def auth_source_open_ldap(
+    ldap_cleanup,
+    module_target_sat,
+    module_org,
+    module_location,
+    open_ldap_data,
+):
+    return module_target_sat.api.AuthSourceLDAP(
         onthefly_register=True,
         account=open_ldap_data['ldap_user_cn'],
         account_password=open_ldap_data['ldap_user_passwd'],

--- a/pytest_fixtures/component/subnet.py
+++ b/pytest_fixtures/component/subnet.py
@@ -1,8 +1,9 @@
 # Subnet Fixtures
-from nailgun import entities
 import pytest
 
 
 @pytest.fixture(scope='module')
-def module_default_subnet(module_org, module_location):
-    return entities.Subnet(location=[module_location], organization=[module_org]).create()
+def module_default_subnet(module_target_sat, module_org, module_location):
+    return module_target_sat.api.Subnet(
+        location=[module_location], organization=[module_org]
+    ).create()

--- a/pytest_fixtures/component/user.py
+++ b/pytest_fixtures/component/user.py
@@ -1,12 +1,9 @@
-from nailgun import entities
 import pytest
 
 
 @pytest.fixture
-def user_not_exists(request):
+def user_not_exists(request, target_sat):
     """Remove a user if it exists. Return whether changes have been applied."""
-    users = entities.User().search(query={'search': f'login={request.param}'})
-    if users:
+    if users := target_sat.api.User().search(query={'search': f'login={request.param}'}):
         users[0].delete()
-        return True
-    return False
+    return bool(users)

--- a/pytest_fixtures/component/user_role.py
+++ b/pytest_fixtures/component/user_role.py
@@ -1,5 +1,4 @@
 from fauxfactory import gen_alphanumeric, gen_string
-from nailgun import entities
 import pytest
 
 
@@ -10,23 +9,25 @@ def class_user_password():
 
 
 @pytest.fixture
-def function_role():
-    return entities.Role().create()
+def function_role(target_sat):
+    return target_sat.api.Role().create()
 
 
 @pytest.fixture(scope='module')
-def module_user(module_org, module_location):
-    return entities.User(organization=[module_org], location=[module_location]).create()
+def module_user(module_target_sat, module_org, module_location):
+    return module_target_sat.api.User(
+        organization=[module_org], location=[module_location]
+    ).create()
 
 
 @pytest.fixture(scope='module')
-def default_viewer_role(module_org, default_location):
+def default_viewer_role(module_target_sat, module_org, default_location):
     """Custom user with viewer role for tests validating visibility of entities or fields created
     by some other user. Created only when accessed, unlike `module_user`.
     """
-    viewer_role = entities.Role().search(query={'search': 'name="Viewer"'})[0]
+    viewer_role = module_target_sat.api.Role().search(query={'search': 'name="Viewer"'})[0]
     custom_password = gen_string('alphanumeric')
-    custom_user = entities.User(
+    custom_user = module_target_sat.api.User(
         admin=False,
         default_organization=module_org,
         location=[default_location],


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15084

### Problem Statement

SAT-22530

Uses of `nailgun.entities.${ENTITY}` should be replaced with `${SATELLITE_INSTANCE}.api.${ENTITY}`.

### Solution

All fixtures under `pytest_fixtures/` now use nailgun through the satellite instance's `api` attribute, and imports of `nailgun.entities` have been removed.

Test results are the same before and after these changes.

#### with PR changes:

PRT job #6979:
```
18:53:58  =========================== short test summary info ============================
18:53:58  FAILED tests/foreman/api/test_host.py::test_positive_create_and_update_with_user [...]
18:53:58  FAILED tests/foreman/ui/test_ldap_authentication.py::test_verify_group_permissions [...]
18:53:58  ERROR tests/foreman/api/test_oscappolicy.py::TestOscapPolicy::test_positive_crud_scap_policy [...]
18:53:58  = 2 failed, 13 passed, 1 skipped, 617 warnings, 1 error in 3674.62s (1:01:14) ==
```

#### master:

PRT job #6996:
```
16:30:58  =========================== short test summary info ============================
16:30:58  FAILED tests/foreman/api/test_host.py::test_positive_create_and_update_with_user [...]
16:30:58  FAILED tests/foreman/ui/test_ldap_authentication.py::test_verify_group_permissions [...]
16:30:58  ERROR tests/foreman/api/test_oscappolicy.py::TestOscapPolicy::test_positive_crud_scap_policy [...]
16:30:58  = 2 failed, 13 passed, 1 skipped, 610 warnings, 1 error in 3667.19s (1:01:07) ==
```

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->