### PR TITLE
[6.13.z] Fix Upgrade scenarios

### DIFF
--- a/tests/upgrades/test_discovery.py
+++ b/tests/upgrades/test_discovery.py
@@ -28,7 +28,7 @@ class TestDiscoveryImage:
     """
 
     @pytest.mark.pre_upgrade
-    def test_pre_upgrade_fdi_version(self, target_sat, save_test_data, request):
+    def test_pre_upgrade_fdi_version(self, target_sat, save_test_data):
         """Test FDI version before upgrade.
 
         :id: preupgrade-8c94841c-6791-4af0-aa9c-e54c8d8b9a92
@@ -43,7 +43,7 @@ class TestDiscoveryImage:
         fdi_package = target_sat.execute('rpm -qa *foreman-discovery-image*').stdout
         # Note: The regular exp takes care of format digit.digit.digit or digit.digit.digit-digit in the output
         pre_upgrade_version = Version(re.search(r'\d+\.\d+\.\d+(-\d+)?', fdi_package).group())
-        save_test_data({'pre_upgrade_version': pre_upgrade_version})
+        save_test_data({'pre_upgrade_version': str(pre_upgrade_version)})
 
     @pytest.mark.post_upgrade(depend_on=test_pre_upgrade_fdi_version)
     def test_post_upgrade_fdi_version(self, target_sat, pre_upgrade_data):
@@ -60,5 +60,5 @@ class TestDiscoveryImage:
         fdi_package = target_sat.execute('rpm -qa *foreman-discovery-image*').stdout
         # Note: The regular exp takes care of format digit.digit.digit or digit.digit.digit-digit in the output
         post_upgrade_version = Version(re.search(r'\d+\.\d+\.\d+(-\d+)?', fdi_package).group())
-        assert post_upgrade_version >= pre_upgrade_version
+        assert post_upgrade_version >= Version(pre_upgrade_version)
         target_sat.unregister()

--- a/tests/upgrades/test_provisioningtemplate.py
+++ b/tests/upgrades/test_provisioningtemplate.py
@@ -12,8 +12,6 @@
 
 """
 
-import json
-
 from fauxfactory import gen_string
 import pytest
 
@@ -75,13 +73,11 @@ class TestScenarioPositiveProvisioningTemplates:
 
         for kind in provisioning_template_kinds:
             assert host.read_template(data={'template_kind': kind})
-
         pre_update_data_dict = {
-            'provision_host_id': host.id,
+            'provision_host_name': host.name,
             'pxe_loader': pxe_loader.pxe_loader,
         }
-        pre_update_json_file = json.dumps(pre_update_data_dict, indent=2)
-        save_test_data(pre_update_json_file)
+        save_test_data(pre_update_data_dict)
 
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_provisioning_templates)
     @pytest.mark.parametrize('pre_upgrade_data', ['bios', 'uefi'], indirect=True)
@@ -106,7 +102,7 @@ class TestScenarioPositiveProvisioningTemplates:
         """
         pxe_loader = pre_upgrade_data.pxe_loader
         pre_upgrade_host = module_target_sat.api.Host().search(
-            query={'search': f'id={pre_upgrade_data.provision_host_id}'}
+            query={'search': f'name={pre_upgrade_data.provision_host_name}'}
         )[0]
         request.addfinalizer(pre_upgrade_host.delete)
         org = module_target_sat.api.Organization(id=pre_upgrade_host.organization.id).read()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16477

### Problem Statement
Provisioning Template and Foreman Discovery Upgrade Scenario tests are failing with JSON parse error. 

### Solution

- Updated  `test_pre_scenario_provisioning_templates` to save hostname instead of host id in pre_upgrade_data file. 
- Saving FDI version in string format in `test_pre_upgrade_fdi_version`  as Version type data is not supported to be stored.


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->