### PR TITLE
[6.14.z] scheduled job can succeed sooner

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -292,7 +292,11 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
             f'Run {command_to_run}', hostname, 'overview.hosts_table'
         )
         assert job_status['overview']['hosts_table'][0]['Host'] == hostname
-        assert job_status['overview']['hosts_table'][0]['Status'] in ('Awaiting start', 'N/A')
+        assert job_status['overview']['hosts_table'][0]['Status'] in (
+            'Awaiting start',
+            'N/A',
+            'success',
+        )
         # recalculate the job left time to be more accurate
         job_left_time = (plan_time - session.browser.get_client_datetime()).total_seconds()
         # the last read time should not take more than 1/4 of the last left time


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15564

### Problem Statement
...then expected by the test design

### Solution
extend the collection of possible states

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->