### PR TITLE
[6.16.z] Select activation key explicitly because of SAT-27348

### DIFF
--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -25,6 +25,7 @@ from robottelo.constants import (
     FAKE_7_CUSTOM_PACKAGE,
     REPO_TYPE,
 )
+from robottelo.utils.issue_handlers import is_open
 
 pytestmark = pytest.mark.tier1
 
@@ -345,11 +346,15 @@ def test_global_registration_form_populate(
 
         session.organization.select(org_name=new_org.name)
         session.browser.refresh()
+        registration_opts = {
+            'general.insecure': True,
+            'advanced.force': True,
+        }
+        # Select activation key explicitly due to SAT-27348
+        if is_open('SAT-27348'):
+            registration_opts['general.activation_keys'] = new_ak.name
         cmd = session.host.get_register_command(
-            {
-                'general.insecure': True,
-                'advanced.force': True,
-            },
+            registration_opts,
             full_read=True,
         )
         assert new_org.name in cmd['general']['organization']


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15990

### Problem Statement
Activation key does not get auto-selected on org change or browser refresh

### Solution
Add a workaround for SAT-27348 while selecting activation key


### Related PRs
https://github.com/SatelliteQE/airgun/pull/1483


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->