### PR TITLE
Fix sanitized_issue_data helper of jira issue handler

### DIFF
--- a/robottelo/utils/issue_handlers/jira.py
+++ b/robottelo/utils/issue_handlers/jira.py
@@ -42,7 +42,7 @@ def sanitized_issue_data(issue, out_fields):
         out_fields {list} -- The list of fields for which data to be retrieved from jira issue
     """
     return {
-        field: eval(mapped_response_fields[field].format(obj_name='issue')) for field in out_fields
+        field: eval(mapped_response_fields[field].format(obj_name=issue)) for field in out_fields
     }
 
 


### PR DESCRIPTION
### Problem Statement
- https://github.com/SatelliteQE/robottelo/pull/15878 introduced `sanitized_issue_data` that is causing BlockedBy to fail

### Solution
- Fix sanitized_issue_data

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->