### PR TITLE
[6.16.z] Fix delete host test through new All host page

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1856,7 +1856,18 @@ def test_all_hosts_delete(target_sat, function_org, function_location, new_host_
     with target_sat.ui_session() as session:
         session.organization.select(function_org.name)
         session.location.select(function_location.name)
+        # Get current headers
+        headers = session.all_hosts.get_displayed_table_headers()
+        stripped_headers = tuple(
+            header for header in headers if header is not None and header != 'Name'
+        )
+        wait_for(lambda: session.browser.refresh(), timeout=5)
+        # Make sure there is only Name column displayed
+        session.all_hosts.manage_table_columns({header: False for header in stripped_headers})
         assert session.all_hosts.delete(host.name)
+        # Get table to original state
+        wait_for(lambda: session.browser.refresh(), timeout=5)
+        session.all_hosts.manage_table_columns({header: True for header in stripped_headers})
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16115

### Problem Statement
Fix the test that is deleting the host via the new All Host UI. It was failing due to a variance in the table header.

### Solution
This PR fixes that by setting the table header to just `Name` and then returning it back to the state at the beginning.




<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->