### PR TITLE
[RHCloud] Update configure_rhai_client registration

### DIFF
--- a/pytest_fixtures/component/rh_cloud.py
+++ b/pytest_fixtures/component/rh_cloud.py
@@ -33,7 +33,7 @@ def rhcloud_registered_hosts(
 ):
     """Fixture that registers content hosts to Satellite and Insights."""
     for vm in mod_content_hosts:
-        vm.configure_rhai_client(
+        vm.configure_insights_client(
             satellite=module_target_sat,
             activation_key=rhcloud_activation_key,
             org=rhcloud_manifest_org,
@@ -51,7 +51,7 @@ def rhel_insights_vm(
     rhel_contenthost.configure_rex(
         satellite=module_target_sat, org=rhcloud_manifest_org, register=False
     )
-    rhel_contenthost.configure_rhai_client(
+    rhel_contenthost.configure_insights_client(
         satellite=module_target_sat,
         activation_key=rhcloud_activation_key,
         org=rhcloud_manifest_org,

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1052,17 +1052,6 @@ class ContentHost(Host, ContentHostMixins):
         :param register: Whether to register client to insights
         :return: None
         """
-        if register:
-            if not activation_key:
-                activation_key = satellite.api.ActivationKey(
-                    content_view=org.default_content_view.id,
-                    environment=org.library.id,
-                    organization=org,
-                ).create()
-            self.register(
-                org, None, activation_key.name, satellite, setup_insights=register_insights
-            )
-
         # Red Hat Insights requires RHEL 6/7/8 repo and it is not
         # possible to sync the repo during the tests, Adding repo file.
         distro_repo_map = {
@@ -1084,6 +1073,17 @@ class ContentHost(Host, ContentHostMixins):
         # Ensure insights-client rpm is installed
         if self.execute('yum install -y insights-client').status != 0:
             raise ContentHostError('Unable to install insights-client rpm')
+        # attempt to register host
+        if register:
+            if not activation_key:
+                activation_key = satellite.api.ActivationKey(
+                    content_view=org.default_content_view.id,
+                    environment=org.library.id,
+                    organization=org,
+                ).create()
+            self.register(
+                org, None, activation_key.name, satellite, setup_insights=register_insights
+            )
 
     def unregister_insights(self):
         """Unregister insights client.

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1038,7 +1038,7 @@ class ContentHost(Host, ContentHostMixins):
             host.host_parameters_attributes = host_parameters
             host.update(['host_parameters_attributes'])
 
-    def configure_rhai_client(
+    def configure_insights_client(
         self, satellite, activation_key, org, rhel_distro, register_insights=True, register=True
     ):
         """Configures a Red Hat Access Insights service on the system by
@@ -1052,7 +1052,7 @@ class ContentHost(Host, ContentHostMixins):
         :param register: Whether to register client to insights
         :return: None
         """
-        # Red Hat Insights requires RHEL 6/7/8 repo and it is not
+        # Red Hat Insights requires RHEL 6/7/8/9 repo and it is not
         # possible to sync the repo during the tests, Adding repo file.
         distro_repo_map = {
             'rhel6': settings.repos.rhel6_os,

--- a/tests/foreman/cli/test_http_proxy.py
+++ b/tests/foreman/cli/test_http_proxy.py
@@ -122,7 +122,7 @@ def test_insights_client_registration_with_http_proxy(
 
     :customerscenario: true
     """
-    rhel_contenthost.configure_rhai_client(
+    rhel_contenthost.configure_insights_client(
         module_target_sat,
         rhcloud_activation_key,
         rhcloud_manifest_org,


### PR DESCRIPTION
Registering a host with insights client was failing. 

After further investigation, It appears that we were are not actually syncing rhel 6 - 9 repos but instead "mocking" them to be enabled...which are needed for insights setup.

This process must have started failing during our update to global registration across components?

My solution to this is to simply move the registration portion of ```confiure_rhai_client``` to be executed AFTER we setup the correct "mock" repositories needed and packages installed.

The other option in my mind was to manually register insights after we setup the repos using 
```insights-client --register```

But the first way allows us to register insights upon Satellite registration (which is the expected behavior) 