### PR TITLE
check subscription header and message on manage manifest page

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -618,6 +618,7 @@ def test_positive_check_manifest_validity_notification(
         target_sat.upload_manifest(function_org.id, function_sca_manifest.content)
 
         # Initially 'Manifest expiring soon' message not found
+        assert not session.subscription.is_subscription_manifest_header_message_display()
         # then update the 'Expire soon days' value from settings > Content
         # value should be greater than 365 to get expected output message
         setting_update.value = 366


### PR DESCRIPTION
### Problem Statement
- Considering newly implemented **6.16.0 feature/RFE** "Notification when manifest is going to expire" and reported bug "Manifest expiration date (year) shows older for all manifest" it is neccessary to check manifest expiration message is disappearing when manifest upload very first time into organization.
- It was left behind because related [airgun PR](https://github.com/SatelliteQE/airgun/pull/1385) merged very early phase of testing.
- During phoenix qe team discussion, we have decided to open new robottelo PR and airgun PR to validate manifest expiration header message functionality before updating settings value (expire_soon_days)

### Solution
Simple assertion is required in existing test case

### Related Issues
No

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_check_manifest_validity_notification'
airgun:
```
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_check_manifest_validity_notification'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->