### PR TITLE
[6.15.z] Fix validation: validate IPv6 proxy URL only when IS_IPV6 is set to True

### DIFF
--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -36,7 +36,12 @@ VALIDATORS = dict(
         Validator('server.ssh_password', default=None),
         Validator('server.verify_ca', default=False),
         Validator('server.is_ipv6', is_type_of=bool, default=False),
-        Validator('server.http_proxy_ipv6_url', is_type_of=str, default=None),
+        # validate http_proxy_ipv6_url only if is_ipv6 is True
+        Validator(
+            'server.http_proxy_ipv6_url',
+            is_type_of=str,
+            when=Validator('server.is_ipv6', eq=True),
+        ),
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15413

### Problem Statement
Using latest robottelo, including the IPv6-related changes, I am running into
```
dynaconf.validator.ValidationError: server.http_proxy_ipv6_url must is_type_of <class 'str'> but it is None in env main
```

This error is caused by a validator that enforces string type, but it is setting the value to None itself. :meow_shrugs:
```
Validator('server.http_proxy_ipv6_url', is_type_of=str, default=None),
```

### Solution
Utilize conditional validation - validate the IPv6 proxy URL setting only when IS_IPV6 is set to True
https://www.dynaconf.com/validation/#conditional-validation

### Related Issues
This should be fixed before #15289 goes in

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->