### PR TITLE
Update new VLAN in VMWare 

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -334,7 +334,7 @@ def test_positive_vmware_custom_profile_end_to_end(
     cpu_hot_add = True
     cdrom_drive = True
     disk_size = '10 GB'
-    network = 'VLAN 1001'  # hardcoding network here as this test won't be doing actual provisioning
+    network = 'VLAN 400'  # hardcoding network here as this test won't be doing actual provisioning
     storage_data = {
         'storage': {
             'controller': VMWARE_CONSTANTS['scsicontroller'],


### PR DESCRIPTION
### Problem Statement
With recent migration of Rocket infrastructure, VLANs are changed causing tests to fail.

### Solution
Updated VLAN in the test

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->