### PR TITLE
[6.14.z] [cherry-pick] Skip assertion for test_satellite_installation if SAT-21086 is open

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1329,7 +1329,7 @@ def common_sat_install_assertions(satellite):
     assert len(result.stdout) == 0
     # no errors in /var/log/foreman/production.log
     result = satellite.execute(r'grep --context=100 -E "\[E\|" /var/log/foreman/production.log')
-    if not is_open('BZ:2247484'):
+    if not is_open('SAT-21086'):
         assert len(result.stdout) == 0
     # no errors/failures in /var/log/foreman-installer/satellite.log
     result = satellite.execute(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15360

See https://github.com/SatelliteQE/robottelo/pull/15358 