### PR TITLE
[6.13.z] updated the manifestor test for dependabot

### DIFF
--- a/.github/dependency_tests.yaml
+++ b/.github/dependency_tests.yaml
@@ -1,7 +1,7 @@
 broker[docker]: "tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'"
 deepdiff: "tests/foreman/endtoend/test_api_endtoend.py -k 'test_positive_get_links'"
 dynaconf[vault]: "tests/foreman/api/test_ldapauthsource.py -k 'test_positive_endtoend'"
-manifester: "tests/foreman/api/test_subscription.py -k 'test_positive_create_after_refresh'"
+manifester: "tests/foreman/cli/test_contentview.py -k 'test_positive_promote_rh_content'"
 navmazing: "tests/foreman/ui/test_repository.py -k 'test_positive_create_as_non_admin_user'"
 pyotp: "tests/foreman/ui/test_ldap_authentication.py -k 'test_positive_login_user_password_otp'"
 pytest-xdist: "tests/foreman/ -n 3 -m 'build_sanity'"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15309

### Problem Statement
Currently the manifestor using the dependabot test is not appropriate, It needed to updated.  

### Solution
Updated the test based on the https://github.com/SatelliteQE/robottelo/pull/15264 PR 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->