### PR TITLE
Remove Data telemetry option from convert2rhel tests

### DIFF
--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -249,6 +249,8 @@ def test_convert2rhel_oracle_with_pre_conversion_template_check(
         and subscription status
 
     :parametrized: yes
+
+    Verifies: SAT-24654
     """
     major = version.split('.')[0]
     assert oracle.execute('yum -y update').status == 0
@@ -316,6 +318,12 @@ def test_convert2rhel_oracle_with_pre_conversion_template_check(
         or host_content['operatingsystem_name'].startswith(f'RedHat {version}')
         or host_content['operatingsystem_name'].startswith(f'RHEL {version}')
     )
+    # Wait for the host to be rebooted and SSH daemon to be started.
+    oracle.wait_for_connection()
+
+    # Verify convert2rhel facts are generated, and verify fact conversions.success is true
+    assert oracle.execute('test -f /etc/rhsm/facts/convert2rhel.facts').status == 0
+    assert host_content['facts']['conversions::success'] == 'true'
 
 
 @pytest.mark.e2e
@@ -336,6 +344,8 @@ def test_convert2rhel_centos_with_pre_conversion_template_check(
         and subscription status
 
     :parametrized: yes
+
+    Verifies: SAT-24654
     """
     host_content = module_target_sat.api.Host(id=centos.hostname).read_json()
     major = version.split('.')[0]
@@ -397,3 +407,10 @@ def test_convert2rhel_centos_with_pre_conversion_template_check(
         or host_content['operatingsystem_name'].startswith(f'RedHat {version}')
         or host_content['operatingsystem_name'].startswith(f'RHEL {version}')
     )
+
+    # Wait for the host to be rebooted and SSH daemon to be started.
+    centos.wait_for_connection()
+
+    # Verify convert2rhel facts are generated, and verify fact conversions.success is true
+    assert centos.execute('test -f /etc/rhsm/facts/convert2rhel.facts').status == 0
+    assert host_content['facts']['conversions::success'] == 'true'

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -272,9 +272,6 @@ def test_convert2rhel_oracle_with_pre_conversion_template_check(
         synchronous=False,
         data={
             'job_template_id': template_id,
-            'inputs': {
-                'Data telemetry': 'yes',
-            },
             'targeting_type': 'static_query',
             'search_query': f'name = {oracle.hostname}',
         },
@@ -299,7 +296,6 @@ def test_convert2rhel_oracle_with_pre_conversion_template_check(
             'inputs': {
                 'Activation Key': activation_key_rhel.id,
                 'Restart': 'yes',
-                'Data telemetry': 'yes',
             },
             'targeting_type': 'static_query',
             'search_query': f'name = {oracle.hostname}',
@@ -355,9 +351,6 @@ def test_convert2rhel_centos_with_pre_conversion_template_check(
         synchronous=False,
         data={
             'job_template_id': template_id,
-            'inputs': {
-                'Data telemetry': 'yes',
-            },
             'targeting_type': 'static_query',
             'search_query': f'name = {centos.hostname}',
         },
@@ -382,7 +375,6 @@ def test_convert2rhel_centos_with_pre_conversion_template_check(
             'inputs': {
                 'Activation Key': activation_key_rhel.id,
                 'Restart': 'yes',
-                'Data telemetry': 'yes',
             },
             'targeting_type': 'static_query',
             'search_query': f'name = {centos.hostname}',


### PR DESCRIPTION
### Problem Statement
Data telemetry input/option is removed from convert2rhel job templates in https://github.com/theforeman/foreman_ansible/pull/710

### Solution
Remove Data telemetry input/option from convert2rhel tests

Also, Adding check to vefify convert2rhel conversion facts to cover SAT-24654
