### PR TITLE
[6.15.z] Add tests for Facts component

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -12,8 +12,10 @@
 
 """
 
-from fauxfactory import gen_string
+from fauxfactory import gen_ipaddr, gen_mac, gen_string
 import pytest
+
+from robottelo.config import settings
 
 pytestmark = [pytest.mark.tier1]
 
@@ -61,3 +63,55 @@ def test_negative_list_by_name(module_target_sat):
     assert (
         module_target_sat.cli.Fact().list(options={'search': f'fact={gen_string("alpha")}'}) == []
     )
+
+
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_positive_update_client_facts_verify_imported_values(
+    module_target_sat, rhel_contenthost, module_org, module_location, module_activation_key
+):
+    """Update client facts and verify the facts are updated in Satellite.
+
+    :id: ea94ccb7-a125-4be3-932a-bfcb035d3604
+
+    :steps:
+        1. Add a new interface to the host.
+        2. Register the host to Satellite
+        3. Update the facts in Satellite.
+        4. Read all the facts for the host.
+        5. Verify that all the facts(new and existing) are updated in Satellite.
+
+    :expectedresults: Facts are successfully updated in the Satellite.
+    """
+    mac_address = gen_mac(multicast=False)
+    ip = gen_ipaddr()
+    # Create eth1 interface on the host
+    add_interface_command = (
+        f'ip link add eth1 type dummy && ifconfig eth1 hw ether {mac_address} &&'
+        f'ip addr add {ip}/24 brd + dev eth1 label eth1:1 &&'
+        'ip link set dev eth1 up'
+    )
+    assert rhel_contenthost.execute(add_interface_command).status == 0
+    result = rhel_contenthost.register(
+        target=module_target_sat,
+        org=module_org,
+        loc=module_location,
+        activation_keys=[module_activation_key.name],
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+    rhel_contenthost.execute('subscription-manager facts --update')
+    facts = module_target_sat.cli.Fact().list(
+        options={'search': f'host={rhel_contenthost.hostname}'}, output_format='json'
+    )
+    facts_dict = {fact['fact']: fact['value'] for fact in facts}
+    expected_values = {
+        'net::interface::eth1::ipv4_address': ip,
+        'net::interface::eth1::mac_address': mac_address.lower(),
+        'network::fqdn': rhel_contenthost.hostname,
+        'lscpu::architecture': rhel_contenthost.arch,
+    }
+    for fact, expected_value in expected_values.items():
+        actual_value = facts_dict.get(fact)
+        assert (
+            actual_value == expected_value
+        ), f'Assertion failed: {fact} (expected: {expected_value}, actual: {actual_value})'

--- a/tests/foreman/ui/test_fact.py
+++ b/tests/foreman/ui/test_fact.py
@@ -1,0 +1,60 @@
+"""Test class for Fact  UI
+
+:Requirement: Fact
+
+:CaseAutomation: Automated
+
+:CaseComponent: Fact
+
+:Team: Rocket
+
+:CaseImportance: High
+
+"""
+
+import pytest
+
+from robottelo.config import settings
+
+
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_positive_upload_host_facts(
+    module_target_sat,
+    rhel_contenthost,
+    module_sca_manifest_org,
+    module_location,
+    module_activation_key,
+):
+    """Verify Facts option is available on the Host UI and it is successfully updated in Satellite after registration
+
+    :id: f32093d2-4088-4025-9623-adb3141bd770
+
+    :steps:
+        1. Register host to Satellite.
+        2. Navigate to the Host page and click on kebab.
+        3. Verify that the facts option is available and is updated on Satellite.
+
+    :expectedresults: Facts option is available on the Host UI and all the facts of the host are updated in Satellite.
+
+    :BZ: 2001552
+
+    :customerscenario: true
+    """
+    with module_target_sat.ui_session() as session:
+        session.organization.select(module_sca_manifest_org.name)
+        session.location.select(module_location.name)
+        cmd = session.host.get_register_command(
+            {
+                'general.activation_keys': module_activation_key.name,
+                'general.insecure': True,
+            }
+        )
+        result = rhel_contenthost.execute(cmd)
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+        rhel_contenthost.execute('subscription-manager facts --update')
+        host_facts = session.host_new.get_host_facts(rhel_contenthost.hostname, fact='network')
+        assert host_facts is not None
+        assert rhel_contenthost.hostname in [
+            var['Value'] for var in host_facts if var['Name'] == 'networkfqdn'
+        ]


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/14933

### Problem Statement
Missing following test scenarios for Facts:

- Update facts for client (CLI and UI)


### Solution
Added test scenario for update client facts

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->