### PR TITLE
Fix AK for errata CLI tests

### DIFF
--- a/pytest_fixtures/component/activationkey.py
+++ b/pytest_fixtures/component/activationkey.py
@@ -26,9 +26,8 @@ def function_activation_key(function_sca_manifest_org, target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_ak(module_lce, module_org, module_target_sat):
+def module_ak(module_org, module_target_sat):
     return module_target_sat.api.ActivationKey(
-        environment=module_lce,
         organization=module_org,
     ).create()
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -608,19 +608,21 @@ class APIFactory:
             # updated entities after promoting
             entities = {k: v.read() for k, v in entities.items()}
 
+        updates = []
         if (  # assign env to ak if not present
             entities['ActivationKey'].environment is None
             or entities['ActivationKey'].environment.id != entities['LifecycleEnvironment'].id
         ):
             entities['ActivationKey'].environment = entities['LifecycleEnvironment']
-            entities['ActivationKey'].update(['environment'])
-            entities = {k: v.read() for k, v in entities.items()}
+            updates.append('environment')
         if (  # assign cv to ak if not present
             entities['ActivationKey'].content_view is None
             or entities['ActivationKey'].content_view.id != entities['ContentView'].id
         ):
             entities['ActivationKey'].content_view = entities['ContentView']
-            entities['ActivationKey'].update(['content_view'])
+            updates.append('content_view')
+        if updates:
+            entities['ActivationKey'].update(['content_view', 'environment'])  # both needed anyway
 
         entities = {k: v.read() for k, v in entities.items()}
         if enable_repos:

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -666,7 +666,12 @@ class CLIFactory:
             # Associate activation key with CV just to be sure
             try:
                 self._satellite.cli.ActivationKey.update(
-                    {'content-view-id': cv_id, 'id': activationkey_id, 'organization-id': org_id}
+                    {
+                        'id': activationkey_id,
+                        'organization-id': org_id,
+                        'content-view-id': cv_id,
+                        'lifecycle-environment-id': env_id,
+                    }
                 )
             except CLIReturnCodeError as err:
                 raise CLIFactoryError(
@@ -818,7 +823,12 @@ class CLIFactory:
             # Associate activation key with CV just to be sure
             try:
                 self._satellite.cli.ActivationKey.update(
-                    {'id': activationkey_id, 'organization-id': org_id, 'content-view-id': cv_id}
+                    {
+                        'id': activationkey_id,
+                        'organization-id': org_id,
+                        'content-view-id': cv_id,
+                        'lifecycle-environment-id': env_id,
+                    }
                 )
             except CLIReturnCodeError as err:
                 raise CLIFactoryError(

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -1162,6 +1162,7 @@ def new_module_ak(
 ):
     new_module_ak = module_target_sat.api.ActivationKey(
         environment=module_lce_library,
+        content_view=module_sca_manifest_org.default_content_view,
         organization=module_sca_manifest_org,
     ).create()
     # Ensure tools repo is enabled in the activation key


### PR DESCRIPTION
### Problem Statement
Since 6.17 Activation keys create and update ops need both - CV and LCE, or none of them.
This new reality broke a couple of tests.


### Solution
This PR fixes CLI errata tests accordingly. Others will follow.


### Related Issues
https://issues.redhat.com/browse/SAT-28577


### PRT test Cases example
There is another fix in katello still missing in stream snap 76 (`--name` is required when `--id` is provided for AK update), that's why I used packit/PRT bellow
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_errata.py
Katello:
    katello: 11166
```
