### PR TITLE
adding the support for ipv4 and ipv6 parameterization for Container and VM

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -30,9 +30,13 @@ def host_conf(request):
         ]
     ):
         deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('container', {})
+        if deploy_kwargs and (network := params.get('network')):
+            deploy_kwargs.update({'Container': network})
     # if we're not using containers or a container isn't available, use a VM
     if not deploy_kwargs:
         deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('vm', {})
+        if network := params.get('network'):
+            deploy_kwargs.update({'deploy_network_type': network})
     conf.update(deploy_kwargs)
     return conf
 

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -42,17 +42,33 @@ def pytest_generate_tests(metafunc):
                     if re.fullmatch(str(matcher[0]), str(setting_rhel_ver))
                 ]
             )
+        network_params = ['ipv6' if settings.server.is_ipv6 else 'ipv4']
         rhel_params = []
+        ids = []
         filtered_versions = set(list_params + match_params)
         # default to all supported versions if no filters were found
         for ver in filtered_versions or settings.supportability.content_hosts.rhel.versions:
             rhel_params.append(dict(rhel_version=ver, no_containers=no_containers))
+
         if rhel_params:
             rhel_params.sort(key=lambda r: str(r['rhel_version']))
+            ids = [f'rhel{r["rhel_version"]}' for r in rhel_params]
+            network_marker = metafunc.definition.get_closest_marker("network")
+            if network_marker and settings.server.is_ipv6:
+                network_params = network_marker.args[0] if network_marker.args else ['ipv6']
+            elif network_marker and not settings.server.is_ipv6:
+                network_params = network_marker.args[0] if network_marker.args else ['ipv4']
+            # Create combinations of rhel_params and containers as dictionaries
+            if network_params:
+                rhel_params = [
+                    {**rhel, 'network': cont} for rhel in rhel_params for cont in network_params
+                ]
+                ids = [f"rhel{param['rhel_version']}-{param['network']}" for param in rhel_params]
+        if rhel_params:
             metafunc.parametrize(
                 content_host_fixture,
                 rhel_params,
-                ids=[f'rhel{r["rhel_version"]}' for r in rhel_params],
+                ids=ids,
                 indirect=True,
             )
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1589,6 +1589,7 @@ class Capsule(ContentHost, CapsuleMixins):
         if settings.server.is_ipv6:
             url = urlparse(settings.server.http_proxy_ipv6_url)
             self.enable_rhsm_proxy(url.hostname, url.port)
+            self.ipv6 = settings.server.is_ipv6
 
     def disable_ipv6_http_proxy(self):
         """Executes procedures for disabling IPv6 HTTP Proxy on Capsule"""
@@ -1771,6 +1772,7 @@ class Satellite(Capsule, SatelliteMixins):
                 'The IPv6 HTTP Proxy setting is not enabled. Skipping the IPv6 HTTP Proxy setup.'
             )
             return None
+        self.ipv6 = settings.server.is_ipv6
         proxy_name = 'Robottelo IPv6 Automation Proxy'
         if not self.cli.HttpProxy.exists(search=('name', proxy_name)):
             http_proxy = self.api.HTTPProxy(
@@ -1780,7 +1782,7 @@ class Satellite(Capsule, SatelliteMixins):
             logger.info(
                 'The IPv6 HTTP Proxy is already enabled. Skipping the IPv6 HTTP Proxy setup.'
             )
-            http_proxy = self.api.HTTPProxy().search(query={'search': f'name={proxy_name}'})[0]
+            http_proxy = self.api.HTTPProxy().search(query={'search': f'name="{proxy_name}"'})[0]
         # Setting HTTP Proxy as default in the settings
         self.cli.Settings.set(
             {

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -8,6 +8,7 @@ def get_client(
     username=None,
     password=None,
     port=22,
+    ipv6=None,
 ):
     """Returns a host object that provides an ssh connection
 
@@ -22,6 +23,7 @@ def get_client(
         username=username or settings.server.ssh_username,
         password=password or settings.server.ssh_password,
         port=port or settings.server.ssh_client.port,
+        ipv6=ipv6 or settings.server.is_ipv6,
     )
 
 
@@ -33,6 +35,7 @@ def command(
     password=None,
     timeout=None,
     port=22,
+    ipv6=None,
 ):
     """Executes SSH command(s) on remote hostname.
 
@@ -48,6 +51,7 @@ def command(
         username=username,
         password=password,
         port=port,
+        ipv6=ipv6,
     )
     result = client.execute(cmd, timeout=timeout)
 


### PR DESCRIPTION
### Problem Statement

Currently, Content-Host-based test-cases/fixtures are not taking an input/param for network type so that the ipv6 / ipv4 satellite can connect with the ipv6 / ipv4 content host.

But, since broker and Tower support provide the param for choosing the network type, we have to alter the content host tests cases/fixtures to take the argument for the network type parameter.

### Solution
As discussed in the brainstorming call on 31st July 2024, we will choose to parameterise tests to provide the network type parameter. That looks like:

`@pytest.mark.network_type(['ipv4', 'ipv6'])` that as value can also take the regex very similar as rhel_ver_list / rhel_Ver_match implementation.

- [x] Generate tests based on the network type parametrization on the test
- [x] Insert the appropriate network type option for spinning the RHEL content host
- [x] The option insertion should be based on container and  no_container
- [x]  Generate the test cases for cross network Satellite-IPv4 - Podman IPv6 and Satellite-IPv6 - Podman IPv4
- [x]  Have at least one test that shows the test generation works.

### CI PR Dependency
1439 

### Test Matrix
Network Marker | Satellite VM/Container | Network Configuration | Tests to Run | Expected Result
-- | -- | -- | -- | --
ipv4 | Yes | present | [rhel7-ipv4], [rhel8-ipv4], [rhel9-ipv4] | Pass
ipv4 | Yes | present (empty list) | [rhel7-ipv4], [rhel8-ipv4], [rhel9-ipv4] | Pass
ipv4 | Yes | present (only ipv4) | [rhel7-ipv4], [rhel8-ipv4], [rhel9-ipv4] | Pass
ipv4 | Yes | present (only ipv6) | [rhel7-ipv6], [rhel8-ipv6], [rhel9-ipv6] | Fail
ipv4 | Yes | present ([ipv4, ipv6]) | [rhel7-ipv6], [rhel8-ipv6], [rhel9-ipv6], [rhel7-ipv4], [rhel8-ipv4], [rhel9-ipv4] | Pass/Fail
ipv6 | Yes | present | [rhel7-ipv6], [rhel8-ipv6], [rhel9-ipv6] | Pass
ipv6 | Yes | present (empty list) | [rhel7-ipv6], [rhel8-ipv6], [rhel9-ipv6] | Pass
ipv6 | Yes | present (only ipv4) | [rhel7-ipv4], [rhel8-ipv4], [rhel9-ipv4] | Fail
ipv6 | Yes | present (only ipv6) | [rhel7-ipv6], [rhel8-ipv6], [rhel9-ipv6] | Pass
ipv6 | Yes | present ([ipv4, ipv6]) | [rhel7-ipv6], [rhel8-ipv6], [rhel9-ipv6], [rhel7-ipv4], [rhel8-ipv4], [rhel9-ipv4] | Pass/Fail

**If there is no marker then it will pick the network based on the Satellite.**   

