### PR TITLE
CE-yum and docker repos support download policy

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -503,15 +503,15 @@ class TestRepository:
         indirect=True,
         ids=lambda x: x['content_type'],
     )
-    def test_negative_create_non_yum_with_download_policy(self, repo_options, target_sat):
-        """Verify that non-YUM repositories cannot be created with
+    def test_negative_create_repos_with_download_policy(self, repo_options, target_sat):
+        """Verify that non-YUM & non-docker repositories cannot be created with
         download policy
 
         :id: 8a59cb31-164d-49df-b3c6-9b90634919ce
 
         :parametrized: yes
 
-        :expectedresults: Non-YUM repository is not created with a download
+        :expectedresults: Non-YUM & non-docker repositories are not created with on_demand download
             policy
 
         :CaseImportance: Critical

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -668,21 +668,20 @@ class TestRepository:
             [
                 {'content-type': content_type, 'download-policy': 'on_demand'}
                 for content_type in REPO_TYPE
-                if content_type != 'yum'
-                if content_type != 'ostree'
+                if content_type not in ['yum', 'docker', 'deb']
             ]
         ),
         indirect=True,
     )
-    def test_negative_create_non_yum_with_download_policy(self, repo_options, module_target_sat):
-        """Verify that non-YUM repositories cannot be created with download
-        policy TODO: Remove ostree from exceptions when ostree is added back in Satellite 7
+    def test_negative_create_repos_with_download_policy(self, repo_options, module_target_sat):
+        """Verify that non-YUM & non-docker repositories cannot be created with download
+        policy
 
         :id: 71388973-50ea-4a20-9406-0aca142014ca
 
         :parametrized: yes
 
-        :expectedresults: Non-YUM repository is not created with a download
+        :expectedresults: Non-YUM & non-docker repositories are not created with on_demand download
             policy
 
         :BZ: 1439835


### PR DESCRIPTION
### Problem Statement
Component audit - SAT-25972
Fix test case- yum and docker repositories support download policy, api and cli tests need to be updated

### Solution
Updated test name: `test_negative_create_repos_with_download_policy`

### Related Issues
NA

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k 'test_negative_create_repos_with_download_policy'
```

```
trigger: test-robottelo
pytest: tests/foreman/cli/test_repository.py -k 'test_negative_create_repos_with_download_policy'
```


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->