### PR TITLE
host info issues fix

### DIFF
--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -157,10 +157,14 @@ class Host(Base):
         return facts
 
     @classmethod
-    def info(cls, options=None):
+    def info(cls, options=None, output_format='json', return_raw_response=None):
         """Show host info"""
         cls.command_sub = 'info'
-        return cls.execute(cls._construct_command(options), output_format='json')
+        return cls.execute(
+            cls._construct_command(options),
+            output_format=output_format,
+            return_raw_response=return_raw_response,
+        )
 
     @classmethod
     def package_install(cls, options):


### PR DESCRIPTION
### Problem Statement
test failures on stream with `TypeError: Host.info() got an unexpected keyword argument 'output_format'`

### Solution
made host info method configurable 


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->