### PR TITLE
[6.13.z][Task 1 - Customer Scenario Checks] Replacing Migrated BZs docstrings token to Jira based

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -427,8 +427,6 @@ def test_positive_verify_updated_fdi_image(target_sat):
 
     Verifies: SAT-24197, SAT-25275
 
-    :BZ: 2271598
-
     :customerscenario: true
 
     :CaseImportance: Critical

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1623,7 +1623,7 @@ def test_errata_list_by_contentview_filter(module_entitlement_manifest_org, modu
 
     :customerscenario: true
 
-    :BZ: 1785146
+    :verifies: SAT-7987
     """
     product = entities.Product(organization=module_entitlement_manifest_org).create()
     repo = module_target_sat.cli_factory.make_repository(

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -43,7 +43,7 @@ def test_host_registration_end_to_end(
 
     :expectedresults: Host registered successfully
 
-    :BZ: 2156926
+    :verifies: SAT-14716
 
     :customerscenario: true
     """

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -78,7 +78,9 @@ def test_positive_install_configure_host(
 
     :customerscenario: true
 
-    :BZ: 2126891, 2026239
+    :BZ: 2026239
+
+    :verifies: SAT-25418
     """
     puppet_infra_host = [session_puppet_enabled_sat, session_puppet_enabled_capsule]
     for client, puppet_proxy in zip(content_hosts, puppet_infra_host, strict=True):

--- a/tests/foreman/destructive/test_clone.py
+++ b/tests/foreman/destructive/test_clone.py
@@ -44,7 +44,9 @@ def test_positive_clone_backup(
 
     :parametrized: yes
 
-    :BZ: 2142514, 2013776
+    :BZ: 2142514
+
+    :Verifies: SAT-10789
 
     :customerscenario: true
     """

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -256,7 +256,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
 
     :expectedresults: REX job should be success and ARF report should be sent to satellite
 
-    :BZ: 1814988
+    :verifies: SAT-19505
     """
     hgrp_name = gen_string('alpha')
     policy_name = gen_string('alpha')

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -192,6 +192,8 @@ def test_end_to_end(
 
     :BZ: 2029192
 
+    :verifies: SAT-23414
+
     :customerscenario: true
     """
     ERRATA_DETAILS = {

--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -115,7 +115,9 @@ def test_positive_update_with_all_users(session, target_sat):
     :expectedresults: Location entity is assigned to user after checkbox
         was enabled and then disabled afterwards
 
-    :BZ: 1321543, 1479736, 1479736
+    :BZ: 1479736
+
+    :verifies: SAT-25386
 
     :BlockedBy: SAT-25386
     """

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -198,7 +198,7 @@ def test_positive_create_with_all_users(session, module_target_sat):
 
     :expectedresults: Organization and user entities assigned to each other
 
-    :BZ: 1321543
+    :verifies: SAT-25386
 
     :BlockedBy: SAT-25386
     """


### PR DESCRIPTION
Replacing Migrated BZs docstrings token to verifies

### Problem Statement
Failed AutoCherrypick of #15812 

### Solution
Manual cherry-pick of the same.

### Related Issues
Closes #15905



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->