### PR TITLE
[6.16.z] Set DNF proxy for IPv6 runs

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -834,6 +834,16 @@ class ContentHost(Host, ContentHostMixins):
             cmd += f' --server.proxy_port={port}'
         self.execute(cmd)
 
+    def enable_dnf_proxy(self, hostname, scheme=None, port=None):
+        """Configures proxy for dnf"""
+        if not scheme:
+            scheme = 'http'
+        cmd = f"echo -e 'proxy = {scheme}://{hostname}"
+        if port:
+            cmd += f':{port}'
+        cmd += "' >> /etc/dnf/dnf.conf"
+        self.execute(cmd)
+
     def add_authorized_key(self, pub_key):
         """Inject a public key into the authorized keys file
 
@@ -1689,10 +1699,6 @@ class Capsule(ContentHost, CapsuleMixins):
         Note: Make sure required repos are enabled before using this.
         """
         if self.os_version.major == 8:
-            if settings.server.is_ipv6:
-                self.execute(
-                    f"echo -e 'proxy={settings.server.http_proxy_ipv6_url}' >> /etc/dnf/dnf.conf"
-                )
             assert (
                 self.execute(
                     f'dnf -y module enable {self.product_rpm_name}:el{self.os_version.major}'
@@ -2325,6 +2331,7 @@ class Satellite(Capsule, SatelliteMixins):
         if enable_proxy and settings.server.is_ipv6:
             url = urlparse(settings.server.http_proxy_ipv6_url)
             self.enable_rhsm_proxy(url.hostname, url.port)
+            self.enable_dnf_proxy(url.hostname, url.scheme, url.port)
         return super().register_contenthost(
             org=org, lce=lce, username=username, password=password, enable_proxy=enable_proxy
         )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16274

### Problem Statement
DNF on the IPv6-only Satellite host can not download metadata as the download mirror/host has only `A` DNS record.

Proxy setting for DNF is being set in the `enable_satellite_or_capsule_module_for_rhel8` method. However, this method executes its steps only on RHEL 8, as is stated in its name. 

Setting proxy for DNF needs to be moved elsewhere.

### Solution
Remove setting DNF proxy from `enable_satellite_or_capsule_module_for_rhel8` and move it to a separate method. Call this method from `Satellite.register_contenthost` method right after we enable the proxy for subscription-manager.

### Related Issues
[SAT-27846](https://issues.redhat.com/browse/SAT-27846)
