### PR TITLE
[6.15.z] Fix hostCollection UI e2e test

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -205,9 +205,7 @@ def _get_content_repository_urls(repos_collection, lce, content_view, module_tar
 
 @pytest.mark.tier2
 @pytest.mark.upgrade
-def test_positive_end_to_end(
-    session, module_target_sat, module_org_with_parameter, smart_proxy_location
-):
+def test_positive_end_to_end(module_target_sat, module_org_with_parameter, smart_proxy_location):
     """Perform end to end testing for host collection component
 
     :id: 1d40bc74-8e05-42fa-b6e3-2999dc3b730d
@@ -222,7 +220,8 @@ def test_positive_end_to_end(
     host = module_target_sat.api.Host(
         organization=module_org_with_parameter, location=smart_proxy_location
     ).create()
-    with session:
+    with module_target_sat.ui_session() as session:
+        session.organization.select(module_org_with_parameter.name)
         session.location.select(smart_proxy_location.name)
         # Create new host collection
         session.hostcollection.create(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16318

### Problem Statement
This test has been failing for a long in our automation and upon investigation I found out that the test does not properly select the organization with which it is supposed to be working.

### Solution
Add select organization action.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostcollection.py -k 'test_positive_end_to_end'