### PR TITLE
CC-client registration with capsule based on setting value

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2741,7 +2741,8 @@ def test_positive_host_registration_with_capsule(
 
     # Check output for "HTTP error code 422: Validation failed: Content view environment content facets is invalid"
     assert 'Validation failed' in result.stderr, f'Error is: {result.stderr}'
-    assert 'HTTP error code 422' in result.stderr, f'Error is: {result.stderr}'
+    if '7' not in rhel_contenthost.deploy_rhel_version:
+        assert 'HTTP error code 422' in result.stderr, f'Error is: {result.stderr}'
 
     # Re-register client with settings "validate_host_lce_content_source_coherence" is set to No
     target_sat.cli.Settings.set(
@@ -2758,4 +2759,5 @@ def test_positive_host_registration_with_capsule(
 
     # Check output there should not any error like "Validation failed" or "HTTP error code 422"
     assert 'Validation failed' not in result.stderr, f'Error is: {result.stderr}'
-    assert 'HTTP error code 422' not in result.stderr, f'Error is: {result.stderr}'
+    if '7' not in rhel_contenthost.deploy_rhel_version:
+        assert 'HTTP error code 422' not in result.stderr, f'Error is: {result.stderr}'

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2684,12 +2684,11 @@ def test_positive_create_host_with_lifecycle_environment_name(
     found_host = any(new_host.name in i.values() for i in hosts)
     assert found_host, 'Assertion failed: host not found'
 
-
 @pytest.mark.rhel_ver_match('^6')
 @pytest.mark.parametrize(
     'setting_update', ['validate_host_lce_content_source_coherence'], indirect=False
 )
-def test_positive_host_registration_with_capsule(
+def test_host_registration_with_capsule_using_content_coherence(
     target_sat,
     setting_update,
     function_sca_manifest_org,
@@ -2741,7 +2740,7 @@ def test_positive_host_registration_with_capsule(
 
     # Check output for "HTTP error code 422: Validation failed: Content view environment content facets is invalid"
     assert 'Validation failed' in result.stderr, f'Error is: {result.stderr}'
-    if '7' not in rhel_contenthost.deploy_rhel_version:
+    if not rhel_contenthost.os_version.major == 7:
         assert 'HTTP error code 422' in result.stderr, f'Error is: {result.stderr}'
 
     # Re-register client with settings "validate_host_lce_content_source_coherence" is set to No
@@ -2759,5 +2758,5 @@ def test_positive_host_registration_with_capsule(
 
     # Check output there should not any error like "Validation failed" or "HTTP error code 422"
     assert 'Validation failed' not in result.stderr, f'Error is: {result.stderr}'
-    if '7' not in rhel_contenthost.deploy_rhel_version:
+    if not rhel_contenthost.os_version.major == 7:
         assert 'HTTP error code 422' not in result.stderr, f'Error is: {result.stderr}'

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2734,8 +2734,8 @@ def test_positive_host_registration_with_capsule(
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # Check output for "HTTP error code 422: Validation failed: Content view environment content facets is invalid"
-    assert "Validation failed" in str(result.stderr[1]), f"Error is: {result.stderr}"
-    assert "HTTP error code 422" in str(result.stderr[1]), f"Error is: {result.stderr}"
+    assert 'Validation failed' in result.stderr, f'Error is: {result.stderr}'
+    assert 'HTTP error code 422' in result.stderr, f'Error is: {result.stderr}'
     rhel_contenthost.unregister()
 
     # Re-register client with settings "validate_host_lce_content_source_coherence" is set to No
@@ -2748,6 +2748,6 @@ def test_positive_host_registration_with_capsule(
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # Check output there should not any error like "Validation failed" or "HTTP error code 422"
-    assert "Validation failed" not in str(result.stderr[1]), f"Error is: {result.stderr}"
-    assert "HTTP error code 422" not in str(result.stderr[1]), f"Error is: {result.stderr}"
+    assert 'Validation failed' not in result.stderr, f'Error is: {result.stderr}'
+    assert 'HTTP error code 422' not in result.stderr, f'Error is: {result.stderr}'
     rhel_contenthost.unregister()


### PR DESCRIPTION
### Problem Statement
[CC SAT-22048](https://issues.redhat.com/browse/SAT-22048)
Registration of the client system with Capsule is successful with the below error message.
`HTTP error code 422: Validation failed: Content view environment content facets is invalid`

### Solution
This PR tests both the scenarios when settings `"validate_host_lce_content_source_coherence" is set to Yes/No`

### Related Issues
N/A

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k 'test_positive_host_registration_with_capsule'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->