### PR TITLE
further api changes for 6.16

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -488,7 +488,12 @@ API_PATHS = {
         '/api/hosts/:host_id/errata/:id',
         '/api/hosts/:host_id/errata/applicability',
     ),
-    'host_packages': ('/api/hosts/:host_id/packages',),
+    'host_packages': (
+        '/api/hosts/:host_id/packages',
+        '/api/host_packages/:id',
+        '/api/host_packages/compare',
+        '/api/host_packages/installed_packages',
+    ),
     'http_proxies': (
         '/api/http_proxies',
         '/api/http_proxies',


### PR DESCRIPTION
### Problem Statement
a bunch of new api endpont added for 6.16

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->