### PR TITLE
[6.16.z] TFA fix for discovery plugin

### DIFF
--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -121,7 +121,7 @@ def test_positive_crud_with_non_admin_user(
 
         session.discoveryrule.delete(new_rule_name)
         dr_val = session.discoveryrule.read_all()
-        assert new_rule_name not in [rule['Name'] for rule in dr_val]
+        assert 'No Discovery Rules found in this context' in dr_val
 
 
 @pytest.mark.tier2
@@ -325,4 +325,4 @@ def test_positive_end_to_end(session, module_org, module_location, module_target
         )
         session.discoveryrule.delete(new_rule_name)
         rules = session.discoveryrule.read_all()
-        assert new_rule_name not in [rule['Name'] for rule in rules]
+        assert 'No Discovery Rules found in this context' in rules


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15783

The failure occurred because the code was deleting the discovery rule, and then attempting to read from the deleted table using the `read_all()` method. To resolve this issue, I added the `read_after_del()` method, which reads the page message after a rule is deleted or if there are no more tables.

Dependent PR: https://github.com/SatelliteQE/airgun/pull/1480