### PR TITLE
Remove old skip_if for closed BZs

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -51,7 +51,6 @@ from robottelo.content_info import (
     get_repomd_revision,
 )
 from robottelo.utils.datafactory import gen_string
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture
@@ -974,26 +973,25 @@ class TestCapsuleContentManagement:
             assert result.status == 0
 
         # Inspect the images with skopeo (BZ#2148813)
-        if not is_open('BZ:2148813'):
-            result = module_capsule_configured.execute('yum -y install skopeo')
+        result = module_capsule_configured.execute('yum -y install skopeo')
+        assert result.status == 0
+
+        target_sat.api.LifecycleEnvironment(
+            id=function_lce.id, registry_unauthenticated_pull='true'
+        ).update(['registry_unauthenticated_pull'])
+
+        sleep(20)
+
+        skopeo_cmd = 'skopeo --debug inspect docker://'
+        for path in repo_paths:
+            result = module_capsule_configured.execute(
+                f'{skopeo_cmd}{target_sat.hostname}/{path}:latest'
+            )
             assert result.status == 0
-
-            target_sat.api.LifecycleEnvironment(
-                id=function_lce.id, registry_unauthenticated_pull='true'
-            ).update(['registry_unauthenticated_pull'])
-
-            sleep(20)
-
-            skopeo_cmd = 'skopeo --debug inspect docker://'
-            for path in repo_paths:
-                result = module_capsule_configured.execute(
-                    f'{skopeo_cmd}{target_sat.hostname}/{path}:latest'
-                )
-                assert result.status == 0
-                result = module_capsule_configured.execute(
-                    f'{skopeo_cmd}{module_capsule_configured.hostname}/{path}:latest'
-                )
-                assert result.status == 0
+            result = module_capsule_configured.execute(
+                f'{skopeo_cmd}{module_capsule_configured.hostname}/{path}:latest'
+            )
+            assert result.status == 0
 
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule')

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -30,7 +30,6 @@ from robottelo.constants import (
     REPOSET,
 )
 from robottelo.utils.datafactory import parametrized, valid_data_list
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -291,14 +290,13 @@ def test_positive_lock_clone_nodelete_unlock_report(target_sat):
     assert template_clone_name == cloned_rt.name
     assert template1 == cloned_rt.template
     # 4. Try to delete template
-    if not is_open('BZ:1680458'):
-        with pytest.raises(HTTPError):
-            rt.delete()
-        # In BZ1680458, exception is thrown but template is deleted anyway
-        assert (
-            len(target_sat.api.ReportTemplate().search(query={'search': f'name="{template_name}"'}))
-            != 0
-        )
+    with pytest.raises(HTTPError):
+        rt.delete()
+    # In BZ1680458, exception is thrown but template is deleted anyway
+    assert (
+        len(target_sat.api.ReportTemplate().search(query={'search': f'name="{template_name}"'}))
+        != 0
+    )
     # 5. Try to edit template
     with pytest.raises(HTTPError):
         target_sat.api.ReportTemplate(id=rt.id, template=template2).update(["template"])

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -29,7 +29,6 @@ from robottelo.utils.datafactory import (
     parametrized,
     valid_data_list,
 )
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -1139,8 +1138,7 @@ def test_create_ak_with_syspurpose_set(module_entitlement_manifest_org, module_t
     assert new_ak['system-purpose']['purpose-addons'] == "test-addon1, test-addon2"
     assert new_ak['system-purpose']['purpose-role'] == "test-role"
     assert new_ak['system-purpose']['purpose-usage'] == "test-usage"
-    if not is_open('BZ:1789028'):
-        assert new_ak['system-purpose']['service-level'] == "Self-Support"
+    assert new_ak['system-purpose']['service-level'] == "Self-Support"
     # Check that system purpose values can be deleted.
     module_target_sat.cli.ActivationKey.update(
         {

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -21,7 +21,6 @@ from robottelo.constants import (
     ENVIRONMENT,
     REPO_TYPE,
 )
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope="module")
@@ -60,11 +59,9 @@ def test_positive_search(session, module_org, module_product, module_repository)
     with session:
         session.organization.select(org_name=module_org.name)
         search = session.containerimagetag.search('latest')
-        if not is_open('BZ:2242515'):
-            assert module_product.name in [i['Product Name'] for i in search]
+        assert module_product.name in [i['Product Name'] for i in search]
         values = session.containerimagetag.read('latest')
-        if not is_open('BZ:2242515'):
-            assert module_product.name == values['details']['product']
+        assert module_product.name == values['details']['product']
         assert values['lce']['table'][0]['Environment'] == ENVIRONMENT
         repo_line = next(
             (item for item in values['repos']['table'] if item['Name'] == module_repository.name),

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -35,7 +35,6 @@ from robottelo.constants import (
     VIRT_WHO_HYPERVISOR_TYPES,
 )
 from robottelo.exceptions import CLIFactoryError
-from robottelo.utils.issue_handlers import is_open
 from robottelo.utils.virtwho import create_fake_hypervisor_content
 
 if not setting_is_set('clients') or not setting_is_set('fake_manifest'):
@@ -220,17 +219,14 @@ def test_positive_end_to_end(
             for repo_index in range(len(module_repos_collection_with_manifest.repos_info))
         }
         assert actual_repos == expected_repos
-        # Check start date for BZ#1920860 (but handle BZ#2112320 offset-by-one bug)
+        # Check start date for BZ#1920860
         custom_product_name = module_repos_collection_with_manifest.custom_product['name']
         custom_sub = next(
             item
             for item in chost['subscriptions']['resources']['assigned']
             if item["Repository Name"] == custom_product_name
         )
-        if is_open('BZ:2112320'):
-            assert startdate in custom_sub['Expires']
-        else:
-            assert startdate in custom_sub['Starts']
+        assert startdate in custom_sub['Starts']
         # Ensure host status and details show correct RHEL lifecycle status
         host_status = session.host.host_status(vm.hostname)
         host_rhel_lcs = session.contenthost.read(vm.hostname, widget_names=['permission_denied'])

--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -16,7 +16,6 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
-from robottelo.utils.issue_handlers import is_open
 from robottelo.utils.virtwho import (
     deploy_configure_by_command,
     get_configure_command,
@@ -124,8 +123,7 @@ class TestScenarioPositiveVirtWho:
         vhd = target_sat.api.VirtWhoConfig(organization_id=org_id).search(
             query={'search': f'name={name}'}
         )[0]
-        if not is_open('BZ:1802395'):
-            assert vhd.status == 'ok'
+        assert vhd.status == 'ok'
         # Verify virt-who status via CLI as we cannot check it via API now
         vhd_cli = target_sat.cli.VirtWhoConfig.exists(search=('name', name))
         assert (


### PR DESCRIPTION
### Problem Statement
These BZs were already closed so we don't need to skip `if open` them anymore:
https://bugzilla.redhat.com/show_bug.cgi?id=1802395
https://bugzilla.redhat.com/show_bug.cgi?id=1789028
https://bugzilla.redhat.com/show_bug.cgi?id=2112320
https://bugzilla.redhat.com/show_bug.cgi?id=1680458
https://bugzilla.redhat.com/show_bug.cgi?id=2148813


### Solution
Remove the `skip_if` conditioning.


### PRT
trigger: test-robottelo
pytest: tests/foreman/api/test_reporttemplates.py::test_positive_lock_clone_nodelete_unlock_report tests/foreman/cli/test_activationkey.py::test_create_ak_with_syspurpose_set tests/foreman/ui/test_containerimagetag.py::test_positive_search
