### PR TITLE
Remove use of install_katello_ca with register_contenthost

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -36,7 +36,7 @@ def rhcloud_registered_hosts(
         vm.configure_rhai_client(
             satellite=module_target_sat,
             activation_key=rhcloud_activation_key.name,
-            org=rhcloud_manifest_org.label,
+            org=rhcloud_manifest_org,
             rhel_distro=f"rhel{vm.os_version.major}",
         )
         assert vm.subscribed
@@ -54,7 +54,7 @@ def rhel_insights_vm(
     rhel_contenthost.configure_rhai_client(
         satellite=module_target_sat,
         activation_key=rhcloud_activation_key.name,
-        org=rhcloud_manifest_org.label,
+        org=rhcloud_manifest_org,
         rhel_distro=f"rhel{rhel_contenthost.os_version.major}",
     )
     # Generate report

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -20,7 +20,6 @@ from broker import Broker
 from broker.hosts import Host
 from dynaconf.vendor.box.exceptions import BoxKeyError
 from fauxfactory import gen_alpha, gen_string
-from manifester import Manifester
 from nailgun import entities
 from packaging.version import Version
 import requests
@@ -41,12 +40,8 @@ from robottelo.constants import (
     CUSTOM_PUPPET_MODULE_REPOS,
     CUSTOM_PUPPET_MODULE_REPOS_PATH,
     CUSTOM_PUPPET_MODULE_REPOS_VERSION,
-    DEFAULT_ARCHITECTURE,
     HAMMER_CONFIG,
     KEY_CLOAK_CLI,
-    PRDS,
-    REPOS,
-    REPOSET,
     RHSSO_NEW_GROUP,
     RHSSO_NEW_USER,
     RHSSO_RESET_PASSWORD,
@@ -107,53 +102,6 @@ def get_sat_rhel_version():
         elif hasattr(settings.robottelo, 'rhel_version'):
             rhel_version = settings.robottelo.rhel_version
     return Version(rhel_version)
-
-
-def setup_capsule(satellite, capsule, org, registration_args=None, installation_args=None):
-    """Given satellite and capsule instances, run the commands needed to set up the capsule
-
-    Note: This does not perform content setup actions on the Satellite
-
-    :param satellite: An instance of this module's Satellite class
-    :param capsule: An instance of this module's Capsule class
-    :param org: An instance of the org to use on the Satellite
-    :param registration_args: A dictionary mapping argument: value pairs for registration
-    :param installation_args: A dictionary mapping argument: value pairs for installation
-    :return: An ssh2-python result object for the installation command.
-
-    """
-    # Unregister capsule incase it's registered to CDN
-    capsule.unregister()
-
-    # Add a manifest to the Satellite
-    with Manifester(manifest_category=settings.manifest.entitlement) as manifest:
-        satellite.upload_manifest(org.id, manifest.content)
-
-    # Enable RHEL 8 BaseOS and AppStream repos and sync
-    for rh_repo_key in ['rhel8_bos', 'rhel8_aps']:
-        satellite.api_factory.enable_rhrepo_and_fetchid(
-            basearch=DEFAULT_ARCHITECTURE,
-            org_id=org.id,
-            product=PRDS['rhel8'],
-            repo=REPOS[rh_repo_key]['name'],
-            reposet=REPOSET[rh_repo_key],
-            releasever=REPOS[rh_repo_key]['releasever'],
-        )
-    product = satellite.api.Product(name=PRDS['rhel8'], organization=org.id).search()[0]
-    product.sync(timeout=1800, synchronous=True)
-
-    if not registration_args:
-        registration_args = {}
-    file, _, cmd_args = satellite.capsule_certs_generate(capsule)
-    if installation_args:
-        cmd_args.update(installation_args)
-    satellite.execute(
-        f'sshpass -p "{capsule.password}" scp -o "StrictHostKeyChecking no" '
-        f'{file} root@{capsule.hostname}:{file}'
-    )
-    capsule.install_katello_ca(satellite)
-    capsule.register_contenthost(org=org.label, **registration_args)
-    return capsule.install(cmd_args)
 
 
 class ContentHostError(Exception):
@@ -674,27 +622,6 @@ class ContentHost(Host, ContentHostMixins):
         self.execute('subscription-manager clean')
         self._satellite = None
 
-    def install_capsule_katello_ca(self, capsule=None):
-        """Downloads and installs katello-ca rpm on the broker virtual machine.
-
-        :param: str capsule: Capsule hostname
-        :raises robottelo.hosts.ContentHostError: If katello-ca wasn't
-            installed.
-        """
-        warnings.warn(
-            message=(
-                'The install_capsule_katello_ca method is deprecated, '
-                'use the register method instead.'
-            ),
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        url = urlunsplit(('http', capsule, 'pub/', '', ''))
-        ca_url = urljoin(url, 'katello-ca-consumer-latest.noarch.rpm')
-        result = self.execute(f'rpm -Uvh {ca_url}')
-        if result.status != 0:
-            raise ContentHostError('Failed to install the katello-ca rpm')
-
     def install_cockpit(self):
         """Installs cockpit on the broker virtual machine.
 
@@ -1095,8 +1022,19 @@ class ContentHost(Host, ContentHostMixins):
         :param bool register: Whether to register to the Satellite. Keyexchange done regardless
         """
         if register:
-            self.install_katello_ca(satellite)
-            self.register_contenthost(org.label, lce='Library')
+            ak = satellite.api.ActivationKey(
+                content_view=org.default_content_view.id,
+                environment=org.library.id,
+                organization=org,
+            ).create()
+            self.register(
+                org,
+                None,
+                ak.name,
+                satellite,
+                setup_remote_execution=True,
+                setup_remote_execution_pull=True,
+            )
             assert self.subscribed
         self.add_rex_key(satellite=satellite)
         if register and subnet_id is not None:
@@ -1132,10 +1070,15 @@ class ContentHost(Host, ContentHostMixins):
         :return: None
         """
         if register:
-            # Install Satellite CA rpm
-            self.install_katello_ca(satellite)
-
-            self.register_contenthost(org, activation_key)
+            if not activation_key:
+                activation_key = satellite.api.ActivationKey(
+                    content_view=org.default_content_view.id,
+                    environment=org.library.id,
+                    organization=org,
+                ).create()
+            self.register(
+                org, None, activation_key.name, satellite, setup_insights=register_insights
+            )
 
         # Red Hat Insights requires RHEL 6/7/8 repo and it is not
         # possible to sync the repo during the tests, Adding repo file.
@@ -1155,16 +1098,9 @@ class ContentHost(Host, ContentHostMixins):
         else:
             self.create_custom_repos(**{rhel_distro: rhel_repo})
 
-        # Install insights-client rpm
+        # Ensure insights-client rpm is installed
         if self.execute('yum install -y insights-client').status != 0:
             raise ContentHostError('Unable to install insights-client rpm')
-
-        if register_insights:
-            # Register client
-            if self.execute('insights-client --register').status != 0:
-                raise ContentHostError('Unable to register client to Insights through Satellite')
-            if self.execute('insights-client --test-connection').status != 0:
-                raise ContentHostError('Test connection failed via insights.')
 
     def unregister_insights(self):
         """Unregister insights client.
@@ -1228,10 +1164,12 @@ class ContentHost(Host, ContentHostMixins):
         """
         rh_repo_ids = rh_repo_ids or []
         repo_labels = repo_labels or []
+        loc = location_title
         if location_title:
             self.set_facts({'locations.facts': {'foreman_location': str(location_title)}})
-        self.install_katello_ca(satellite)
-        result = self.register_contenthost(org_label, activation_key=activation_key, lce=lce)
+            loc = satellite.api.Location().search(query={'search': f'name="{location_title}"'})[0]
+        org = satellite.api.Organization().search(query={'search': f'name="{org_label}"'})[0]
+        result = self.register(org, loc, activation_key, satellite)
         if not self.subscribed:
             logger.info(result.stdout)
             raise CLIFactoryError('Virtual machine failed subscription')
@@ -2222,13 +2160,12 @@ class Satellite(Capsule, SatelliteMixins):
             assert task_status['result'] == 'success'
 
         # register contenthost
-        rhel_contenthost.install_katello_ca(self)
-        register = rhel_contenthost.register_contenthost(
-            org=module_org.label,
-            lce='Library',
-            name=f'{gen_string("alpha")}-{rhel_contenthost.hostname}',
-            force=True,
-        )
+        ak = self.api.ActivationKey(
+            content_view=module_org.default_content_view.id,
+            environment=module_org.library.id,
+            organization=module_org,
+        ).create()
+        register = rhel_contenthost.register(module_org, None, ak.name, self)
         assert register.status == 0, (
             f'Failed to register the host: {rhel_contenthost.hostname}:'
             f'rc: {register.status}: {register.stderr}'

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -2058,7 +2058,7 @@ class TestContentView:
         # assert that this is the same content view
         assert content_view['name'] == user_content_view['name']
         # Create activation key with content view
-        ak_name = gen_alphanumeric
+        ak_name = gen_alphanumeric()
         target_sat.cli.ActivationKey.create(
             {
                 'organization-id': org.id,

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -122,14 +122,11 @@ def test_insights_client_registration_with_http_proxy(
 
     :customerscenario: true
     """
-    rhel_contenthost.configure_rex(
-        satellite=module_target_sat, org=rhcloud_manifest_org, register=False
-    )
     rhel_contenthost.configure_rhai_client(
-        satellite=module_target_sat,
-        activation_key=rhcloud_activation_key.name,
-        org=rhcloud_manifest_org.label,
-        rhel_distro=f"rhel{rhel_contenthost.os_version.major}",
+        module_target_sat,
+        rhcloud_activation_key,
+        rhcloud_manifest_org,
+        f"rhel{rhel_contenthost.os_version.major}",
     )
     assert rhel_contenthost.execute('insights-client --register').status == 0
     assert rhel_contenthost.execute('insights-client --test-connection').status == 0

--- a/tests/foreman/destructive/test_capsule_loadbalancer.py
+++ b/tests/foreman/destructive/test_capsule_loadbalancer.py
@@ -121,8 +121,7 @@ def setup_haproxy(
     haproxy_ak = content_for_client['client_ak']
     haproxy.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
     haproxy.execute('firewall-cmd --runtime-to-permanent')
-    haproxy.install_katello_ca(module_target_sat)
-    haproxy.register_contenthost(module_org.label, haproxy_ak.name)
+    haproxy.register(module_org, None, haproxy_ak.name, module_target_sat)
     result = haproxy.execute('yum install haproxy policycoreutils-python-utils -y')
     assert result.status == 0
     haproxy.execute('rm -f /etc/haproxy/haproxy.cfg')
@@ -229,8 +228,6 @@ def test_loadbalancer_install_package(
         {'organization-id': loadbalancer_setup['module_org'].id}
     )
     assert rhel_contenthost.hostname in [host['name'] for host in hosts]
-
-    result = rhel_contenthost.execute('rpm -qa | grep katello-ca-consumer')
 
     # Find which capsule the host is registered to since it's RoundRobin
     # The following also asserts the above result

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1186,9 +1186,8 @@ class TestEndToEnd:
         # step 2.18: Provision a client
         # TODO this isn't provisioning through satellite as intended
         # Note it wasn't well before the change that added this todo
-        rhel_contenthost.install_katello_ca(target_sat)
         # Register client with foreman server using act keys
-        rhel_contenthost.register_contenthost(org.label, activation_key_name)
+        rhel_contenthost.register(org, None, activation_key.name, target_sat)
         assert rhel_contenthost.subscribed
         # Install rpm on client
         package_name = 'katello-agent'

--- a/tests/foreman/endtoend/test_cli_endtoend.py
+++ b/tests/foreman/endtoend/test_cli_endtoend.py
@@ -317,9 +317,8 @@ def test_positive_cli_end_to_end(function_sca_manifest, target_sat, rhel_content
     # step 2.18: Provision a client
     # TODO this isn't provisioning through satellite as intended
     # Note it wasn't well before the change that added this todo
-    rhel_contenthost.install_katello_ca(target_sat)
     # Register client with foreman server using act keys
-    rhel_contenthost.register_contenthost(org['label'], activation_key['name'])
+    rhel_contenthost.register(org, None, activation_key['name'], target_sat)
     assert rhel_contenthost.subscribed
     # Install rpm on client
     package_name = 'katello-agent'

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -19,7 +19,6 @@ import yaml
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_SETTINGS_YML, PRDS, REPOS, REPOSET
-from robottelo.hosts import setup_capsule
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
 
@@ -213,7 +212,6 @@ def test_capsule_installation(sat_non_default_install, cap_ready_rhel, setting_u
     :customerscenario: true
     """
     # Get Capsule repofile, and enable and download satellite-capsule
-    org = sat_non_default_install.api.Organization().create()
     cap_ready_rhel.register_to_cdn()
     cap_ready_rhel.download_repofile(
         product='capsule',
@@ -230,7 +228,7 @@ def test_capsule_installation(sat_non_default_install, cap_ready_rhel, setting_u
     cap_ready_rhel.install_satellite_or_capsule_package()
     assert cap_ready_rhel.execute('rpm -q foreman-proxy-fapolicyd').status == 0
     # Setup Capsule
-    setup_capsule(sat_non_default_install, cap_ready_rhel, org)
+    cap_ready_rhel.capsule_setup(sat_host=sat_non_default_install)
     assert sat_non_default_install.api.Capsule().search(
         query={'search': f'name={cap_ready_rhel.hostname}'}
     )[0]

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -152,8 +152,7 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
             query={'search': f'name={product.name}'}
         )[0]
         ak.add_subscriptions(data={'subscription_id': subscription.id})
-        rhel_contenthost.install_katello_ca(target_sat)
-        rhel_contenthost.register_contenthost(org=function_org.name, activation_key=ak.name)
+        rhel_contenthost.register(function_org, None, ak.name, target_sat)
         rhel_contenthost.add_rex_key(satellite=target_sat)
         rhel_contenthost.install_katello_host_tools()
         rhel_contenthost.execute('subscription-manager refresh')

--- a/tests/upgrades/test_hostcontent.py
+++ b/tests/upgrades/test_hostcontent.py
@@ -55,8 +55,12 @@ class TestScenarioDBseedHostMismatch:
 
         :customerscenario: true
         """
-        rhel7_contenthost_module.install_katello_ca(target_sat)
-        rhel7_contenthost_module.register_contenthost(org=function_org.label, lce='Library')
+        ak = self.api.ActivationKey(
+            content_view=function_org.default_content_view.id,
+            environment=function_org.library.id,
+            organization=function_org,
+        ).create()
+        rhel7_contenthost_module.register(function_org, function_location, ak.name, target_sat)
 
         assert rhel7_contenthost_module.nailgun_host.organization.id == function_org.id
 

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -152,8 +152,7 @@ class TestScenarioCustomRepoCheck:
                 query={'search': f'name={product.name}'}
             )[0]
             ak.add_subscriptions(data={'subscription_id': subscription.id})
-        sat_upgrade_chost.install_katello_ca(target_sat)
-        sat_upgrade_chost.register_contenthost(org.label, ak.name)
+        sat_upgrade_chost.register(org, None, ak.name, target_sat)
         sat_upgrade_chost.execute('subscription-manager repos --enable=*;yum clean all')
         result = sat_upgrade_chost.execute(f'yum install -y {FAKE_0_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -132,8 +132,7 @@ class TestSubscriptionAutoAttach:
             auto_attach=False,
         ).create()
         activation_key.add_subscriptions(data={'subscription_id': subscription[0].id})
-        rhel_contenthost.install_katello_ca(target_sat)
-        rhel_contenthost.register_contenthost(org=org.name, activation_key=activation_key.name)
+        rhel_contenthost.register(org, None, activation_key.name, target_sat)
         assert rhel_contenthost.subscribed
         save_test_data(
             {


### PR DESCRIPTION
### Problem Statement
We will be removing the katello-ca-consumer RPM by default. Our automation should only use global registration anyway.

### Solution
Swap uses of `install_katello_ca` and `register_contenthost` to the `register` method which uses global registration. Use default location and a basic activation key where needed.

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py::test_positive_install_package_via_rex tests/foreman/cli/test_http_proxy.py::test_insights_client_registration_with_http_proxy tests/foreman/ui/test_subscription.py::test_positive_view_vdc_subscription_products tests/foreman/destructive/test_host.py::TestHostCockpit::test_positive_cockpit tests/foreman/cli/test_contentview.py::TestContentView::test_positive_sub_host_with_restricted_user_perm_at_custom_loc tests/foreman/cli/test_contentview.py::TestContentView::test_positive_sub_host_with_restricted_user_perm_at_default_loc tests/foreman/destructive/test_capsule_loadbalancer.py::test_loadbalancer_install_package tests/foreman/endtoend/test_api_endtoend.py::TestEndToEnd::test_positive_end_to_end tests/foreman/endtoend/test_cli_endtoend.py::test_positive_cli_end_to_end tests/foreman/installer/test_installer.py::test_capsule_installation 
