### PR TITLE
Add test for host with .ics domain name

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -142,11 +142,17 @@ def common_sat_install_assertions(satellite):
 def install_satellite(satellite, installer_args, enable_fapolicyd=False):
     # Register for RHEL8 repos, get Ohsnap repofile, and enable and download satellite
     satellite.register_to_cdn()
-    satellite.download_repofile(
-        product='satellite',
-        release=settings.server.version.release,
-        snap=settings.server.version.snap,
-    )
+    if settings.server.version.source == 'nightly':
+        satellite.create_custom_repos(
+            satellite_repo=settings.repos.satellite_repo,
+            satmaintenance_repo=settings.repos.satmaintenance_repo,
+        )
+    else:
+        satellite.download_repofile(
+            product='satellite',
+            release=settings.server.version.release,
+            snap=settings.server.version.snap,
+        )
     if enable_fapolicyd:
         if satellite.execute('rpm -q satellite-maintain').status == 0:
             # Installing the rpm on existing sat needs sat-maintain perms

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -258,17 +258,25 @@ def test_positive_read_from_details_page(session, module_host_template):
 
 
 def test_read_host_with_ics_domain(
-    session, module_host_template, module_location, module_org, target_sat
+    session, module_host_template, module_location, module_org, module_target_sat
 ):
     """Create new Host with ics domain name and verify that it can be read
 
     :id: 54e3db92-16c2-412b-bf68-44d479c5987b
 
+    :steps:
+        1. Create a host with a domain ending in .ics
+        2. Read the host's details through the UI
+
     :expectedresults: Host ending with ics domain name can be accessed through Host UI
+
+    :customerscenario: true
+
+    :Verifies: SAT-26202
     """
     template = module_host_template
     template.name = gen_string('alpha').lower()
-    ics_domain = target_sat.api.Domain(
+    ics_domain = module_target_sat.api.Domain(
         location=[module_location],
         organization=[module_org],
         name=gen_string('alpha').lower() + '.ics',
@@ -276,7 +284,7 @@ def test_read_host_with_ics_domain(
     template.domain = ics_domain
     host = template.create()
     host_name = host.name
-    with session:
+    with module_target_sat.ui_session() as session:
         values = session.host_new.get_details(host_name, widget_names='details')
         assert (
             values['details']['system_properties']['sys_properties']['domain']

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -257,6 +257,34 @@ def test_positive_read_from_details_page(session, module_host_template):
         assert 'Admin User' in values['properties']['properties_table']['Owner']
 
 
+def test_read_host_with_ics_domain(
+    session, module_host_template, module_location, module_org, target_sat
+):
+    """Create new Host with ics domain name and verify that it can be read
+
+    :id: 54e3db92-16c2-412b-bf68-44d479c5987b
+
+    :expectedresults: Host ending with ics domain name can be accessed through Host UI
+    """
+    template = module_host_template
+    template.name = gen_string('alpha').lower()
+    ics_domain = target_sat.api.Domain(
+        location=[module_location],
+        organization=[module_org],
+        name=gen_string('alpha').lower() + '.ics',
+    ).create()
+    template.domain = ics_domain
+    host = template.create()
+    host_name = host.name
+    with session:
+        values = session.host_new.get_details(host_name, widget_names='details')
+        assert (
+            values['details']['system_properties']['sys_properties']['domain']
+            == template.domain.name
+        )
+        assert values['details']['system_properties']['sys_properties']['name'] == host_name
+
+
 @pytest.mark.tier4
 def test_positive_read_from_edit_page(session, host_ui_options):
     """Create new Host and read all its content through edit page
@@ -273,9 +301,6 @@ def test_positive_read_from_edit_page(session, host_ui_options):
         values = session.host.read(host_name)
         assert values['host']['name'] == host_name.partition('.')[0]
         assert values['host']['organization'] == api_values['host.organization']
-        assert values['host']['location'] == api_values['host.location']
-        assert values['host']['lce'] == ENVIRONMENT
-        assert values['host']['content_view'] == DEFAULT_CV
         assert (
             values['operating_system']['architecture']
             == api_values['operating_system.architecture']


### PR DESCRIPTION
### Problem Statement
This is testing a case where hosts assigned a domain ending in .ics cause Satellite to error out on old and new UI when navigating to the details page. 

### Related Issues
https://issues.redhat.com/browse/SAT-26202

### PRT 
trigger: test-robottelo
pytest: tests/foreman/ui/test_host.py -k 'test_read_host_with_ics_domain'
