### PR TITLE
[6.14.z] Fix assertions in file repo tests

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -1729,7 +1729,7 @@ class TestRepository:
                 'content-type': 'srpm',
             }
         )
-        assert f"Successfully uploaded file '{SRPM_TO_UPLOAD}'" in result[0]['message']
+        assert f'Successfully uploaded file {SRPM_TO_UPLOAD}' in result[0]['message']
         assert (
             int(target_sat.cli.Repository.info({'id': repo['id']})['content-counts']['source-rpms'])
             == 1
@@ -2569,7 +2569,7 @@ class TestFileRepository:
                 'product-id': repo['product']['id'],
             }
         )
-        assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
+        assert f'Successfully uploaded file {RPM_TO_UPLOAD}' in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['content-counts']['files'] == '1'
         filesearch = entities.File().search(
@@ -2614,7 +2614,7 @@ class TestFileRepository:
                 'product-id': repo['product']['id'],
             }
         )
-        assert f"Successfully uploaded file '{RPM_TO_UPLOAD}'" in result[0]['message']
+        assert f'Successfully uploaded file {RPM_TO_UPLOAD}' in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert int(repo['content-counts']['files']) > 0
         files = target_sat.cli.File.list({'repository-id': repo['id']})
@@ -2779,7 +2779,7 @@ class TestFileRepository:
                 'product-id': repo['product']['id'],
             }
         )
-        assert f"Successfully uploaded file '{text_file_name}'" in result[0]['message']
+        assert f"Successfully uploaded file {text_file_name}" in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         # Assert there is only one file
         assert repo['content-counts']['files'] == '1'
@@ -2797,7 +2797,7 @@ class TestFileRepository:
                 'product-id': repo['product']['id'],
             }
         )
-        assert f"Successfully uploaded file '{text_file_name}'" in result[0]['message']
+        assert f"Successfully uploaded file {text_file_name}" in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         # Assert there is still only one file
         assert repo['content-counts']['files'] == '1'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15138

### Problem Statement
Several file-repo tests have been failing too long for a wrong assertion message.


### Solution
Fix them all with this PR in a near term.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py -k 'upload_remove_srpm_content or upload_file_to_file_repo or remove_file or file_repo_contains_only_newer_file'
