### PR TITLE
[6.13.z] Remove nailgun.entities imports in tests/foreman/longrun

### DIFF
--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -14,7 +14,6 @@
 
 from datetime import datetime, timedelta
 
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -32,10 +31,10 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 
 @pytest.fixture(scope='module')
-def module_lce_library(module_entitlement_manifest_org):
+def module_lce_library(module_target_sat, module_entitlement_manifest_org):
     """Returns the Library lifecycle environment from chosen organization"""
     return (
-        entities.LifecycleEnvironment()
+        module_target_sat.api.LifecycleEnvironment()
         .search(
             query={
                 'search': f'name={ENVIRONMENT} and '
@@ -47,15 +46,15 @@ def module_lce_library(module_entitlement_manifest_org):
 
 
 @pytest.fixture(scope='module')
-def dev_lce(module_entitlement_manifest_org):
-    return entities.LifecycleEnvironment(
+def dev_lce(module_target_sat, module_entitlement_manifest_org):
+    return module_target_sat.api.LifecycleEnvironment(
         name='DEV', organization=module_entitlement_manifest_org
     ).create()
 
 
 @pytest.fixture(scope='module')
-def qe_lce(module_entitlement_manifest_org, dev_lce):
-    return entities.LifecycleEnvironment(
+def qe_lce(module_target_sat, module_entitlement_manifest_org, dev_lce):
+    return module_target_sat.api.LifecycleEnvironment(
         name='QE', prior=dev_lce, organization=module_entitlement_manifest_org
     ).create()
 
@@ -77,20 +76,22 @@ def sat_client_repo(module_entitlement_manifest_org, module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def custom_repo(module_entitlement_manifest_org):
+def custom_repo(module_target_sat, module_entitlement_manifest_org):
     """Enable custom errata repository"""
-    custom_repo = entities.Repository(
+    custom_repo = module_target_sat.api.Repository(
         url=settings.repos.yum_9.url,
-        product=entities.Product(organization=module_entitlement_manifest_org).create(),
+        product=module_target_sat.api.Product(
+            organization=module_entitlement_manifest_org
+        ).create(),
     ).create()
     assert custom_repo.sync()['result'] == 'success'
     return custom_repo
 
 
 @pytest.fixture(scope='module')
-def module_cv(module_entitlement_manifest_org, sat_client_repo, custom_repo):
+def module_cv(module_target_sat, module_entitlement_manifest_org, sat_client_repo, custom_repo):
     """Publish both repos into module CV"""
-    module_cv = entities.ContentView(
+    module_cv = module_target_sat.api.ContentView(
         organization=module_entitlement_manifest_org,
         repository=[sat_client_repo.id, custom_repo.id],
     ).create()
@@ -99,15 +100,17 @@ def module_cv(module_entitlement_manifest_org, sat_client_repo, custom_repo):
 
 
 @pytest.fixture(scope='module')
-def module_ak(module_entitlement_manifest_org, module_cv, custom_repo, module_lce_library):
+def module_ak(
+    module_target_sat, module_entitlement_manifest_org, module_cv, custom_repo, module_lce_library
+):
     """Create a module AK in Library LCE"""
-    ak = entities.ActivationKey(
+    ak = module_target_sat.api.ActivationKey(
         content_view=module_cv,
         environment=module_lce_library,
         organization=module_entitlement_manifest_org,
     ).create()
     # Fetch available subscriptions
-    subs = entities.Subscription(organization=module_entitlement_manifest_org).search()
+    subs = module_target_sat.api.Subscription(organization=module_entitlement_manifest_org).search()
     assert len(subs) > 0
     # Add default subscription to activation key
     sub_found = False
@@ -122,9 +125,9 @@ def module_ak(module_entitlement_manifest_org, module_cv, custom_repo, module_lc
     )
     # Add custom subscription to activation key
     prod = custom_repo.product.read()
-    custom_sub = entities.Subscription(organization=module_entitlement_manifest_org).search(
-        query={'search': f'name={prod.name}'}
-    )
+    custom_sub = module_target_sat.api.Subscription(
+        organization=module_entitlement_manifest_org
+    ).search(query={'search': f'name={prod.name}'})
     ak.add_subscriptions(data={'subscription_id': custom_sub[0].id})
     # Enable custom repo in activation key
     all_content = ak.product_content(data={'content_access_mode_all': '1'})['results']
@@ -170,7 +173,7 @@ def host(
     )
     # Add filter of type include but do not include anything.
     # this will hide all RPMs from selected erratum before publishing.
-    entities.RPMContentViewFilter(
+    module_target_sat.api.RPMContentViewFilter(
         content_view=module_cv, inclusion=True, name='Include Nothing'
     ).create()
     module_cv.publish()
@@ -178,15 +181,10 @@ def host(
     return rhel7_contenthost_module
 
 
-def get_applicable_errata(repo):
-    """Retrieves applicable errata for the given repo"""
-    return entities.Errata(repository=repo).search(query={'errata_restrict_applicable': True})
-
-
 @pytest.mark.tier4
 @pytest.mark.upgrade
 def test_positive_noapply_api(
-    module_entitlement_manifest_org, module_cv, custom_repo, host, dev_lce
+    module_target_sat, module_entitlement_manifest_org, module_cv, custom_repo, host, dev_lce
 ):
     """Check if api incremental update can be done without
     actually applying it
@@ -206,12 +204,14 @@ def test_positive_noapply_api(
     cvv = versions[-1].read()
     cvv.promote(data={'environment_ids': dev_lce.id})
 
-    # Get the applicable errata
-    errata_list = get_applicable_errata(custom_repo)
+    # Get the applicable errata for the given repo
+    errata_list = module_target_sat.api.Errata(repository=custom_repo).search(
+        query={'errata_restrict_applicable': True}
+    )
     assert len(errata_list) > 0
 
     # Apply incremental update using the first applicable errata
-    outval = entities.ContentViewVersion().incremental_update(
+    outval = module_target_sat.api.ContentViewVersion().incremental_update(
         data={
             'content_view_version_environments': [
                 {

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -14,7 +14,6 @@
 
 from broker import Broker
 from fauxfactory import gen_string
-from nailgun import entities
 import pytest
 
 from robottelo.config import settings
@@ -69,15 +68,19 @@ def default_proxy(module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def lifecycle_env(module_org):
+def lifecycle_env(module_target_sat, module_org):
     """Create lifecycle environment"""
-    return entities.LifecycleEnvironment(organization=module_org, name=gen_string('alpha')).create()
+    return module_target_sat.api.LifecycleEnvironment(
+        organization=module_org, name=gen_string('alpha')
+    ).create()
 
 
 @pytest.fixture(scope='module')
-def content_view(module_org):
+def content_view(module_target_sat, module_org):
     """Create content view"""
-    return entities.ContentView(organization=module_org, name=gen_string('alpha')).create()
+    return module_target_sat.api.ContentView(
+        organization=module_org, name=gen_string('alpha')
+    ).create()
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -90,7 +93,7 @@ def activation_key(module_target_sat, module_org, lifecycle_env, content_view):
     ]
 
     for repo in repo_values:
-        activation_key = entities.ActivationKey(
+        activation_key = module_target_sat.api.ActivationKey(
             name=repo.get('akname'), environment=lifecycle_env, organization=module_org
         ).create()
         # Setup org for a custom repo for RHEL6, RHEL7 and RHEL8.


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15220

### Problem Statement

SAT-22504

Uses of `nailgun.entities.${ENTITY}` should be replaced with `${SATELLITE_INSTANCE}.api.${ENTITY}`.

### Solution

All tests under `tests/foreman/longrun/` now use nailgun through the satellite instance's `api` attribute, and imports of `nailgun.entities` have been removed.