### PR TITLE
Fix assertions in file repo tests

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1729,7 +1729,7 @@ class TestRepository:
                 'content-type': 'srpm',
             }
         )
-        assert f"Successfully uploaded file '{SRPM_TO_UPLOAD}'" in result[0]['message']
+        assert f'Successfully uploaded file {SRPM_TO_UPLOAD}' in result[0]['message']
         assert (
             int(target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['srpms']) == 1
         )
@@ -2566,7 +2566,7 @@ class TestFileRepository:
                 'product-id': repo['product']['id'],
             }
         )
-        assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
+        assert f'Successfully uploaded file {RPM_TO_UPLOAD}' in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['content-counts']['files'] == '1'
         filesearch = entities.File().search(
@@ -2611,7 +2611,7 @@ class TestFileRepository:
                 'product-id': repo['product']['id'],
             }
         )
-        assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
+        assert f'Successfully uploaded file {RPM_TO_UPLOAD}' in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert int(repo['content-counts']['files']) > 0
         files = target_sat.cli.File.list({'repository-id': repo['id']})
@@ -2776,7 +2776,7 @@ class TestFileRepository:
                 'product-id': repo['product']['id'],
             }
         )
-        assert f"Successfully uploaded file '{text_file_name}'" in result[0]['message']
+        assert f"Successfully uploaded file {text_file_name}" in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         # Assert there is only one file
         assert repo['content-counts']['files'] == '1'
@@ -2794,7 +2794,7 @@ class TestFileRepository:
                 'product-id': repo['product']['id'],
             }
         )
-        assert f"Successfully uploaded file '{text_file_name}'" in result[0]['message']
+        assert f"Successfully uploaded file {text_file_name}" in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         # Assert there is still only one file
         assert repo['content-counts']['files'] == '1'


### PR DESCRIPTION
### Problem Statement
Several file-repo tests have been failing too long for a wrong assertion message.


### Solution
Fix them all with this PR in a near term.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py -k 'upload_remove_srpm_content or upload_file_to_file_repo or remove_file or file_repo_contains_only_newer_file'
