### PR TITLE
Start using uv

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,9 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache
+      UV_SYSTEM_PYTHON: 1
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v4
@@ -26,21 +29,33 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Restore uv cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.uv-cache
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+            uv-${{ runner.os }}
+
       - name: Install Dependencies
         run: |
           sudo apt update
           sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
-          wget https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          pip install -U pip wheel
-          pip uninstall -y pycurl
-          pip install --compile --no-cache-dir pycurl
-          pip install -U --no-cache-dir -r requirements.txt -r requirements-optional.txt
+          uv pip uninstall pycurl
+          uv pip install --compile --no-cache-dir pycurl
+          uv pip install -r requirements.txt -r requirements-optional.txt
           for conffile in conf/*.yaml.template; do mv -- "$conffile" "${conffile%.yaml.template}.yaml"; done
-          cp broker_settings.yaml.example broker_settings.yaml
           cp .env.example .env
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci
 
       - name: Collect Tests
         run: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -15,6 +15,9 @@ jobs:
     strategy:
       matrix:
         python-version: [3.12]
+    env:
+      UV_CACHE_DIR: /tmp/.uv-cache
+      UV_SYSTEM_PYTHON: 1
     steps:
       - name: Checkout Robottelo
         uses: actions/checkout@v4
@@ -24,21 +27,33 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Set up uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+
+      - name: Restore uv cache
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.uv-cache
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+            uv-${{ runner.os }}
+
       - name: Install Dependencies
         run: |
-          sudo apt-get update -y
+          sudo apt update
           sudo apt-get install -y libgnutls28-dev libcurl4-openssl-dev libssl-dev
-          wget https://raw.githubusercontent.com/SatelliteQE/broker/master/broker_settings.yaml.example
           # link vs compile time ssl implementations can break the environment when installing requirements
           # Uninstall pycurl - its likely not installed, but in case the ubuntu-latest packages change
           # Then compile and install it with PYCURL_SSL_LIBRARY set to openssl
-          pip install -U pip
-          pip uninstall -y pycurl
-          pip install --compile --no-cache-dir pycurl
-          pip install -U -r requirements.txt -r requirements-optional.txt
+          uv pip uninstall pycurl
+          uv pip install --compile --no-cache-dir pycurl
+          uv pip install -r requirements.txt -r requirements-optional.txt
           for conffile in conf/*.yaml.template; do mv -- "$conffile" "${conffile%.yaml.template}.yaml"; done
-          cp broker_settings.yaml.example broker_settings.yaml
           cp .env.example .env
+
+      - name: Minimize uv cache
+        run: uv cache prune --ci
 
       - name: Customer scenario check
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM fedora:38
 MAINTAINER https://github.com/SatelliteQE
 
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
 RUN dnf install -y gcc git make cmake libffi-devel openssl-devel python3-devel \
-    python3-pip redhat-rpm-config which libcurl-devel libxml2-devel
+    redhat-rpm-config which libcurl-devel libxml2-devel
 
 COPY / /robottelo/
 WORKDIR /robottelo
 
 ENV PYCURL_SSL_LIBRARY=openssl
-RUN pip install -r requirements.txt
+ENV UV_SYSTEM_PYTHON=1
+RUN uv pip install -r requirements.txt
 
 CMD make test-robottelo

--- a/scripts/config_helpers.py
+++ b/scripts/config_helpers.py
@@ -1,3 +1,12 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "click",
+#     "deepdiff",
+#     "logzero",
+#     "pyyaml",
+# ]
+# ///
 """A series of commands to help with robottelo configuration"""
 
 from pathlib import Path

--- a/scripts/customer_scenarios.py
+++ b/scripts/customer_scenarios.py
@@ -1,4 +1,12 @@
 #!/usr/bin/env python
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "click",
+#     "requests",
+#     "testimony",
+# ]
+# ///
 from functools import cache
 
 import click

--- a/scripts/fixture_cli.py
+++ b/scripts/fixture_cli.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "click",
+#     "pytest",
+# ]
+# ///
 from pathlib import Path
 
 import click

--- a/scripts/tokenize_customer_scenario.py
+++ b/scripts/tokenize_customer_scenario.py
@@ -1,6 +1,11 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "codemod",
+# ]
+# ///
 """
 This script adds ':customerscenario: true' to all tests by uuid
-depends on `pip install https://github.com/facebook/codemod/tarball/master`
 
 On command line should be like:
 

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -1,3 +1,9 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "dynaconf",
+# ]
+# ///
 """Usage: python scripts/validate_config.py"""
 
 from dynaconf.validator import ValidationError


### PR DESCRIPTION
UV[1] is turning out to be a great new replacement for pip and other tools in the packaging ecosystem.
This change starts with moving to uv for our GitHub actions, Dockerfile, and introduces UV's script dependency mangement.
This last part will allow people to simply `uv run scripts/some_script.py` without having to worry about non-robottelo dependencies.

[1] - https://docs.astral.sh/uv/
