### PR TITLE
Fix for teardown failures

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -691,7 +691,7 @@ class ContentHost(Host, ContentHostMixins):
         if force:
             options['force'] = str(force).lower()
 
-        self._satellite = target
+        self._satellite = target.satellite
         cmd = target.satellite.cli.HostRegistration.generate_command(options)
         return self.execute(cmd.strip('\n'))
 
@@ -703,7 +703,7 @@ class ContentHost(Host, ContentHostMixins):
         :return: The result of the API call.
         """
         kwargs['insecure'] = kwargs.get('insecure', True)
-        self._satellite = target
+        self._satellite = target.satellite
         command = target.satellite.api.RegistrationCommand(**kwargs).create()
         return self.execute(command.strip('\n'))
 


### PR DESCRIPTION
### Problem Statement
https://github.com/SatelliteQE/robottelo/pull/15931 broke teardown of tests which use contenthosts registered through a Capsule because the registration target (where the host is registered to, Capsule in this case) was assigned to the host's `self.satellite` [here](https://github.com/SatelliteQE/robottelo/blob/8dfeed3304a5f6cd3183654855ab19a326d231ec/robottelo/hosts.py#L694), and in teardown we try to search and delete the host [here](https://github.com/SatelliteQE/robottelo/blob/fee2d1413959dd9b71f24eeabb7641dc51424126/robottelo/hosts.py#L178), which fails since Capsule has no API
```
"error during teardown:\n'Capsule' object has no attribute 'api'"
```


### Solution
As per @ogajduse++ proposal, provide the Satellite instance in host's `self.satellite` instead of the registration target (Capsule) so that it can be searched and destroyed at the Sat side.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k test_host_registration_with_capsule_using_content_coherence
