### PR TITLE
[6.15.z] Add end-to-end test for facts

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -179,7 +179,7 @@ class SystemFacts:
         if result.status == 0:
             for line in result.stdout.splitlines():
                 if ': ' in line:
-                    key, val = line.split(': ')
+                    key, val = line.split(': ', 1)
                 else:
                     key = last_key
                     val = f'{fact_dict[key]} {line}'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15818

### Problem Statement
Missing end-to-end scenario for facts
Existing implementation of get_facts() method splits the string on colon. With RHEL9, we have fact values which contains colon like 'lscpu.vulnerability_spec_rstack_overflow: Vulnerable: Safe RET, no microcode'. This raises Value error ``ValueError: too many values to unpack (expected 2)`.

### Solution
Added e2e for facts 
Updated the code to split the string on the first colon and treat the first half as key and rest of it as value.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->