### PR TITLE
Fix test_positive_health_check_by_tags

### DIFF
--- a/tests/foreman/maintain/test_health.py
+++ b/tests/foreman/maintain/test_health.py
@@ -119,7 +119,7 @@ def test_positive_health_check_by_tags(sat_maintain):
     :expectedresults: Health check should pass for listed tags.
     """
     result = sat_maintain.cli.Health.list_tags().stdout
-    output = [i.split("]\x1b[0m")[0] for i in result.split("\x1b[36m[") if i]
+    output = [tag.strip("[]") for tag in result.strip().split("\n")]
     for tag in output:
         assert (
             sat_maintain.cli.Health.check(


### PR DESCRIPTION
### Problem Statement
test_positive_health_check_by_tags is failing as the code to get the tag names is broken.

### Solution
- Update the code logic

### Related Issues
- SAT-27378

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->