### PR TITLE
[6.15.z] eol version check

### DIFF
--- a/conf/subscription.yaml.template
+++ b/conf/subscription.yaml.template
@@ -5,3 +5,5 @@ SUBSCRIPTION:
   RHN_PASSWORD:
   # subscription pool id
   RHN_POOLID:
+  # lifecycle API url
+  LIFECYCLE_API_URL:

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -43,6 +43,7 @@ VALIDATORS = dict(
         Validator('subscription.rhn_username', must_exist=True),
         Validator('subscription.rhn_password', must_exist=True),
         Validator('subscription.rhn_poolid', must_exist=True),
+        Validator('subscription.lifecycle_api_url', must_exist=True),
     ],
     ansible_hub=[
         Validator('ansible_hub.url', must_exist=True),

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2062,6 +2062,7 @@ WEBHOOK_METHODS = [
     "DELETE",
     "PATCH",
 ]
+LIFECYCLE_METADATA_FILE = '/usr/share/satellite/lifecycle-metadata.yml'
 
 OPENSSH_RECOMMENDATION = 'Decreased security: OpenSSH config permissions'
 DNF_RECOMMENDATION = (

--- a/tests/foreman/api/test_eol_banner.py
+++ b/tests/foreman/api/test_eol_banner.py
@@ -1,0 +1,55 @@
+"""Test module for EOL tracking
+
+:Requirement: Dashboard
+
+:CaseAutomation: Automated
+
+:CaseComponent: Dashboard
+
+:Team: Endeavour
+
+:CaseImportance: High
+"""
+
+from datetime import datetime
+
+import pytest
+import requests
+import yaml
+
+from robottelo.config import settings
+from robottelo.constants import LIFECYCLE_METADATA_FILE
+from robottelo.logging import logger
+
+
+@pytest.mark.tier2
+def test_positive_check_eol_date(target_sat):
+    """Check if the EOL date for the satellite version
+
+    :id: 1c2f0d19-a357-4461-9ace-edb468f9ca5c
+
+    :expectedresults: EOL date from satellite-lifecycle package is accurate
+    """
+    current_version = '.'.join(target_sat.version.split('.')[0:2])
+    output = yaml.load(target_sat.execute(rf'cat {LIFECYCLE_METADATA_FILE}').stdout, yaml.Loader)
+    logger.debug(f'contents of {LIFECYCLE_METADATA_FILE} :{output}')
+    eol_datetime = datetime.strptime(output['releases'][current_version]['end_of_life'], '%Y-%m-%d')
+    result = requests.get(settings.subscription.lifecycle_api_url, verify=False)
+    if result.status_code != 200:
+        result.raise_for_status()
+    versions = result.json()['data'][0]['versions']
+    version = [v for v in versions if v['name'] == current_version]
+    if len(version) > 0:
+        api_date = [
+            (p['date_format'], p['date'])
+            for p in version[0]['phases']
+            if p['name'] == 'Maintenance support'
+        ]
+        if api_date[0][0] == 'string':
+            assert eol_datetime.strftime("%B, %Y") in api_date[0][1]
+        elif api_date[0][0] == 'date':
+            assert eol_datetime.strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + 'Z' == api_date[0][1]
+        else:
+            pytest.fail("Unexpcted date format returned")
+    else:
+        pytest.skip("The Satellite version is not GA yet")

--- a/tests/foreman/api/test_eol_banner.py
+++ b/tests/foreman/api/test_eol_banner.py
@@ -28,6 +28,8 @@ def test_positive_check_eol_date(target_sat):
 
     :id: 1c2f0d19-a357-4461-9ace-edb468f9ca5c
 
+    :BlockedBy: SAT-25522
+
     :expectedresults: EOL date from satellite-lifecycle package is accurate
     """
     current_version = '.'.join(target_sat.version.split('.')[0:2])


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/13253

### Problem Statement
This supplements tests for the EOL banner feature. The eol date for the version is defined in the satellite-lifecycle package (so that there is the same solution for connected and disconnected sats). This test aims to check the date in the package is correctly updated. 

### Solution
Comparing the date from the package with the date from the lifecycle api.

Keeping in draft state, as the EOL banner just got to 6.15, but not yet to older releases and the lifecycle api contains data only for released versions

### Related Issues

satellite-jenkins MR 1185