### PR TITLE
Update repository tests with supported checksums

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -882,6 +882,7 @@ PULP_ARTIFACT_DIR = '/var/lib/pulp/media/artifact/'
 PULP_EXPORT_DIR = '/var/lib/pulp/exports/'
 PULP_IMPORT_DIR = '/var/lib/pulp/imports/'
 EXPORT_LIBRARY_NAME = 'Export-Library'
+SUPPORTED_REPO_CHECKSUMS = ['sha256', 'sha384', 'sha512']
 
 PUPPET_COMMON_INSTALLER_OPTS = {
     'foreman-proxy-puppetca': 'true',

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -59,9 +59,17 @@ def repo_options_custom_product(request, module_org, module_target_sat):
 
 
 @pytest.fixture
-def repo(repo_options, module_target_sat):
+def repo(repo_options, target_sat):
     """Create a new repository."""
-    return module_target_sat.api.Repository(**repo_options).create()
+    repo = target_sat.api.Repository(**repo_options).create()
+    target_sat.wait_for_tasks(
+        search_query='Actions::Katello::Repository::MetadataGenerate'
+        f' and resource_id = {repo.id}'
+        ' and resource_type = Katello::Repository',
+        max_tries=6,
+        search_rate=10,
+    )
+    return repo
 
 
 class TestRepository:

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -33,6 +33,7 @@ from robottelo.constants import (
     REPO_TYPE,
     RPM_TO_UPLOAD,
     SRPM_TO_UPLOAD,
+    SUPPORTED_REPO_CHECKSUMS,
     DataFile,
 )
 from robottelo.constants.repos import (
@@ -449,7 +450,7 @@ class TestRepository:
                     'content-type': 'yum',
                     'download-policy': 'immediate',
                 }
-                for checksum_type in ('sha1', 'sha256')
+                for checksum_type in SUPPORTED_REPO_CHECKSUMS
             ]
         ),
         indirect=True,
@@ -1282,7 +1283,7 @@ class TestRepository:
         **parametrized([{'content-type': 'yum', 'download-policy': 'immediate'}]),
         indirect=True,
     )
-    @pytest.mark.parametrize('checksum_type', ['sha1', 'sha256'])
+    @pytest.mark.parametrize('checksum_type', SUPPORTED_REPO_CHECKSUMS)
     def test_positive_update_checksum_type(
         self, repo_options, repo, checksum_type, module_target_sat
     ):
@@ -1312,7 +1313,7 @@ class TestRepository:
                     'checksum-type': checksum_type,
                     'download-policy': 'on_demand',
                 }
-                for checksum_type in ('sha1', 'sha256')
+                for checksum_type in SUPPORTED_REPO_CHECKSUMS
             ]
         ),
         indirect=True,
@@ -2097,7 +2098,7 @@ class TestRepository:
 #                     'publish-via-http': 'false',
 #                     'url': FEDORA_OSTREE_REPO,
 #                 }
-#                 for checksum_type in ('sha1', 'sha256')
+#                 for checksum_type in SUPPORTED_REPO_CHECKSUMS
 #             ]
 #         ),
 #         indirect=True,

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -106,7 +106,15 @@ def repo_options(request, module_org, module_product):
 @pytest.fixture
 def repo(repo_options, target_sat):
     """create a new repository."""
-    return target_sat.cli_factory.make_repository(repo_options)
+    repo = target_sat.cli_factory.make_repository(repo_options)
+    target_sat.wait_for_tasks(
+        search_query='Actions::Katello::Repository::MetadataGenerate'
+        f' and resource_id = {repo["id"]}'
+        ' and resource_type = Katello::Repository',
+        max_tries=6,
+        search_rate=10,
+    )
+    return repo
 
 
 @pytest.fixture

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -13,7 +13,7 @@
 """
 
 from datetime import datetime, timedelta
-from random import randint, shuffle
+from random import choice, randint, shuffle
 
 from navmazing import NavigationTriesExceeded
 import pytest
@@ -28,6 +28,7 @@ from robottelo.constants import (
     REPO_TYPE,
     REPOS,
     REPOSET,
+    SUPPORTED_REPO_CHECKSUMS,
     DataFile,
 )
 from robottelo.constants.repos import (
@@ -414,15 +415,15 @@ def test_positive_end_to_end_custom_yum_crud(session, module_org, module_prod, m
     :CaseImportance: High
     """
     repo_name = gen_string('alpha')
-    checksum_type = 'sha256'
+    checksum_type = choice(SUPPORTED_REPO_CHECKSUMS)
     new_repo_name = gen_string('alphanumeric')
-    new_checksum_type = 'sha1'
+    new_checksum_type = choice([cs for cs in SUPPORTED_REPO_CHECKSUMS if cs != checksum_type])
     gpg_key = module_target_sat.api.GPGKey(
-        content=DataFile.VALID_GPG_KEY_FILE.read_bytes(),
+        content=DataFile.VALID_GPG_KEY_FILE.read_text(),
         organization=module_org,
     ).create()
     new_gpg_key = module_target_sat.api.GPGKey(
-        content=DataFile.VALID_GPG_KEY_BETA_FILE.read_bytes(),
+        content=DataFile.VALID_GPG_KEY_BETA_FILE.read_text(),
         organization=module_org,
     ).create()
     with session:


### PR DESCRIPTION
### Problem Statement
SHA1 is no longer supported by Pulp (see https://projects.theforeman.org/issues/37522) which renders even more tests failing in validation for `sha1` in stream builds:
```
WARNING  nailgun.client:client.py:126 Received HTTP 422 response: {"displayMessage":"Validation failed: Checksum type is not included in the list","errors":{"checksum_type":["is not included in the list"]}}
```


### Solution
Define the supported checksums in constants and use them.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py tests/foreman/cli/test_repository.py -k checksum
