### PR TITLE
Add rhel9 to the change content source test

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -2037,7 +2037,7 @@ def change_content_source_prep(
 
 
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('[78]')
+@pytest.mark.rhel_ver_match('[789]')
 def test_change_content_source(session, change_content_source_prep, rhel_contenthost):
     """
     This test excercises different ways to change host's content source


### PR DESCRIPTION
Add Rhel 9 to the test matrix of the change content source test.

<img width="252" alt="image" src="https://github.com/user-attachments/assets/48079d4e-2e9e-4d6b-8376-1781042a55c3">



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->