### PR TITLE
[6.16.z] Mark test_positive_configure_cloud_connector for PIT

### DIFF
--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -109,6 +109,7 @@ def fixture_setup_rhc_satellite(
 
 @pytest.mark.e2e
 @pytest.mark.tier3
+@pytest.mark.pit_server
 def test_positive_configure_cloud_connector(
     session,
     module_target_sat,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16239

### Problem Statement
Missing PIT coverage for RH Cloud Connector

### Solution
Mark test_positive_configure_cloud_connector for PIT

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->