### PR TITLE
[6.15.z] Remove satellite6-upgrade traces from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,11 +81,6 @@ tests/foreman/pytest.ini
 /conf/*.conf
 !/conf/supportability.yaml
 
-# I don't know where those 2 files come from
-# but they are always there.
-full_upgrade
-upgrade_highlights
-
 #Robottelo artifact
 screenshots/
 tmp/


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15891

### Problem Statement
`full_upgrade` and `upgrade_highlights` are traces of satellite6-upgrade.

### Solution
remove them from .gitignore

### Related Issues
They should have been removed from .gitignore in #11331.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->