### PR TITLE
[6.15.z] Fix missing self

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -803,7 +803,7 @@ class TestContentView:
         assert 'Failed to create ContentView with data:' in str(context)
 
     @pytest.mark.tier3
-    def test_positive_update_composite_with_component_ids(module_org, module_target_sat):
+    def test_positive_update_composite_with_component_ids(self, module_org, module_target_sat):
         """Update a composite content view with a component_ids option
 
         :id: e6106ff6-c526-40f2-bdc0-ae291f7b267e


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15184

### Problem Statement

Fix missing self call forgotten in https://github.com/SatelliteQE/robottelo/pull/14678

### Solution


### Related Tests

tests/foreman/cli/test_contentview.py::TestContentView::test_positive_update_composite_with_component_ids

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->