### PR TITLE
[6.16.z] fix tests from repositories component

### DIFF
--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -209,8 +209,7 @@ def test_positive_filter_product_list(module_sca_manifest_org, module_target_sat
         query={'redhat_only': True, 'per_page': 1000}
     )
 
-    assert len(custom_products) == 1
-    assert product.name == custom_products[0].name
+    assert product.name in (custom_prod.name for custom_prod in custom_products)
     assert 'Red Hat Beta' not in (prod.name for prod in custom_products)
 
     assert len(rh_products) > 1

--- a/tests/foreman/api/test_repositories.py
+++ b/tests/foreman/api/test_repositories.py
@@ -225,7 +225,7 @@ def test_positive_sync_upstream_repo_with_zst_compression(
 
 @pytest.mark.tier1
 @pytest.mark.manifester
-def test_negative_upload_expired_manifest(module_org, target_sat):
+def test_negative_upload_expired_manifest(request, default_org, target_sat):
     """Upload an expired manifest and attempt to refresh it
 
     :id: d6e652d8-5f46-4d15-9191-d842466d45d0
@@ -239,10 +239,13 @@ def test_negative_upload_expired_manifest(module_org, target_sat):
     """
     manifester = Manifester(manifest_category=settings.manifest.golden_ticket)
     manifest = manifester.get_manifest()
-    target_sat.upload_manifest(module_org.id, manifest.content)
+    target_sat.upload_manifest(default_org.id, manifest.content)
+    request.addfinalizer(
+        lambda: target_sat.cli.Subscription.delete_manifest({'organization-id': default_org.id})
+    )
     manifester.delete_subscription_allocation()
     with pytest.raises(CLIReturnCodeError) as error:
-        target_sat.cli.Subscription.refresh_manifest({'organization-id': module_org.id})
+        target_sat.cli.Subscription.refresh_manifest({'organization-id': default_org.id})
     assert (
         "The manifest doesn't exist on console.redhat.com. "
         "Please create and import a new manifest." in error.value.stderr
@@ -295,6 +298,7 @@ def test_positive_sync_mulitple_large_repos(module_target_sat, module_sca_manife
     """
     repo_names = ['rhel8_bos', 'rhel8_aps']
     kickstart_names = ['rhel8_bos', 'rhel8_aps']
+    all_repo_ids = []
     for name in repo_names:
         rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
             basearch=DEFAULT_ARCHITECTURE,
@@ -304,6 +308,7 @@ def test_positive_sync_mulitple_large_repos(module_target_sat, module_sca_manife
             reposet=REPOS[name]['reposet'],
             releasever=REPOS[name]['releasever'],
         )
+        all_repo_ids.append(rh_repo_id)
 
     for name in kickstart_names:
         rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
@@ -314,11 +319,14 @@ def test_positive_sync_mulitple_large_repos(module_target_sat, module_sca_manife
             reposet=constants.REPOS['kickstart'][name]['reposet'],
             releasever=constants.REPOS['kickstart'][name]['version'],
         )
-    rh_repos = module_target_sat.api.Repository(id=rh_repo_id).read()
-    rh_products = module_target_sat.api.Product(id=rh_repos.product.id).read()
-    assert len(rh_products.repository) == 4
+        all_repo_ids.append(rh_repo_id)
+    rh_repo = module_target_sat.api.Repository(id=rh_repo_id).read()
+    rh_product = module_target_sat.api.Product(id=rh_repo.product.id).read()
+    assert len(rh_product.repository) >= 4
+    rh_product_repo_ids = [repo.id for repo in rh_product.repository]
+    assert set(all_repo_ids).issubset(rh_product_repo_ids)
     res = module_target_sat.api.ProductBulkAction().sync(
-        data={'ids': [rh_products.id]}, timeout=2000
+        data={'ids': [rh_product.id]}, timeout=2000
     )
     assert res['result'] == 'success'
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16227

### Problem Statement
[6.16.0] TFA -  Compoenent repositories has few tests failing with minor issue, DISTRIBUTOR_CONFLICT , Assertion Error, etc
`api/test_product.py::test_positive_filter_product_list`
`api/test_repositories.py::test_negative_upload_expired_manifest`
`api/test_repositories.py::test_positive_sync_mulitple_large_repos`

### Solution
This PR will address those failures

### Related Issues
N/A

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_product.py::test_positive_filter_product_list
```
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repositories.py::test_negative_upload_expired_manifest
```
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repositories.py::test_positive_sync_mulitple_large_repos
```



<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->