### PR TITLE
[6.15.z] Remove old CV UI tests

### DIFF
--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -51,6 +51,8 @@ from robottelo.utils.datafactory import gen_string
 
 VERSION = 'Version 1.0'
 
+pytestmark = [pytest.mark.stubbed]
+
 
 @pytest.fixture(scope='module')
 def module_org(module_target_sat):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14989

As part of CV Eval, it's time to clean up this old test file - these tests haven't passed in several versions, as this whole set of screens has been removed. Functionality to test the new CV UI is ongoing as part of eval work. 