### PR TITLE
[6.13.z] Reorder finalizers in CV upgrade test

### DIFF
--- a/tests/upgrades/test_contentview.py
+++ b/tests/upgrades/test_contentview.py
@@ -88,7 +88,6 @@ class TestContentView:
         cv = target_sat.api.ContentView(organization=org.id).search(
             query={'search': f'name="{cv_name}"'}
         )[0]
-        request.addfinalizer(cv.delete)
         yum_repo = target_sat.api.Repository(organization=org.id).search(
             query={'search': f'name="{pre_test_name}_yum_repo"'}
         )[0]
@@ -97,6 +96,7 @@ class TestContentView:
             query={'search': f'name="{pre_test_name}_file_repo"'}
         )[0]
         request.addfinalizer(file_repo.delete)
+        request.addfinalizer(cv.delete)  # the order matters - addfinalizer works like a stack/LIFO
         cv.repository = []
         cv.update(['repository'])
         assert len(cv.read_json()['repositories']) == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15185

### Problem Statement
It looks like the previous reorder done in https://github.com/SatelliteQE/robottelo/pull/14036 on Mar 15 has broken the test teardown since we now attempt to destroy the repo before we destroy the CV where it is published in, so we get 500:
```
DEBUG    nailgun.client:client.py:105 Making HTTP DELETE request to https://satellite.redhat.com/katello/api/v2/repositories/1118 with options {'auth': None, 'verify': None, 'headers': {'content-type': 'application/json'}}, no params and no data.
WARNING  nailgun.client:client.py:126 Received HTTP 500 response: {"displayMessage":"Repository cannot be deleted since it has already been included in a published Content View. Please delete all Content View versions containing this repository before attempting to delete it.","errors":["Repository cannot be deleted since it has already been included in a published Content View. Please delete all Content View versions containing this repository before attempting to delete it."]}
```


### Solution
Make the order opposite again.


### Localrun results
Pre
```
(venv) [vsedmik@fedora robottelo]$ pytest -m pre_upgrade tests/upgrades/test_contentview.py
tests/upgrades/test_contentview.py .                 [100%]
======= 1 passed, 1 deselected, 7 warnings in 39.59s =======
```
Post
```
(venv) [vsedmik@fedora robottelo]$ pytest -m post_upgrade tests/upgrades/test_contentview.py
tests/upgrades/test_contentview.py .                 [100%]
======= 1 passed, 1 deselected, 7 warnings in 53.35s =======
```