### PR TITLE
[6.14.z] Setting sanity hostname attr initially

### DIFF
--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -14,6 +14,7 @@ from robottelo.logging import logger
 def align_to_satellite(request, worker_id, satellite_factory):
     """Attempt to align a Satellite to the current xdist worker"""
     if 'build_sanity' in request.config.option.markexpr:
+        settings.set("server.hostname", None)
         yield
         if settings.server.hostname:
             sanity_sat = Satellite(settings.server.hostname)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15350

### Problem Statement
Sanity is failing with `server.hostname` attribute not found. Earlier the dynaconf validator was setting it as a default value and attribute but that Is removed in PR https://github.com/SatelliteQE/robottelo/pull/15340.

### Solution
Setting the hostname attribute to server for sanity.

### Local Testing

```
In [2]: settings.server.hostname
---------------------------------------------------------------------------
BoxKeyError                               Traceback (most recent call last)
Cell In[2], line 1
----> 1 settings.server.hostname

File ~/venv/robottelo312/src/dynaconf/dynaconf/utils/boxing.py:18, in evaluate_lazy_format.<locals>.evaluate(dynabox, item, *args, **kwargs)
     16 @wraps(f)
     17 def evaluate(dynabox, item, *args, **kwargs):
---> 18     value = f(dynabox, item, *args, **kwargs)
     19     settings = dynabox._box_config["box_settings"]
     21     if getattr(value, "_dynaconf_lazy_format", None):

File ~/venv/robottelo312/src/dynaconf/dynaconf/utils/boxing.py:41, in DynaBox.__getattr__(self, item, *args, **kwargs)
     39 except (AttributeError, KeyError):
     40     n_item = find_the_correct_casing(item, self) or item
---> 41     return super().__getattr__(n_item, *args, **kwargs)

File ~/venv/robottelo312/src/dynaconf/dynaconf/vendor/box/box.py:360, in Box.__getattr__(self, item)
    358     if self._box_config['default_box']:
    359         return self.__get_default(item)
--> 360     raise BoxKeyError(str(err)) from None
    361 return value

BoxKeyError: "'DynaBox' object has no attribute 'hostname'"

In [3]: settings.set("server.hostname", None)

In [4]: type(settings.server.hostname)
NoneType
```


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->