### PR TITLE
Fix IPA and RHSSO.

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2543,7 +2543,7 @@ class IPAHost(Host):
                 _, password = line.split(': ', 2)
                 break
         self.execute(f'ipa service-add HTTP/{self.satellite.hostname}')
-        _, domain = self.hostname.split('.', 1)
+        domain = self.execute('ipa realmdomains-show | awk \'{print $2}\'').stdout.strip()
         result = self.satellite.execute(
             f"ipa-client-install --password '{password}' "
             f'--domain {domain} '


### PR DESCRIPTION
IPA domain isn't necessarily the same as DNS domain so connect using DNS domain and there detect the actual IPA domain.

RHSSO used nonexistent ssh_session methods, perhaps this has changed over time. I made it use the execute method and workarounded bug that happens when calling 'hammer auth login oauth' non-interactively by faking tty.