### PR TITLE
[6.13.z] using custom org for user timezone test

### DIFF
--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -647,7 +647,7 @@ def test_negative_update_name(new_name, module_org, module_target_sat):
 
 
 @pytest.mark.tier2
-def test_positive_create_user_with_timezone(module_org, module_target_sat):
+def test_positive_create_user_with_timezone(module_target_sat):
     """Create and remove user with valid timezone in an organization
 
     :id: b9b92c00-ee99-4da2-84c5-0a576a862100
@@ -665,6 +665,12 @@ def test_positive_create_user_with_timezone(module_org, module_target_sat):
 
     :expectedresults: User created and removed successfully with valid timezone
     """
+    name = valid_org_names_list()[0]
+    label = valid_labels_list()[0]
+    desc = list(valid_data_list().values())[0]
+    org = module_target_sat.cli_factory.make_org(
+        {'name': name, 'label': label, 'description': desc}
+    )
     users_timezones = [
         'Pacific Time (US & Canada)',
         'International Date Line West',
@@ -674,10 +680,10 @@ def test_positive_create_user_with_timezone(module_org, module_target_sat):
     ]
     for timezone in users_timezones:
         user = module_target_sat.cli_factory.user({'timezone': timezone, 'admin': '1'})
-        module_target_sat.cli.Org.add_user({'name': module_org.name, 'user': user['login']})
-        org_info = module_target_sat.cli.Org.info({'name': module_org.name})
+        module_target_sat.cli.Org.add_user({'name': org.name, 'user': user['login']})
+        org_info = module_target_sat.cli.Org.info({'name': org.name})
         assert user['login'] in org_info['users']
         assert user['timezone'] == timezone
-        module_target_sat.cli.Org.remove_user({'id': module_org.id, 'user-id': user['id']})
-        org_info = module_target_sat.cli.Org.info({'name': module_org.name})
+        module_target_sat.cli.Org.remove_user({'id': org.id, 'user-id': user['id']})
+        org_info = module_target_sat.cli.Org.info({'name': org.name})
         assert user['login'] not in org_info['users']


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16261

### Problem Statement
the test failed kind of mysteriously on module_org not found when associating the user. Local runs are ok, I suspect some interference with other tests from module. 

### Solution
Trying out a version with custom org

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->