### PR TITLE
[6.13.z] Fix validation: validate IPv6 proxy URL only when IS_IPV6 is set to True

### DIFF
--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -35,6 +35,13 @@ VALIDATORS = dict(
         Validator('server.ssh_username', default='root'),
         Validator('server.ssh_password', default=None),
         Validator('server.verify_ca', default=False),
+        Validator('server.is_ipv6', is_type_of=bool, default=False),
+        # validate http_proxy_ipv6_url only if is_ipv6 is True
+        Validator(
+            'server.http_proxy_ipv6_url',
+            is_type_of=str,
+            when=Validator('server.is_ipv6', eq=True),
+        ),
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),


### PR DESCRIPTION
this PR backports #15413