### PR TITLE
Add a couple of fixes for PIT

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -659,6 +659,7 @@ def test_positive_install_in_hc(
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 @pytest.mark.e2e
+@pytest.mark.pit_client
 def test_positive_install_multiple_in_host(
     target_sat, rhel_contenthost, module_org, activation_key, module_lce
 ):
@@ -1377,7 +1378,6 @@ def errata_host_lce(module_sca_manifest_org, target_sat):
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-@pytest.mark.pit_client
 @pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('8')
 def test_errata_installation_with_swidtags(

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -294,7 +294,10 @@ def test_sca_end_to_end(
     content_view.publish()
     assert len(content_view.repository) == 2
     host = rhel_contenthost.nailgun_host
-    host.content_facet_attributes = {'content_view_id': content_view.id}
+    host.content_facet_attributes = {
+        'content_view_id': content_view.id,
+        'lifecycle_environment_id': module_ak.environment.id,
+    }
     host.update(['content_facet_attributes'])
     rhel_contenthost.run('subscription-manager repos --enable *')
     repos = rhel_contenthost.run('subscription-manager refresh && yum repolist')

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -92,7 +92,7 @@ def vm(
     )
     host_id = host[0].id
     host_content = module_target_sat.api.Host(id=host_id).read_json()
-    assert host_content["subscription_status"] == 5
+    assert host_content['subscription_facet_attributes']['uuid']
     rhel7_contenthost_module.install_katello_host_tools()
     return rhel7_contenthost_module
 


### PR DESCRIPTION
Proposed changes:
1. Use `test_positive_install_multiple_in_host` instead of `test_errata_installation_with_swidtags` for PIT testing.
2. When updating CV in `content_facet_atttributes` we need to provide LCE too.
3. In 6.16 `subscription_status` was removed. Assert host registration via uuid instead.