### PR TITLE
Add test for host multi-CV

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -815,6 +815,7 @@ class ContentHost(Host, ContentHostMixins):
         org='Default_Organization',
         activation_key=None,
         lce='Library',
+        environments=None,
         consumerid=None,
         force=True,
         releasever=None,
@@ -863,6 +864,8 @@ class ContentHost(Host, ContentHostMixins):
             cmd += f' --activationkey {activation_key}'
         elif lce:
             cmd += f' --environment {lce}{userpass}'
+        elif environments:
+            cmd += f' --environments {environments}{userpass}'
         elif consumerid:
             cmd += f' --consumerid {consumerid}{userpass}'
         else:


### PR DESCRIPTION
### Problem Statement

There is no test coverage for existing features around multi-CV.

### Solution

Add tests covering existing functionality. This PR adds the first test, covering the downstream Setting that is not exposed.


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->