### PR TITLE
Do not store extraheader http auth in git config

### DIFF
--- a/.github/workflows/update_robottelo_image.yml
+++ b/.github/workflows/update_robottelo_image.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # do not store the auth token in git config
+          persist-credentials: false
 
       - name: Get image tag
         id: image_tag


### PR DESCRIPTION
### Problem Statement
Github `checkout` action stores an authentication token by default in `.git/config`.
```ini
[http "https://github.com/"]
        extraheader = AUTHORIZATION: basic sometoken==
```

That causes auth issues when using robottelo image from quay.io when the auth token expires.


### Solution
Do not store the auth token in the git config.
