### PR TITLE
[6.13.z] Add manifester_inventory to ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ logs/**
 /inventory.yaml
 
 # manifester local files
+/manifester_inventory.yaml
 /manifester_settings.yaml
 /manifests/
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15842

### Problem Statement
Manifester's inventory file shows up in the "Untracked files"  list. This file should never be put in SCM.

### Solution
put the manifester inventory file path in the `.gitignore` file.
