### PR TITLE
removed outdated webhook action from parametrization

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2038,7 +2038,6 @@ WEBHOOK_EVENTS = [
     "actions.remote_execution.run_host_job_ansible_enable_web_console_succeeded",
     "actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_succeeded",
     "actions.remote_execution.run_host_job_ansible_run_host_succeeded",
-    "actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded",
     "actions.remote_execution.run_host_job_ansible_run_playbook_succeeded",
     "actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_succeeded",
     "actions.remote_execution.run_host_job_foreman_openscap_run_scans_succeeded",


### PR DESCRIPTION
### Problem Statement
  "actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded" no longer around in stream 

### Solution
confirmed with dev that this is an intentional change, related to https://github.com/theforeman/foreman_ansible/pull/712


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->