### PR TITLE
[6.14.z] Installer Assertions in test context rather than in helper (#15461)

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -333,7 +333,6 @@ def installer_satellite(request):
     :params request: A pytest request object and this fixture is looking for
         broker object of class satellite
     """
-    sat_version = settings.server.version.release
     if 'sanity' in request.config.option.markexpr:
         sat = Satellite(settings.server.hostname)
     else:
@@ -346,9 +345,7 @@ def installer_satellite(request):
         release=settings.server.version.release,
         snap=settings.server.version.snap,
     )
-    sat.execute('dnf -y module enable satellite:el8 && dnf -y install satellite')
-    installed_version = sat.execute('rpm --query satellite').stdout
-    assert sat_version in installed_version
+    sat.install_satellite_or_capsule_package()
     # Install Satellite
     sat.execute(
         InstallerCommand(

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1765,6 +1765,25 @@ class Capsule(ContentHost, CapsuleMixins):
         self._cli._configured = True
         return self._cli
 
+    def enable_satellite_or_capsule_module_for_rhel8(self):
+        """Enable Satellite/Capsule module for RHEL8.
+        Note: Make sure required repos are enabled before using this.
+        """
+        if self.os_version.major == 8:
+            assert (
+                self.execute(
+                    f'dnf -y module enable {self.product_rpm_name}:el{self.os_version.major}'
+                ).status
+                == 0
+            )
+
+    def install_satellite_or_capsule_package(self):
+        """Install Satellite/Capsule package. Also handles module enablement for RHEL8.
+        Note: Make sure required repos are enabled before using this.
+        """
+        self.enable_satellite_or_capsule_module_for_rhel8()
+        assert self.execute(f'dnf -y install {self.product_rpm_name}').status == 0
+
 
 class Satellite(Capsule, SatelliteMixins):
     product_rpm_name = 'satellite'


### PR DESCRIPTION
### Problem Statement
Failed AutoCherrypick of #15461 

### Solution
Closes #15462 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->