### PR TITLE
Make default_os name and major versions configurable (#14670)

### DIFF
--- a/conf/supportability.yaml
+++ b/conf/supportability.yaml
@@ -1,4 +1,5 @@
 supportability:
   content_hosts:
+    default_os_name: "RedHat"
     rhel:
       versions: [7,'7_fips', 8, '8_fips', 9, '9_fips']

--- a/pytest_fixtures/component/os.py
+++ b/pytest_fixtures/component/os.py
@@ -2,31 +2,34 @@
 from nailgun import entities
 import pytest
 
+from robottelo.config import settings
+
 
 @pytest.fixture(scope='session')
 def default_os(
     default_architecture,
     default_partitiontable,
     default_pxetemplate,
-    request,
+    session_target_sat,
 ):
-    """Returns an Operating System entity read from searching Redhat family
+    """Returns an Operating System entity read from searching for supportability.content_host.default_os_name"""
+    search_string = f'name="{settings.supportability.content_hosts.default_os_name}"'
 
-    Indirect parametrization should pass an operating system version string like 'RHEL 7.9'
-    Default operating system will find the first RHEL6 or RHEL7 entity
-    """
-    os = getattr(request, 'param', None)
-    if os is None:
-        search_string = 'name="RedHat" AND (major="6" OR major="7" OR major="8")'
-    else:
-        version = os.split(' ')[1].split('.')
-        search_string = f'family="Redhat" AND major="{version[0]}" AND minor="{version[1]}"'
-    os = entities.OperatingSystem().search(query={'search': search_string})[0].read()
+    try:
+        os = (
+            session_target_sat.api.OperatingSystem()
+            .search(query={'search': search_string})[0]
+            .read()
+        )
+    except IndexError as e:
+        raise RuntimeError(f"Could not find operating system for '{search_string}'") from e
+
     os.architecture.append(default_architecture)
     os.ptable.append(default_partitiontable)
     os.provisioning_template.append(default_pxetemplate)
     os.update(['architecture', 'ptable', 'provisioning_template'])
-    return entities.OperatingSystem(id=os.id).read()
+
+    return session_target_sat.api.OperatingSystem(id=os.id).read()
 
 
 @pytest.fixture(scope='module')
@@ -36,8 +39,6 @@ def module_os():
 
 @pytest.fixture(scope='module')
 def os_path(default_os):
-    from robottelo.config import settings
-
     # Check what OS was found to use correct media
     if default_os.major == "6":
         os_distr_url = settings.repos.rhel6_os

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -4,7 +4,10 @@ from robottelo.constants import AZURERM_VALID_REGIONS, VALID_GCE_ZONES
 
 VALIDATORS = dict(
     supportability=[
-        Validator('supportability.content_hosts.rhel.versions', must_exist=True, is_type_of=list)
+        Validator('supportability.content_hosts.rhel.versions', must_exist=True, is_type_of=list),
+        Validator(
+            'supportability.content_hosts.default_os_name', must_exist=True, default='RedHat'
+        ),
     ],
     server=[
         Validator('server.hostname', default=''),


### PR DESCRIPTION
### Problem Statement

 fix failed cherry-pick

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->