### PR TITLE
[6.13.z][Combined Jenkins Ask] Capsule testing for sanity (#15948)

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -305,7 +305,7 @@ def sat_ready_rhel(request):
 
 @pytest.fixture
 def cap_ready_rhel():
-    rhel_version = Version(settings.capsule.version.release)
+    rhel_version = Version(settings.capsule.version.rhel_version)
     deploy_args = {
         'deploy_rhel_version': rhel_version.base_version,
         'deploy_flavor': settings.flavors.default,

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1419,8 +1419,6 @@ def test_installer_options_and_sections(filter):
 
 
 @pytest.mark.tier1
-@pytest.mark.build_sanity
-@pytest.mark.first_sanity
 @pytest.mark.pit_server
 @pytest.mark.parametrize(
     "installer_satellite", [settings.server.version.rhel_version], indirect=True
@@ -1456,6 +1454,8 @@ def test_satellite_installation(installer_satellite):
 @pytest.mark.e2e
 @pytest.mark.tier1
 @pytest.mark.pit_server
+@pytest.mark.build_sanity
+@pytest.mark.first_sanity
 @pytest.mark.parametrize(
     "installer_satellite", [settings.server.version.rhel_version], indirect=True
 )


### PR DESCRIPTION
### Problem Statement
Caspule Test isnt a part of sanity testing due to several reasons:
1. Most test cases were dependent on Satellite and not on capsule
2. The running time for sanity for separate capsule checkout and installation, configuration exceeds our target sanity runtime

### Solution
Adding capsule installer test as part of sanity since Sanity is replacing bats tests in jenkins migration in delivery.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->