### PR TITLE
Update tests for change in network configuration

### DIFF
--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -241,51 +241,6 @@ class TestProvisioningTemplate:
                     in rendered
                 )
 
-    @pytest.mark.rhel_ver_match('[^6]')
-    def test_positive_provision_template_check_net_interface(
-        self,
-        module_sync_kickstart_content,
-        module_target_sat,
-        module_sca_manifest_org,
-        module_location,
-        module_default_org_view,
-        module_lce_library,
-        default_architecture,
-        default_partitiontable,
-    ):
-        """Read the Provision template and verify correct network interface is created.
-
-        :id: 971c4dd0-548d-411a-9c5a-f351370bb860
-
-        :expectedresults: The rendered provision template has correct network interface.
-
-        :BZ: 2148433
-
-        :customerscenario: true
-
-        :parametrized: yes
-        """
-        macaddress = gen_mac(multicast=False)
-        capsule = module_target_sat.nailgun_smart_proxy
-        host = module_target_sat.api.Host(
-            organization=module_sca_manifest_org,
-            location=module_location,
-            name=gen_string('alpha').lower(),
-            mac=macaddress,
-            operatingsystem=module_sync_kickstart_content.os,
-            architecture=default_architecture,
-            domain=module_sync_kickstart_content.domain,
-            root_pass=settings.provisioning.host_root_password,
-            ptable=default_partitiontable,
-            content_facet_attributes={
-                'content_source_id': capsule.id,
-                'content_view_id': module_default_org_view.id,
-                'lifecycle_environment_id': module_lce_library.id,
-            },
-        ).create()
-        provision_template = host.read_template(data={'template_kind': 'provision'})['template']
-        assert 'ifcfg-$sanitized_real' in provision_template
-
     @pytest.mark.e2e
     @pytest.mark.rhel_ver_match('[^6]')
     def test_positive_template_check_ipxe(


### PR DESCRIPTION
### Problem Statement
As part of fix in network configuration SAT-23034, ifcfg created during provisioning of host has been removed and keyfile created by anaconda will be the only path for configuring network.

### Solution
Updated tests of provisioning to remove ifcfg and update it with keyfile created by anaconda.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->