### PR TITLE
fix in computeresource_rhev

### DIFF
--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -656,7 +656,7 @@ def test_positive_provision_rhev_image_based_and_disassociate(
         assert host_info.get('network').get('mac') == rhv_vm.get_nics()[0].mac.address
         # Check the host is associated to the CR
         assert 'compute-resource' in host_info
-        assert host_info['compute-resource'] == name
+        assert host_info['compute-resource']['name'] == name
         # Done. Do not try to SSH, this image-based test should work even without
         # being in the same network as RHEV. We checked the VM exists and
         # that's enough.


### PR DESCRIPTION
### Problem Statement
It was unable to fetch the name because the output was coming in dictionary format due to changes in the info() method. Please refer to the PR - https://github.com/SatelliteQE/robottelo/pull/15599

### Solution
Small changes have been made here to fetch the name from the dictionary during the assertion.
