### PR TITLE
Fix upgrade scenarios tests

### DIFF
--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -152,8 +152,16 @@ class TestScenarioCustomRepoCheck:
                 query={'search': f'name={product.name}'}
             )[0]
             ak.add_subscriptions(data={'subscription_id': subscription.id})
+        # Override/enable all AK repos (disabled by default since 6.15)
+        c_labels = [
+            i['label'] for i in ak.product_content(data={'content_access_mode_all': '1'})['results']
+        ]
+        ak.content_override(
+            data={
+                'content_overrides': [{'content_label': label, 'value': '1'} for label in c_labels]
+            }
+        )
         sat_upgrade_chost.register(org, None, ak.name, target_sat)
-        sat_upgrade_chost.execute('subscription-manager repos --enable=*;yum clean all')
         result = sat_upgrade_chost.execute(f'yum install -y {FAKE_0_CUSTOM_PACKAGE_NAME}')
         assert result.status == 0
 


### PR DESCRIPTION
### Problem Statement
1. Errata upgrade scenario is failing in 6.16.z for two reasons 
  - in 6.15 (pre_upgrade) new orgs are SCA-enabled by default.
  - Custom products are disabled by default.
2. Custom repo check scenario is failing because custom products are disabled by default.


### Solution
1. Add subscriptions only if SCA is disabled in the pre_upgrade test (on 6.15).
2. Override AK custom repos to enabled.


### Local results
Pre:
```
(venv) [vsedmik@localhost robottelo]$ pytest -m pre_upgrade tests/upgrades/test_errata.py -k test_pre_scenario_generate_errata_for_client[rhel7-ipv4]
================================================= test session starts =================================================
collected 6 items / 5 deselected / 1 selected                                                                                                                                                                                          

tests/upgrades/test_errata.py .                                                                                 [100%]

=============================== 1 passed, 5 deselected, 7 warnings in 612.35s (0:10:12) ===============================

(venv) [vsedmik@fedora robottelo]$ pytest -m pre_upgrade tests/upgrades/test_repository.py -k test_pre_scenario_custom_repo_check
================================================= test session starts =================================================
collected 14 items / 13 deselected / 1 selected                                                                                                                                                                                        

tests/upgrades/test_repository.py .                                                                             [100%]

=============================== 1 passed, 13 deselected, 7 warnings in 64.52s (0:01:04) ===============================
```
Post:
```
(venv) [vsedmik@fedora robottelo]$ pytest -m post_upgrade tests/upgrades/test_errata.py -k test_post_scenario_errata_count_installation[rhel7]
================================================= test session starts =================================================
collected 6 items / 5 deselected / 1 selected                                                                                                                                                                                          

tests/upgrades/test_errata.py .                                                                                 [100%]

=============================== 1 passed, 5 deselected, 7 warnings in 121.94s (0:02:01) ===============================

(venv) [vsedmik@fedora robottelo]$ pytest -m post_upgrade tests/upgrades/test_repository.py -k test_post_scenario_custom_repo_check
================================================= test session starts =================================================
collected 14 items / 13 deselected / 1 selected                                                                                                                                                                                        

tests/upgrades/test_repository.py .                                                                             [100%]

==================================== 1 passed, 13 deselected, 7 warnings in 35.88s ====================================
```
