### PR TITLE
changes to the capsule upgrade playbook test

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -17,55 +17,28 @@ import pytest
 from robottelo.config import settings
 from robottelo.hosts import get_sat_version
 from robottelo.utils import ohsnap
+from robottelo.utils.issue_handlers import is_open
 
 CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
 
 @pytest.mark.tier4
-def test_positive_run_capsule_upgrade_playbook(module_capsule_configured, target_sat):
-    """Run Capsule Upgrade playbook against an External Capsule
+def test_positive_find_capsule_upgrade_playbook(target_sat):
+    """Check that Capsule Upgrade playbook is present on Satellite
 
-    :id: 9ec6903d-2bb7-46a5-8002-afc74f06d83b
+    :id: 7d9fd42f-289f-4b14-a65e-93ddc8ea759a
 
-    :steps:
-        1. Create a Capsule VM, add REX key.
-        2. Run the Capsule Upgrade Playbook.
-
-    :expectedresults: Capsule is upgraded successfully
+    :expectedresults: Capsule upgrade playbook is found on Satellite
 
     :BZ: 2152951
 
     :CaseImportance: Medium
     """
-    template_name = 'Capsule Upgrade Playbook'
-    template_id = (
-        target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})[0].id
+    template_name = (
+        'Smart Proxy Upgrade Playbook' if is_open('BZ:2152951') else 'Capsule Upgrade Playbook'
     )
-    module_capsule_configured.add_rex_key(satellite=target_sat)
-    job = target_sat.api.JobInvocation().run(
-        synchronous=False,
-        data={
-            'job_template_id': template_id,
-            'inputs': {
-                'target_version': CAPSULE_TARGET_VERSION,
-                'whitelist_options': 'repositories-validate,repositories-setup,non-rh-packages',
-            },
-            'targeting_type': 'static_query',
-            'search_query': f'name = {module_capsule_configured.hostname}',
-        },
-    )
-    target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
-    result = target_sat.api.JobInvocation(id=job['id']).read()
-    assert result.succeeded == 1
-    result = target_sat.execute('satellite-maintain health check')
-    assert result.status == 0
-    for line in result.stdout:
-        assert 'FAIL' not in line
-    result = target_sat.api.SmartProxy(
-        id=target_sat.api.SmartProxy(name=target_sat.hostname).search()[0].id
-    ).refresh()
-    feature_set = {feat['name'] for feat in result['features']}
-    assert {'Ansible', 'Dynflow', 'Script', 'Pulpcore', 'Logs'}.issubset(feature_set)
+    templates = target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})
+    assert len(templates) > 0
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
### Problem Statement
We are not really equipped to test the full capsule upgrade in the regular automation and I wouldn't say it's necessary. Meanwhile there came also an *update* playbook, that will be covered with https://github.com/SatelliteQE/robottelo/pull/15863 (awaits packaging)

### Solution
This pr changes the *upgrade* playbook tests to merely check that the playbook is around

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->