### PR TITLE
[6.16.z] Customer Case testing for database issues

### DIFF
--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -1081,6 +1081,28 @@ class TestContentViewRedHatContent:
 
 
 @pytest.mark.tier2
+def test_repository_rpms_id_type(target_sat):
+    """Katello_repository_rpms_id_seq needs to have the type bigint to allow
+    repeated publishing of Content Views by customers.
+
+    :id: a506782f-1edd-4568-99bb-d289212156ba
+
+    :steps:
+        1. Login to the Satellite cli and access the foreman posgres shell
+        2. Search for katello_repository_rpms_id_seq
+
+    :expectedresults: katello_repository_rpms_id_seq should have the type bigint, and not the type integer
+
+    :CaseImportance: Medium
+    """
+    db_out = target_sat.execute(
+        'sudo -u postgres psql -d foreman -c "select * from pg_sequences where sequencename=\'katello_repository_rpms_id_seq\';"'
+    )
+    assert 'bigint' in db_out.stdout
+    assert 'integer' not in db_out.stdout
+
+
+@pytest.mark.tier2
 def test_negative_readonly_user_actions(
     target_sat, function_role, content_view, module_org, module_lce
 ):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16566

### Problem Statement
Test case covering 6.16 Bug surrounding database data types. This is currently in the Content View test suite as it presents itself when publishing Content Views with the repository contained, open to moving this to repository suite.

### Related Issues
https://issues.redhat.com/browse/SAT-24878

### PRT
trigger: test-robottelo
pytest: tests/foreman/api/test_contentview.py -k 'test_repository_rpm_size'
