### PR TITLE
Enable repos for long failing hostCollection UI tests

### DIFF
--- a/tests/foreman/ui/test_hostcollection.py
+++ b/tests/foreman/ui/test_hostcollection.py
@@ -61,7 +61,9 @@ def module_repos_collection(module_org_with_parameter, module_lce, module_target
             module_target_sat.cli_factory.YumRepository(url=settings.repos.yum_6.url),
         ],
     )
-    repos_collection.setup_content(module_org_with_parameter.id, module_lce.id)
+    repos_collection.setup_content(
+        org_id=module_org_with_parameter.id, lce_id=module_lce.id, override=True
+    )
     return repos_collection
 
 


### PR DESCRIPTION
### Problem Statement
6 UI host collection tests require that the reposets which are assigned to the hosts are enabled by the test setup which is not happening at the moment in 6.15.z.

### Solution
Add repository override parameter to the `setup_content` function which is part of the `module_repos_collection` fixture that is used by the failing tests.
![image](https://github.com/user-attachments/assets/a8460f8e-0c5d-45b4-8368-a06c5ed7fe65)


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_hostcollection.py -k 'test_positive_install_package or test_positive_remove_package or test_positive_upgrade_package or test_positive_install_package_group or test_positive_install_remove_package_group or test_positive_install_errata'
```