### PR TITLE
[6.14.z] Adapt to changes in broker stderr handling

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -246,7 +246,7 @@ class SystemInfo:
             f"ss -tnaH sport ge {port_pool[0]} sport le {port_pool[-1]}"
             " | awk '{n=split($4, p, \":\"); print p[n]}' | sort -u"
         )
-        if ss_cmd.stderr[1]:
+        if ss_cmd.stderr:
             raise CapsuleTunnelError(
                 f'Failed to create ssh tunnel: Error getting port status: {ss_cmd.stderr}'
             )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15442

### Problem Statement

Since version 0.5 broker accesses the list and
decodes the stderr

https://github.com/SatelliteQE/broker/blob/master/broker/helpers.py#L512

### Solution

Simple code adaptation

### Related Issues

https://github.com/SatelliteQE/robottelo/pull/15394

### relevant tests

tests/foreman/api/test_location.py::TestLocation::test_positive_create_update_and_remove_capsule
tests/foreman/cli/test_organization.py::test_positive_add_and_remove_capsules

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->