### PR TITLE
Update API endpoint for host facts

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -355,7 +355,6 @@ API_PATHS = {
         '/api/usergroups/:usergroup_id/external_usergroups/:id/refresh',
     ),
     'fact_values': ('/api/fact_values',),
-    'host_facts': ('/api/hosts/:host_id/facts',),
     'file_units': ('/katello/api/files', '/katello/api/files/compare', '/katello/api/files/:id'),
     'filters': (
         '/api/filters',


### PR DESCRIPTION
### Problem Statement
API endpoint for facts values : /api/hosts/:host_id/facts was incorrectly placed causing test failure.

### Solution
Updated.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->