### PR TITLE
[6.14.z] Add jira comments based on Jira labels

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1728,6 +1728,8 @@ OPEN_STATUSES = ("NEW", "ASSIGNED", "POST", "MODIFIED")
 CLOSED_STATUSES = ("ON_QA", "VERIFIED", "RELEASE_PENDING", "CLOSED")
 WONTFIX_RESOLUTIONS = ("WONTFIX", "CANTFIX", "DEFERRED")
 # Jira statuses used by Robottelo issue handler.
+JIRA_TESTS_PASSED_LABEL = "tests-passed"
+JIRA_TESTS_FAILED_LABEL = "tests-failed"
 JIRA_OPEN_STATUSES = ("New", "Backlog", "Refinement", "To Do", "In Progress")
 JIRA_ONQA_STATUS = "Review"
 JIRA_CLOSED_STATUSES = ("Release Pending", "Closed")

--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -208,6 +208,7 @@ def get_data_jira(issue_ids, cached_data=None):  # pragma: no cover
         "key",
         "summary",
         "status",
+        "labels",
         "resolution",
         "fixVersions",
     ]
@@ -234,6 +235,7 @@ def get_data_jira(issue_ids, cached_data=None):  # pragma: no cover
             'key': issue['key'],
             'summary': issue['fields']['summary'],
             'status': issue['fields']['status']['name'],
+            'labels': issue['fields']['labels'],
             'resolution': issue['fields']['resolution']['name']
             if issue['fields']['resolution']
             else '',
@@ -279,12 +281,14 @@ def add_comment_on_jira(
     comment,
     comment_type=settings.jira.comment_type,
     comment_visibility=settings.jira.comment_visibility,
+    labels=None,
 ):
     """Adds a new comment to a Jira issue.
 
     Arguments:
         issue_id {str} -- Jira issue number, ex. SAT-12232
         comment {str}  -- Comment to add on the issue.
+        lables {list} - Add/Remove Jira labels, ex. [{'add':'tests_passed'},{'remove':'tests_failed'}]
         comment_type {str}  -- Type of comment to add.
         comment_visibility {str}  -- Comment visibility.
 
@@ -299,24 +303,25 @@ def add_comment_on_jira(
             'and provide --jira-comment pytest option."'
         )
         return None
-    data = try_from_cache(issue_id)
-    if data["status"] in settings.jira.issue_status:
-        logger.debug(f"Adding a new comment on {issue_id} Jira issue.")
-        response = requests.post(
-            f"{settings.jira.url}/rest/api/latest/issue/{issue_id}/comment",
-            json={
-                "body": comment,
-                "visibility": {
-                    "type": comment_type,
-                    "value": comment_visibility,
-                },
-            },
+    if labels:
+        logger.debug(f"Updating labels for {issue_id} issue. \n labels: \n {labels}")
+        response = requests.put(
+            f"{settings.jira.url}/rest/api/latest/issue/{issue_id}/",
+            json={"update": {"labels": labels}},
             headers={"Authorization": f"Bearer {settings.jira.api_key}"},
         )
         response.raise_for_status()
-        return response.json()
-    logger.warning(
-        f"Jira comments are currently disabled for this issue because it's in {data['status']} state. "
-        f"Please update issue_status in jira.conf to overide this behaviour."
+    logger.debug(f"Adding a new comment on {issue_id} Jira issue. \n comment: \n {comment}")
+    response = requests.post(
+        f"{settings.jira.url}/rest/api/latest/issue/{issue_id}/comment",
+        json={
+            "body": comment,
+            "visibility": {
+                "type": comment_type,
+                "value": comment_visibility,
+            },
+        },
+        headers={"Authorization": f"Bearer {settings.jira.api_key}"},
     )
-    return None
+    response.raise_for_status()
+    return response.json()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15686

### Problem Statement
- Reduce the frequency of commenting test results on Jira. 

### Solution
Take action based on labels
- Initially set a Pass/Fail label based on the test result
- If the state changes add a comment
- If the state is already failing, and test is failing, still add a comment
- If the state is already passing, and the test passes, don’t add a comment

### Related Issues
- SAT-26505 and SAT-26504

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->