### PR TITLE
updated in hammer ping stderr parsing

### DIFF
--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -37,7 +37,7 @@ def test_positive_ping(target_sat, switch_user):
     :customerscenario: true
     """
     result = target_sat.execute(f"su - {'postgres' if switch_user else 'root'} -c 'hammer ping'")
-    assert result.stderr[1].decode() == ''
+    assert result.stderr == ''
 
     # Filter lines containing status
     statuses = [line for line in result.stdout.splitlines() if 'status:' in line.lower()]


### PR DESCRIPTION
### Problem Statement
automation failures with `IndexError: string index out of range`

### Solution
this pr

### Related Issues
note to self: prt  won't run atm, rerun later with:

trigger: test-robottelo
pytest: tests/foreman/cli/test_ping.py -k test_positive_ping[non-root]
