### PR TITLE
Fix AK tests assertion errors

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -793,7 +793,6 @@ def test_positive_add_redhat_and_custom_products(module_target_sat, function_sca
     assert {REPOSET['rhst7'], repo['name']} == {pc['name'] for pc in content}
 
 
-@pytest.mark.skip_if_not_set('clients')
 @pytest.mark.tier3
 @pytest.mark.upgrade
 @pytest.mark.rhel_ver_match('[^6]')


### PR DESCRIPTION
### Problem Statement
Assertion errors detected but not a product bug; also different automation problems spotted.


### Solution
Fix it in robottelo:
1. In `test_positive_usage_limit` we don't need assert particular result code, we need to ensure the registrations fails and we got the proper message.
2. Interference between `test_positive_add_custom_product` and `test_positive_create_content_and_check_enabled` causes fail since `content` had item from the previously run test (not only `[0]`). We can go `function_org` or sort the `content` based on `id`. I've chosen the first option though the second one worked too.
3. `conf/client.yaml` has been removed as obsoleted but one decorator using that survived, making `test_positive_update_aks_to_chost` fail. Removing the last survivor here.


### PRT test Cases example
1.
trigger: test-robottelo
pytest: tests/foreman/cli/test_activationkey.py -k test_positive_usage_limit
2.
trigger: test-robottelo
pytest: tests/foreman/cli/test_activationkey.py -k 'test_positive_create_content_and_check_enabled or test_positive_add_custom_product'
3.
trigger: test-robottelo
pytest: tests/foreman/cli/test_activationkey.py -k test_positive_update_aks_to_chost