### PR TITLE
[6.15.z] Updates for CV component eval

### DIFF
--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -768,8 +768,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter is not updated
 
-        :BZ: 1328943
-
         :CaseImportance: Critical
         """
         cvf_name = gen_string('utf8')

--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -626,52 +626,17 @@ def test_positive_promote_multiple_with_docker_repo(
 
 
 @pytest.mark.tier2
-def test_positive_promote_with_docker_repo_composite(
-    session, module_target_sat, module_org, module_prod
-):
-    """Add docker repository to composite content view and publish it.
-    Then promote it to the next available lifecycle-environment.
-
-    :id: 1c7817c7-60b5-4383-bc6f-2878c2b27fa5
-
-    :expectedresults: Docker repository is promoted to content view
-        found in the specific lifecycle-environment.
-
-    :CaseImportance: High
-    """
-    lce = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
-    repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
-    ).create()
-    content_view = module_target_sat.api.ContentView(
-        composite=False, organization=module_org, repository=[repo]
-    ).create()
-    content_view.publish()
-    content_view = content_view.read()
-    composite_cv = module_target_sat.api.ContentView(
-        component=[content_view.version[-1]], composite=True, organization=module_org
-    ).create()
-    composite_cv.publish()
-    with session:
-        result = session.contentview.promote(composite_cv.name, VERSION, lce.name)
-        assert f'Promoted to {lce.name}' in result['Status']
-        assert lce.name in result['Environments']
-
-
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_promote_multiple_with_docker_repo_composite(
     session, module_target_sat, module_org, module_prod
 ):
-    """Add docker repository to composite content view and publish it
-    Then promote it to the multiple available lifecycle environments.
+    """Add docker repository to composite content view and publish it.
+    Then promote it to multiple available lifecycle environments.
 
     :id: b735b1fa-3d60-4fc0-92d2-4af0ab003097
 
-    :expectedresults: Docker repository is promoted to content view
-        found in the specific lifecycle-environments.
-
-    :CaseImportance: Low
+    :expectedresults: Docker repository published in a content view
+        is promoted to multiple lifecycle-environments.
     """
     repo = module_target_sat.api.Repository(
         url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15043

### Problem Statement
CV component eval proposes several changes to be done for content view tests.


### Solution
This PR addresses some of them, mostly merges and some minor modifications. In particular:
1. `test_positive_remove_cv_version_from_env` is merged with `test_positive_remove_cv_version_from_multi_env`
2. `test_positive_promote_with_docker_repo_composite` is merged with `test_positive_promote_multiple_with_docker_repo_composite`
3. `test_positive_add_custom_repo_by_name` is parametrized for adding repo by `id` and incorrect BZ reference is removed
4. `test_negative_update_with_name` another test case where incorrect BZ reference is removed
5. `test_positive_arbitrary_file_sync_over_capsule` is removed since it is already implemented in [test_positive_sync_file_repo](https://github.com/SatelliteQE/robottelo/blob/ac4b0cfcea803c8653c4476992f5a81d0ccb4c82/tests/foreman/api/test_capsulecontent.py#L1084)
6. `test_positive_restart_dynflow_publish` and `test_positive_restart_dynflow_promote` are removed since they represent obsolete workflows nowadays


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k 'test_positive_add_custom_repo_by or test_positive_remove_cv_version_from_multi_env and not capsule'