### PR TITLE
add test for capsule update playbook 

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -15,10 +15,7 @@
 import pytest
 
 from robottelo.config import settings
-from robottelo.hosts import get_sat_version
 from robottelo.utils import ohsnap
-
-CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
 
 @pytest.mark.tier4
@@ -36,6 +33,51 @@ def test_positive_find_capsule_upgrade_playbook(target_sat):
     template_name = 'Capsule Upgrade Playbook'
     templates = target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})
     assert len(templates) > 0
+
+
+@pytest.mark.tier4
+def test_positive_run_capsule_update_playbook(module_capsule_configured, target_sat):
+    """Run Capsule Upgrade playbook against an External Capsule
+
+    :id: 9ec6903d-2bb7-46a5-8002-afc74f06d83b
+
+    :steps:
+        1. Create a Capsule VM, add REX key.
+        2. Run the Capsule Upgrade Playbook.
+
+    :expectedresults: Capsule is upgraded successfully
+
+    :CaseImportance: Medium
+    """
+
+    template_name = 'Capsule Update Playbook'
+    template_id = (
+        target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})[0].id
+    )
+    module_capsule_configured.add_rex_key(satellite=target_sat)
+    job = target_sat.api.JobInvocation().run(
+        synchronous=False,
+        data={
+            'job_template_id': template_id,
+            'inputs': {
+                'whitelist_options': 'repositories-validate,repositories-setup,non-rh-packages',
+            },
+            'targeting_type': 'static_query',
+            'search_query': f'name = {module_capsule_configured.hostname}',
+        },
+    )
+    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
+    result = target_sat.api.JobInvocation(id=job['id']).read()
+    assert result.succeeded == 1
+    result = target_sat.execute('satellite-maintain health check')
+    assert result.status == 0
+    for line in result.stdout:
+        assert 'FAIL' not in line
+    result = target_sat.api.SmartProxy(
+        id=target_sat.api.SmartProxy(name=target_sat.hostname).search()[0].id
+    ).refresh()
+    feature_set = {feat['name'] for feat in result['features']}
+    assert {'Dynflow', 'Script', 'Pulpcore', 'Logs'}.issubset(feature_set)
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
### Problem Statement
Adjusting to the recent changes in satellite-maintain, for the test's scenario (upgrade from stream to stream) it no longer makes sense to specify the target version.

### Solution


### Related Issues
https://github.com/SatelliteQE/robottelo/pull/15862 is also needed to make this work, but that change is meant to be cherrypickes, while this should be master only

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->