### PR TITLE
Add tests for multi-CV hosts

### DIFF
--- a/pytest_fixtures/component/contentview.py
+++ b/pytest_fixtures/component/contentview.py
@@ -76,3 +76,24 @@ def session_multicv_sat(session_satellite_host):
     session_satellite_host.enable_multicv_setting()
     session_satellite_host.update_setting('allow_multiple_content_views', 'True')
     return session_satellite_host
+
+
+@pytest.fixture(scope='session')
+def session_multicv_org(session_multicv_sat):
+    return session_multicv_sat.api.Organization().create()
+
+
+@pytest.fixture(scope='session')
+def session_multicv_default_ak(session_multicv_sat, session_multicv_org):
+    return session_multicv_sat.api.ActivationKey(
+        organization=session_multicv_org,
+        content_view=session_multicv_org.default_content_view.id,
+        environment=session_multicv_org.library.id,
+    ).create()
+
+
+@pytest.fixture(scope='session')
+def session_multicv_lce(session_multicv_sat, session_multicv_org):
+    return session_multicv_sat.api.LifecycleEnvironment(
+        organization=session_multicv_org,
+    ).create()

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -41,6 +41,10 @@ class EnablePluginsSatellite:
 
     def enable_multicv_setting(self):
         """Makes multi-CV setting available in the downstream Satellite"""
+        if len(
+            self.api.Setting().search(query={'search': 'name={"allow_multiple_content_views"}'})
+        ):
+            return  # Setting is already exposed
         cfg_file = 'upstream_only_settings.rb'
         cfg_path = self.execute(f'find /usr/share/gems/gems/ -name {cfg_file}').stdout.strip()
         assert cfg_file in cfg_path, 'Config file not found'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -451,7 +451,6 @@ class ContentHost(Host, ContentHostMixins):
     def enable_repo(self, repo, force=False):
         """Enables specified Red Hat repository on the broker virtual machine.
         Does nothing if downstream capsule or satellite tools repo was passed.
-        Custom repos are enabled by default when registering a host.
 
         :param repo: Red Hat repository name.
         :param force: enforce enabling command, even when custom repos are
@@ -480,6 +479,20 @@ class ContentHost(Host, ContentHostMixins):
 
     def subscription_manager_list(self):
         return self.execute('subscription-manager list')
+
+    def subscription_manager_environments_set(
+        self,
+        env_names,
+        username=settings.server.admin_username,
+        password=settings.server.admin_password,
+    ):
+        """
+        Reassign the host to the specified content view environments
+        """
+        assert isinstance(env_names, str)
+        return self.execute(
+            f'subscription-manager environments --set="{env_names}" --username={username} --password={password}'
+        )
 
     def subscription_manager_get_pool(self, sub_list=None):
         """


### PR DESCRIPTION
### Problem Statement

Test coverage for multi-CV functionality is needed

### Solution

Add tests for multi-CV:

1. basic multi-CV registration (positive)
2. multi-CV assignment with sub-man environments & repo access
3. ~~multi-CV assignment via hammer (not working yet)~~ I moved this to [another PR](https://github.com/SatelliteQE/robottelo/pull/15880) so I am marking this PR as ready for review.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->