### PR TITLE
[6.16.z] Skip AK upgrade test until SAT-28048 is resolved

### DIFF
--- a/tests/upgrades/test_activation_key.py
+++ b/tests/upgrades/test_activation_key.py
@@ -63,6 +63,8 @@ class TestActivationKey:
 
         :expectedresults: Activation key should be created successfully and it's subscription id
             should be same with custom repos product id.
+
+        :BlockedBy: SAT-28048
         """
         ak = activation_key_setup['ak']
         org_subscriptions = target_sat.api.Subscription(
@@ -91,6 +93,8 @@ class TestActivationKey:
 
         :expectedresults: Activation key's entities should be same after upgrade and activation
             key update and delete should work.
+
+        :BlockedBy: SAT-28048
         """
         pre_test_name = dependent_scenario_name
         org = target_sat.api.Organization().search(query={'search': f'name={pre_test_name}_org'})


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16398

### Problem Statement
One particular `pre_upgrade` test makes the upgrade fail, which blocks other `post_upgrade` tests run.

### Solution
Skip the test until the issue is fixed

### Related Issues
https://issues.redhat.com/browse/SAT-28048

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->