### PR TITLE
[6.14.z] [CV Eval] Test Coverage for ccv interaction with incremental update

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3051,6 +3051,93 @@ class TestContentView:
         assert '1.1' in [cvv_['version'] for cvv_ in content_view['versions']]
 
     @pytest.mark.tier2
+    def test_ccv_inc_update_autopublish(self, module_org, module_product, module_target_sat):
+        """A CCV containing a CV that has an incremental update applied should auto-publish
+
+        :Verifies: SATQE-17141
+
+        :id: b36e3fd1-7dfe-4c71-aaed-deafb10f577e
+
+        :customerscenario: true
+
+        :expectedresults: CCV is auto-published when composite CV recieves an inc update
+
+        :CaseImportance: Medium
+
+        """
+        repo = module_target_sat.cli_factory.make_repository(
+            {
+                'product-id': module_product.id,
+                'content-type': 'yum',
+                'url': settings.repos.yum_1.url,
+            }
+        )
+        module_target_sat.cli.Repository.synchronize({'id': repo['id']})
+        content_view = module_target_sat.cli_factory.make_content_view(
+            {'organization-id': module_org.id, 'repository-ids': repo['id']}
+        )
+        module_target_sat.cli.ContentView.add_repository(
+            {
+                'id': content_view['id'],
+                'organization-id': module_org.id,
+                'repository-id': repo['id'],
+            }
+        )
+        cvf = module_target_sat.cli_factory.make_content_view_filter(
+            {
+                'content-view-id': content_view['id'],
+                'inclusion': 'true',
+                'name': gen_string('alpha'),
+                'type': 'rpm',
+            },
+        )
+        module_target_sat.cli_factory.content_view_filter_rule(
+            {
+                'content-view-filter-id': cvf['filter-id'],
+                'name': FAKE_2_CUSTOM_PACKAGE_NAME,
+                'version': 5.21,
+            }
+        )
+        module_target_sat.cli.ContentView.publish({'id': content_view['id']})
+        content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
+        assert len(content_view['versions']) == 1
+        cv_version = content_view['versions'][0]
+        composite_view = module_target_sat.cli_factory.make_content_view(
+            {'composite': True, 'auto-publish': 'true', 'organization-id': module_org.id}
+        )
+        module_target_sat.cli.ContentView.component_add(
+            {
+                'composite-content-view-id': composite_view['id'],
+                'component-content-view-id': content_view['id'],
+                'latest': True,
+            }
+        )
+        # Check if Composive CV has been published before and after incremental update
+        composite_view = module_target_sat.cli.ContentView.info({'id': composite_view['id']})
+        assert len(composite_view['versions']) == 0
+        module_target_sat.cli.ContentView.version_incremental_update(
+            {
+                'content-view-version-id': cv_version['id'],
+                'errata-ids': settings.repos.yum_1.errata[1],
+            }
+        )
+        task_status = module_target_sat.wait_for_tasks(
+            search_query=(
+                f'Actions::Katello::ContentView::Publish and organization_id = {module_org.id}'
+            ),
+            max_tries=50,
+            search_rate=5,
+        )
+        assert task_status[0].result == 'success'
+        composite_view = module_target_sat.cli.ContentView.info({'id': composite_view['id']})
+        assert len(composite_view['versions']) == 1
+        # Also check that the description of the version contains Auto Publish
+        cvv = module_target_sat.cli.ContentView.version_list(
+            {'content-view-id': composite_view['id']}
+        )
+        assert 'Auto Publish' in cvv[0]['description']
+
+    @pytest.mark.tier2
     def test_version_info_by_lce(self, module_org, module_target_sat):
         """Hammer version info can be passed the lce id/name argument without error
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15525

### Problem Statement
Adds coverage for https://bugzilla.redhat.com/show_bug.cgi?id=1974225 / https://issues.redhat.com/browse/SATQE-17141


### Related Issues
There is one usage of time.sleep(2) - this is to allow the incremental update to propagate, and trigger the CCV publish, but there's probably a better way for this to be done. 

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k 'test_ccv_inc_update_autopublish'
