### PR TITLE
Fix umask setting fixture

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -211,14 +211,12 @@ def function_synced_AC_repo(target_sat, function_org, function_product):
 
 @pytest.fixture
 def function_restrictive_umask(target_sat):
-    original_mask = target_sat.execute('umask').stdout.strip()[-3:]
     new_mask = '077'
-    target_sat.execute(f'sed -i "s/umask {original_mask}/umask {new_mask}/g" /etc/bashrc')
-    assert (
-        new_mask in target_sat.execute('umask').stdout
-    ), f'Failed to set umask from {original_mask} to {new_mask}'
+    mask_override = f'umask {new_mask} # {gen_string("alpha")}'
+    target_sat.execute(f'echo "{mask_override}" >> /etc/bashrc')
+    assert new_mask in target_sat.execute('umask').stdout, f'Failed to set new umask to {new_mask}'
     yield
-    target_sat.execute(f'sed -i "s/umask {new_mask}/umask {original_mask}/g" /etc/bashrc')
+    target_sat.execute(f'sed -i "/{mask_override}/d" /etc/bashrc')
 
 
 @pytest.mark.run_in_one_thread


### PR DESCRIPTION
### Problem Statement
Default umask settings defined in `/etc/bashrc` (used for non-login shell, which is what robottelo use for `target_sat.execute(...)`) is different in RHEL8 and RHEL9.

In RHEL8 we can find:
```
    if [ $UID -gt 199 ] && [ "`/usr/bin/id -gn`" = "`/usr/bin/id -un`" ]; then
       umask 002
    else
       umask 022
    fi
```
while in RHEL9:
```
    # Set default umask for non-login shell only if it is set to 0
    [ `umask` -eq 0 ] && umask 022
```
That `[ ]` test is important there, since it prevents umask setting if it's non-zero already (yes it is) and thus blocks the fixture to set it more restrictively with `sed` (as used before) when running against RHEL9 based Satellite.


### Solution
Override it no matter what previous code is and return it back on tear-down.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_satellitesync.py -k with_permissions