### PR TITLE
changes to use the beaker urls for running upstream sanity

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -7,7 +7,7 @@ CAPSULE:
     # The snap version currently testing (if applicable)
     # SNAP:
     # The source of Capsule packages. Can be one of:
-    # internal, ga
+    # internal, ga, nightly
     SOURCE: "internal"
     # The base os rhel version where the capsule installed
     # RHEL_VERSION:

--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -11,8 +11,12 @@ from robottelo.utils.url import ipv6_hostname_translation, is_url
 
 
 def post(settings):
-    settings_cache_path = Path(f'settings_cache-{settings.server.version.release}.json')
-    if getattr(settings.robottelo.settings, 'get_fresh', True):
+    settings_cache_path = Path(
+        f'settings_cache-{settings.server.version.release}-{settings.server.version.snap}.json'
+    )
+    if settings.server.version.source == 'nightly':
+        data = Box({'REPOS': {}})
+    elif getattr(settings.robottelo.settings, 'get_fresh', True):
         data = get_repos_config(settings)
         write_cache(settings_cache_path, data)
     else:

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -9,7 +9,7 @@ SERVER:
     # The snap version currently testing (if applicable)
     SNAP: 1.0
     # The source of Satellite packages. Can be one of:
-    # internal, ga
+    # internal, ga, nightly
     SOURCE: "internal"
     # The RHEL Base OS Version(x.y) where the Satellite is installed
     RHEL_VERSION: '9'

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -362,12 +362,19 @@ def installer_satellite(request):
         for repo in sat.SATELLITE_CDN_REPOS.values():
             sat.enable_repo(repo, force=True)
     else:
-        # get ohsnap repofile
-        sat.download_repofile(
-            product='satellite',
-            release=settings.server.version.release,
-            snap=settings.server.version.snap,
-        )
+        if settings.server.version.source == 'nightly':
+            sat.create_custom_repos(
+                satellite_repo=settings.repos.satellite_repo,
+                satmaintenance_repo=settings.repos.satmaintenance_repo,
+            )
+        else:
+            # get ohsnap repofile
+            sat.download_repofile(
+                product='satellite',
+                release=settings.server.version.release,
+                snap=settings.server.version.snap,
+            )
+
     if settings.robottelo.rhel_source == "internal":
         # disable rhel repos from cdn
         sat.disable_repo("rhel-*")

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -13,7 +13,7 @@ VALIDATORS = dict(
         Validator('server.hostname', is_type_of=str),
         Validator('server.hostnames', must_exist=True, is_type_of=list),
         Validator('server.version.release', must_exist=True),
-        Validator('server.version.source', default='internal', is_in=['internal', 'ga']),
+        Validator('server.version.source', default='internal', is_in=['internal', 'ga', 'nightly']),
         Validator('server.version.rhel_version', must_exist=True, cast=str),
         Validator(
             'server.xdist_behavior', must_exist=True, is_in=['run-on-one', 'balance', 'on-demand']
@@ -79,7 +79,9 @@ VALIDATORS = dict(
     ],
     capsule=[
         Validator('capsule.version.release', must_exist=True),
-        Validator('capsule.version.source', default='internal', is_in=['internal', 'ga']),
+        Validator(
+            'capsule.version.source', default='internal', is_in=['internal', 'ga', 'nightly']
+        ),
         Validator('capsule.deploy_workflows', must_exist=True, is_type_of=dict),
         Validator('capsule.deploy_workflows.product', must_exist=True),
         Validator('capsule.deploy_workflows.os', must_exist=True),


### PR DESCRIPTION
### Problem Statement
Currently, the sanity tests are tightly coupled with "Oh Snap" for retrieving required repository URLs. This creates a dependency that hinders the flexibility of running the same tests with alternative URL sources, such as Beaker URLs. The reliance on "Oh Snap" is particularly limiting when running upstream sanity tests right after building the necessary bits. This dependency affects the ability to run tests in different environments efficiently.

### Solution
This PR aims to decouple the sanity tests from "Oh Snap" by introducing a more flexible approach for handling repository URLs. Instead of relying exclusively on "Oh Snap" to fetch the URLs, we will modify the behaviour to allow passing the repository URLs directly through a repos file. This approach provides more control and adaptability, enabling tests to run seamlessly with either Beaker URLs or other sources without modifying the core logic.

By doing this, we improve the modularity of the tests, allowing upstream sanity runs to proceed immediately after building the necessary bits, enhancing efficiency and reducing dependencies on external services.

### CI PR Dependancy 

**1504**

### Test Result
```
============================= test session starts ==============================
collecting ... collected 5450 items / 5439 deselected / 11 selected

tests/foreman/installer/test_installer.py::test_satellite_installation 
tests/foreman/api/test_computeresource_gce.py::TestGCEHostProvisioningTestCase::test_positive_gce_host_provisioned[sat] 
tests/foreman/api/test_organization.py::TestOrganization::test_positive_create_with_name_and_description[alphanumeric] 
tests/foreman/api/test_repository.py::TestRepositorySync::test_positive_sync_rh 
tests/foreman/api/test_user.py::TestUserRole::test_positive_create_with_role[1] 
tests/foreman/endtoend/test_api_endtoend.py::TestEndToEnd::test_positive_find_admin_user 
tests/foreman/installer/test_installer.py::test_capsule_installation

======= 12 passed, 5439 deselected, 5681 warnings in 3269.71s (0:54:29) ========
```


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->