### PR TITLE
[6.14.z] No Compose Sanity Test with its marker

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -26,6 +26,7 @@ def pytest_configure(config):
         "capsule_only: For satellite-maintain tests to run only on Capsules",
         "manifester: Tests that require manifester",
         "ldap: Tests related to ldap authentication",
+        "no_compose : Skip the marked sanity test for nightly compose",
     ]
     markers.extend(module_markers())
     for marker in markers:

--- a/tests/foreman/sanity/test_bvt.py
+++ b/tests/foreman/sanity/test_bvt.py
@@ -22,6 +22,7 @@ from robottelo.utils.ohsnap import ohsnap_snap_rpms
 pytestmark = [pytest.mark.build_sanity]
 
 
+@pytest.mark.no_compose
 def test_installed_packages_with_versions(target_sat):
     """Compare the packages that suppose to be installed from repo vs installed packages
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16052

### Problem Statement
- RPMs diff validation sanity test cannot be run with nightly compose since the packages for diff are not available in ohsnap
- Cant filter out tests today for such case 

### Solution
- New marker introduced `no_compose` to be added on a test to filter out from sanity
- RPM diff test updated with the marker


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->