### PR TITLE
[master]: Changes for new 6.16.z branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,6 @@ updates:
       - "6.15.z"
       - "6.14.z"
       - "6.13.z"
-      - "6.12.z"
 
   # Maintain dependencies for our GitHub Actions
   - package-ecosystem: "github-actions"
@@ -30,4 +29,3 @@ updates:
       - "6.15.z"
       - "6.14.z"
       - "6.13.z"
-      - "6.12.z"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.16.z'
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
@@ -23,6 +24,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.16.z'
       - "CherryPick"
       - "dependencies"
       - "6.15.z"

--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -15,7 +15,7 @@ ROBOTTELO:
   RUN_ONE_DATAPOINT: false
   # Satellite version supported by this branch
   # UNDR version is used for some URL composition
-  SATELLITE_VERSION: "6.16"
+  SATELLITE_VERSION: "6.17"
   # The Base OS RHEL Version(x.y) where the satellite would be installed
   RHEL_VERSION: "8.9"
   # Dynaconf and Dynaconf hooks related options

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -6,9 +6,9 @@ from box import Box
 from nailgun import entities
 
 # This should be updated after each version branch
-SATELLITE_VERSION = "6.16"
+SATELLITE_VERSION = "6.17"
 SATELLITE_OS_VERSION = "8"
-SAT_NON_GA_VERSIONS = ['6.15', '6.16']
+SAT_NON_GA_VERSIONS = ['6.16', '6.17']
 
 # Default system ports
 HTTPS_PORT = '443'

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -306,7 +306,6 @@ def test_positive_update_counts(target_sat, module_capsule_configured):
     )
 
 
-@pytest.mark.stream
 @pytest.mark.parametrize('repair_type', ['repo', 'cv', 'lce'])
 @pytest.mark.parametrize(
     'module_synced_content',

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -406,7 +406,6 @@ def test_positive_check_installer_hammer_ping(target_sat):
             assert 'ok' in line
 
 
-@pytest.mark.stream
 @pytest.mark.upgrade
 @pytest.mark.tier3
 @pytest.mark.build_sanity


### PR DESCRIPTION

  ### Problem Statement
  New 6.16.z downstream and master points to stream that is 6.17
  ### Solution
  - Dependabot.yaml cherrypicks to 6.16.z
  - Robottelo conf and constants now uses 6.17 and 6.16.z satellite versions
