### PR TITLE
ignore dependency modules during prt execution rule matching

### DIFF
--- a/.github/dependency_tests.yaml
+++ b/.github/dependency_tests.yaml
@@ -1,6 +1,6 @@
-broker[docker,hussh,podman]: "tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'"
+broker: "tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'"
 deepdiff: "tests/foreman/endtoend/test_api_endtoend.py -k 'test_positive_get_links'"
-dynaconf[vault]: "tests/foreman/api/test_ldapauthsource.py -k 'test_positive_endtoend'"
+dynaconf: "tests/foreman/api/test_ldapauthsource.py -k 'test_positive_endtoend'"
 manifester: "tests/foreman/cli/test_contentview.py -k 'test_positive_promote_rh_content'"
 navmazing: "tests/foreman/ui/test_repository.py -k 'test_positive_create_as_non_admin_user'"
 pyotp: "tests/foreman/ui/test_ldap_authentication.py -k 'test_positive_login_user_password_otp'"

--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -25,7 +25,7 @@ jobs:
         id: yaml
         uses: mikefarah/yq@master
         with:
-          cmd: yq eval '.["${{ steps.metadata.outputs.dependency-names }}"]' ./.github/dependency_tests.yaml
+          cmd: yq eval '.["${{ steps.metadata.outputs.dependency-names }}"|split("[")[0]]' ./.github/dependency_tests.yaml
 
       - name: Add the PRT Comment
         if:  steps.yaml.outputs.result != 'null'


### PR DESCRIPTION
### Problem Statement
Currently, the keys inside `dependency_tests.yaml` file need to *exactly* match the relevant dependencies in order for the GHA step to produce a positive match.
this requires extra maintenance, e.g.
https://github.com/SatelliteQE/robottelo/pull/16469

where the ordering of the listed modules didn't match and thus the GHA did not trigger the correct action.

### Solution
Since we don't take any special action based on the listed dependency modules, we might loose the matching pattern a bit to completely ignore it.
this is achieved by simply chaining one more `jq` function behind the selector, that splits the string by `[` char and takes the first part of the resulting array.
```
$ yq eval '.["broker"|split("[")[0]]' dependency_tests.yaml
yq eval '.["broker[docker,hussh,podman]"|split("[")[0]]' dependency_tests.yaml
tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'
```
this seems to be safe with the strings that do not contain the `[` at all:
```
$ yq eval '.["broker"|split("[")[0]]' dependency_tests.yaml
tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'

```




### Related Issues
https://github.com/SatelliteQE/robottelo/pull/16469

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->