### PR TITLE
[6.15.z] Fetch pre_upgrade data based on node properties

### DIFF
--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -90,6 +90,7 @@ import os
 from box import Box
 import pytest
 
+from robottelo.config import settings
 from robottelo.logging import logger
 from robottelo.utils.decorators.func_locker import lock_function
 
@@ -260,11 +261,13 @@ def pre_upgrade_data(request):
         start_index = test_node_id.find('[') + 1
         end_index = test_node_id.find(']')
         extracted_value = test_node_id[start_index:end_index]
-        upgrade_data[extracted_value] = _read_test_data(test_node_id)
+        if request.param in extracted_value:
+            upgrade_data[extracted_value] = _read_test_data(test_node_id)
     if len(upgrade_data) == 1:
         param_value = next(iter(upgrade_data.values()))
     else:
-        param_value = upgrade_data.get(request.param)
+        network_type = 'ipv6' if settings.server.is_ipv6 else 'ipv4'
+        param_value = upgrade_data.get(f'{request.param}-{network_type}')
         if param_value is None:
             pytest.fail(f"Invalid test parameter: {request.param}. Test data not found.")
     return Box(param_value)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16423

### Problem Statement
During TFA I've seen several `post_upgrade` failures for "`rhel_contenthost`-parametrized" upgrade scenario tests where the pre-data could not be fetched from the `scenario_entities` file:
```
failed on setup with "Failed: Invalid test parameter: rhel7. Test data not found."
```

The reason is that the pre-upgrade test names are now suffixed with `-ipv4` or `-ipv6` so the `scenario_entities` hold items like this:
```
{"tests/upgrades/test_repository.py::TestSimpleContentAccessOnly::test_pre_simple_content_access_only[rhel7-ipv4]": {...}}
```
while [this piece of code](https://github.com/SatelliteQE/robottelo/blob/master/tests/upgrades/conftest.py#L267) requires the exact param, which is just `rhel7`, `rhel8`, `rhel9`.


### Solution(?)
There are probably more than one solution and I'm not sure which one would be the best.

Initially I thought we could go regardless the `ipvX` suffix since I supposed the pipelines were separated (first commit).
That's probably not a good solution when we start decorating tests with `['ipv4', 'ipv6']` explicitly, so I took the network type from the settings.

Please let me know if there is a better place where to get that information from in scope of the `pre_upgrade_data` fixture.
