### PR TITLE
Fix container tags related failures

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -211,10 +211,10 @@ class TestDockerRepository:
 
         :CaseImportance: Critical
         """
-        assert int(repo['content-counts']['container-image-manifests']) == 0
+        assert int(repo['content-counts']['container-manifests']) == 0
         module_target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
-        assert int(repo['content-counts']['container-image-manifests']) > 0
+        assert int(repo['content-counts']['container-manifests']) > 0
 
     @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(valid_docker_repository_names()))


### PR DESCRIPTION
### Problem Statement
1. Name for container image tags was unified with API some time ago but we haven't update our tests.
2. The `container-image-tags-filter` has been deprecated and is not printed by hammer. It will be replaced win `included-tags` and `excluded-tags`.


### Solution
This PR fixes 1. and skips 2. until the bugjira is closed


### Related issues
https://issues.redhat.com/browse/SAT-26322


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_docker.py::TestDockerRepository::test_positive_sync tests/foreman/cli/test_repository.py::TestRepository::test_positive_synchronize_docker_repo_set_tags_later_additive tests/foreman/cli/test_repository.py::TestRepository::test_positive_synchronize_docker_repo_set_tags_later_content_only tests/foreman/cli/test_repository.py::TestRepository::test_negative_synchronize_docker_repo_with_mix_valid_invalid_tags tests/foreman/cli/test_repository.py::TestRepository::test_negative_synchronize_docker_repo_with_invalid_tags
