### PR TITLE
[6.16.z] Add conditioning for pool attach

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -317,6 +317,7 @@ SM_OVERALL_STATUS = {
     'current': 'Overall Status: Current',
     'invalid': 'Overall Status: Invalid',
     'insufficient': 'Overall Status: Insufficient',
+    'disabled': 'Overall Status: Disabled',
     'unknown': 'Overall Status: Unknown',
 }
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -46,6 +46,7 @@ from robottelo.constants import (
     RHSSO_RESET_PASSWORD,
     RHSSO_USER_UPDATE,
     SATELLITE_VERSION,
+    SM_OVERALL_STATUS,
 )
 from robottelo.exceptions import CLIFactoryError, DownloadFileError, HostPingFailed
 from robottelo.host_helpers import CapsuleMixins, ContentHostMixins, SatelliteMixins
@@ -1429,8 +1430,6 @@ class ContentHost(Host, ContentHostMixins):
 
     def register_to_cdn(self, pool_ids=None, enable_proxy=False):
         """Subscribe satellite to CDN"""
-        if pool_ids is None:
-            pool_ids = [settings.subscription.rhn_poolid]
         self.reset_rhsm()
         cmd_result = self.register_contenthost(
             org=None,
@@ -1443,11 +1442,17 @@ class ContentHost(Host, ContentHostMixins):
             raise ContentHostError(
                 f'Error during registration, command output: {cmd_result.stdout}'
             )
-        cmd_result = self.subscription_manager_attach_pool(pool_ids)[0]
-        if cmd_result.status != 0:
-            raise ContentHostError(
-                f'Error during pool attachment, command output: {cmd_result.stdout}'
-            )
+        # Attach a pool only if the Org isn't SCA yet
+        sub_status = self.subscription_manager_status().stdout
+        if SM_OVERALL_STATUS['disabled'] not in sub_status:
+            if pool_ids in [None, []]:
+                pool_ids = [settings.subscription.rhn_poolid]
+            for pid in pool_ids:
+                int(pid, 16)  # raises ValueError if not a HEX number
+            cmd_result = self.subscription_manager_attach_pool(pool_ids)
+            for res in cmd_result:
+                if res.status != 0:
+                    raise ContentHostError(f'Pool attachment failed with output: {res.stdout}')
 
     def ping_host(self, host):
         """Check the provisioned host status by pinging the ip of host


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16575

### Problem Statement
The default RH-Sat-QE account will be flipped to the SCA mode soon (currently the SCA is disabled there). As a result pools manipulation like attach/auto-attach won't be applicable when registering hosts via that account.


### Solution
We should get rid of using pools. But before we do so and before we really flip for SCA, we could check the subscription status of the host being registered and attach pool only when it is still in the entitlement mode.


### Testing
I tested the dummie bellow locally and ensured the registration succeeds for both account modes, SCA and entitlement.
Also tried Manifester using the offline token from my SCA account and worked well.
```
def test_dummie(target_sat, rhel_contenthost, module_sca_manifest_org):
    rhel_contenthost.register_to_cdn()
    rhel_contenthost.unregister()
```
Result:
```
(venv) [vsedmik@fedora robottelo]$ pytest tests/foreman/cli/test_host.py -k dummie
=============================== test session starts ===============================
collected 102 items / 96 deselected / 6 selected                                                                                                                                                                                       

tests/foreman/cli/test_host.py ......                                       [100%]

=========== 6 passed, 96 deselected, 286 warnings in 1569.86s (0:26:09) ===========
```

### Other considerations
There are still several areas in robottelo where the subscriptions are attached like in the entitlement mode - typically Activation Keys and Hosts. Since this functionality is still supported by Satellite, I'm not going to remove that yet.
