### PR TITLE
[6.15.z] [CC Automation] Update API test to use refresh-all and add CLI test for bulk actions

### DIFF
--- a/robottelo/cli/acs.py
+++ b/robottelo/cli/acs.py
@@ -10,6 +10,7 @@ Parameters::
 
 Subcommands::
 
+    bulk            Modify alternate content sources in bulk
     create          Create an alternate content source to download content from during repository
                     syncing. Note: alternate content sources are global and affect ALL sync actions
                     on their capsules regardless of organization.
@@ -36,4 +37,30 @@ class ACS(Base):
     def refresh(cls, options=None):
         """Refresh the ACS"""
         cls.command_sub = 'refresh'
+        return cls.execute(cls._construct_command(options))
+
+
+class ACSBulk(Base):
+    """
+    Manipulates Alternate Content Sources in bulk
+    """
+
+    command_base = 'alternate-content-source bulk'
+
+    @classmethod
+    def destroy(cls, options=None):
+        """Destroy the ACS(s)"""
+        cls.command_sub = 'destroy'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def refresh(cls, options=None):
+        """Refresh the ACS(s)"""
+        cls.command_sub = 'refresh'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def refresh_all(cls, options=None):
+        """Refresh all ACSs"""
+        cls.command_sub = 'refresh-all'
         return cls.execute(cls._construct_command(options))

--- a/tests/foreman/cli/test_acs.py
+++ b/tests/foreman/cli/test_acs.py
@@ -255,3 +255,52 @@ def test_negative_check_simplified_validations(
     )
     assert f'Upstream username {VAL_MUST_BLANK}' in context.value.message
     assert f'Upstream password {VAL_MUST_BLANK}' in context.value.message
+
+
+def test_bulk_actions(module_target_sat, module_yum_repo):
+    """Perform bulk actions with an ACS through CLI.
+
+    :id: cf798893-cbc3-40c8-aa8a-03a6dedb0828
+
+    :CaseImportance: Medium
+
+    :BZ: 2159967
+
+    :Verifies: SAT-18199
+
+    :steps:
+        1. Create several ACSes.
+        2. Bulk refresh them all by ID
+        3. Bulk refresh them all by refresh-all
+        4. Bulk destroy some of them.
+        5. Cleanup the rest.
+
+    :expectedresults:
+        1. All ACSes can be refreshed via bulk action.
+        2. Only the proper ACSes are deleted on bulk destroy.
+    """
+    acs_ids = []
+    for _ in range(3):
+        # Create
+        acs = module_target_sat.cli.ACS.create(
+            {
+                'name': gen_alphanumeric(),
+                'alternate-content-source-type': 'simplified',
+                'content-type': 'yum',
+                'smart-proxy-ids': module_target_sat.nailgun_capsule.id,
+                'product-ids': [module_yum_repo.product.id],
+            }
+        )
+        acs_ids.append(acs['id'])
+    res = module_target_sat.cli.ACSBulk.refresh({'ids': acs_ids})
+    assert res.strip() == 'Successfully refreshed specified alternate content sources'
+    res = module_target_sat.cli.ACSBulk.refresh_all()
+    assert res.strip() == 'Successfully refreshed all alternate content sources'
+    res = module_target_sat.cli.ACSBulk.destroy({'ids': acs_ids[1:]})
+    assert res.strip() == 'Sucessfully destroyed specified alternate content sources'
+
+    list = [item['id'] for item in module_target_sat.cli.ACS.list()]
+    # assert the first stayed and rest was deleted
+    assert acs_ids[0] in list
+    assert acs_ids[1:] not in list
+    module_target_sat.cli.ACS.delete({'id': acs_ids[0]})


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15451

### Problem Statement
Adds test coverage for: https://bugzilla.redhat.com/show_bug.cgi?id=2126420 / https://issues.redhat.com/browse/SAT-18199

### Related Issues
Also updates robottelo CLI to support `hammer alternate-content-source bulk` actions, and the API test to cover the endpoint added in https://github.com/SatelliteQE/nailgun/pull/1086

PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_acs.py -k 'test_positive_run_bulk_actions'

trigger: test-robottelo
pytest: tests/foreman/cli/test_acs.py -k 'test_bulk_actions'
