### PR TITLE
[6.16.z] adding verifies tag for cockpit test

### DIFF
--- a/tests/foreman/destructive/test_host.py
+++ b/tests/foreman/destructive/test_host.py
@@ -44,9 +44,11 @@ class TestHostCockpit:
             4. restart the satellite services.
             5. check cockpit page is loaded and displays sat host info.
 
-        expectedresults:
+        :expectedresults:
             1. cockpit service is restarted after the services restart.
             2. cockpit page is loaded and displays sat host info
+
+        :Verifies: SAT-27411
 
         :parametrized: yes
         """


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16471

### Problem Statement
just for tracability

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->