### PR TITLE
Fixing the sha field

### DIFF
--- a/.github/workflows/auto_cherry_pick_merged.yaml
+++ b/.github/workflows/auto_cherry_pick_merged.yaml
@@ -118,7 +118,7 @@ jobs:
       - name: Cherrypicking to zStream branch
         id: cherrypick
         if: ${{ startsWith(matrix.branch, '6.') && matrix.branch != needs.get-parentPR-details.outputs.base_ref }}
-        uses: jyejare/github-cherry-pick-action@given_pulls_cp
+        uses: jyejare/github-cherry-pick-action@main
         with:
           token: ${{ secrets.CHERRYPICK_PAT }}
           pull_number: ${{ env.number }}


### PR DESCRIPTION
### Problem Statement
The Merged PRs cherrypick GHA is using the non main branch.

### Solution
Switched to use the main branch.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->