### PR TITLE
[6.14.z] Use jira issue to get bug status

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -299,7 +299,7 @@ class TestAnsibleCfgMgmt:
 
         # gather ansible facts by running ansible roles on the host
         host.play_ansible_roles()
-        if is_open('BZ:2216471'):
+        if is_open('SAT-18656'):
             wait_for(
                 lambda: len(rex_contenthost.nailgun_host.get_facts()) > 0,
                 timeout=30,

--- a/tests/foreman/api/test_organization.py
+++ b/tests/foreman/api/test_organization.py
@@ -75,7 +75,7 @@ class TestOrganization:
             headers={'content-type': 'text/plain'},
             verify=False,
         )
-        if is_open('BZ:2228820'):
+        if is_open('SAT-20559'):
             assert response.status_code in [http.client.UNSUPPORTED_MEDIA_TYPE, 500]
         else:
             assert response.status_code == http.client.UNSUPPORTED_MEDIA_TYPE

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -557,11 +557,11 @@ def test_rhel_pxe_provisioning_fips_enabled(
     # Verify FIPS is enabled on host after provisioning is completed sucessfully
     if int(host_os.major) >= 8:
         result = provisioning_host.execute('fips-mode-setup --check')
-        fips_status = 'FIPS mode is disabled' if is_open('BZ:2240076') else 'FIPS mode is enabled'
+        fips_status = 'FIPS mode is disabled' if is_open('SAT-20386') else 'FIPS mode is enabled'
         assert fips_status in result.stdout
     else:
         result = provisioning_host.execute('cat /proc/sys/crypto/fips_enabled')
-        assert (0 if is_open('BZ:2240076') else 1) == int(result.stdout)
+        assert (0 if is_open('SAT-20386') else 1) == int(result.stdout)
 
     # Run a command on the host using REX to verify that Satellite's SSH key is present on the host
     template_id = (

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -34,7 +34,7 @@ def test_selinux_status(target_sat):
     result = target_sat.execute('getenforce')
     assert 'Enforcing' in result.stdout
     # check there are no SELinux denials
-    if not is_open('BZ:2263294'):
+    if not is_open('SAT-23121'):
         result = target_sat.execute('ausearch --input-logs -m avc -ts today --raw')
         assert result.status == 1, 'Some SELinux denials were found in journal.'
 

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -401,7 +401,7 @@ def test_positive_vmware_custom_profile_end_to_end(
             assert provider_content['cluster'] == settings.vmware.cluster
             assert provider_content['annotation_notes'] == annotation_notes
             assert provider_content['virtual_hw_version'] == virtual_hw_version
-            if not is_open('BZ:2266672'):
+            if not is_open('SAT-23630'):
                 assert values['provider_content']['firmware'] == firmware
             assert provider_content['resource_pool'] == resource_pool
             assert provider_content['folder'] == folder


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15359

### Problem Statement
We have migrated to Jira and some of the bz have been closed without being fixed/resolved. It's causing is_open function to return false status and we're now running the assertion which fails.

### Solution
- Use Jira issues to get the bug status

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->