### PR TITLE
[6.16.z] Bump manifester from 0.0.14 to 0.2.3 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ deepdiff==7.0.1
 dynaconf[vault]==3.2.5
 fauxfactory==3.1.1
 jinja2==3.1.4
-manifester==0.0.14
+manifester==0.2.3
 navmazing==1.2.2
 productmd==1.38
 pyotp==2.9.0


### PR DESCRIPTION
Manual Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15264, for which we missed adding 6.16.z label before merge

Bumps [manifester](https://github.com/SatelliteQE/manifester) from 0.0.14 to 0.2.3.
- [Release notes](https://github.com/SatelliteQE/manifester/releases)
- [Commits](https://github.com/SatelliteQE/manifester/compare/v0.0.14...v0.2.3)

---
updated-dependencies:
- dependency-name: manifester dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>
Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
(cherry picked from commit 00839faa83a0a91bf2673912eade9da94cf06881)

