### PR TITLE
[6.15.z] Add support for overriding jira issues to comment on.

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -7,22 +7,13 @@ import pytest
 from robottelo.config import settings
 from robottelo.hosts import get_sat_rhel_version
 from robottelo.logging import collection_logger as logger
+from robottelo.utils import parse_comma_separated_list
 from robottelo.utils.issue_handlers.jira import are_any_jira_open
 
 FMT_XUNIT_TIME = '%Y-%m-%dT%H:%M:%S'
 IMPORTANCE_LEVELS = []
 selected = []
 deselected = []
-
-
-def parse_comma_separated_list(option_value):
-    if isinstance(option_value, str):
-        if option_value.lower() == 'true':
-            return True
-        if option_value.lower() == 'false':
-            return False
-        return [item.strip() for item in option_value.split(',')]
-    return None
 
 
 def pytest_addoption(parser):

--- a/robottelo/utils/__init__.py
+++ b/robottelo/utils/__init__.py
@@ -55,3 +55,14 @@ def slugify_component(string, keep_hyphens=True):
     if not keep_hyphens:
         string = string.replace('-', '_')
     return re.sub("[^-_a-zA-Z0-9]", "", string.lower())
+
+
+def parse_comma_separated_list(option_value):
+    """Mainly used for parsing pytest option values."""
+    if isinstance(option_value, str):
+        if option_value.lower() == 'true':
+            return True
+        if option_value.lower() == 'false':
+            return False
+        return [item.strip() for item in option_value.split(',')]
+    return None

--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -292,7 +292,7 @@ def add_comment_on_jira(
         [list of dicts] -- [{'id':..., 'status':..., 'resolution': ...}]
     """
     # Raise a warning if any of the following option is not set. Note: It's a xor condition.
-    if settings.jira.enable_comment != pytest.jira_comments:
+    if settings.jira.enable_comment != bool(pytest.jira_comments):
         logger.warning(
             'Jira comments are currently disabled for this run. '
             'To enable it, please set "enable_comment" to "true" in "config/jira.yaml '


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15427

### Problem Statement
- We have a `--jira-comments` pytest option that we use to add comments to Jira issues for tests marked with `Verifies` or `BlockedBy` doc fields. Atm, this can't be overridden, and one has to mark each test with these fields. 
- The JPL team has requested this enhancement so that we can use it in standalone PRT runs.

### Solution
- Update logic for `--jira-comments` to override issues to comment test results on. 

### Usage 
- `pytest tests/foreman/api/test_ping.py --jira-comments` Comment test results on issues mentioned in `Verifies` and `BlockedBy` doc fields(No change, this is primary use case).
- `pytest tests/foreman/api/test_ping.py --jira-comments 'SAT-24796,SAT-25230'` Comment test results on `SAT-24796` and `SAT-25230`.

### Related Issues
- SAT-25884
- https://github.com/SatelliteQE/robottelo/pull/15104 

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->