### PR TITLE
Add PIT marker to clone tests

### DIFF
--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -22,6 +22,7 @@ SSH_PASS = settings.server.ssh_password
 pytestmark = pytest.mark.destructive
 
 
+@pytest.mark.pit_server
 @pytest.mark.e2e
 @pytest.mark.parametrize(
     "sat_ready_rhel",
@@ -130,7 +131,6 @@ def test_positive_clone_backup(
     )
 
 
-@pytest.mark.pit_server
 def test_positive_list_tasks(target_sat):
     """Test that satellite-clone --list-tasks command doesn't fail.
 


### PR DESCRIPTION
### Problem Statement
We missed a satellite-clone breaking bug when upgrading to RHEL 8.10. See SAT-25484

### Solution
Let's run the actual cloning process on PIT server

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->