### PR TITLE
Several ContentView test fixes

### DIFF
--- a/robottelo/cli/contentview.py
+++ b/robottelo/cli/contentview.py
@@ -134,7 +134,7 @@ class ContentView(Base):
         return result
 
     @classmethod
-    def version_incremental_update(cls, options, output_format='csv'):
+    def version_incremental_update(cls, options, output_format='base'):
         """Performs incremental update of the content-view's version"""
         cls.command_sub = 'version incremental-update'
         if options is None:

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1211,6 +1211,7 @@ def test_negative_non_readonly_user_actions(target_sat, content_view, function_r
         target_sat.api.ContentView(id=content_view.id).read()
 
 
+@pytest.mark.stubbed
 class TestOstreeContentView:
     """Tests for ostree contents in content views."""
 
@@ -1314,6 +1315,7 @@ class TestOstreeContentView:
         assert len(content_view.read().version[0].read().environment) == 2
 
 
+@pytest.mark.stubbed
 class TestContentViewRedHatOstreeContent:
     """Tests for publishing and promoting cv with RH ostree contents."""
 

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1618,7 +1618,7 @@ class TestContentView:
             {'id': new_cv['id'], 'repository-id': module_rhel_content['id']}
         )
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
-        assert len(new_cv['yum-repositories']) == 0
+        assert 'yum-repositories' not in new_cv
         # Publish a new version of CV once more
         module_target_sat.cli.ContentView.publish({'id': new_cv['id']})
         new_cv = module_target_sat.cli.ContentView.info({'id': new_cv['id']})
@@ -3501,10 +3501,13 @@ class TestContentViewFileRepo:
         module_target_sat.cli.ContentView.add_repository(
             {'id': cv['id'], 'repository-id': repo['id'], 'organization-id': module_org.id}
         )
+        cv_info = module_target_sat.cli.ContentView.info({'id': cv['id']})
+        assert cv_info['file-repositories'][0]['id'] == repo['id'], 'File repo should be listed'
         module_target_sat.cli.ContentView.remove_repository(
             {'id': cv['id'], 'repository-id': repo['id']}
         )
-        assert cv['file-repositories'][0]['id'] != repo['id']
+        cv_info = module_target_sat.cli.ContentView.info({'id': cv['id']})
+        assert 'file-repositories' not in cv_info, 'No file repo should be listed'
 
     @pytest.mark.tier3
     def test_positive_arbitrary_file_repo_promotion(

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -3113,10 +3113,7 @@ class TestContentView:
         result = module_target_sat.cli.ContentView.version_incremental_update(
             {'content-view-version-id': cvv['id'], 'errata-ids': settings.repos.yum_1.errata[1]}
         )
-        # Inc update output format is pretty weird - list of dicts where each
-        # key's value is actual line from stdout
-        result = [line.strip() for line_dict in result for line in line_dict.values()]
-        assert FAKE_2_CUSTOM_PACKAGE not in [line.strip() for line in result]
+        assert FAKE_2_CUSTOM_PACKAGE not in result
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         assert '1.1' in [cvv_['version'] for cvv_ in content_view['versions']]
 
@@ -3613,7 +3610,7 @@ class TestContentViewFileRepo:
         result = module_target_sat.cli.ContentView.version_incremental_update(
             {'content-view-version-id': cvv['id'], 'errata-ids': settings.repos.yum_1.errata[0]}
         )
-        assert result[2]
+        assert f'Content View: {content_view["name"]} version 1.1' in result
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         assert '1.1' in [cvv_['version'] for cvv_ in content_view['versions']]
 

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -587,7 +587,7 @@ class TestDockerContentView:
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         module_target_sat.cli.ContentView.version_promote(
             {
-                'id': content_view['versions'][-1]['id'],
+                'id': sorted(cvv['id'] for cvv in content_view['versions'])[-1],
                 'to-lifecycle-environment-id': lce['id'],
             }
         )
@@ -668,7 +668,7 @@ class TestDockerContentView:
         content_view = module_target_sat.cli.ContentView.info({'id': content_view['id']})
         module_target_sat.cli.ContentView.version_promote(
             {
-                'id': content_view['versions'][-1]['id'],
+                'id': sorted(cvv['id'] for cvv in content_view['versions'])[-1],
                 'to-lifecycle-environment-id': lce['id'],
             }
         )


### PR DESCRIPTION
### Problem Statement
Several CV tests are failing for various reasons:
1. Ostree cases used to be skipped since hooked on a CLOSED_WONT_FIX BZ. The `skip_if_open` has been removed [here](https://github.com/SatelliteQE/robottelo/pull/16347/files#diff-b03329885851f0dc9923b776b4b70c4b716e716615b21cbf57f9b3247905060c)
2. Repo removal test cases are failing for a long time with key error since the `file-repositories` nor `yum-repositories` are returned by hammer if there are no repos to be listed.
3. `sat.cli.version_incremental_update(output_format='csv')` does not return anything when CSV format is requested since there is nothing to be listed in that format.
4. CV versions listing changed. There was an old sorting issue which was fixed but affected test cases were not.


### Solution
1. I had to choose if to stub or remove the Ostree cases. Decided to stub them since there still is _some_ support for them in upstream.
2. Just assert the fields are not listed after repo removal.
3. Decided to default to the `base` output format since that returns at least the CV version. The assertion in `test_positive_inc_update_no_lce` was done above an empty list, that's why it passed anyway.
4. Use `sorted` to get the latest CV version.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k 'rh_content_removed or file_repo_removal or e_inc_update'
```
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_docker.py -k name_change_after_promotion
```
