### PR TITLE
Add network type option for Host checkout 

### DIFF
--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -167,6 +167,7 @@ def custom_leapp_host(upgrade_path, module_target_sat, module_sca_manifest_org, 
         host_class=ContentHost,
         deploy_rhel_version=upgrade_path['source_version'],
         deploy_flavor=settings.flavors.default,
+        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
     ) as chost:
         result = chost.register(
             module_sca_manifest_org, None, function_leapp_ak.name, module_target_sat

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -876,6 +876,7 @@ def test_positive_apply_for_all_hosts(
         workflow='deploy-rhel',
         host_class=ContentHost,
         _count=num_hosts,
+        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
     ) as hosts:
         if not isinstance(hosts, list) or len(hosts) != num_hosts:
             pytest.fail('Failed to provision the expected number of hosts.')


### PR DESCRIPTION
### Problem Statement
Host checkout failing for IPv6 because we are missing parameter "deploy_network_type" while checking out host.

### Solution
Added parameter "deploy_network_type" while host checkout.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->