### PR TITLE
[6.15.z] Base robottelo image on fedora/python-312

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-FROM fedora:38
+FROM quay.io/fedora/python-312:latest
 MAINTAINER https://github.com/SatelliteQE
+
+ENV PYCURL_SSL_LIBRARY=openssl \
+    ROBOTTELO_DIR="${HOME}/robottelo"
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 
-RUN dnf install -y gcc git make cmake libffi-devel openssl-devel python3-devel \
-    redhat-rpm-config which libcurl-devel libxml2-devel
+USER 1001
+COPY --chown=1001:0 / ${ROBOTTELO_DIR}
 
-COPY / /robottelo/
-WORKDIR /robottelo
-
-ENV PYCURL_SSL_LIBRARY=openssl
-ENV UV_SYSTEM_PYTHON=1
+WORKDIR "${ROBOTTELO_DIR}"
 RUN uv pip install -r requirements.txt
 
 CMD make test-robottelo


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16248

Base robottelo image on the `fedora/python-312` image. That would allow us to base our downstream image on it.

## Podman build log
```text
$ podman build --no-cache -t robottelo-local .
STEP 1/9: FROM quay.io/fedora/python-312:latest
STEP 2/9: MAINTAINER https://github.com/SatelliteQE
--> d669f41f9ea5
STEP 3/9: ENV PYCURL_SSL_LIBRARY=openssl     ROBOTTELO_DIR="${HOME}/robottelo"
--> a4e15a5fcdd9
STEP 4/9: COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
--> e7b226925b66
STEP 5/9: USER 1001
--> f4e8829f8cc9
STEP 6/9: COPY --chown=1001:0 / ${ROBOTTELO_DIR}
--> cadf482df7df
STEP 7/9: WORKDIR "${ROBOTTELO_DIR}"
--> adeac0daeeff
STEP 8/9: RUN uv pip install -r requirements.txt
Resolved 282 packages in 5.88s
Prepared 281 packages in 7.85s
Installed 282 packages in 428ms
 + adal==1.2.7
 + aenum==3.1.15
 + aiohappyeyeballs==2.4.0
 + aiohttp==3.10.5
 + aiosignal==1.3.1
 + airgun==0.0.1 (from git+https://github.com/SatelliteQE/airgun.git@64f48b088c50f273f42ff0864b55ebbb9ef85269)
 .
 .
 .
 + multidict==6.0.5
 + mypy-extensions==1.0.0
 + nailgun==0.32.0 (from git+https://github.com/SatelliteQE/nailgun.git@5d8d770b8bb46ca8a338f6ddb4c4cfcca2bc80eb)
 + navmazing==1.2.2
 + netaddr==1.3.0
 + netifaces==0.11.0
 .
 .
 .
 + rfc3986==2.0.0
 + rich==13.8.0
 + robottelo==0.1.0 (from file:///opt/app-root/src/robottelo)
 + rpds-py==0.20.0
 + rsa==4.9
 .
 .
 .
 + yarl==1.9.11
 + zc-lockfile==3.0.post1
 + zipp==3.20.1
--> 3bb1a6289a89
STEP 9/9: CMD make test-robottelo
COMMIT robottelo-local
--> d64cd8d76d74
Successfully tagged localhost/robottelo-local:latest
d64cd8d76d74b2d259fbbbddee5b06f6389e7019b9e74153b84874c718235d2a
```