### PR TITLE
Remove deprecated assertions for HTTP Proxy CLI

### DIFF
--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -264,14 +264,13 @@ def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
     )
 
     # Set the HTTP proxy through bulk action for both products to the selected proxy
-    res = module_target_sat.cli.Product.update_proxy(
+    module_target_sat.cli.Product.update_proxy(
         {
             'ids': f"{product_a['id']},{product_b['id']}",
             'http-proxy-policy': 'use_selected_http_proxy',
             'http-proxy-id': http_proxy_b['id'],
         }
     )
-    assert 'Product proxy updated' in res
     module_target_sat.wait_for_tasks(
         search_query=(
             f'Actions::Katello::Repository::Update and organization_id = {module_org.id}'
@@ -296,10 +295,9 @@ def test_positive_assign_http_proxy_to_products(module_org, module_target_sat):
         assert int(info['content-counts']['packages']) == FAKE_0_YUM_REPO_PACKAGES_COUNT
 
     # Set the HTTP proxy through bulk action for both products to None
-    res = module_target_sat.cli.Product.update_proxy(
+    module_target_sat.cli.Product.update_proxy(
         {'ids': f"{product_a['id']},{product_b['id']}", 'http-proxy-policy': 'none'}
     )
-    assert 'Product proxy updated' in res
     module_target_sat.wait_for_tasks(
         search_query=(
             f'Actions::Katello::Repository::Update and organization_id = {module_org.id}'


### PR DESCRIPTION
### Problem Statement
Product update with HTTP proxy now runs `Actions::Katello::Repository::Update` synchronously - shows the "dot progress bar" instead of printing 'Product proxy updated' message and running the task async as we are used to in previous versions.
```
[root@sat ~]# hammer product update-proxy --ids=5,6 --http-proxy-policy='use_selected_http_proxy' --http-proxy-id=2
[..........................................................................................................] [100%]
[root@sat ~]# 
```


### Solution
Remove the assertion for that message and just keep testing the result.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_http_proxy.py -k test_positive_assign_http_proxy_to_products
