### PR TITLE
Automate test_positive_ansible_variables_imported_with_roles

### DIFF
--- a/robottelo/cli/ansible.py
+++ b/robottelo/cli/ansible.py
@@ -64,3 +64,9 @@ class Ansible(Base):
         """Information about ansible variables"""
         cls.command_sub = 'variables info'
         return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def variables_list(cls, options=None):
+        """Information about ansible variables"""
+        cls.command_sub = 'variables list'
+        return cls.execute(cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -73,6 +73,12 @@ class Host(Base):
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
+    def ansible_roles_list(cls, options=None):
+        """Remove ansible list"""
+        cls.command_sub = 'ansible-roles list'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
     def disassociate(cls, options):
         """Disassociate the host from a CR."""
         cls.command_sub = 'disassociate'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -622,6 +622,8 @@ class ContentHost(Host, ContentHostMixins):
         force=False,
         insecure=True,
         hostgroup=None,
+        auth_username=None,
+        auth_password=None,
     ):
         """Registers content host to the Satellite or Capsule server
         using a global registration template.
@@ -642,6 +644,8 @@ class ContentHost(Host, ContentHostMixins):
         :param force: Register the content host even if it's already registered.
         :param insecure: Don't verify server authenticity.
         :param hostgroup: hostgroup to register with
+        :param auth_username: username required if non-admin user
+        :param auth_password: password required if non-admin user
         :return: SSHCommandResult instance filled with the result of the registration
         """
         options = {
@@ -692,7 +696,20 @@ class ContentHost(Host, ContentHostMixins):
             options['force'] = str(force).lower()
 
         self._satellite = target.satellite
-        cmd = target.satellite.cli.HostRegistration.generate_command(options)
+        if auth_username and auth_password:
+            user = target.satellite.cli.User.list({'search': f'login={auth_username}'})
+            if user:
+                register_role = target.satellite.cli.Role.info({'name': 'Register hosts'})
+                target.satellite.cli.User.add_role(
+                    {'id': user[0]['id'], 'role-id': register_role['id']}
+                )
+                cmd = target.satellite.cli.HostRegistration.with_user(
+                    auth_username, auth_password
+                ).generate_command(options)
+            else:
+                raise CLIFactoryError(f'User {auth_username} doesn\'t exist')
+        else:
+            cmd = target.satellite.cli.HostRegistration.generate_command(options)
         return self.execute(cmd.strip('\n'))
 
     def api_register(self, target, **kwargs):

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -253,22 +253,6 @@ class TestAnsibleCfgMgmt:
 
     @pytest.mark.stubbed
     @pytest.mark.tier3
-    def test_positive_ansible_variables_imported_with_roles(self):
-        """Verify that, when Ansible roles are imported, their variables are imported simultaneously
-
-        :id: 107c53e8-5a8a-4291-bbde-fbd66a0bb85e
-
-        :steps:
-            1. Import Ansible roles
-            2. Navigate to Configure > Variables
-
-        :expectedresults: Verify that any variables in the role were also imported to Satellite
-
-        :CaseAutomation: NotAutomated
-        """
-
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_ansible_roles_ignore_list(self):
         """Verify that the ignore list setting prevents selected roles from being available for import
 


### PR DESCRIPTION
### Problem Statement
1. test_positive_ansible_variables_imported_with_roles is stubbed/Manual test.

### Solution
1. Automate test_positive_ansible_variables_imported_with_roles for admin and non-admin users
2. Remove unrelated tests


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->