### PR TITLE
[6.16] Small Workaround for Manage Columns test for All Hosts page

### DIFF
--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -1231,6 +1231,9 @@ def test_all_hosts_manage_columns(target_sat, new_host_ui):
         'Boot time': True,
     }
     with target_sat.ui_session() as session:
+        # Small workaround for an existing bug, reloads the page
+        session.all_hosts.get_displayed_table_headers()
+        wait_for(lambda: session.browser.refresh(), timeout=5)
         session.all_hosts.manage_table_columns(columns)
         displayed_columns = session.all_hosts.get_displayed_table_headers()
         for column, is_displayed in columns.items():


### PR DESCRIPTION
### Problem Statement
There is a small inconsistency seen rarely in local testing, but seemingly consistently in CI where the Manage Columns button is only appearing upon refresh, as opposed to when first navigating to the page. 

This would be something that I'd like to get resolved in the future if this issue with the page is resolved. 

### Solution
This is a somewhat clumsy attempt to fix this issues for testing, as the issue isn't seen locally, so is hard to reproduce. This simply "navigates" to the page, reloads, and then attempts to run the actual test. 

### Related Issues
https://github.com/SatelliteQE/robottelo/issues/16292
https://issues.redhat.com/browse/SAT-27868 (Bug in question)

### PRT
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_all_hosts_manage_columns'

