### PR TITLE
[6.16.z] parse package details page link and validate plus sign

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -880,6 +880,8 @@ class CLIFactory:
             custom_repo_url = settings.repos.rhel6_os
         elif options.get('repository') == constants.REPOS['rhel7']['name']:
             custom_repo_url = settings.repos.rhel7_os
+        elif options.get('repository') == constants.REPOS['rhel8_aps']['name']:
+            custom_repo_url = settings.repos.rhel8_os.appstream
         elif 'Satellite Capsule' in options.get('repository'):
             custom_repo_url = settings.repos.capsule_repo
         if force_use_cdn or settings.robottelo.cdn or not custom_repo_url:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16641

### Problem Statement
Customer Case - SAT-26967 - When clicking on the page in the web interface showing the details of a package, there are hyperlinks for "Installed On", "Applicable To" and "Upgradable For".  When you click on any of those three links, they open search pages with a search term like this:

`applicable_rpms=httpd-2.4.37-65.module+el8.10.0 22069 b47f5c72.1.x86_64`

### Solution
Provided fix along with airgun changes would solve this problem and parse link correctly
`installed_package=httpd-2.4.37-65.module+el8.10.0+22069+b47f5c72.1.x86_64`

### Related Issues
Airgun PR - https://github.com/SatelliteQE/airgun/pull/1593


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_package.py -k 'test_positive_parse_package_name_url'
airgun: 1593

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->