### PR TITLE
Check ipa command failure reason, improve logging. Logout first before attempting login.

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2608,8 +2608,10 @@ class IPAHost(Host):
     def add_user_to_usergroup(self, member_username, member_group):
         self._kinit_admin()
         result = self.execute(f'ipa group-add-member {member_group} --users={member_username}')
-        if result.status != 0:
-            raise IPAHostError('Failed to add the user to usergroup')
+        if result.status != 0 and 'This entry is already a member' not in result.stdout:
+            raise IPAHostError(
+                f'Failed to add the user to usergroup.\nSTDOUT: {result.stdout}\nSTDERR: {result.stderr}'
+            )
 
     def remove_user_from_usergroup(self, member_username, member_group):
         self._kinit_admin()

--- a/tests/foreman/cli/test_ldapauthsource.py
+++ b/tests/foreman/cli/test_ldapauthsource.py
@@ -260,6 +260,7 @@ class TestIPAAuthSource:
         assert ext_user_group['auth-source'] == auth_source['server']['name']
         user_group = module_target_sat.cli.UserGroup.info({'id': user_group['id']})
         assert len(user_group['users']) == 0
+        module_target_sat.cli.Auth.logout()
         result = module_target_sat.cli.Auth.with_user(
             username=member_username, password=default_ipa_host.ldap_user_passwd
         ).status()


### PR DESCRIPTION
### Problem Statement
This test fails in automation with:
```
tests/foreman/cli/test_ldapauthsource.py:246: in test_usergroup_sync_with_refresh
    default_ipa_host.add_user_to_usergroup(member_username, member_group)
robottelo/hosts.py:2594: in add_user_to_usergroup
    raise IPAHostError('Failed to add the user to usergroup')
E   robottelo.hosts.IPAHostError: Failed to add the user to usergroup
```
After fixing it by adding said user and group in our IPA instance, it fails on repeated runs because the user is already a member.
After fixing that by checking failure reason, it fails with an error known already from https://github.com/SatelliteQE/robottelo/pull/16092 