### PR TITLE
Verify port 8443 is disabled on default capsule installation

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -207,6 +207,8 @@ def test_capsule_installation(sat_non_default_install, cap_ready_rhel, setting_u
 
     :CaseImportance: Critical
 
+    :Verifies: SAT-24520
+
     :BZ: 1984400
 
     :customerscenario: true
@@ -257,6 +259,14 @@ def test_capsule_installation(sat_non_default_install, cap_ready_rhel, setting_u
 
     result = cap_ready_rhel.cli.Health.check()
     assert 'FAIL' not in result.stdout
+
+    # Verify foreman-proxy-content-reverse-proxy and port 8443 are disabled on default installation
+    help_result = cap_ready_rhel.execute(
+        "satellite-installer --full-help | grep foreman-proxy-content-reverse-proxy"
+    )
+    assert "Add reverse proxy to the parent (current: false)" in help_result.stdout
+    port_result = cap_ready_rhel.execute("ss -tuln | grep 8443")
+    assert not port_result.stdout
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
### Problem Statement
- Verify port 8443 is disabled on default capsule installation

### Solution
- Update test_capsule_installation

### Related Issues
- SAT-24520

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->