### PR TITLE
[6.15.z][Sanity Testing] Capsule Sanity Testing for capsule sync (#16558)

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -199,8 +199,11 @@ def large_capsule_configured(large_capsule_host, target_sat):
 @pytest.fixture(scope='module')
 def module_capsule_configured(request, module_capsule_host, module_target_sat):
     """Configure the capsule instance with the satellite from settings.server.hostname"""
-    if not request.config.option.n_minus:
+    if not any([request.config.option.n_minus, 'build_sanity' in request.config.option.markexpr]):
         module_capsule_host.capsule_setup(sat_host=module_target_sat)
+    # The capsule is being set here by capsule installation test of `test_installer.py` for sanity
+    if 'build_sanity' in request.config.option.markexpr:
+        return Capsule.get_host_by_hostname(settings.capsule.hostname)
     return module_capsule_host
 
 

--- a/pytest_fixtures/core/xdist.py
+++ b/pytest_fixtures/core/xdist.py
@@ -6,7 +6,7 @@ from broker import Broker
 import pytest
 
 from robottelo.config import configure_airgun, configure_nailgun, settings
-from robottelo.hosts import Satellite
+from robottelo.hosts import Capsule, Satellite
 from robottelo.logging import logger
 
 
@@ -16,6 +16,12 @@ def align_to_satellite(request, worker_id, satellite_factory):
     if 'build_sanity' in request.config.option.markexpr:
         settings.set("server.hostname", None)
         yield
+        # Checkout Sanity Capsule finally
+        if settings.capsule.hostname:
+            sanity_cap = Capsule.get_host_by_hostname(settings.capsule.hostname)
+            sanity_cap.unregister()
+            Broker(hosts=[sanity_cap]).checkin()
+        # Checkout Sanity Satellite finally
         if settings.server.hostname:
             sanity_sat = Satellite(settings.server.hostname)
             sanity_sat.unregister()

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -23,6 +23,7 @@ from fauxfactory import gen_alpha, gen_string
 from manifester import Manifester
 from nailgun import entities
 from packaging.version import Version
+import pytest
 import requests
 from ssh2.exceptions import AuthenticationError
 from wait_for import TimedOutError, wait_for
@@ -397,6 +398,13 @@ class ContentHost(Host, ContentHostMixins):
     def teardown(self):
         logger.debug('START: tearing down host %s', self)
         if not self.blank and not getattr(self, '_skip_context_checkin', False):
+            if (
+                hasattr(pytest, 'capsule_sanity')
+                and pytest.capsule_sanity is True
+                and type(self) is Capsule
+            ):
+                logger.debug('END: Skipping tearing down caspule host %s for sanity', self)
+                return
             self.unregister()
             if type(self) is not Satellite:  # do not delete Satellite's host record
                 self._delete_host_record()

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -572,6 +572,8 @@ class TestCapsuleContentManagement:
         assert set(sat_isos) == set(caps_isos)
 
     @pytest.mark.tier4
+    @pytest.mark.build_sanity
+    @pytest.mark.order(after="tests/foreman/installer/test_installer.py::test_capsule_installation")
     @pytest.mark.skip_if_not_set('capsule', 'fake_manifest')
     def test_positive_on_demand_sync(
         self,


### PR DESCRIPTION
CherryPick of #16558 

### Problem Statement
- The capsule sanity support has been added in https://github.com/SatelliteQE/robottelo/pull/15948
- The capsule sync test was asked to cover as the DEVs build test was covering it.

### Solution
- The support is added for capsule sync.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->