### PR TITLE
[6.14.z] pit marker for webhook test

### DIFF
--- a/tests/foreman/cli/test_webhook.py
+++ b/tests/foreman/cli/test_webhook.py
@@ -57,6 +57,7 @@ def assert_created(options, hook):
 
 class TestWebhook:
     @pytest.mark.tier3
+    @pytest.mark.pit_server
     @pytest.mark.e2e
     def test_positive_end_to_end(self, webhook_factory, class_target_sat):
         """Test creation, list, update and removal of webhook


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15940

### Problem Statement
adding pit marker for webhook test

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->