### PR TITLE
[6.16] Add test for All Hosts CVE Bulk action

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -41,6 +41,7 @@ from robottelo.constants import (
 )
 from robottelo.constants.repos import CUSTOM_FILE_REPO
 from robottelo.utils.datafactory import gen_string
+from tests.foreman.api.test_errata import cv_publish_promote
 
 
 def _get_set_from_list_of_dict(value):
@@ -1876,6 +1877,45 @@ def test_all_hosts_bulk_delete(target_sat, function_org, function_location, new_
         session.organization.select(function_org.name)
         session.location.select(function_location.name)
         assert session.all_hosts.bulk_delete_all()
+
+
+@pytest.mark.tier2
+def test_all_hosts_bulk_cve_reassign(
+    target_sat, mod_content_hosts, module_org, module_location, module_lce, module_cv, new_host_ui
+):
+    """Create several hosts, and bulk assigns them a new CVE via All Hosts UI
+
+    :id: 9acb3cf3-c042-4cc7-abdf-31f9a7f1fff0
+
+    :expectedresults: Multiple hosts are successfully assigned to a new LCE and CV
+
+    :CaseComponent:Hosts-Content
+
+    :Team: Phoenix-subscriptions
+    """
+    lce2 = target_sat.api.LifecycleEnvironment(organization=module_org).create()
+    module_cv = target_sat.api.ContentView(id=module_cv.id).read()
+    module_cv = cv_publish_promote(target_sat, module_org, module_cv, module_lce)['content-view']
+    module_cv = cv_publish_promote(target_sat, module_org, module_cv, lce2)['content-view']
+    ak = target_sat.api.ActivationKey(
+        organization=module_org,
+        environment=module_lce,
+        content_view=module_cv,
+    ).create()
+    for host in mod_content_hosts:
+        host.register(
+            activation_keys=ak.name,
+            target=target_sat,
+            org=module_org,
+            loc=None,
+        )
+    with target_sat.ui_session() as session:
+        session.organization.select(module_org.name)
+        session.all_hosts.manage_cve(lce=lce2.name, cv=module_cv.name)
+        wait_for(lambda: session.browser.refresh(), timeout=5)
+        table = session.all_hosts.read_table()
+        for row in table:
+            assert row['Lifecycle environment'] == lce2.name
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
Test exercising the new Bulk CVE assignment action in the All Hosts page.  Test is probably not perfectly formatted, but it gets the job done. Appreciate any feedback.

Requires: https://github.com/SatelliteQE/airgun/pull/1514