### PR TITLE
Set customer scenario to True

### DIFF
--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -38,6 +38,10 @@ class TestAnsibleCfgMgmt:
 
         :id: 90acea37-4c2f-42e5-92a6-0c88148f4fb6
 
+        :customerscenario: true
+
+        :Verifies: SAT-19619
+
         :steps:
             1. Import Ansible roles if none have been imported yet.
             2. Create an Anible variable, populating all fields on the creation form.


### PR DESCRIPTION
### Problem Statement
The test is a customer BZ but we missed to add the docstring.

### Solution
Added the docstring for customer scenario and BZ.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->