### PR TITLE
[6.15.z] Modify test_positive_assign_ansible_role_variable_on_host to verify roles

### DIFF
--- a/robottelo/cli/ansible.py
+++ b/robottelo/cli/ansible.py
@@ -54,6 +54,12 @@ class Ansible(Base):
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
+    def variables_delete(cls, options=None):
+        """Delete ansible variables"""
+        cls.command_sub = 'variables delete'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
     def variables_info(cls, options=None):
         """Information about ansible variables"""
         cls.command_sub = 'variables info'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15477

### Problem Statement
As per suggestions provided in component audit-2, we need to add a test to verify roles assignment with variables on host, and also cover multiple roles with webUI

### Solution
We had this test to verify roles assignment with variables on host, just modifying the existing test to cover multiple roles, and verifying roles assigned on details page with few more changes 