### PR TITLE
[6.13.z] Replace skip_if with BlockedBy for migrated BZ

### DIFF
--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -1584,7 +1584,6 @@ class TestContentViewSync:
         assert len(importing_cvv) == 1
 
     @pytest.mark.tier3
-    @pytest.mark.skip_if_open("BZ:2262379")
     def test_postive_export_import_ansible_collection_repo(
         self,
         target_sat,
@@ -1605,6 +1604,10 @@ class TestContentViewSync:
 
         :expectedresults:
             1. Imported library should have the ansible collection present in the imported product.
+
+        :BlockedBy: SAT-23051
+
+        :Verifies: SAT-23051
         """
         # setup ansible_collection product and repo
         export_product = target_sat.cli_factory.make_product({'organization-id': function_org.id})


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15479

### Problem Statement
BZ was CLOSED MIGRATED (to Jira) without the actual fix. We need to keep skipping based on Jira status instead.


### Solution
This PR.
