### PR TITLE
Actions comment pull request bump fix

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -163,8 +163,8 @@ jobs:
         with:
           message: |
             trigger: test-robottelo
-          pr_number: ${{ steps.create_pr.outputs.pr_number }}
-          GITHUB_TOKEN: ${{ secrets._REPO_ADMIN_TOKEN }}
+          pr-number: ${{ steps.create_pr.outputs.pr_number }}
+          github-token: ${{ secrets._REPO_ADMIN_TOKEN }}
 
       - name: add the no-cherrypick label
         uses: actions/github-script@v7
@@ -299,8 +299,8 @@ jobs:
         with:
           message: |
             trigger: test-robottelo
-          pr_number: ${{ steps.create_pr.outputs.pr_number }}
-          GITHUB_TOKEN: ${{ secrets._REPO_ADMIN_TOKEN }}
+          pr-number: ${{ steps.create_pr.outputs.pr_number }}
+          github-token: ${{ secrets._REPO_ADMIN_TOKEN }}
 
       - name: add the no-cherrypick label
         uses: actions/github-script@v7

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -81,8 +81,8 @@ jobs:
         with:
           message: |
             ${{ needs.find-the-parent-prt-comment.outputs.prt_comment }}
-          pr_number: ${{ steps.cherrypick.outputs.number  }}
-          GITHUB_TOKEN: ${{ secrets.CHERRYPICK_PAT }}
+          pr-number: ${{ steps.cherrypick.outputs.number  }}
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
 
       - name: is autoMerging enabled for Auto CherryPicked PRs ?
         if: ${{ always() && steps.cherrypick.outcome == 'success' && contains(github.event.pull_request.labels.*.name, 'AutoMerge_Cherry_Picked') }}

--- a/.github/workflows/auto_cherry_pick_merged.yaml
+++ b/.github/workflows/auto_cherry_pick_merged.yaml
@@ -137,8 +137,8 @@ jobs:
         with:
           message: |
             ${{ needs.get-parentPR-details.outputs.prt_comment }}
-          pr_number: ${{ steps.cherrypick.outputs.number  }}
-          GITHUB_TOKEN: ${{ secrets.CHERRYPICK_PAT }}
+          pr-number: ${{ steps.cherrypick.outputs.number  }}
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
 
       - name: is autoMerging enabled for Auto CherryPicked PRs ?
         if: ${{ always() && steps.cherrypick.outcome == 'success' && contains(needs.get-parentPR-details.outputs.labels.*.name, 'AutoMerge_Cherry_Picked') }}

--- a/.github/workflows/prt_result.yml
+++ b/.github/workflows/prt_result.yml
@@ -40,8 +40,8 @@ jobs:
             PRT Comment: ${{ github.event.inputs.prt_comment }}
             Test Result : ${{ github.event.inputs.pytest_result }}
             ```
-          pr_number: ${{ github.event.inputs.pr_number }}
-          GITHUB_TOKEN: ${{ secrets.CHERRYPICK_PAT }}
+          pr-number: ${{ github.event.inputs.pr_number }}
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
 
       - name: Add the PRT passed/failed labels
         id: prt-status


### PR DESCRIPTION
### Problem Statement
After upgrade to from version 2 to 3 for thollander/actions-comment-pull-request@v3 causing issues in PRT and other GHA's after looking at closely https://github.com/SatelliteQE/robottelo/actions/runs/11361084949/job/31600069885#step:2:2 I believe this mostly because of the changes in the parameters 

### Solution
updated the GHA to use the updated parameters 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->