### PR TITLE
Add upgrade scenario test for docker manifest indexing

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -706,9 +706,28 @@ FILTER_ERRATA_DATE = {'updated': "updated", 'issued': "issued"}
 REPORT_TEMPLATE_FILE = 'report_template.txt'
 CONTAINER_REGISTRY_HUB = 'https://mirror.gcr.io'
 RH_CONTAINER_REGISTRY_HUB = 'https://registry.redhat.io/'
+PULP_CONTAINER_REGISTRY_HUB = 'https://ghcr.io'
 CONTAINER_UPSTREAM_NAME = 'library/busybox'
 DOCKER_REPO_UPSTREAM_NAME = 'openshift3/logging-elasticsearch'
 CONTAINER_RH_REGISTRY_UPSTREAM_NAME = 'openshift3/ose-metrics-hawkular-openshift-agent'
+BOOTABLE_REPO = {
+    'upstream_name': 'pulp/bootc-labeled',
+    'manifests_count': 1,
+    'bootable': True,
+    'flatpak': False,
+    'labels_count': 2,
+    'annotations_count': 2,
+}
+FLATPAK_REPO = {
+    'upstream_name': 'pulp/oci-net.fishsoup.hello',
+    'manifests_count': 2,
+    'bootable': False,
+    'flatpak': True,
+    'labels_count': 10,
+    'annotations_count': 0,
+}
+LABELLED_REPOS = [BOOTABLE_REPO, FLATPAK_REPO]
+CONTAINER_MANIFEST_LABELS = {'annotations', 'labels', 'is_bootable', 'is_flatpak'}
 CONTAINER_CLIENTS = ['docker', 'podman']
 CUSTOM_LOCAL_FOLDER = '/var/lib/pulp/imports/myrepo/'
 CUSTOM_LOCAL_FILE = '/var/lib/pulp/imports/myrepo/test.txt'

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1850,11 +1850,11 @@ class TestDockerRepository:
             [
                 {
                     'content_type': 'docker',
-                    'docker_upstream_name': repo['upstream_name'],
+                    'docker_upstream_name': item['upstream_name'],
                     'name': gen_string('alpha'),
                     'url': constants.PULP_CONTAINER_REGISTRY_HUB,
                 }
-                for repo in LABELLED_REPOS
+                for item in LABELLED_REPOS
             ]
         ),
         indirect=True,

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -412,17 +412,17 @@ class TestScenarioContainerRepoSync:
         :expectedresults: Container repositories are synced and ready for upgrade.
         """
         repos = dict()
-        for model in LABELLED_REPOS:
+        for item in LABELLED_REPOS:
             repo = target_sat.api.Repository(
                 content_type='docker',
-                docker_upstream_name=model['upstream_name'],
+                docker_upstream_name=item['upstream_name'],
                 product=module_product,
                 url=PULP_CONTAINER_REGISTRY_HUB,
             ).create()
             repo.sync()
             repo = repo.read()
             assert repo.content_counts['docker_manifest'] > 0
-            repos[model['upstream_name']] = repo.id
+            repos[item['upstream_name']] = repo.id
         save_test_data(repos)
 
     @pytest.mark.post_upgrade(depend_on=test_pre_container_repo_sync)


### PR DESCRIPTION
### Problem Statement
We need a test case to verify that docker manifest labels, annotations and other flags are indexed
- after 6.15 -> 6.16 upgrade in the post-upgrade task.
- during repo sync at 6.16


### Solution
This PR adds such cases.
Needs https://github.com/SatelliteQE/nailgun/pull/1188


### Test resuts
For upgrade scenario (delivered in f-m 1.6.8):
PRE:
```
Launching pytest with arguments -m pre_upgrade -k test_pre_container_repo_sync tests/upgrades/test_repository.py --no-header --no-summary -q in /home/vsedmik/PycharmProjects/robottelo

============================= test session starts ==============================
collecting ... collected 10 items / 9 deselected / 1 selected

tests/upgrades/test_repository.py::TestScenarioContainerRepoSync::test_pre_container_repo_sync 

======================= 1 passed, 9 deselected in 47.61s =======================
```
POST:
```
Launching pytest with arguments -m post_upgrade -k test_post_container_repo_sync tests/upgrades/test_repository.py --no-header --no-summary -q in /home/vsedmik/PycharmProjects/robottelo

============================= test session starts ==============================
collecting ... collected 10 items / 9 deselected / 1 selected

tests/upgrades/test_repository.py::TestScenarioContainerRepoSync::test_post_container_repo_sync 

======================= 1 passed, 9 deselected in 17.82s =======================
```

For repo sync test case
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k manifest_labels
nailgun: 1188
```