### PR TITLE
[6.16.z] Remove install_katello_ca for good

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -198,7 +198,7 @@ def katello_host_tools_tracer_host(rex_contenthost, target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_container_contenthost(request, module_target_sat):
+def module_container_contenthost(request, module_target_sat, module_org, module_activation_key):
     """Fixture that installs docker on the content host"""
     request.param = {
         "rhel_version": "8",
@@ -207,8 +207,6 @@ def module_container_contenthost(request, module_target_sat):
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
-        # needed for docker commands to accept Satellite's cert
-        host.install_katello_ca(module_target_sat)
         for client in constants.CONTAINER_CLIENTS:
             assert (
                 host.execute(f'yum -y install {client}').status == 0
@@ -216,6 +214,11 @@ def module_container_contenthost(request, module_target_sat):
         assert (
             host.execute('systemctl enable --now podman').status == 0
         ), 'Start of podman service failed'
+        host.unregister()
+        assert (
+            host.register(module_org, None, module_activation_key.name, module_target_sat).status
+            == 0
+        )
         yield host
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15931

### Problem Statement
Katello-ca is going to be removed from 6.16 and we should use GR everywhere. The last place where is has been used is `module_container_contenthost`.

### Solution
Update `module_container_contenthost` to use GR and remove the `install_katello_ca` for good.

### Related Issues
https://issues.redhat.com/browse/SAT-25401

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_container_management.py -k pull_image
