### PR TITLE
[6.15.z] Handle int type conf key for dynaconf ipv6 migration

### DIFF
--- a/robottelo/utils/url.py
+++ b/robottelo/utils/url.py
@@ -18,6 +18,7 @@ def is_ipv4_url(text):
 
 def ipv6_translator(settings_list, setting_major, data):
     """Translates the hostname containing IPv4 to IPv6 and updates the settings object"""
+    setting_major = list(map(str, setting_major))
     dotted_settings = '.'.join(setting_major)
     for _key, _val in settings_list.items():
         if is_ipv4_url(_val):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15630

### Problem Statement
- Confs having integer type setting complaints when migrating all the settings that contain Ipv4 string to convert to Ipv6 even though the int setting does not have Ipv4 containing value .

Stacktrace:
```
dotted_settings = '.'.join(setting_major)
for _key, _val in settings_list.items():

TypeError: sequence item 6: expected str instance, int found

```

### Solution
- Altering the settings to string just when setting the converted value which should not change the type of any integer setting.

### Related Issues and Description
- The solution currently works for us because we don't have any IPV4-specific URLs under integer type setting. 
- But if we do in the future we will face the  issue of `converting the key from an integer type parent or key as dynaconf assists it to be string` for which the issue https://github.com/dynaconf/dynaconf/issues/1161 is raised in dynaconf,

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->