### PR TITLE
[6.16.z] Update dependancy-merge workflow as for other z-stream branches

### DIFF
--- a/.github/workflows/dependency_merge.yml
+++ b/.github/workflows/dependency_merge.yml
@@ -1,46 +1,30 @@
-name: Dependabot Auto Merge
-on: pull_request
-
-permissions:
-  pull-requests: write
+name: Dependabot Auto Merge - ZStream
+on:
+  pull_request_target:
+    branches-ignore:
+      - master
 
 jobs:
   dependabot:
     name: dependabot-auto-merge
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
     steps:
-      - name: Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2
+      - id: find-prt-comment
+        name: Find the prt comment
+        uses: peter-evans/find-comment@v2
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          issue-number: ${{ github.event.number }}
+          body-includes: "trigger: test-robottelo"
+          direction: last
 
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Find the tests for the dependency requirement
-        id: yaml
-        uses: mikefarah/yq@master
-        with:
-          cmd: yq eval '.["${{ steps.metadata.outputs.dependency-names }}"]' ./.github/dependency_tests.yaml
-
-      - name: Add the PRT Comment
-        if:  steps.yaml.outputs.result != 'null'
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            trigger: test-robottelo\r
-            pytest: ${{ steps.yaml.outputs.result }}
       - name: Wait for PRT checks to get initiated
-        if: steps.yaml.outputs.result != 'null'
+        if: steps.find-prt-comment.outputs.comment-body != ''
         run: |
           echo "Waiting for ~ 10 mins, PRT to be initiated." && sleep 600
+
       - name: Fetch and Verify the PRT status
-        if: steps.yaml.outputs.result != 'null'
+        if: steps.find-prt-comment.outputs.comment-body != ''
         id: outcome
         uses: omkarkhatavkar/wait-for-status-checks@main
         with:
@@ -54,7 +38,7 @@ jobs:
         uses: lewagon/wait-on-check-action@v1.3.4
         with:
           ref: ${{ github.head_ref }}
-          repo-token: ${{ secrets.CHERRYPICK_PAT }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           wait-interval: 60
           running-workflow-name: 'dependabot-auto-merge'
           allowed-conclusions: success,skipped
@@ -63,7 +47,7 @@ jobs:
         name: Auto merge of dependabot PRs.
         uses: "pascalgn/automerge-action@v0.16.4"
         env:
-          GITHUB_TOKEN: "${{ secrets.CHERRYPICK_PAT }}"
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "dependencies"
           MERGE_METHOD: "squash"
           MERGE_RETRIES: 5


### PR DESCRIPTION
### Problem Statement
dependancy-merge GHA using same configuration as the master causing failure in the automerge.

### Solution
 Update dependancy-merge workflow as for other z-stream branches

### Related Issues
Skipped workflow - https://github.com/SatelliteQE/robottelo/actions/runs/11045045674/job/30681991976?pr=16500
Previously handled for 6.15.z in - https://github.com/SatelliteQE/robottelo/pull/13947