### PR TITLE
[6.14.z] Remove nailgun entity_mixin import from discovery tests

### DIFF
--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -90,6 +90,15 @@ def get_url():
     return urlunsplit((scheme, hostname, '', '', ''))
 
 
+def admin_nailgun_config():
+    """Return a NailGun configuration file constructed from default admin user credentials.
+
+    :return: ``nailgun.config.ServerConfig`` object, populated from admin user credentials.
+
+    """
+    return ServerConfig(get_url(), get_credentials(), verify=settings.server.verify_ca)
+
+
 def user_nailgun_config(username=None, password=None):
     """Return a NailGun configuration file constructed from default values.
 

--- a/tests/foreman/destructive/test_discoveredhost.py
+++ b/tests/foreman/destructive/test_discoveredhost.py
@@ -13,10 +13,10 @@
 from copy import copy
 import re
 
-from nailgun import entity_mixins
 import pytest
 from wait_for import TimedOutError, wait_for
 
+from robottelo.config import admin_nailgun_config
 from robottelo.logging import logger
 
 pytestmark = pytest.mark.destructive
@@ -124,7 +124,7 @@ def _assert_discovered_host(host, channel=None, user_config=None, sat=None):
         # raise assertion error
         raise AssertionError('Timed out waiting for "/facts" 201 response') from err
 
-    default_config = entity_mixins.DEFAULT_SERVER_CONFIG
+    default_config = admin_nailgun_config()
 
     try:
         wait_for(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15164

### Problem Statement
Remove nailgun entity_mixin import from discovery tests, and replace entity_mixins.DEFAULT_SERVER_CONFIG 

### Solution
Replacing entity_mixins.DEFAULT_SERVER_CONFIG with new default_nailgun_config method, which is same as existing user_nailgun_config method
And, we don't have any automated tests under this module, verifying default_nailgun_config() method in https://github.com/SatelliteQE/robottelo/pull/15163
