### PR TITLE
[6.15.z] Bump broker to 0.5

### DIFF
--- a/.github/dependency_tests.yaml
+++ b/.github/dependency_tests.yaml
@@ -1,4 +1,4 @@
-broker[docker]: "tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'"
+broker[docker,podman,hussh]: "tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'"
 deepdiff: "tests/foreman/endtoend/test_api_endtoend.py -k 'test_positive_get_links'"
 dynaconf[vault]: "tests/foreman/api/test_ldapauthsource.py -k 'test_positive_endtoend'"
 manifester: "tests/foreman/cli/test_contentview.py -k 'test_positive_promote_rh_content'"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 apypie==0.4.0
 betelgeuse==1.11.0
-broker[docker]==0.4.9
+broker[docker,podman,hussh]==0.5.0
 cryptography==42.0.8
 deepdiff==7.0.1
 dynaconf[vault]==3.2.5


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15221

This requirement update also adds in the podman and hussh dependency groups.

trigger: test-robottelo
pytest: tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'