### PR TITLE
[6.15.z] Remove nailgun.entities imports in tests/foreman/cli

### DIFF
--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -12,7 +12,6 @@
 
 import time
 
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -88,9 +87,11 @@ def vm(
     rhel7_contenthost_module.register(
         module_sca_manifest_org, None, rh_repo_setup_ak.name, module_target_sat
     )
-    host = entities.Host().search(query={'search': f'name={rhel7_contenthost_module.hostname}'})
+    host = module_target_sat.api.Host().search(
+        query={'search': f'name={rhel7_contenthost_module.hostname}'}
+    )
     host_id = host[0].id
-    host_content = entities.Host(id=host_id).read_json()
+    host_content = module_target_sat.api.Host(id=host_id).read_json()
     assert host_content["subscription_status"] == 5
     rhel7_contenthost_module.install_katello_host_tools()
     return rhel7_contenthost_module

--- a/tests/foreman/cli/test_discoveryrule.py
+++ b/tests/foreman/cli/test_discoveryrule.py
@@ -17,7 +17,6 @@ import random
 
 from box import Box
 from fauxfactory import gen_choice, gen_integer, gen_string
-from nailgun.entities import Role as RoleEntity, User as UserEntity
 import pytest
 from requests import HTTPError
 
@@ -439,12 +438,14 @@ class TestDiscoveryRuleRole:
     """Implements Foreman discovery Rules tests along with roles from CLI."""
 
     @pytest.fixture(scope='class')
-    def class_user_manager(self, class_user_password, class_org, class_location):
+    def class_user_manager(self, class_target_sat, class_user_password, class_org, class_location):
         try:
-            manager_role = RoleEntity().search(query={'search': 'name="Discovery Manager"'})[0]
+            manager_role = class_target_sat.api.Role().search(
+                query={'search': 'name="Discovery Manager"'}
+            )[0]
         except IndexError:
             pytest.fail('Discovery Manager role was not found, setup cannot continue')
-        user = UserEntity(
+        user = class_target_sat.api.User(
             organization=[class_org],
             location=[class_location],
             password=class_user_password,
@@ -458,12 +459,14 @@ class TestDiscoveryRuleRole:
             logger.error('Exception while deleting class scope user entity in teardown')
 
     @pytest.fixture(scope='class')
-    def class_user_reader(self, class_user_password, class_org, class_location):
+    def class_user_reader(self, class_target_sat, class_user_password, class_org, class_location):
         try:
-            reader_role = RoleEntity().search(query={'search': 'name="Discovery Reader"'})[0]
+            reader_role = class_target_sat.api.Role().search(
+                query={'search': 'name="Discovery Reader"'}
+            )[0]
         except IndexError:
             pytest.fail('Discovery Manager role was not found, setup cannot continue')
-        user = UserEntity(
+        user = class_target_sat.api.User(
             organization=[class_org],
             location=[class_location],
             password=class_user_password,

--- a/tests/foreman/cli/test_hostgroup.py
+++ b/tests/foreman/cli/test_hostgroup.py
@@ -13,7 +13,6 @@
 """
 
 from fauxfactory import gen_integer
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -118,7 +117,7 @@ def test_positive_create_with_multiple_entities_and_delete(
         # Common entities
         name = valid_hostgroups_list()[0]
         loc = session_puppet_enabled_sat.cli_factory.make_location()
-        org_2 = entities.Organization().create()
+        org_2 = session_puppet_enabled_sat.api.Organization().create()
         orgs = [module_puppet_org, org_2]
         env = session_puppet_enabled_sat.cli_factory.make_environment(
             {'location-ids': loc['id'], 'organization-ids': org_2.id}

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -13,7 +13,6 @@
 """
 
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.constants import LDAP_ATTR, LDAP_SERVER_TYPE
@@ -22,15 +21,15 @@ from robottelo.utils.datafactory import generate_strings_list, parametrized
 
 
 @pytest.fixture
-def ldap_tear_down():
+def ldap_tear_down(module_target_sat):
     """Teardown the all ldap settings user, usergroup and ldap delete"""
     yield
-    ldap_auth_sources = entities.AuthSourceLDAP().search()
+    ldap_auth_sources = module_target_sat.api.AuthSourceLDAP().search()
     for ldap_auth in ldap_auth_sources:
-        users = entities.User(auth_source=ldap_auth).search()
+        users = module_target_sat.api.User(auth_source=ldap_auth).search()
         for user in users:
             user.delete()
-        user_groups = entities.UserGroup().search()
+        user_groups = module_target_sat.api.UserGroup().search()
         if user_groups:
             user_groups[0].delete()
         ldap_auth.delete()
@@ -150,15 +149,15 @@ class TestADAuthSource:
 class TestIPAAuthSource:
     """Implements FreeIPA ldap auth feature tests in CLI"""
 
-    def _clean_up_previous_ldap(self):
+    def _clean_up_previous_ldap(self, sat_instance):
         """clean up the all ldap settings user, usergroup and ldap delete"""
-        ldap = entities.AuthSourceLDAP().search()
+        ldap = sat_instance.api.AuthSourceLDAP().search()
         for ldap_auth in range(len(ldap)):
-            users = entities.User(auth_source=ldap[ldap_auth]).search()
+            users = sat_instance.api.User(auth_source=ldap[ldap_auth]).search()
             for user in range(len(users)):
                 users[user].delete()
             ldap[ldap_auth].delete()
-        user_groups = entities.UserGroup().search()
+        user_groups = sat_instance.api.UserGroup().search()
         for user_group in user_groups:
             user_group.delete()
 
@@ -218,7 +217,7 @@ class TestIPAAuthSource:
 
         :CaseImportance: Medium
         """
-        self._clean_up_previous_ldap()
+        self._clean_up_previous_ldap(module_target_sat)
         ipa_group_base_dn = default_ipa_host.group_base_dn.replace('foobargroup', 'foreman_group')
         member_username = 'foreman_test'
         member_group = 'foreman_group'
@@ -305,7 +304,7 @@ class TestIPAAuthSource:
 
         :CaseImportance: Medium
         """
-        self._clean_up_previous_ldap()
+        self._clean_up_previous_ldap(module_target_sat)
         ipa_group_base_dn = default_ipa_host.group_base_dn.replace('foobargroup', 'foreman_group')
         member_username = 'foreman_test'
         member_group = 'foreman_group'

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -13,7 +13,6 @@
 """
 
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -959,7 +958,7 @@ class TestOpenScap:
 
         :CaseImportance: Medium
         """
-        host = entities.Host()
+        host = module_target_sat.api.Host()
         host.create()
         name = gen_string('alpha')
         scap_policy = module_target_sat.cli_factory.make_scap_policy(

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -14,7 +14,6 @@
 
 import random
 
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -29,9 +28,9 @@ pytestmark = [
 
 
 @pytest.fixture(scope='module')
-def ostree_user_credentials():
+def ostree_user_credentials(module_target_sat):
     password = 'password'
-    user = entities.User(admin=True, password=password).create()
+    user = module_target_sat.api.User(admin=True, password=password).create()
     return user.login, password
 
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -16,7 +16,6 @@ from random import choice
 from string import punctuation
 
 from fauxfactory import gen_alphanumeric, gen_integer, gen_string, gen_url
-from nailgun import entities
 import pytest
 import requests
 from wait_for import wait_for
@@ -230,7 +229,7 @@ class TestRepository:
         ),
         indirect=True,
     )
-    def test_positive_create_with_auth_yum_repo(self, repo_options, repo):
+    def test_positive_create_with_auth_yum_repo(self, target_sat, repo_options, repo):
         """Create YUM repository with basic HTTP authentication
 
         :id: da8309fd-3076-427b-a96f-8d883d6e944f
@@ -243,7 +242,7 @@ class TestRepository:
         """
         for key in 'url', 'content-type':
             assert repo.get(key) == repo_options[key]
-        repo = entities.Repository(id=repo['id']).read()
+        repo = target_sat.api.Repository(id=repo['id']).read()
         assert repo.upstream_username == repo_options['upstream-username']
 
     @pytest.mark.tier1
@@ -2569,7 +2568,7 @@ class TestFileRepository:
         assert f'Successfully uploaded file {RPM_TO_UPLOAD}' in result[0]['message']
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         assert repo['content-counts']['files'] == '1'
-        filesearch = entities.File().search(
+        filesearch = target_sat.api.File().search(
             query={"search": f"name={RPM_TO_UPLOAD} and repository={repo['name']}"}
         )
         assert filesearch[0].name == RPM_TO_UPLOAD
@@ -2780,7 +2779,7 @@ class TestFileRepository:
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         # Assert there is only one file
         assert repo['content-counts']['files'] == '1'
-        filesearch = entities.File().search(
+        filesearch = target_sat.api.File().search(
             query={"search": f"name={text_file_name} and repository={repo['name']}"}
         )
         assert text_file_name == filesearch[0].name
@@ -2798,7 +2797,7 @@ class TestFileRepository:
         repo = target_sat.cli.Repository.info({'id': repo['id']})
         # Assert there is still only one file
         assert repo['content-counts']['files'] == '1'
-        filesearch = entities.File().search(
+        filesearch = target_sat.api.File().search(
             query={"search": f"name={text_file_name} and repository={repo['name']}"}
         )
         # Assert file name has not changed

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -14,7 +14,6 @@
 
 from fauxfactory import gen_string
 from manifester import Manifester
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -186,13 +185,13 @@ def test_positive_delete_manifest_as_another_user(target_sat, function_entitleme
 
     :CaseImportance: Medium
     """
-    org = entities.Organization().create()
+    org = target_sat.api.Organization().create()
     user1_password = gen_string('alphanumeric')
-    user1 = entities.User(
+    user1 = target_sat.api.User(
         admin=True, password=user1_password, organization=[org], default_organization=org
     ).create()
     user2_password = gen_string('alphanumeric')
-    user2 = entities.User(
+    user2 = target_sat.api.User(
         admin=True, password=user2_password, organization=[org], default_organization=org
     ).create()
     # use the first admin to upload a manifest

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -16,7 +16,6 @@ from datetime import datetime, timedelta
 from time import sleep
 
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.constants import PRDS, REPOS, REPOSET
@@ -240,7 +239,7 @@ def test_positive_update_interval(module_org, test_data, request, target_sat):
             'organization-id': module_org.id,
         }
     )
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     target_sat.cli.SyncPlan.update(
         {'id': new_sync_plan['id'], 'interval': test_data['new-interval']}
@@ -272,7 +271,7 @@ def test_positive_update_sync_date(module_org, request, target_sat):
             'organization-id': module_org.id,
         }
     )
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Assert that sync date matches data passed
     assert new_sync_plan['start-date'] == today.strftime("%Y/%m/%d %H:%M:%S")
@@ -355,7 +354,7 @@ def test_positive_info_enabled_field_is_displayed(module_org, request, target_sa
     :CaseImportance: Critical
     """
     new_sync_plan = target_sat.cli_factory.sync_plan({'organization-id': module_org.id})
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     result = target_sat.cli.SyncPlan.info({'id': new_sync_plan['id']})
     assert result.get('enabled') is not None
@@ -418,7 +417,7 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request,
             'sync-date': datetime.utcnow().strftime(SYNC_DATE_FMT),
         }
     )
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
     repo = target_sat.cli_factory.make_repository({'product-id': product['id']})
@@ -454,7 +453,7 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request,
             ),
         }
     )
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Associate sync plan with product
     target_sat.cli.Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})
@@ -509,7 +508,7 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
             'cron-expression': [f'*/{cron_multiple} * * * *'],
         }
     )
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Verify product is not synced and doesn't have any content
     validate_repo_content(target_sat, repo, ['errata', 'packages'], after_sync=False)
@@ -572,7 +571,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
             'cron-expression': [f'*/{cron_multiple} * * * *'],
         }
     )
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Verify products have not been synced yet
     logger.info(
@@ -651,7 +650,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
             ),
         }
     )
-    sync_plan = entities.SyncPlan(organization=org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Associate sync plan with product
     target_sat.cli.Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})
@@ -721,7 +720,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
             'cron-expression': [f'*/{cron_multiple} * * * *'],
         }
     )
-    sync_plan = entities.SyncPlan(organization=org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Verify product is not synced and doesn't have any content
     with pytest.raises(AssertionError):
@@ -773,7 +772,7 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
             'sync-date': start_date.strftime(SYNC_DATE_FMT),
         }
     )
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Associate sync plan with product
     target_sat.cli.Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})
@@ -822,7 +821,7 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
             'sync-date': start_date.strftime(SYNC_DATE_FMT),
         }
     )
-    sync_plan = entities.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
+    sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Associate sync plan with product
     target_sat.cli.Product.set_sync_plan({'id': product['id'], 'sync-plan-id': new_sync_plan['id']})

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -13,7 +13,6 @@
 import base64
 
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 import requests
 
@@ -80,7 +79,7 @@ class TestTemplateSyncTestCase:
         target_sat.cli.TemplateSync.imports(
             {'repo': dir_path, 'prefix': prefix, 'organization-ids': module_org.id, 'lock': 'true'}
         )
-        ptemplate = entities.ProvisioningTemplate().search(
+        ptemplate = target_sat.api.ProvisioningTemplate().search(
             query={'per_page': 10, 'search': f'name~{prefix}', 'organization_id': module_org.id}
         )
         if ptemplate:

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -23,7 +23,6 @@ import random
 from time import sleep
 
 from fauxfactory import gen_alphanumeric, gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -336,9 +335,9 @@ class TestSshKeyInUser:
     ssh_key = gen_ssh_keypairs()[1]
 
     @pytest.fixture(scope='module')
-    def module_user(self):
+    def module_user(self, module_target_sat):
         """Create an user"""
-        return entities.User().create()
+        return module_target_sat.api.User().create()
 
     @pytest.mark.tier1
     def test_positive_CRD_ssh_key(self, module_user, module_target_sat):


### PR DESCRIPTION
### Problem Statement

SAT-22500

Uses of `nailgun.entities.${ENTITY}` should be replaced with `${SATELLITE_INSTANCE}.api.${ENTITY}`.

### Solution

All tests under tests/foreman/cli/ now use nailgun through the satellite instance's `api` attribute, and imports of `nailgun.entities` have been removed.
