### PR TITLE
Fix brace expansion syntax in reset_rhsm

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -598,7 +598,7 @@ class ContentHost(Host, ContentHostMixins):
         """Global Registration points the host's sub-man to talk to the Sattelite's Candlepin
         but saves the original rhsm.conf. Reset the rhsm.conf so that it points back to the CDN.
         """
-        self.execute(r'\cp -f /etc/rhsm/rhsm.conf{.bak,}')
+        self.execute(r'\cp -f /etc/rhsm/rhsm.conf{,.bak}')
         self.execute('subscription-manager clean')
         self._satellite = None
 


### PR DESCRIPTION
### Problem Statement
As currently written, the brace expansion in the `reset_rhsm` method uses incorrect syntax that produces the following error:
```
# cp -f /etc/rhsm//rhsm.conf{.bak,}
cp: cannot stat '/etc/rhsm//rhsm.conf.bak': No such file or directory
```

### Solution
Place the comma separator immediately after the opening brace.
```
# cp -f /etc/rhsm//rhsm.conf{,.bak}
# ll /etc/rhsm/rhsm.conf*
-rw-r--r--. 1 root root 3141 Jan 25  2024 /etc/rhsm/rhsm.conf
-rw-r--r--. 1 root root 3141 Oct 25 12:36 /etc/rhsm/rhsm.conf.bak
```
