### PR TITLE
[6.16.z] Fix HTTP proxy teardown

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -29,4 +29,5 @@ def setup_http_proxy(request, module_manifest_org, target_sat):
     yield http_proxy, request.param
     target_sat.update_setting('content_default_http_proxy', content_proxy_value)
     target_sat.update_setting('http_proxy', general_proxy_value)
-    http_proxy.delete()
+    if http_proxy:
+        http_proxy.delete()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15229

### Problem Statement
In #14513 I overlooked that `http_proxy` can be even `None` which does not implement the `delete()` method so the teardown fails with
```
pytest_fixtures/component/http_proxy.py:32: in setup_http_proxy
    http_proxy.delete()
E   AttributeError: 'NoneType' object has no attribute 'delete'
```


### Solution
Delete only existing objects.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_http_proxy.py -k test_positive_install_content_with_http_proxy