### PR TITLE
[6.14.z] Replace old method of registration with global registration in robottelo

### DIFF
--- a/pytest_fixtures/component/activationkey.py
+++ b/pytest_fixtures/component/activationkey.py
@@ -32,6 +32,15 @@ def module_ak_with_cv(module_lce, module_org, module_promoted_cv, module_target_
     ).create()
 
 
+@pytest.fixture
+def function_ak_with_cv(function_lce, function_org, function_promoted_cv, target_sat):
+    return target_sat.api.ActivationKey(
+        content_view=function_promoted_cv,
+        environment=function_lce,
+        organization=function_org,
+    ).create()
+
+
 @pytest.fixture(scope='module')
 def module_ak_with_synced_repo(module_org, module_target_sat):
     """Prepare an activation key with synced repository for host registration"""

--- a/pytest_fixtures/component/contentview.py
+++ b/pytest_fixtures/component/contentview.py
@@ -17,12 +17,27 @@ def module_published_cv(module_org, module_target_sat):
     return content_view.read()
 
 
+@pytest.fixture
+def function_published_cv(function_org, target_sat):
+    content_view = target_sat.api.ContentView(organization=function_org).create()
+    content_view.publish()
+    return content_view.read()
+
+
 @pytest.fixture(scope="module")
 def module_promoted_cv(module_lce, module_published_cv, module_target_sat):
     """Promote published content view"""
     content_view_version = module_published_cv.version[0]
     content_view_version.promote(data={'environment_ids': module_lce.id})
     return module_published_cv
+
+
+@pytest.fixture
+def function_promoted_cv(function_lce, function_published_cv, target_sat):
+    """Promote published content view"""
+    content_view_version = function_published_cv.version[0]
+    content_view_version.promote(data={'environment_ids': function_lce.id})
+    return function_published_cv
 
 
 @pytest.fixture(scope='module')

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -807,6 +807,17 @@ class ContentHost(Host, ContentHostMixins):
         cmd = target.satellite.cli.HostRegistration.generate_command(options)
         return self.execute(cmd.strip('\n'))
 
+    def api_register(self, target, **kwargs):
+        """Register a content host using global registration through API.
+
+        :param target: Satellite or Capsule object to register to.
+        :param kwargs: Additional keyword arguments to pass to the API call.
+        :return: The result of the API call.
+        """
+        kwargs['insecure'] = kwargs.get('insecure', True)
+        command = target.satellite.api.RegistrationCommand(**kwargs).create()
+        return self.execute(command.strip('\n'))
+
     def register_contenthost(
         self,
         org='Default_Organization',

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -152,18 +152,18 @@ def centos(
     c2r_sub = module_target_sat.api.Subscription(
         organization=module_entitlement_manifest_org.id, name=repo.product.name
     ).search()[0]
-    act_key = create_activation_key(
+    ak = create_activation_key(
         module_target_sat, module_entitlement_manifest_org, module_lce, cv, c2r_sub.id
     )
 
     # Register CentOS host with Satellite
-    command = module_target_sat.api.RegistrationCommand(
+    result = centos_host.api_register(
+        module_target_sat,
         organization=module_entitlement_manifest_org,
-        activation_keys=[act_key.name],
+        activation_keys=[ak.name],
         location=smart_proxy_location,
-        insecure=True,
-    ).create()
-    assert centos_host.execute(command).status == 0
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     if centos_host.execute('needs-restarting -r').status == 1:
         centos_host.power_control(state='reboot')
@@ -221,21 +221,21 @@ def oracle(
     c2r_sub = module_target_sat.api.Subscription(
         organization=module_entitlement_manifest_org, name=repo.product.name
     ).search()[0]
-    act_key = create_activation_key(
+    ak = create_activation_key(
         module_target_sat, module_entitlement_manifest_org, module_lce, cv, c2r_sub.id
     )
     # UBI repo required for subscription-manager packages on Oracle
     ubi_url = settings.repos.convert2rhel.ubi7 if major == '7' else settings.repos.convert2rhel.ubi8
 
     # Register Oracle host with Satellite
-    command = module_target_sat.api.RegistrationCommand(
+    result = oracle_host.api_register(
+        module_target_sat,
         organization=module_entitlement_manifest_org,
-        activation_keys=[act_key.name],
+        activation_keys=[ak.name],
         location=smart_proxy_location,
-        insecure=True,
         repo=ubi_url,
-    ).create()
-    assert oracle_host.execute(command).status == 0
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     yield oracle_host
     # close ssh session before teardown, because of reboot in conversion it may cause problems

--- a/tests/foreman/api/test_hostcollection.py
+++ b/tests/foreman/api/test_hostcollection.py
@@ -433,8 +433,13 @@ def test_positive_add_remove_subscription(module_org, module_ak_cv_lce, target_s
     # Create and register VMs as members of Host Collection
     with Broker(nick='rhel7', host_class=ContentHost, _count=2) as hosts:
         for client in hosts:
-            client.install_katello_ca(target_sat)
-            client.register_contenthost(module_org.label, module_ak_cv_lce.name)
+            result = client.api_register(
+                target_sat,
+                organization=module_org,
+                activation_keys=[module_ak_cv_lce.name],
+            )
+            assert result.status == 0, f'Failed to register host: {result.stderr}'
+
         # Read host_collection back from Satellite to get host_ids
         host_collection = module_ak_cv_lce.host_collection[0].read()
         host_ids = [host.id for host in host_collection.host]

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -28,6 +28,7 @@ pytestmark = pytest.mark.tier1
 
 
 @pytest.mark.e2e
+@pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 def test_host_registration_end_to_end(
     module_entitlement_manifest_org,
@@ -51,15 +52,12 @@ def test_host_registration_end_to_end(
     :customerscenario: true
     """
     org = module_entitlement_manifest_org
-    command = module_target_sat.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        module_target_sat,
         organization=org,
         activation_keys=[module_activation_key.name],
-        location=module_location,
-    ).create()
-
-    result = rhel_contenthost.execute(command)
-    rc = 1 if rhel_contenthost.os_version.major == 6 else 0
-    assert result.status == rc, f'Failed to register host: {result.stderr}'
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # Verify server.hostname and server.port from subscription-manager config
     assert module_target_sat.hostname == rhel_contenthost.subscription_config['server']['hostname']
@@ -70,17 +68,15 @@ def test_host_registration_end_to_end(
     module_target_sat.api.SmartProxy(id=nc.id, organization=[org]).update(['organization'])
     module_target_sat.api.SmartProxy(id=nc.id, location=[module_location]).update(['location'])
 
-    command = module_target_sat.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        module_target_sat,
         smart_proxy=nc,
         organization=org,
         activation_keys=[module_activation_key.name],
         location=module_location,
         force=True,
-    ).create()
-    result = rhel_contenthost.execute(command)
-
-    rc = 1 if rhel_contenthost.os_version.major == 6 else 0
-    assert result.status == rc, f'Failed to register host: {result.stderr}'
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # Verify server.hostname and server.port from subscription-manager config
     assert (
@@ -114,30 +110,32 @@ def test_positive_allow_reregistration_when_dmi_uuid_changed(
     uuid_2 = str(uuid.uuid4())
     org = module_entitlement_manifest_org
     target_sat.execute(f'echo \'{{"dmi.system.uuid": "{uuid_1}"}}\' > /etc/rhsm/facts/uuid.facts')
-    command = target_sat.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        target_sat,
         organization=org,
         activation_keys=[module_activation_key.name],
         location=module_location,
-    ).create()
-    result = rhel_contenthost.execute(command)
-    assert result.status == 0
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+
     result = rhel_contenthost.execute('subscription-manager clean')
     assert result.status == 0
     target_sat.execute(f'echo \'{{"dmi.system.uuid": "{uuid_2}"}}\' > /etc/rhsm/facts/uuid.facts')
-    command = target_sat.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        target_sat,
         organization=org,
         activation_keys=[module_activation_key.name],
         location=module_location,
-    ).create()
-    result = rhel_contenthost.execute(command)
-    assert result.status == 0
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
 
 
+@pytest.mark.rhel_ver_match('8')
 def test_positive_update_packages_registration(
     module_target_sat,
     module_entitlement_manifest_org,
     module_location,
-    rhel8_contenthost,
+    rhel_contenthost,
     module_activation_key,
 ):
     """Test package update on host post registration
@@ -147,29 +145,29 @@ def test_positive_update_packages_registration(
     :expectedresults: Package update is successful on host post registration.
     """
     org = module_entitlement_manifest_org
-    org = module_entitlement_manifest_org
-    command = module_target_sat.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        module_target_sat,
         organization=org,
-        location=module_location,
         activation_keys=[module_activation_key.name],
+        location=module_location,
         update_packages=True,
-    ).create()
-    result = rhel8_contenthost.execute(command)
+    )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     package = constants.FAKE_7_CUSTOM_PACKAGE
     repo_url = settings.repos.yum_3['url']
-    rhel8_contenthost.create_custom_repos(fake_yum=repo_url)
-    result = rhel8_contenthost.execute(f"yum install -y {package}")
+    rhel_contenthost.create_custom_repos(fake_yum=repo_url)
+    result = rhel_contenthost.execute(f"yum install -y {package}")
     assert result.status == 0
 
 
+@pytest.mark.rhel_ver_match('8')
 @pytest.mark.no_containers
 def test_positive_rex_interface_for_global_registration(
     module_target_sat,
     module_entitlement_manifest_org,
     module_location,
-    rhel8_contenthost,
+    rhel_contenthost,
     module_activation_key,
 ):
     """Test remote execution interface is set for global registration
@@ -189,20 +187,21 @@ def test_positive_rex_interface_for_global_registration(
     ip = gen_ipaddr()
     # Create eth1 interface on the host
     add_interface_command = f'ip link add eth1 type dummy;ifconfig eth1 hw ether {mac_address};ip addr add {ip}/24 brd + dev eth1 label eth1:1;ip link set dev eth1 up'
-    result = rhel8_contenthost.execute(add_interface_command)
+    result = rhel_contenthost.execute(add_interface_command)
     assert result.status == 0
     org = module_entitlement_manifest_org
-    command = module_target_sat.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        module_target_sat,
         organization=org,
-        location=module_location,
         activation_keys=[module_activation_key.name],
+        location=module_location,
         update_packages=True,
         remote_execution_interface='eth1',
-    ).create()
-    result = rhel8_contenthost.execute(command)
+    )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
+
     host = module_target_sat.api.Host().search(
-        query={'search': f'name={rhel8_contenthost.hostname}'}
+        query={'search': f'name={rhel_contenthost.hostname}'}
     )[0]
     # Check if eth1 interface is set for remote execution
     for interface in host.read_json()['interfaces']:
@@ -257,11 +256,11 @@ def test_negative_capsule_without_registration_enabled(
     error_message = '422 Client Error'
     with pytest.raises(HTTPError, match=f'{error_message}') as context:
         module_target_sat.api.RegistrationCommand(
+            module_target_sat,
             smart_proxy=nc,
             organization=org,
             location=module_location,
             activation_keys=[module_ak_with_cv.name],
-            insecure=True,
         ).create()
     assert (
         "Proxy lacks one of the following features: 'Registration', 'Templates'"
@@ -307,7 +306,8 @@ def test_positive_host_registration_with_non_admin_user_with_setup_false(
         location=[module_location],
     ).create()
     user_cfg = user_nailgun_config(login, password)
-    command = module_target_sat.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        module_target_sat,
         server_config=user_cfg,
         organization=module_org,
         activation_keys=[module_activation_key.name],
@@ -316,8 +316,7 @@ def test_positive_host_registration_with_non_admin_user_with_setup_false(
         setup_remote_execution=False,
         setup_remote_execution_pull=False,
         update_packages=False,
-    ).create()
-    result = rhel_contenthost.execute(command)
+    )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # verify package install for insights-client didn't run when Setup Insights is false
@@ -355,13 +354,12 @@ def test_negative_verify_bash_exit_status_failing_host_registration(
     """
     ak = module_target_sat.api.ActivationKey(name=gen_string('alpha')).create()
     # Try registration command generated with AK not in same as selected organization
-    command = module_target_sat.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        module_target_sat,
         organization=module_sca_manifest_org,
         activation_keys=[ak.name],
         location=module_location,
-    ).create()
-    result = rhel_contenthost.execute(command)
-
+    )
     # verify status code when registrationCommand fails to register on host
     assert result.status == 1
     assert 'Couldn\'t find activation key' in result.stderr

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -592,8 +592,12 @@ def test_positive_generate_entitlements_report(setup_content, target_sat):
     """
     with Broker(nick='rhel7', host_class=ContentHost) as vm:
         ak, org = setup_content
-        vm.install_katello_ca(target_sat)
-        vm.register_contenthost(org.label, ak.name)
+        result = vm.api_register(
+            target_sat,
+            organization=org,
+            activation_keys=[ak.name],
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
         assert vm.subscribed
         rt = (
             target_sat.api.ReportTemplate()
@@ -631,8 +635,12 @@ def test_positive_schedule_entitlements_report(setup_content, target_sat):
     """
     with Broker(nick='rhel7', host_class=ContentHost) as vm:
         ak, org = setup_content
-        vm.install_katello_ca(target_sat)
-        vm.register_contenthost(org.label, ak.name)
+        result = vm.api_register(
+            target_sat,
+            organization=org,
+            activation_keys=[ak.name],
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
         assert vm.subscribed
         rt = (
             target_sat.api.ReportTemplate()

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -230,8 +230,12 @@ def test_positive_subscription_status_disabled(
 
     :CaseImportance: Medium
     """
-    rhel_contenthost.install_katello_ca(target_sat)
-    rhel_contenthost.register_contenthost(module_sca_manifest_org.label, module_ak.name)
+    result = rhel_contenthost.api_register(
+        target_sat,
+        organization=module_sca_manifest_org,
+        activation_keys=[module_ak.name],
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert rhel_contenthost.subscribed
     host_content = target_sat.api.Host(id=rhel_contenthost.nailgun_host.id).read_raw().content
     assert 'Simple Content Access' in str(host_content)
@@ -241,8 +245,9 @@ def test_positive_subscription_status_disabled(
 @pytest.mark.e2e
 @pytest.mark.pit_client
 @pytest.mark.pit_server
+@pytest.mark.rhel_ver_match('7')
 def test_sca_end_to_end(
-    module_ak, rhel7_contenthost, module_sca_manifest_org, rh_repo, custom_repo, target_sat
+    module_ak, rhel_contenthost, module_sca_manifest_org, rh_repo, custom_repo, target_sat
 ):
     """Perform end to end testing for Simple Content Access Mode
 
@@ -257,9 +262,13 @@ def test_sca_end_to_end(
 
     :CaseImportance: Critical
     """
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(module_sca_manifest_org.label, module_ak.name)
-    assert rhel7_contenthost.subscribed
+    result = rhel_contenthost.api_register(
+        target_sat,
+        organization=module_sca_manifest_org,
+        activation_keys=[module_ak.name],
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    assert rhel_contenthost.subscribed
     # Check to see if Organization is in SCA Mode
     assert (
         target_sat.api.Organization(id=module_sca_manifest_org.id).read().simple_content_access
@@ -274,7 +283,7 @@ def test_sca_end_to_end(
     assert 'Simple Content Access' in ak_context.value.response.text
     # Verify that you cannot attach a subscription to an Host in SCA Mode
     with pytest.raises(HTTPError) as host_context:
-        target_sat.api.HostSubscription(host=rhel7_contenthost.nailgun_host.id).add_subscriptions(
+        target_sat.api.HostSubscription(host=rhel_contenthost.nailgun_host.id).add_subscriptions(
             data={'subscriptions': [{'id': subscription.id, 'quantity': 1}]}
         )
     assert 'Simple Content Access' in host_context.value.response.text
@@ -284,24 +293,22 @@ def test_sca_end_to_end(
     content_view.update(['repository'])
     content_view.publish()
     assert len(content_view.repository) == 2
-    host = rhel7_contenthost.nailgun_host
-    host.content_facet_attributes = {
-        'content_view_id': content_view.id,
-        'lifecycle_environment_id': module_ak.environment.id,
-    }
+    host = rhel_contenthost.nailgun_host
+    host.content_facet_attributes = {'content_view_id': content_view.id}
     host.update(['content_facet_attributes'])
-    rhel7_contenthost.run('subscription-manager repos --enable *')
-    repos = rhel7_contenthost.run('subscription-manager refresh && yum repolist')
+    rhel_contenthost.run('subscription-manager repos --enable *')
+    repos = rhel_contenthost.run('subscription-manager refresh && yum repolist')
     assert content_view.repository[1].name in repos.stdout
     assert 'Red Hat Satellite Tools' in repos.stdout
     # install package and verify it succeeds or is already installed
-    package = rhel7_contenthost.run('yum install -y python-pulp-manifest')
+    package = rhel_contenthost.run('yum install -y python-pulp-manifest')
     assert 'Complete!' in package.stdout or 'already installed' in package.stdout
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.tier2
 def test_positive_candlepin_events_processed_by_stomp(
-    rhel7_contenthost, function_entitlement_manifest, function_org, target_sat
+    rhel_contenthost, function_entitlement_manifest, function_org, target_sat
 ):
     """Verify that Candlepin events are being read and processed by
         attaching subscriptions, validating host subscriptions status,
@@ -339,9 +346,13 @@ def test_positive_candlepin_events_processed_by_stomp(
         environment=target_sat.api.LifecycleEnvironment(id=function_org.library.id),
         auto_attach=True,
     ).create()
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(function_org.name, ak.name)
-    host = target_sat.api.Host().search(query={'search': f'name={rhel7_contenthost.hostname}'})
+    result = rhel_contenthost.api_register(
+        target_sat,
+        organization=function_org,
+        activation_keys=[ak.name],
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    host = target_sat.api.Host().search(query={'search': f'name={rhel_contenthost.hostname}'})
     host_id = host[0].id
     host_content = target_sat.api.Host(id=host_id).read_json()
     assert host_content['subscription_status'] == 2
@@ -360,7 +371,8 @@ def test_positive_candlepin_events_processed_by_stomp(
     assert '0 Failed' in response['message']
 
 
-def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel7_contenthost, target_sat):
+@pytest.mark.rhel_ver_match('7')
+def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel_contenthost, target_sat):
     """Verify that a content host with an expired SCA cert can
         re-register successfully
 
@@ -396,12 +408,14 @@ def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel7_conte
     ).create()
     # registering the content host with no content enabled/synced in the org
     # should create a client SCA cert with no content
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(
-        org=module_sca_manifest_org.label, activation_key=ak.name
+    result = rhel_contenthost.api_register(
+        target_sat,
+        organization=module_sca_manifest_org,
+        activation_keys=[ak.name],
     )
-    assert rhel7_contenthost.subscribed
-    rhel7_contenthost.unregister()
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    assert rhel_contenthost.subscribed
+    rhel_contenthost.unregister()
     # syncing content with the content host unregistered should invalidate
     # the previous client SCA cert
     rh_repo_id = target_sat.api_factory.enable_rhrepo_and_fetchid(
@@ -414,10 +428,16 @@ def test_positive_expired_SCA_cert_handling(module_sca_manifest_org, rhel7_conte
     )
     rh_repo = target_sat.api.Repository(id=rh_repo_id).read()
     rh_repo.sync()
-    # re-registering the host should test whether Candlepin gracefully handles
+    # re-registering the host (using force=True) should test whether Candlepin gracefully handles
     # registration of a host with an expired SCA cert
-    rhel7_contenthost.register_contenthost(module_sca_manifest_org.label, ak.name)
-    assert rhel7_contenthost.subscribed
+    result = rhel_contenthost.api_register(
+        target_sat,
+        organization=module_sca_manifest_org,
+        activation_keys=[ak.name],
+        force=True,
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    assert rhel_contenthost.subscribed
 
 
 @pytest.mark.stubbed

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -593,7 +593,7 @@ def test_negative_update_usage_limit(module_org, module_target_sat):
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_usage_limit(module_org, target_sat):
+def test_positive_usage_limit(module_org, module_location, target_sat):
     """Test that Usage limit actually limits usage
 
     :id: 00ded856-e939-4140-ac84-91b6a8643623
@@ -628,11 +628,9 @@ def test_positive_usage_limit(module_org, target_sat):
     )
     with Broker(nick='rhel7', host_class=ContentHost, _count=2) as clients:
         vm1, vm2 = clients
-        vm1.install_katello_ca(target_sat)
-        vm1.register_contenthost(module_org.label, new_ak['name'])
+        vm1.register(module_org, module_location, new_ak['name'], target_sat)
         assert vm1.subscribed
-        vm2.install_katello_ca(target_sat)
-        result = vm2.register_contenthost(module_org.label, new_ak['name'])
+        result = vm2.register(module_org, module_location, new_ak['name'], target_sat)
         assert not vm2.subscribed
         assert result.status == 70
         assert len(result.stderr) > 0
@@ -876,7 +874,7 @@ def test_positive_delete_subscription(function_entitlement_manifest_org, module_
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, target_sat):
+def test_positive_update_aks_to_chost(module_org, module_location, rhel7_contenthost, target_sat):
     """Check if multiple Activation keys can be attached to a
     Content host
 
@@ -904,9 +902,13 @@ def test_positive_update_aks_to_chost(module_org, rhel7_contenthost, target_sat)
         )
         for _ in range(2)
     ]
-    rhel7_contenthost.install_katello_ca(target_sat)
     for i in range(2):
-        rhel7_contenthost.register_contenthost(module_org.label, new_aks[i]['name'])
+        rhel7_contenthost.register(
+            org=module_org,
+            loc=module_location,
+            activation_keys=new_aks[i]['name'],
+            target=target_sat,
+        )
         assert rhel7_contenthost.subscribed
 
 
@@ -1634,20 +1636,19 @@ def test_positive_subscription_quantity_attached(function_org, rhel7_contenthost
     target_sat.cli_factory.setup_org_for_a_custom_repo(
         {
             'url': settings.repos.yum_0.url,
-            'organization-id': org['id'],
+            'organization-id': org.id,
             'activationkey-id': result['activationkey-id'],
             'content-view-id': result['content-view-id'],
             'lifecycle-environment-id': result['lifecycle-environment-id'],
         }
     )
-    subs = target_sat.cli.Subscription.list({'organization-id': org['id']}, per_page=False)
+    subs = target_sat.cli.Subscription.list({'organization-id': org.id}, per_page=False)
     subs_lookup = {s['id']: s for s in subs}
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(org['label'], activation_key=ak['name'])
+    rhel7_contenthost.register(org, None, ak['name'], target_sat)
     assert rhel7_contenthost.subscribed
 
     ak_subs = target_sat.cli.ActivationKey.subscriptions(
-        {'activation-key': ak['name'], 'organization-id': org['id']}, output_format='json'
+        {'activation-key': ak['name'], 'organization-id': org.id}, output_format='json'
     )
     assert len(ak_subs) == 2  # one for #rh product, one for custom product
     for ak_sub in ak_subs:
@@ -1660,7 +1661,9 @@ def test_positive_subscription_quantity_attached(function_org, rhel7_contenthost
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_positive_ak_with_custom_product_on_rhel6(module_org, rhel6_contenthost, target_sat):
+def test_positive_ak_with_custom_product_on_rhel6(
+    module_org, module_location, rhel6_contenthost, target_sat
+):
     """Registering a rhel6 host using an ak with custom repos should not fail
 
     :id: d02c2664-8034-4562-914a-3b68f0c35b32
@@ -1681,6 +1684,5 @@ def test_positive_ak_with_custom_product_on_rhel6(module_org, rhel6_contenthost,
         {'url': settings.repos.yum_1.url, 'organization-id': module_org.id}
     )
     ak = target_sat.api.ActivationKey(id=entities_ids['activationkey-id']).read()
-    rhel6_contenthost.install_katello_ca(target_sat)
-    result = rhel6_contenthost.register_contenthost(module_org.label, activation_key=ak.name)
+    result = rhel6_contenthost.register(module_org.label, module_location, ak.name, target_sat)
     assert 'The system has been registered with ID' in result.stdout

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -599,7 +599,8 @@ def test_positive_list_and_unregister(
 
     :parametrized: yes
     """
-    rhel7_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    result = rhel7_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    assert result.status == 0
     assert rhel7_contenthost.subscribed
     hosts = target_sat.cli.Host.list({'organization-id': module_org.id})
     assert rhel7_contenthost.hostname in [host['name'] for host in hosts]
@@ -612,7 +613,7 @@ def test_positive_list_and_unregister(
 @pytest.mark.cli_host_create
 @pytest.mark.tier3
 def test_positive_list_by_last_checkin(
-    module_lce, module_org, module_promoted_cv, rhel7_contenthost, target_sat
+    module_org, rhel7_contenthost, target_sat, module_ak_with_cv
 ):
     """List all content hosts using last checkin criteria
 
@@ -626,11 +627,8 @@ def test_positive_list_by_last_checkin(
 
     :parametrized: yes
     """
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(
-        module_org.label,
-        lce=f'{module_lce.label}/{module_promoted_cv.label}',
-    )
+    result = rhel7_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert rhel7_contenthost.subscribed
     hosts = target_sat.cli.Host.list(
         {'search': 'last_checkin = "Today" or last_checkin = "Yesterday"'}
@@ -642,7 +640,7 @@ def test_positive_list_by_last_checkin(
 @pytest.mark.cli_host_create
 @pytest.mark.tier3
 def test_positive_list_infrastructure_hosts(
-    module_lce, module_org, module_promoted_cv, rhel7_contenthost, target_sat
+    module_org, rhel7_contenthost, target_sat, module_ak_with_cv
 ):
     """List infrasturcture hosts (Satellite and Capsule)
 
@@ -652,11 +650,8 @@ def test_positive_list_infrastructure_hosts(
 
     :parametrized: yes
     """
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(
-        module_org.label,
-        lce=f'{module_lce.label}/{module_promoted_cv.label}',
-    )
+    result = rhel7_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    assert result.status == 0
     assert rhel7_contenthost.subscribed
     target_sat.cli.Host.update({'name': target_sat.hostname, 'new-organization-id': module_org.id})
     # list satellite hosts
@@ -1802,10 +1797,6 @@ def test_positive_install_package_via_rex(
 
 
 # -------------------------- HOST SUBSCRIPTION SUBCOMMAND FIXTURES --------------------------
-@pytest.fixture
-def host_subscription_client(rhel7_contenthost, target_sat):
-    rhel7_contenthost.install_katello_ca(target_sat)
-    return rhel7_contenthost
 
 
 @pytest.fixture
@@ -1823,6 +1814,7 @@ def ak_with_subscription(
 
 
 # -------------------------- HOST SUBSCRIPTION SUBCOMMAND SCENARIOS -------------------------
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
 def test_positive_register(
@@ -1830,7 +1822,7 @@ def test_positive_register(
     module_promoted_cv,
     module_lce,
     module_ak_with_cv,
-    host_subscription_client,
+    rhel_contenthost,
     target_sat,
 ):
     """Attempt to register a host
@@ -1844,7 +1836,7 @@ def test_positive_register(
     hosts = target_sat.cli.Host.list(
         {
             'organization-id': module_org.id,
-            'search': host_subscription_client.hostname,
+            'search': rhel_contenthost.hostname,
         }
     )
     assert len(hosts) == 0
@@ -1853,18 +1845,18 @@ def test_positive_register(
             'organization-id': module_org.id,
             'content-view-id': module_promoted_cv.id,
             'lifecycle-environment-id': module_lce.id,
-            'name': host_subscription_client.hostname,
+            'name': rhel_contenthost.hostname,
         }
     )
     hosts = target_sat.cli.Host.list(
         {
             'organization-id': module_org.id,
-            'search': host_subscription_client.hostname,
+            'search': rhel_contenthost.hostname,
         }
     )
     assert len(hosts) > 0
     host = target_sat.cli.Host.info({'id': hosts[0]['id']})
-    assert host['name'] == host_subscription_client.hostname
+    assert host['name'] == rhel_contenthost.hostname
     # note: when not registered the following command lead to exception,
     # see unregister
     host_subscriptions = target_sat.cli.ActivationKey.subscriptions(
@@ -1878,6 +1870,7 @@ def test_positive_register(
     assert len(host_subscriptions) == 0
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
 def test_positive_attach(
@@ -1887,7 +1880,7 @@ def test_positive_attach(
     module_ak_with_cv,
     module_rhst_repo,
     default_subscription,
-    host_subscription_client,
+    rhel_contenthost,
     target_sat,
 ):
     """Attempt to attach a subscription to host
@@ -1910,14 +1903,13 @@ def test_positive_attach(
             'organization-id': module_org.id,
             'content-view-id': module_promoted_cv.id,
             'lifecycle-environment-id': module_lce.id,
-            'name': host_subscription_client.hostname,
+            'name': rhel_contenthost.hostname,
         }
     )
-    host = target_sat.cli.Host.info({'name': host_subscription_client.hostname})
-    host_subscription_client.register_contenthost(
-        module_org.name, activation_key=module_ak_with_cv.name
-    )
-    assert host_subscription_client.subscribed
+    host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
+    result = rhel_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    assert result.status == 0
+    assert rhel_contenthost.subscribed
     # attach the subscription to host
     target_sat.cli.Host.subscription_attach(
         {
@@ -1926,23 +1918,23 @@ def test_positive_attach(
             'quantity': 2,
         }
     )
-    host_subscription_client.enable_repo(module_rhst_repo)
-    # ensure that katello agent can be installed
+    rhel_contenthost.enable_repo(module_rhst_repo)
+    # ensure that katello-host-tools can be installed
     try:
-        host_subscription_client.install_katello_agent()
+        rhel_contenthost.install_katello_host_tools()
     except ContentHostError:
         pytest.fail('ContentHostError raised unexpectedly!')
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
 def test_positive_attach_with_lce(
     module_org,
-    module_promoted_cv,
-    module_lce,
+    module_ak_with_cv,
     module_rhst_repo,
     default_subscription,
-    host_subscription_client,
+    rhel_contenthost,
     target_sat,
 ):
     """Attempt to attach a subscription to host, registered by lce
@@ -1958,13 +1950,10 @@ def test_positive_attach_with_lce(
 
     :parametrized: yes
     """
-    host_subscription_client.register_contenthost(
-        module_org.name,
-        lce=f'{module_lce.name}/{module_promoted_cv.name}',
-        auto_attach=False,
-    )
-    assert host_subscription_client.subscribed
-    host = target_sat.cli.Host.info({'name': host_subscription_client.hostname})
+    res = rhel_contenthost.register(module_org, None, module_ak_with_cv.name, target_sat)
+    assert res.status == 0, f'Failed to register host: {res.stderr}'
+    assert rhel_contenthost.subscribed
+    host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
     target_sat.cli.Host.subscription_attach(
         {
             'host-id': host['id'],
@@ -1972,18 +1961,19 @@ def test_positive_attach_with_lce(
             'quantity': 2,
         }
     )
-    host_subscription_client.enable_repo(module_rhst_repo)
-    # ensure that katello agent can be installed
+    rhel_contenthost.enable_repo(module_rhst_repo)
+    # ensure that katello-host-tools can be installed
     try:
-        host_subscription_client.install_katello_agent()
+        rhel_contenthost.install_katello_host_tools()
     except ContentHostError:
         pytest.fail('ContentHostError raised unexpectedly!')
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
 def test_negative_without_attach(
-    module_org, module_promoted_cv, module_lce, host_subscription_client, target_sat
+    module_org, module_promoted_cv, module_lce, rhel_contenthost, target_sat
 ):
     """Register content host from satellite, register client to uuid
     of that content host, as there was no attach on the client,
@@ -2000,26 +1990,32 @@ def test_negative_without_attach(
             'organization-id': module_org.id,
             'content-view-id': module_promoted_cv.id,
             'lifecycle-environment-id': module_lce.id,
-            'name': host_subscription_client.hostname,
+            'name': rhel_contenthost.hostname,
         }
     )
-    host = target_sat.cli.Host.info({'name': host_subscription_client.hostname})
-    host_subscription_client.register_contenthost(
+    host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
+
+    rhel_contenthost.register_contenthost(
         module_org.name,
         lce=None,  # required, to jump into right branch in register_contenthost method
         consumerid=host['subscription-information']['uuid'],
         force=False,
     )
-    client_status = host_subscription_client.subscription_manager_status()
+    client_status = rhel_contenthost.subscription_manager_status()
     assert SM_OVERALL_STATUS['current'] in client_status.stdout
-    repo_list = host_subscription_client.subscription_manager_list_repos()
+    repo_list = rhel_contenthost.subscription_manager_list_repos()
     assert "This system has no repositories available through subscriptions." in repo_list.stdout
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
 def test_negative_without_attach_with_lce(
-    target_sat, host_subscription_client, function_org, function_lce
+    target_sat,
+    rhel_contenthost,
+    function_ak_with_cv,
+    function_org,
+    function_lce,
 ):
     """Attempt to enable a repository of a subscription that was not
     attached to a host
@@ -2033,10 +2029,6 @@ def test_negative_without_attach_with_lce(
     :parametrized: yes
     """
     content_view = target_sat.api.ContentView(organization=function_org).create()
-    ak = target_sat.api.ActivationKey(
-        environment=function_lce,
-        organization=function_org,
-    ).create()
     target_sat.cli_factory.setup_org_for_a_rh_repo(
         {
             'product': PRDS['rhel'],
@@ -2045,7 +2037,7 @@ def test_negative_without_attach_with_lce(
             'organization-id': function_org.id,
             'content-view-id': content_view.id,
             'lifecycle-environment-id': function_lce.id,
-            'activationkey-id': ak.id,
+            'activationkey-id': function_ak_with_cv.id,
             'subscription': DEFAULT_SUBSCRIPTION_NAME,
         },
         force_use_cdn=True,
@@ -2056,23 +2048,15 @@ def test_negative_without_attach_with_lce(
     content_view.read().version[-1].promote(data={'environment_ids': host_lce.id, 'force': False})
 
     # register client
-    host_subscription_client.register_contenthost(
-        function_org.name,
-        lce=f'{host_lce.name}/{content_view.name}',
-        auto_attach=False,
-    )
-
-    # get list of available subscriptions which are matched with default subscription
-    subscriptions = host_subscription_client.run(
-        f'subscription-manager list --available --matches "{DEFAULT_SUBSCRIPTION_NAME}" --pool-only'
-    )
-    pool_id = subscriptions.stdout.strip()
-    # attach to plain RHEL subsctiption
-    host_subscription_client.subscription_manager_attach_pool([pool_id])
-    assert host_subscription_client.subscribed
-    host_subscription_client.enable_repo(REPOS['rhst7']['id'])
+    result = rhel_contenthost.register(function_org, None, function_ak_with_cv.name, target_sat)
+    assert result.status == 0
+    assert rhel_contenthost.subscribed
+    res = rhel_contenthost.enable_repo(REPOS['rhsclient7']['id'])
+    assert res.status == 0
+    assert f"Repository '{REPOS['rhsclient7']['id']}' is enabled for this system." in res.stdout
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.e2e
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
@@ -2083,7 +2067,7 @@ def test_positive_remove(
     module_lce,
     ak_with_subscription,
     default_subscription,
-    host_subscription_client,
+    rhel_contenthost,
     target_sat,
 ):
     """Attempt to remove a subscription from content host
@@ -2099,10 +2083,10 @@ def test_positive_remove(
             'organization-id': module_org.id,
             'content-view-id': module_promoted_cv.id,
             'lifecycle-environment-id': module_lce.id,
-            'name': host_subscription_client.hostname,
+            'name': rhel_contenthost.hostname,
         }
     )
-    host = target_sat.cli.Host.info({'name': host_subscription_client.hostname})
+    host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
     host_subscriptions = target_sat.cli.ActivationKey.subscriptions(
         {
             'organization-id': module_org.id,
@@ -2112,9 +2096,8 @@ def test_positive_remove(
         output_format='json',
     )
     assert default_subscription.name not in [sub['name'] for sub in host_subscriptions]
-    host_subscription_client.register_contenthost(
-        module_org.name, activation_key=ak_with_subscription.name
-    )
+    res = rhel_contenthost.register(module_org, None, ak_with_subscription.name, target_sat)
+    assert res.status == 0, f'Failed to register host: {res.stderr}'
     target_sat.cli.Host.subscription_attach(
         {
             'host-id': host['id'],
@@ -2147,6 +2130,7 @@ def test_positive_remove(
     assert default_subscription.name not in [sub['name'] for sub in host_subscriptions]
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
 def test_positive_auto_attach(
@@ -2155,7 +2139,7 @@ def test_positive_auto_attach(
     module_lce,
     module_rhst_repo,
     ak_with_subscription,
-    host_subscription_client,
+    rhel_contenthost,
     target_sat,
 ):
     """Attempt to auto attach a subscription to content host
@@ -2172,26 +2156,27 @@ def test_positive_auto_attach(
             'organization-id': module_org.id,
             'content-view-id': module_promoted_cv.id,
             'lifecycle-environment-id': module_lce.id,
-            'name': host_subscription_client.hostname,
+            'name': rhel_contenthost.hostname,
         }
     )
-    host = target_sat.cli.Host.info({'name': host_subscription_client.hostname})
-    host_subscription_client.register_contenthost(
-        module_org.name, activation_key=ak_with_subscription.name
-    )
+    host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
+
+    res = rhel_contenthost.register(module_org, None, ak_with_subscription.name, target_sat)
+    assert res.status == 0, f'Failed to register host: {res.stderr}'
     target_sat.cli.Host.subscription_auto_attach({'host-id': host['id']})
-    host_subscription_client.enable_repo(module_rhst_repo)
-    # ensure that katello agent can be installed
+    rhel_contenthost.enable_repo(module_rhst_repo)
+    # ensure that katello-host-tools can be installed
     try:
-        host_subscription_client.install_katello_agent()
+        rhel_contenthost.install_katello_host_tools()
     except ContentHostError:
         pytest.fail('ContentHostError raised unexpectedly!')
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3
 def test_positive_unregister_host_subscription(
-    module_org, module_rhst_repo, ak_with_subscription, host_subscription_client, target_sat
+    module_org, module_rhst_repo, ak_with_subscription, rhel_contenthost, target_sat
 ):
     """Attempt to unregister host subscription
 
@@ -2202,15 +2187,13 @@ def test_positive_unregister_host_subscription(
     :parametrized: yes
     """
     # register the host client
-    host_subscription_client.register_contenthost(
-        module_org.name, activation_key=ak_with_subscription.name
-    )
-
-    assert host_subscription_client.subscribed
-    host_subscription_client.run('subscription-manager attach --auto')
-    host_subscription_client.enable_repo(module_rhst_repo)
-    assert host_subscription_client.subscribed
-    host = target_sat.cli.Host.info({'name': host_subscription_client.hostname})
+    res = rhel_contenthost.register(module_org, None, ak_with_subscription.name, target_sat)
+    assert res.status == 0, f'Failed to register host: {res.stderr}'
+    assert rhel_contenthost.subscribed
+    rhel_contenthost.run('subscription-manager attach --auto')
+    rhel_contenthost.enable_repo(module_rhst_repo)
+    assert rhel_contenthost.subscribed
+    host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
     host_subscriptions = target_sat.cli.ActivationKey.subscriptions(
         {
             'organization-id': module_org.id,
@@ -2220,7 +2203,7 @@ def test_positive_unregister_host_subscription(
         output_format='json',
     )
     assert len(host_subscriptions) > 0
-    target_sat.cli.Host.subscription_unregister({'host': host_subscription_client.hostname})
+    target_sat.cli.Host.subscription_unregister({'host': rhel_contenthost.hostname})
     with pytest.raises(CLIReturnCodeError):
         # raise error that the host was not registered by
         # subscription-manager register
@@ -2233,6 +2216,7 @@ def test_positive_unregister_host_subscription(
         )
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.pit_client
 @pytest.mark.pit_server
 @pytest.mark.cli_host_subscription
@@ -2245,7 +2229,7 @@ def test_syspurpose_end_to_end(
     module_lce,
     module_rhst_repo,
     default_subscription,
-    host_subscription_client,
+    rhel_contenthost,
 ):
     """Create a host with system purpose values set by activation key.
 
@@ -2276,13 +2260,12 @@ def test_syspurpose_end_to_end(
         }
     )
     # Register a host using the activation key
-    host_subscription_client.register_contenthost(
-        module_org.name, activation_key=activation_key.name
-    )
-    assert host_subscription_client.subscribed
-    host_subscription_client.run('subscription-manager attach --auto')
-    host_subscription_client.enable_repo(module_rhst_repo)
-    host = target_sat.cli.Host.info({'name': host_subscription_client.hostname})
+    res = rhel_contenthost.register(module_org, None, activation_key.name, target_sat)
+    assert res.status == 0, f'Failed to register host: {res.stderr}'
+    assert rhel_contenthost.subscribed
+    rhel_contenthost.run('subscription-manager attach --auto')
+    rhel_contenthost.enable_repo(module_rhst_repo)
+    host = target_sat.cli.Host.info({'name': rhel_contenthost.hostname})
     # Assert system purpose values are set in the host as expected
     assert host['subscription-information']['system-purpose']['purpose-addons'] == purpose_addons
     assert host['subscription-information']['system-purpose']['purpose-role'] == "test-role"
@@ -2315,7 +2298,7 @@ def test_syspurpose_end_to_end(
     assert len(host_subscriptions) > 0
     assert host_subscriptions[0]['name'] == default_subscription.name
     # Unregister host
-    target_sat.cli.Host.subscription_unregister({'host': host_subscription_client.hostname})
+    target_sat.cli.Host.subscription_unregister({'host': rhel_contenthost.hostname})
     with pytest.raises(CLIReturnCodeError):
         # raise error that the host was not registered by
         # subscription-manager register

--- a/tests/foreman/cli/test_hostcollection.py
+++ b/tests/foreman/cli/test_hostcollection.py
@@ -318,9 +318,8 @@ def test_positive_register_host_ak_with_host_collection(module_org, module_ak_wi
     )
 
     with Broker(nick='rhel7', host_class=ContentHost) as client:
-        client.install_katello_ca(target_sat)
         # register the client host with the current activation key
-        client.register_contenthost(module_org.name, activation_key=module_ak_with_cv.name)
+        client.register(module_org, None, module_ak_with_cv.name, target_sat)
         assert client.subscribed
         # note: when registering the host, it should be automatically added to the host-collection
         client_host = target_sat.cli.Host.info({'name': client.hostname})

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -49,7 +49,7 @@ def test_host_registration_end_to_end(
     """
     org = module_entitlement_manifest_org
     result = rhel_contenthost.register(
-        org, module_location, [module_activation_key.name], module_target_sat
+        org, module_location, module_activation_key.name, module_target_sat
     )
 
     rc = 1 if rhel_contenthost.os_version.major == 6 else 0
@@ -70,7 +70,7 @@ def test_host_registration_end_to_end(
     result = rhel_contenthost.register(
         org,
         module_location,
-        [module_activation_key.name],
+        module_activation_key.name,
         module_capsule_configured,
         force=True,
     )

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -833,8 +833,13 @@ def test_positive_schedule_entitlements_report(
     :parametrized: yes
     """
     client = rhel7_contenthost
-    client.install_katello_ca(target_sat)
-    client.register_contenthost(module_entitlement_manifest_org.label, local_ak['name'])
+    result = client.register(
+        module_entitlement_manifest_org,
+        None,
+        local_ak.name,
+        target_sat,
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert client.subscribed
     scheduled_csv = target_sat.cli.ReportTemplate.schedule(
         {
@@ -902,9 +907,13 @@ def test_positive_generate_hostpkgcompare(
     with Broker(nick='rhel7', host_class=ContentHost, _count=2) as hosts:
         for client in hosts:
             # Create RHEL hosts via broker and register content host
-            client.install_katello_ca(target_sat)
-            # Register content host, install katello-agent
-            client.register_contenthost(module_entitlement_manifest_org.label, local_ak['name'])
+            result = client.register(
+                module_entitlement_manifest_org,
+                None,
+                local_ak.name,
+                target_sat,
+            )
+            assert result.status == 0, f'Failed to register host: {result.stderr}'
             assert client.subscribed
             clients.append(client)
             client.enable_repo(REPOS['rhst7']['id'])
@@ -1029,8 +1038,13 @@ def test_positive_generate_installed_packages_report(
         }
     )
     client = rhel_contenthost
-    client.install_katello_ca(target_sat)
-    client.register_contenthost(module_entitlement_manifest_org.label, local_ak['name'])
+    result = client.register(
+        module_entitlement_manifest_org,
+        None,
+        local_ak.name,
+        target_sat,
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert client.subscribed
     client.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE_NAME} {FAKE_1_CUSTOM_PACKAGE}')
     result_html = target_sat.cli.ReportTemplate.generate(

--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -252,7 +252,7 @@ def test_positive_candlepin_events_processed_by_STOMP():
 
 @pytest.mark.tier2
 def test_positive_auto_attach_disabled_golden_ticket(
-    module_org, golden_ticket_host_setup, rhel7_contenthost_class, target_sat
+    module_org, module_location, golden_ticket_host_setup, rhel7_contenthost_class, target_sat
 ):
     """Verify that Auto-Attach is disabled or "Not Applicable"
     when a host organization is in Simple Content Access mode (Golden Ticket)
@@ -270,8 +270,9 @@ def test_positive_auto_attach_disabled_golden_ticket(
 
     :CaseImportance: Medium
     """
-    rhel7_contenthost_class.install_katello_ca(target_sat)
-    rhel7_contenthost_class.register_contenthost(module_org.label, golden_ticket_host_setup['name'])
+    rhel7_contenthost_class.register(
+        module_org, module_location, golden_ticket_host_setup['name'], target_sat
+    )
     assert rhel7_contenthost_class.subscribed
     host = target_sat.cli.Host.list({'search': rhel7_contenthost_class.hostname})
     host_id = host[0]['id']

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -40,15 +40,14 @@ def test_host_registration_rex_pull_mode(
     org = module_org
     client_repo = settings.repos.SATCLIENT_REPO[f'rhel{rhel_contenthost.os_version.major}']
     # register host to satellite with pull provider rex
-    command = module_satellite_mqtt.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        module_satellite_mqtt,
         organization=org,
         location=module_location,
         activation_keys=[module_ak_with_cv.name],
         setup_remote_execution_pull=True,
-        insecure=True,
         repo=client_repo,
-    ).create()
-    result = rhel_contenthost.execute(command)
+    )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # check mqtt client is running
@@ -64,17 +63,16 @@ def test_host_registration_rex_pull_mode(
     module_satellite_mqtt.api.SmartProxy(id=nc.id, location=[module_location]).update(['location'])
 
     # register host to capsule with pull provider rex
-    command = module_satellite_mqtt.api.RegistrationCommand(
+    result = rhel_contenthost.api_register(
+        module_satellite_mqtt,
         smart_proxy=nc,
         organization=org,
         location=module_location,
         activation_keys=[module_ak_with_cv.name],
         setup_remote_execution_pull=True,
         repo=client_repo,
-        insecure=True,
         force=True,
-    ).create()
-    result = rhel_contenthost.execute(command)
+    )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # check mqtt client is running

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -820,7 +820,7 @@ def test_positive_add_docker_repo_ccv(session, module_org, module_target_sat):
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_positive_add_host(session, module_org, rhel6_contenthost, target_sat):
+def test_positive_add_host(session, module_org, rhel_contenthost, target_sat):
     """Test that hosts can be associated to Activation Keys
 
     :id: 886e9ea5-d917-40e0-a3b1-41254c4bf5bf
@@ -840,21 +840,20 @@ def test_positive_add_host(session, module_org, rhel6_contenthost, target_sat):
         ).search()[0],
         organization=module_org,
     ).create()
-
-    rhel6_contenthost.install_katello_ca(target_sat)
-    rhel6_contenthost.register_contenthost(module_org.label, ak.name)
-    assert rhel6_contenthost.subscribed
+    result = rhel_contenthost.register(module_org, None, ak.name, target_sat)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    assert rhel_contenthost.subscribed
     with session:
         session.location.select(constants.DEFAULT_LOC)
         session.organization.select(module_org.name)
         ak = session.activationkey.read(ak.name, widget_names='content_hosts')
         assert len(ak['content_hosts']['table']) == 1
-        assert ak['content_hosts']['table'][0]['Name'] == rhel6_contenthost.hostname
+        assert ak['content_hosts']['table'][0]['Name'] == rhel_contenthost.hostname
 
 
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
-def test_positive_delete_with_system(session, rhel6_contenthost, target_sat):
+def test_positive_delete_with_system(session, rhel_contenthost, target_sat):
     """Delete an Activation key which has registered systems
 
     :id: 86cd070e-cf46-4bb1-b555-e7cb42e4dc9f
@@ -885,9 +884,9 @@ def test_positive_delete_with_system(session, rhel6_contenthost, target_sat):
         )
         assert session.activationkey.search(name)[0]['Name'] == name
         session.activationkey.add_subscription(name, product_name)
-        rhel6_contenthost.install_katello_ca(target_sat)
-        rhel6_contenthost.register_contenthost(org.label, name)
-        assert rhel6_contenthost.subscribed
+        result = rhel_contenthost.register(org, None, name, target_sat)
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+        assert rhel_contenthost.subscribed
         session.activationkey.delete(name)
         assert session.activationkey.search(name)[0]['Name'] != name
 
@@ -918,11 +917,10 @@ def test_negative_usage_limit(session, module_org, target_sat):
         assert ak['details']['hosts_limit'] == hosts_limit
     with Broker(nick='rhel6', host_class=ContentHost, _count=2) as hosts:
         vm1, vm2 = hosts
-        vm1.install_katello_ca(target_sat)
-        vm1.register_contenthost(module_org.label, name)
+        result = vm1.register(module_org, None, name, target_sat)
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
         assert vm1.subscribed
-        vm2.install_katello_ca(target_sat)
-        result = vm2.register_contenthost(module_org.label, name)
+        result = vm2.register(module_org, None, name, target_sat)
         assert not vm2.subscribed
         assert len(result.stderr)
         assert f'Max Hosts ({hosts_limit}) reached for activation key' in str(result.stderr)
@@ -932,7 +930,7 @@ def test_negative_usage_limit(session, module_org, target_sat):
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
-def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenthost, target_sat):
+def test_positive_add_multiple_aks_to_system(session, module_org, rhel_contenthost, target_sat):
     """Check if multiple Activation keys can be attached to a system
 
     :id: 4d6b6b69-9d63-4180-af2e-a5d908f8adb7
@@ -976,14 +974,14 @@ def test_positive_add_multiple_aks_to_system(session, module_org, rhel6_contenth
             ]
             assert product_name in subscriptions
         # Create VM
-        rhel6_contenthost.install_katello_ca(target_sat)
-        rhel6_contenthost.register_contenthost(module_org.label, ','.join([key_1_name, key_2_name]))
-        assert rhel6_contenthost.subscribed
+        result = rhel_contenthost.register(module_org, None, [key_1_name, key_2_name], target_sat)
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+        assert rhel_contenthost.subscribed
         # Assert the content-host association with activation keys
         for key_name in [key_1_name, key_2_name]:
             ak = session.activationkey.read(key_name, widget_names='content_hosts')
             assert len(ak['content_hosts']['table']) == 1
-            assert ak['content_hosts']['table'][0]['Name'] == rhel6_contenthost.hostname
+            assert ak['content_hosts']['table'][0]['Name'] == rhel_contenthost.hostname
 
 
 @pytest.mark.skip_if_not_set('clients')
@@ -1015,11 +1013,12 @@ def test_positive_host_associations(session, target_sat):
     ).create()
     with Broker(nick='rhel7', host_class=ContentHost, _count=2) as hosts:
         vm1, vm2 = hosts
-        vm1.install_katello_ca(target_sat)
-        vm1.register_contenthost(org.label, ak1.name)
+        result = vm1.register(org, None, ak1.name, target_sat)
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
         assert vm1.subscribed
-        vm2.install_katello_ca(target_sat)
-        vm2.register_contenthost(org.label, ak2.name)
+
+        result = vm2.register(org, None, ak2.name, target_sat)
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
         assert vm2.subscribed
         with session:
             session.organization.select(org.name)
@@ -1085,8 +1084,8 @@ def test_positive_service_level_subscription_with_custom_product(
     activation_key.service_level = 'Premium'
     activation_key = activation_key.update(['service_level'])
 
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(org.label, activation_key=activation_key.name)
+    result = rhel7_contenthost.register(org, None, activation_key.name, target_sat)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert rhel7_contenthost.subscribed
     result = rhel7_contenthost.run('subscription-manager list --consumed')
     assert result.status == 0
@@ -1142,10 +1141,11 @@ def test_positive_delete_manifest(session, function_entitlement_manifest_org, ta
         assert not ak['subscriptions']['resources']['assigned']
 
 
+@pytest.mark.rhel_ver_list([6])
 @pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.repos_hosting_url), reason='Missing repos_hosting_url')
-def test_positive_ak_with_custom_product_on_rhel6(session, rhel6_contenthost, target_sat):
+def test_positive_ak_with_custom_product_on_rhel6(rhel_contenthost, target_sat):
     """Registering a rhel6 host using an ak with custom repos should not fail
 
     :id: 4efed0b5-99af-4933-bea7-92a33984ce10
@@ -1167,15 +1167,16 @@ def test_positive_ak_with_custom_product_on_rhel6(session, rhel6_contenthost, ta
         {'url': settings.repos.yum_1.url, 'organization-id': org.id}
     )
     ak = target_sat.api.ActivationKey(id=entities_ids['activationkey-id']).read()
-    rhel6_contenthost.install_katello_ca(target_sat)
-    result = rhel6_contenthost.register_contenthost(org.label, activation_key=ak.name)
+
+    result = rhel_contenthost.register(org, None, ak.name, target_sat)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert 'The system has been registered with ID' in result.stdout
     with target_sat.ui_session() as session:
         session.location.select(constants.DEFAULT_LOC)
         session.organization.select(org.name)
         ak = session.activationkey.read(ak.name, widget_names='content_hosts')
         assert len(ak['content_hosts']['table']) == 1
-        assert ak['content_hosts']['table'][0]['Name'] == rhel6_contenthost.hostname
+        assert ak['content_hosts']['table'][0]['Name'] == rhel_contenthost.hostname
 
 
 def test_positive_custom_products_disabled_by_default_ak(

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -180,13 +180,14 @@ class TestAnsibleCfgMgmt:
         target_sat.api.AnsibleRoles().sync(
             data={'proxy_id': proxy_id, 'role_names': [SELECTED_ROLE]}
         )
-        command = target_sat.api.RegistrationCommand(
+        result = rhel_contenthost.api_register(
+            target_sat,
             organization=module_org,
-            location=module_location,
             activation_keys=[module_activation_key.name],
-        ).create()
-        result = rhel_contenthost.execute(command)
+            location=module_location,
+        )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
+
         target_host = rhel_contenthost.nailgun_host
         default_value = '[\"test\"]'  # fmt: skip
         parameter_type = 'array'

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -599,8 +599,8 @@ def test_positive_generate_all_installed_packages_report(
         }
     )
     client = rhel_contenthost
-    client.install_katello_ca(target_sat)
-    client.register_contenthost(org.label, ak.name)
+    result = client.register(org, None, ak.name, target_sat)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert client.subscribed
     client.execute(f'yum -y install {FAKE_0_CUSTOM_PACKAGE_NAME} {FAKE_1_CUSTOM_PACKAGE}')
     with session:

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -451,9 +451,10 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(
         assert set(col) == set(checkbox_dict)
 
 
+@pytest.mark.rhel_ver_match('7')
 @pytest.mark.tier3
 def test_positive_subscription_status_disabled_golden_ticket(
-    session, golden_ticket_host_setup, rhel7_contenthost, target_sat
+    session, golden_ticket_host_setup, rhel_contenthost, target_sat
 ):
     """Verify that Content host Subscription status is set to 'Disabled'
      for a golden ticket manifest
@@ -470,13 +471,13 @@ def test_positive_subscription_status_disabled_golden_ticket(
 
     :CaseImportance: Medium
     """
-    rhel7_contenthost.install_katello_ca(target_sat)
     org, ak = golden_ticket_host_setup
-    rhel7_contenthost.register_contenthost(org.label, ak.name)
-    assert rhel7_contenthost.subscribed
+    result = rhel_contenthost.register(org, None, ak.name, target_sat)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    assert rhel_contenthost.subscribed
     with session:
         session.organization.select(org_name=org.name)
-        host = session.contenthost.read(rhel7_contenthost.hostname, widget_names='details')[
+        host = session.contenthost.read(rhel_contenthost.hostname, widget_names='details')[
             'details'
         ]['subscription_status']
         assert 'Simple Content Access' in host
@@ -521,8 +522,8 @@ def test_positive_candlepin_events_processed_by_STOMP(
         organization=org,
         environment=target_sat.api.LifecycleEnvironment(id=org.library.id),
     ).create()
-    rhel7_contenthost.install_katello_ca(target_sat)
-    rhel7_contenthost.register_contenthost(org.name, ak.name)
+    result = rhel7_contenthost.register(org, None, ak.name, target_sat)
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
     with session:
         session.organization.select(org_name=org.name)
         host = session.contenthost.read(rhel7_contenthost.hostname, widget_names='details')[


### PR DESCRIPTION
…elo (#14034)

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->