### PR TITLE
Satellite version validation skip for nightly

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -109,7 +109,8 @@ def extract_help(filter='params'):
 
 def common_sat_install_assertions(satellite):
     sat_version = 'stream' if satellite.is_stream else satellite.version
-    assert settings.server.version.release == sat_version
+    if settings.server.version.source != 'nightly':
+        assert settings.server.version.release == sat_version
 
     # no errors/failures in journald
     result = satellite.execute(


### PR DESCRIPTION
### Problem Statement
Satellite version validation is failing as the full version is not being seeded in UMB. But while comparing the UMB satellite version with the installed satellite rpm, it fails.

### Solution
Skipping the version comparison until we have a proper solution from Delivery.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->