### PR TITLE
[6.14.z] Fix tests post Upgrade Fabric Removal from Rocket Team

### DIFF
--- a/tests/upgrades/test_provisioningtemplate.py
+++ b/tests/upgrades/test_provisioningtemplate.py
@@ -12,6 +12,8 @@
 
 """
 
+import json
+
 from fauxfactory import gen_string
 import pytest
 
@@ -74,12 +76,12 @@ class TestScenarioPositiveProvisioningTemplates:
         for kind in provisioning_template_kinds:
             assert host.read_template(data={'template_kind': kind})
 
-        save_test_data(
-            {
-                'provision_host_id': host.id,
-                'pxe_loader': pxe_loader.pxe_loader,
-            }
-        )
+        pre_update_data_dict = {
+            'provision_host_id': host.id,
+            'pxe_loader': pxe_loader.pxe_loader,
+        }
+        pre_update_json_file = json.dumps(pre_update_data_dict, indent=2)
+        save_test_data(pre_update_json_file)
 
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_provisioning_templates)
     @pytest.mark.parametrize('pre_upgrade_data', ['bios', 'uefi'], indirect=True)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15985

### Problem Statement
The upgrade tests are failing with JSON decode error as data saved is in dictionary format instead of json format.

### Solution
Updated tests to convert to json before saving pre-upgrade data

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->