### PR TITLE
[6.15.z] FAM: don't set a password for auth_source_ldap tests

### DIFF
--- a/conf/fam.yaml.template
+++ b/conf/fam.yaml.template
@@ -32,7 +32,6 @@ FAM:
     # Parameter for external_usergroup testing
     auth_source_ldap_host: ldap.example.com
     auth_source_ldap_account: ansible
-    auth_source_ldap_account_password: pass
     auth_source_ldap_base_dn: dc=example,dc=com
     auth_source_ldap_attr_login: uid
     auth_source_ldap_groups_base: cn=groups,cn=accounts,dc=example,dc=com


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15647

### Problem Statement

the password field is protected, so the API doesn't return it and thus we always detect a change, failing tests

### Solution

don't set the password field

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->