### PR TITLE
[6.15.z] Fix ipv6 proxy url validation

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1646,7 +1646,7 @@ class Capsule(ContentHost, CapsuleMixins):
 
     def enable_ipv6_http_proxy(self):
         """Execute procedures for enabling IPv6 HTTP Proxy on Capsule using SM"""
-        if all([settings.server.is_ipv6, settings.server.http_proxy_ipv6_url]):
+        if settings.server.is_ipv6:
             url = urlparse(settings.server.http_proxy_ipv6_url)
             self.enable_rhsm_proxy(url.hostname, url.port)
 
@@ -1826,7 +1826,7 @@ class Satellite(Capsule, SatelliteMixins):
 
     def enable_ipv6_http_proxy(self):
         """Execute procedures for enabling IPv6 HTTP Proxy"""
-        if not all([settings.server.is_ipv6, settings.server.http_proxy_ipv6_url]):
+        if not settings.server.is_ipv6:
             logger.warning(
                 'The IPv6 HTTP Proxy setting is not enabled. Skipping the IPv6 HTTP Proxy setup.'
             )
@@ -2411,7 +2411,7 @@ class Satellite(Capsule, SatelliteMixins):
     ):
         """Satellite Registration to CDN"""
         # Enabling proxy for IPv6
-        if enable_proxy and all([settings.server.is_ipv6, settings.server.http_proxy_ipv6_url]):
+        if enable_proxy and settings.server.is_ipv6:
             url = urlparse(settings.server.http_proxy_ipv6_url)
             self.enable_rhsm_proxy(url.hostname, url.port)
         return super().register_contenthost(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15594

### Problem Statement
`http_proxy_ipv6_url` is accessed despite ipv6 is set to false on default.

```
pytest_fixtures/core/broker.py:55: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/usr/lib/python3.11/contextlib.py:137: in __enter__
    return next(self.gen)
pytest_fixtures/core/broker.py:37: in _target_sat_imp
    _default_sat.enable_ipv6_http_proxy()
robottelo/hosts.py:1829: in enable_ipv6_http_proxy
    if not all([settings.server.is_ipv6, settings.server.http_proxy_ipv6_url]):
../../../.virtualenvs/robottelo/lib/python3.11/site-packages/dynaconf/utils/boxing.py:18: in evaluate
    value = f(dynabox, item, *args, **kwargs)
../../../.virtualenvs/robottelo/lib/python3.11/site-packages/dynaconf/utils/boxing.py:41: in __getattr__
    return super().__getattr__(n_item, *args, **kwargs)


E     dynaconf.vendor.box.exceptions.BoxKeyError: "'DynaBox' object has no attribute 'http_proxy_ipv6_url'"
```

### Solution

using lazy evaluation the missing setting
will not be queried when ipv6 is disabled (default)

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->