### PR TITLE
Jira replacing bz for customer scenarios check

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -48,7 +48,7 @@ jobs:
           echo "assignees: pondrejk " >> .env.md
           echo "labels: Documentation" >> .env.md
           echo "---" >> .env.md
-          echo CS_TAGS="$(make customer-scenario-check)" >> .env.md
+          echo CS_TAGS="$(make customer-scenario-check-jira)" >> .env.md
           if grep 'The following tests need customerscenario tags' .env.md; then
             echo "::set-output name=result::0"
           fi

--- a/Makefile
+++ b/Makefile
@@ -169,8 +169,11 @@ clean-cache:
 
 clean-all: docs-clean logs-clean pyc-clean clean-cache clean-shared
 
-customer-scenario-check:
-	@scripts/customer_scenarios.py
+customer-scenario-check-bz:
+	@scripts/customer_scenarios.py --bz
+
+customer-scenario-check-jira:
+	@scripts/customer_scenarios.py --jira
 
 vault-login:
 	@scripts/vault_login.py --login

--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -53,7 +53,7 @@ def config_migrations(settings, data):
     :type data: dict
     """
     logger.info('Running config migration hooks')
-    sys.path.append(str(Path(__file__).parent))
+    sys.path.append(str(Path(__file__).parent.parent))
     from conf import migrations
 
     migration_functions = [

--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -156,9 +156,7 @@ def collect_data_jira(collected_data, cached_data):  # pragma: no cover
     """
     jira_data = (
         get_data_jira(
-            [item for item in collected_data if item.startswith('SAT-')],
-            cached_data=cached_data,
-            jira_fields=common_jira_fields,
+            [item for item in collected_data if item.startswith('SAT-')], cached_data=cached_data
         )
         or []
     )
@@ -227,6 +225,9 @@ def get_data_jira(issue_ids, cached_data=None, jira_fields=None):  # pragma: no 
     Returns:
         [list of dicts] -- [{'id':..., 'status':..., 'resolution': ...}]
     """
+    if not jira_fields:
+        jira_fields = common_jira_fields
+
     if not issue_ids:
         return []
 
@@ -276,7 +277,7 @@ def get_single_jira(issue_id, cached_data=None):  # pragma: no cover
         try:
             jira_data = cached_data[f"{issue_id}"]['data']
         except (KeyError, TypeError):
-            jira_data = get_data_jira([str(issue_id)], cached_data, jira_fields=common_jira_fields)
+            jira_data = get_data_jira([str(issue_id)], cached_data)
             jira_data = jira_data and jira_data[0]
         CACHED_RESPONSES['get_single'][issue_id] = jira_data
     return jira_data or get_default_jira(issue_id)

--- a/scripts/customer_scenarios.py
+++ b/scripts/customer_scenarios.py
@@ -41,6 +41,12 @@ def get_bz_data(paths):
 
 
 def get_tests_path_without_customer_tag(paths):
+    """Returns the path and test name that does not have customerscenario token even though
+    it has verifies token when necessary
+
+    Arguments:
+        paths {list} -- List of test modules paths
+    """
     testcases = testimony.get_testcases(paths)
     result = {}
     for path, tests in testcases.items():
@@ -101,6 +107,11 @@ def query_bz(data):
 
 
 def query_jira(data):
+    """Returns the list of path and test name for missing customerscenario token
+
+    Arguments:
+         data {dict} -- The list of test modules and tests without customerscenario tags
+    """
     output = []
     sfdc_counter_field = 'customfield_12313440'
     with click.progressbar(data.items()) as bar:


### PR DESCRIPTION
### Problem Statement
- Broken Customer Scenarios Tagging as we have switched from Bugzilla to Jira
- The newly created and migrated BZs to Jira are not being tracked for customer scenarios
- Broken Customer Scenarios report in polarion

### Solution
- Switching the Customer Scenarios Tagging identification from Bugzilla to Jira
- New jira specific Customer Scenarios script functions are added 
- The existing Jira module is modified to work for all the possible scenarios  like jira test selection / commenting  and customer scenarios scripting
- The weekly check GHA now uses jira based integration for customer scenario checks

### Results
```
# ./scripts/customer_scenarios.py --jira
[####################################]  100%          
The following tests need customerscenario tags:
tests/foreman/cli/test_remoteexecution.py ['test_positive_timeout_to_kill', 'SAT-25243']
tests/foreman/cli/test_satellitesync.py ['test_positive_export_library_custom_repo', 'SAT-24884']
```