### PR TITLE
Skip assertion for test_satellite_installation if SAT-21086 is open

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -103,7 +103,7 @@ def common_sat_install_assertions(satellite):
     assert len(result.stdout) == 0
     # no errors in /var/log/foreman/production.log
     result = satellite.execute(r'grep --context=100 -E "\[E\|" /var/log/foreman/production.log')
-    if not is_open('BZ:2247484'):
+    if not is_open('SAT-21086'):
         assert len(result.stdout) == 0
     # no errors/failures in /var/log/foreman-installer/satellite.log
     result = satellite.execute(


### PR DESCRIPTION
### Problem Statement
- test_satellite_installation is failing on assertion as we have migrated to Jira and the BZ is now closed without being actually resolved causing is_open to report false status.

### Solution
- Use SAT-21086 to check the bug status and skip assertion accordingly.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->