### PR TITLE
[6.15.z] Updates for upgrades component eval

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -76,12 +76,14 @@ def test_positive_end_to_end(
         2. For each repo set global default HTTP proxy and sync it.
         3. For each repo set specific HTTP proxy and sync it.
         4. For each repo set no HTTP proxy and sync it.
-        5. Discover yum type repo through HTTP proxy.
-        6. Discover docker type repo through HTTP proxy.
+        5. Refresh manifest through HTTP proxy.
+        6. Discover yum type repo through HTTP proxy.
+        7. Discover docker type repo through HTTP proxy.
 
     :expectedresults:
         1. All repository updates and syncs succeed.
-        2. Yum and docker repos can be discovered through HTTP proxy.
+        2. Manifest can be refreshed through HTTP proxy.
+        3. Yum and docker repos can be discovered through HTTP proxy.
 
     :BZ: 2011303, 2042473, 2046337
 
@@ -113,6 +115,12 @@ def test_positive_end_to_end(
             assert (
                 'success' in module_target_sat.api.Repository(id=repo.id).sync()['result']
             ), f'Sync of a {repo.content_type} repo with {policy} HTTP policy failed'
+
+    # Refresh manifest through HTTP proxy
+    res = module_target_sat.api.Subscription().refresh_manifest(
+        data={'organization_id': module_org.id}
+    )
+    assert 'success' in res['result']
 
     # Discover yum type repo through HTTP proxy
     repo_name = 'fakerepo01'

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -1029,26 +1029,6 @@ def test_positive_delete_products(module_org, target_sat):
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_delete_synced_product(module_org, module_target_sat):
-    """Create a sync plan with one synced product and delete it.
-
-    :id: 195d8fec-1fa0-42ab-84a5-32dd81a285ca
-
-    :expectedresults: A sync plan is created with one synced product and
-        sync plan can be deleted.
-    """
-    sync_plan = module_target_sat.api.SyncPlan(organization=module_org).create()
-    product = module_target_sat.api.Product(organization=module_org).create()
-    module_target_sat.api.Repository(product=product).create()
-    sync_plan.add_products(data={'product_ids': [product.id]})
-    product.sync()
-    sync_plan.delete()
-    with pytest.raises(HTTPError):
-        sync_plan.read()
-
-
-@pytest.mark.tier2
-@pytest.mark.upgrade
 def test_positive_delete_synced_product_custom_cron(module_org, module_target_sat):
     """Create a sync plan with custom cron with one synced
     product and delete it.

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -872,26 +872,29 @@ def test_positive_delete_subscription(function_entitlement_manifest_org, module_
 
 @pytest.mark.tier3
 @pytest.mark.upgrade
-def test_positive_update_aks_to_chost(module_org, module_location, rhel7_contenthost, target_sat):
-    """Check if multiple Activation keys can be attached to a
-    Content host
+@pytest.mark.rhel_ver_match('[^6]')
+def test_positive_update_aks_to_chost(
+    module_org, module_location, rhel_contenthost, module_target_sat
+):
+    """Check if multiple Activation keys can be attached to a Content host
 
     :id: 24fddd9c-03ae-41a7-8649-72296cbbafdf
 
-    :expectedresults: Multiple Activation keys are attached to a Content
-        host
+    :expectedresults: Multiple Activation keys are attached to a Content host
 
     :parametrized: yes
     """
-    env = target_sat.cli_factory.make_lifecycle_environment({'organization-id': module_org.id})
-    new_cv = target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
-    target_sat.cli.ContentView.publish({'id': new_cv['id']})
-    cvv = target_sat.cli.ContentView.info({'id': new_cv['id']})['versions'][0]
-    target_sat.cli.ContentView.version_promote(
+    env = module_target_sat.cli_factory.make_lifecycle_environment(
+        {'organization-id': module_org.id}
+    )
+    new_cv = module_target_sat.cli_factory.make_content_view({'organization-id': module_org.id})
+    module_target_sat.cli.ContentView.publish({'id': new_cv['id']})
+    cvv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})['versions'][0]
+    module_target_sat.cli.ContentView.version_promote(
         {'id': cvv['id'], 'to-lifecycle-environment-id': env['id']}
     )
     new_aks = [
-        target_sat.cli_factory.make_activation_key(
+        module_target_sat.cli_factory.make_activation_key(
             {
                 'lifecycle-environment-id': env['id'],
                 'content-view': new_cv['name'],
@@ -900,14 +903,14 @@ def test_positive_update_aks_to_chost(module_org, module_location, rhel7_content
         )
         for _ in range(2)
     ]
-    for i in range(2):
-        rhel7_contenthost.register(
+    for ak in new_aks:
+        rhel_contenthost.register(
             org=module_org,
             loc=module_location,
-            activation_keys=new_aks[i]['name'],
-            target=target_sat,
+            activation_keys=ak['name'],
+            target=module_target_sat,
         )
-        assert rhel7_contenthost.subscribed
+        assert rhel_contenthost.subscribed
 
 
 @pytest.mark.stubbed

--- a/tests/foreman/cli/test_contentaccess.py
+++ b/tests/foreman/cli/test_contentaccess.py
@@ -177,17 +177,15 @@ def test_positive_erratum_installable(vm, module_target_sat):
 
 
 @pytest.mark.tier2
-def test_negative_rct_not_shows_golden_ticket_enabled(
+def test_negative_rct_not_shows_sca_enabled(
     target_sat, function_org, function_entitlement_manifest
 ):
-    """Assert restricted manifest has no Golden Ticket enabled .
+    """Assert restricted (entitlement) manifest does not show SCA enabled.
 
     :id: 754c1be7-468e-4795-bcf9-258a38f3418b
 
     :steps:
-
         1. Run `rct cat-manifest /tmp/restricted_manifest.zip`.
-
 
     :expectedresults:
         1. Assert `Content Access Mode: Simple Content Access` is not present.
@@ -205,13 +203,12 @@ def test_negative_rct_not_shows_golden_ticket_enabled(
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_rct_shows_golden_ticket_enabled(module_sca_manifest, target_sat):
-    """Assert unrestricted manifest has Golden Ticket enabled .
+def test_positive_rct_shows_sca_enabled(module_sca_manifest, module_target_sat):
+    """Assert unrestricted (SCA) manifest shows SCA enabled.
 
     :id: 0c6e2f88-1a86-4417-9248-d7bd20584197
 
     :steps:
-
         1. Run `rct cat-manifest /tmp/unrestricted_manifest.zip`.
 
     :expectedresults:
@@ -220,8 +217,8 @@ def test_positive_rct_shows_golden_ticket_enabled(module_sca_manifest, target_sa
     :CaseImportance: Medium
     """
     with module_sca_manifest as manifest:
-        target_sat.put(f'{manifest.path}', f'{manifest.name}')
-    result = target_sat.execute(f'rct cat-manifest {module_sca_manifest.name}')
+        module_target_sat.put(f'{manifest.path}', f'{manifest.name}')
+    result = module_target_sat.execute(f'rct cat-manifest {module_sca_manifest.name}')
     assert result.status == 0
     assert 'Content Access Mode: Simple Content Access' in result.stdout
 

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -148,23 +148,31 @@ class TestRepository:
         assert repo.get('upstream-repository-name') == repo_options['docker-upstream-name']
 
     @pytest.mark.tier1
+    @pytest.mark.upgrade
     @pytest.mark.parametrize(
         'repo_options',
         **parametrized([{'name': name} for name in valid_data_list().values()]),
         indirect=True,
     )
-    def test_positive_create_with_name(self, repo_options, repo):
-        """Check if repository can be created with random names
+    def test_positive_create_delete_with_name(self, repo_options, repo, module_target_sat):
+        """Check if repository can be created with random names and deleted by the name.
 
         :id: 604dea2c-d512-4a27-bfc1-24c9655b6ea9
 
         :parametrized: yes
 
-        :expectedresults: Repository is created and has random name
+        :expectedresults:
+            1. Repository is created and has random name.
+            2. Repository can be deleted using that name.
 
         :CaseImportance: Critical
         """
-        assert repo.get('name') == repo_options['name']
+        assert repo['name'] == repo_options['name']
+        module_target_sat.cli.Repository.delete(
+            {'name': repo['name'], 'product-id': repo_options['product-id']}
+        )
+        with pytest.raises(CLIReturnCodeError):
+            module_target_sat.cli.Repository.info({'id': repo['id']})
 
     @pytest.mark.tier1
     @pytest.mark.parametrize(
@@ -1324,30 +1332,6 @@ class TestRepository:
         """
         with pytest.raises(CLIFactoryError):
             module_target_sat.cli_factory.make_repository(repo_options)
-
-    @pytest.mark.tier1
-    @pytest.mark.upgrade
-    @pytest.mark.parametrize(
-        'repo_options',
-        **parametrized([{'name': name} for name in valid_data_list().values()]),
-        indirect=True,
-    )
-    def test_positive_delete_by_name(self, repo_options, repo, module_target_sat):
-        """Check if repository can be created and deleted
-
-        :id: 463980a4-dbcf-4178-83a6-1863cf59909a
-
-        :parametrized: yes
-
-        :expectedresults: Repository is created and then deleted
-
-        :CaseImportance: Critical
-        """
-        module_target_sat.cli.Repository.delete(
-            {'name': repo['name'], 'product-id': repo_options['product-id']}
-        )
-        with pytest.raises(CLIReturnCodeError):
-            module_target_sat.cli.Repository.info({'id': repo['id']})
 
     @pytest.mark.tier1
     @pytest.mark.parametrize(

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -298,48 +298,6 @@ def test_positive_discover_repo_via_new_product(session, module_org):
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
-@pytest.mark.usefixtures('allow_repo_discovery')
-def test_positive_discover_module_stream_repo_via_existing_product(
-    session, module_org, module_target_sat
-):
-    """Create repository with module streams via repo-discovery under an existing product.
-
-    :id: e7b9e2c4-7ecd-4cde-8f74-961fbac8919c
-
-    :BZ: 1676642
-
-    :steps:
-        1. Create a product.
-        2. From Content > Products, click on the Repo Discovery button.
-        3. Enter a url containing a yum repository with module streams, e.g.,
-           settings.repos.module_stream_1.url.
-        4. Click the Discover button.
-
-    :expectedresults: Repositories are discovered.
-    """
-    repo_name = gen_string('alpha')
-    repo_label = gen_string('alpha')
-    product = module_target_sat.api.Product(organization=module_org).create()
-    with session:
-        session.organization.select(org_name=module_org.name)
-        session.product.discover_repo(
-            {
-                'repo_type': 'Yum Repositories',
-                'url': settings.repos.module_stream_1.url,
-                'discovered_repos.repos': "/",
-                'create_repo.product_type': 'Existing Product',
-                'create_repo.product_content.product_name': product.name,
-                'create_repo.create_repos_table': [
-                    {"Repository Name": repo_name, "Repository Label": repo_label}
-                ],
-            }
-        )
-        assert repo_name in session.repository.search(product.name, repo_name)[0]['Name']
-
-
-@pytest.mark.tier2
-@pytest.mark.upgrade
-@pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_sync_custom_repo_yum(session, module_org, module_target_sat):
     """Create Custom yum repos and sync it via the repos page.
 

--- a/tests/upgrades/test_syncplan.py
+++ b/tests/upgrades/test_syncplan.py
@@ -51,52 +51,6 @@ class TestSyncPlan:
         product = product.read()
         assert product.sync_plan.id == sync_plan.id
 
-    @pytest.mark.pre_upgrade
-    def test_pre_disabled_sync_plan_logic(self, request, target_sat):
-        """Pre-upgrade scenario that creates a sync plan with both disabled and
-        enabled recurring logic.
-
-        :id: preupgrade-c75bd43d-d868-461a-9fc3-a1fc7dccc77a
-
-        :steps:
-            1. Create Product
-            2. Create Sync Plan
-            3. Assign sync plan to product
-            4. Disable the sync plan's recurring logic
-            5. Re enable the sync plan
-
-        :expectedresults: Sync plan is created and assigned to a product. The associated recurring
-            logic is cancelled and then the plan is re-enabled so that it gets a new recurring logic.
-
-        :BZ: 1887511
-
-        :customerscenario: true
-        """
-        org = target_sat.api.Organization(name=f'{request.node.name}_org').create()
-        sync_plan = target_sat.api.SyncPlan(
-            organization=org, name=f'{request.node.name}_syncplan', interval="weekly"
-        ).create()
-        product = target_sat.api.Product(
-            organization=org, name=f'{request.node.name}_prod'
-        ).create()
-        target_sat.api.Repository(product=product, name=f'{request.node.name}_repos').create()
-        sync_plan.add_products(data={'product_ids': [product.id]})
-        product.sync()
-        product = product.read()
-        assert product.sync_plan.id == sync_plan.id
-        # Note the recurring logic ID for later assert a new one was created
-        old_id = sync_plan.foreman_tasks_recurring_logic.id
-        # Cancel the recurring logic
-        target_sat.api.RecurringLogic(id=old_id).read()
-        target_sat.api.RecurringLogic(id=old_id).cancel()
-        # Re-enable the sync plan (it will get a new recurring logic)
-        sync_plan.enabled = True
-        sync_plan.update(['enabled'])
-        sync_plan = sync_plan.read()
-        assert sync_plan.enabled
-        # Assert a new recurring logic was assigned
-        assert sync_plan.foreman_tasks_recurring_logic.id != old_id
-
     @pytest.mark.post_upgrade(depend_on=test_pre_sync_plan_migration)
     def test_post_sync_plan_migration(self, request, dependent_scenario_name, target_sat):
         """After upgrade, Sync interval update should work on existing sync plan(created before
@@ -137,40 +91,3 @@ class TestSyncPlan:
                 sync_plan.update(['interval'])
             sync_plan = sync_plan.read()
             assert sync_plan.interval == SYNC_INTERVAL[sync_interval]
-
-    @pytest.mark.post_upgrade(depend_on=test_pre_disabled_sync_plan_logic)
-    def test_post_disabled_sync_plan_logic(self, request, dependent_scenario_name, target_sat):
-        """Upgrade proceedes without RecurringLogicCancelledExceptionerror.
-        After upgrade, Sync interval should still be enabled.
-
-        :id: postupgrade-c75bd43d-d868-461a-9fc3-a1fc7dccc77a
-
-        :steps:
-            1. Verify sync plan exists and works.
-            2. Check the all available sync_interval type update with pre-created sync_plan.
-
-        :expectedresults: Update proceedes without any errors. After upgrade, the sync plan
-            should remain the same with all entities
-
-        :BZ: 1887511
-
-        :customerscenario: true
-
-        """
-        pre_test_name = dependent_scenario_name
-        org = target_sat.api.Organization().search(query={'search': f'name="{pre_test_name}_org"'})[
-            0
-        ]
-        request.addfinalizer(org.delete)
-        product = target_sat.api.Product(organization=org.id).search(
-            query={'search': f'name="{pre_test_name}_prod"'}
-        )[0]
-        request.addfinalizer(product.delete)
-        sync_plan = target_sat.api.SyncPlan(organization=org.id).search(
-            query={'search': f'name="{pre_test_name}_syncplan"'}
-        )[0]
-        request.addfinalizer(sync_plan.delete)
-        assert product.sync_plan.id == sync_plan.id
-        assert sync_plan.name == f'{pre_test_name}_syncplan'
-        assert sync_plan.interval == 'weekly'
-        assert sync_plan.enabled


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15415

### Problem Statement
During component eval some changes were proposed by PX/SD/QE for upgrade tests (scenario and all-tiers).


### Solution
This PR just implements a few of them, mostly related to @SatelliteQE/phoenix 
For reference check the _Component feedback sheet - Team Platform_ g-sheet

Split into a bunch of tiny commits, one per each g-sheet line 


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_activationkey.py -k test_positive_update_aks_to_chost