### PR TITLE
Update host registration hammer command to use repo_data option over deprecated repo and repo_gpg_key_url option and test the new option

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -611,8 +611,7 @@ class ContentHost(Host, ContentHostMixins):
         setup_remote_execution_pull=False,
         operating_system=None,
         packages=None,
-        repo=None,
-        repo_gpg_key_url=None,
+        repo_data=None,
         remote_execution_interface=None,
         update_packages=False,
         ignore_subman_errors=False,
@@ -632,8 +631,7 @@ class ContentHost(Host, ContentHostMixins):
         :param setup_remote_execution_pull: Deploy pull provider client on host
         :param operating_system: Operating system.
         :param packages: A list of packages to install on the host when registered.
-        :param repo: Repository to be added before the registration is performed, supply url.
-        :param repo_gpg_key_url: Public key to verify the package signatures, supply url.
+        :param repo_data: Array with repository URL and corresponding GPG key URL.
         :param remote_execution_interface: Identifier of the host interface for remote execution.
         :param update_packages: Update all packages on the host.
         :param ignore_subman_errors: Ignore subscription manager errors.
@@ -674,8 +672,8 @@ class ContentHost(Host, ContentHostMixins):
             options['hostgroup-id'] = hostgroup.id
         if packages is not None:
             options['packages'] = '+'.join(packages)
-        if repo is not None:
-            options['repo'] = repo
+        if repo_data is not None:
+            options['repo-data'] = repo_data
         if setup_insights is not None:
             options['setup-insights'] = str(setup_insights).lower()
         if setup_remote_execution is not None:
@@ -684,8 +682,6 @@ class ContentHost(Host, ContentHostMixins):
             options['setup-remote-execution-pull'] = str(setup_remote_execution_pull).lower()
         if remote_execution_interface is not None:
             options['remote-execution-interface'] = remote_execution_interface
-        if repo_gpg_key_url is not None:
-            options['repo-gpg-key-url'] = repo_gpg_key_url
         if ignore_subman_errors:
             options['ignore-subman-errors'] = str(ignore_subman_errors).lower()
         if force:

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -124,7 +124,7 @@ def test_negative_time_to_pickup(
         module_ak_with_cv.name,
         module_capsule_configured_mqtt,
         setup_remote_execution_pull=True,
-        repo=client_repo.baseurl,
+        repo_data=f'repo={client_repo.baseurl}',
     )
     template_id = (
         module_target_sat.api.JobTemplate()
@@ -257,7 +257,7 @@ def test_positive_check_longrunning_job(
         module_ak_with_cv.name,
         module_capsule_configured_mqtt,
         setup_remote_execution_pull=True,
-        repo=client_repo.baseurl,
+        repo_data=f'repo={client_repo.baseurl}',
     )
     template_id = (
         module_target_sat.api.JobTemplate()

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -471,7 +471,7 @@ class TestAnsibleREX:
             None,
             module_ak_with_cv.name,
             target_sat,
-            repo=settings.repos.yum_3.url,
+            repo_data=f'repo={settings.repos.yum_3.url}',
         )
         assert result.status == 0, f'Failed to register host: {result.stderr}'
         # install package

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -22,6 +22,7 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import CLIENT_PORT
 from robottelo.exceptions import CLIReturnCodeError
+from robottelo.utils.issue_handlers import is_open
 
 pytestmark = pytest.mark.tier1
 
@@ -295,3 +296,41 @@ def test_positive_custom_facts_for_host_registration(
     for interface in interfaces:
         for interface_name in interface.values():
             assert interface_name in str(host_info['network-interfaces'])
+
+
+@pytest.mark.upgrade
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_positive_global_registration_with_gpg_repo(
+    module_sca_manifest_org,
+    module_location,
+    module_activation_key,
+    module_target_sat,
+    rhel_contenthost,
+):
+    """Verify host registration command gets generated and host is registered successfully with gpg repo enabled.
+
+    :id: 8f01d904-dd52-47eb-b909-975574a7c7c7
+
+    :steps:
+        1. Register host with global registration template with gpg repo and key to Satellite.
+
+    :expectedresults: Host is successfully registered, gpg repo is enabled.
+    """
+    org = module_sca_manifest_org
+    repo_url = settings.repos.gr_yum_repo.url
+    repo_gpg_url = settings.repos.gr_yum_repo.gpg_url
+    result = rhel_contenthost.register(
+        org,
+        module_location,
+        module_activation_key.name,
+        module_target_sat,
+        repo_data=f'repo={repo_url},repo_gpg_key_url={repo_gpg_url}',
+    )
+    assert result.status == 0
+    assert rhel_contenthost.subscribed
+    result = rhel_contenthost.execute('yum -v repolist')
+    assert repo_url in result.stdout
+    assert result.status == 0
+    if not is_open('SAT-27653'):
+        assert rhel_contenthost.execute('dnf install -y bear').status == 0

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -360,7 +360,7 @@ class TestRemoteExecution:
             None,
             module_ak_with_cv.name,
             target_sat,
-            repo=settings.repos.yum_3.url,
+            repo_data=f'repo={settings.repos.yum_3.url}',
         )
         # Install packages
         invocation_command = target_sat.cli_factory.job_invocation(
@@ -424,7 +424,7 @@ class TestRemoteExecution:
             None,
             module_ak_with_cv.name,
             target_sat,
-            repo=settings.repos.yum_1.url,
+            repo_data=f'repo={settings.repos.yum_1.url}',
         )
         # Install the package groups
         invocation_command = target_sat.cli_factory.job_invocation(
@@ -473,7 +473,7 @@ class TestRemoteExecution:
             None,
             module_ak_with_cv.name,
             target_sat,
-            repo=settings.repos.yum_1.url,
+            repo_data=f'repo={settings.repos.yum_1.url}',
         )
         client.run(f'dnf install -y {constants.FAKE_1_CUSTOM_PACKAGE}')
         # Install errata
@@ -969,7 +969,7 @@ class TestPullProviderRex:
             module_ak_with_cv.name,
             module_capsule_configured_mqtt,
             packages=['katello-agent'],
-            repo=client_repo.baseurl,
+            repo_data=f'repo={client_repo.baseurl}',
             ignore_subman_errors=True,
             force=True,
         )
@@ -1074,7 +1074,7 @@ class TestPullProviderRex:
             module_ak_with_cv.name,
             module_capsule_configured_mqtt,
             setup_remote_execution_pull=True,
-            repo=client_repo.baseurl,
+            repo_data=f'repo={client_repo.baseurl}',
             ignore_subman_errors=True,
             force=True,
         )
@@ -1182,7 +1182,7 @@ class TestPullProviderRex:
             module_ak_with_cv.name,
             module_capsule_configured_mqtt,
             setup_remote_execution_pull=True,
-            repo=client_repo.baseurl,
+            repo_data=f'repo={client_repo.baseurl}',
             ignore_subman_errors=True,
             force=True,
         )
@@ -1278,7 +1278,7 @@ class TestPullProviderRex:
             module_ak_with_cv.name,
             module_capsule_configured_mqtt,
             setup_remote_execution_pull=True,
-            repo=client_repo.baseurl,
+            repo_data=f'repo={client_repo.baseurl}',
             ignore_subman_errors=True,
             force=True,
         )
@@ -1368,7 +1368,7 @@ class TestPullProviderRex:
             module_ak_with_cv.name,
             module_capsule_configured_mqtt,
             setup_remote_execution_pull=True,
-            repo=client_repo.baseurl,
+            repo_data=f'repo={client_repo.baseurl}',
             ignore_subman_errors=True,
             force=True,
         )


### PR DESCRIPTION
### Problem Statement
Host registration command have new option "repo-data" which combines "repo" and "repo-gpg-key-url" option(both are deprecated now).

### Solution
Updated hammer host registration method to accept new option and removed older deprecated options.
Created a test to test repo-data option 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->