### PR TITLE
[6.14.z] Automate test_positive_ansible_variables_installed_with_collection

### DIFF
--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -190,6 +190,61 @@ class TestAnsibleCfgMgmt:
         )
         assert 'Ansible role has been disassociated.' in result[0]['message']
 
+    @pytest.mark.tier3
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+    def test_positive_ansible_variables_installed_with_collection(
+        self, request, target_sat, module_org, module_ak_with_cv, rhel_contenthost
+    ):
+        """Verify that installing an Ansible collection also imports
+        any variables associated with the roles avaialble in the collection
+
+        :id: 7ff88022-fe9b-482f-a6bb-3922036a1e1c
+
+        :steps:
+            1. Register a content host with Satellite
+            2. Install a ansible collection with roles from ansible-galaxy
+            3. Import any role with variables from installed ansible collection
+            4. Assert that the role is imported along with associated variables
+            5. Assign that role to a host and verify the role assigned to the host
+
+        :expectedresults: Verify variables associated to role from collection are also imported along with roles
+
+        :bz: 1982753
+        """
+        SELECTED_COLLECTION = 'oasis_roles.system'
+        SELECTED_ROLE = 'oasis_roles.system.sshd'
+        SELECTED_VAR = 'sshd_allow_password_login'
+
+        @request.addfinalizer
+        def _finalize():
+            result = target_sat.cli.Ansible.roles_delete({'name': SELECTED_ROLE})
+            assert f'Ansible role [{SELECTED_ROLE}] was deleted.' in result[0]['message']
+
+        result = rhel_contenthost.register(
+            module_org,
+            None,
+            module_ak_with_cv.name,
+            target_sat,
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
+        target_host = rhel_contenthost.nailgun_host
+        proxy_id = target_sat.nailgun_smart_proxy.id
+
+        for path in ['/etc/ansible/collections', '/usr/share/ansible/collections']:
+            target_sat.execute(f'ansible-galaxy collection install -p {path} {SELECTED_COLLECTION}')
+            target_sat.cli.Ansible.roles_sync({'role-names': SELECTED_ROLE, 'proxy-id': proxy_id})
+            result = target_sat.cli.Host.ansible_roles_assign(
+                {'id': target_host.id, 'ansible-roles': f'{SELECTED_ROLE}'}
+            )
+            assert 'Ansible roles were assigned to the host' in result[0]['message']
+
+            result = target_sat.cli.Ansible.variables_list(
+                {'search': f'ansible_role="{SELECTED_ROLE}"'}
+            )
+            assert result[0]['variable'] == SELECTED_VAR
+            # Remove the ansible collection from collection_paths
+            target_sat.execute(f'rm -rf {path}/ansible_collections/')
+
 
 @pytest.mark.tier3
 @pytest.mark.upgrade

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -230,28 +230,6 @@ class TestAnsibleCfgMgmt:
             ]
 
     @pytest.mark.stubbed
-    @pytest.mark.tier2
-    def test_positive_role_variable_information(self):
-        """Create and assign variables to an Ansible Role and verify that the information in
-        the new UI is displayed correctly
-
-        :id: 4ab2813a-6b83-4907-b104-0473465814f5
-
-        :steps:
-            1. Register a RHEL host to Satellite.
-            2. Import all roles available by default.
-            3. Create a host group and assign one of the Ansible roles to the host group.
-            4. Assign the host to the host group.
-            5. Assign one roles to the RHEL host.
-            6. Create a variable and associate it with the role assigned to the Host.
-            7. Create a variable and associate it with the role assigned to the Hostgroup.
-            8. Navigate to the new UI for the given Host.
-            9. Select the 'Ansible' tab, then the 'Variables' sub-tab.
-
-        :expectedresults: The variables information for the given Host is visible.
-        """
-
-    @pytest.mark.stubbed
     @pytest.mark.tier3
     def test_positive_ansible_roles_ignore_list(self):
         """Verify that the ignore list setting prevents selected roles from being available for import
@@ -263,24 +241,6 @@ class TestAnsibleCfgMgmt:
             2. Navigate to Configure > Roles
 
         :expectedresults: Verify that any roles on the ignore list are not available for import
-
-        :CaseAutomation: NotAutomated
-        """
-
-    @pytest.mark.stubbed
-    @pytest.mark.tier3
-    def test_positive_ansible_variables_installed_with_collection(self):
-        """Verify that installing an Ansible collection also imports
-        any variables associated with the collection
-
-        :id: 7ff88022-fe9b-482f-a6bb-3922036a1e1c
-
-        :steps:
-            1. Install an Ansible collection
-            2. Navigate to Configure > Variables
-
-        :expectedresults: Verify that any variables associated with the collection
-            are present on Configure > Variables
 
         :CaseAutomation: NotAutomated
         """


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16489

### Problem Statement

1. test_positive_ansible_variables_installed_with_collection is stubbed/Manual test.

### Solution
1. Automate test_positive_ansible_variables_imported_with_roles for admin and non-admin users
Remove unrelated tests


### Related Issues
This PR includes changes from https://github.com/SatelliteQE/robottelo/pull/16431, this needs to be rebased after merge