### PR TITLE
Harden docker/podman asserts a bit

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -51,6 +51,7 @@ from robottelo.content_info import (
     get_repomd_revision,
 )
 from robottelo.utils.datafactory import gen_string
+from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture
@@ -909,6 +910,8 @@ class TestCapsuleContentManagement:
 
         :BZ: 2125244, 2148813
 
+        :Verifies: SAT-25813
+
         :customerscenario: true
         """
         upstream_names = [
@@ -972,11 +975,15 @@ class TestCapsuleContentManagement:
                     f'{con_client} search {module_capsule_configured.hostname}/{path}'
                 )
                 assert result.status == 0
+                if not is_open('SAT-25813'):
+                    assert f'{module_capsule_configured.hostname}/{path}' in result.stdout
 
                 result = module_container_contenthost.execute(
                     f'{con_client} pull {module_capsule_configured.hostname}/{path}'
                 )
                 assert result.status == 0
+                result = module_container_contenthost.execute(f'{con_client} images')
+                assert f'{module_capsule_configured.hostname}/{path}' in result.stdout
 
                 result = module_container_contenthost.execute(
                     f'{con_client} rmi {module_capsule_configured.hostname}/{path}'

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -648,7 +648,7 @@ class TestRepository:
     def test_positive_update_repo_url_and_unprotected_flag(self, repo):
         """Update repository url and unprotected flag to another valid one.
 
-        :id: 0ef399a7-6d3a-4746-b415-298794497c51
+        :id: 45ddfea2-ba37-45b8-95bb-9e92b8a3a946
 
         :parametrized: yes
 


### PR DESCRIPTION
### Problem Statement
We are testing `docker/podman search` against capsule already but we just check the status, not what is actually returned in stdout. And of course an issue appeared where the search returns nothing but 0 result code. (see bellow)


### Solution
Check if the image is returned by the search.
Also check if `docker/podman pull` actually pulled the image.


### Related Issues
https://issues.redhat.com/browse/SAT-25813


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k sync_container_repo_end_to_end