### PR TITLE
[6.16.z] remove host subscription and update host_status check for sca-only

### DIFF
--- a/robottelo/utils/virtwho.py
+++ b/robottelo/utils/virtwho.py
@@ -611,11 +611,9 @@ def hypervisor_guest_mapping_check_legacy_ui(
     org_session.location.select(default_location.name)
     hypervisor_display_name = org_session.contenthost.search(hypervisor_name)[0]['Name']
     hypervisorhost = org_session.contenthost.read_legacy_ui(hypervisor_display_name)
-    assert hypervisorhost['details']['subscription_status'] == 'Simple Content Access'
     assert hypervisorhost['details']['virtual_guest'] == '1 Content Host'
     # Check virtual guest subscription status and hypervisor host and virtual guest mapping in Legacy UI
     virtualguest = org_session.contenthost.read_legacy_ui(guest_name)
-    assert virtualguest['details']['subscription_status'] == 'Simple Content Access'
     assert virtualguest['details']['virtual_host'] == hypervisor_display_name
 
 
@@ -624,7 +622,7 @@ def hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_n
     hypervisorhost_new_overview = org_session.host_new.get_details(
         hypervisor_display_name, 'overview'
     )
-    assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '2'
+    assert hypervisorhost_new_overview['overview']['host_status']['status_success'] == '1'
     # hypervisor host Check details
     hypervisorhost_new_detais = org_session.host_new.get_details(hypervisor_display_name, 'details')
     assert (
@@ -637,7 +635,7 @@ def hypervisor_guest_mapping_newcontent_ui(org_session, hypervisor_name, guest_n
     )
     # Check guest overview
     guest_new_overview = org_session.host_new.get_details(guest_name, 'overview')
-    assert guest_new_overview['overview']['host_status']['status_success'] == '2'
+    assert guest_new_overview['overview']['host_status']['status_success'] == '1'
     # Check guest details
     virtualguest_new_detais = org_session.host_new.get_details(guest_name, 'details')
     assert (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16106

### Problem Statement
remove host subscription and update host_status check for sca-only

Test Case : PASS
```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/foreman/virtwho/ui/test_esx_sca.py -k test_positive_deploy_configure_by_id_script --disable-pytest-warnings -q
..                                                                                                                                         [100%]
2 passed, 16 deselected, 24 warnings in 906.52s (0:15:06)

```