### PR TITLE
Fix host owner checking and test name typo

### DIFF
--- a/tests/foreman/api/test_host.py
+++ b/tests/foreman/api/test_host.py
@@ -144,7 +144,7 @@ def test_positive_update_owner_type(
     host.owner = owners[owner_type]
     host = host.update(['owner_type', 'owner'])
     assert host.owner_type == owner_type
-    assert host.owner.read() == owners[owner_type]
+    assert module_target_sat.api.User(id=host.owner.id).read() == owners[owner_type]
 
 
 @pytest.mark.tier1
@@ -468,13 +468,13 @@ def test_positive_create_and_update_with_user(
     host = module_target_sat.api.Host(
         owner=module_user, owner_type='User', organization=module_org, location=module_location
     ).create()
-    assert host.owner.read() == module_user
+    assert module_target_sat.api.User(id=host.owner.id).read() == module_user
     new_user = module_target_sat.api.User(
         organization=[module_org], location=[module_location]
     ).create()
     host.owner = new_user
     host = host.update(['owner'])
-    assert host.owner.read() == new_user
+    assert module_target_sat.api.User(id=host.owner.id).read() == new_user
 
 
 @pytest.mark.tier2

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -176,7 +176,7 @@ class TestUser:
         assert location['name'] == user['default-location']
 
     @pytest.mark.tier1
-    def test_positive_create_with_defaut_org(self, module_target_sat):
+    def test_positive_create_with_default_org(self, module_target_sat):
         """Check if user with default organization can be created
 
         :id: cc692b6f-2519-429b-8ecb-c4bb51ed3544


### PR DESCRIPTION
# Not needed. Fixed by https://github.com/SatelliteQE/nailgun/pull/1153

### Problem Statement

There are a couple API test failures related to host owner checking, like the following from PRT job 7043:

```
14:46:30      @pytest.mark.tier2
14:46:30      def test_positive_create_and_update_with_user(
14:46:30          module_org, module_location, module_user, module_target_sat
14:46:30      ):
14:46:30          """Create and update host with user specified
14:46:30      
14:46:30          :id: 72e20f8f-17dc-4e38-8ac1-d08df8758f56
14:46:30      
14:46:30          :expectedresults: A host is created and updated with expected user assigned
14:46:30          """
14:46:30          host = module_target_sat.api.Host(
14:46:30              owner=module_user, owner_type='User', organization=module_org, location=module_location
14:46:30          ).create()
14:46:30  >       assert host.owner.read() == module_user
14:46:30  E       AssertionError: assert nailgun.entities.User(admin=False, auth_source=nailgun.entities.AuthSourceLDAP(id=1), auth_source_name='Internal', def..., login='AYpQhUAYUeu', mail='hAzyluvC@example.com', organization=[nailgun.entities.Organization(id=13)], role=[], id=5) == robottelo.hosts.DecClass(admin=False, auth_source=nailgun.entities.AuthSourceLDAP(id=1), auth_source_name='Internal', ..., login='AYpQhUAYUeu', mail='hAzyluvC@example.com', organization=[nailgun.entities.Organization(id=13)], role=[], id=5)
14:46:30  E        +  where nailgun.entities.User(admin=False, auth_source=nailgun.entities.AuthSourceLDAP(id=1), auth_source_name='Internal', def..., login='AYpQhUAYUeu', mail='hAzyluvC@example.com', organization=[nailgun.entities.Organization(id=13)], role=[], id=5) = <bound method User.read of nailgun.entities.User(id=5)>()
14:46:30  E        +    where <bound method User.read of nailgun.entities.User(id=5)> = nailgun.entities.User(id=5).read
14:46:30  E        +      where nailgun.entities.User(id=5) = nailgun.entities.Host(all_parameters=[{'priority': 0, 'created_at': '2024-02-21 00:29:10 UTC', 'updated_at': '2024-02-...nailgun.entities.Interface(host=nailgun.entities.Host(id=8), id=8)], build_status_label='Installed', owner_type='User').owner
14:46:30  
14:46:30  tests/foreman/api/test_host.py:471: AssertionError
14:46:30  =============================== warnings summary ======
```

These tests that compare `host.owner` to a `user` instance, but the comparison fails because they are instances of different classes:
- `host.owner` is a `nailgun.entity.User` instance
- `module_user` and other entities returned from `module_target_sat.api.ENTITY_NAME` are wrapped in a `robottelo.hosts.DecClass` instance.

This CLI test also has a typo in the name:
`tests/foreman/cli/test_user.py::TestUser::test_positive_create_with_defaut_org`

### Solution

Update tests to compare `host.owner` to `module_user` and similar objects:
- `tests/foreman/api/test_host.py::test_positive_update_owner_type[User]`
- `tests/foreman/api/test_host.py::test_positive_update_owner_type[Usergroup]`
- `tests/foreman/api/test_host.py::test_positive_create_and_update_with_user`

Update test name (`defaut` -> `default`):
- `tests/foreman/cli/test_user.py::TestUser::test_positive_create_with_default_org`

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->