### PR TITLE
[6.16.z] adjusting test_positive_create_user_by_org_admin

### DIFF
--- a/tests/foreman/api/test_role.py
+++ b/tests/foreman/api/test_role.py
@@ -1380,14 +1380,12 @@ class TestCannedRole:
             2. Create user and assign above Org Admin role to it
             3. Login with above Org Admin user
             4. Attempt to create new users
-            5. Attempt to create location
 
         :expectedresults:
 
             1. Org Admin should be able to create new users
             2. Only Org Admin role should be available to assign to its users
             3. Org Admin should be able to assign Org Admin role to its users
-            4. Org Admin should be able create locations
 
         :BZ: 1538316, 1825698
 
@@ -1422,9 +1420,6 @@ class TestCannedRole:
         ).create()
         assert user_login == user.login
         assert org_admin.id == user.role[0].id
-        name = gen_string('alphanumeric')
-        location = target_sat.api.Location(sc_user, name=name).create()
-        assert location.name == name
 
     @pytest.mark.tier2
     def test_positive_access_users_inside_org_admin_taxonomies(self, role_taxonomies, target_sat):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16460

### Problem Statement

The previous skip if open on 1825698 evaluated as bz still open (it was closed as wontfix -- not sure if that was intended behavior or is_open), the conditional was removed in 
https://github.com/SatelliteQE/robottelo/commit/cc2518de45bb3f1a262fb97211c76e78975d3fb6#diff-a592fe4f270d817114eaa8fdeb69888f79909778460bffcb24c062166681654fL1425
hence test failures

### Solution
remove assertions on action that won't be fixed

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->