### PR TITLE
Remove sanity marker from GCE test until issue is fixed on IPv6 satellite

### DIFF
--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -22,6 +22,7 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import GCE_RHEL_CLOUD_PROJECTS, VALID_GCE_ZONES
+from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.mark.skip_if_not_set('gce')
@@ -228,6 +229,10 @@ class TestGCEHostProvisioningTestCase:
     @pytest.mark.tier1
     @pytest.mark.pit_server
     @pytest.mark.build_sanity
+    @pytest.mark.skipif(
+        ((settings.server.is_ipv6) and is_open('SAT-27997')),
+        reason='Google CR APIs failing for IPv6',
+    )
     @pytest.mark.parametrize('sat_gce', ['sat', 'puppet_sat'], indirect=True)
     def test_positive_gce_host_provisioned(self, class_host, google_host):
         """Host can be provisioned on Google Cloud


### PR DESCRIPTION
### Problem Statement
tests/foreman/api/test_computeresource_gce.py::test_positive_gce_host_provisioned test is failing on IPv6 Satellite with 500 error. This test is marked for sanity and thus causing sanity pipeline to fail. 

### Solution
Until we fix this issue on IPv6, we are  removing sanity marker from the test.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->