### PR TITLE
Update fact names changed in 6.16

### DIFF
--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -23,7 +23,14 @@ pytestmark = [pytest.mark.tier1]
 
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
-    'fact', ['uptime', 'os::family', 'uptime_seconds', 'memorysize', 'ipaddress']
+    'fact',
+    [
+        'system_uptime',
+        'os::family',
+        'system_uptime::seconds',
+        'memory::system::total',
+        'networking::ip',
+    ],
 )
 def test_positive_list_by_name(fact, module_target_sat):
     """Test Fact List


### PR DESCRIPTION
### Problem Statement
Names of few fact values have been changed causing test failures
uptime -> system_uptime
uptime_seconds -> system_uptime::seconds
memorysize -> memory::system::total
ipaddress -> networking::ip

### Solution
Updated the fact values 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->