### PR TITLE
[6.14.z] Upgrade Capsule features test

### DIFF
--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -12,6 +12,7 @@
 
 """
 
+import json
 import os
 
 import pytest
@@ -34,6 +35,46 @@ def cleanup(target_sat, content_view, repo, product):
 
     # To clean the orphaned content for next run, it is used to fix KCS#4820591
     target_sat.execute('foreman-rake katello:delete_orphaned_content')
+
+
+class TestCapsuleFeatures:
+    @pytest.mark.pre_upgrade
+    def test_pre_capsule_features(self, pre_configured_capsule, save_test_data):
+        """Pre-upgrade scenario that checks for Capsule enabled features
+
+        :id: preupgrade-1a50f0ec-482e-11ef-a468-98fa9b11ac24
+
+        :steps:
+            1. Before Satellite upgrade check for enabled features on a Capsule
+
+        :expectedresults:
+            1. List of Capsule features
+        """
+        features = json.loads(pre_configured_capsule.get_features())
+        save_test_data({'features': features})
+
+    @pytest.mark.post_upgrade(depend_on=test_pre_capsule_features)
+    def test_post_capsule_features(self, pre_configured_capsule, pre_upgrade_data):
+        """Post-upgrade scenario that sync capsule from satellite and then
+        verifies if the repo/rpm of pre-upgrade scenario is synced to capsule
+
+
+        :id: postupgrade-1a50f0ec-482e-11ef-a468-98fa9b11ac24
+
+        :steps:
+            1. After satellite upgrade check for enabled features on a Capsule
+
+        :expectedresults:
+            1. Capsule features before and after Upgrade match
+        """
+        pre_features = set(pre_upgrade_data.get('features'))
+        post_features = set(json.loads(pre_configured_capsule.get_features()))
+        assert (
+            post_features == pre_features
+        ), 'capsule features after and before upgrade are differrent'
+        pre_configured_capsule.nailgun_capsule.refresh()
+        refreshed_features = set(json.loads(pre_configured_capsule.get_features()))
+        assert refreshed_features == pre_features, 'capsule features after refresh are differrent'
 
 
 class TestCapsuleSync:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15726

### Problem Statement
PX recommends to consider adding check for refreshing capsule feature to make sure we have same features enabled before and after upgrade. 

### Solution
New upgrade-scenarios test

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->