### PR TITLE
Fix remove satellite packages test

### DIFF
--- a/tests/foreman/destructive/test_packages.py
+++ b/tests/foreman/destructive/test_packages.py
@@ -84,5 +84,5 @@ def test_negative_remove_satellite_packages(sat_maintain):
         assert result.status != 0
         assert (
             'Problem: The operation would result in removing the following protected packages: satellite'
-            in str(result.stderr[1])
+            in str(result.stderr)
         )


### PR DESCRIPTION
Failing in automation because it's grabbing the second character in the stderr. Not sure why this changed but this should do the trick.

trigger: test-robottelo
pytest: tests/foreman/destructive/test_packages.py::test_negative_remove_satellite_packages[capsule]

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->