### PR TITLE
[6.15.z] Update pit coverage for Platform teams components

### DIFF
--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -14,9 +14,13 @@
 
 import pytest
 
+from robottelo.config import settings
+
 
 @pytest.mark.e2e
-@pytest.mark.rhel_ver_list([7, 8])
+@pytest.mark.pit_server
+@pytest.mark.pit_client
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.tier1
 def test_positive_register(
     module_org,

--- a/tests/foreman/cli/test_capsule.py
+++ b/tests/foreman/cli/test_capsule.py
@@ -35,8 +35,6 @@ def test_positive_import_puppet_classes(session_puppet_enabled_sat, puppet_proxy
 
 
 @pytest.mark.stubbed
-@pytest.mark.e2e
-@pytest.mark.upgrade
 def test_positive_capsule_content():
     """Registered and provisioned hosts can consume content from capsule
 

--- a/tests/foreman/destructive/test_leapp_satellite.py
+++ b/tests/foreman/destructive/test_leapp_satellite.py
@@ -17,6 +17,7 @@ from robottelo.hosts import get_sat_rhel_version, get_sat_version
 
 
 @pytest.mark.e2e
+@pytest.mark.pit_server
 @pytest.mark.skipif(
     get_sat_version().minor != 11 and get_sat_rhel_version().major > 7,
     reason='Run only on sat6.11el7',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15938

### Problem Statement
- Pit markers for some of the Platform team components are missing.

### Solution
- Evaluate tests and add pit markers accordingly.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->