### PR TITLE
[6.13.z] Add test coverage for SAT-24197

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -439,10 +439,8 @@ def test_positive_verify_updated_fdi_image(target_sat):
     target_sat.register_to_cdn()
     target_sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
 
-    if target_sat.os_version.major == 9:
-        version = '8.9' if is_open('SAT-25275') else str(target_sat.os_version)
-    elif target_sat.os_version.major == 8:
-        version = '8.9' if is_open('SAT-24197') else str(target_sat.os_version)
+    # For older zstreams, we still have this version of foreman-discovery-image
+    version = '8.6' 
 
     result = target_sat.execute(f'grep "url=" {discovery_ks_path}')
     assert version in result.stdout

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -13,8 +13,6 @@
 import pytest
 from wait_for import wait_for
 
-from robottelo.utils.issue_handlers import is_open
-
 pytestmark = [pytest.mark.run_in_one_thread]
 
 
@@ -440,7 +438,7 @@ def test_positive_verify_updated_fdi_image(target_sat):
     target_sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
 
     # For older zstreams, we still have this version of foreman-discovery-image
-    version = '8.6' 
+    version = '8.6'
 
     result = target_sat.execute(f'grep "url=" {discovery_ks_path}')
     assert version in result.stdout


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15521

### Problem Statement
Missing  test coverage for SAT-24197, to verify foreman-discovery-image is built on latest up-to-date RHEL

### Solution
Add test coverage for SAT-24197, to verify foreman-discovery-image is built on latest up-to-date RHEL

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->