### PR TITLE
[6.16.z] Fix upgrade errata scenario for 6.16.z

### DIFF
--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -129,6 +129,8 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
         :customerscenario: true
         """
         rhel_contenthost._skip_context_checkin = True
+        # Orgs are SCA-enabled by default since 6.15
+        function_org.sca_disable()
         environment = target_sat.api.LifecycleEnvironment(organization=function_org).search(
             query={'search': f'name={constants.ENVIRONMENT}'}
         )[0]
@@ -152,6 +154,15 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
             query={'search': f'name={product.name}'}
         )[0]
         ak.add_subscriptions(data={'subscription_id': subscription.id})
+        # Override/enable all AK repos (disabled by default since 6.15)
+        c_labels = [
+            i['label'] for i in ak.product_content(data={'content_access_mode_all': '1'})['results']
+        ]
+        ak.content_override(
+            data={
+                'content_overrides': [{'content_label': label, 'value': '1'} for label in c_labels]
+            }
+        )
         rhel_contenthost.register(function_org, None, ak.name, target_sat)
         rhel_contenthost.add_rex_key(satellite=target_sat)
         rhel_contenthost.install_katello_host_tools()


### PR DESCRIPTION
### Problem Statement
Errata upgrade scenario is failing in 6.16.z for two reasons:
1. In 6.15 (pre_upgrade) new orgs are SCA-enabled by default.
2. Custom products are disabled by default.


### Solution
1. Disable SCA in the pre_upgrade test (on 6.15).
2. Override AK custom repos to enabled.


### Local results
Pre:
```
(venv) [vsedmik@localhost robottelo]$ pytest -m pre_upgrade tests/upgrades/test_errata.py -k test_pre_scenario_generate_errata_for_client[rhel7-ipv4]
================================================= test session starts =================================================
collected 6 items / 5 deselected / 1 selected                                                                                                                                                                                          

tests/upgrades/test_errata.py .                                                                                 [100%]

=============================== 1 passed, 5 deselected, 7 warnings in 612.35s (0:10:12) ===============================
```
Post:
```
(venv) [vsedmik@fedora robottelo]$ pytest -m post_upgrade tests/upgrades/test_errata.py -k test_post_scenario_errata_count_installation[rhel7]
================================================= test session starts =================================================
collected 6 items / 5 deselected / 1 selected                                                                                                                                                                                          

tests/upgrades/test_errata.py .                                                                                 [100%]

=============================== 1 passed, 5 deselected, 7 warnings in 121.94s (0:02:01) ===============================
```
