### PR TITLE
updated the gha to handle extras e.g. broker[docker,hussh,podman]

### DIFF
--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -25,7 +25,7 @@ jobs:
         id: yaml
         uses: mikefarah/yq@master
         with:
-          cmd: yq e '.["${{ steps.metadata.outputs.dependency-names }}"]' ./.github/dependency_tests.yaml
+          cmd: yq eval '.["${{ steps.metadata.outputs.dependency-names }}"]' ./.github/dependency_tests.yaml
 
       - name: Add the PRT Comment
         if:  steps.yaml.outputs.result != 'null'


### PR DESCRIPTION
### Problem Statement
Depedanbot auto-merge GHA is not raising the PRT comment in case of dependency has extras  e.g.  broker[docker,hussh,podman]

### Solution
Adding eval is solving this issue and tested locally 

```bash
> ls
CODEOWNERS               PULL_REQUEST_TEMPLATE.md auto_assign.yml          dependabot.yml           dependency_tests.yaml    workflows
> yq eval '.["pyotp"]' dependency_tests.yaml
tests/foreman/ui/test_ldap_authentication.py -k 'test_positive_login_user_password_otp'
> yq eval '.["broker[docker,podman,hussh]"]' dependency_tests.yaml
tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'
> yq eval '.["dynaconf[vault]"]' dependency_tests.yaml
tests/foreman/api/test_ldapauthsource.py -k 'test_positive_endtoend'```

