### PR TITLE
[6.16.z] update subscription_status_label to subscription_facet_attribute

### DIFF
--- a/tests/upgrades/test_virtwho.py
+++ b/tests/upgrades/test_virtwho.py
@@ -136,14 +136,18 @@ class TestScenarioPositiveVirtWho:
         # Vefify the connection of the guest on Content host
         hypervisor_name = pre_upgrade_data.get('hypervisor_name')
         guest_name = pre_upgrade_data.get('guest_name')
-        hosts = [hypervisor_name, guest_name]
-        for hostname in hosts:
-            result = (
-                target_sat.api.Host(organization=org_id)
-                .search(query={'search': hostname})[0]
-                .read_json()
-            )
-            assert result['subscription_status_label'] == 'Simple Content Access'
+        result = (
+            target_sat.api.Host(organization=org_id)
+            .search(query={'search': hypervisor_name})[0]
+            .read_json()
+        )
+        assert result['subscription_facet_attributes']['virtual_guests'][0]['name'] == guest_name
+        result = (
+            target_sat.api.Host(organization=org_id)
+            .search(query={'search': guest_name})[0]
+            .read_json()
+        )
+        assert hypervisor_name in result['subscription_facet_attributes']['virtual_host']['name']
 
         # Verify the virt-who config-file exists.
         config_file = get_configure_file(vhd.id)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16516

### Problem Statement
update subscription_status_label to subscription_facet_attribute, as there is no subscription_status_label 

Test Cases :  PASS
```
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/upgrades/test_virtwho.py  -m pre_upgrade --disable-pytest-warnings
============================================================== test session starts ===============================================================
platform linux -- Python 3.11.7, pytest-8.3.2, pluggy-1.5.0
Mandatory Requirements Mismatch: cryptography==43.0.1 broker[docker,podman,hussh]==0.5.7 pytest-reportportal==5.4.2 nailgun @ git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun deepdiff==8.0.1 pytest==8.3.3 productmd==1.40 manifester==0.2.8 airgun @ git+https://github.com/SatelliteQE/airgun.git@master#egg=airgun
Optional Requirements Mismatch: sphinx-autoapi==3.3.2 ruff==0.6.7
To update mismatched requirements, run the pytest command with '--update-required-reqs' OR '--update-all-reqs' option.
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gitrepo/robottelo
configfile: pyproject.toml
plugins: reportportal-5.4.1, order-1.3.0, ibutsu-2.2.4, fixturecollection-0.1.2, cov-5.0.0, services-2.2.1, xdist-3.6.1, mock-3.14.0
collected 2 items / 1 deselected / 1 selected                                                                                                    

tests/upgrades/test_virtwho.py .                                                                                                           [100%]

============================================ 1 passed, 1 deselected, 11 warnings in 99.98s (0:01:39) =============================================
(robottelo_vv_master) [root@dell-per740-68-vm-05 robottelo]# pytest ./tests/upgrades/test_virtwho.py  -m post_upgrade --disable-pytest-warnings
============================================================== test session starts ===============================================================
platform linux -- Python 3.11.7, pytest-8.3.2, pluggy-1.5.0
Mandatory Requirements Mismatch: deepdiff==8.0.1 manifester==0.2.8 pytest==8.3.3 pytest-reportportal==5.4.2 productmd==1.40 broker[docker,podman,hussh]==0.5.7 cryptography==43.0.1 airgun @ git+https://github.com/SatelliteQE/airgun.git@master#egg=airgun nailgun @ git+https://github.com/SatelliteQE/nailgun.git@master#egg=nailgun
Optional Requirements Mismatch: ruff==0.6.7 sphinx-autoapi==3.3.2
To update mismatched requirements, run the pytest command with '--update-required-reqs' OR '--update-all-reqs' option.
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/gitrepo/robottelo
configfile: pyproject.toml
plugins: reportportal-5.4.1, order-1.3.0, ibutsu-2.2.4, fixturecollection-0.1.2, cov-5.0.0, services-2.2.1, xdist-3.6.1, mock-3.14.0
collected 2 items / 1 deselected / 1 selected                                                                                                    

tests/upgrades/test_virtwho.py .                                                                                                           [100%]

================================================= 1 passed, 1 deselected, 12 warnings in 59.17s ==================================================

```