### PR TITLE
[6.15.z] Automate a stubbed test to install Ansible collection from galaxy

### DIFF
--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -511,8 +511,12 @@ class TestAnsibleREX:
         result = client.execute(f'systemctl status {service}')
         assert result.status == 0
 
-    @pytest.mark.rhel_ver_list([8])
-    def test_positive_install_ansible_collection(self, rex_contenthost, target_sat):
+    @pytest.mark.upgrade
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+    def test_positive_install_ansible_collection(
+        self, rhel_contenthost, target_sat, module_org, module_ak_with_cv
+    ):
         """Test whether Ansible collection can be installed via Ansible REX
 
         :id: ad25aee5-4ea3-4743-a301-1c6271856f79
@@ -526,9 +530,11 @@ class TestAnsibleREX:
 
         :expectedresults: Ansible collection can be installed on content host via REX.
         """
-        client = rex_contenthost
+        client = rhel_contenthost
         # Enable Ansible repository and Install ansible or ansible-core package
-        client.create_custom_repos(rhel8_aps=settings.repos.rhel8_os.appstream)
+        client.register(module_org, None, module_ak_with_cv.name, target_sat)
+        rhel_repo_urls = getattr(settings.repos, f'rhel{client.os_version.major}_os', None)
+        rhel_contenthost.create_custom_repos(**rhel_repo_urls)
         assert client.execute('dnf -y install ansible-core').status == 0
 
         collection_job = target_sat.cli_factory.job_invocation(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15595

### Problem Statement
We've stubbed test - test_positive_install_ansible_collection_via_job_invocation, which we need to automate as part of component audit

### Solution
1. Automating the stubbed test to verify install of ansible collection with user inputted collection list and collection path
2. Updating tests to use rhel_contenthost fixtures instead of rex_contenthost
3. Add upgrade marker to existing cli test to install ansible collection

### Related Issues
