### PR TITLE
[6.16.z] improve installer tests compatibility with pit

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -7,7 +7,7 @@ CAPSULE:
     # The snap version currently testing (if applicable)
     # SNAP:
     # The source of Capsule packages. Can be one of:
-    # internal, ga, beta
+    # internal, ga
     SOURCE: "internal"
     # The base os rhel version where the capsule installed
     # RHEL_VERSION:

--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -18,6 +18,9 @@ ROBOTTELO:
   SATELLITE_VERSION: "6.17"
   # The Base OS RHEL Version(x.y) where the satellite would be installed
   RHEL_VERSION: "8.10"
+  # The source of RHEL packages. Can be one of:
+  # internal, ga (CDN)
+  RHEL_SOURCE: "ga"
   # Dynaconf and Dynaconf hooks related options
   SETTINGS:
     GET_FRESH: true

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -4,15 +4,15 @@ SERVER:
   #  - replace.with.satellite.hostname
   #  - replace.with.satellite.hostname
   VERSION:
-    # The full release version (6.9.2)
-    RELEASE: 6.9.2
+    # The full release version (6.16.0)
+    RELEASE: 6.16.0
     # The snap version currently testing (if applicable)
     SNAP: 1.0
     # The source of Satellite packages. Can be one of:
-    # internal, ga, beta
+    # internal, ga
     SOURCE: "internal"
     # The RHEL Base OS Version(x.y) where the Satellite is installed
-    RHEL_VERSION: '7'
+    RHEL_VERSION: '9'
   # If the the satellite server is IPv6 server
   IS_IPV6: False
   # HTTP Proxy url for IPv6 satellite to connect for outer world access

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -13,7 +13,7 @@ VALIDATORS = dict(
         Validator('server.hostname', is_type_of=str),
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
-        Validator('server.version.source', must_exist=True),
+        Validator('server.version.source', default='internal', is_in=['internal', 'ga']),
         Validator('server.version.rhel_version', must_exist=True, cast=str),
         Validator(
             'server.xdist_behavior', must_exist=True, is_in=['run-on-one', 'balance', 'on-demand']
@@ -79,7 +79,7 @@ VALIDATORS = dict(
     ],
     capsule=[
         Validator('capsule.version.release', must_exist=True),
-        Validator('capsule.version.source', must_exist=True),
+        Validator('capsule.version.source', default='internal', is_in=['internal', 'ga']),
         Validator('capsule.deploy_workflows', must_exist=True, is_type_of=dict),
         Validator('capsule.deploy_workflows.product', must_exist=True),
         Validator('capsule.deploy_workflows.os', must_exist=True),
@@ -316,6 +316,7 @@ VALIDATORS = dict(
     ],
     robottelo=[
         Validator('robottelo.settings.ignore_validation_errors', is_type_of=bool, default=False),
+        Validator('robottelo.rhel_source', default='ga', is_in=['ga', 'internal']),
     ],
     shared_function=[
         Validator('shared_function.storage', is_in=('file', 'redis'), default='file'),

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -57,6 +57,22 @@ class VersionedContent:
             raise ValueError(f'Unsupported system version: {self._v_major}') from err
 
     @cached_property
+    def SATELLITE_CDN_REPOS(self):
+        sat_version = ".".join(settings.server.version.release.split('.')[0:2])
+        return {
+            'satellite': f"satellite-{sat_version}-for-rhel-{self._v_major}-x86_64-rpms",
+            'sat-maintenance': f"satellite-maintenance-{sat_version}-for-rhel-{self._v_major}-x86_64-rpms",
+        }
+
+    @cached_property
+    def CAPSULE_CDN_REPOS(self):
+        sat_version = ".".join(settings.server.version.release.split('.')[0:2])
+        return {
+            'capsule': f"satellite-capsule-{sat_version}-for-rhel-{self._v_major}-x86_64-rpms",
+            'sat-maintenance': f"satellite-maintenance-{sat_version}-for-rhel-{self._v_major}-x86_64-rpms",
+        }
+
+    @cached_property
     def OSCAP(self):
         return {
             'default_content': constants.OSCAP_DEFAULT_CONTENT[f'rhel{self._v_major}_content'],

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -64,8 +64,9 @@ POWER_OPERATIONS = {
 
 @lru_cache
 def lru_sat_ready_rhel(rhel_ver):
+    """Deploy bare RHEL system ready for Satellite installation."""
     rhel_version = rhel_ver or settings.server.version.rhel_version
-    deploy_args = {
+    deploy_args = settings.server.deploy_arguments | {
         'deploy_rhel_version': rhel_version,
         'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
         'deploy_flavor': settings.flavors.default,
@@ -470,6 +471,9 @@ class ContentHost(Host, ContentHostMixins):
         if force or settings.robottelo.cdn or not downstream_repo:
             return self.execute(f'subscription-manager repos --enable {repo}')
         return None
+
+    def disable_repo(self, repo):
+        return self.execute(f'subscription-manager repos --disable {repo}')
 
     def subscription_manager_list_repos(self):
         return self.execute('subscription-manager repos --list')

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -18,9 +18,10 @@ import yaml
 
 from robottelo import ssh
 from robottelo.config import settings
-from robottelo.constants import FOREMAN_SETTINGS_YML, PRDS, REPOS, REPOSET
+from robottelo.constants import DEFAULT_ARCHITECTURE, FOREMAN_SETTINGS_YML, PRDS, REPOS, REPOSET
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
+from robottelo.utils.ohsnap import dogfood_repository
 
 SATELLITE_SERVICES = [
     'dynflow-sidekiq@orchestrator',
@@ -153,6 +154,114 @@ def install_satellite(satellite, installer_args, enable_fapolicyd=False):
     )
 
 
+def setup_capsule_repos(satellite, capsule_host, org, ak):
+    """
+    Enables repositories that are necessary to install capsule
+    1. Enable RHEL repositories based on configuration
+    2. Enable capsule repositories based on configuration
+    3. Synchonize repositories
+    """
+    # List of sync tasks - all repos will be synced asynchronously
+    sync_tasks = []
+
+    # Enable and sync RHEL BaseOS and AppStream repos
+    if settings.robottelo.rhel_source == "internal":
+        # Configure internal sources as custom repositories
+        product_rhel = satellite.api.Product(organization=org.id).create()
+        for repourl in settings.repos.get(f'rhel{capsule_host.os_version.major}_os').values():
+            repo = satellite.api.Repository(
+                organization=org.id, product=product_rhel, content_type='yum', url=repourl
+            ).create()
+            # custom repos need to be explicitly enabled
+            ak.content_override(
+                data={
+                    'content_overrides': [
+                        {
+                            'content_label': '_'.join([org.label, product_rhel.label, repo.label]),
+                            'value': '1',
+                        }
+                    ]
+                }
+            )
+    else:
+        # use AppStream and BaseOS from CDN
+        for rh_repo_key in [
+            f'rhel{capsule_host.os_version.major}_bos',
+            f'rhel{capsule_host.os_version.major}_aps',
+        ]:
+            satellite.api_factory.enable_rhrepo_and_fetchid(
+                basearch=DEFAULT_ARCHITECTURE,
+                org_id=org.id,
+                product=PRDS[f'rhel{capsule_host.os_version.major}'],
+                repo=REPOS[rh_repo_key]['name'],
+                reposet=REPOSET[rh_repo_key],
+                releasever=REPOS[rh_repo_key]['releasever'],
+            )
+        product_rhel = satellite.api.Product(
+            name=PRDS[f'rhel{capsule_host.os_version.major}'], organization=org.id
+        ).search()[0]
+    sync_tasks.append(satellite.api.Product(id=product_rhel.id).sync(synchronous=False))
+
+    # Enable and sync Capsule repos
+    if settings.capsule.version.source == "ga":
+        # enable Capsule repos from CDN
+        for repo in capsule_host.CAPSULE_CDN_REPOS.values():
+            reposet = satellite.api.RepositorySet(organization=org.id).search(
+                query={'search': repo}
+            )[0]
+            reposet.enable()
+            # repos need to be explicitly enabled in AK
+            ak.content_override(
+                data={
+                    'content_overrides': [
+                        {
+                            'content_label': reposet.label,
+                            'value': '1',
+                        }
+                    ]
+                }
+            )
+            sync_tasks.append(satellite.api.Product(id=reposet.product.id).sync(synchronous=False))
+    else:
+        # configure internal source as custom repos
+        product_capsule = satellite.api.Product(organization=org.id).create()
+        for repo_variant in ['capsule', 'maintenance']:
+            dogfood_repo = dogfood_repository(
+                ohsnap=settings.ohsnap,
+                repo=repo_variant,
+                product="capsule",
+                release=settings.capsule.version.release,
+                os_release=capsule_host.os_version.major,
+                snap=settings.capsule.version.snap,
+            )
+            repo = satellite.api.Repository(
+                organization=org.id,
+                product=product_capsule,
+                content_type='yum',
+                url=dogfood_repo.baseurl,
+            ).create()
+            # custom repos need to be explicitly enabled
+            ak.content_override(
+                data={
+                    'content_overrides': [
+                        {
+                            'content_label': '_'.join(
+                                [org.label, product_capsule.label, repo.label]
+                            ),
+                            'value': '1',
+                        }
+                    ]
+                }
+            )
+        sync_tasks.append(satellite.api.Product(id=product_capsule.id).sync(synchronous=False))
+
+    # Wait for asynchronous sync tasks
+    satellite.wait_for_tasks(
+        search_query=(f'id ^ "{",".join(task["id"] for task in sync_tasks)}"'),
+        poll_timeout=1800,
+    )
+
+
 @pytest.fixture(scope='module')
 def sat_default_install(module_sat_ready_rhels):
     """Install Satellite with default options"""
@@ -162,6 +271,19 @@ def sat_default_install(module_sat_ready_rhels):
     ]
     install_satellite(module_sat_ready_rhels[0], installer_args)
     sat = module_sat_ready_rhels[0]
+    sat.enable_ipv6_http_proxy()
+    return sat
+
+
+@pytest.fixture(scope='module')
+def sat_fapolicyd_install(module_sat_ready_rhels):
+    """Install Satellite with default options and fapolicyd enabled"""
+    installer_args = [
+        'scenario satellite',
+        f'foreman-initial-admin-password {settings.server.admin_password}',
+    ]
+    install_satellite(module_sat_ready_rhels[1], installer_args, enable_fapolicyd=True)
+    sat = module_sat_ready_rhels[1]
     sat.enable_ipv6_http_proxy()
     return sat
 
@@ -177,8 +299,8 @@ def sat_non_default_install(module_sat_ready_rhels):
         'enable-foreman-plugin-discovery',
         'foreman-proxy-plugin-discovery-install-images true',
     ]
-    install_satellite(module_sat_ready_rhels[1], installer_args, enable_fapolicyd=True)
-    sat = module_sat_ready_rhels[1]
+    install_satellite(module_sat_ready_rhels[2], installer_args, enable_fapolicyd=True)
+    sat = module_sat_ready_rhels[2]
     sat.enable_ipv6_http_proxy()
     sat.execute('dnf -y --disableplugin=foreman-protector install foreman-discovery-image')
     return sat
@@ -190,16 +312,18 @@ def sat_non_default_install(module_sat_ready_rhels):
 @pytest.mark.parametrize(
     'setting_update', [f'http_proxy={settings.http_proxy.un_auth_proxy_url}'], indirect=True
 )
-def test_capsule_installation(sat_non_default_install, cap_ready_rhel, setting_update):
+def test_capsule_installation(
+    sat_fapolicyd_install, cap_ready_rhel, module_sca_manifest, setting_update
+):
     """Run a basic Capsule installation with fapolicyd
 
     :id: 64fa85b6-96e6-4fea-bea4-a30539d59e65
 
     :steps:
-        1. Get a fapolicyd enabled Satellite
-        2. Configure capsule repos
-        3. Install and enable fapolicyd
-        4. Enable capsule module
+        1. Use Satellite with fapolicyd enabled
+        2. Configure RHEL and Capsule repos on Satellite
+        3. Register Capsule machine to consume Satellite content
+        4. Install and enable fapolicyd
         5. Install and setup capsule
 
     :expectedresults:
@@ -215,25 +339,39 @@ def test_capsule_installation(sat_non_default_install, cap_ready_rhel, setting_u
 
     :customerscenario: true
     """
-    # Get Capsule repofile, and enable and download satellite-capsule
-    cap_ready_rhel.register_to_cdn()
-    cap_ready_rhel.download_repofile(
-        product='capsule',
-        release=settings.server.version.release,
-        snap=settings.server.version.snap,
-    )
-    # Enable fapolicyd
+    # Create testing organization
+    org = sat_fapolicyd_install.api.Organization().create()
+
+    # Unregister capsule in case it's registered to CDN
+    cap_ready_rhel.unregister()
+
+    # Add a manifest to the Satellite
+    sat_fapolicyd_install.upload_manifest(org.id, module_sca_manifest.content)
+    # Create capsule certs and activation key
+    file, _, cmd_args = sat_fapolicyd_install.capsule_certs_generate(cap_ready_rhel)
+    sat_fapolicyd_install.session.remote_copy(file, cap_ready_rhel)
+    ak = sat_fapolicyd_install.api.ActivationKey(organization=org, environment=org.library).create()
+
+    setup_capsule_repos(sat_fapolicyd_install, cap_ready_rhel, org, ak)
+
+    cap_ready_rhel.register(org, None, ak.name, sat_fapolicyd_install)
+
+    # Install (enable) fapolicyd
     assert (
         cap_ready_rhel.execute(
             'dnf -y install fapolicyd && systemctl enable --now fapolicyd'
         ).status
         == 0
     )
+
+    # Install Capsule package
     cap_ready_rhel.install_satellite_or_capsule_package()
     assert cap_ready_rhel.execute('rpm -q foreman-proxy-fapolicyd').status == 0
+
     # Setup Capsule
-    cap_ready_rhel.capsule_setup(sat_host=sat_non_default_install)
-    assert sat_non_default_install.api.Capsule().search(
+    cap_ready_rhel.install(cmd_args)
+
+    assert sat_fapolicyd_install.api.Capsule().search(
         query={'search': f'name={cap_ready_rhel.hostname}'}
     )[0]
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15308

This change improves compatibility with PIT testing.

- added RHEL_SOURCE variable to robottelo.conf to choose which repositories to use. ga - use released RHEL, internal - use custom RHEL (e.g. release candidate)
- removed 'beta' from available sources of satellite and capsule as we don't use beta releases any more
- updated validators

We can choose source repositories for RHEL and Satellite. Following combinations of sat@rhel are possible:
internal@internal - pre-release testing
ga@internal - PIT testing
internal@ga - common testing
ga@ga - invalid combination (we don't care about retesting already published products)
The same applies for Capsule. It's also possible to use different version of Capsule and Satellite (e.g. n-1 testing)

- reworked satellite installation - use RHEL and Satellite sources as defined by _robottelo.rhel_source_ and _server.version_
- reworked capsule installation - setup RHEL and Capsule sources on Satellite, register capsule as host and perform capsule installation

See SAT-26896
