### PR TITLE
[6.14.z] Satisfy validators, enable template config validation (#15932)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,7 +9,6 @@ env:
     PYCURL_SSL_LIBRARY: openssl
     ROBOTTELO_BUGZILLA__API_KEY: ${{ secrets.BUGZILLA_KEY }}
     ROBOTTELO_JIRA__API_KEY: ${{ secrets.JIRA_KEY }}
-    ROBOTTELO_ROBOTTELO__SETTINGS__IGNORE_VALIDATION_ERRORS: true
 
 jobs:
   codechecks:

--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -16,4 +16,4 @@ CAPSULE:
     PRODUCT: deploy-capsule  # workflow to deploy OS with product running on top of it
     OS: deploy-rhel  # workflow to deploy OS that is ready to run the product
   # Dictionary of arguments which should be passed along to the deploy workflow
-  DEPLOY_ARGUMENTS:
+  DEPLOY_ARGUMENTS: {}

--- a/conf/gce.yaml.template
+++ b/conf/gce.yaml.template
@@ -1,8 +1,8 @@
 GCE:
   # Google Provider as Compute Resource
   # client json Certificate path which is local path on satellite
-  CERT_PATH: /path/to/certificate.json
+  CERT_PATH: /usr/share/foreman/path/to/certificate.json
   # Zones
-  ZONE: example-zone
+  ZONE: northamerica-northeast1-a
   # client certificate
   CERT: "{}" # client json Certificate

--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -1,4 +1,5 @@
 RH_CLOUD:
+  TOKEN: this-isnt-the-token
   INSTALL_RHC: false
   ORGANIZATION: org_name
   ACTIVATION_KEY: ak_name

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -28,6 +28,7 @@ def get_settings():
         settings = LazySettings(
             envvar_prefix="ROBOTTELO",
             core_loaders=["YAML"],
+            root_path=str(robottelo_root_dir),
             settings_file="settings.yaml",
             preload=["conf/*.yaml"],
             includes=["settings.local.yaml", ".secrets.yaml", ".secrets_*.yaml"],

--- a/settings.sample.yaml
+++ b/settings.sample.yaml
@@ -3,6 +3,11 @@
 # example:
 # `export SATQE_SERVER__HOSTNAME=myserver.redhat.com`
 ---
+
+# merge settings from this file with the files that were preloaded from the conf/ directory
+# see: https://www.dynaconf.com/merging/
+dynaconf_merge: true
+
 server:
   admin_password: "<str>"
   admin_username: "<str>"


### PR DESCRIPTION
Backport of #15932.

* Satisfy validators, enable template config validation

Plus make the local settings file work by adding dynaconf_merge and root_path

* Update conf/rh_cloud.yaml.template

Co-authored-by: Jake Callahan <jacob.callahan05@gmail.com>

---------

Co-authored-by: Jake Callahan <jacob.callahan05@gmail.com>
(cherry picked from commit 81071b3a049ee5b0337524142c67ba0b5632dd13)

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->