### PR TITLE
merged possible test from api repositories

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -639,37 +639,29 @@ class TestRepository:
         assert repo.checksum_type == updated_checksum
 
     @pytest.mark.tier1
+    @pytest.mark.parametrize(
+        'repo_options', [{'unprotected': False}], ids=['protected'], indirect=True
+    )
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
-    def test_positive_update_url(self, repo):
-        """Update repository url to another valid one.
+    def test_positive_update_repo_url_and_unprotected_flag(self, repo):
+        """Update repository url and unprotected flag to another valid one.
 
-        :id: 8fbc11f0-a5c5-498e-a314-87958dcd7832
+        :id: 0ef399a7-6d3a-4746-b415-298794497c51
 
-        :expectedresults: The repository url can be updated.
+        :parametrized: yes
+
+        :expectedresults: The repository url and unprotected flag can be updated.
 
         :CaseImportance: Critical
         """
+        # Update repo url
         repo.url = settings.repos.yum_2.url
         repo = repo.update(['url'])
         assert repo.url == settings.repos.yum_2.url
 
-    @pytest.mark.tier1
-    @pytest.mark.parametrize(
-        'repo_options', [{'unprotected': False}], ids=['protected'], indirect=True
-    )
-    def test_positive_update_unprotected(self, repo):
-        """Update repository unprotected flag to another valid one.
-
-        :id: c55d169a-8f11-4bf8-9913-b3d39fee75f0
-
-        :parametrized: yes
-
-        :expectedresults: The repository unprotected flag can be updated.
-
-        :CaseImportance: Critical
-        """
+        # Update repo unprotected flag
         assert repo.unprotected is False
         repo.unprotected = True
         repo = repo.update(['unprotected'])


### PR DESCRIPTION
### Problem Statement
Component audit - SAT-23548
Merge 2 related scenarios
1. test_positive_update_unprotected
2. test_positive_update_url

### Solution
New test name: test_positive_update_repo_url_and_unprotected_flag

### Related Issues
NA

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k 'test_positive_update_repo_url_and_unprotected_flag'
```

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->