### PR TITLE
[6.16.z] Switch back to client-1 repo against Satellite 6.16

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -149,9 +149,9 @@ def get_dogfood_satclient_repos(settings):
     for ver in rhels:
         data[f'RHEL{ver}'] = get_ohsnap_repo_url(
             settings,
-            repo='client-2',
+            repo='client',
             product='client',
-            release='client-2',
+            release='client',
             os_release=ver,
         )
     return data


### PR DESCRIPTION
Reverts SatelliteQE/robottelo#16409
(revert 6.16.z cherrypick only)

### Problem
There are not yet **client tests** identified therefore we cannot cover both client-1 and client-2 repos w/o duplicating whole test matrix

### Solution
Temporary solution is to use **client-1** repo against Satellite **6.16** and use **client-2** repo against Satellite **Stream** so that we don't duplicate whole matrix while we have coverage for both client repos.
 (We are missing testing specific client repo across multiple satellite versions anyway.)