### PR TITLE
[6.15.z] Fix container tags related failures

### DIFF
--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -211,10 +211,10 @@ class TestDockerRepository:
 
         :CaseImportance: Critical
         """
-        assert int(repo['content-counts']['container-image-manifests']) == 0
+        assert int(repo['content-counts']['container-manifests']) == 0
         module_target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
-        assert int(repo['content-counts']['container-image-manifests']) > 0
+        assert int(repo['content-counts']['container-manifests']) > 0
 
     @pytest.mark.tier1
     @pytest.mark.parametrize('new_name', **parametrized(valid_docker_repository_names()))

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -53,6 +53,7 @@ from robottelo.utils.datafactory import (
     valid_docker_repository_names,
     valid_http_credentials,
 )
+from robottelo.utils.issue_handlers import is_open
 from tests.foreman.api.test_contentview import content_view
 
 YUM_REPOS = (
@@ -82,9 +83,7 @@ def _validated_image_tags_count(repo, sat):
     immediately after synchronization), which was CLOSED WONTFIX
     """
     wait_for(
-        lambda: int(
-            _get_image_tags_count(repo=repo, sat=sat)['content-counts']['container-image-tags']
-        )
+        lambda: int(_get_image_tags_count(repo=repo, sat=sat)['content-counts']['container-tags'])
         > 0,
         timeout=30,
         delay=2,
@@ -901,13 +900,17 @@ class TestRepository:
         tags = 'latest'
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        assert not repo['container-image-tags-filter']
-        assert int(repo['content-counts']['container-image-tags']) >= 2
+        if not is_open('SAT-26322'):
+            assert not repo['included-container-image-tags']
+        tags_count = int(repo['content-counts']['container-tags'])
+        assert tags_count >= 2, 'insufficient tags count in the repo'
         target_sat.cli.Repository.update({'id': repo['id'], 'include-tags': tags})
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        assert tags in repo['container-image-tags-filter']
-        assert int(repo['content-counts']['container-image-tags']) >= 2
+        # assert tags in repo['container-image-tags-filter']
+        assert (
+            int(repo['content-counts']['container-tags']) == tags_count
+        ), 'unexpected change of tags count'
 
     @pytest.mark.tier2
     @pytest.mark.parametrize(
@@ -939,13 +942,18 @@ class TestRepository:
         tags = 'latest'
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        assert not repo['container-image-tags-filter']
-        assert int(repo['content-counts']['container-image-tags']) >= 2
+        if not is_open('SAT-26322'):
+            assert not repo['included-container-image-tags']
+        tags_count = int(repo['content-counts']['container-tags'])
+        assert tags_count >= 2, 'insufficient tags count in the repo'
         target_sat.cli.Repository.update({'id': repo['id'], 'include-tags': tags})
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        assert tags in repo['container-image-tags-filter']
-        assert int(repo['content-counts']['container-image-tags']) <= 2
+        if not is_open('SAT-26322'):
+            assert tags in repo['included-container-image-tags']
+        assert (
+            int(repo['content-counts']['container-tags']) == len(tags.split(',')) < tags_count
+        ), 'unexpected change of tags count'
 
     @pytest.mark.tier2
     @pytest.mark.parametrize(
@@ -976,9 +984,10 @@ class TestRepository:
         """
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = _validated_image_tags_count(repo=repo, sat=target_sat)
-        for tag in repo_options['include-tags'].split(','):
-            assert tag in repo['container-image-tags-filter']
-        assert int(repo['content-counts']['container-image-tags']) == 1
+        if not is_open('SAT-26322'):
+            for tag in repo_options['include-tags'].split(','):
+                assert tag in repo['included-container-image-tags']
+        assert int(repo['content-counts']['container-tags']) == 1
 
     @pytest.mark.tier2
     @pytest.mark.parametrize(
@@ -1009,9 +1018,10 @@ class TestRepository:
         """
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         repo = target_sat.cli.Repository.info({'id': repo['id']})
-        for tag in repo_options['include-tags'].split(','):
-            assert tag in repo['container-image-tags-filter']
-        assert int(repo['content-counts']['container-image-tags']) == 0
+        if not is_open('SAT-26322'):
+            for tag in repo_options['include-tags'].split(','):
+                assert tag in repo['included-container-image-tags']
+        assert int(repo['content-counts']['container-tags']) == 0
 
     @pytest.mark.tier2
     @pytest.mark.parametrize(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15598

### Problem Statement
1. Name for container image tags was unified with API some time ago but we haven't update our tests.
2. The `container-image-tags-filter` has been deprecated and is not printed by hammer. It will be replaced win `included-tags` and `excluded-tags`.


### Solution
This PR fixes 1. and skips 2. until the bugjira is closed


### Related issues
https://issues.redhat.com/browse/SAT-26322


 ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_docker.py::TestDockerRepository::test_positive_sync tests/foreman/cli/test_repository.py::TestRepository::test_positive_synchronize_docker_repo_set_tags_later_additive tests/foreman/cli/test_repository.py::TestRepository::test_positive_synchronize_docker_repo_set_tags_later_content_only tests/foreman/cli/test_repository.py::TestRepository::test_negative_synchronize_docker_repo_with_mix_valid_invalid_tags tests/foreman/cli/test_repository.py::TestRepository::test_negative_synchronize_docker_repo_with_invalid_tags
