### PR TITLE
[6.13.z] Fix CLI import puppet class test

### DIFF
--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -19,7 +19,7 @@ pytestmark = [pytest.mark.run_in_one_thread]
 
 @pytest.mark.skip_if_not_set('fake_capsules')
 @pytest.mark.tier1
-def test_positive_import_puppet_classes(session_puppet_enabled_sat):
+def test_positive_import_puppet_classes(session_puppet_enabled_sat, puppet_proxy_port_range):
     """Import puppet classes from proxy
 
     :id: 42e3a9c0-62e1-4049-9667-f3c0cdfe0b04


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15650

### Problem Statement
This test is failing but the API version which is very similar isn't.

### Solution
Add missing fixture setup.

### Related Issues


trigger: test-robottelo
pytest: tests/foreman/cli/test_capsule.py::test_positive_import_puppet_classes

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->