### PR TITLE
[6.15.z] Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI

### DIFF
--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -29,6 +29,8 @@ from robottelo.utils.virtwho import (
     get_configure_id,
     get_configure_option,
     get_virtwho_status,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
     restart_virtwho_service,
     update_configure_option,
 )
@@ -51,23 +53,22 @@ class TestVirtwhoConfigforEsx:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_debug_option(

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -18,6 +18,8 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
 )
 
 
@@ -36,23 +38,22 @@ class TestVirtwhoConfigforHyperv:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -18,6 +18,8 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
 )
 
 
@@ -36,23 +38,22 @@ class TestVirtwhoConfigforKubevirt:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -18,6 +18,8 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
 )
 
 
@@ -36,23 +38,22 @@ class TestVirtwhoConfigforLibvirt:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -22,6 +22,8 @@ from robottelo.utils.virtwho import (
     get_configure_id,
     get_configure_option,
     get_hypervisor_ahv_mapping,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
 )
 
 
@@ -40,23 +42,22 @@ class TestVirtwhoConfigforNutanix:
             2. No error msg in /var/log/rhsm/rhsm.log
             3. Report is sent to satellite
             4. Subscription Status set to 'Simple Content Access', and generate mapping in Legacy UI
-            5. Config can be deleted
+            5. Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+            6. Config can be deleted
 
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15288

Test Cases: PASS

```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_hyperv_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 17 deselected, 11 warnings in 461.63s (0:07:41)
=============================================================================
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 17 deselected, 11 warnings in 461.63s (0:07:41)
2024-06-04 03:49:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_libvirt_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 2 deselected, 11 warnings in 534.11s (0:08:54)
2024-06-04 04:15:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_nutanix_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 6 deselected, 11 warnings in 530.85s (0:08:50)
2024-06-04 04:27:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_kubevirt_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 2 deselected, 11 warnings in 634.01s (0:10:34)
2024-06-04 04:39:01 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.

```