### PR TITLE
[6.15.z] PIT markers for Interoperability Testing: CapsuleContent (#15892)

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -244,6 +244,7 @@ class TestCapsuleContentManagement:
     @pytest.mark.skip_if_open("BZ:2025494")
     @pytest.mark.e2e
     @pytest.mark.tier4
+    @pytest.mark.pit_client
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_updated_repo(
         self,
@@ -352,6 +353,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.e2e
     @pytest.mark.tier4
+    @pytest.mark.pit_client
     @pytest.mark.skip_if_not_set('capsule', 'fake_manifest')
     def test_positive_capsule_sync(
         self,
@@ -875,6 +877,7 @@ class TestCapsuleContentManagement:
 
     @pytest.mark.tier4
     @pytest.mark.e2e
+    @pytest.mark.pit_client
     @pytest.mark.skip_if_not_set('capsule')
     def test_positive_sync_container_repo_end_to_end(
         self,

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -45,6 +45,7 @@ from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
     indirect=True,
 )
 @pytest.mark.stream
+@pytest.mark.pit_client
 def test_positive_content_counts_for_mixed_cv(
     target_sat,
     module_capsule_configured,
@@ -181,6 +182,7 @@ def test_positive_content_counts_for_mixed_cv(
 
 
 @pytest.mark.stream
+@pytest.mark.pit_client
 def test_positive_update_counts(target_sat, module_capsule_configured):
     """Verify the update counts functionality
 

--- a/tests/foreman/ui/test_capsulecontent.py
+++ b/tests/foreman/ui/test_capsulecontent.py
@@ -52,6 +52,7 @@ def capsule_default_org(module_target_sat, module_capsule_configured, default_or
     ],
     indirect=True,
 )
+@pytest.mark.pit_client
 def test_positive_content_counts_for_mixed_cv(
     target_sat,
     module_capsule_configured,


### PR DESCRIPTION
Failed CP of #15892

Expect `API::test_positive_sync_container_repo_end_to_end` to fail, while [SAT-25813](https://issues.redhat.com/browse/SAT-25813) is still open.