### PR TITLE
[6.15.z] update network VLAN1001 to VLAN400

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -333,7 +333,7 @@ def test_positive_vmware_custom_profile_end_to_end(
     cpu_hot_add = True
     cdrom_drive = True
     disk_size = '10 GB'
-    network = 'VLAN 1001'  # hardcoding network here as this test won't be doing actual provisioning
+    network = 'VLAN 400'  # hardcoding network here as this test won't be doing actual provisioning
     storage_data = {
         'storage': {
             'controller': VMWARE_CONSTANTS['scsicontroller'],


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16377

The VLAN has been changed, requiring an update in this test. Previously, the `VLAN was set to 1001`, but it has now been updated to `VLAN 400`