### PR TITLE
Installer Assertions in test context rather than in helper

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -353,7 +353,6 @@ def installer_satellite(request):
     :params request: A pytest request object and this fixture is looking for
         broker object of class satellite
     """
-    sat_version = settings.server.version.release
     if 'sanity' in request.config.option.markexpr:
         sat = Satellite(settings.server.hostname)
     else:
@@ -367,8 +366,6 @@ def installer_satellite(request):
         snap=settings.server.version.snap,
     )
     sat.install_satellite_or_capsule_package()
-    installed_version = sat.execute('rpm --query satellite').stdout
-    assert sat_version in installed_version
     # Install Satellite
     sat.execute(
         InstallerCommand(


### PR DESCRIPTION
### Problem Statement
The assertion failure in the installer test helper blocks the installation of the satellite itself in the installer test and mainly in sanity testing making all the other tests unable to reach out to the satellite as it's not installed.

### Solution
- Removing the assertion from helper function as its already under the context of the test assertions.
- Now we don't unblock installer execution and the rest of the tests should validate the build from sanity execution.

### Related Issues
Refer build sanity failure of 6.15.2 and the related thread in the automation slack channel.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->