### PR TITLE
capsule upgrade playbook test adjustments

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -51,7 +51,7 @@ def test_positive_run_capsule_upgrade_playbook(module_capsule_configured, target
             'job_template_id': template_id,
             'inputs': {
                 'target_version': CAPSULE_TARGET_VERSION,
-                'whitelist_options': 'repositories-validate,repositories-setup',
+                'whitelist_options': 'repositories-validate,repositories-setup,non-rh-packages',
             },
             'targeting_type': 'static_query',
             'search_query': f'name = {module_capsule_configured.hostname}',


### PR DESCRIPTION
### Problem Statement
Upgrade check `non-rh-packages` fails when promtail is installed

### Solution
adding a whitelist option to make the upgrade playbook run pass 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->