### PR TITLE
[6.14.z] 6.15.z-alernative solution for default subscription search option

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -205,10 +205,11 @@ def test_positive_access_with_non_admin_user_with_manifest(
         default_organization=org,
     ).create()
     with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
-        assert (
-            session.subscription.search(f'name = "{DEFAULT_SUBSCRIPTION_NAME}"')[0]['Name']
-            == DEFAULT_SUBSCRIPTION_NAME
-        )
+        all_subscriptions = session.subscription.read_subscriptions()
+        assert len(all_subscriptions) > 0
+        assert any(
+            [sub['Name'] == DEFAULT_SUBSCRIPTION_NAME for sub in all_subscriptions]
+        ), 'Default subsciption not found'
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15237

### Problem Statement

- Test case `test_positive_access_with_non_admin_user_with_manifest` from UI > test_subscription.py was failing due to wrong (empty search) result, search box xpath was incorrect and gave below error.
- Airgun PR [[Link]](https://github.com/SatelliteQE/airgun/pull/1405) will fix xpath

**Error:**
`E   TypeError: 'NoneType' object is not subscriptable`

### Solution

- This alernate solution will search for all subscriptions and iterate over it, break the for loop once it matches with DEFAULT_SUBSCRIPTION_NAME
- `session.subscription.search(f'name = "{DEFAULT_SUBSCRIPTION_NAME}"')[0]['Name']` this part searches correctly but returns all present subsriptions from Subscription page instead of `Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)`, also returns `Red Hat Beta Access` as 0th entry

### Related Issues
https://github.com/SatelliteQE/airgun/pull/1405

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_access_with_non_admin_user_with_manifest'

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_access_with_non_admin_user_with_manifest'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->