### PR TITLE
[6.16.z] api changes for 6.16

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -157,6 +157,7 @@ API_PATHS = {
         '/katello/api/capsules/:id/content/sync',
         '/katello/api/capsules/:id/content/sync',
         '/katello/api/capsules/:id/content/reclaim_space',
+        '/katello/api/capsules/:id/content/verify_checksum',
     ),
     'capsules': ('/katello/api/capsules', '/katello/api/capsules/:id'),
     'common_parameters': (
@@ -296,6 +297,7 @@ API_PATHS = {
         '/katello/api/content_view_versions/:id/promote',
         '/katello/api/content_view_versions/:id/republish_repositories',
         '/katello/api/content_view_versions/incremental_update',
+        '/katello/api/content_view_versions/:id/verify_checksum',
     ),
     'dashboard': ('/api/dashboard',),
     'debs': ('/katello/api/debs/:id', '/katello/api/debs/compare'),
@@ -405,6 +407,7 @@ API_PATHS = {
         '/api/hosts/:host_id/subscriptions',
         '/api/hosts/:host_id/subscriptions',
         '/api/hosts/:host_id/subscriptions/add_subscriptions',
+        '/api/hosts/:host_id/subscriptions/remove_subscriptions',
         '/api/hosts/:host_id/subscriptions/auto_attach',
         '/api/hosts/:host_id/subscriptions/available_release_versions',
         '/api/hosts/:host_id/subscriptions/enabled_repositories',
@@ -461,6 +464,8 @@ API_PATHS = {
     ),
     'hosts_bulk_actions': (
         '/api/hosts/bulk',
+        '/api/hosts/bulk/build',
+        '/api/hosts/bulk/reassign_hostgroups',
         '/api/hosts/bulk/add_host_collections',
         '/api/hosts/bulk/remove_host_collections',
         '/api/hosts/bulk/add_subscriptions',
@@ -611,7 +616,11 @@ API_PATHS = {
         '/katello/api/package_groups/:id',
         '/katello/api/package_groups/compare',
     ),
-    'packages': ('/katello/api/packages/:id', '/katello/api/packages/compare'),
+    'packages': (
+        '/katello/api/packages/:id',
+        '/katello/api/packages/compare',
+        '/katello/api/packages/thindex',
+    ),
     'parameters': (
         '/api/hosts/:host_id/parameters',
         '/api/hosts/:host_id/parameters',
@@ -624,6 +633,7 @@ API_PATHS = {
         '/api/permissions',
         '/api/permissions/:id',
         '/api/permissions/resource_types',
+        '/api/permissions/current_permissions',
     ),
     'personal_access_tokens': (
         '/api/users/:user_id/personal_access_tokens',
@@ -703,12 +713,7 @@ API_PATHS = {
         '/api/api/hosts/:id/available_remote_execution_features',
     ),
     'scap_content_profiles': ('/api/compliance/scap_content_profiles',),
-    'simple_content_access': (
-        '/katello/api/organizations/:organization_id/simple_content_access/eligible',
-        '/katello/api/organizations/:organization_id/simple_content_access/enable',
-        '/katello/api/organizations/:organization_id/simple_content_access/disable',
-        '/katello/api/organizations/:organization_id/simple_content_access/status',
-    ),
+    'simple_content_access': (),
     'registration': ('/api/register', '/api/register'),
     'registration_commands': ('/api/registration_commands',),
     'report_templates': (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16307

### Problem Statement
Api changes found in 6.16 compared to the previous version. The list was shared with dev for check. Prt may fail in master, running anyway for automerge

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->