### PR TITLE
[6.15.z] Do not store uv cache, uv to use venv interpreter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ FROM quay.io/fedora/python-312:latest
 MAINTAINER https://github.com/SatelliteQE
 
 ENV PYCURL_SSL_LIBRARY=openssl \
-    ROBOTTELO_DIR="${HOME}/robottelo"
+    ROBOTTELO_DIR="${HOME}/robottelo" \
+    UV_PYTHON="${APP_ROOT}/bin/python3" \
+    UV_NO_CACHE=1
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16396

### Problem Statement
1. uv cache bloats the image and also causes issues in the downstream image build
2. during the image build, in the RUN step, the shell environment is not sourced, the python environment in `$APP_ROOT` is not activated and therefore `VIRTUAL_ENV` env variable is not defined. That causes uv not to discover the venv interpreter and it creates its env in `.venv` and installs robottelo in it.

### Solution
1. as the upstream fedora/python-312 image forces `pip` to not create the cache, we should mimic it for `uv` too
	* set `UV_NO_CACHE=1`
2. Tell uv to use Python from the existing virtual env 
    * set `UV_PYTHON="${APP_ROOT}/bin/python3"`


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->