### PR TITLE
[6.15.z] update azure subnet network to default

### DIFF
--- a/tests/foreman/api/test_computeresource_azurerm.py
+++ b/tests/foreman/api/test_computeresource_azurerm.py
@@ -193,8 +193,8 @@ class TestAzureRMHostProvisioningTestCase:
             "script_uris": AZURERM_FILE_URI,
             "image_id": self.rhel7_ft_img,
         }
-
-        nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+        results = module_azurerm_cr.available_networks()['results']
+        nw_id = next((item for item in results if item['name'] == 'default'), None)['id']
         request.cls.interfaces_attributes = {
             "0": {
                 "compute_attributes": {
@@ -343,8 +343,8 @@ class TestAzureRMUserDataProvisioning:
             "script_uris": AZURERM_FILE_URI,
             "image_id": self.rhel7_ud_img,
         }
-
-        nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+        results = module_azurerm_cr.available_networks()['results']
+        nw_id = next((item for item in results if item['name'] == 'default'), None)['id']
         request.cls.interfaces_attributes = {
             "0": {
                 "compute_attributes": {
@@ -495,8 +495,8 @@ class TestAzureRMCustomImageFinishTemplateProvisioning:
             "script_uris": AZURERM_FILE_URI,
             "image_id": AZURERM_RHEL7_FT_CUSTOM_IMG_URN,
         }
-
-        nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+        results = module_azurerm_cr.available_networks()['results']
+        nw_id = next((item for item in results if item['name'] == 'default'), None)['id']
         request.cls.interfaces_attributes = {
             "0": {
                 "compute_attributes": {

--- a/tests/foreman/cli/test_computeresource_azurerm.py
+++ b/tests/foreman/cli/test_computeresource_azurerm.py
@@ -322,7 +322,8 @@ class TestAzureRMFinishTemplateProvisioning:
             f'script_uris={AZURERM_FILE_URI},'
             f'premium_os_disk={self.premium_os_disk}'
         )
-        nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+        results = module_azurerm_cr.available_networks()['results']
+        nw_id = next((item for item in results if item['name'] == 'default'), None)['id']
         request.cls.interfaces_attributes = (
             f'compute_network={nw_id},compute_public_ip=Static,compute_private_ip=false'
         )
@@ -454,7 +455,8 @@ class TestAzureRMUserDataProvisioning:
             f'script_uris={AZURERM_FILE_URI},'
             f'premium_os_disk={self.premium_os_disk}'
         )
-        nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+        results = module_azurerm_cr.available_networks()['results']
+        nw_id = next((item for item in results if item['name'] == 'default'), None)['id']
         request.cls.interfaces_attributes = (
             f'compute_network={nw_id},compute_public_ip=Dynamic,compute_private_ip=false'
         )

--- a/tests/foreman/ui/test_computeresource_azurerm.py
+++ b/tests/foreman/ui/test_computeresource_azurerm.py
@@ -30,7 +30,8 @@ pytestmark = [pytest.mark.skip_if_not_set('azurerm')]
 def module_azure_cp_attrs(module_azurerm_cr, module_azurerm_custom_finishimg, sat_azure):
     """Create compute attributes on COMPUTE_PROFILE_SMALL"""
 
-    nw_id = module_azurerm_cr.available_networks()['results'][-1]['id']
+    results = module_azurerm_cr.available_networks()['results']
+    nw_id = next((item for item in results if item['name'] == 'default'), None)['id']
     return sat_azure.api.ComputeAttribute(
         compute_profile=COMPUTE_PROFILE_SMALL,
         compute_resource=module_azurerm_cr,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16023

- The Azure subnet value is not set correctly in the automation fixture, which is preventing it from fetching the default subnet from the azure.yaml file. 
- To address this, the code has been updated to fetch the default subnet and remove the indexing that could potentially cause issues in the future.