### PR TITLE
[6.13.z] Mark UI tests as end-to-end for Rocket Team Components

### DIFF
--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -6,7 +6,7 @@
 
 :Team: Rocket
 
-:CaseImportance: High
+:CaseImportance: Critical
 
 :CaseAutomation: Automated
 
@@ -202,6 +202,7 @@ def precondition_check_upgrade_and_install_leapp_tool(custom_leapp_host):
         custom_leapp_host.power_control(state='reboot', ensure=True)
 
 
+@pytest.mark.e2e
 @pytest.mark.parametrize(
     'upgrade_path',
     [

--- a/tests/foreman/ui/test_computeprofiles.py
+++ b/tests/foreman/ui/test_computeprofiles.py
@@ -17,6 +17,7 @@ from nailgun import entities
 import pytest
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_location, module_org):

--- a/tests/foreman/ui/test_computeresource.py
+++ b/tests/foreman/ui/test_computeresource.py
@@ -49,7 +49,7 @@ def rhev_data():
 
 
 @pytest.mark.tier2
-def test_positive_end_to_end(session, rhev_data, module_org, module_location):
+def test_positive_end_to_end(session, rhev_data, module_target_sat):
     """Perform end to end testing for compute resource RHEV.
 
     :id: 3c079675-e5d3-490e-9b7e-1c2950f9965d
@@ -356,8 +356,9 @@ def test_positive_update_organization(session, rhev_data, module_location):
         assert new_organization.name in resource_values['organizations']['resources']['assigned']
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
-def test_positive_image_end_to_end(session, rhev_data, module_location, target_sat):
+def test_positive_image_end_to_end(session, rhev_data, target_sat):
     """Perform end to end testing for compute resource RHV component image.
 
     :id: 62a5c52f-dd15-45e7-8200-c64bb335474f

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -74,10 +74,10 @@ def module_azure_hg(
     ).create()
 
 
+@pytest.mark.e2e
 @pytest.mark.tier4
 @pytest.mark.parametrize('sat_azure', ['sat'], indirect=True)
 def test_positive_end_to_end_azurerm_ft_host_provision(
-    session,
     sat_azure,
     azurermclient,
     module_azurerm_custom_finishimg,
@@ -151,13 +151,13 @@ def test_positive_end_to_end_azurerm_ft_host_provision(
             raise error
 
 
+@pytest.mark.e2e
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'sat_azure', ['sat', 'puppet_sat'], indirect=True, ids=['satellite', 'puppet_enabled']
 )
 def test_positive_azurerm_host_provision_ud(
-    session,
     sat_azure,
     azurermclient,
     module_azurerm_cloudimg,

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -41,6 +41,7 @@ def module_ec2_settings():
     )
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.skip_if_not_set('http_proxy')
 @pytest.mark.skip_if_open("BZ:2032530")

--- a/tests/foreman/ui/test_computeresource_gce.py
+++ b/tests/foreman/ui/test_computeresource_gce.py
@@ -29,11 +29,12 @@ from robottelo.constants import (
 )
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skip_if_not_set('http_proxy', 'gce')
 def test_positive_default_end_to_end_with_custom_profile(
-    session, sat_gce_org, sat_gce_loc, gce_cert, sat_gce
+    sat_gce_org, sat_gce_loc, gce_cert, sat_gce
 ):
     """Create GCE compute resource with default properties and apply it's basic functionality.
 
@@ -140,12 +141,12 @@ def test_positive_default_end_to_end_with_custom_profile(
         assert not session.computeresource.search(new_cr_name)
 
 
+@pytest.mark.e2e
 @pytest.mark.tier4
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('gce')
 @pytest.mark.parametrize('sat_gce', ['sat', 'puppet_sat'], indirect=True)
 def test_positive_gce_provision_end_to_end(
-    session,
     request,
     sat_gce,
     sat_gce_org,
@@ -225,13 +226,13 @@ def test_positive_gce_provision_end_to_end(
             assert gceapi_vm.is_stopping or gceapi_vm.is_stopped
 
 
+@pytest.mark.e2e
 @pytest.mark.tier4
 @pytest.mark.upgrade
 @pytest.mark.run_in_one_thread
 @pytest.mark.skip_if_not_set('gce')
 @pytest.mark.parametrize('sat_gce', ['sat', 'puppet_sat'], indirect=True)
 def test_positive_gce_cloudinit_provision_end_to_end(
-    session,
     request,
     sat_gce,
     sat_gce_org,

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -118,13 +118,13 @@ def test_positive_end_to_end(session, module_target_sat, module_org, module_loca
         assert not session.computeresource.search(new_cr_name)
 
 
+@pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
 @pytest.mark.tier4
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_end_to_end(
     request,
-    session,
     setting_update,
     module_sca_manifest_org,
     module_location,
@@ -155,7 +155,9 @@ def test_positive_provision_end_to_end(
         location=[module_location],
         organization=[module_sca_manifest_org],
     ).create()
-    with session:
+    with sat.ui_session() as session:
+        session.organization.select(module_sca_manifest_org.name)
+        session.location.select(module_location.name)
         session.host.create(
             {
                 'host.name': hostname,

--- a/tests/foreman/ui/test_config_group.py
+++ b/tests/foreman/ui/test_config_group.py
@@ -21,6 +21,7 @@ def module_puppet_class(session_puppet_enabled_sat):
     return session_puppet_enabled_sat.api.PuppetClass().create()
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_class):

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -63,6 +63,7 @@ def gen_int32(min_value=1):
     return gen_integer(min_value=min_value, max_value=max_value)
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 def test_positive_crud_with_non_admin_user(
     module_location, manager_user, module_org, module_target_sat
@@ -232,6 +233,7 @@ def test_positive_list_host_based_on_rule_search_query(
         assert values['properties']['properties_table']['IP Address'] == ip_address
 
 
+@pytest.mark.e2e
 @pytest.mark.tier3
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_org, module_location, module_target_sat):

--- a/tests/foreman/ui/test_operatingsystem.py
+++ b/tests/foreman/ui/test_operatingsystem.py
@@ -18,6 +18,7 @@ from robottelo.constants import HASH_TYPE
 from robottelo.utils.datafactory import gen_string
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 def test_positive_end_to_end(session, module_org, module_location, target_sat):
     """Create all possible entities that required for operating system and then

--- a/tests/foreman/ui/test_puppetclass.py
+++ b/tests/foreman/ui/test_puppetclass.py
@@ -16,6 +16,7 @@ from fauxfactory import gen_string
 import pytest
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_org, module_puppet_loc):

--- a/tests/foreman/ui/test_puppetenvironment.py
+++ b/tests/foreman/ui/test_puppetenvironment.py
@@ -18,6 +18,7 @@ from robottelo.constants import DEFAULT_CV, ENVIRONMENT
 from robottelo.utils.datafactory import gen_string
 
 
+@pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.tier2
 def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_org, module_puppet_loc):

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -66,6 +66,7 @@ def module_domain(session_puppet_enabled_sat, module_host):
     return session_puppet_enabled_sat.api.Domain(id=module_host.domain.id).read()
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_classes, sc_params_list):
     """Perform end to end testing for smart class parameter component

--- a/tests/foreman/ui/test_subnet.py
+++ b/tests/foreman/ui/test_subnet.py
@@ -27,6 +27,7 @@ def module_dom(module_target_sat, module_org, module_location):
     d.delete()
 
 
+@pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_end_to_end(session, module_target_sat, module_dom):


### PR DESCRIPTION
### Problem Statement
Manual  cherrypick of https://github.com/SatelliteQE/robottelo/pull/14702

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->