### PR TITLE
Fix test selection issue for --verifies-issues option

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -115,7 +115,7 @@ def handle_verification_issues(item, verifies_marker, verifies_issues):
             verifies_args = verifies_marker.args[0]
             if all(issue not in verifies_issues for issue in verifies_args):
                 log_and_deselect(item, '--verifies-issues')
-            return False
+                return False
     return True
 
 


### PR DESCRIPTION
### Problem Statement
Fix the indention issue in handle_verification_issues that is causing problems collecting tests with --verifies-issues option.

### Solution
Fix indentation