### PR TITLE
[6.16.z] Logout first before attempting login

### DIFF
--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -131,6 +131,7 @@ class TestADAuthSource:
             {'id': user_group['id'], 'role-id': viewer_role['id']}
         )
         user_group = module_target_sat.cli.UserGroup.info({'id': user_group['id']})
+        module_target_sat.cli.Auth.logout()
         result = module_target_sat.cli.Auth.with_user(
             username=ad_data['ldap_user_name'], password=ad_data['ldap_user_passwd']
         ).status()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16092

### Problem Statement
```
tests/foreman/cli/test_ldapauthsource.py:137: in test_positive_refresh_usergroup_with_ad
    assert LOGGEDIN_MSG.format(ad_data['ldap_user_name']) in result[0]['message']
E   assert "Using configured credentials for user 'foobar'." in "Session exists, currently logged in as 'admin'."
E    +  where "Using configured credentials for user 'foobar'." = <built-in method format of str object at 0x7fa687146010>('foobar')
E    +    where <built-in method format of str object at 0x7fa687146010> = "Using configured credentials for user '{0}'.".format
```

### Solution
Logout before attemting to login