### PR TITLE
[6.13.z] removed server.hostname validator for resolve rhel 8.10 formatting issue

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           # To skip vault login in pull request checks
           export VAULT_SECRET_ID_FOR_DYNACONF=somesecret
+          export ROBOTTELO_SERVER__HOSTNAME=""
           pytest -sv tests/robottelo/
 
       - name: Make Docs

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -10,7 +10,7 @@ VALIDATORS = dict(
         ),
     ],
     server=[
-        Validator('server.hostname', default=''),
+        Validator('server.hostname', is_type_of=str),
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
         Validator('server.version.source', must_exist=True),


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15340

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->