### PR TITLE
preserve the build sanity server for debugging

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -387,7 +387,7 @@ def installer_satellite(request):
         configure_nailgun()
         configure_airgun()
     yield sat
-    if 'sanity' not in request.config.option.markexpr:
+    if 'sanity' not in request.config.option.markexpr and settings.server.auto_checkin:
         sat = Satellite.get_host_by_hostname(sat.hostname)
         sat.unregister()
         Broker(hosts=[sat]).checkin()


### PR DESCRIPTION
### Problem Statement
Currently, the build sanity server is checked in as part of the pytest session, regardless of whether the build sanity test passes or fails. This process makes it challenging to identify the root cause of any issues immediately. To improve this, we propose delaying the check-in of the build sanity server and preserving it for a specified period. This will allow us to use the preserved instance to investigate the root cause of issues or provide it to the delivery team for further analysis.

### Solution
This PR handles the preservation of the sanity server

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->