### PR TITLE
[Customer Case] Applied Errata report with invalid errata

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -474,9 +474,9 @@ def test_positive_applied_errata_report_with_invalid_errata(
 
     :expectedresults: A report is generated without failures
 
-    :CaseImportance: High
-
     :BZ: 2176368
+
+    :customerscenario: true
     """
     activation_key = target_sat.api.ActivationKey(
         environment=function_lce, organization=function_org


### PR DESCRIPTION
Customer case automation for generating an applied errata report after applying an invalid errata. 

All we need to test here is to make sure the report is generated without failure. However, because we never actually apply any errata, the report is an empty list. We can just assume it generated if there are no failures, but if anyone has any ideas on a potential assert that can be made im open to suggestions. 