### PR TITLE
[6.15.z] Replace skip_if with BlockedBy for migrated httpboot BZ

### DIFF
--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -323,7 +323,6 @@ def test_rhel_ipxe_provisioning(
     assert provisioning_host.subscribed, 'Host is not subscribed'
 
 
-@pytest.mark.skip_if_open("BZ:2242925")
 @pytest.mark.e2e
 @pytest.mark.upgrade
 @pytest.mark.parametrize('pxe_loader', ['http_uefi'], indirect=True)
@@ -359,7 +358,9 @@ def test_rhel_httpboot_provisioning(
 
     :parametrized: yes
 
-    :BZ: 2242925
+    :BlockedBy: SAT-20684
+
+    :Verifies: SAT-20684
     """
     sat = module_provisioning_sat.sat
     # update grub2-efi package


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15673

### Problem Statement
BZ was CLOSED MIGRATED (to Jira) without the actual fix. We need to keep skipping based on Jira status instead.

### Solution
Replace skip_if with BlockedBy for migrated BZ
