### PR TITLE
Add Satellite Network Type Attribute to Results

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -152,6 +152,9 @@ def pytest_collection_modifyitems(items, config):
     sat_version = settings.server.version.get('release')
     snap_version = settings.server.version.get('snap', '')
 
+    # Satellite Network Type on which tests are running on
+    satellite_network_type = 'ipv6' if settings.server.is_ipv6 else 'ipv4'
+
     # split the option string and handle no option, single option, multiple
     # config.getoption(default) doesn't work like you think it does, hence or ''
     importance = [i.lower() for i in (config.getoption('importance') or '').split(',') if i != '']
@@ -223,6 +226,9 @@ def pytest_collection_modifyitems(items, config):
         item.user_properties.append(("BaseOS", rhel_version))
         item.user_properties.append(("SatelliteVersion", sat_version))
         item.user_properties.append(("SnapVersion", snap_version))
+
+        # Network Type user property
+        item.user_properties.append(("SatelliteNetworkType", satellite_network_type))
 
         # exit early if no filters were passed
         if importance or component or team:


### PR DESCRIPTION
### Problem Statement
The Satellite Network Type Attribute in results json is needed for test results filtering.

### Solution
The attribute is added to results and the value is based on `is_ipv6` configuration.

### Results

**Ipv4 Value:**
```
<property name="SatelliteNetworkType" value="ipv4" />
```

**Ipv6 Value:**

```
<property name="SatelliteNetworkType" value="ipv6" />
```

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->