### PR TITLE
add teardown condition to execute other test seamlessly

### DIFF
--- a/tests/foreman/cli/test_subscription.py
+++ b/tests/foreman/cli/test_subscription.py
@@ -281,7 +281,7 @@ def test_positive_auto_attach_disabled_golden_ticket(
     assert "This host's organization is in Simple Content Access mode" in str(context.value)
 
 
-def test_negative_check_katello_reimport(target_sat, function_org):
+def test_negative_check_katello_reimport(request, target_sat, function_org):
     """Verify katello:reimport trace should not fail with an TypeError
 
     :id: b7508a1c-7798-4649-83a3-cf94c7409c96
@@ -297,6 +297,7 @@ def test_negative_check_katello_reimport(target_sat, function_org):
 
     :BZ: 2225534, 2253621
     """
+    request.addfinalizer(lambda: function_org.delete())
     remote_path = f'/tmp/{EXPIRED_MANIFEST}'
     target_sat.put(DataFile.EXPIRED_MANIFEST_FILE, remote_path)
     # Import expired manifest & refresh
@@ -307,13 +308,16 @@ def test_negative_check_katello_reimport(target_sat, function_org):
         'grep -i "Katello::HttpErrors::BadRequest: This Organization\'s subscription '
         'manifest has expired. Please import a new manifest" /var/log/foreman/production.log'
     )
-    assert exec_val.status
+    assert exec_val.status == 0
     # Delete expired manifest
     target_sat.cli.Subscription.delete_manifest({'organization-id': function_org.id})
     # Re-import new manifest & refresh
     manifester = Manifester(manifest_category=settings.manifest.golden_ticket)
     manifest = manifester.get_manifest()
     target_sat.upload_manifest(function_org.id, manifest.content)
+    request.addfinalizer(
+        lambda: target_sat.cli.Subscription.delete_manifest({'organization-id': function_org.id})
+    )
     ret_val = target_sat.cli.Subscription.refresh_manifest({'organization-id': function_org.id})
     assert 'Candlepin job status: SUCCESS' in ret_val
     # Additional check, katello:reimport trace should not fail with TypeError


### PR DESCRIPTION
### Problem Statement
Did not delete `expired manifest` from the organization after it's use in test `test_negative_check_katello_reimport`, when test unable to execute succesfully it then it was creating problem with other test defined in UI > test_subscription.py
Both test uses same xdist worker to run.

### Solution
With the help of finalizer, delete manifest and organization from test case after it's use, it will depends on test execution result.

### Related Issues
N/A

### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_subscription.py -k 'test_negative_check_katello_reimport'

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->