### PR TITLE
[6.16.z] Update verifies jira in FDI validation test

### DIFF
--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -427,7 +427,7 @@ def test_positive_verify_updated_fdi_image(target_sat):
 
     :expectedresults: Installed foreman-discovery-image is built on latest up-to-date RHEL
 
-    Verifies: SAT-24197, SAT-25275
+    Verifies: SAT-24197, SAT-27541
 
     :customerscenario: true
 
@@ -438,7 +438,7 @@ def test_positive_verify_updated_fdi_image(target_sat):
     target_sat.execute('yum -y --disableplugin=foreman-protector install foreman-discovery-image')
 
     if target_sat.os_version.major == 9:
-        version = '8.10' if is_open('SAT-25275') else str(target_sat.os_version)
+        version = '8.10' if is_open('SAT-27541') else str(target_sat.os_version)
     elif target_sat.os_version.major == 8:
         version = str(target_sat.os_version)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16698

### Problem Statement
SAT-25275 was closed in favor of SAT-27541, which caused this test to fail for EL9

### Solution
Removing SAT-25275 used in is_open, and updating it to use SAT-27541

