### PR TITLE
[6.16.z] avoiding host details will be seen in the test result

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -310,7 +310,10 @@ def sat_non_default_install(module_sat_ready_rhels):
 @pytest.mark.tier1
 @pytest.mark.pit_server
 @pytest.mark.parametrize(
-    'setting_update', [f'http_proxy={settings.http_proxy.un_auth_proxy_url}'], indirect=True
+    'setting_update',
+    [f'http_proxy={settings.http_proxy.un_auth_proxy_url}'],
+    indirect=True,
+    ids=["un_auth_proxy"],
 )
 def test_capsule_installation(
     sat_fapolicyd_install, cap_ready_rhel, module_sca_manifest, setting_update


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16553

### Problem Statement
The current pytest parameterization exposes sensitive host details, such as proxy URLs, in the test results. This can lead to unintended exposure of confidential information in logs or reports, which is undesirable when sharing test results over PRT

### Solution
To address this, we will update the pytest parameterization to use a custom ID (un_auth_proxy) instead of displaying the actual proxy URL. By doing so, we ensure that the test results are cleaner and more secure, as sensitive host details are hidden. 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->