### PR TITLE
Bump broker from 0.5.6 to 0.5.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 
 apypie==0.4.0
 betelgeuse==1.11.0
-broker[docker,podman,hussh]==0.5.6
+broker[docker,podman,hussh]==0.5.7
 cryptography==43.0.1
 deepdiff==8.0.1
 dynaconf[vault]==3.2.6


### PR DESCRIPTION
I'm dependabot now.

Bumping this version to start PRT testing on the release earlier.
