### PR TITLE
fix parameterisation issue to run test for rhel7/8/9

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2733,8 +2733,7 @@ def test_positive_create_host_with_lifecycle_environment_name(
     assert found_host, 'Assertion failed: host not found'
 
 
-@pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('9')
+@pytest.mark.rhel_ver_match('^6')
 @pytest.mark.parametrize(
     'setting_update', ['validate_host_lce_content_source_coherence'], indirect=False
 )


### PR DESCRIPTION
### Problem Statement
Small mistake in PR https://github.com/SatelliteQE/robottelo/pull/15428 related to paramerization. So test will only run for rhel9. @damoore044 notice this when 6.15.z CP PR ran only one test case.

### Solution
Update marker for test

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k 'test_host_registration_with_capsule_using_content_coherence'

### Note
@damoore044 Please Ack and merge this PR once PRT pass for all 6 rhel versions.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->