### PR TITLE
[6.16.z] Use client-2 repo against Satellite 6.16+

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -149,9 +149,9 @@ def get_dogfood_satclient_repos(settings):
     for ver in rhels:
         data[f'RHEL{ver}'] = get_ohsnap_repo_url(
             settings,
-            repo='client',
+            repo='client-2',
             product='client',
-            release='client',
+            release='client-2',
             os_release=ver,
         )
     return data


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16397

### Problem Statement
Satellite 6.16 includes **Puppet 8** so there is now new `Client-2` repo that provides Puppet 8 agent while `Client` repo continues to provide Puppet 7 agent.

### Solution
Use `Client-2` repo when running against Satellite 6.16 and newer

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->