### PR TITLE
[6.14.z] Remove non-existing ansible modules

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1897,8 +1897,6 @@ FAM_TEST_PLAYBOOKS = [
     "http_proxy",
     "image",
     "installation_medium",
-    "inventory_plugin_ansible",
-    "inventory_plugin",
     "job_invocation",
     "job_template",
     "katello_hostgroup",


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15549

### Problem Statement
These parametrize into our FAM tests but don't actually exist. Not sure how they got copied over.

### Solution
Remove them since they are not real modules.

### Related Issues


Note: This doesn't really need any testing, it will just no longer parametrize these.