### PR TITLE
add PIT marker for repositories test

### DIFF
--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -2754,7 +2754,8 @@ def test_positive_syncable_yum_format_repo_import(target_sat, module_org):
     assert repodata['sync']['status'] == 'Success'
 
 
-@pytest.mark.rhel_ver_list([9])
+@pytest.mark.pit_client
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_positive_install_uploaded_rpm_on_host(
     target_sat, rhel_contenthost, function_org, function_lce
 ):


### PR DESCRIPTION
### Problem Statement
PIT marker missing for repositories component.

### Solution
This PR changes

### Related Issues
Proposing new `default_rhel_version`, changes made into the gitlab `MR-1413`

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->