### PR TITLE
Remove install_katello_ca for good

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -198,7 +198,7 @@ def katello_host_tools_tracer_host(rex_contenthost, target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_container_contenthost(request, module_target_sat, default_org):
+def module_container_contenthost(request, module_target_sat, module_org, module_activation_key):
     """Fixture that installs docker on the content host"""
     request.param = {
         "rhel_version": "8",
@@ -215,15 +215,10 @@ def module_container_contenthost(request, module_target_sat, default_org):
             host.execute('systemctl enable --now podman').status == 0
         ), 'Start of podman service failed'
         host.unregister()
-        # register the host to Satellite to accept its cert
-        ak = module_target_sat.cli_factory.make_activation_key(
-            {
-                'lifecycle-environment': 'Library',
-                'content-view': 'Default Organization View',
-                'organization-id': default_org.id,
-            }
+        assert (
+            host.register(module_org, None, module_activation_key.name, module_target_sat).status
+            == 0
         )
-        assert host.register(default_org, None, ak.name, module_target_sat).status == 0
         yield host
 
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -677,6 +677,7 @@ class ContentHost(Host, ContentHostMixins):
         if force:
             options['force'] = str(force).lower()
 
+        self._satellite = target
         cmd = target.satellite.cli.HostRegistration.generate_command(options)
         return self.execute(cmd.strip('\n'))
 
@@ -688,6 +689,7 @@ class ContentHost(Host, ContentHostMixins):
         :return: The result of the API call.
         """
         kwargs['insecure'] = kwargs.get('insecure', True)
+        self._satellite = target
         command = target.satellite.api.RegistrationCommand(**kwargs).create()
         return self.execute(command.strip('\n'))
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -12,7 +12,6 @@ import re
 from tempfile import NamedTemporaryFile
 import time
 from urllib.parse import urljoin, urlparse, urlunsplit
-import warnings
 
 import apypie
 from box import Box
@@ -568,39 +567,6 @@ class ContentHost(Host, ContentHostMixins):
         result = self.execute('yum install -y katello-host-tools')
         if result.status != 0:
             raise ContentHostError('Failed to install katello-host-tools')
-
-    def install_katello_ca(self, satellite):
-        """Downloads and installs katello-ca rpm on the content host.
-
-        :param str satellite: robottelo.hosts.Satellite instance
-
-        :return: None.
-        :raises robottelo.hosts.ContentHostError: If katello-ca wasn't
-            installed.
-        """
-        warnings.warn(
-            message='The install_katello_ca method is deprecated, use the register method instead.',
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        self._satellite = satellite
-        self.execute(
-            f'curl --insecure --output katello-ca-consumer-latest.noarch.rpm \
-                    {satellite.url_katello_ca_rpm}'
-        )
-        # check if the host is fips-enabled
-        result = self.execute('sysctl crypto.fips_enabled')
-        if 'crypto.fips_enabled = 1' in result.stdout:
-            self.execute('rpm -Uvh --nodigest --nofiledigest katello-ca-consumer-latest.noarch.rpm')
-        else:
-            self.execute('rpm -Uvh katello-ca-consumer-latest.noarch.rpm')
-        # Not checking the status here, as rpm could be installed before
-        # and installation may fail
-        result = self.execute(f'rpm -q katello-ca-consumer-{satellite.hostname}')
-        # Checking the status here to verify katello-ca rpm is actually
-        # present in the system
-        if satellite.hostname not in result.stdout:
-            raise ContentHostError('Failed to download and install the katello-ca rpm')
 
     def remove_katello_ca(self):
         """Removes katello-ca rpm from the broker virtual machine.


### PR DESCRIPTION
### Problem Statement
Katello-ca is going to be removed from 6.16 and we should use GR everywhere. The last place where is has been used is `module_container_contenthost`.

### Solution
Update `module_container_contenthost` to use GR and remove the `install_katello_ca` for good.

### Related Issues
https://issues.redhat.com/browse/SAT-25401

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_container_management.py -k pull_image
