### PR TITLE
Automate puppet-agent8 testing by parametrizing existing puppet tests

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -153,9 +153,9 @@ def get_dogfood_satclient_repos(settings):
     for ver in rhels:
         data[f'RHEL{ver}'] = get_ohsnap_repo_url(
             settings,
-            repo='client-2',
+            repo='client',
             product='client',
-            release='client-2',
+            release='client',
             os_release=ver,
         )
     return data

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -920,7 +920,9 @@ class ContentHost(Host, ContentHostMixins):
                 f'Failed to put hostname in ssh known_hosts files:\n{result.stderr}'
             )
 
-    def configure_puppet(self, proxy_hostname=None, run_puppet_agent=True):
+    def configure_puppet(
+        self, proxy_hostname=None, run_puppet_agent=True, install_puppet_agent7=False
+    ):
         """Configures puppet on the virtual machine/Host.
         :param proxy_hostname: external capsule hostname
         :return: None.
@@ -929,12 +931,21 @@ class ContentHost(Host, ContentHostMixins):
         if proxy_hostname is None:
             proxy_hostname = settings.server.hostname
 
-        self.create_custom_repos(
-            sat_client=settings.repos['SATCLIENT_REPO'][f'RHEL{self.os_version.major}']
-        )
+        if install_puppet_agent7:
+            self.create_custom_repos(
+                sat_client=settings.repos['SATCLIENT_REPO'][f'RHEL{self.os_version.major}']
+            )
+        else:
+            self.create_custom_repos(
+                sat_client=settings.repos['SATCLIENT2_REPO'][f'RHEL{self.os_version.major}']
+            )
+
         result = self.execute('yum install puppet-agent -y')
         if result.status != 0:
             raise ContentHostError('Failed to install the puppet-agent rpm')
+
+        rpm_version = self.execute('rpm -q --qf "%{VERSION}" puppet-agent').stdout
+        assert '7' in rpm_version if install_puppet_agent7 else '7' not in rpm_version
 
         cert_name = self.hostname
         puppet_conf = (

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -52,8 +52,9 @@ def test_positive_CRD_satellite(run_puppet_agent, session_puppet_enabled_sat):
 
 @pytest.mark.e2e
 @pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.parametrize('client_repo_ver', ['1', '2'], ids=['client1', 'client2'])
 def test_positive_install_configure_host(
-    session_puppet_enabled_sat, session_puppet_enabled_capsule, content_hosts
+    session_puppet_enabled_sat, session_puppet_enabled_capsule, content_hosts, client_repo_ver
 ):
     """Test that puppet-agent can be installed from the sat-client repo
     and configured to report back to the Satellite.
@@ -84,7 +85,9 @@ def test_positive_install_configure_host(
     """
     puppet_infra_host = [session_puppet_enabled_sat, session_puppet_enabled_capsule]
     for client, puppet_proxy in zip(content_hosts, puppet_infra_host, strict=True):
-        client.configure_puppet(proxy_hostname=puppet_proxy.hostname)
+        client.configure_puppet(
+            proxy_hostname=puppet_proxy.hostname, install_puppet_agent7=(client_repo_ver == '1')
+        )
         report = session_puppet_enabled_sat.cli.ConfigReport.list(
             {'search': f'host~{client.hostname}'}
         )
@@ -102,8 +105,9 @@ def test_positive_install_configure_host(
 
 @pytest.mark.e2e
 @pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.parametrize('client_repo_ver', ['1', '2'], ids=['client1', 'client2'])
 def test_positive_run_puppet_agent_generate_report_when_no_message(
-    session_puppet_enabled_sat, rhel_contenthost
+    session_puppet_enabled_sat, rhel_contenthost, client_repo_ver
 ):
     """Verify that puppet-agent can be installed from the sat-client repo
     and configured to report back to the Satellite, and contains the origin
@@ -134,7 +138,11 @@ def test_positive_run_puppet_agent_generate_report_when_no_message(
     """
     sat = session_puppet_enabled_sat
     client = rhel_contenthost
-    client.configure_puppet(proxy_hostname=sat.hostname, run_puppet_agent=False)
+    client.configure_puppet(
+        proxy_hostname=sat.hostname,
+        run_puppet_agent=False,
+        install_puppet_agent7=(client_repo_ver == '1'),
+    )
     # Run either 'puppet agent --detailed-exitcodes' or 'systemctl restart puppet'
     # to generate Puppet config report for host without any messages
     assert client.execute('/opt/puppetlabs/bin/puppet agent --detailed-exitcodes').status == 0


### PR DESCRIPTION
### Problem Statement
We're missing test coverage for puppet-agent8 testing which is provided by new client-2 repository

### Solution
Automate puppet-agent8 testing by parametrizing existing puppet tests with puppet-agent7

### Related Issues
satellite-jenkins MR#1480