### PR TITLE
changed requirements for activation keys

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -111,8 +111,16 @@ def activation_key(module_target_sat, module_org, lifecycle_env):
         content_view = module_target_sat.api.ContentView(
             organization=module_org, name=repo.get('cvname')
         ).create()
+        content_view.publish()
+        content_view = content_view.read()
+        assert len(content_view.version) == 1, "CV not publised"
+        version = content_view.version[0].read()
+        version.promote(data={'environment_ids': lifecycle_env.id, 'force': True})
         activation_key = module_target_sat.api.ActivationKey(
-            name=repo.get('akname'), environment=lifecycle_env, organization=module_org
+            name=repo.get('akname'),
+            environment=lifecycle_env,
+            content_view=content_view,
+            organization=module_org,
         ).create()
         # Setup org for a custom repo for RHEL6, RHEL7 and RHEL8.
         module_target_sat.cli_factory.setup_org_for_a_custom_repo(


### PR DESCRIPTION
### Problem Statement
no longer possible to create an AK with LCE only, both LCE and CV need to be supplied

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->