### PR TITLE
preparation for new yggdrasil

### DIFF
--- a/tests/foreman/api/test_remoteexecution.py
+++ b/tests/foreman/api/test_remoteexecution.py
@@ -142,10 +142,13 @@ def test_negative_time_to_pickup(
     )
     assert result.status == 0, f'Failed to register host: {result.stderr}'
     # check mqtt client is running
-    result = rhel_contenthost.execute('systemctl status yggdrasild')
+    service_name = (
+        'yggdrasil' if float(rhel_contenthost.os_distribution_version) > 9.5 else 'yggdrasild'
+    )
+    result = rhel_contenthost.execute(f'systemctl status {service_name}')
     assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
     # stop yggdrasil client on host
-    result = rhel_contenthost.execute('systemctl stop yggdrasild')
+    result = rhel_contenthost.execute(f'systemctl stop {service_name}')
     assert result.status == 0, f'Failed to stop yggdrasil on client: {result.stderr}'
 
     # run script provider rex command with time_to_pickup
@@ -205,11 +208,10 @@ def test_negative_time_to_pickup(
     global_ttp.value = default_global_ttp
     global_ttp.update(['value'])
     # start yggdrasil client on host
-    result = rhel_contenthost.execute('systemctl start yggdrasild')
+    result = rhel_contenthost.execute(f'systemctl start {service_name}')
     assert result.status == 0, f'Failed to start on client: {result.stderr}'
-    result = rhel_contenthost.execute('systemctl status yggdrasild')
+    result = rhel_contenthost.execute(f'systemctl status {service_name}')
     assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
-    rhel_contenthost.execute('yggdrasil status')
 
 
 @pytest.mark.tier3

--- a/tests/foreman/destructive/test_registration.py
+++ b/tests/foreman/destructive/test_registration.py
@@ -52,9 +52,11 @@ def test_host_registration_rex_pull_mode(
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # check mqtt client is running
-    result = rhel_contenthost.execute('systemctl status yggdrasild')
+    service_name = (
+        'yggdrasil' if float(rhel_contenthost.os_distribution_version) > 9.5 else 'yggdrasild'
+    )
+    result = rhel_contenthost.execute(f'systemctl status {service_name}')
     assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
-    assert rhel_contenthost.execute('yggdrasil status').status == 0
     mqtt_url = f'mqtts://{module_satellite_mqtt.hostname}:1883'
     assert rhel_contenthost.execute(f'cat /etc/yggdrasil/config.toml | grep {mqtt_url}').status == 0
 
@@ -77,9 +79,8 @@ def test_host_registration_rex_pull_mode(
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
     # check mqtt client is running
-    result = rhel_contenthost.execute('systemctl status yggdrasild')
+    result = rhel_contenthost.execute(f'systemctl status {service_name}')
     assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
-    assert rhel_contenthost.execute('yggdrasil status').status == 0
     new_mqtt_url = f'mqtts://{module_capsule_configured_mqtt.hostname}:1883'
     assert (
         rhel_contenthost.execute(f'cat /etc/yggdrasil/config.toml | grep {new_mqtt_url}').status


### PR DESCRIPTION
### Problem Statement
SAT-27476

template changes and a different service name on rhel 10 and 9.6+

### Solution
this pr

### Related Issues
awaits https://github.com/theforeman/foreman/pull/10340

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->