### PR TITLE
Fix pre_upgrade_data for single postupgrade tes

### DIFF
--- a/tests/upgrades/conftest.py
+++ b/tests/upgrades/conftest.py
@@ -261,12 +261,9 @@ def pre_upgrade_data(request):
         end_index = test_node_id.find(']')
         extracted_value = test_node_id[start_index:end_index]
         upgrade_data[extracted_value] = _read_test_data(test_node_id)
-    if len(upgrade_data) == 1:
-        param_value = next(iter(upgrade_data.values()))
-    else:
-        param_value = upgrade_data.get(request.param)
-        if param_value is None:
-            pytest.fail(f"Invalid test parameter: {request.param}. Test data not found.")
+    param_value = upgrade_data.get(request.param)
+    if param_value is None:
+        pytest.fail(f"Invalid test parameter: {request.param}. Test data not found.")
     return Box(param_value)
 
 


### PR DESCRIPTION
### Problem Statement
It is not possible to run single postupgrade test

### Solution
Avoid slicing pre_upgrade_data dictionary for single postupgrade test

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->