### PR TITLE
Fix AK for errata UI tests

### DIFF
--- a/pytest_fixtures/component/activationkey.py
+++ b/pytest_fixtures/component/activationkey.py
@@ -26,9 +26,8 @@ def function_activation_key(function_sca_manifest_org, target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_ak(module_lce, module_org, module_target_sat):
+def module_ak(module_org, module_target_sat):
     return module_target_sat.api.ActivationKey(
-        environment=module_lce,
         organization=module_org,
     ).create()
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -608,19 +608,21 @@ class APIFactory:
             # updated entities after promoting
             entities = {k: v.read() for k, v in entities.items()}
 
+        updates = []
         if (  # assign env to ak if not present
             entities['ActivationKey'].environment is None
             or entities['ActivationKey'].environment.id != entities['LifecycleEnvironment'].id
         ):
             entities['ActivationKey'].environment = entities['LifecycleEnvironment']
-            entities['ActivationKey'].update(['environment'])
-            entities = {k: v.read() for k, v in entities.items()}
+            updates.append('environment')
         if (  # assign cv to ak if not present
             entities['ActivationKey'].content_view is None
             or entities['ActivationKey'].content_view.id != entities['ContentView'].id
         ):
             entities['ActivationKey'].content_view = entities['ContentView']
-            entities['ActivationKey'].update(['content_view'])
+            updates.append('content_view')
+        if updates:
+            entities['ActivationKey'].update(['content_view', 'environment'])  # both needed anyway
 
         entities = {k: v.read() for k, v in entities.items()}
         if enable_repos:


### PR DESCRIPTION
### Problem Statement
Since 6.17 Activation keys create and update ops need both - CV and LCE, or none of them. 
This new reality broke a couple of tests.


### Solution
This PR fixes UI errata tests accordingly. Others will follow.


### Related Issues
https://issues.redhat.com/browse/SAT-28577


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_errata.py
