### PR TITLE
pit marker for hammer ping test

### DIFF
--- a/tests/foreman/cli/test_ping.py
+++ b/tests/foreman/cli/test_ping.py
@@ -17,6 +17,7 @@ import pytest
 pytestmark = [pytest.mark.tier1, pytest.mark.upgrade]
 
 
+@pytest.mark.pit_server
 @pytest.mark.parametrize('switch_user', [False, True], ids=['root', 'non-root'])
 def test_positive_ping(target_sat, switch_user):
     """hammer ping return code


### PR DESCRIPTION
### Problem Statement
just adding the pit marker for the hammer ping test

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->