### PR TITLE
Add multi-cv enable helper and fixture

### DIFF
--- a/pytest_fixtures/component/contentview.py
+++ b/pytest_fixtures/component/contentview.py
@@ -68,3 +68,11 @@ def module_cv_repo(module_org, module_repository, module_lce, module_target_sat)
     content_view = content_view.read()
     content_view.version[0].promote(data={'environment_ids': module_lce.id, 'force': False})
     return content_view
+
+
+@pytest.fixture(scope='session')
+def session_multicv_sat(session_satellite_host):
+    """Satellite with multi-CV enabled"""
+    session_satellite_host.enable_multicv_setting()
+    session_satellite_host.update_setting('allow_multiple_content_views', 'True')
+    return session_satellite_host

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -39,6 +39,18 @@ class EnablePluginsSatellite:
         assert 'Success!' in result.stdout
         return self
 
+    def enable_multicv_setting(self):
+        cfg_file = 'upstream_only_settings.rb'
+        cfg_path = self.execute(f'find /usr/share/gems/gems/ -name {cfg_file}').stdout.strip()
+        assert cfg_file in cfg_path, 'Config file not found'
+        self.execute(
+            f'sed -i "s/allow_multiple_content_views/#allow_multiple_content_views/g" {cfg_path}'
+        )
+        self.cli.Service.restart()
+        assert len(
+            self.api.Setting().search(query={'search': f'name={"allow_multiple_content_views"}'})
+        ), 'Multi-CV enablement failed'
+
 
 class ContentInfo:
     """Miscellaneous content helper methods"""

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -40,6 +40,7 @@ class EnablePluginsSatellite:
         return self
 
     def enable_multicv_setting(self):
+        """Makes multi-CV setting available in the downstream Satellite"""
         cfg_file = 'upstream_only_settings.rb'
         cfg_path = self.execute(f'find /usr/share/gems/gems/ -name {cfg_file}').stdout.strip()
         assert cfg_file in cfg_path, 'Config file not found'


### PR DESCRIPTION
### Problem Statement
There is a "Multi-CV" feature partially implemented into 6.16 as a tech preview and we need to deliver related coverage for the implemented bits. For this reason we need to enable the feature in a non-standard way until it's released.


### Solution
This PR just adds a helper to enable related setting (to be used with any Satellite) and a session-scoped fixture which would provide Satellite with that setting enabled and set.
