### PR TITLE
Fix SATELLITE_VERSION and SAT_NON_GA_VERSIONS in constants

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -6,9 +6,9 @@ from box import Box
 from nailgun import entities
 
 # This should be updated after each version branch
-SATELLITE_VERSION = "6.17"
+SATELLITE_VERSION = "6.16"
 SATELLITE_OS_VERSION = "8"
-SAT_NON_GA_VERSIONS = ['6.17']
+SAT_NON_GA_VERSIONS = ['6.16', '6.17']
 
 # Default system ports
 HTTPS_PORT = '443'


### PR DESCRIPTION
### Problem Statement
`SATELLITE_VERSION` and `SAT_NON_GA_VERSIONS` constants are wrongly set as 6.16 is not GA yet. This is causing `test_positive_capsule_repositories_setup` and `test_positive_satellite_repositories_setup` to fail and probably some other tests too.
### Solution
Fix `SATELLITE_VERSION` and `SAT_NON_GA_VERSIONS` in constants

### Related Issues
- SAT-27753

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->