### PR TITLE
CSV formatting fixes

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -463,10 +463,10 @@ def configure_hammer_no_negotiate(parametrized_enrolled_sat):
 def hammer_logout(parametrized_enrolled_sat):
     """Logout in Hammer."""
     result = parametrized_enrolled_sat.cli.Auth.logout()
-    assert result.split("\n")[1] == LOGGEDOUT
+    assert result[0]['message'] == LOGGEDOUT
     yield
     result = parametrized_enrolled_sat.cli.Auth.logout()
-    assert result.split("\n")[1] == LOGGEDOUT
+    assert result[0]['message'] == LOGGEDOUT
 
 
 @pytest.fixture

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -62,7 +62,7 @@ class Repository(Base):
         cls.command_sub = 'synchronize'
         return cls.execute(
             cls._construct_command(options),
-            output_format='base',
+            output_format='csv',
             ignore_stderr=True,
             return_raw_response=return_raw_response,
             timeout=timeout,

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -102,7 +102,7 @@ class TestADAuthSource:
             based on user-sync
         """
         ad_data = ad_data()
-        LOGEDIN_MSG = "Using configured credentials for user '{0}'."
+        LOGGEDIN_MSG = "Using configured credentials for user '{0}'."
         auth_source = module_target_sat.cli_factory.ldap_auth_source(
             {
                 'name': gen_string('alpha'),
@@ -134,7 +134,7 @@ class TestADAuthSource:
         result = module_target_sat.cli.Auth.with_user(
             username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
         ).status()
-        assert LOGEDIN_MSG.format(ad_data['ldap_user_name']) in result.split("\n")[1]
+        assert LOGGEDIN_MSG.format(ad_data['ldap_user_name']) in result[0]['message']
         module_target_sat.cli.UserGroupExternal.refresh(
             {'user-group-id': user_group['id'], 'name': member_group}
         )
@@ -221,7 +221,7 @@ class TestIPAAuthSource:
         ipa_group_base_dn = default_ipa_host.group_base_dn.replace('foobargroup', 'foreman_group')
         member_username = 'foreman_test'
         member_group = 'foreman_group'
-        LOGEDIN_MSG = "Using configured credentials for user '{0}'."
+        LOGGEDIN_MSG = "Using configured credentials for user '{0}'."
         auth_source_name = gen_string('alpha')
         auth_source = module_target_sat.cli_factory.ldap_auth_source(
             {
@@ -262,7 +262,7 @@ class TestIPAAuthSource:
         result = module_target_sat.cli.Auth.with_user(
             username=member_username, password=default_ipa_host.ldap_user_passwd
         ).status()
-        assert LOGEDIN_MSG.format(member_username) in result[0]['message']
+        assert LOGGEDIN_MSG.format(member_username) in result[0]['message']
         with pytest.raises(CLIReturnCodeError) as error:
             module_target_sat.cli.Role.with_user(
                 username=member_username, password=default_ipa_host.ldap_user_passwd
@@ -308,7 +308,7 @@ class TestIPAAuthSource:
         ipa_group_base_dn = default_ipa_host.group_base_dn.replace('foobargroup', 'foreman_group')
         member_username = 'foreman_test'
         member_group = 'foreman_group'
-        LOGEDIN_MSG = "Using configured credentials for user '{0}'."
+        LOGGEDIN_MSG = "Using configured credentials for user '{0}'."
         auth_source_name = gen_string('alpha')
         auth_source = module_target_sat.cli_factory.ldap_auth_source(
             {
@@ -349,7 +349,7 @@ class TestIPAAuthSource:
         result = module_target_sat.cli.Auth.with_user(
             username=member_username, password=default_ipa_host.ldap_user_passwd
         ).status()
-        assert LOGEDIN_MSG.format(member_username) in result[0]['message']
+        assert LOGGEDIN_MSG.format(member_username) in result[0]['message']
         list = module_target_sat.cli.Role.with_user(
             username=member_username, password=default_ipa_host.ldap_user_passwd
         ).list()

--- a/tests/foreman/destructive/test_auth.py
+++ b/tests/foreman/destructive/test_auth.py
@@ -18,7 +18,7 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import HAMMER_CONFIG
 
-LOGEDIN_MSG = "Session exists, currently logged in as '{0}'"
+LOGGEDIN_MSG = "Session exists, currently logged in as '{0}'"
 password = gen_string('alpha')
 pytestmark = pytest.mark.destructive
 
@@ -45,7 +45,7 @@ def test_positive_password_reset(target_sat):
         {'username': settings.server.admin_username, 'password': reset_password}
     )
     result = target_sat.cli.Auth.with_user().status()
-    assert LOGEDIN_MSG.format(settings.server.admin_username) in result.split("\n")[1]
+    assert LOGGEDIN_MSG.format(settings.server.admin_username) in result[0]['message']
     assert target_sat.cli.Org.with_user().list()
 
 
@@ -72,5 +72,5 @@ def test_positive_password_reset_chosen(target_sat):
         {'username': settings.server.admin_username, 'password': new_password}
     )
     result = target_sat.cli.Auth.with_user().status()
-    assert LOGEDIN_MSG.format(settings.server.admin_username) in result.split("\n")[1]
+    assert LOGGEDIN_MSG.format(settings.server.admin_username) in result[0]['message']
     assert target_sat.cli.Org.with_user().list()


### PR DESCRIPTION
### Problem Statement

Previously, CLI commands run with `hammer --output csv [COMMAND]` would in some cases return non-CSV output. Over time, robottelo's `parse_csv` method developed several workarounds to handle these bugs.

### Solution

This PR removes all of the workaround code from `parse_csv`, as all of the corresponding issues are fixed as of Satellite 6.16.

### Related Issues

SAT-26483

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->