### PR TITLE
[6.14.z] remove no_proxy default check in /etc/virt-who.conf

### DIFF
--- a/tests/foreman/virtwho/api/test_esx_sca.py
+++ b/tests/foreman/virtwho/api/test_esx_sca.py
@@ -250,8 +250,6 @@ class TestVirtWhoConfigforEsx:
         deploy_configure_by_command(
             command, form_data_api['hypervisor_type'], org=module_sca_manifest_org.label
         )
-        # Check default NO_PROXY option
-        assert get_configure_option('no_proxy', ETC_VIRTWHO_CONFIG) == '*'
         # Check HTTTP Proxy and No_PROXY option
         http_proxy_url, http_proxy_name, http_proxy_id = create_http_proxy(
             http_type='http', org=module_sca_manifest_org, location=default_location


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15592

### Problem Statement
As the default no_proxy is not enabled in /etc/virt-who.conf , if the no_proxy is not set, it will also not enable in /etc/virt-who.conf , so remove the default check
[system_environment]
#http_proxy=
#https_proxy=
#no_proxy=

Test Cases: PASS
```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/api/test_esx_sca.py -k test_positive_proxy_option --disable-pytest-warnings -q
.                                                                                                                                                                                                           [100%]
1 passed, 12 deselected, 3 warnings in 174.34s (0:02:54)
```