### PR TITLE
Remove nailgun.entities imports in tests/foreman/longrun

### DIFF
--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -167,11 +167,6 @@ def host(
     return rhel7_contenthost_module
 
 
-def get_applicable_errata(satellite, repo):
-    """Retrieves applicable errata for the given repo"""
-    return satellite.api.Errata(repository=repo).search(query={'errata_restrict_applicable': True})
-
-
 @pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_noapply_api(
@@ -195,8 +190,11 @@ def test_positive_noapply_api(
     cvv = versions[-1].read()
     cvv.promote(data={'environment_ids': dev_lce.id})
 
-    # Get the applicable errata
-    errata_list = get_applicable_errata(module_target_sat, custom_repo)
+    # Get the applicable errata for the given repo
+    errata_list = module_target_sat.api.Errata(repository=custom_repo).search(
+        query={'errata_restrict_applicable': True}
+    )
+
     assert len(errata_list) > 0
 
     # Apply incremental update using the first applicable errata

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -14,7 +14,6 @@
 
 from broker import Broker
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -69,15 +68,19 @@ def default_proxy(module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def lifecycle_env(module_org):
+def lifecycle_env(module_target_sat, module_org):
     """Create lifecycle environment"""
-    return entities.LifecycleEnvironment(organization=module_org, name=gen_string('alpha')).create()
+    return module_target_sat.api.LifecycleEnvironment(
+        organization=module_org, name=gen_string('alpha')
+    ).create()
 
 
 @pytest.fixture(scope='module')
-def content_view(module_org):
+def content_view(module_target_sat, module_org):
     """Create content view"""
-    return entities.ContentView(organization=module_org, name=gen_string('alpha')).create()
+    return module_target_sat.api.ContentView(
+        organization=module_org, name=gen_string('alpha')
+    ).create()
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -90,7 +93,7 @@ def activation_key(module_target_sat, module_org, lifecycle_env, content_view):
     ]
 
     for repo in repo_values:
-        activation_key = entities.ActivationKey(
+        activation_key = module_target_sat.api.ActivationKey(
             name=repo.get('akname'), environment=lifecycle_env, organization=module_org
         ).create()
         # Setup org for a custom repo for RHEL6, RHEL7 and RHEL8.


### PR DESCRIPTION
### Problem Statement

SAT-22504

Uses of `nailgun.entities.${ENTITY}` should be replaced with `${SATELLITE_INSTANCE}.api.${ENTITY}`.

### Solution

All tests under `tests/foreman/longrun/` now use nailgun through the satellite instance's `api` attribute, and imports of `nailgun.entities` have been removed.

Test results are the same before and after these changes, and the test failure is unrelated.

PRT:

job/robottelo-pr-testing/7183/console

```
14:59:31  =========================== short test summary info ============================
14:59:31  ERROR tests/foreman/longrun/test_oscap.py::test_positive_oscap_run_via_ansible[rhel7] - robottelo.exceptions.CLIReturnCodeError: CLIReturnCodeError(status=70, stderr='Error: scap_content not found.\n', msg='Command "scap-content info" finished with status 70\nstderr contains:\nError: scap_content not found.\n'
14:59:31  ============= 1 passed, 45 warnings, 1 error in 903.10s (0:15:03) ==============
```

PRT against master:

job/robottelo-pr-testing/7213/console

```
09:52:46  =========================== short test summary info ============================
09:52:46  ERROR tests/foreman/longrun/test_oscap.py::test_positive_oscap_run_via_ansible[rhel7] - robottelo.exceptions.CLIReturnCodeError: CLIReturnCodeError(status=70, stderr='Error: scap_content not found.\n', msg='Command "scap-content info" finished with status 70\nstderr contains:\nError: scap_content not found.\n'
09:52:46  ============= 1 passed, 46 warnings, 1 error in 1034.34s (0:17:14) =============
```
