### PR TITLE
[6.13.z] Unify obtaining instance name

### DIFF
--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -58,6 +58,11 @@ def get_exp_files(sat_maintain, backup_type, skip_pulp=False):
     return expected_files
 
 
+def get_instance_name(sat_maintain):
+    """Get the instance name depending on target type."""
+    return 'satellite' if type(sat_maintain) is Satellite else 'capsule'
+
+
 @pytest.mark.include_capsule
 @pytest.mark.parametrize('backup_type', ['online', 'offline'])
 def test_positive_backup_preserve_directory(
@@ -126,7 +131,7 @@ def test_positive_backup_split_pulp_tar(
     :BZ: 2164413
     """
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
-    instance = 'satellite' if type(sat_maintain) is Satellite else 'capsule'
+    instance = get_instance_name(sat_maintain)
     set_size = 100
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,
@@ -170,7 +175,7 @@ def test_positive_backup_capsule_features(
         2. expected files are present in the backup
     """
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
-    instance = 'satellite' if type(sat_maintain) is Satellite else 'capsule'
+    instance = get_instance_name(sat_maintain)
     features = 'dns,tftp,dhcp,openscap'
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,
@@ -206,7 +211,7 @@ def test_positive_backup_all(sat_maintain, setup_backup_tests, module_synced_rep
         1. both backups succeed
     """
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
-    instance = 'satellite' if type(sat_maintain) is Satellite else 'capsule'
+    instance = get_instance_name(sat_maintain)
     sat_maintain.execute(f'mkdir -m 0777 {subdir}')
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,
@@ -426,7 +431,7 @@ def test_positive_puppet_backup_restore(
     sat_maintain.enable_puppet_satellite()
 
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
-    instance = 'satellite' if type(sat_maintain) is Satellite else 'capsule'
+    instance = get_instance_name(sat_maintain)
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,
         backup_type=backup_type,
@@ -511,7 +516,7 @@ def test_positive_backup_restore(
     :BZ: 2172540, 1978764, 1979045
     """
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
-    instance = 'satellite' if type(sat_maintain) is Satellite else 'capsule'
+    instance = get_instance_name(sat_maintain)
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,
         backup_type=backup_type,
@@ -597,6 +602,7 @@ def test_positive_backup_restore_incremental(
         5. system health check succeeds
         6. content is present after restore
     """
+    instance = get_instance_name(sat_maintain)
     subdir = f'{BACKUP_DIR}backup-{gen_string("alpha")}'
     result = sat_maintain.cli.Backup.run_backup(
         backup_dir=subdir,
@@ -606,7 +612,7 @@ def test_positive_backup_restore_incremental(
     assert result.status == 0
     assert 'FAIL' not in result.stdout
 
-    init_backup_dir = re.findall(rf'{subdir}\/satellite-backup-.*-[0-5][0-9]', result.stdout)[0]
+    init_backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
 
     # create additional content
     secondary_repo = sat_maintain.api.Repository(
@@ -625,7 +631,7 @@ def test_positive_backup_restore_incremental(
     assert 'FAIL' not in result.stdout
 
     # check for expected files
-    inc_backup_dir = re.findall(rf'{subdir}\/satellite-backup-.*-[0-5][0-9]', result.stdout)[0]
+    inc_backup_dir = re.findall(rf'{subdir}\/{instance}-backup-.*-[0-5][0-9]', result.stdout)[0]
     files = sat_maintain.execute(f'ls -a {inc_backup_dir}').stdout.split('\n')
     files = [i for i in files if not re.compile(r'^\.*$').search(i)]
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15813

### Problem Statement

Duplicate code

### Solution

see PR

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->