### PR TITLE
Fixing rh cloud rhai failures

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -35,7 +35,7 @@ def rhcloud_registered_hosts(
     for vm in mod_content_hosts:
         vm.configure_rhai_client(
             satellite=module_target_sat,
-            activation_key=rhcloud_activation_key.name,
+            activation_key=rhcloud_activation_key,
             org=rhcloud_manifest_org,
             rhel_distro=f"rhel{vm.os_version.major}",
         )
@@ -53,7 +53,7 @@ def rhel_insights_vm(
     )
     rhel_contenthost.configure_rhai_client(
         satellite=module_target_sat,
-        activation_key=rhcloud_activation_key.name,
+        activation_key=rhcloud_activation_key,
         org=rhcloud_manifest_org,
         rhel_distro=f"rhel{rhel_contenthost.os_version.major}",
     )

--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -32,6 +32,8 @@ def fixture_enable_rhc_repos(target_sat):
 
 
 @pytest.mark.e2e
+@pytest.mark.pit_server
+@pytest.mark.pit_client
 @pytest.mark.tier3
 @pytest.mark.destructive
 def test_positive_configure_cloud_connector(target_sat, default_org, fixture_enable_rhc_repos):

--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -32,8 +32,6 @@ def fixture_enable_rhc_repos(target_sat):
 
 
 @pytest.mark.e2e
-@pytest.mark.pit_server
-@pytest.mark.pit_client
 @pytest.mark.tier3
 @pytest.mark.destructive
 def test_positive_configure_cloud_connector(target_sat, default_org, fixture_enable_rhc_repos):


### PR DESCRIPTION
As part of the [Remove use of install_katello_ca with register_contenthost](https://github.com/SatelliteQE/robottelo/pull/15395) effort. The attribute "label" was removed from rhcloud_manifest_org. 

In recent automation runs, we are seeing some left over attributes that I THINK need to be removed.

I am removing .name from rhcloud_activation_key and will be doing prt testing
