### PR TITLE
Fix cli contenthost tests

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -507,7 +507,7 @@ class TestContentView:
         source_cv = module_target_sat.cli.ContentView.info({'id': source_cv['id']})
         assert source_cv['activation-keys'][0] == ac_key['name']
         destination_cv = module_target_sat.cli.ContentView.info({'id': destination_cv['id']})
-        assert len(destination_cv['activation-keys']) == 0
+        assert 'activation-keys' not in destination_cv
 
         module_target_sat.cli.ContentView.remove(
             {
@@ -518,7 +518,7 @@ class TestContentView:
             }
         )
         source_cv = module_target_sat.cli.ContentView.info({'id': source_cv['id']})
-        assert len(source_cv['activation-keys']) == 0
+        assert 'activation-keys' not in source_cv
         destination_cv = module_target_sat.cli.ContentView.info({'id': destination_cv['id']})
         assert destination_cv['activation-keys'][0] == ac_key['name']
 
@@ -673,7 +673,7 @@ class TestContentView:
             {'id': new_cv['id'], 'repository-id': new_repo['id']}
         )
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
-        assert len(new_cv['yum-repositories']) == 0
+        assert 'yum-repositories' not in new_cv
 
     @pytest.mark.tier1
     def test_positive_remove_repository_by_name(
@@ -705,7 +705,7 @@ class TestContentView:
             {'id': new_cv['id'], 'repository': new_repo['name']}
         )
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
-        assert len(new_cv['yum-repositories']) == 0
+        assert 'yum-repositories' not in new_cv
 
     @pytest.mark.tier2
     def test_positive_remove_version_by_id_from_composite(
@@ -810,7 +810,7 @@ class TestContentView:
             }
         )
         comp_cv = module_target_sat.cli.ContentView.info({'id': comp_cv['id']})
-        assert len(comp_cv['components']) == 0
+        assert 'components' not in comp_cv
 
     @pytest.mark.tier3
     def test_positive_create_composite_with_component_ids(self, module_org, module_target_sat):
@@ -1299,9 +1299,7 @@ class TestContentView:
             {'organization-id': module_org.id}
         )
         print("Hello, the org ID is currently", module_org.id)
-        result = module_target_sat.cli.ContentView.list(
-            {'organization-id': module_org.id}, per_page=False
-        )
+        result = module_target_sat.cli.ContentView.list({'organization-id': module_org.id})
         content_view = random.choice([cv for cv in result if cv['name'] == constants.DEFAULT_CV])
         cvv = module_target_sat.cli.ContentView.version_list(
             {'content-view-id': content_view['content-view-id']}
@@ -1574,7 +1572,7 @@ class TestContentView:
             'yum-repositories',
             'container-image-repositories',
         ]:
-            assert len(new_cv[repo_type]) == 0
+            assert repo_type not in new_cv
         # Publish a new version of CV
         module_target_sat.cli.ContentView.publish({'id': new_cv['id']})
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})


### PR DESCRIPTION
### Problem Statement

if a key's value is zero the key is not displayed anymore but removed.

### Solution

adapt assertion to check absence of key

### Related tests

tests/foreman/cli/test_contentview.py::TestContentView::test_positive_remove_repository_by_id
tests/foreman/cli/test_contentview.py::TestContentView::test_positive_remove_repository_by_name
tests/foreman/cli/test_contentview.py::TestContentView::test_positive_republish_after_content_removed
tests/foreman/cli/test_contentview.py::TestContentView::test_positive_remove_lce_by_id_and_reassign_ak
tests/foreman/cli/test_contentview.py::TestContentView::test_positive_remove_component_by_name
tests/foreman/cli/test_contentview.py::TestContentView::test_positive_create_composite_with_component_ids



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->