### PR TITLE
remove summary from module streams details section

### DIFF
--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -58,7 +58,7 @@ def test_positive_module_stream_details_search_in_repo(session, module_org, modu
         assert session.modulestream.search('name = duck')[0]['Name'].startswith('duck')
         walrus_details = session.modulestream.read('walrus', '5.21')
         expected_module_details = {
-            'Summary': 'Walrus 5.21 module',
+            'Summary': '',  # Empty in web ui
             'Context': 'deadbeef',
             'Name': 'walrus',
             'Stream': '5.21',


### PR DESCRIPTION
### Problem Statement
- Test from foreman UI module stream is failing due to change in xpath from `ModuleStreamView` and `ModuleStreamDetailsView` classes when webdriver trying to access header breadcrumb and module stream details tab.
- `Summary` from details tab is getting empty value as there is nothing on UI, also hammer cli doesn't have summary key/value 

```
[root@satellite-ip ~]# hammer module-stream info --id 1
Id:                 1
Module Stream Name: walrus
Stream:             5.21
Uuid:               /pulp/api/v3/content/rpm/modulemds/01908233-44b2-7c7e-aa28-5a950aa04ae0/
Version:            20180704144203
Architecture:       x86_64
Context:            deadbeef
Repositories:       
 1) Id:   7
    Name: mQVxvxizcV
```

### Solution
- Update xpaths from airgun view modulestream classes
- Summary section doesn't give any value so keeping it empty (added screenshot for reference)

### Related Issues
Airgun PR: https://github.com/SatelliteQE/airgun/pull/1456

### PRT Comment
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_modulestreams.py -k test_positive_module_stream_details_search_in_repo
airgun: 1456
```
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_modulestreams.py -k test_positive_module_stream_details_search_in_repo
airgun: 1456
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
![Screenshot from 2024-07-05 18-12-01](https://github.com/SatelliteQE/robottelo/assets/29180264/fa5a359f-30b7-4c20-bb25-3a49dcc6ce70)

