### PR TITLE
[6.13.z] Remove flake8

### DIFF
--- a/docs/code_standards.rst
+++ b/docs/code_standards.rst
@@ -23,9 +23,9 @@ Black
 
 Linting
 
-* All code will be linted to black-compatible `PEP8`_ standards using `flake8`_.
-* In the root of the **Robottelo** directory, run :code:`flake8 .`
-* If flake8 returns errors, make corrections before submitting a pull request.
+* All code will be linted to black-compatible `PEP8`_ standards using `ruff linter`_.
+* In the root of the **Robottelo** directory, run :code:`ruff check .`
+* If ruff linter returns errors, make corrections before submitting a pull request.
 * pre-commit configuration is available, and its use is strongly encouraged in local development.
 
 Docstrings
@@ -146,7 +146,7 @@ Categorize each standard into how strictly they are enforced
 
 
 .. _PEP8: http://legacy.python.org/dev/peps/pep-0008/
-.. _flake8: http://flake8.readthedocs.org/
+.. _ruff linter: https://docs.astral.sh/ruff/linter/
 .. _testimony: https://github.com/SatelliteQE/testimony
 .. _sphinx: http://sphinx-doc.org/markup/para.html
 .. _properly format strings: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting

--- a/docs/committing.rst
+++ b/docs/committing.rst
@@ -41,11 +41,11 @@ documented, it doesn’t exist.
 In order to ensure you are able to pass the Travis CI build, it is recommended
 that you run the following commands in the base of your Robottelo directory.::
 
-    $ flake8 .
+    $ ruff check .
     $ make test-docstrings
     $ make test-robottelo
 
-:code:`flake8` will ensure that the changes you made are not in violation of
+:code:`ruff linter` will ensure that the changes you made are not in violation of
 PEP8 standards. If the command gives no output, then you have passed. If not,
 then address any corrections recommended.
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,8 +1,8 @@
 # For running tests and checking code quality using these modules.
-flake8==7.1.1
 pytest-cov==5.0.0
 redis==5.0.8
 pre-commit==3.8.0
+ruff==0.5.7
 
 # For generating documentation.
 sphinx==8.0.2

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -33,7 +33,6 @@ from robottelo.constants.repos import CUSTOM_RPM_REPO
 from robottelo.utils.issue_handlers import is_open
 
 API_PATHS = {
-    # flake8:noqa (line-too-long)
     'activation_keys': (
         '/katello/api/activation_keys',
         '/katello/api/activation_keys',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15877

### Problem Statement
flake8 is long gone from robottelo, see #12621. 

### Solution
Let's remove its traces in the repository.
