### PR TITLE
Fix reporttemplate test

### DIFF
--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -396,7 +396,7 @@ def test_positive_generate_report_sanitized(module_target_sat):
 
     result = module_target_sat.cli.ReportTemplate.generate({'name': report_template['name']})
     assert 'Name,Operating System' in result  # verify header of custom template
-    assert f'{host["name"]},"{host["operating-system"]["operating-system"]}"' in result
+    assert f'{host["name"]},"{host["operating-system"]["operating-system"]["name"]}"' in result
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
### Problem Statement

api changes

### Solution

access name property

### Related tests

tests/foreman/cli/test_reporttemplates.py::test_positive_generate_report_sanitized

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->