### PR TITLE
[6.15.z] adding :BlockedBy to org/loc tests

### DIFF
--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -103,7 +103,6 @@ def test_positive_end_to_end(session, target_sat):
         assert not session.location.search(location_name)
 
 
-@pytest.mark.skip_if_open("BZ:1321543")
 @pytest.mark.tier2
 def test_positive_update_with_all_users(session, target_sat):
     """Create location and do not add user to it. Check and uncheck
@@ -118,6 +117,8 @@ def test_positive_update_with_all_users(session, target_sat):
         was enabled and then disabled afterwards
 
     :BZ: 1321543, 1479736, 1479736
+
+    :BlockedBy: SAT-25386
     """
     user = target_sat.api.User().create()
     loc = target_sat.api.Location().create()

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -187,7 +187,6 @@ def test_positive_search_scoped(session):
             assert session.organization.search(query)[0]['Name'] == org_name
 
 
-@pytest.mark.skip_if_open("BZ:1321543")
 @pytest.mark.tier2
 def test_positive_create_with_all_users(session, module_target_sat):
     """Create organization and new user. Check 'all users' setting for
@@ -201,6 +200,8 @@ def test_positive_create_with_all_users(session, module_target_sat):
     :expectedresults: Organization and user entities assigned to each other
 
     :BZ: 1321543
+
+    :BlockedBy: SAT-25386
     """
     user = module_target_sat.api.User().create()
     org = module_target_sat.api.Organization().create()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15608

### Problem Statement
bz closed as migrated, tests no longer skipped

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->