### PR TITLE
[Task 1 - Customer Scenario Checks] Replacing Migrated BZs docstrings token to Jira based 

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1709,7 +1709,7 @@ class TestCapsuleContentManagement:
 
         :BlockedBy: SAT-25503
 
-        :BZ: 2284027
+        :verifies: SAT-26453
 
         :customerscenario: true
         """

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -61,6 +61,8 @@ def test_positive_provision_end_to_end(
     :customerscenario: true
 
     :BZ: 2186114
+
+    :verifies: SAT-18721
     """
     sat = module_provisioning_sat.sat
     name = gen_string('alpha').lower()

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -458,7 +458,7 @@ def test_positive_repair_artifacts(
         2. All variants of verify_checksum task are able to repair all types of damage for all
            supported content types.
 
-    :BZ: 2127537
+    :verifies: SAT-16330
 
     :customerscenario: true
 

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -429,8 +429,6 @@ def test_positive_verify_updated_fdi_image(target_sat):
 
     Verifies: SAT-24197, SAT-25275
 
-    :BZ: 2271598
-
     :customerscenario: true
 
     :CaseImportance: Critical

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1498,7 +1498,7 @@ def test_errata_list_by_contentview_filter(module_sca_manifest_org, module_targe
 
     :customerscenario: true
 
-    :BZ: 1785146
+    :verifies: SAT-7987
     """
     product = module_target_sat.api.Product(organization=module_sca_manifest_org).create()
     repo = module_target_sat.cli_factory.make_repository(

--- a/tests/foreman/cli/test_oscap.py
+++ b/tests/foreman/cli/test_oscap.py
@@ -584,13 +584,9 @@ class TestOpenScap:
         :expectedresults: The policy is created and associated successfully.
             Policies can be listed after hostgroup removal.
 
-        :bz: 1728157
-
-        :Verifies: SAT-19502
+        :Verifies: SAT-19502, SAT-19492
 
         :customerscenario: true
-
-        :Verifies: SAT-19492
 
         :CaseImportance: Medium
         """

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -46,7 +46,7 @@ def test_host_registration_end_to_end(
 
     :expectedresults: Host registered successfully with valid owner name
 
-    :BZ: 2156926, 2252768
+    :verifies: SAT-21682, SAT-14716
 
     :customerscenario: true
     """

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -188,7 +188,9 @@ class TestRemoteExecution:
 
         :id: 0cd75cab-f699-47e6-94d3-4477d2a94bb7
 
-        :BZ: 1451675, 1804685, 2258968
+        :BZ: 1451675, 1804685
+
+        :verifies: SAT-22554
 
         :expectedresults: Verify the job was successfully run under the
             effective user identity on host, make sure the password is

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -78,7 +78,9 @@ def test_positive_install_configure_host(
 
     :customerscenario: true
 
-    :BZ: 2126891, 2026239
+    :BZ: 2026239
+
+    :verifies: SAT-25418
     """
     puppet_infra_host = [session_puppet_enabled_sat, session_puppet_enabled_capsule]
     for client, puppet_proxy in zip(content_hosts, puppet_infra_host, strict=True):

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -49,9 +49,7 @@ def test_positive_clone_backup(
 
     :parametrized: yes
 
-    :BZ: 2142514, 2013776
-
-    :Verifies: SAT-10789
+    :Verifies: SAT-10789, SAT-15437, SAT-13950
 
     :customerscenario: true
     """

--- a/tests/foreman/destructive/test_fm_upgrade.py
+++ b/tests/foreman/destructive/test_fm_upgrade.py
@@ -32,7 +32,7 @@ def test_negative_ipv6_update_check(sat_maintain):
 
     :customerscenario: true
 
-    :BZ: 2277393
+    :verifies: SAT-24811
 
     :expectedresults: Update check fails due to ipv6.disable=1 in boot options
     """

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -459,7 +459,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
 
     :BlockedBy: SAT-19505
 
-    :BZ: 1814988
+    :verifies: SAT-19505
     """
     contenthost = rex_contenthost
     os_version = contenthost.os_version.major

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -312,7 +312,9 @@ def test_positive_vmware_custom_profile_end_to_end(
 
     :expectedresults: Compute profiles are updated successfully with all the values.
 
-    :BZ: 1315277, 2266672
+    :BZ: 1315277
+
+    :verifies: SAT-23630
     """
     cr_name = gen_string('alpha')
     guest_os_names = [

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -73,7 +73,9 @@ def test_positive_provision_pxe_host(
     :expectedresults: Host should be provisioned and entry from
         discovered host should be auto removed.
 
-    :BZ: 1728306, 1731112, 2258024
+    :BZ: 1728306, 1731112
+
+    :verifies: SAT-22452
 
     :CaseImportance: High
     """
@@ -152,7 +154,9 @@ def test_positive_custom_provision_pxe_host(
     :expectedresults: Host should be provisioned and entry from
         discovered host should be auto removed.
 
-    :BZ: 2238952, 2268544, 2258024, 2025523
+    :BZ: 2025523
+
+    :verifies: SAT-22452, SAT-20098, SAT-23860
 
     :customerscenario: true
 

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -316,7 +316,7 @@ def test_end_to_end(
 
     :parametrized: yes
 
-    :BZ: 2029192, 2265095
+    :verifies: SAT-23414, SAT-7998
 
     :customerscenario: true
     """

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -116,7 +116,9 @@ def test_positive_update_with_all_users(session, target_sat):
     :expectedresults: Location entity is assigned to user after checkbox
         was enabled and then disabled afterwards
 
-    :BZ: 1321543, 1479736, 1479736
+    :BZ: 1479736
+
+    :verifies: SAT-25386
 
     :BlockedBy: SAT-25386
     """

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -199,7 +199,7 @@ def test_positive_create_with_all_users(session, module_target_sat):
 
     :expectedresults: Organization and user entities assigned to each other
 
-    :BZ: 1321543
+    :verifies: SAT-25386
 
     :BlockedBy: SAT-25386
     """

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -586,8 +586,6 @@ def test_positive_check_manifest_validity_notification(
     :expectedresults:
         1. 'Manifest expired', 'Manifest expiring soon' messages appear on Manage Manifest modal box
 
-    :BZ: 2075163
-
     :Verifies: SAT-11630
 
     :customerscenario: true


### PR DESCRIPTION
### Problem Statement 1
The customer scenario check is based on the Bugzilla today, but since bug management is moved to Jira and the bugs have been closed as `CLOSED MIGRATED`, the customer scenario check is broken.

Also, the new bugs are being created on the Jira, hence it's vital to update the test docstrings to have the details from Jira instead.


### Solution 1
- Migrate all the bugs closed as `CLOSED MIGRATED` to get their latest updates from Jira as a new destination.

Also,
The BZs which are not migrated are kept for reference 
Some of the tests have already covered the verified token and hence only the BZ reference is removed.

### Next
- Step 2 / Next PR would switch the logic of customer scenario checks from BZ to Jira.

### Notes

Why are we linking to the parent Jira to the automated test even though there are clones an subtasks?
- The today's focus is Just to remediate the broken  customer scenario check based on BZ
- The `fix_version` was missing on some of the clones at the time of writing this PR
- Parents has the customer cases attached, whereas some clones don’t hence finding the link to customer scenarios is hard

The issue that could happen to link the test to parent Jira ?
- The broken status-based test collection or any other logic

Should we be needing the revisit, if some logic/implementation needs stricter status of a jira ids linked to the tests?
- Yes, we may. But for now, fixing the customer scenario checks is more important.