### PR TITLE
Add test coverage for Manage packages feature

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -114,7 +114,7 @@ def content_hosts(request):
 
 @pytest.fixture(scope='module')
 def mod_content_hosts(request):
-    """A module-level fixture that provides two rhel7 content hosts object"""
+    """A module-level fixture that provides two rhel content hosts object"""
     with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
         hosts[0].set_infrastructure_type('physical')
         yield hosts

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -6,6 +6,7 @@ from robottelo.config import settings
 TARGET_FIXTURES = [
     'rhel_contenthost',
     'module_rhel_contenthost',
+    'mod_content_hosts',
     'content_hosts',
     'module_provisioning_rhel_content',
     'capsule_provisioning_rhel_content',

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2197,7 +2197,6 @@ def test_positive_manage_packages(
     - package_management_action: install_1_pckg, install_2_pckgs, upgrade_1_pckg, upgrade_all_pckgs, remove_1_pckg, remove_2_pckgs
     - finish_via: rex or custom_rex
     All this leads to 2 * 6 * 2 = 24 test cases in total.
-    For the visual representation of the test matrix see: https://miro.com/app/board/uXjVK0pTODA=/?share_link_id=776786926115
 
     :id: 1d6760ca-9c7e-4267-9a4b-3f91d50c8eb1
 

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2301,10 +2301,8 @@ def test_positive_manage_packages(
         # Set flags based on current type of the finish
         match finish_via:
             case 'rex':
-                manage_by_rex_flag = True
                 manage_by_customized_rex_flag = False
             case 'custom_rex':
-                manage_by_rex_flag = False
                 manage_by_customized_rex_flag = True
 
         # Get the latest versions of wanted packages on the tested hosts
@@ -2369,7 +2367,6 @@ def test_positive_manage_packages(
             packages_to_upgrade=packages_to_upgrade,
             packages_to_install=packages_to_install,
             packages_to_remove=packages_to_remove,
-            manage_by_rex=manage_by_rex_flag,
             manage_by_customized_rex=manage_by_customized_rex_flag,
         )
 
@@ -2388,11 +2385,11 @@ def test_positive_manage_packages(
             )
 
         elif upgrade_all_packages_flag:
-            if manage_by_rex_flag:
+            if not manage_by_customized_rex_flag:
                 module_target_sat.wait_for_tasks(
                     f'action: "Upgrade all packages" and resource_id = {job_id}'
                 )
-            elif manage_by_customized_rex_flag:
+            else:
                 module_target_sat.wait_for_tasks(
                     f'action: "Update package(s)" and resource_id = {job_id}'
                 )

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -16,6 +16,7 @@ import copy
 import csv
 import os
 import re
+import time
 
 from airgun.exceptions import DisabledWidgetError, NoSuchElementException
 from box import Box
@@ -2150,3 +2151,317 @@ def test_host_status_honors_taxonomies(
     with module_target_sat.ui_session(test_name, user=login, password=password) as session:
         statuses = session.host.host_statuses()
     assert len([status for status in statuses if int(status['count'].split(': ')[1]) != 0]) == 1
+
+
+@pytest.mark.parametrize(
+    'module_repos_collection_with_setup',
+    [
+        {
+            'distro': 'rhel8',
+            'YumRepository': {'url': settings.repos.yum_3.url},
+        }
+    ],
+    ids=['yum3'],
+    indirect=True,
+)
+@pytest.mark.parametrize('finish_via', ['rex', 'custom_rex'])
+@pytest.mark.parametrize(
+    'package_management_action',
+    [
+        'install_1_pckg',
+        'install_2_pckgs',
+        'upgrade_1_pckg',
+        'upgrade_all_pckgs',
+        'remove_1_pckg',
+        'remove_2_pckgs',
+    ],
+)
+@pytest.mark.parametrize('number_of_hosts', [1, 2], ids=['1_host', '2_hosts'])
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+@pytest.mark.no_containers
+def test_positive_manage_packages(
+    request,
+    module_target_sat,
+    mod_content_hosts,
+    module_repos_collection_with_setup,
+    new_host_ui,
+    number_of_hosts,
+    package_management_action,
+    finish_via,
+):
+    """
+    This test is testing the new Satellite feature - Managing packages on hosts via the new All hosts UI.
+    It is highly parametrized so it can test various package management actions on various hosts.
+    Test cases are defined by the combination of the following parameters:
+    - number_of_hosts: 1 or 2
+    - package_management_action: install_1_pckg, install_2_pckgs, upgrade_1_pckg, upgrade_all_pckgs, remove_1_pckg, remove_2_pckgs
+    - finish_via: rex or custom_rex
+    All this leads to 2 * 6 * 2 = 24 test cases in total.
+    For the visual representation of the test matrix see: https://miro.com/app/board/uXjVK0pTODA=/?share_link_id=776786926115
+
+    :id: 1d6760ca-9c7e-4267-9a4b-3f91d50c8eb1
+
+    :steps:
+        1. Setup hosts on Satellite, override reposets to enabled and refresh applicability so the package profile is updated
+        2. Setup all the control flags for airgun entity
+        3. Setup packages on the selected hosts so they can be managed in the next steps
+        4. Run the selected package management action on the selected hosts
+        5. Wait for the specific tasks to finish
+        6. Assert the results
+
+    :expectedresults: Various package management actions should run successfully on various hosts
+
+    :CaseComponent: Hosts-Content
+
+    :parametrized: yes
+
+    :Team: Phoenix-content
+    """
+
+    packages = ['panda', 'seal']
+
+    for host in mod_content_hosts:
+        host.add_rex_key(module_target_sat)
+        module_repos_collection_with_setup.setup_virtual_machine(host)
+
+    product_name = module_repos_collection_with_setup.custom_product.name
+
+    with module_target_sat.ui_session() as session:
+        session.organization.select(module_repos_collection_with_setup.organization['name'])
+
+        for host in mod_content_hosts:
+            if (
+                session.host_new.get_repo_sets(host.hostname, product_name)[0]['Status']
+                == 'Disabled'
+            ):
+                session.host_new.override_repo_sets(
+                    host.hostname, product_name, "Override to enabled"
+                )
+                session.host_new.refresh_applicability(host.hostname)
+                latest_refresh_applicability_id = int(
+                    module_target_sat.cli.JobInvocation().list()[0]['id']
+                )
+                module_target_sat.wait_for_tasks(
+                    search_query=(
+                        f'action: "Upload package profile for a host" and resource_id = {latest_refresh_applicability_id}'
+                    )
+                )
+
+        # Define hosts to test based on the number of hosts
+        hosts_to_test = []
+        match number_of_hosts:
+            case 1:
+                hosts_to_test = [mod_content_hosts[0]]
+            case 2:
+                hosts_to_test = mod_content_hosts
+
+        # Set default value to management action flags
+        upgrade_all_packages_flag = upgrade_packages_flag = install_packages_flag = (
+            remove_packages_flag
+        ) = False
+
+        # Set flags according to current parametrization
+        match package_management_action:
+            case 'install_1_pckg':
+                install_packages_flag = True
+                packages_to_install = [packages[0]]
+                packages_to_upgrade = None
+                packages_to_remove = None
+
+            case 'install_2_pckgs':
+                install_packages_flag = True
+                packages_to_install = packages
+                packages_to_upgrade = None
+                packages_to_remove = None
+
+            case 'upgrade_1_pckg':
+                upgrade_packages_flag = True
+                packages_to_install = None
+                packages_to_upgrade = [packages[0]]
+                packages_to_remove = None
+
+            case 'upgrade_all_pckgs':
+                upgrade_packages_flag = True
+                upgrade_all_packages_flag = True
+                packages_to_install = None
+                packages_to_upgrade = packages
+                packages_to_remove = None
+
+            case 'remove_1_pckg':
+                remove_packages_flag = True
+                packages_to_install = None
+                packages_to_upgrade = None
+                packages_to_remove = [packages[0]]
+
+            case 'remove_2_pckgs':
+                remove_packages_flag = True
+                packages_to_install = None
+                packages_to_upgrade = None
+                packages_to_remove = packages
+
+        # Set flags based on current type of the finish
+        match finish_via:
+            case 'rex':
+                manage_by_rex_flag = True
+                manage_by_customized_rex_flag = False
+            case 'custom_rex':
+                manage_by_rex_flag = False
+                manage_by_customized_rex_flag = True
+
+        # Get the latest versions of wanted packages on the tested hosts
+        tested_hosts_packages_latest_version_dicts = {}
+        for host in hosts_to_test:
+            # Check the latests versions of wanted packages
+            result = host.run(f'dnf list {" ".join(packages)}').stdout
+            # Cropping dnf output so it shows only packages
+            packages_list = [line for line in result.split('\n')[3:-1]]
+            packages_latest_version_dict = {}
+            # Create dict containing {'package_name': 'version', ...} for further checks
+            for item in packages_list:
+                parts = item.split()
+                # Remove architecture part from package name
+                package_name = parts[0].split('.')[0]
+                version = parts[1]  # parts look like ['package_name', 'version', 'repo']
+                packages_latest_version_dict[package_name] = version
+
+            tested_hosts_packages_latest_version_dicts[host.hostname] = (
+                packages_latest_version_dict  # {'example.com':{'package_name': 'version', ...}, ...}
+            )
+
+        used_action = package_management_action.split('_')[0]
+
+        if used_action == 'install':
+            # Checking if wanted packages are available so they can be installed in the next step
+            for host in hosts_to_test:
+                assert host.run(f'rpm -q {" ".join(packages_to_install)}').status == len(
+                    packages_to_install
+                ), 'Some of the packages are already installed!'
+
+        elif used_action == 'upgrade':
+            # Installing and downgrading packages so they can be upgraded in the next step
+            for host in hosts_to_test:
+                assert (
+                    host.run(
+                        f'dnf list available | grep -E "{"|".join(packages_to_upgrade)}"'
+                    ).status
+                    == 0
+                ), 'Wanted packages are not available!'
+                assert (
+                    host.run(f'dnf install {" ".join(packages_to_upgrade)} -y').status == 0
+                ), 'Could not install wanted packages!'
+                assert (
+                    host.run(f'dnf downgrade {" ".join(packages_to_upgrade)} -y').status == 0
+                ), 'Packages were not downgraded!'
+
+        elif used_action == 'remove':
+            # Installing packages so they can be removed in the next step
+            for host in hosts_to_test:
+                assert (
+                    host.run(f'dnf install {" ".join(packages_to_remove)} -y').status == 0
+                ), 'Could not install wanted packages!'
+
+        # Run airgun entity which performs Package management action based on the flags set above
+        session.all_hosts.manage_packages(
+            host_names=[host.hostname for host in hosts_to_test],
+            upgrade_all_packages=upgrade_all_packages_flag,
+            upgrade_packages=upgrade_packages_flag,
+            install_packages=install_packages_flag,
+            remove_packages=remove_packages_flag,
+            packages_to_upgrade=packages_to_upgrade,
+            packages_to_install=packages_to_install,
+            packages_to_remove=packages_to_remove,
+            manage_by_rex=manage_by_rex_flag,
+            manage_by_customized_rex=manage_by_customized_rex_flag,
+        )
+
+        # Wait till the job launched by the management action is finished
+        job_id = int(module_target_sat.cli.JobInvocation().list()[0]['id'])
+        if install_packages_flag:
+            module_target_sat.wait_for_tasks(
+                search_query=(
+                    f'action: "Install package(s) name ^ ({",".join(packages_to_install)})" and resource_id = {job_id}'
+                ),
+            )
+
+        elif upgrade_packages_flag and (not upgrade_all_packages_flag):
+            module_target_sat.wait_for_tasks(
+                f'action:  "Update package(s) name ^ ({",".join(packages_to_upgrade)})" and resource_id = {job_id}'
+            )
+
+        elif upgrade_all_packages_flag:
+            if manage_by_rex_flag:
+                module_target_sat.wait_for_tasks(
+                    f'action: "Upgrade all packages" and resource_id = {job_id}'
+                )
+            elif manage_by_customized_rex_flag:
+                module_target_sat.wait_for_tasks(
+                    f'action: "Update package(s)" and resource_id = {job_id}'
+                )
+
+        elif remove_packages_flag:
+            module_target_sat.wait_for_tasks(
+                f'action: "Remove packages name ^ ({",".join(packages_to_remove)})" and resource_id = {job_id}'
+            )
+
+        # MAKE ASSERTS AFTER INSTALLING PACKAGES
+        if used_action == 'install':
+            for host in hosts_to_test:
+                # Check that all the wanted packages are installed
+                assert (
+                    host.run(f'rpm -q {" ".join(packages_to_install)}').status == 0
+                ), 'Some of the wanted packages is not installed!'
+
+                # Get versions of installed packages
+                installed_packages = host.run(
+                    f'rpm -qa {" ".join(packages_to_install)}'
+                ).stdout.split('\n')[:-1]
+                installed_packages_version_dict = {}
+                # Create dict containing {'installed_package_name': 'version', ...} for further checks
+                for package in installed_packages:
+                    package_name, version = package.split('-')[0], '-'.join(package.split('-')[1:])
+                    installed_packages_version_dict[package_name] = version[
+                        : version.rfind('.')
+                    ].strip()
+
+                # Check that the latest version of packages is installed
+                for package in packages_to_install:
+                    assert (
+                        installed_packages_version_dict[package]
+                        == tested_hosts_packages_latest_version_dicts[host.hostname][package]
+                    ), f'Package "{package}" is not installed in the latest version!'
+
+        # MAKE ASSERTS AFTER UPGRADING PACKAGES
+        elif used_action == 'upgrade':
+            for host in hosts_to_test:
+                # Get versions of installed packages
+                installed_packages = host.run(
+                    f'rpm -qa {" ".join(packages_to_upgrade)}'
+                ).stdout.split('\n')[:-1]
+                installed_packages_version_dict = {}
+                # Create dict containing {'installed_package_name': 'version', ...} for further checks
+                for package in installed_packages:
+                    package_name, version = package.split('-')[0], '-'.join(package.split('-')[1:])
+                    installed_packages_version_dict[package_name] = version[
+                        : version.rfind('.')
+                    ].strip()
+
+                # Check that the package was upgraded to the latest version
+                for package in packages_to_upgrade:
+                    assert (
+                        installed_packages_version_dict[package]
+                        == tested_hosts_packages_latest_version_dicts[host.hostname][package]
+                    ), f'Package "{package}" is not upgraded to the latest version!'
+
+        # MAKE ASSERTS AFTER REMOVING PACKAGES
+        elif used_action == 'remove':
+            for host in hosts_to_test:
+                # Assert that all the wanted packages were removed
+                assert host.run(f'rpm -qa {" ".join(packages_to_remove)}').stdout == ''
+
+    @request.addfinalizer
+    def _cleanup():
+        for host in hosts_to_test:
+            time.sleep(5)
+            assert (
+                host.run(f'dnf remove {" ".join(packages)} -y').status == 0
+            ), 'Could not remove installed packages in a finalizer!'

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2214,7 +2214,7 @@ def test_positive_manage_packages(
 
     :parametrized: yes
 
-    :Team: Phoenix-content
+    :Team: Phoenix-subscriptions
     """
 
     packages = ['panda', 'seal']


### PR DESCRIPTION
### Problem Statement
This Robottelo PR adds test coverage for the Manage Packages wizard. 
It is a new 6.16 feature with which users can manage packages.

`test_positive_manage_packages` is parametrized and the test cases are defined by the combination of the following parameters:

- `number_of_hosts`: 1 or 2

-  `package_management_action`: install_1_pckg, install_2_pckgs, upgrade_1_pckg, upgrade_all_pckgs, remove_1_pckg, remove_2_pckgs
- `finish_via`: rex or custom_rex

All this leads to 2 * 6 * 2 = 24 test cases in total.
<!--For the visual representation of the test matrix see: https://miro.com/app/board/uXjVK0pTODA=/?share_link_id=776786926115-->
Visual representation of the test matrix:
<img width="932" alt="Screenshot 2024-08-13 at 16 31 55" src="https://github.com/user-attachments/assets/cf884908-a564-4268-b3e6-c882dba353d3">


Depends on https://github.com/SatelliteQE/airgun/pull/1489

### PRT test Cases example

```
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_positive_manage_packages'
env:
    ROBOTTELO_server__version__snap: '69.0'
    ROBOTTELO_server__deploy_arguments__deploy_snap_version: '69.0'
airgun: 1489
Katello:
    katello: 11101
```

<img width="385" alt="test_positive_manage_packages" src="https://github.com/user-attachments/assets/9ef68329-c758-44a0-8f92-890f02a660e2">