### PR TITLE
[6.16.z] 6.16.0 Quickfix: CV filter, Errata list cmd

### DIFF
--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -388,6 +388,8 @@ def cv_publish_promote(sat, cv, org, lce, force=False):
     :type org: entities.Organization
     :param lce: lifecycle environment
     :type lce: entities.LifecycleEnvironment
+
+    :return int: :id of the content-view-version now published/promoted.
     """
     sat.cli.ContentView.publish({'id': cv.id, 'organization': org})
     # Sort CV Version results by --id, grab last version (latest)
@@ -400,6 +402,7 @@ def cv_publish_promote(sat, cv, org, lce, force=False):
             'force': force,
         }
     )
+    return cvv_id
 
 
 def cv_filter_cleanup(sat, filter_id, cv, org, lce):
@@ -1508,11 +1511,12 @@ def test_errata_list_by_contentview_filter(module_sca_manifest_org, module_targe
     cv = module_target_sat.api.ContentView(
         organization=module_sca_manifest_org, repository=[repo.id]
     ).create()
-    cv_publish_promote(module_target_sat, cv, module_sca_manifest_org, lce)
+    cvv_id = cv_publish_promote(module_target_sat, cv, module_sca_manifest_org, lce)
     errata_count = len(
         module_target_sat.cli.Erratum.list(
             {
                 'organization-id': module_sca_manifest_org.id,
+                'content-view-version-id': cvv_id,
                 'content-view-id': cv.id,
             }
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16150

### Problem Statement
Just need to pass the CVV id/label or LCE id/label for command (not required for 6.15.z and earlier).

### Related Issue (6.16.0 snap 1.0 failure ipv4)
```
robottelo.exceptions.CLIReturnCodeError: CLIReturnCodeError(status=64, stderr="Error: At least one of options 
--content-view-version-id, --content-view-version, --environment-id, --lifecycle-environment is required.\n\n
See: 'hammer erratum <list|index> --help'.\n",
```

### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py::test_errata_list_by_contentview_filter

```