### PR TITLE
[master]: Changes for new 6.16.z branch

### DIFF
--- a/tests/foreman/cli/test_artifacts.py
+++ b/tests/foreman/cli/test_artifacts.py
@@ -46,7 +46,6 @@ def module_synced_content(
     return Box(prod=module_product, repo=repo, cv=cv.read(), sync_time=sync_time)
 
 
-@pytest.mark.stream
 @pytest.mark.parametrize('repair_type', ['repo', 'cv', 'product'])
 @pytest.mark.parametrize(
     'module_synced_content',


### PR DESCRIPTION
  ### Problem Statement
  New 6.16.z downstream and master points to stream that is 6.17
  ### Solution
  - Dependabot.yaml cherrypicks to 6.16.z
  - Robottelo conf and constants now uses 6.17 and 6.16.z satellite versions
### Jira Ref
- [SAT-27343](https://issues.redhat.com/browse/SAT-27343)
- [SAT-27344](https://issues.redhat.com/browse/SAT-27344)