### PR TITLE
[6.15.z] [CV Eval] Test for CV Eval/BZ

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -20,6 +20,7 @@ Subcommands::
     info                          Show a content view
     list                          List content views
     publish                       Publish a content view
+    purge                         Delete old versions of a content view
     remove                        Remove versions and/or environments from a
                                   content view and reassign systems and keys
     remove-from-environment       Remove a content view from an environment
@@ -111,6 +112,12 @@ class ContentView(Base):
     def publish(cls, options, timeout=1500000):
         """Publishes a new version of content-view."""
         cls.command_sub = 'publish'
+        return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)
+
+    @classmethod
+    def purge(cls, options, timeout='25m'):
+        """Purges old versions of content-view. Defaults to keeping 3"""
+        cls.command_sub = 'purge'
         return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)
 
     @classmethod

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3132,6 +3132,47 @@ class TestContentView:
         list_info = module_target_sat.cli.ContentView.list({'name': cv.name})
         assert set(list_info[0]['repository-ids'].split(', ')) == set(id_list)
 
+    @pytest.mark.tier2
+    def test_cv_version_purge(self, module_org, module_target_sat):
+        """Hammer content-view purge correctly purges CV Versions, instead
+        of just up to the per page value
+
+        :id: c2db24cd-946a-4cb6-828d-0e0f38b8ef00
+
+        :steps:
+            1. Create a CV
+            2. Publish the CV 50 times
+            3. Run hammer content-view purge --id <cv.id>
+
+        :expectedresults: Hammer should purge all but 3 old versions, not just up to the per page value
+
+        :Verifies: SAT-15185
+
+        :customerscenario: true
+        """
+        content_view = module_target_sat.cli_factory.make_content_view(
+            {'organization-id': module_org.id}
+        )
+        cv_count = 50
+        for _ in range(cv_count):
+            module_target_sat.cli.ContentView.publish({'id': content_view['id']})
+        cvv = module_target_sat.cli.ContentView.version_list(
+            {'content-view-id': content_view['id']}
+        )
+        assert len(cvv) == cv_count
+        response = module_target_sat.cli.ContentView.purge({'id': content_view['id']})
+        assert all(
+            [
+                f"Version '{v+1}.0' of content view '{content_view.name}' deleted." in response
+                for v in range(cv_count - 4)
+            ]
+        )
+        # Check that the correct number of Versions were purged.
+        cvv = module_target_sat.cli.ContentView.version_list(
+            {'content-view-id': content_view['id']}
+        )
+        assert len(cvv) == 4
+
     def test_positive_validate_force_promote_warning(self, target_sat, function_org):
         """Test cv promote shows warning of 'force promotion' for out of sequence LCE
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15519

### Problem Statement
Test Coverage for https://bugzilla.redhat.com/show_bug.cgi?id=2137318/https://issues.redhat.com/browse/SAT-15185

### Solution
Added Test + support for `content view version purge`

trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k 'test_cv_version_purge'
