### PR TITLE
Use unique repos for artifacts repair tests

### DIFF
--- a/tests/foreman/cli/test_artifacts.py
+++ b/tests/foreman/cli/test_artifacts.py
@@ -19,10 +19,6 @@ from box import Box
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
-)
 from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
 from robottelo.content_info import get_repo_files_urls_by_url
 
@@ -57,17 +53,18 @@ def module_synced_content(
     [
         {'content_type': 'yum', 'url': settings.repos.yum_0.url},
         {'content_type': 'file', 'url': CUSTOM_FILE_REPO},
+        # The following repos should be unique through robottelo to avoid 'No NEW artifacts found'
         {
             'content_type': 'docker',
-            'docker_upstream_name': CONTAINER_UPSTREAM_NAME,
-            'url': CONTAINER_REGISTRY_HUB,
+            'docker_upstream_name': 'libpod/busybox',
+            'url': 'https://quay.io',
         },
         {
             'content_type': 'ansible_collection',
             'url': ANSIBLE_GALAXY,
             'ansible_collection_requirements': '{collections: [ \
-                    { name: theforeman.foreman, version: "2.1.0" }, \
-                    { name: theforeman.operations, version: "0.1.0"} ]}',
+                    { name: icinga.icinga, version: "0.3.3" }, \
+                    { name: icinga.icinga, version: "0.3.2"} ]}',
         },
     ],
     indirect=True,


### PR DESCRIPTION
### Problem Statement
For the artifacts repair test we need to identify the particular artifacts to repair. For yum and file repos we do so through published files/urls, but for docker and AC repos we do so based on the artifact creation time, which must be newer than the repo sync time. And since all repos from all organizations on a Satellite share the artifacts based on their checksum (their actual content), we need to ensure that the artifacts were synced for the very first time in that test, not earlier by another test.

My previous assumption was that the module-scoped `module_target_sat` would provide a brand new Satellite for the module with no repos previously synced, but the recent failures prove the assumption was wrong and the repos were synced somewhere else before:
```
tests/foreman/cli/test_artifacts.py:131: in test_positive_artifact_repair
    assert len(artifacts) > 0, 'No NEW artifacts found'
E   AssertionError: No NEW artifacts found
```


### Solution
There are three approaches we could take that comes to my mind:
1. Use `@pytest.mark.destructive` to ensure spin up of a new SAT. But that would mean 24 SATs spinned up, one for every parametrization - definitely not a nice way.
2. Add a new `module_local_sat` fixture to spin up a new module-scoped SAT, but that would block me from using existing fixtures which act against the original `module_target_sat`.
3. Just use unique repos for this test case so that they are not pre-synced in another test.

In the end I decided to go with 3.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_artifacts.py -k repair
