### PR TITLE
Remove reverse proxy assertion code from test_capsule_installation

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -434,14 +434,6 @@ def test_capsule_installation(
     result = cap_ready_rhel.cli.Health.check()
     assert 'FAIL' not in result.stdout
 
-    # Verify foreman-proxy-content-reverse-proxy and port 8443 are disabled on default installation
-    help_result = cap_ready_rhel.execute(
-        "satellite-installer --full-help | grep foreman-proxy-content-reverse-proxy"
-    )
-    assert "Add reverse proxy to the parent (current: false)" in help_result.stdout
-    port_result = cap_ready_rhel.execute("ss -tuln | grep 8443")
-    assert not port_result.stdout
-
 
 @pytest.mark.e2e
 @pytest.mark.tier1


### PR DESCRIPTION
### Problem Statement
We have dropped support for port 8443 as a reverse proxy in Stream and it's causing test_capsule_installation to fail.

### Solution
- Remove code for reverse proxy 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->