### PR TITLE
Update OS tests for password hashing default from sha256 to sha512

### DIFF
--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -48,13 +48,15 @@ class TestOperatingSystem:
         :expectedresults: All CRUD operations are performed successfully.
 
         :BZ: 2101435, 1230902
+
+        :Verifies: SAT-26071
         """
         name = gen_string('alpha')
         desc = gen_string('alpha')
         os_family = 'Redhat'
         minor_version = gen_string('numeric')
         major_version = gen_string('numeric', 5)
-        pass_hash = 'SHA256'
+        default_pass_hash = 'SHA512'
         os_parameters = [{'name': gen_string('alpha'), 'value': gen_string('alpha')}]
         ptable = module_target_sat.api.PartitionTable().create()
         medium = module_target_sat.api.Media(organization=[module_org]).create()
@@ -69,7 +71,6 @@ class TestOperatingSystem:
             major=major_version,
             family=os_family,
             architecture=[module_architecture],
-            password_hash=pass_hash,
             provisioning_template=[template],
             ptable=[ptable],
             medium=[medium],
@@ -81,12 +82,12 @@ class TestOperatingSystem:
         assert os.major == major_version
         assert os.description == desc
         assert os.architecture[0].id == module_architecture.id
-        assert os.password_hash == pass_hash
         assert os.ptable[0].id == ptable.id
         assert os.provisioning_template[0].id == template.id
         assert os.medium[0].id == medium.id
         assert os.os_parameters_attributes[0]['name'] == os_parameters[0]['name']
         assert os.os_parameters_attributes[0]['value'] == os_parameters[0]['value']
+        assert os.password_hash == default_pass_hash
         # Read OS
         os = module_target_sat.api.OperatingSystem(id=os.id).read()
         assert os.name == name
@@ -95,18 +96,18 @@ class TestOperatingSystem:
         assert os.major == major_version
         assert os.description == desc
         assert os.architecture[0].id == module_architecture.id
-        assert os.password_hash == pass_hash
         assert str(ptable.id) in str(os.ptable)
         assert str(template.id) in str(os.provisioning_template)
         assert os.medium[0].id == medium.id
         assert os.os_parameters_attributes[0]['name'] == os_parameters[0]['name']
         assert os.os_parameters_attributes[0]['value'] == os_parameters[0]['value']
+        assert os.password_hash == default_pass_hash
         new_name = gen_string('alpha')
         new_desc = gen_string('alpha')
         new_os_family = 'Rhcos'
         new_minor_version = gen_string('numeric')
         new_major_version = gen_string('numeric', 5)
-        new_pass_hash = 'SHA512'
+        new_pass_hash = 'SHA256'
         new_arch = module_target_sat.api.Architecture().create()
         new_ptable = module_target_sat.api.PartitionTable().create()
         new_medium = module_target_sat.api.Media(organization=[module_org]).create()

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -486,11 +486,13 @@ def test_rhel_pxe_provisioning_fips_enabled(
     :parametrized: yes
 
     :BZ: 2240076
+
+    :Verifies: SAT-26071
     """
     sat = module_provisioning_sat.sat
     host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
-    # Verify password hashing algorithm SHA256 is set in OS used for provisioning
-    assert module_provisioning_rhel_content.os.password_hash == 'SHA256'
+    # Verify password hashing algorithm SHA512 is set in OS used for provisioning
+    assert module_provisioning_rhel_content.os.password_hash == 'SHA512'
 
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,

--- a/tests/foreman/cli/test_operatingsystem.py
+++ b/tests/foreman/cli/test_operatingsystem.py
@@ -51,11 +51,13 @@ class TestOperatingSystem:
             7. Check if OS is deleted
 
         :expectedresults: All CRUD operations are performed successfully.
+
+        :Verifies: SAT-26071
         """
         name = gen_string('alpha')
         desc = gen_string('alpha')
         os_family = 'Redhat'
-        pass_hash = 'SHA256'
+        default_pass_hash = 'SHA512'
         minor_version = gen_string('numeric', 1)
         major_version = gen_string('numeric', 1)
         architecture = target_sat.cli_factory.make_architecture()
@@ -68,7 +70,7 @@ class TestOperatingSystem:
                 'name': name,
                 'description': desc,
                 'family': os_family,
-                'password-hash': pass_hash,
+                'password-hash': default_pass_hash,
                 'major': major_version,
                 'minor': minor_version,
                 'architecture-ids': architecture['id'],


### PR DESCRIPTION
### Problem Statement
In upstream, we've recently changed the default password hashing algorithm from sha256 to sha512
https://github.com/theforeman/foreman/pull/10206

### Solution
Updating the OS tests so that the default password hashing is tested, and updating the provisioning test to ensure the password hashing is verified on provisioned hosts
