### PR TITLE
[6.14.z] add hypervisor host and guest subscription status and mapping check mapping

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -40,7 +40,7 @@ class TestVirtwhoConfigforEsx:
     @pytest.mark.upgrade
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui
+        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
     ):
         """Verify configure created and deployed with id.
 
@@ -50,12 +50,24 @@ class TestVirtwhoConfigforEsx:
             1. Config can be created and deployed by command or script
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
-            4. Virtual sku can be generated and attached
+            4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
             5. Config can be deleted
 
         :CaseImportance: High
         """
+        hypervisor_name, guest_name = deploy_type_ui
+        # Check virt-wh oconfig status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        org_session.location.select(default_location.name)
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
+        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
+        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
+        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
+        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
+        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
 
     @pytest.mark.tier2
     def test_positive_debug_option(

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -25,7 +25,7 @@ class TestVirtwhoConfigforHyperv:
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui
+        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
     ):
         """Verify configure created and deployed with id.
 
@@ -35,12 +35,24 @@ class TestVirtwhoConfigforHyperv:
             1. Config can be created and deployed by command or script
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
-            4. Virtual sku can be generated and attached
+            4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
             5. Config can be deleted
 
         :CaseImportance: High
         """
+        hypervisor_name, guest_name = deploy_type_ui
+        # Check virt-wh oconfig status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        org_session.location.select(default_location.name)
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
+        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
+        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
+        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
+        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
+        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -25,7 +25,7 @@ class TestVirtwhoConfigforKubevirt:
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui
+        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
     ):
         """Verify configure created and deployed with id.
 
@@ -35,12 +35,24 @@ class TestVirtwhoConfigforKubevirt:
             1. Config can be created and deployed by command or script
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
-            4. Virtual sku can be generated and attached
+            4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
             5. Config can be deleted
 
         :CaseImportance: High
         """
+        hypervisor_name, guest_name = deploy_type_ui
+        # Check virt-wh oconfig status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        org_session.location.select(default_location.name)
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
+        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
+        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
+        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
+        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
+        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -25,7 +25,7 @@ class TestVirtwhoConfigforLibvirt:
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui
+        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
     ):
         """Verify configure created and deployed with id.
 
@@ -35,12 +35,24 @@ class TestVirtwhoConfigforLibvirt:
             1. Config can be created and deployed by command or script
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
-            4. Virtual sku can be generated and attached
+            4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
             5. Config can be deleted
 
         :CaseImportance: High
         """
+        hypervisor_name, guest_name = deploy_type_ui
+        # Check virt-wh oconfig status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        org_session.location.select(default_location.name)
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
+        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
+        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
+        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
+        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
+        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -29,7 +29,7 @@ class TestVirtwhoConfigforNutanix:
     @pytest.mark.tier2
     @pytest.mark.parametrize('deploy_type_ui', ['id', 'script'], indirect=True)
     def test_positive_deploy_configure_by_id_script(
-        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui
+        self, module_sca_manifest_org, org_session, form_data_ui, deploy_type_ui, default_location
     ):
         """Verify configure created and deployed with id.
 
@@ -39,11 +39,24 @@ class TestVirtwhoConfigforNutanix:
             1. Config can be created and deployed by command or script
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
-            4. Config can be deleted
+            4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
+            5. Config can be deleted
 
         :CaseImportance: High
         """
+        hypervisor_name, guest_name = deploy_type_ui
+        # Check virt-wh oconfig status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        org_session.location.select(default_location.name)
+        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
+        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
+        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
+        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
+        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
+        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
+        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
+        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15064

add hypervisor host and guest subscription status and mapping check mapping
Cases PASS:
```
robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_deploy_configure_by_id_script --disable-pytest-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 34 deselected, 29 warnings in 539.09s (0:08:59)
2024-05-21 00:27:04 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_hyperv_sca.py -k test_positive_deploy_configure_by_id_script --disable-pytest-warnings -q
..                                                                                                                                                                                                          [100%]
2 passed, 4 deselected, 25 warnings in 645.48s (0:10:45)
2024-05-21 00:56:01 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

```
depend the PR https://github.com/SatelliteQE/airgun/pull/1389