### PR TITLE
[6.15.z] Fix failing registration tests

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -119,10 +119,11 @@ def test_positive_allow_reregistration_when_dmi_uuid_changed(
         location=module_location,
     )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
-
+    target_sat.execute(f'echo \'{{"dmi.system.uuid": "{uuid_2}"}}\' > /etc/rhsm/facts/uuid.facts')
+    result = rhel_contenthost.execute('subscription-manager unregister')
+    assert result.status == 0
     result = rhel_contenthost.execute('subscription-manager clean')
     assert result.status == 0
-    target_sat.execute(f'echo \'{{"dmi.system.uuid": "{uuid_2}"}}\' > /etc/rhsm/facts/uuid.facts')
     result = rhel_contenthost.api_register(
         target_sat,
         organization=org,

--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -229,7 +229,7 @@ def test_positive_global_registration_end_to_end(
     # Assert that a yum update was made this day ("Update" or "I, U" in history)
     timezone_offset = rhel_contenthost.execute('date +"%:z"').stdout.strip()
     tzinfo = datetime.strptime(timezone_offset, '%z').tzinfo
-    result = rhel_contenthost.execute('yum history | grep U')
+    result = rhel_contenthost.execute('yum history | grep -E "I|U"')
     assert result.status == 0
     assert datetime.now(tzinfo).strftime('%Y-%m-%d') in result.stdout
     # Set "Connect to host using IP address"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15778

### Problem Statement
Few tests failing in registration 

### Solution
Fixed the tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->