### PR TITLE
Add a scap remediation feature test

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -277,9 +277,9 @@ def test_positive_oscap_remediation(
     """Run an OSCAP scan and remediate through WebUI
 
     :id: 55b919ef-432f-4186-b22a-01bb8ce39b3f
-    
+
     :Verifies: SAT-23240
-    
+
     :setup: scap content, scap policy, host group associated with the policy
 
     :steps:

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -277,7 +277,7 @@ def test_positive_oscap_remediation(
     """Run an OSCAP scan and remediate through WebUI
 
     :id: 55b919ef-432f-4186-b22a-01bb8ce39b3f
-
+:Verifies: SAT-23240
     :setup: scap content, scap policy, host group associated with the policy
 
     :steps:

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -277,7 +277,9 @@ def test_positive_oscap_remediation(
     """Run an OSCAP scan and remediate through WebUI
 
     :id: 55b919ef-432f-4186-b22a-01bb8ce39b3f
-:Verifies: SAT-23240
+    
+    :Verifies: SAT-23240
+    
     :setup: scap content, scap policy, host group associated with the policy
 
     :steps:

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -329,7 +329,7 @@ def test_positive_oscap_remediation(
         # Remediate
         with target_sat.ui_session() as session:
             assert (
-                vm.execute("rpm -q aide").status != 0
+                vm.execute('rpm -q aide').status != 0
             ), 'This test expects package "aide" NOT to be installed but it is. If this fails, it\'s probably a matter of wrong assumption of this test, not a product bug.'
             title = 'xccdf_org.ssgproject.content_rule_package_aide_installed'
             session.organization.select(module_org.name)


### PR DESCRIPTION
### Problem Statement
https://issues.redhat.com/browse/SAT-23240

### Solution
Add an entity in airgun and test through WebUI (this is a WebUI-only feature). Create a host, run a scan, remediate an issue.

Requires https://github.com/SatelliteQE/airgun/pull/1441
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->