### PR TITLE
Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -51,12 +51,13 @@ class TestVirtwhoConfigforEsx:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
         org_session.location.select(default_location.name)
@@ -68,6 +69,41 @@ class TestVirtwhoConfigforEsx:
         virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
         assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
         assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisorhost_new_overview = org_session.host_new.get_details(
+            hypervisor_display_name, 'overview'
+        )
+        assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '2'
+        # hypervisor host Check details
+        hypervisorhost_new_detais = org_session.host_new.get_details(
+            hypervisor_display_name, 'details'
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
+        # Check guest overview
+        guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
+        assert guest_new_overview['overview']['host_status']['status_success'] == '2'
+        # Check guest details
+        virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
 
     @pytest.mark.tier2
     def test_positive_debug_option(

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -36,12 +36,13 @@ class TestVirtwhoConfigforHyperv:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
         org_session.location.select(default_location.name)
@@ -53,6 +54,41 @@ class TestVirtwhoConfigforHyperv:
         virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
         assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
         assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisorhost_new_overview = org_session.host_new.get_details(
+            hypervisor_display_name, 'overview'
+        )
+        assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '2'
+        # hypervisor host Check details
+        hypervisorhost_new_detais = org_session.host_new.get_details(
+            hypervisor_display_name, 'details'
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
+        # Check guest overview
+        guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
+        assert guest_new_overview['overview']['host_status']['status_success'] == '2'
+        # Check guest details
+        virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -36,12 +36,13 @@ class TestVirtwhoConfigforKubevirt:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
         org_session.location.select(default_location.name)
@@ -53,6 +54,41 @@ class TestVirtwhoConfigforKubevirt:
         virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
         assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
         assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisorhost_new_overview = org_session.host_new.get_details(
+            hypervisor_display_name, 'overview'
+        )
+        assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '2'
+        # hypervisor host Check details
+        hypervisorhost_new_detais = org_session.host_new.get_details(
+            hypervisor_display_name, 'details'
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
+        # Check guest overview
+        guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
+        assert guest_new_overview['overview']['host_status']['status_success'] == '2'
+        # Check guest details
+        virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -36,12 +36,13 @@ class TestVirtwhoConfigforLibvirt:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
         org_session.location.select(default_location.name)
@@ -53,6 +54,41 @@ class TestVirtwhoConfigforLibvirt:
         virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
         assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
         assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisorhost_new_overview = org_session.host_new.get_details(
+            hypervisor_display_name, 'overview'
+        )
+        assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '2'
+        # hypervisor host Check details
+        hypervisorhost_new_detais = org_session.host_new.get_details(
+            hypervisor_display_name, 'details'
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
+        # Check guest overview
+        guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
+        assert guest_new_overview['overview']['host_status']['status_success'] == '2'
+        # Check guest details
+        virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -40,12 +40,13 @@ class TestVirtwhoConfigforNutanix:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
         org_session.location.select(default_location.name)
@@ -57,6 +58,41 @@ class TestVirtwhoConfigforNutanix:
         virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
         assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
         assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisorhost_new_overview = org_session.host_new.get_details(
+            hypervisor_display_name, 'overview'
+        )
+        assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '2'
+        # hypervisor host Check details
+        hypervisorhost_new_detais = org_session.host_new.get_details(
+            hypervisor_display_name, 'details'
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            hypervisorhost_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
+        # Check guest overview
+        guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
+        assert guest_new_overview['overview']['host_status']['status_success'] == '2'
+        # Check guest details
+        virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties'][
+                'virtual_host'
+            ]
+            == hypervisor_display_name
+        )
+        assert (
+            virtualguest_new_detais['details']['system_properties']['sys_properties']['name']
+            == guest_name
+        )
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(


### PR DESCRIPTION
Test Cases: PASS

```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_hyperv_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 17 deselected, 11 warnings in 461.63s (0:07:41)
=============================================================================
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 17 deselected, 11 warnings in 461.63s (0:07:41)
2024-06-04 03:49:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_libvirt_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 2 deselected, 11 warnings in 534.11s (0:08:54)
2024-06-04 04:15:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_nutanix_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 6 deselected, 11 warnings in 530.85s (0:08:50)
2024-06-04 04:27:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_kubevirt_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 2 deselected, 11 warnings in 634.01s (0:10:34)
2024-06-04 04:39:01 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

```