### PR TITLE
[6.16.z] Automate test_positive_ansible_variables_imported_with_roles

### DIFF
--- a/robottelo/cli/ansible.py
+++ b/robottelo/cli/ansible.py
@@ -64,3 +64,9 @@ class Ansible(Base):
         """Information about ansible variables"""
         cls.command_sub = 'variables info'
         return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def variables_list(cls, options=None):
+        """Information about ansible variables"""
+        cls.command_sub = 'variables list'
+        return cls.execute(cls._construct_command(options), output_format='csv')

--- a/robottelo/cli/host.py
+++ b/robottelo/cli/host.py
@@ -73,6 +73,12 @@ class Host(Base):
         return cls.execute(cls._construct_command(options), output_format='csv')
 
     @classmethod
+    def ansible_roles_list(cls, options=None):
+        """Remove ansible list"""
+        cls.command_sub = 'ansible-roles list'
+        return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
     def disassociate(cls, options):
         """Disassociate the host from a CR."""
         cls.command_sub = 'disassociate'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -621,6 +621,8 @@ class ContentHost(Host, ContentHostMixins):
         force=False,
         insecure=True,
         hostgroup=None,
+        auth_username=None,
+        auth_password=None,
     ):
         """Registers content host to the Satellite or Capsule server
         using a global registration template.
@@ -641,6 +643,8 @@ class ContentHost(Host, ContentHostMixins):
         :param force: Register the content host even if it's already registered.
         :param insecure: Don't verify server authenticity.
         :param hostgroup: hostgroup to register with
+        :param auth_username: username required if non-admin user
+        :param auth_password: password required if non-admin user
         :return: SSHCommandResult instance filled with the result of the registration
         """
         options = {
@@ -691,7 +695,20 @@ class ContentHost(Host, ContentHostMixins):
             options['force'] = str(force).lower()
 
         self._satellite = target.satellite
-        cmd = target.satellite.cli.HostRegistration.generate_command(options)
+        if auth_username and auth_password:
+            user = target.satellite.cli.User.list({'search': f'login={auth_username}'})
+            if user:
+                register_role = target.satellite.cli.Role.info({'name': 'Register hosts'})
+                target.satellite.cli.User.add_role(
+                    {'id': user[0]['id'], 'role-id': register_role['id']}
+                )
+                cmd = target.satellite.cli.HostRegistration.with_user(
+                    auth_username, auth_password
+                ).generate_command(options)
+            else:
+                raise CLIFactoryError(f'User {auth_username} doesn\'t exist')
+        else:
+            cmd = target.satellite.cli.HostRegistration.generate_command(options)
         return self.execute(cmd.strip('\n'))
 
     def api_register(self, target, **kwargs):

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -13,9 +13,14 @@ from time import sleep
 
 from fauxfactory import gen_string
 import pytest
+import yaml
 
-from robottelo.config import settings
+from robottelo.config import (
+    robottelo_tmp_dir,
+    settings,
+)
 from robottelo.exceptions import CLIFactoryError
+from robottelo.utils.issue_handlers import is_open
 
 
 def assert_job_invocation_result(
@@ -555,3 +560,114 @@ class TestAnsibleREX:
         assert result['success'] == '1'
         collection_path = client.execute('ls ~/ansible_collections').stdout
         assert 'oasis_roles' in collection_path
+
+    @pytest.mark.tier3
+    @pytest.mark.no_containers
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+    @pytest.mark.parametrize('auth_type', ['admin', 'non-admin'])
+    def test_positive_ansible_variables_imported_with_roles(
+        self, request, auth_type, target_sat, module_org, module_ak_with_cv, rhel_contenthost
+    ):
+        """Verify that when Ansible roles are imported, their variables are imported simultaneously
+
+        :id: 107c53e8-5a8a-4291-bbde-fbd66a0bb85e
+
+        :steps:
+            1. Register a content host with satellite
+            2. Create a custom role with variables and import it into satellite
+            3. Assert that the role is imported along with associated variables
+            4. Assign that role to a host and verify the role is assigned to the host
+            5. Run the Ansible role
+
+        :expectedresults:
+            1. Verify variables associated to role are also imported along with roles
+            2. Verify custom role is successfully assigned and running on a host
+
+        :verifies: SAT-28198
+        """
+        username = settings.server.admin_username
+        password = settings.server.admin_password
+        if auth_type == 'non-admin':
+            username = gen_string('alpha')
+            user = target_sat.cli_factory.user(
+                {
+                    'admin': False,
+                    'login': username,
+                    'password': password,
+                    'organization-ids': module_org.id,
+                }
+            )
+            target_sat.cli.User.add_role(
+                {'id': user['id'], 'login': username, 'role': 'Ansible Roles Manager'}
+            )
+
+        @request.addfinalizer
+        def _finalize():
+            result = target_sat.cli.Ansible.roles_delete({'name': SELECTED_ROLE})
+            assert f'Ansible role [{SELECTED_ROLE}] was deleted.' in result[0]['message']
+            target_sat.execute(f'rm -rvf /etc/ansible/roles/{SELECTED_ROLE}')
+
+        SELECTED_ROLE = gen_string('alphanumeric')
+        playbook = f'{robottelo_tmp_dir}/playbook.yml'
+        vars = f'{robottelo_tmp_dir}/vars.yml'
+        target_sat.execute(f'ansible-galaxy init --init-path /etc/ansible/roles/ {SELECTED_ROLE}')
+        tasks_file = f'/etc/ansible/roles/{SELECTED_ROLE}/tasks/main.yml'
+        vars_file = f'/etc/ansible/roles/{SELECTED_ROLE}/{"defaults" if is_open("SAT-28198") else "vars"}/main.yml'
+        tasks_main = [
+            {
+                'name': 'Copy SSH keys',
+                'copy': {
+                    'src': '/var/lib/foreman-proxy/ssh/{{ item }}',
+                    'dest': '/root/.ssh',
+                    'owner': 'root',
+                    'group': 'root',
+                    'mode': '0400',
+                },
+                'loop': '{{ ssh_keys }}',
+            }
+        ]
+        vars_main = {'ssh_keys': ['id_rsa_foreman_proxy.pub', 'id_rsa_foreman_proxy']}
+        with open(playbook, 'w') as f:
+            yaml.dump(tasks_main, f, sort_keys=False, default_flow_style=False)
+        with open(vars, 'w') as f:
+            yaml.dump(vars_main, f, sort_keys=False, default_flow_style=False)
+        target_sat.put(playbook, tasks_file)
+        target_sat.put(vars, vars_file)
+
+        result = rhel_contenthost.register(
+            module_org,
+            None,
+            module_ak_with_cv.name,
+            target_sat,
+            auth_username=username,
+            auth_password=password,
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+        proxy_id = target_sat.nailgun_smart_proxy.id
+        target_host = rhel_contenthost.nailgun_host
+        target_sat.cli.Ansible.with_user(username, password).roles_sync(
+            {'role-names': SELECTED_ROLE, 'proxy-id': proxy_id}
+        )
+        result = target_sat.cli.Host.with_user(username, password).ansible_roles_assign(
+            {'id': target_host.id, 'ansible-roles': f'{SELECTED_ROLE}'}
+        )
+        assert 'Ansible roles were assigned to the host' in result[0]['message']
+
+        role_list = target_sat.cli.Host.with_user(username, password).ansible_roles_list(
+            {'name': target_host.name}
+        )
+        assert role_list[0]['name'] == SELECTED_ROLE
+
+        result = target_sat.cli.Ansible.with_user(username, password).variables_list(
+            {'search': f'ansible_role="{SELECTED_ROLE}"'}
+        )
+        assert result[0]['variable'] == 'ssh_keys'
+
+        job_id = target_sat.cli.Host.ansible_roles_play({'name': rhel_contenthost.hostname})[0].get(
+            'id'
+        )
+        target_sat.wait_for_tasks(
+            f'resource_type = JobInvocation and resource_id = {job_id} and action ~ "hosts job"'
+        )
+        result = target_sat.cli.JobInvocation.info({'id': job_id})['success']
+        assert result == '1'

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -253,22 +253,6 @@ class TestAnsibleCfgMgmt:
 
     @pytest.mark.stubbed
     @pytest.mark.tier3
-    def test_positive_ansible_variables_imported_with_roles(self):
-        """Verify that, when Ansible roles are imported, their variables are imported simultaneously
-
-        :id: 107c53e8-5a8a-4291-bbde-fbd66a0bb85e
-
-        :steps:
-            1. Import Ansible roles
-            2. Navigate to Configure > Variables
-
-        :expectedresults: Verify that any variables in the role were also imported to Satellite
-
-        :CaseAutomation: NotAutomated
-        """
-
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
     def test_positive_ansible_roles_ignore_list(self):
         """Verify that the ignore list setting prevents selected roles from being available for import
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16431

### Problem Statement
1. test_positive_ansible_variables_imported_with_roles is stubbed/Manual test.

### Solution
1. Automate test_positive_ansible_variables_imported_with_roles for admin and non-admin users
2. Remove unrelated tests


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->