### PR TITLE
Add hdm to installer's UPSTREAM_SPECIFIC_MODULES & fix comparison

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -50,6 +50,7 @@ UPSTREAM_SPECIFIC_MODULES = {
     'foreman::plugin::dlm',
     'foreman::plugin::expire_hosts',
     'foreman::plugin::git_templates',
+    'foreman::plugin::hdm',
     'foreman::plugin::hooks',
     'foreman::plugin::kernel_care',
     'foreman::plugin::monitoring',
@@ -67,6 +68,7 @@ UPSTREAM_SPECIFIC_MODULES = {
     'foreman_proxy::plugin::acd',
     'foreman_proxy::plugin::dns::powerdns',
     'foreman_proxy::plugin::dns::route53',
+    'foreman_proxy::plugin::hdm',
     'foreman_proxy::plugin::monitoring',
     'foreman_proxy::plugin::salt',
 }

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -429,7 +429,7 @@ def test_installer_modules_check(target_sat):
     sat_yaml = yaml.safe_load(sat_output.stdout)
     upstream_yaml = yaml.safe_load(upstream_output.stdout)
 
-    assert sat_yaml.keys() == (upstream_yaml.keys() - UPSTREAM_SPECIFIC_MODULES)
+    assert set(sat_yaml.keys()) == (upstream_yaml.keys() - UPSTREAM_SPECIFIC_MODULES)
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
### Problem Statement

This has two problems. First of all, HDM is a new plugin that recently started shipping upstream, but don't ship downstream.

The second problem is that the diff is hard to read. On the right hand side it is `dict_keys() - set()` which results in a set. While you can compare `dict_keys` and `set`, the resulting diff isn't very useful because pytest doesn't diff the elements.

### Solution

For the first problem, hdm is added to installer's `UPSTREAM_SPECIFIC_MODULES`.

The second problem is solved by converting the left hand side into a set so it's comparing two sets. Technically that's also correct because for us the order doesn't matter either; it's only about the elements.

### Related Issues

https://github.com/theforeman/foreman-installer/commit/de26c75efc9e6a6224dc0bd8dadee762faf2f163 added HDM to the upstream installer.