### PR TITLE
[6.15.z] [KatelloTracer] Adding PIT markers

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2400,6 +2400,7 @@ def test_positive_dump_enc_yaml(target_sat):
 
 
 # -------------------------- HOST TRACE SUBCOMMAND SCENARIOS -------------------------
+@pytest.mark.pit_client
 @pytest.mark.tier3
 @pytest.mark.rhel_ver_match('[^6].*')
 def test_positive_tracer_list_and_resolve(tracer_host, target_sat):

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1767,6 +1767,7 @@ def test_positive_set_multi_line_and_with_spaces_parameter_value(
         assert host_parameters[param_name] == param_value
 
 
+@pytest.mark.pit_client
 @pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6].*')
 def test_positive_tracer_enable_reload(tracer_install_host, target_sat):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15752

Adding PIT markers for interop testing 