### PR TITLE
[6.16.z] Remove unused code related to is_open bz

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -244,7 +244,6 @@ class TestCapsuleContentManagement:
         assert new_checksum in checksum_types
         assert original_checksum not in checksum_types
 
-    @pytest.mark.skip_if_open("BZ:2025494")
     @pytest.mark.e2e
     @pytest.mark.tier4
     @pytest.mark.pit_client
@@ -761,7 +760,6 @@ class TestCapsuleContentManagement:
         caps_files = get_repo_files_by_url(caps_repo_url)
         assert len(caps_files) == packages_count
 
-    @pytest.mark.skip_if_open("BZ:2122780")
     @pytest.mark.tier4
     @pytest.mark.skip_if_not_set('capsule', 'fake_manifest')
     def test_positive_capsule_pub_url_accessible(self, module_capsule_configured):

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1211,7 +1211,6 @@ def test_negative_non_readonly_user_actions(target_sat, content_view, function_r
         target_sat.api.ContentView(id=content_view.id).read()
 
 
-@pytest.mark.skip_if_open("BZ:1625783")
 class TestOstreeContentView:
     """Tests for ostree contents in content views."""
 
@@ -1315,7 +1314,6 @@ class TestOstreeContentView:
         assert len(content_view.read().version[0].read().environment) == 2
 
 
-@pytest.mark.skip_if_open("BZ:1625783")
 class TestContentViewRedHatOstreeContent:
     """Tests for publishing and promoting cv with RH ostree contents."""
 

--- a/tests/foreman/api/test_operatingsystem.py
+++ b/tests/foreman/api/test_operatingsystem.py
@@ -267,7 +267,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             target_sat.api.OperatingSystem(description=gen_string('alphanumeric', 256)).create()
 
-    @pytest.mark.skip_if_open('BZ:2101435')
     @pytest.mark.tier1
     @pytest.mark.parametrize('major_version', **parametrized((gen_string('numeric', 6), '', '-6')))
     def test_negative_create_with_invalid_major_version(self, major_version, target_sat):
@@ -375,7 +374,6 @@ class TestOperatingSystem:
         with pytest.raises(HTTPError):
             os = target_sat.api.OperatingSystem(id=os.id, name=new_name).update(['name'])
 
-    @pytest.mark.skip_if_open('BZ:2101435')
     @pytest.mark.tier1
     def test_negative_update_major_version(self, target_sat):
         """Create operating entity providing the initial major version,

--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -17,7 +17,6 @@ import pytest
 from robottelo.config import settings
 from robottelo.hosts import get_sat_version
 from robottelo.utils import ohsnap
-from robottelo.utils.issue_handlers import is_open
 
 CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
@@ -38,9 +37,7 @@ def test_positive_run_capsule_upgrade_playbook(module_capsule_configured, target
 
     :CaseImportance: Medium
     """
-    template_name = (
-        'Smart Proxy Upgrade Playbook' if is_open('BZ:2152951') else 'Capsule Upgrade Playbook'
-    )
+    template_name = 'Capsule Upgrade Playbook'
     template_id = (
         target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})[0].id
     )

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -30,7 +30,6 @@ from robottelo.exceptions import CLIReturnCodeError
 from robottelo.utils.datafactory import parametrized
 
 
-@pytest.mark.skip_if_open('BZ:2137950')
 @pytest.mark.tier1
 def test_negative_disable_repository_with_cv(module_sca_manifest_org, target_sat):
     """Attempt to disable a Repository that is published in a Content View

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -221,7 +221,6 @@ class TestRepository:
         assert default_dl_policy
         assert repo.download_policy == default_dl_policy[0].value
 
-    @pytest.mark.skip_if_open("BZ:2042473")
     @pytest.mark.tier1
     @pytest.mark.parametrize(
         'repo_options', **datafactory.parametrized([{'content_type': 'yum'}]), indirect=True
@@ -781,7 +780,6 @@ class TestRepository:
         with pytest.raises(HTTPError):
             repo.update(['name'])
 
-    @pytest.mark.skip_if_open('BZ:1311113')
     @pytest.mark.tier1
     def test_negative_update_label(self, repo):
         """Attempt to update repository label to another one.
@@ -871,7 +869,6 @@ class TestRepository:
         # Verify it has finished
         assert repo.read().content_counts['rpm'] >= 1
 
-    @pytest.mark.skip_if_open("BZ:2035025")
     @pytest.mark.tier2
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
@@ -2141,7 +2138,6 @@ class TestDockerRepository:
 class TestSRPMRepository:
     """Tests specific to using repositories containing source RPMs."""
 
-    @pytest.mark.skip_if_open("BZ:2016047")
     @pytest.mark.upgrade
     @pytest.mark.tier2
     def test_positive_srpm_upload_publish_promote_cv(

--- a/tests/foreman/api/test_rhc.py
+++ b/tests/foreman/api/test_rhc.py
@@ -15,8 +15,6 @@
 from fauxfactory import gen_string
 import pytest
 
-from robottelo.utils.issue_handlers import is_open
-
 
 @pytest.fixture
 def fixture_enable_rhc_repos(target_sat):
@@ -49,12 +47,6 @@ def test_positive_configure_cloud_connector(target_sat, default_org, fixture_ena
 
     :CaseImportance: Critical
     """
-
-    # Delete old satellite  hostname if BZ#2130173 is open
-    if is_open('BZ:2130173'):
-        host = target_sat.api.Host().search(query={'search': f"! {target_sat.hostname}"})[0]
-        host.delete()
-
     # Copy foreman-proxy user's key to root@localhost user's authorized_keys
     target_sat.add_rex_key(satellite=target_sat)
 

--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -1422,10 +1422,9 @@ class TestCannedRole:
         ).create()
         assert user_login == user.login
         assert org_admin.id == user.role[0].id
-        if not is_open('BZ:1825698'):
-            name = gen_string('alphanumeric')
-            location = target_sat.api.Location(sc_user, name=name).create()
-            assert location.name == name
+        name = gen_string('alphanumeric')
+        location = target_sat.api.Location(sc_user, name=name).create()
+        assert location.name == name
 
     @pytest.mark.tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies, target_sat):
@@ -1457,7 +1456,6 @@ class TestCannedRole:
         except HTTPError as err:
             pytest.fail(str(err))
 
-    @pytest.mark.skip_if_open('BZ:1825698')
     @pytest.mark.tier2
     def test_positive_create_nested_location(self, role_taxonomies, target_sat):
         """Org Admin can create nested locations

--- a/tests/foreman/api/test_settings.py
+++ b/tests/foreman/api/test_settings.py
@@ -89,7 +89,6 @@ def test_positive_update_login_page_footer_text_with_long_string(setting_update)
     assert setting_update.value == login_text_value
 
 
-@pytest.mark.skip_if_open("BZ:1470083")
 @pytest.mark.tier2
 @pytest.mark.parametrize('setting_update', ['discovery_hostname'], indirect=True)
 def test_negative_update_hostname_with_empty_fact(setting_update):

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -791,7 +791,6 @@ class TestTemplateSyncTestCase:
             template['message']['templates'][0]['additional_errors'] == 'Failed to parse metadata'
         )
 
-    @pytest.mark.skip_if_open('BZ:1787355')
     @pytest.mark.tier2
     def test_positive_import_json_output_filtered_skip_message(
         self, create_import_export_local_dir, module_org, module_target_sat

--- a/tests/foreman/cli/test_computeresource_rhev.py
+++ b/tests/foreman/cli/test_computeresource_rhev.py
@@ -281,7 +281,6 @@ def test_positive_add_image_rhev_with_name(rhev, module_os, module_target_sat):
     assert result[0]['uuid'] == rhev.image_uuid
 
 
-@pytest.mark.skip_if_open("BZ:1829239")
 @pytest.mark.tier2
 def test_negative_add_image_rhev_with_invalid_uuid(rhev, module_os, module_target_sat):
     """Attempt to add invalid image to the RHEV compute resource

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3429,7 +3429,6 @@ class TestContentViewFileRepo:
         assert int(new_repo['content-counts']['files']) > 0
         return new_repo
 
-    @pytest.mark.skip_if_open('BZ:1610309')
     @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_addition(
         self, module_org, module_product, module_target_sat
@@ -3471,7 +3470,6 @@ class TestContentViewFileRepo:
         cv = module_target_sat.cli.ContentView.info({'id': cv['id']})
         assert cv['file-repositories'][0]['name'] == repo['name']
 
-    @pytest.mark.skip_if_open('BZ:1908465')
     @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_removal(
         self, module_org, module_product, module_target_sat

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -21,7 +21,6 @@ from robottelo.utils.issue_handlers import is_open
 pytestmark = [pytest.mark.tier1]
 
 
-@pytest.mark.skip_if_open('BZ:2161294')
 @pytest.mark.upgrade
 @pytest.mark.parametrize(
     'fact', ['uptime', 'os::family', 'uptime_seconds', 'memorysize', 'ipaddress']

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -40,7 +40,6 @@ from robottelo.utils.datafactory import (
     valid_data_list,
     valid_hosts_list,
 )
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope="module")
@@ -706,14 +705,14 @@ def test_positive_list_infrastructure_hosts(
     target_sat.cli.Host.update({'name': target_sat.hostname, 'new-organization-id': module_org.id})
     # list satellite hosts
     hosts = target_sat.cli.Host.list({'search': 'infrastructure_facet.foreman=true'})
-    assert len(hosts) == 2 if is_open('BZ:1994685') else len(hosts) == 1
+    assert len(hosts) == 2
     hostnames = [host['name'] for host in hosts]
     assert rhel7_contenthost.hostname not in hostnames
     assert target_sat.hostname in hostnames
     # list capsule hosts
     hosts = target_sat.cli.Host.list({'search': 'infrastructure_facet.smart_proxy_id=1'})
     hostnames = [host['name'] for host in hosts]
-    assert len(hosts) == 2 if is_open('BZ:1994685') else len(hosts) == 1
+    assert len(hosts) == 2
     assert rhel7_contenthost.hostname not in hostnames
     assert target_sat.hostname in hostnames
 
@@ -859,7 +858,7 @@ def test_positive_list_with_nested_hostgroup(target_sat):
     logger.info(f'Host info: {host}')
     assert host['operating-system']['medium'] == options.medium.name
     assert host['operating-system']['partition-table'] == options.ptable.name  # inherited
-    if not is_open('BZ:2215294') or not target_sat.is_stream:
+    if not target_sat.is_stream:
         assert 'id' in host['content-information']['lifecycle-environment']
         assert int(host['content-information']['lifecycle-environment']['id']) == int(lce.id)
         assert int(host['content-information']['content-view']['id']) == int(

--- a/tests/foreman/cli/test_organization.py
+++ b/tests/foreman/cli/test_organization.py
@@ -342,8 +342,6 @@ def test_positive_add_and_remove_media(module_org, module_target_sat):
 
 
 @pytest.mark.tier2
-@pytest.mark.skip_if_open("BZ:1845860")
-@pytest.mark.skip_if_open("BZ:1886876")
 def test_positive_add_and_remove_templates(module_org, module_target_sat):
     """Add and remove provisioning templates to organization
 

--- a/tests/foreman/cli/test_oscap_tailoringfiles.py
+++ b/tests/foreman/cli/test_oscap_tailoringfiles.py
@@ -183,7 +183,6 @@ class TestTailoringFiles:
         :CaseImportance: Medium
         """
 
-    @pytest.mark.skip_if_open("BZ:1857572")
     @pytest.mark.tier2
     def test_positive_download_tailoring_file(self, tailoring_file_path, target_sat):
         """Download the tailoring file from satellite

--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -68,7 +68,6 @@ def ostree_repo_with_user(ostree_user_credentials, module_target_sat):
     return {'cv': cv, 'org': org, 'ostree_repo': ostree_repo, 'product': product}
 
 
-@pytest.mark.skip_if_open("BZ:1625783")
 def test_positive_list(ostree_user_credentials, ostree_repo_with_user, module_target_sat):
     """List Ostree Branches
 
@@ -96,7 +95,6 @@ def test_positive_list_by_repo_id(
     assert len(result) > 0
 
 
-@pytest.mark.skip_if_open("BZ:1625783")
 def test_positive_list_by_product_id(
     ostree_repo_with_user, ostree_user_credentials, module_target_sat
 ):
@@ -112,7 +110,6 @@ def test_positive_list_by_product_id(
     assert len(result) > 0
 
 
-@pytest.mark.skip_if_open("BZ:1625783")
 def test_positive_list_by_org_id(ostree_repo_with_user, ostree_user_credentials, module_target_sat):
     """List Ostree branches by org id
 
@@ -126,7 +123,6 @@ def test_positive_list_by_org_id(ostree_repo_with_user, ostree_user_credentials,
     assert len(result) > 0
 
 
-@pytest.mark.skip_if_open("BZ:1625783")
 def test_positive_list_by_cv_id(ostree_repo_with_user, ostree_user_credentials, module_target_sat):
     """List Ostree branches by cv id
 
@@ -140,7 +136,6 @@ def test_positive_list_by_cv_id(ostree_repo_with_user, ostree_user_credentials, 
     assert len(result) > 0
 
 
-@pytest.mark.skip_if_open("BZ:1625783")
 def test_positive_info_by_id(ostree_user_credentials, ostree_repo_with_user, module_target_sat):
     """Get info for Ostree branch by id
 

--- a/tests/foreman/cli/test_product.py
+++ b/tests/foreman/cli/test_product.py
@@ -212,7 +212,6 @@ def test_product_list_with_default_settings(module_org, target_sat):
 
 
 @pytest.mark.tier2
-@pytest.mark.skip_if_open('BZ:1999541')
 def test_positive_product_sync_state(module_org, module_target_sat):
     """hammer product info shows correct sync state.
 

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -641,7 +641,6 @@ def test_negative_nonauthor_of_report_cant_download_it(module_target_sat):
 
 
 @pytest.mark.tier2
-@pytest.mark.skip_if_open('BZ:1750924')
 def test_positive_generate_with_name_and_org(module_target_sat):
     """Generate Host Status report, specifying template name and organization
 
@@ -675,7 +674,6 @@ def test_positive_generate_with_name_and_org(module_target_sat):
 
 
 @pytest.mark.tier2
-@pytest.mark.skip_if_open('BZ:1782807')
 def test_positive_generate_ansible_template(module_target_sat):
     """Report template named 'Ansible Inventory' (default name is specified in settings)
     must be present in Satellite 6.7 and later in order to provide enhanced functionality

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -711,7 +711,6 @@ class TestRepository:
         assert repo['sync']['status'] == 'Success'
         assert int(repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT
 
-    @pytest.mark.skip_if_open("BZ:2035025")
     @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
@@ -1460,7 +1459,6 @@ class TestRepository:
         new_repo = target_sat.cli.Repository.info({'id': new_repo['id']})
         assert int(new_repo['content-counts']['files']) == CUSTOM_FILE_REPO_FILES_COUNT + 1
 
-    @pytest.mark.skip_if_open("BZ:1410916")
     @pytest.mark.tier2
     @pytest.mark.parametrize(
         'repo_options',
@@ -1861,7 +1859,6 @@ class TestRepository:
         }
 
     @pytest.mark.tier1
-    @pytest.mark.skip_if_open('BZ:2002653')
     def test_negative_update_red_hat_repo(self, module_manifest_org, module_target_sat):
         """Updates to Red Hat products fail.
 

--- a/tests/foreman/destructive/test_remoteexecution.py
+++ b/tests/foreman/destructive/test_remoteexecution.py
@@ -19,7 +19,6 @@ import pytest
 
 from robottelo.config import get_credentials
 from robottelo.hosts import get_sat_version
-from robottelo.utils.issue_handlers import is_open
 
 CAPSULE_TARGET_VERSION = f'6.{get_sat_version().minor}.z'
 
@@ -42,9 +41,7 @@ def test_negative_run_capsule_upgrade_playbook_on_satellite(target_sat):
 
     :CaseImportance: Medium
     """
-    template_name = (
-        'Smart Proxy Upgrade Playbook' if is_open('BZ:2152951') else 'Capsule Upgrade Playbook'
-    )
+    template_name = 'Capsule Upgrade Playbook'
     template_id = (
         target_sat.api.JobTemplate().search(query={'search': f'name="{template_name}"'})[0].id
     )

--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -30,7 +30,6 @@ from robottelo.config import (
     user_nailgun_config,
 )
 from robottelo.constants.repos import CUSTOM_RPM_REPO
-from robottelo.utils.issue_handlers import is_open
 
 API_PATHS = {
     'activation_keys': (
@@ -908,10 +907,6 @@ API_PATHS = {
 def filtered_api_paths():
     """Filter the API_PATHS dict based on BZs that impact various endpoints"""
     missing = defaultdict(list)
-    if is_open('BZ:1887932'):
-        missing['subscriptions'].append(
-            '/katello/api/activation_keys/:activation_key_id/subscriptions'
-        )
     filtered_paths = API_PATHS.copy()
     for endpoint, missing_paths in missing.items():
         filtered_paths[endpoint] = tuple(

--- a/tests/foreman/ui/test_branding.py
+++ b/tests/foreman/ui/test_branding.py
@@ -16,7 +16,6 @@ import pytest
 
 
 @pytest.mark.e2e
-@pytest.mark.skip_if_open("BZ:2105949")
 def test_verify_satellite_login_screen_info(target_sat):
     """Verify Satellite version on the login screen
 

--- a/tests/foreman/ui/test_computeresource_ec2.py
+++ b/tests/foreman/ui/test_computeresource_ec2.py
@@ -43,7 +43,6 @@ def module_ec2_settings():
 @pytest.mark.e2e
 @pytest.mark.tier2
 @pytest.mark.skip_if_not_set('http_proxy')
-@pytest.mark.skip_if_open("BZ:2032530")
 def test_positive_default_end_to_end_with_custom_profile(
     session, module_org, module_location, module_ec2_settings, module_target_sat
 ):

--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -1219,7 +1219,6 @@ def test_positive_promote_composite_with_custom_content(
         assert f'Promoted to {lce.name}' in result['Status']
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier2
 def test_positive_publish_rh_content_with_errata_by_date_filter(
@@ -1343,7 +1342,6 @@ def test_positive_remove_cv_version_from_default_env(
         assert ENVIRONMENT not in cvv['Environments']
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_remove_promoted_cv_version_from_default_env(
@@ -1391,7 +1389,6 @@ def test_positive_remove_promoted_cv_version_from_default_env(
         assert cvv['yum_repositories']['table'][0]['Name']
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 def test_positive_remove_qe_promoted_cv_version_from_default_env(
     session, module_target_sat, module_org, target_sat
@@ -1448,7 +1445,6 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(
         assert all(item in cvv_table[0]['Environments'] for item in [dev_lce.name, qe_lce.name])
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 @pytest.mark.parametrize(
@@ -1522,7 +1518,6 @@ def test_positive_remove_cv_version_from_env(
         assert all(item in cvv['Environments'] for item in [ENVIRONMENT, dev_lce.name, qe_lce.name])
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.upgrade
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
@@ -1819,7 +1814,6 @@ def test_positive_add_package_filter(session, module_target_sat, module_org, tar
         assert expected_packages == actual_packages
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 def test_positive_add_package_inclusion_filter_and_publish(
     session, module_target_sat, module_org, target_sat
@@ -1867,7 +1861,6 @@ def test_positive_add_package_inclusion_filter_and_publish(
         assert not packages[0]['Name']
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 def test_positive_add_package_exclusion_filter_and_publish(
     session, module_target_sat, module_org, target_sat
@@ -1915,7 +1908,6 @@ def test_positive_add_package_exclusion_filter_and_publish(
         assert not packages[0]['Name']
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_remove_package_from_exclusion_filter(
@@ -1965,7 +1957,6 @@ def test_positive_remove_package_from_exclusion_filter(
         assert packages[0]['Name'] == package_name
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 def test_positive_update_inclusive_filter_package_version(
     session, module_target_sat, module_org, target_sat
@@ -2031,7 +2022,6 @@ def test_positive_update_inclusive_filter_package_version(
         assert packages[0]['Version'] == '5.21'
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 def test_positive_update_exclusive_filter_package_version(
     session, module_target_sat, module_org, target_sat
@@ -2097,7 +2087,6 @@ def test_positive_update_exclusive_filter_package_version(
         assert packages[0]['Version'] == '0.71'
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_all_security_errata_by_date_range_filter(
@@ -2258,7 +2247,6 @@ def test_positive_promote_with_rh_custom_spin(session, module_target_sat, target
         assert f'Promoted to {lce.name}' in result['Status']
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_all_security_errata_by_id_filter(session, module_target_sat, module_org):
@@ -2306,7 +2294,6 @@ def test_positive_add_all_security_errata_by_id_filter(session, module_target_sa
         )
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 def test_positive_add_errata_filter(session, module_target_sat, module_org, target_sat):
     """add errata to content views filter
@@ -2344,7 +2331,6 @@ def test_positive_add_errata_filter(session, module_target_sat, module_org, targ
         }
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_add_module_stream_filter(session, module_target_sat, module_org, target_sat):
@@ -2420,7 +2406,6 @@ def test_positive_add_package_group_filter(session, module_target_sat, module_or
         assert cvf['content_tabs']['assigned'][0]['Name'] == package_group
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_update_filter_affected_repos(session, module_target_sat, module_org, target_sat):
@@ -2727,7 +2712,6 @@ def test_positive_rh_mixed_content_end_to_end(
         assert session.contentview.search_version(cv_name, VERSION)[0]['Version'] != VERSION
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_errata_inc_update_list_package(session, module_target_sat, target_sat):
@@ -2787,7 +2771,6 @@ def test_positive_errata_inc_update_list_package(session, module_target_sat, tar
         assert set(result[4:]).issubset(packages)
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_composite_child_inc_update(
@@ -2954,7 +2937,6 @@ def test_positive_module_stream_end_to_end(session, module_target_sat, module_or
         assert session.contentview.search(cv_name)[0]['Name'] != cv_name
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_search_module_streams_in_content_view(
@@ -3315,7 +3297,6 @@ def test_negative_non_readonly_user_actions(module_org, test_name, target_sat):
         assert 'Navigation failed to reach [All]' in str(context.value)
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_conservative_solve_dependencies(
@@ -3395,7 +3376,6 @@ def test_positive_conservative_solve_dependencies(
             assert not package[0]['Name']
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 def test_positive_conservative_dep_solving_with_multiversion_packages(
     session, module_org, target_sat
@@ -3466,7 +3446,6 @@ def test_positive_conservative_dep_solving_with_multiversion_packages(
         assert package[0]['Version'] == '0.71'
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
 def test_positive_depsolve_with_module_errata(session, module_target_sat, module_org, target_sat):
@@ -3544,7 +3523,6 @@ def test_positive_depsolve_with_module_errata(session, module_target_sat, module
         assert result['errata']['table'][0]['Errata ID'] == settings.repos.yum_10.errata[0]
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 def test_positive_filter_by_pkg_group_name(session, module_target_sat, module_org, target_sat):
     """Publish a filtered version of a Content View, filtering on the package group's name.
@@ -3585,7 +3563,6 @@ def test_positive_filter_by_pkg_group_name(session, module_target_sat, module_or
         assert expected_packages == [pkg['Name'] for pkg in result['rpm_packages']['table']]
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier3
 def test_positive_inc_update_should_not_fail(session, module_target_sat, module_org):
     """Incremental update after removing a package should not give a 400 error code
@@ -3643,7 +3620,6 @@ def test_positive_inc_update_should_not_fail(session, module_target_sat, module_
         assert packages[0]['Name'] == package1_name
 
 
-@pytest.mark.skip_if_open('BZ:2086957')
 @pytest.mark.tier2
 def test_positive_no_duplicate_key_violate_unique_constraint_using_filters(
     session, module_entitlement_manifest_org, target_sat

--- a/tests/foreman/ui/test_dashboard.py
+++ b/tests/foreman/ui/test_dashboard.py
@@ -18,7 +18,6 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import FAKE_7_CUSTOM_PACKAGE
 from robottelo.utils.datafactory import gen_string
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.mark.tier2
@@ -64,9 +63,6 @@ def test_positive_host_configuration_status(session, target_sat):
         'status.enabled = false',
         'not has last_report and status.enabled = true',
     ]
-    if is_open('BZ:1631219'):
-        criteria_list.pop()
-        search_strings_list.pop()
 
     with session:
         session.organization.select(org_name=org.name)

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -665,7 +665,6 @@ def test_positive_remove_parameter_non_admin_user(
 
 
 @pytest.mark.tier3
-@pytest.mark.skip_if_open("BZ:2059576")
 def test_negative_remove_parameter_non_admin_user(
     test_name, module_org, smart_proxy_location, target_sat
 ):

--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -515,7 +515,6 @@ def test_positive_install_errata(
         assert _is_package_installed(vm_content_hosts, constants.FAKE_2_CUSTOM_PACKAGE)
 
 
-@pytest.mark.skip_if_open("BZ:2094815")
 @pytest.mark.tier3
 def test_positive_change_assigned_content(
     session,

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -1055,7 +1055,6 @@ def test_timeout_and_cac_card_ejection():
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA', 'OPENLDAP'], indirect=True)
 @pytest.mark.tier2
-@pytest.mark.skip_if_open('BZ:1670397')
 def test_verify_attribute_of_users_are_updated(
     session, ldap_auth_source, ldap_tear_down, target_sat
 ):
@@ -1162,7 +1161,6 @@ def test_login_failure_if_internal_user_exist(
         target_sat.api.User(id=user.id).delete()
 
 
-@pytest.mark.skip_if_open("BZ:1812688")
 @pytest.mark.tier2
 def test_userlist_with_external_admin(
     session, auth_source_ipa, ldap_tear_down, groups_teardown, target_sat
@@ -1232,7 +1230,6 @@ def test_userlist_with_external_admin(
         assert remote_admin_session.user.search(idm_user)[0]['Username'] == idm_user
 
 
-@pytest.mark.skip_if_open('BZ:1883209')
 @pytest.mark.tier2
 def test_positive_group_sync_open_ldap_authsource(
     test_name,

--- a/tests/foreman/ui/test_modulestreams.py
+++ b/tests/foreman/ui/test_modulestreams.py
@@ -40,7 +40,6 @@ def module_yum_repo(module_product, module_target_sat):
     return yum_repo
 
 
-@pytest.mark.skip_if_open("BZ:1948758")
 @pytest.mark.tier2
 def test_positive_module_stream_details_search_in_repo(session, module_org, module_yum_repo):
     """Create product with yum repository assigned to it. Search for

--- a/tests/foreman/ui/test_oscapcontent.py
+++ b/tests/foreman/ui/test_oscapcontent.py
@@ -18,8 +18,6 @@ from robottelo.constants import DataFile
 from robottelo.utils.datafactory import gen_string
 
 
-@pytest.mark.skip_if_open("BZ:2167937")
-@pytest.mark.skip_if_open("BZ:2133151")
 @pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(
@@ -67,8 +65,6 @@ def test_positive_end_to_end(
         assert not session.oscapcontent.search(new_title)
 
 
-@pytest.mark.skip_if_open("BZ:2167937")
-@pytest.mark.skip_if_open("BZ:2133151")
 @pytest.mark.tier1
 def test_negative_create_with_same_name(session, oscap_content_path, default_org, default_location):
     """Create OpenScap content with same name

--- a/tests/foreman/ui/test_oscappolicy.py
+++ b/tests/foreman/ui/test_oscappolicy.py
@@ -25,8 +25,6 @@ def module_host_group(default_location, default_org, module_target_sat):
     ).create()
 
 
-@pytest.mark.skip_if_open("BZ:2167937")
-@pytest.mark.skip_if_open("BZ:2133151")
 @pytest.mark.tier2
 def test_positive_check_dashboard(
     session,
@@ -101,8 +99,6 @@ def test_positive_check_dashboard(
         # assert policy_details['HostBreakdownChart']['hosts_breakdown'] == '100%Not audited'
 
 
-@pytest.mark.skip_if_open("BZ:2167937")
-@pytest.mark.skip_if_open("BZ:2133151")
 @pytest.mark.tier1
 @pytest.mark.upgrade
 def test_positive_end_to_end(

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -491,7 +491,6 @@ def test_positive_end_to_end_custom_module_streams_crud(session, module_org, mod
         assert not session.repository.search(module_prod.name, repo_name)
 
 
-@pytest.mark.skip_if_open("BZ:1743271")
 @pytest.mark.tier2
 @pytest.mark.upgrade
 def test_positive_upstream_with_credentials(session, module_prod):

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -21,7 +21,6 @@ import pytest
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.logging import logger
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -133,13 +132,6 @@ def test_positive_configure_cloud_connector(
 
     :BZ: 1818076
     """
-    # Delete old satellite hostname if BZ#2130173 is open
-    if is_open('BZ:2130173'):
-        host = module_target_sat.api.Host().search(
-            query={'search': f"! {module_target_sat.hostname}"}
-        )[0]
-        host.delete()
-
     # Copy foreman-proxy user's key to root@localhost user's authorized_keys
     module_target_sat.add_rex_key(satellite=module_target_sat)
 

--- a/tests/foreman/ui/test_smartclassparameter.py
+++ b/tests/foreman/ui/test_smartclassparameter.py
@@ -168,7 +168,6 @@ def test_positive_end_to_end(session_puppet_enabled_sat, module_puppet_classes, 
 
 
 @pytest.mark.tier2
-@pytest.mark.skip_if_open("BZ:2015911")
 def test_positive_create_matcher_attribute_priority(
     session_puppet_enabled_sat,
     module_puppet_org,
@@ -264,7 +263,6 @@ def test_positive_create_matcher_attribute_priority(
 
 
 @pytest.mark.tier2
-@pytest.mark.skip_if_open("BZ:2015911")
 def test_positive_create_matcher_avoid_duplicate(
     session_puppet_enabled_sat,
     module_puppet_org,

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -75,7 +75,6 @@ def test_positive_sync_rh_repos(session, target_sat, module_sca_manifest_org):
         assert all([result == 'Syncing Complete.' for result in results])
 
 
-@pytest.mark.skip_if_open("BZ:1625783")
 @pytest.mark.tier2
 @pytest.mark.upgrade
 @pytest.mark.skipif((not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url')
@@ -103,7 +102,6 @@ def test_positive_sync_custom_ostree_repo(session, module_custom_product, module
 
 
 @pytest.mark.run_in_one_thread
-@pytest.mark.skip_if_open("BZ:1625783")
 @pytest.mark.skip_if_not_set('fake_manifest')
 @pytest.mark.tier2
 @pytest.mark.upgrade


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16347

### Problem Statement
- We have unused code related to `is_open` and `skip_if_open` bugzilla. We have migrated from using Bugzilla to Jira we don't need it anymore. 

### Solution
- Remove unused code related to is_open bz

### Related Issues
- SAT-27966

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->