### PR TITLE
[6.14.z] Build: Add  to safe directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ USER 1001
 COPY --chown=1001:0 / ${ROBOTTELO_DIR}
 
 WORKDIR "${ROBOTTELO_DIR}"
-RUN uv pip install -r requirements.txt
+RUN git config --global --add safe.directory ${ROBOTTELO_DIR} && \
+    uv pip install -r requirements.txt
 
 CMD make test-robottelo


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16491

### Problem Statement
Running `git status` gives us the following output.
```
fatal: detected dubious ownership in repository at '/opt/app-root/src/robottelo'
To add an exception for this directory, call:

	git config --global --add safe.directory /opt/app-root/src/robottelo
```

### Solution
Add the directory to the list of safe directories to the global git config.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->