### PR TITLE
[6.15.z] Fix content host finalizer

### DIFF
--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -871,7 +871,7 @@ def test_positive_check_ignore_facts_os_setting(
         # Change necessary setting to true
         set_ignore_facts_for_os(module_target_sat, True)
         # Add cleanup function to roll back setting to default value
-        request.addfinalizer(set_ignore_facts_for_os)
+        request.addfinalizer(lambda: set_ignore_facts_for_os(module_target_sat, False))
         # Read all facts for corresponding host
         facts = host.get_facts(data={'per_page': 10000})['results'][vm.hostname]
         # Modify OS facts to another values and upload them to the server


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15186

### Problem Statement
The `test_positive_check_ignore_facts_os_setting` fails in teardown with
```
failed on teardown with "TypeError: set_ignore_facts_for_os() missing 1 required positional argument: 'module_target_sat'"
```


### Solution
This PR, hopefully.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k test_positive_check_ignore_facts_os_setting