### PR TITLE
[6.15.z] Fix PR #15726 for missing unpushed changes

### DIFF
--- a/tests/upgrades/test_capsule.py
+++ b/tests/upgrades/test_capsule.py
@@ -72,7 +72,7 @@ class TestCapsuleFeatures:
         assert (
             post_features == pre_features
         ), 'capsule features after and before upgrade are differrent'
-        pre_configured_capsule.nailgun_capsule.refresh()
+        pre_configured_capsule.nailgun_smart_proxy.refresh()
         refreshed_features = set(json.loads(pre_configured_capsule.get_features()))
         assert refreshed_features == pre_features, 'capsule features after refresh are differrent'
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15846

### Problem Statement
In #15726 I provided results of testing however I forgot to push very last change from local to my origin/PR resulting in failed test:
```
AttributeError: 'DecClass' object has no attribute 'refresh'
```

### Solution
Push missing change for #15726

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->