### PR TITLE
pit marker for oscap

### DIFF
--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -240,8 +240,6 @@ class TestTailoringFiles:
 
     @pytest.mark.stubbed
     @pytest.mark.tier4
-    @pytest.mark.pit_server
-    @pytest.mark.pit_client
     @pytest.mark.upgrade
     def test_positive_oscap_run_with_tailoring_file_and_capsule(self):
         """End-to-End Oscap run with tailoring files and default capsule

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -224,6 +224,8 @@ def scap_prerequisites(module_org, default_proxy, target_sat):
 @pytest.mark.upgrade
 @pytest.mark.tier4
 @pytest.mark.rhel_ver_match('[^6].*')
+@pytest.mark.pit_server
+@pytest.mark.pit_client
 def test_positive_oscap_run_via_ansible(
     module_org,
     default_proxy,


### PR DESCRIPTION
### Problem Statement
adding pit marker for scap client test, removed marker from stubbed test (leaving the unstubbing/removal decision for component evaluation)


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->