### PR TITLE
[6.16.z] RFE for 6.16 Coverage, small issue with splitting repo_task for id

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -403,12 +403,9 @@ class TestContentView:
         existing_versions = cv_info['versions']
         # perform async repository sync
         repo_task = module_target_sat.cli.Repository.synchronize(
-            {
-                'id': custom_repo['id'],
-                'async': True,
-            }
+            {'id': custom_repo['id'], 'async': True}
         )
-        repo_task_id = repo_task.split()[-1].rstrip('.')
+        repo_task_id = repo_task[0]['id']
         # attempt to publish a new version of the content view
         with pytest.raises(CLIReturnCodeError) as err:
             module_target_sat.cli.ContentView.publish({'id': module_cv.id})


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16135

### Problem Statement
For RFE [SAT-20281](https://issues.redhat.com/browse/SAT-20281): _Should not be able to publish CV while syncing contained repo_ (6.16.0+)
Small failure in new CLI coverage, non-product issue.
The repo_task is now a list of tasks, with dictionary containing 'message' and 'id'. 
No need to split the id from message anymore.

### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py::TestContentView::test_negative_publish_during_repo_sync
```