### PR TITLE
[6.15.z] Fix pxeless discovery test

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -316,7 +316,7 @@ def pxe_loader(request):
 
 
 @pytest.fixture
-def pxeless_discovery_host(provisioning_host, module_discovery_sat):
+def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
     """Fixture for returning a pxe-less discovery host for provisioning"""
     sat = module_discovery_sat.sat
     image_name = f"{gen_string('alpha')}-{module_discovery_sat.iso}"
@@ -333,6 +333,7 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat):
         workflow='import-disk-image',
         import_disk_image_name=image_name,
         import_disk_image_url=(f'https://{sat.hostname}/pub/{fdi}'),
+        firmware_type=pxe_loader.vm_firmware,
     ).execute()
     # Change host to boot discovery image
     Broker(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16340

Problem Statement
pxeless discovery tests  are going to fail due to change in workflow var

Solution
This pr updates the var in the fixture

Related Issues
