### PR TITLE
Retry/Rerun PR Autocherrypick post merge

### DIFF
--- a/.github/workflows/auto_cherry_pick_merged.yaml
+++ b/.github/workflows/auto_cherry_pick_merged.yaml
@@ -1,0 +1,169 @@
+### The workflow for retrying/rerunning the merged PRs AutoCherryPick which was missed/failed due to any circumstances
+name: Retry Merged PRs AutoCherryPick
+
+# Run on workflow dispatch from CI
+on:
+  workflow_dispatch:
+    inputs:
+      parent_pr:
+        type: string
+        description: |
+          An identifier for parent PR to retry it's cherrypick
+          e.g 12314
+
+      branches:
+        type: string
+        description: |
+          Comma separated list of branches where the master PR to be cherrypicked.
+          e.g: 6.15.z, 6.16.z
+
+env:
+  number: ${{ github.event.inputs.parent_pr }}
+  is_dependabot_pr: ''
+
+jobs:
+  get-parentPR-details:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.parentPR.outputs.labels }}
+      state: ${{ steps.parentPR.outputs.state }}
+      base_ref: ${{ steps.parentPR.outputs.base_ref }}
+      assignee: ${{ steps.parentPR.outputs.assignee }}
+      title: ${{ steps.parentPR.outputs.title }}
+      prt_comment: ${{ steps.fc.outputs.comment-body }}
+
+    steps:
+      - name: Find parent PR details
+        id: parentPR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: ${{ env.number }},
+            });
+            core.setOutput('labels', pr.labels);
+            core.setOutput('state', pr.state);
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('assignee', pr.assignee.login);
+            core.setOutput('title', pr.title);
+
+      - name: Find & Save last PRT comment of Parent PR
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ env.number }}
+          body-includes: "trigger: test-robottelo"
+          direction: last
+
+      - name: Print PR details
+        run: |
+          echo "Labels are ${{ steps.parentPR.outputs.labels }}"
+          echo "State is ${{ steps.parentPR.outputs.state }}"
+          echo "Base Ref is ${{ steps.parentPR.outputs.base_ref }}"
+          echo "Assignee is ${{ steps.parentPR.outputs.assignee }}"
+          echo "Title is ${{ steps.parentPR.outputs.title }}"
+
+  arrayconversion:
+    needs: get-parentPR-details
+    if: ${{ needs.get-parentPR-details.outputs.state }} == closed
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.conversion.outputs.branches }}
+    steps:
+      - name: Convert String to List
+        id: conversion
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branches = "${{ github.event.inputs.branches }}";
+            const branchesArray = branches.includes(',') ? branches.split(',').map(item => item.trim()) : [branches.trim()];
+            core.setOutput('branches', JSON.stringify(branchesArray));
+
+
+  run-the-branch-matrix:
+    name: Auto Cherry Pick to labeled branches
+    runs-on: ubuntu-latest
+    needs: [arrayconversion, get-parentPR-details]
+    if: ${{ needs.arrayconversion.outputs.branches != '' }}
+    strategy:
+      matrix:
+        branch: ${{ fromJson(needs.arrayconversion.outputs.branches) }}
+    steps:
+      - name: Tell me the branch name
+        run: |
+          echo "Branch is: ${{ matrix.branch }}"
+
+      # Needed to avoid out-of-memory error
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
+      ## Robottelo Repo Checkout
+      - uses: actions/checkout@v4
+        if: ${{ startsWith(matrix.branch, '6.') && matrix.branch != needs.get-parentPR-details.outputs.base_ref }}
+        with:
+          fetch-depth: 0
+
+      ## Set env var for dependencies label PR
+      - name: Set env var is_dependabot_pr to `dependencies` to set the label
+        if: contains(needs.get-parentPR-details.outputs.labels.*.name, 'dependencies')
+        run: |
+          echo "is_dependabot_pr=dependencies" >> $GITHUB_ENV
+
+      ## CherryPicking and AutoMerging
+      - name: Cherrypicking to zStream branch
+        id: cherrypick
+        if: ${{ startsWith(matrix.branch, '6.') && matrix.branch != needs.get-parentPR-details.outputs.base_ref }}
+        uses: jyejare/github-cherry-pick-action@given_pulls_cp
+        with:
+          token: ${{ secrets.CHERRYPICK_PAT }}
+          pull_number: ${{ env.number }}
+          branch: ${{ matrix.branch }}
+          labels: |
+            Auto_Cherry_Picked
+            ${{ matrix.branch }}
+            No-CherryPick
+            ${{ env.is_dependabot_pr }}
+          assignees: ${{ needs.get-parentPR-details.outputs.assignee }}
+
+      - name: Add Parent PR's PRT comment to Auto_Cherry_Picked PR's
+        id: add-parent-prt-comment
+        if: ${{ always() && needs.get-parentPR-details.outputs.prt_comment != '' && steps.cherrypick.outcome == 'success' }}
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            ${{ needs.get-parentPR-details.outputs.prt_comment }}
+          pr_number: ${{ steps.cherrypick.outputs.number  }}
+          GITHUB_TOKEN: ${{ secrets.CHERRYPICK_PAT }}
+
+      - name: is autoMerging enabled for Auto CherryPicked PRs ?
+        if: ${{ always() && steps.cherrypick.outcome == 'success' && contains(needs.get-parentPR-details.outputs.labels.*.name, 'AutoMerge_Cherry_Picked') }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: ${{ steps.cherrypick.outputs.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["AutoMerge_Cherry_Picked"]
+            })
+
+      - name: Check if cherrypick pr is created
+        id: search_pr
+        if: always()
+        run: |
+          PR_TITLE="[${{ matrix.branch }}] ${{ needs.get-parentPR-details.outputs.title }}"
+          API_URL="https://api.github.com/repos/${{ github.repository }}/pulls?state=open"
+          PR_SEARCH_RESULT=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "$API_URL" | jq --arg title "$PR_TITLE" '.[] | select(.title == $title)')
+          if [ -n "$PR_SEARCH_RESULT" ]; then
+            echo "pr_found=true" >> $GITHUB_OUTPUT
+            echo "PR is Found with title $PR_TITLE"
+          else
+            echo "pr_found=false" >> $GITHUB_OUTPUT
+            echo "PR is not Found with title $PR_TITLE"
+          fi


### PR DESCRIPTION
### Problem Statement
Following are the scenarios when we were not able to rerun the Merged PRs AutoCherrypick:
- Autocherrypicking failed due to OOM/unidentified_abort during ACP GHA run
- Missed adding the version label while autocherrypicking for a specific version
- Retry of AutoCherrypicking of a big PR when failed with conflicts due to others didn't cherry-pick the changes. Now we could ask others to fix their cherrypicks and simply retry the big PRs ACP from this GHA.
- Bulk PRs cherry-pick in about to depreciate branch, but need the branch for immediate testing or for multiple reasons
- etc

### Solution
- We should be able to handle all the above scenarios now with the new standalone `Retry Merged PRs AutoCherryPick`

### Related PR:
- https://github.com/jyejare/github-cherry-pick-action/pull/42 Allows to take PR number as an input for cherry-picking 

### Tip:
Do as many retries as you want and we wont create issues for failures, because you will have one already from original `AutoCherryPick` GHA. Good Luck 👍 

### Example usage:

- Go to `Actions` tab in Robottelo Github Repository
- Select `Retry Merged PRs AutoCherryPick` GHA from left pane.
- Choose to run the workflow from the dropdown in the right corner.
- Select a branch to run the workflow from or where the PR exists for cherry-picking. E.g `master` to cherry-pick from `stream` branch
- Next, enter parent PR number
- Next, comma-separated list of branches to cherry-pick the PR into.

<img width="1320" alt="Screenshot 2024-06-28 at 4 13 35 PM" src="https://github.com/SatelliteQE/robottelo/assets/11752425/3db697f3-f52d-435c-9f8d-fa0c7d2d1c35">

### Testing (Success) :
https://github.com/jyejare/test-acp/actions/runs/9661992453/job/26651194469 
