### PR TITLE
[6.15.z] Use RHEL8 for container contenthost

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -197,25 +197,25 @@ def katello_host_tools_tracer_host(rex_contenthost, target_sat):
     return rex_contenthost
 
 
-@pytest.fixture
-def container_contenthost(request, target_sat):
+@pytest.fixture(scope='module')
+def module_container_contenthost(request, module_target_sat):
     """Fixture that installs docker on the content host"""
     request.param = {
-        "rhel_version": "7",
+        "rhel_version": "8",
         "distro": "rhel",
         "no_containers": True,
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
-        host.install_katello_ca(target_sat)
-        repos = {
-            'server': settings.repos.rhel7_os,
-            'optional': settings.repos.rhel7_optional,
-            'extras': settings.repos.rhel7_extras,
-        }
-        host.create_custom_repos(**repos)
-        for service in constants.CONTAINER_CLIENTS:
-            host.execute(f'yum -y install {service}')
-            host.execute(f'systemctl start {service}')
+        host.register_to_cdn()
+        # needed for docker commands to accept Satellite's cert
+        host.install_katello_ca(module_target_sat)
+        for client in constants.CONTAINER_CLIENTS:
+            assert (
+                host.execute(f'yum -y install {client}').status == 0
+            ), f'{client} installation failed'
+        assert (
+            host.execute('systemctl enable --now podman').status == 0
+        ), 'Start of podman service failed'
         yield host
 
 

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -866,7 +866,7 @@ class TestCapsuleContentManagement:
         self,
         target_sat,
         module_capsule_configured,
-        container_contenthost,
+        module_container_contenthost,
         function_org,
         function_product,
         function_lce,
@@ -943,29 +943,29 @@ class TestCapsuleContentManagement:
         ]
 
         for con_client in CONTAINER_CLIENTS:
-            result = container_contenthost.execute(
+            result = module_container_contenthost.execute(
                 f'{con_client} login -u {settings.server.admin_username}'
                 f' -p {settings.server.admin_password} {module_capsule_configured.hostname}'
             )
             assert result.status == 0
 
             for path in repo_paths:
-                result = container_contenthost.execute(
+                result = module_container_contenthost.execute(
                     f'{con_client} search {module_capsule_configured.hostname}/{path}'
                 )
                 assert result.status == 0
 
-                result = container_contenthost.execute(
+                result = module_container_contenthost.execute(
                     f'{con_client} pull {module_capsule_configured.hostname}/{path}'
                 )
                 assert result.status == 0
 
-                result = container_contenthost.execute(
+                result = module_container_contenthost.execute(
                     f'{con_client} rmi {module_capsule_configured.hostname}/{path}'
                 )
                 assert result.status == 0
 
-            result = container_contenthost.execute(
+            result = module_container_contenthost.execute(
                 f'{con_client} logout {module_capsule_configured.hostname}'
             )
             assert result.status == 0

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -54,7 +54,9 @@ class TestDockerClient:
     """
 
     @pytest.mark.tier3
-    def test_positive_pull_image(self, module_org, container_contenthost, target_sat):
+    def test_positive_pull_image(
+        self, request, module_org, module_container_contenthost, target_sat
+    ):
         """A Docker-enabled client can use ``docker pull`` to pull a
         Docker image off a Satellite 6 instance.
 
@@ -74,15 +76,18 @@ class TestDockerClient:
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         try:
-            result = container_contenthost.execute(
+            result = module_container_contenthost.execute(
                 f'docker login -u {settings.server.admin_username}'
                 f' -p {settings.server.admin_password} {target_sat.hostname}'
             )
             assert result.status == 0
+            request.addfinalizer(
+                lambda: module_container_contenthost.execute(f'docker logout {target_sat.hostname}')
+            )
 
             # publishing takes few seconds sometimes
             result, _ = wait_for(
-                lambda: container_contenthost.execute(f'docker pull {repo["published-at"]}'),
+                lambda: module_container_contenthost.execute(f'docker pull {repo["published-at"]}'),
                 num_sec=60,
                 delay=2,
                 fail_condition=lambda out: out.status != 0,
@@ -90,25 +95,25 @@ class TestDockerClient:
             )
             assert result.status == 0
             try:
-                result = container_contenthost.execute(f'docker run {repo["published-at"]}')
+                result = module_container_contenthost.execute(f'docker run {repo["published-at"]}')
                 assert result.status == 0
             finally:
                 # Stop and remove the container
-                result = container_contenthost.execute(
+                result = module_container_contenthost.execute(
                     f'docker ps -a | grep {repo["published-at"]}'
                 )
                 container_id = result.stdout[0].split()[0]
-                container_contenthost.execute(f'docker stop {container_id}')
-                container_contenthost.execute(f'docker rm {container_id}')
+                module_container_contenthost.execute(f'docker stop {container_id}')
+                module_container_contenthost.execute(f'docker rm {container_id}')
         finally:
             # Remove docker image
-            container_contenthost.execute(f'docker rmi {repo["published-at"]}')
+            module_container_contenthost.execute(f'docker rmi {repo["published-at"]}')
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier3
     @pytest.mark.e2e
     def test_positive_container_admin_end_to_end_search(
-        self, module_org, container_contenthost, target_sat
+        self, request, module_org, module_container_contenthost, target_sat
     ):
         """Verify that docker command line can be used against
         Satellite server to search for container images stored
@@ -166,34 +171,37 @@ class TestDockerClient:
             }
         )
         docker_repo_uri = (
-            f' {target_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
-            f'{CONTAINER_UPSTREAM_NAME} '
+            f'{target_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
+            f'{CONTAINER_UPSTREAM_NAME}'
         ).lower()
 
         # 3. Try to search for docker images on Satellite
         remote_search_command = f'docker search {target_sat.hostname}/{CONTAINER_UPSTREAM_NAME}'
-        result = container_contenthost.execute(remote_search_command)
+        result = module_container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri not in result.stdout
 
         # 4. Use Docker client to login to Satellite docker hub
-        result = container_contenthost.execute(
+        result = module_container_contenthost.execute(
             f'docker login -u {settings.server.admin_username}'
             f' -p {settings.server.admin_password} {target_sat.hostname}'
         )
         assert result.status == 0
+        request.addfinalizer(
+            lambda: module_container_contenthost.execute(f'docker logout {target_sat.hostname}')
+        )
 
         # 5. Search for docker images
-        result = container_contenthost.execute(remote_search_command)
+        result = module_container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri in result.stdout
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = container_contenthost.execute(f'docker logout {target_sat.hostname}')
+        result = module_container_contenthost.execute(f'docker logout {target_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to search for docker images
-        result = container_contenthost.execute(remote_search_command)
+        result = module_container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri not in result.stdout
 
@@ -207,7 +215,7 @@ class TestDockerClient:
         )
 
         # 9. Search for docker images
-        result = container_contenthost.execute(remote_search_command)
+        result = module_container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri in result.stdout
 
@@ -215,7 +223,7 @@ class TestDockerClient:
     @pytest.mark.tier3
     @pytest.mark.e2e
     def test_positive_container_admin_end_to_end_pull(
-        self, module_org, container_contenthost, target_sat
+        self, request, module_org, module_container_contenthost, target_sat
     ):
         """Verify that docker command line can be used against
         Satellite server to pull in container images stored
@@ -280,20 +288,23 @@ class TestDockerClient:
 
         # 3. Try to pull in docker image from Satellite
         docker_pull_command = f'docker pull {docker_repo_uri}'
-        result = container_contenthost.execute(docker_pull_command)
-        assert result.status == 1
+        result = module_container_contenthost.execute(docker_pull_command)
+        assert result.status != 0
 
         # 4. Use Docker client to login to Satellite docker hub
-        result = container_contenthost.execute(
+        result = module_container_contenthost.execute(
             f'docker login -u {settings.server.admin_username}'
             f' -p {settings.server.admin_password} {target_sat.hostname}'
         )
         assert result.status == 0
+        request.addfinalizer(
+            lambda: module_container_contenthost.execute(f'docker logout {target_sat.hostname}')
+        )
 
         # 5. Pull in docker image
         # publishing takes few seconds sometimes
         result, _ = wait_for(
-            lambda: container_contenthost.execute(docker_pull_command),
+            lambda: module_container_contenthost.execute(docker_pull_command),
             num_sec=60,
             delay=2,
             fail_condition=lambda out: out.status != 0,
@@ -302,12 +313,12 @@ class TestDockerClient:
         assert result.status == 0
 
         # 6. Use Docker client to log out of Satellite docker hub
-        result = container_contenthost.execute(f'docker logout {target_sat.hostname}')
+        result = module_container_contenthost.execute(f'docker logout {target_sat.hostname}')
         assert result.status == 0
 
         # 7. Try to pull in docker image
-        result = container_contenthost.execute(docker_pull_command)
-        assert result.status == 1
+        result = module_container_contenthost.execute(docker_pull_command)
+        assert result.status != 0
 
         # 8. Set 'Unauthenticated Pull' option to true
         target_sat.cli.LifecycleEnvironment.update(
@@ -319,11 +330,11 @@ class TestDockerClient:
         )
 
         # 9. Pull in docker image
-        result = container_contenthost.execute(docker_pull_command)
+        result = module_container_contenthost.execute(docker_pull_command)
         assert result.status == 0
 
     def test_negative_pull_content_with_longer_name(
-        self, target_sat, container_contenthost, module_org
+        self, request, target_sat, module_container_contenthost, module_org
     ):
         """Verify that long name CV publishes when CV & docker repo both have a larger name.
 
@@ -383,19 +394,20 @@ class TestDockerClient:
         )
 
         podman_pull_command = (
-            f"podman pull --tls-verify=false {target_sat.hostname}/{module_org.label.lower()}"
-            f"-{lce['label'].lower()}-{cv['label'].lower()}-{product['label'].lower()}-{repo_name}"
+            f"podman pull --tls-verify=false {target_sat.hostname}/{module_org.label}"
+            f"-{lce['label']}-{cv['label']}-{product['label']}-{repo_name}".lower()
         )
 
         # 4. Pull in docker image
         assert (
-            container_contenthost.execute(
+            module_container_contenthost.execute(
                 f'podman login -u {settings.server.admin_username}'
                 f' -p {settings.server.admin_password} {target_sat.hostname}'
             ).status
             == 0
         )
+        request.addfinalizer(
+            lambda: module_container_contenthost.execute(f'podman logout {target_sat.hostname}')
+        )
 
-        assert container_contenthost.execute(podman_pull_command).status == 0
-
-        assert container_contenthost.execute(f'podman logout {target_sat.hostname}').status == 0
+        assert module_container_contenthost.execute(podman_pull_command).status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15179

### Problem Statement
Some of our tests are failing to pull docker images with OCI artifacts using obsolete version of docker client provided by RHEL7 extras repo.
(see [BZ#2262793](https://bugzilla.redhat.com/show_bug.cgi?id=2262793))


### Solution
Let's move forward to RHEL8 and newer version of podman/docker.
Proposed changes in this PR:
1. Use RHEL8 with newer podman/docker client.
2. Rescope `container_contenthost` fixture to module. This speeds up current tests from ~45 minutes to ~15 minutes. The downside is we need to ensure `podman logout` is performed on teardown (via `request.addfinalizer`).


### Related Issues
With the new podman new issue was identified (which has not been hit with the old docker client): https://issues.redhat.com/browse/SAT-25328
Since the [fix PR](https://github.com/Katello/katello/pull/11006) is up already, let's test it with packit.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_container_management.py
Katello:
    katello: 11006
```