### PR TITLE
[6.14.z] Combine discovery reboot and reboot_all test

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -238,30 +238,6 @@ def provisioning_host(module_ssh_key_file, pxe_loader):
 
 
 @pytest.fixture
-def provision_multiple_hosts(module_ssh_key_file, pxe_loader, request):
-    """Fixture to check out two blank VMs"""
-    vlan_id = settings.provisioning.vlan_id
-    cd_iso = (
-        ""  # TODO: Make this an optional fixture parameter (update vm_firmware when adding this)
-    )
-    with Broker(
-        workflow=settings.provisioning.provisioning_host_workflow,
-        host_class=ContentHost,
-        _count=getattr(request, 'param', 2),
-        target_vlan_id=vlan_id,
-        target_vm_firmware=pxe_loader.vm_firmware,
-        target_pxeless_image=cd_iso,
-        blank=True,
-        target_memory='6GiB',
-        auth=module_ssh_key_file,
-    ) as hosts:
-        yield hosts
-
-        for prov_host in hosts:
-            prov_host.blank = getattr(prov_host, 'blank', False)
-
-
-@pytest.fixture
 def provisioning_hostgroup(
     module_provisioning_sat,
     module_sca_manifest_org,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16572

Combining discovery reboot and reboot_all test into one