### PR TITLE
[6.15.z] Remove CSV parser workaround

### DIFF
--- a/robottelo/cli/hammer.py
+++ b/robottelo/cli/hammer.py
@@ -4,7 +4,7 @@ import csv
 import json
 import re
 
-from robottelo.config import logger
+from robottelo.logging import logger
 
 
 def _normalize(header):
@@ -39,14 +39,6 @@ def _normalize_obj(obj):
 
 def parse_csv(output):
     """Parse CSV output from Hammer CLI and return a Python dictionary."""
-
-    # https://projects.theforeman.org/issues/37264
-    NON_CSV_PATTERN = r'\d+ task\(s\), \d+ success, \d+ fail'
-
-    output, num_changes = re.subn(NON_CSV_PATTERN, '', output)
-    if num_changes > 0:
-        logger.warning(f'Removed output from CLI based on regex: {NON_CSV_PATTERN!s}')
-
     output = output.splitlines()
 
     # Normalize the column names to use when generating the dictionary

--- a/robottelo/cli/repository.py
+++ b/robottelo/cli/repository.py
@@ -61,7 +61,7 @@ class Repository(Base):
         cls.command_sub = 'synchronize'
         return cls.execute(
             cls._construct_command(options),
-            output_format='base',
+            output_format='csv',
             ignore_stderr=True,
             return_raw_response=return_raw_response,
             timeout=timeout,


### PR DESCRIPTION
### Problem Statement

A previous PR https://github.com/SatelliteQE/robottelo/pull/15823 removed outdated code from robottelo's hammer CSV output handling. This PR removes the last workaround, now that the fix for https://projects.theforeman.org/issues/37264  is included in 6.15 with rubygem-hammer_cli_foreman_tasks-0.0.21-1.el8sat.noarch.

### Solution

Remove the workaround that scans for non-CSV patterns in the output.

### Related Issues

SAT-27296

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->