### PR TITLE
Update offline backup files list

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -204,14 +204,6 @@ def module_capsule_configured(request, module_capsule_host, module_target_sat):
     return module_capsule_host
 
 
-@pytest.fixture(scope='session')
-def session_capsule_configured(request, session_capsule_host, session_target_sat):
-    """Configure the capsule instance with the satellite from settings.server.hostname"""
-    if not request.config.option.n_minus:
-        session_capsule_host.capsule_setup(sat_host=session_target_sat)
-    return session_capsule_host
-
-
 @pytest.fixture(scope='module')
 def module_capsule_configured_mqtt(request, module_capsule_configured):
     """Configure the capsule instance with the satellite from settings.server.hostname,

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -30,9 +30,8 @@ BACKUP_DIR = "/tmp/"
 
 
 BASIC_FILES = {"config_files.tar.gz", ".config.snar", "metadata.yml"}
-OFFLINE_FILES = {"pgsql_data.tar.gz", ".postgres.snar"} | BASIC_FILES
-ONLINE_SAT_FILES = {"candlepin.dump", "foreman.dump", "pulpcore.dump"} | BASIC_FILES
-ONLINE_CAPS_FILES = {"pulpcore.dump"} | BASIC_FILES
+SAT_FILES = {"candlepin.dump", "foreman.dump", "pulpcore.dump"} | BASIC_FILES
+CAPS_FILES = {"pulpcore.dump"} | BASIC_FILES
 CONTENT_FILES = {"pulp_data.tar", ".pulp.snar"}
 
 
@@ -43,16 +42,8 @@ NOPREV_MSG = "ERROR: option '--incremental': Previous backup " "directory does n
 assert_msg = "Some required backup files are missing"
 
 
-def get_exp_files(sat_maintain, backup_type, skip_pulp=False):
-    if type(sat_maintain) is Satellite:
-        # for remote db you get always online backup regardless specified backup type
-        expected_files = (
-            ONLINE_SAT_FILES
-            if backup_type == 'online' or sat_maintain.is_remote_db()
-            else OFFLINE_FILES
-        )
-    else:
-        expected_files = ONLINE_CAPS_FILES if backup_type == 'online' else OFFLINE_FILES
+def get_exp_files(sat_maintain, skip_pulp=False):
+    expected_files = SAT_FILES if type(sat_maintain) is Satellite else CAPS_FILES
     if not skip_pulp:
         expected_files = expected_files | CONTENT_FILES
     return expected_files
@@ -93,7 +84,7 @@ def test_positive_backup_preserve_directory(
     files = sat_maintain.execute(f'ls -a {subdir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
-    expected_files = get_exp_files(sat_maintain, backup_type)
+    expected_files = get_exp_files(sat_maintain)
     assert set(files).issuperset(expected_files), assert_msg
 
 
@@ -141,7 +132,7 @@ def test_positive_backup_split_pulp_tar(
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
-    expected_files = get_exp_files(sat_maintain, backup_type)
+    expected_files = get_exp_files(sat_maintain)
     assert set(files).issuperset(expected_files), assert_msg
 
     # Check the split works
@@ -185,7 +176,7 @@ def test_positive_backup_capsule_features(
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
-    expected_files = get_exp_files(sat_maintain, backup_type)
+    expected_files = get_exp_files(sat_maintain)
     assert set(files).issuperset(expected_files), assert_msg
 
 
@@ -234,47 +225,6 @@ def test_positive_backup_all(sat_maintain, setup_backup_tests, module_synced_rep
     )
     assert result.status == 0
     assert 'FAIL' not in result.stdout
-
-
-@pytest.mark.include_capsule
-def test_positive_backup_offline_logical(sat_maintain, setup_backup_tests, module_synced_repos):
-    """Take an offline backup with '--include-db-dumps' option provided
-
-    :id: dafac83f-75e1-455e-b77f-15fed4eed884
-
-    :parametrized: yes
-
-    :steps:
-        1. create a backup
-        2. check that appropriate files are created
-
-    :expectedresults:
-        1. backup succeeds
-        2. files for both, offline and online, backup type are created
-    """
-    subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
-    instance = 'satellite' if type(sat_maintain) is Satellite else 'capsule'
-    result = sat_maintain.cli.Backup.run_backup(
-        backup_dir=subdir,
-        backup_type='offline',
-        options={'assumeyes': True, 'plaintext': True, 'include-db-dumps': True},
-    )
-    assert result.status == 0
-    assert 'FAIL' not in result.stdout
-
-    # Check for expected files
-    backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
-    files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
-    files = [i for i in files if not re.compile(r'^\.*$').search(i)]
-
-    if type(sat_maintain) is Satellite:
-        if sat_maintain.is_remote_db():
-            expected_files = ONLINE_SAT_FILES | CONTENT_FILES
-        else:
-            expected_files = OFFLINE_FILES | ONLINE_SAT_FILES | CONTENT_FILES
-    else:
-        expected_files = OFFLINE_FILES | ONLINE_CAPS_FILES | CONTENT_FILES
-    assert set(files).issuperset(expected_files), assert_msg
 
 
 @pytest.mark.include_capsule
@@ -407,7 +357,7 @@ def test_positive_puppet_backup_restore(
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
-    expected_files = get_exp_files(sat_maintain, backup_type)
+    expected_files = get_exp_files(sat_maintain)
     assert set(files).issuperset(expected_files), assert_msg
 
     # Run restore
@@ -446,8 +396,8 @@ def test_positive_puppet_backup_restore(
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
 def test_positive_backup_restore(
     sat_maintain,
-    session_target_sat,
-    session_capsule_configured,
+    module_target_sat,
+    module_capsule_configured,
     setup_backup_tests,
     module_synced_repos,
     backup_type,
@@ -493,7 +443,7 @@ def test_positive_backup_restore(
     files = sat_maintain.execute(f'ls -a {backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
-    expected_files = get_exp_files(sat_maintain, backup_type, skip_pulp)
+    expected_files = get_exp_files(sat_maintain, skip_pulp)
     assert set(files).issuperset(expected_files), assert_msg
 
     # Run restore
@@ -529,7 +479,7 @@ def test_positive_backup_restore(
         assert rh_repo.id == module_synced_repos['rh'].id
     else:
         repo_path = module_synced_repos['custom'].full_path.replace(
-            session_target_sat.hostname, session_capsule_configured.hostname
+            module_target_sat.hostname, module_capsule_configured.hostname
         )
         repo_files = get_repo_files_by_url(repo_path)
         assert len(repo_files) == constants.FAKE_0_YUM_REPO_PACKAGES_COUNT
@@ -596,7 +546,7 @@ def test_positive_backup_restore_incremental(
     files = sat_maintain.execute(f'ls -a {inc_backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 
-    expected_files = get_exp_files(sat_maintain, backup_type)
+    expected_files = get_exp_files(sat_maintain)
     assert set(files).issuperset(expected_files), assert_msg
 
     # restore initial backup and check system health


### PR DESCRIPTION
### Problem Statement
- https://github.com/theforeman/foreman_maintain/pull/893 affects the list of files generated during offline backup. 

### Solution
- Update the `OFFLINE_SAT_FILES` to reflect changes.
- Remove `test_positive_backup_offline_logical`
- Remove unwanted code

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->