### PR TITLE
[6.14.z]-Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI #15401

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -530,3 +530,51 @@ def get_configure_command_option(deploy_type, args, org=DEFAULT_ORG):
     if deploy_type == 'name':
         return f"hammer -u {username} -p {password} virt-who-config deploy --name {args['name']} --organization '{org}' "
     return None
+
+
+def hypervisor_guest_mapping_check_legacy_ui(
+    org_session, form_data_ui, default_location, hypervisor_name, guest_name
+):
+    # Check virt-who config status
+    assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+    # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
+    org_session.location.select(default_location.name)
+    hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
+    hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
+    assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
+    assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
+    # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
+    virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
+    assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
+    assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+
+
+def hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name):
+    hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
+    hypervisorhost_new_overview = org_session.host_new.get_details(
+        hypervisor_display_name, 'overview'
+    )
+    assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '2'
+    # hypervisor host Check details
+    hypervisorhost_new_detais = org_session.host_new.get_details(hypervisor_display_name, 'details')
+    assert (
+        hypervisorhost_new_detais['details']['system_properties']['sys_properties']['virtual_host']
+        == hypervisor_display_name
+    )
+    assert (
+        hypervisorhost_new_detais['details']['system_properties']['sys_properties']['name']
+        == guest_name
+    )
+    # Check guest overview
+    guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
+    assert guest_new_overview['overview']['host_status']['status_success'] == '2'
+    # Check guest details
+    virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
+    assert (
+        virtualguest_new_detais['details']['system_properties']['sys_properties']['virtual_host']
+        == hypervisor_display_name
+    )
+    assert (
+        virtualguest_new_detais['details']['system_properties']['sys_properties']['name']
+        == guest_name
+    )

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -29,6 +29,8 @@ from robottelo.utils.virtwho import (
     get_configure_id,
     get_configure_option,
     get_virtwho_status,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
     restart_virtwho_service,
     update_configure_option,
 )
@@ -56,18 +58,16 @@ class TestVirtwhoConfigforEsx:
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_debug_option(

--- a/tests/foreman/virtwho/ui/test_hyperv_sca.py
+++ b/tests/foreman/virtwho/ui/test_hyperv_sca.py
@@ -18,6 +18,8 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
 )
 
 
@@ -41,18 +43,16 @@ class TestVirtwhoConfigforHyperv:
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_kubevirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_kubevirt_sca.py
@@ -18,6 +18,8 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
 )
 
 
@@ -41,18 +43,16 @@ class TestVirtwhoConfigforKubevirt:
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_libvirt_sca.py
+++ b/tests/foreman/virtwho/ui/test_libvirt_sca.py
@@ -18,6 +18,8 @@ from robottelo.utils.virtwho import (
     get_configure_file,
     get_configure_id,
     get_configure_option,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
 )
 
 
@@ -41,18 +43,16 @@ class TestVirtwhoConfigforLibvirt:
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(

--- a/tests/foreman/virtwho/ui/test_nutanix_sca.py
+++ b/tests/foreman/virtwho/ui/test_nutanix_sca.py
@@ -22,6 +22,8 @@ from robottelo.utils.virtwho import (
     get_configure_id,
     get_configure_option,
     get_hypervisor_ahv_mapping,
+    hypervisor_guest_mapping_check_legacy_ui,
+    hypervisor_guest_mapping_newcontent_ui,
 )
 
 
@@ -45,18 +47,16 @@ class TestVirtwhoConfigforNutanix:
         :CaseImportance: High
         """
         hypervisor_name, guest_name = deploy_type_ui
-        # Check virt-wh oconfig status
+        # Check virt-who config status
         assert org_session.virtwho_configure.search(form_data_ui['name'])[0]['Status'] == 'ok'
+
         # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        org_session.location.select(default_location.name)
-        hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
-        hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-        assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
-        assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
-        # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
-        virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-        assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
-        assert virtualguest['details']['virtual_host'] == hypervisor_display_name
+        hypervisor_guest_mapping_check_legacy_ui(
+            org_session, form_data_ui, default_location, hypervisor_name, guest_name
+        )
+
+        # Check Hypervisor host subscription status and hypervisor host and virtual guest mapping in UI
+        hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_name)
 
     @pytest.mark.tier2
     def test_positive_hypervisor_id_option(


### PR DESCRIPTION
fixed the cherrypick failed https://github.com/SatelliteQE/robottelo/issues/15401

Test Cases : PASS
```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_hyperv_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 17 deselected, 11 warnings in 461.63s (0:07:41)
=============================================================================
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_esx_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 17 deselected, 11 warnings in 461.63s (0:07:41)
2024-06-04 03:49:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_libvirt_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 2 deselected, 11 warnings in 534.11s (0:08:54)
2024-06-04 04:15:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_nutanix_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 6 deselected, 11 warnings in 530.85s (0:08:50)
2024-06-04 04:27:38 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_kubevirt_sca.py  -k test_positive_deploy_configure_by_id_script[id] --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 2 deselected, 11 warnings in 634.01s (0:10:34)
2024-06-04 04:39:01 - robottelo - WARNING - missing grid_url or session_id. unable to clean video files.


```