### PR TITLE
[6.15.z] [CC Automation] Test for hammer host list command with cv and lce fields 

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -287,6 +287,54 @@ def test_positive_search_all_field_sets(module_target_sat):
         assert field in list(output_field_sets[host_idx].keys())
 
 
+@pytest.mark.rhel_ver_match('8')
+@pytest.mark.cli_host_subscription
+@pytest.mark.tier3
+def test_positive_host_list_with_cv_and_lce(
+    target_sat,
+    rhel_contenthost,
+    function_ak_with_cv,
+    function_promoted_cv,
+    function_org,
+    function_lce,
+):
+    """The output from hammer host list correctly includes both Content View and
+    Lifecycle Environment fields. Specifying these fields explicitly in the command
+    also yields the correct output.
+
+    :id: 3ece2a52-0b91-453e-a4ea-c0376d79fd2d
+
+    :steps:
+        1. Register a Host
+        2. Run the hammer host list command
+        3. Verify information is correct and that both CV and LCE are in the output
+        4. Run the hammer list command with CV and LCE fields specified
+        5. Verify information is correct and that both CV and LCE are in the output
+
+    :expectedresults: Both cases should return CV and LCE in the output
+
+    :Verifies: SAT-23576, SAT-22677
+
+    :customerscenario: true
+    """
+    # register client
+    result = rhel_contenthost.register(function_org, None, function_ak_with_cv.name, target_sat)
+    assert result.status == 0
+    assert rhel_contenthost.subscribed
+    # list host command without specifying cv or lce
+    host_list = target_sat.cli.Host.list(output_format='json')
+    host = next(i for i in host_list if i['name'] == rhel_contenthost.hostname)
+    assert host['content-view'] == function_promoted_cv.name
+    assert host['lifecycle-environment'] == function_lce.name
+    # list host command with specifying cv and lce
+    host_list_fields = target_sat.cli.Host.list(
+        options={'fields': ['Name', 'Content view', 'Lifecycle environment']}, output_format='json'
+    )
+    host = next(i for i in host_list_fields if i['name'] == rhel_contenthost.hostname)
+    assert host['content-view'] == function_promoted_cv.name
+    assert host['lifecycle-environment'] == function_lce.name
+
+
 # -------------------------- CREATE SCENARIOS -------------------------
 @pytest.mark.e2e
 @pytest.mark.cli_host_create


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15484

This test covers two customer cases: SAT-23576 and SAT-22677.

The first part checks that CV and LCE are returned when using the hammer host list command. The second part checks that users can specify the CV and LCE fields explicitly on the hammer host list command.
