### PR TITLE
[6.16.z] Updates for CV component eval

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1007,16 +1007,19 @@ class TestContentView:
         assert filter_info['rules'][0]['id'] == content_view_filter_rule['rule-id']
 
     @pytest.mark.tier1
-    def test_positive_add_custom_repo_by_name(self, module_org, module_product, module_target_sat):
-        """Associate custom content to a content view with name
+    @pytest.mark.parametrize('add_by_name', [True, False], ids=['name', 'id'])
+    def test_positive_add_custom_repo_by(
+        self, module_org, module_product, module_target_sat, add_by_name
+    ):
+        """Associate custom content to a content view with repository name and/or id.
 
         :id: 62431e11-bec6-4444-abb0-e3758ba25fd8
 
-        :expectedresults: whether repos are added to cv.
+        :parametrized: yes
+
+        :expectedresults: Repositories can be added to the CV using their name and/or id.
 
         :CaseImportance: Critical
-
-        :BZ: 1343006
         """
         new_repo = module_target_sat.cli_factory.make_repository(
             {'content-type': 'yum', 'product-id': module_product.id}
@@ -1025,17 +1028,19 @@ class TestContentView:
         module_target_sat.cli.Repository.synchronize({'id': new_repo['id']})
         # Create CV
         new_cv = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
-        # Associate repo to CV with names.
-        module_target_sat.cli.ContentView.add_repository(
-            {
-                'name': new_cv['name'],
-                'organization': module_org.name,
-                'product': module_product.name,
-                'repository': new_repo['name'],
-            }
+        # Associate repo to CV
+        opts = {
+            'name': new_cv['name'],
+            'organization': module_org.name,
+            'product': module_product.name,
+        }
+        opts.update(
+            {'repository': new_repo['name']} if add_by_name else {'repository-id': new_repo['id']}
         )
+        module_target_sat.cli.ContentView.add_repository(opts)
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
         assert new_cv['yum-repositories'][0]['name'] == new_repo['name']
+        assert new_cv['yum-repositories'][0]['id'] == new_repo['id']
 
     @pytest.mark.tier2
     def test_negative_add_same_yum_repo_twice(self, module_org, module_product, module_target_sat):
@@ -2323,38 +2328,6 @@ class TestContentView:
             'lifecycle-environments'
         ]
 
-    @pytest.mark.stubbed
-    def test_positive_restart_dynflow_promote(self):
-        """attempt to restart a failed content view promotion
-
-        :id: 2be23f85-3f62-4319-87ea-41f28cf401dc
-
-        :steps:
-            1. (Somehow) cause a CV promotion to fail.  Not exactly sure how
-               yet.
-            2. Via Dynflow, restart promotion
-
-        :expectedresults: Promotion is restarted.
-
-        :CaseAutomation: NotAutomated
-        """
-
-    @pytest.mark.stubbed
-    def test_positive_restart_dynflow_publish(self):
-        """attempt to restart a failed content view publish
-
-        :id: 24468014-46b2-403e-8ed6-2daeda5a0163
-
-        :steps:
-            1. (Somehow) cause a CV publish  to fail.  Not exactly sure how
-               yet.
-            2. Via Dynflow, restart publish
-
-        :expectedresults: Publish is restarted.
-
-        :CaseAutomation: NotAutomated
-        """
-
     @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -2522,132 +2495,6 @@ class TestContentView:
         }
         assert {lce_dev['name']} == content_view_version_lce_names
 
-    @pytest.mark.tier2
-    @pytest.mark.skipif(
-        (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
-    )
-    def test_positive_remove_cv_version_from_env(self, module_org, module_target_sat):
-        """Remove promoted content view version from environment
-
-        :id: 577757ac-b184-4ece-9310-182dd5ceb718
-
-        :steps:
-
-            1. Create a content view
-            2. Add a yum repo and a docker repo to the content view
-            3. Publish the content view
-            4. Promote the content view version to multiple environments
-               Library -> DEV -> QE -> STAGE -> PROD
-            5. remove the content view version from PROD environment
-            6. Assert: content view version exists only in Library, DEV, QE,
-               STAGE and not in PROD
-            7. Promote again from STAGE -> PROD
-
-        :expectedresults: Content view version exist in Library, DEV, QE,
-            STAGE, PROD
-
-        :CaseImportance: High
-        """
-        lce_dev = module_target_sat.cli_factory.make_lifecycle_environment(
-            {'organization-id': module_org.id}
-        )
-        lce_qe = module_target_sat.cli_factory.make_lifecycle_environment(
-            {'organization-id': module_org.id, 'prior': lce_dev['name']}
-        )
-        lce_stage = module_target_sat.cli_factory.make_lifecycle_environment(
-            {'organization-id': module_org.id, 'prior': lce_qe['name']}
-        )
-        lce_prod = module_target_sat.cli_factory.make_lifecycle_environment(
-            {'organization-id': module_org.id, 'prior': lce_stage['name']}
-        )
-        custom_yum_product = module_target_sat.cli_factory.make_product(
-            {'organization-id': module_org.id}
-        )
-        custom_yum_repo = module_target_sat.cli_factory.make_repository(
-            {
-                'content-type': 'yum',
-                'product-id': custom_yum_product['id'],
-                'url': settings.repos.yum_1.url,
-            }
-        )
-        module_target_sat.cli.Repository.synchronize({'id': custom_yum_repo['id']})
-        docker_product = module_target_sat.cli_factory.make_product(
-            {'organization-id': module_org.id}
-        )
-        docker_repository = module_target_sat.cli_factory.make_repository(
-            {
-                'content-type': 'docker',
-                'docker-upstream-name': constants.CONTAINER_UPSTREAM_NAME,
-                'name': gen_string('alpha', 20),
-                'product-id': docker_product['id'],
-                'url': constants.CONTAINER_REGISTRY_HUB,
-            }
-        )
-        module_target_sat.cli.Repository.synchronize({'id': docker_repository['id']})
-        content_view = module_target_sat.cli_factory.make_content_view(
-            {'organization-id': module_org.id}
-        )
-        for repo in [custom_yum_repo, docker_repository]:
-            module_target_sat.cli.ContentView.add_repository(
-                {
-                    'id': content_view['id'],
-                    'organization-id': module_org.id,
-                    'repository-id': repo['id'],
-                }
-            )
-        module_target_sat.cli.ContentView.publish({'id': content_view['id']})
-        content_view_versions = module_target_sat.cli.ContentView.info({'id': content_view['id']})[
-            'versions'
-        ]
-        assert len(content_view_versions) > 0
-        content_view_version = content_view_versions[-1]
-        for lce in [lce_dev, lce_qe, lce_stage, lce_prod]:
-            module_target_sat.cli.ContentView.version_promote(
-                {'id': content_view_version['id'], 'to-lifecycle-environment-id': lce['id']}
-            )
-        # ensure that the published content version is in Library, DEV, QE,
-        # STAGE and PROD environments
-        assert {
-            constants.ENVIRONMENT,
-            lce_dev['name'],
-            lce_qe['name'],
-            lce_stage['name'],
-            lce_prod['name'],
-        } == _get_content_view_version_lce_names_set(
-            content_view['id'], content_view_version['id'], sat=module_target_sat
-        )
-        # remove content view version from PROD lifecycle environment
-        module_target_sat.cli.ContentView.remove_from_environment(
-            {
-                'id': content_view['id'],
-                'organization-id': module_org.id,
-                'lifecycle-environment': lce_prod['name'],
-            }
-        )
-        # ensure content view version is not in PROD and only in Library, DEV,
-        # QE and STAGE environments
-        assert {
-            constants.ENVIRONMENT,
-            lce_dev['name'],
-            lce_qe['name'],
-            lce_stage['name'],
-        } == _get_content_view_version_lce_names_set(
-            content_view['id'], content_view_version['id'], sat=module_target_sat
-        )
-        # promote content view version to PROD environment again
-        module_target_sat.cli.ContentView.version_promote(
-            {'id': content_view_version['id'], 'to-lifecycle-environment-id': lce_prod['id']}
-        )
-        assert {
-            constants.ENVIRONMENT,
-            lce_dev['name'],
-            lce_qe['name'],
-            lce_stage['name'],
-            lce_prod['name'],
-        } == _get_content_view_version_lce_names_set(
-            content_view['id'], content_view_version['id'], sat=module_target_sat
-        )
-
     @pytest.mark.tier3
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -2658,15 +2505,17 @@ class TestContentView:
         :id: 997cfd7d-9029-47e2-a41e-84f4370b5ce5
 
         :steps:
-
             1. Create a content view
             2. Add a yum repo and a docker to the content view
             3. Publish the content view
             4. Promote the content view version to multiple environments
                Library -> DEV -> QE -> STAGE -> PROD
             5. Remove content view version from QE, STAGE and PROD
+            6. Assert the CVV exists only in Library and DEV
+            7. Promote again from DEV -> QE -> STAGE
+            8. Assert the CVV exists in Library, DEV, QE and STAGE
 
-        :expectedresults: Content view version exists only in Library, DEV
+        :expectedresults: Content view version exists in the right LCEs for each step.
 
         :CaseImportance: High
         """
@@ -2738,8 +2587,7 @@ class TestContentView:
         } == _get_content_view_version_lce_names_set(
             content_view['id'], content_view_version['id'], sat=module_target_sat
         )
-        # remove content view version from QE, STAGE, PROD lifecycle
-        # environments
+        # remove content view version from QE, STAGE, PROD lifecycle environments
         for lce in [lce_qe, lce_stage, lce_prod]:
             module_target_sat.cli.ContentView.remove_from_environment(
                 {
@@ -2748,9 +2596,22 @@ class TestContentView:
                     'lifecycle-environment': lce['name'],
                 }
             )
-        # ensure content view version is not in PROD and only in Library, DEV,
-        # QE and STAGE environments
+        # ensure content view version is not in QE, STAGE, PROD and only in Library and DEV envs
         assert {constants.ENVIRONMENT, lce_dev['name']} == _get_content_view_version_lce_names_set(
+            content_view['id'], content_view_version['id'], sat=module_target_sat
+        )
+        # Promote again from DEV -> QE -> STAGE
+        for lce in [lce_qe, lce_stage]:
+            module_target_sat.cli.ContentView.version_promote(
+                {'id': content_view_version['id'], 'to-lifecycle-environment-id': lce['id']}
+            )
+        # ensure content view version is not in PROD and only in Library, DEV, QE and STAGE envs
+        assert {
+            constants.ENVIRONMENT,
+            lce_dev['name'],
+            lce_qe['name'],
+            lce_stage['name'],
+        } == _get_content_view_version_lce_names_set(
             content_view['id'], content_view_version['id'], sat=module_target_sat
         )
 
@@ -3521,32 +3382,6 @@ class TestContentViewFileRepo:
             {'id': cv['id'], 'repository-id': repo['id']}
         )
         assert cv['file-repositories'][0]['id'] != repo['id']
-
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
-    @pytest.mark.upgrade
-    def test_positive_arbitrary_file_sync_over_capsule(self):
-        """Check a File Repository with Arbitrary File can be added to a
-        Content View is synced throughout capsules
-
-        :id: ffa59550-464c-40dc-9bd2-444331f73708
-
-        :Setup:
-            1. Create a File Repository (FR)
-            2. Upload an arbitrary file to it
-            3. Create a Content View (CV)
-            4. Add the FR to the CV
-            5. Create a Capsule
-            6. Connect the Capsule with Satellite/Foreman host
-
-        :steps:
-            1. Start synchronization
-
-        :expectedresults: Check CV with FR is synced over Capsule
-
-        :CaseAutomation: NotAutomated
-
-        """
 
     @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_promotion(

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -768,8 +768,6 @@ class TestContentViewFilter:
 
         :expectedresults: Content view filter is not updated
 
-        :BZ: 1328943
-
         :CaseImportance: Critical
         """
         cvf_name = gen_string('utf8')

--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -627,52 +627,17 @@ def test_positive_promote_multiple_with_docker_repo(
 
 
 @pytest.mark.tier2
-def test_positive_promote_with_docker_repo_composite(
-    session, module_target_sat, module_org, module_prod
-):
-    """Add docker repository to composite content view and publish it.
-    Then promote it to the next available lifecycle-environment.
-
-    :id: 1c7817c7-60b5-4383-bc6f-2878c2b27fa5
-
-    :expectedresults: Docker repository is promoted to content view
-        found in the specific lifecycle-environment.
-
-    :CaseImportance: High
-    """
-    lce = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
-    repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
-    ).create()
-    content_view = module_target_sat.api.ContentView(
-        composite=False, organization=module_org, repository=[repo]
-    ).create()
-    content_view.publish()
-    content_view = content_view.read()
-    composite_cv = module_target_sat.api.ContentView(
-        component=[content_view.version[-1]], composite=True, organization=module_org
-    ).create()
-    composite_cv.publish()
-    with session:
-        result = session.contentview.promote(composite_cv.name, VERSION, lce.name)
-        assert f'Promoted to {lce.name}' in result['Status']
-        assert lce.name in result['Environments']
-
-
-@pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_promote_multiple_with_docker_repo_composite(
     session, module_target_sat, module_org, module_prod
 ):
-    """Add docker repository to composite content view and publish it
-    Then promote it to the multiple available lifecycle environments.
+    """Add docker repository to composite content view and publish it.
+    Then promote it to multiple available lifecycle environments.
 
     :id: b735b1fa-3d60-4fc0-92d2-4af0ab003097
 
-    :expectedresults: Docker repository is promoted to content view
-        found in the specific lifecycle-environments.
-
-    :CaseImportance: Low
+    :expectedresults: Docker repository published in a content view
+        is promoted to multiple lifecycle-environments.
     """
     repo = module_target_sat.api.Repository(
         url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15043

### Problem Statement
CV component eval proposes several changes to be done for content view tests.


### Solution
This PR addresses some of them, mostly merges and some minor modifications. In particular:
1. `test_positive_remove_cv_version_from_env` is merged with `test_positive_remove_cv_version_from_multi_env`
2. `test_positive_promote_with_docker_repo_composite` is merged with `test_positive_promote_multiple_with_docker_repo_composite`
3. `test_positive_add_custom_repo_by_name` is parametrized for adding repo by `id` and incorrect BZ reference is removed
4. `test_negative_update_with_name` another test case where incorrect BZ reference is removed
5. `test_positive_arbitrary_file_sync_over_capsule` is removed since it is already implemented in [test_positive_sync_file_repo](https://github.com/SatelliteQE/robottelo/blob/ac4b0cfcea803c8653c4476992f5a81d0ccb4c82/tests/foreman/api/test_capsulecontent.py#L1084)
6. `test_positive_restart_dynflow_publish` and `test_positive_restart_dynflow_promote` are removed since they represent obsolete workflows nowadays


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k 'test_positive_add_custom_repo_by or test_positive_remove_cv_version_from_multi_env and not capsule'