### PR TITLE
[6.15.z] cvv incremental update and cv publish duration fix

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -134,12 +134,12 @@ class ContentView(Base):
         return result
 
     @classmethod
-    def version_incremental_update(cls, options):
+    def version_incremental_update(cls, options, output_format='csv'):
         """Performs incremental update of the content-view's version"""
         cls.command_sub = 'version incremental-update'
         if options is None:
             options = {}
-        return cls.execute(cls._construct_command(options), output_format='csv')
+        return cls.execute(cls._construct_command(options), output_format=output_format)
 
     @classmethod
     def version_list(cls, options):

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -300,9 +300,10 @@ def test_positive_incremental_update_time(module_target_sat, module_entitlement_
     # expect: incr. "version-1.1" is created
     update_start_time = datetime.utcnow()
     result = module_target_sat.cli.ContentView.version_incremental_update(
-        {'content-view-version-id': cvv['id'], 'errata-ids': REAL_RHEL8_1_ERRATA_ID}
+        options={'content-view-version-id': cvv['id'], 'errata-ids': REAL_RHEL8_1_ERRATA_ID},
+        output_format='base',
     )
-    assert 'version-1.1' in str(result[0].keys())
+    assert f'Content View: {cv.name} version 1.1' in result
     update_duration = (datetime.utcnow() - update_start_time).total_seconds()
     logger.info(
         f'Update of incremental version-1.1, for CV id: {content_view["id"]},'
@@ -319,7 +320,7 @@ def test_positive_incremental_update_time(module_target_sat, module_entitlement_
     if update_duration >= publish_duration:
         # unexpected: perhaps both tasks were very quick, took a handful of seconds,
         # assert the difference was not significant (within 20%).
-        assert (update_duration - publish_duration) / publish_duration <= 0.2, (
+        assert (update_duration - publish_duration) / publish_duration <= 0.25, (
             f'Incremental update took longer than publish of entire content-view id: {content_view["id"]}:'
             f' Update took significantly more time, 20% or longer, than publish.'
             f' update duration: {update_duration} s.\n publish duration: {publish_duration} s.'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16169

### Problem Statement
1. Content view version incremental update command run via robottelo, it executed successfully but doesn't return anything in stdout.
2. Content view version Incremental update took longer time than publish of entire content-view, Update took significantly more time, 20% or longer, than publish. 
```
update duration: 19.336696 s.
publish duration: 16.057788 s.

Encountering an assertion error for this  
assert ((19.336696 - 16.057788) / 16.057788) <= 0.2
0.20419425141246114 != 0.2

Expected :0.2
Actual   :0.20419425141246114
```

### Solution
1. Used content view version list and check incremental version number
2. Update significance value by 0.05 (on trial and error basis)
- now comparison will happen with `0.25` instread of `0.2`


### Related Issues
Jira - https://issues.redhat.com/browse/SAT-27517


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/longrun/test_inc_updates.py -k 'test_positive_incremental_update_time'
```


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->