### PR TITLE
[6.15.z] passing ipv6 params valued for direct Host calls

### DIFF
--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -22,7 +22,7 @@ def _clean_video(session_id, test):
 
         if settings.ui.grid_url and session_id:
             grid = urlparse(url=settings.ui.grid_url)
-            infra_grid = Host(hostname=grid.hostname)
+            infra_grid = Host(hostname=grid.hostname, ipv6=settings.server.is_ipv6)
             infra_grid.execute(command=f'rm -rf /var/www/html/videos/{session_id}')
             logger.info(f"video cleanup for session {session_id} is complete")
         else:

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -195,6 +195,7 @@ class ContentHost(Host, ContentHostMixins):
             # key file based authentication
             kwargs.update({'key_filename': auth})
         self._satellite = kwargs.get('satellite')
+        self.ipv6 = kwargs.get('ipv6', settings.server.is_ipv6)
         self.blank = kwargs.get('blank', False)
         super().__init__(hostname=hostname, **kwargs)
 
@@ -1047,7 +1048,7 @@ class ContentHost(Host, ContentHostMixins):
         # sat6 under the capsule --> certifcates or on capsule via cli "puppetserver
         # ca list", so that we sign it.
         self.execute('/opt/puppetlabs/bin/puppet agent -t')
-        proxy_host = Host(hostname=proxy_hostname)
+        proxy_host = Host(hostname=proxy_hostname, ipv6=settings.server.is_ipv6)
         proxy_host.execute(f'puppetserver ca sign --certname {cert_name}')
 
         if run_puppet_agent:
@@ -2440,6 +2441,7 @@ class SSOHost(Host):
     def __init__(self, sat_obj, **kwargs):
         self.satellite = sat_obj
         kwargs['hostname'] = kwargs.get('hostname', settings.rhsso.host_name)
+        kwargs['ipv6'] = kwargs.get('ipv6', settings.server.is_ipv6)
         super().__init__(**kwargs)
 
     def get_rhsso_client_id(self):
@@ -2611,6 +2613,7 @@ class IPAHost(Host):
     def __init__(self, sat_obj, **kwargs):
         self.satellite = sat_obj
         kwargs['hostname'] = kwargs.get('hostname', settings.ipa.hostname)
+        kwargs['ipv6'] = kwargs.get('ipv6', settings.server.is_ipv6)
         # Allow the class to be constructed from kwargs
         kwargs['from_dict'] = True
         kwargs.update(
@@ -2712,6 +2715,7 @@ class ProxyHost(Host):
         self._conf_dir = '/etc/squid/'
         self._access_log = '/var/log/squid/access.log'
         kwargs['hostname'] = urlparse(url).hostname
+        kwargs['ipv6'] = kwargs.get('ipv6', settings.server.is_ipv6)
         super().__init__(**kwargs)
 
     def add_user(self, name, passwd):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15964

### Problem Statement
To successfully establish IPv6 SSH connections, the ipv6 parameter must be set to true for the Host class. This configuration is necessary for the SSH provider, apart from hussh module. It is partly required for direct access to the Host object using broker imports.

### Solution
This PR passing the IPV6 setting as param to host object 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->