### PR TITLE
[6.16.z] Fix failing provisioning tests

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -387,6 +387,9 @@ class ProvisioningSetup:
             if host:
                 host[0].delete()
             assert not self.api.Host().search(query={'search': f'name={hostname}'})
+        # Workaround SAT-28381
+        assert self.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
+        assert self.execute('systemctl restart dhcpd').status == 0
         # Workaround BZ: 2207698
         assert self.cli.Service.restart().status == 0
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16414

### Problem Statement
Provisioning tests are failing due to uncleaned dhcp leases in the satellite due to recent infra change

### Solution
Handle the lease cleanup and fix them

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->