### PR TITLE
[6.15.z] Unsigned Install for swid-tools & dnf-plugin-swidtags

### DIFF
--- a/tests/foreman/api/test_errata.py
+++ b/tests/foreman/api/test_errata.py
@@ -1359,8 +1359,8 @@ def _set_prerequisites_for_swid_repos(vm):
         f'curl --insecure --remote-name {settings.repos.swid_tools_repo}', vm
     )
     _run_remote_command_on_content_host('mv *swid*.repo /etc/yum.repos.d', vm)
-    _run_remote_command_on_content_host('yum install -y swid-tools', vm)
-    _run_remote_command_on_content_host('yum install -y dnf-plugin-swidtags', vm)
+    _run_remote_command_on_content_host('yum install -y --nogpgcheck swid-tools', vm)
+    _run_remote_command_on_content_host('yum install -y --nogpgcheck dnf-plugin-swidtags', vm)
 
 
 def _validate_swid_tags_installed(vm, module_name):


### PR DESCRIPTION
### Problem Statement
Swid tools and dnf-plugin-swidtags rpms are both unsigned.
Causes failure on yum install of these packages.

### Solution
- We can use `--nogpgcheck` flag to install the unsigned prereqs. 
- OR we can remove this test case from 6.15, `test_errata_installation_with_swidtags`, 
as it is non-critical and was already removed from 6.16+



### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_errata.py::test_errata_installation_with_swidtags
```