### PR TITLE
[6.16.z] Update download_repofile helper to create repo file with product name

### DIFF
--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -112,7 +112,7 @@ class VersionedContent:
         if not proxy and settings.server.is_ipv6:
             proxy = settings.server.http_proxy_ipv6_url
         url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap, proxy=proxy)
-        command = f'curl -o /etc/yum.repos.d/dogfood.repo -L {url}'
+        command = f'curl -o /etc/yum.repos.d/{product}.repo -L {url}'
         if settings.server.is_ipv6:
             command += f' -x {settings.server.http_proxy_ipv6_url}'
         self.execute(command)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16410

### Problem Statement
We are creating all product repofiles with `dogfood.repo` name and it's causing capsule n-1 to test to fail with `"Satellite_Engineering_Satellite_6_15_Composes_Satellite_Capsule_6_15_RHEL8" is already defined, cannot redefine (file: /etc/yum.repos.d/dogfood.repo)` as the workflow used in the pipeline create the same repofiles too, but with specific product name, for example `satellite.repo`. This causes installer to fail as repo is now defined more than once in the configuration.

### Solution
- Update `download_repofile` helper to download repo to repofile named after the product.

### Related Issues
- SAT-27944

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->