### PR TITLE
Add CV to the AK creation as a new requirement

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -353,7 +353,9 @@ def test_capsule_installation(
     # Create capsule certs and activation key
     file, _, cmd_args = sat_fapolicyd_install.capsule_certs_generate(cap_ready_rhel)
     sat_fapolicyd_install.session.remote_copy(file, cap_ready_rhel)
-    ak = sat_fapolicyd_install.api.ActivationKey(organization=org, environment=org.library).create()
+    ak = sat_fapolicyd_install.api.ActivationKey(
+        organization=org, environment=org.library, content_view=org.default_content_view
+    ).create()
 
     setup_capsule_repos(sat_fapolicyd_install, cap_ready_rhel, org, ak)
 


### PR DESCRIPTION
### Problem Statement
Sanity is failing in `test_capsule_installation` since AK creation needs both, LCE and CV to be provided at the creation time since snap 73.


### Solution
Use `Deafult_org_view` since it was used before anyway.


### Related Issues
https://issues.redhat.com/browse/SAT-28353


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/installer/test_installer.py -k test_capsule_installation
