### PR TITLE
[6.16.z] Avoid calling decode on str

### DIFF
--- a/tests/foreman/destructive/test_rename.py
+++ b/tests/foreman/destructive/test_rename.py
@@ -191,7 +191,10 @@ def test_negative_rename_sat_wrong_passwd(module_target_sat):
         f'satellite-change-hostname -y {new_hostname} -u {username} -p {password}'
     )
     assert result.status == 1
-    assert BAD_CREDS_MSG in result.stderr[1].decode()
+    assert BAD_CREDS_MSG in result.stderr
+    # assert no changes were made
+    hostname_result = module_target_sat.execute('hostname')
+    assert original_name == hostname_result.stdout.strip(), "Invalid hostame assigned"
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16214

### Problem Statement

In tests we see this failure:

    AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?

### Solution

This implies that the strerr value is a str, which you can't decode. I can't find the specific change, but this implies the result used to be a byte string and is now decoded elsewhere.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->