### PR TITLE
[6.16.z] avoiding the ohsnap repo url incase of nightly

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -142,11 +142,17 @@ def common_sat_install_assertions(satellite):
 def install_satellite(satellite, installer_args, enable_fapolicyd=False):
     # Register for RHEL8 repos, get Ohsnap repofile, and enable and download satellite
     satellite.register_to_cdn()
-    satellite.download_repofile(
-        product='satellite',
-        release=settings.server.version.release,
-        snap=settings.server.version.snap,
-    )
+    if settings.server.version.source == 'nightly':
+        satellite.create_custom_repos(
+            satellite_repo=settings.repos.satellite_repo,
+            satmaintenance_repo=settings.repos.satmaintenance_repo,
+        )
+    else:
+        satellite.download_repofile(
+            product='satellite',
+            release=settings.server.version.release,
+            snap=settings.server.version.snap,
+        )
     if enable_fapolicyd:
         assert (
             satellite.execute('dnf -y install fapolicyd && systemctl enable --now fapolicyd').status


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16672

### Problem Statement
avoiding the oh-snap repo url in case of nightly, This was missed in my previous work related to upstream sanity  

### Solution
Nightly checks will be added to the satellite repos based on the environment.  

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->