### PR TITLE
Move SAT_NON_GA_VERSIONS constant to robottelo config

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -120,7 +120,6 @@ jobs:
           old_url="https://raw.githubusercontent.com/SatelliteQE/robottelo/master/tests/foreman/data/uri.sh"
           new_url="https://raw.githubusercontent.com/SatelliteQE/robottelo/${{ github.event.inputs.target_branch }}/tests/foreman/data/uri.sh"
           FILE_PATH="./robottelo/constants/__init__.py"
-          awk '/SAT_NON_GA_VERSIONS =/ { sub(/\[[^,]*, /, "[", $0) } 1' "$FILE_PATH" > temp && mv temp "$FILE_PATH"
           sed -i.bak "s|${old_url}|${new_url}|" "$FILE_PATH"
           rm "$FILE_PATH.bak"
 
@@ -258,7 +257,6 @@ jobs:
           # update the version
           sed -i.bak "s/SATELLITE_VERSION = \"$old_stream_version\"/SATELLITE_VERSION = \"$new_stream_version\"/" "$FILE_PATH"
           sed -i.bak "s/  SATELLITE_VERSION: \"$old_stream_version\"/  SATELLITE_VERSION: \"$new_stream_version\"/" ./conf/robottelo.yaml.template
-          sed -i.bak "s/SAT_NON_GA_VERSIONS = \[.*\]/SAT_NON_GA_VERSIONS = $non_ga_versions/" "$FILE_PATH"
           rm "$FILE_PATH.bak" "./conf/robottelo.yaml.template.bak"
 
       - name: git status

--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -16,6 +16,10 @@ ROBOTTELO:
   # Satellite version supported by this branch
   # UNDR version is used for some URL composition
   SATELLITE_VERSION: "6.17"
+  # Update non-ga versions with each release
+  SAT_NON_GA_VERSIONS:
+    - '6.16'
+    - '6.17'
   # The Base OS RHEL Version(x.y) where the satellite would be installed
   RHEL_VERSION: "8.10"
   # The source of RHEL packages. Can be one of:

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -317,6 +317,12 @@ VALIDATORS = dict(
     robottelo=[
         Validator('robottelo.settings.ignore_validation_errors', is_type_of=bool, default=False),
         Validator('robottelo.rhel_source', default='ga', is_in=['ga', 'internal']),
+        Validator(
+            'robottelo.sat_non_ga_versions',
+            is_type_of=list,
+            default=[],
+            cast=lambda x: list(map(str, x)),
+        ),
     ],
     shared_function=[
         Validator('shared_function.storage', is_in=('file', 'redis'), default='file'),

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -8,7 +8,6 @@ from nailgun import entities
 # This should be updated after each version branch
 SATELLITE_VERSION = "6.17"
 SATELLITE_OS_VERSION = "8"
-SAT_NON_GA_VERSIONS = ['6.16', '6.17']
 
 # Default system ports
 HTTPS_PORT = '443'

--- a/tests/foreman/maintain/test_advanced.py
+++ b/tests/foreman/maintain/test_advanced.py
@@ -16,7 +16,7 @@ import pytest
 import yaml
 
 from robottelo.config import robottelo_tmp_dir, settings
-from robottelo.constants import MAINTAIN_HAMMER_YML, SAT_NON_GA_VERSIONS
+from robottelo.constants import MAINTAIN_HAMMER_YML
 from robottelo.hosts import get_sat_rhel_version, get_sat_version
 
 sat_x_y_release = f'{get_sat_version().major}.{get_sat_version().minor}'
@@ -298,7 +298,7 @@ def test_positive_satellite_repositories_setup(sat_maintain):
     """
     sat_version = ".".join(sat_maintain.version.split('.')[0:2])
     result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': sat_version})
-    if sat_version not in SAT_NON_GA_VERSIONS:
+    if sat_version not in settings.robottelo.sat_non_ga_versions:
         assert result.status == 0
         assert 'FAIL' not in result.stdout
         result = sat_maintain.execute('yum repolist')
@@ -331,7 +331,7 @@ def test_positive_capsule_repositories_setup(sat_maintain):
     """
     sat_version = ".".join(sat_maintain.version.split('.')[0:2])
     result = sat_maintain.cli.Advanced.run_repositories_setup(options={'version': sat_version})
-    if sat_version not in SAT_NON_GA_VERSIONS:
+    if sat_version not in settings.robottelo.sat_non_ga_versions:
         assert result.status == 0
         assert 'FAIL' not in result.stdout
         result = sat_maintain.execute('yum repolist')


### PR DESCRIPTION
### Problem Statement
- With the current approach we have to maintain the `SAT_NON_GA_VERSIONS` across other branches

### Solution
- Move `SAT_NON_GA_VERSIONS` constant to robottelo config

### Related Issues
- SAT-27753
- Depend on satellite-jenkins#1465

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->