### PR TITLE
[6.15.z] fixing the order for broker dependancy to select the tests

### DIFF
--- a/.github/dependency_tests.yaml
+++ b/.github/dependency_tests.yaml
@@ -1,4 +1,4 @@
-broker[docker,podman,hussh]: "tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'"
+broker[docker,hussh,podman]: "tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'"
 deepdiff: "tests/foreman/endtoend/test_api_endtoend.py -k 'test_positive_get_links'"
 dynaconf[vault]: "tests/foreman/api/test_ldapauthsource.py -k 'test_positive_endtoend'"
 manifester: "tests/foreman/cli/test_contentview.py -k 'test_positive_promote_rh_content'"


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16469

### Problem Statement
depndabot select the list dependancies in alphabetical order, does not match the correct test key 

### Solution
fixing the order for broker depedancy to select the tests

```
(robottelo-env) omkarkhatavkar@Omkars-MacBook-Pro robottelo % yq eval '.["broker[docker,hussh,podman]"]' .github/dependency_tests.yaml
tests/foreman/ -k 'test_host_registration_end_to_end or test_positive_erratum_applicability or test_positive_upload_content'
```


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->