### PR TITLE
test ping fix for 6.15

### DIFF
--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -37,7 +37,7 @@ def test_positive_ping(target_sat, switch_user):
     :customerscenario: true
     """
     result = target_sat.execute(f"su - {'postgres' if switch_user else 'root'} -c 'hammer ping'")
-    assert result.stderr[1].decode() == ''
+    assert result.stderr == ''
 
     # Filter lines containing status
     statuses = [line for line in result.stdout.splitlines() if 'status:' in line.lower()]


### PR DESCRIPTION
### Problem Statement
```
tests/foreman/cli/test_ping.py:40: in test_positive_ping
    assert result.stderr[1].decode() == ''
E   IndexError: string index out of range
```
6.15 branch only

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->