### PR TITLE
updated server.hostname validator for resolve rhel 8.10 formatting issue

### DIFF
--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -10,7 +10,7 @@ VALIDATORS = dict(
         ),
     ],
     server=[
-        Validator('server.hostname', default=''),
+        Validator('server.hostname', must_exist=True),
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
         Validator('server.version.source', must_exist=True),


### PR DESCRIPTION
### Problem Statement
Currently the settings.server.hostname validator updates the settings.server.version.rhel_version from string value of `8.10` to `8.1` 

### Solution
Removed the validator settigns.server.hostname 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->