### PR TITLE
[6.14.z] Add setup for luna_hostgroup test playbook

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -42,7 +42,19 @@ def sync_roles(target_sat):
 
 
 @pytest.fixture(scope='module')
-def setup_fam(module_target_sat, module_sca_manifest):
+def install_import_ansible_role(module_target_sat):
+    """Installs and imports the thulium_drake.motd role used in the luna_hostgroup test playbook"""
+    module_target_sat.execute(
+        'ansible-galaxy role install thulium_drake.motd -p /usr/share/ansible/roles'
+    )
+    proxy_id = module_target_sat.nailgun_smart_proxy.id
+    module_target_sat.api.AnsibleRoles().sync(
+        data={'proxy_id': proxy_id, 'role_names': 'thulium_drake.motd'}
+    )
+
+
+@pytest.fixture(scope='module')
+def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_role):
     # Execute AAP WF for FAM setup
     Broker().execute(workflow='fam-test-setup', source_vm=module_target_sat.name)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15550

### Problem Statement
The `luna_hostgroup` test playbook fails in CI because we are missing an ansible role that the hostgroup is trying to use.

### Solution
Install and import the role as part of the setup for the machine.

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/sys/test_fam.py::test_positive_run_modules_and_roles[luna_hostgroup]

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->