### PR TITLE
[6.13.z] Remove promtail configuration option

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -286,7 +286,6 @@ def get_deploy_args(request):
     deploy_args = {
         'deploy_rhel_version': rhel_version.base_version,
         'deploy_flavor': settings.flavors.default,
-        'promtail_config_template_file': 'config_sat.j2',
         'workflow': settings.server.deploy_workflows.os,
     }
     if hasattr(request, 'param'):
@@ -310,7 +309,6 @@ def cap_ready_rhel():
     deploy_args = {
         'deploy_rhel_version': rhel_version.base_version,
         'deploy_flavor': settings.flavors.default,
-        'promtail_config_template_file': 'config_sat.j2',
         'workflow': settings.capsule.deploy_workflows.os,
     }
     with Broker(**deploy_args, host_class=Capsule) as host:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -67,7 +67,6 @@ def lru_sat_ready_rhel(rhel_ver):
     deploy_args = {
         'deploy_rhel_version': rhel_version,
         'deploy_flavor': settings.flavors.default,
-        'promtail_config_template_file': 'config_sat.j2',
         'workflow': settings.server.deploy_workflows.os,
     }
     return Broker(**deploy_args, host_class=Satellite).checkout()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15763

### Problem Statement
We have removed `config_sat.j2` from our internal repository. The promtail configuration that made promtail watch for changes in Satellite-related log files was merged to a general config file, therefore we do not need to specify the file anymore.

### Solution
Remove the `promtail_config_template_file` broker argument, use the default (the only one we now have) promtail configuration file.

### Related Issues
* satlab-tower!1090 (merged)

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->