### PR TITLE
Automate a stubbed test to install Ansible collection from galaxy

### DIFF
--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -511,8 +511,12 @@ class TestAnsibleREX:
         result = client.execute(f'systemctl status {service}')
         assert result.status == 0
 
-    @pytest.mark.rhel_ver_list([8])
-    def test_positive_install_ansible_collection(self, rex_contenthost, target_sat):
+    @pytest.mark.upgrade
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+    def test_positive_install_ansible_collection(
+        self, rhel_contenthost, target_sat, module_org, module_ak_with_cv
+    ):
         """Test whether Ansible collection can be installed via Ansible REX
 
         :id: ad25aee5-4ea3-4743-a301-1c6271856f79
@@ -526,9 +530,11 @@ class TestAnsibleREX:
 
         :expectedresults: Ansible collection can be installed on content host via REX.
         """
-        client = rex_contenthost
+        client = rhel_contenthost
         # Enable Ansible repository and Install ansible or ansible-core package
-        client.create_custom_repos(rhel8_aps=settings.repos.rhel8_os.appstream)
+        client.register(module_org, None, module_ak_with_cv.name, target_sat)
+        rhel_repo_urls = getattr(settings.repos, f'rhel{client.os_version.major}_os', None)
+        rhel_contenthost.create_custom_repos(**rhel_repo_urls)
         assert client.execute('dnf -y install ansible-core').status == 0
 
         collection_job = target_sat.cli_factory.job_invocation(

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -809,9 +809,11 @@ class TestAnsibleREX:
         :CaseAutomation: NotAutomated
         """
 
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
-    def test_positive_install_ansible_collection_via_job_invocation(self):
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+    def test_positive_install_ansible_collection(
+        self, rhel_contenthost, target_sat, module_org, module_ak_with_cv
+    ):
         """Verify that Ansible collections can be installed on hosts via job invocations
 
         :id: d4096aef-f6fc-41b6-ae56-d19b1f49cd42
@@ -825,9 +827,38 @@ class TestAnsibleREX:
             6. Click "Submit"
 
         :expectedresults: The Ansible collection is successfully installed on the host
-
-        :CaseAutomation: NotAutomated
         """
+        client = rhel_contenthost
+        # Enable Ansible repository and Install ansible or ansible-core package
+        client.register(module_org, None, module_ak_with_cv.name, target_sat)
+        rhel_repo_urls = getattr(settings.repos, f'rhel{client.os_version.major}_os', None)
+        rhel_contenthost.create_custom_repos(**rhel_repo_urls)
+        assert client.execute('dnf -y install ansible-core').status == 0
+
+        with target_sat.ui_session() as session:
+            session.organization.select(module_org.name)
+            collections_names = 'oasis_roles.system'
+            session.jobinvocation.run(
+                {
+                    'category_and_template.job_category': 'Ansible Galaxy',
+                    'category_and_template.job_template': 'Ansible Collection - Install from Galaxy',
+                    'target_hosts_and_inputs.targetting_type': 'Hosts',
+                    'target_hosts_and_inputs.targets': client.hostname,
+                    'target_hosts_and_inputs.ansible_collections_list': collections_names,
+                    'advanced_fields.ansible_collections_path': '~/',
+                }
+            )
+            job_description = f'Install collections \'{collections_names}\' from galaxy'
+            session.jobinvocation.wait_job_invocation_state(
+                entity_name=job_description, host_name=client.hostname
+            )
+            status = session.jobinvocation.read(
+                entity_name=job_description, host_name=client.hostname
+            )
+            assert status['overview']['hosts_table'][0]['Status'] == 'success'
+
+            collection_path = client.execute('ls ~/ansible_collections').stdout
+            assert 'oasis_roles' in collection_path
 
     @pytest.mark.stubbed
     @pytest.mark.tier2


### PR DESCRIPTION
### Problem Statement
We've stubbed test - test_positive_install_ansible_collection_via_job_invocation, which we need to automate as part of component audit

### Solution
1. Automating the stubbed test to verify install of ansible collection with user inputted collection list and collection path
2. Updating tests to use rhel_contenthost fixtures instead of rex_contenthost
3. Add upgrade marker to existing cli test to install ansible collection

### Related Issues
