### PR TITLE
[6.15.z] Remove fixed BZ from leapp tests and update RHEL8 to 8.10

### DIFF
--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -24,7 +24,7 @@ from robottelo.logging import logger
 synced_repos = pytest.StashKey[dict]
 
 RHEL7_VER = '7.9'
-RHEL8_VER = '8.9'
+RHEL8_VER = '8.10'
 RHEL9_VER = '9.4'
 
 RHEL_REPOS = {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15137

### Problem Statement
BZ for leapp test has been fixed and in review state, so it can be removed.
Also,  RHEL8 is updated to 8.10.

### Solution
Removed the fixed BZ and reverted the target version change.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->