### PR TITLE
[6.15.z] Increase search rate for syncplan polling

### DIFF
--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -230,7 +230,7 @@ def test_positive_synchronize_custom_product_custom_cron_real_time(session, modu
             f' and organization_id = {module_org.id}'
             f' and resource_id = {repo.id}'
             ' and resource_type = Katello::Repository',
-            search_rate=10,
+            search_rate=15,
             max_tries=20,
         )
         validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])
@@ -295,7 +295,7 @@ def test_positive_synchronize_custom_product_custom_cron_past_sync_date(
             f' and organization_id = {module_org.id}'
             f' and resource_id = {repo.id}'
             ' and resource_type = Katello::Repository',
-            search_rate=10,
+            search_rate=15,
             max_tries=20,
         )
         validate_repo_content(repo, ['erratum', 'rpm', 'package_group'])


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15452

### Problem Statement

The timediff was increased to 5 minutes.
On 'fast' UIs this can lead to poll timeouts.

### Solution

Increasing the search rate to 15 fixes this:
15 * 20 / 60 = 5


### Related Issues
https://github.com/SatelliteQE/robottelo/pull/15172

### Relevant tests
tests/foreman/ui/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_real_time
tests/foreman/ui/test_syncplan.py::test_positive_synchronize_custom_product_custom_cron_past_sync_date


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->