### PR TITLE
Add test to check Satellite documention links for GA'ed Satellite

### DIFF
--- a/tests/foreman/ui/test_documentation_links.py
+++ b/tests/foreman/ui/test_documentation_links.py
@@ -1,0 +1,92 @@
+"""Test module for verifying Documentation links
+
+:Requirement: Branding
+
+:CaseAutomation: Automated
+
+:CaseComponent: Branding
+
+:Team: Platform
+
+:CaseImportance: High
+
+"""
+
+from collections import defaultdict
+
+import pytest
+import requests
+
+from robottelo.config import settings
+from robottelo.logging import logger
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(
+    (settings.server.version.release.split('.')[0:2] in settings.robottelo.sat_non_ga_versions),
+    reason="The test don't yet support verifying documentation links for non GA'ed Satellite release.",
+)
+def test_positive_documentation_links(target_sat):
+    """Verify that Satellite documentation links are working.
+        Note: At the moment, the test doesn't support verifying links hidden behind a button.
+        Currently, the only such link is on RH Cloud > Inventory Upload page.
+
+    :id: 5e6cba22-896a-4d86-95b4-87d0cc2f1cb6
+
+    :Steps:
+
+        1. Gather documentation links present on various Satellite pages.
+        2. Verify the links are working (returns 200).
+
+    :expectedresults: All the Documentation links present on Satellite are working
+    """
+    pages = [
+        'about',
+        'settings',
+        'bookmark',
+        'role',
+        'ldapauthentication',
+        'cloudinventory',
+        'ansiblevariables',
+        'ansibleroles',
+        'discoveryrule',
+        'global_parameter',
+        'oscapreport',
+        'oscappolicy',
+        'oscapcontent',
+        'jobtemplate',
+        'provisioningtemplate',
+        'partitiontable',
+        'operatingsystem',
+        'host',
+        'discoveredhosts',
+        'reporttemplate',
+        'configreport',
+        'jobinvocation',
+        'audit',
+        'factvalue',
+        'dashboard',
+    ]
+    all_links = defaultdict(list)
+    pages_with_broken_links = defaultdict(list)
+    with target_sat.ui_session() as session:
+        for page in pages:
+            page_object = getattr(session, page)
+            if page == "host":
+                view = page_object.navigate_to(page_object, 'Register')
+            elif page == "oscappolicy":
+                view = page_object.navigate_to(page_object, 'New')
+            else:
+                view = page_object.navigate_to(page_object, 'All')
+            # Get the doc links present on the page.
+            all_links[page] = view.documentation_links()
+            assert all_links[page], f"Couldn't find any documentation links on {page} page."
+        logger.info(
+            f"Following are the documentation links collected from Satellite: \n {all_links}"
+        )
+        for page in pages:
+            for link in all_links[page]:
+                if requests.get(link, verify=False).status_code != 200:
+                    pages_with_broken_links[page].append(link)
+                    logger.info(f"Following link on {page} page seems broken: \n {link}")
+        assert not pages_with_broken_links, f"There are Satellite pages with broken documentation links. \n {print(pages_with_broken_links)}"


### PR DESCRIPTION
### Problem Statement
Historically, after a Satellite release, we have found that the documentation links on Satellite pages were broken, causing bugs and customer cases to be filed, resulting in a poor user experience.

### Solution
- Add airgun support to get documentation links from a Satellite page. See https://github.com/SatelliteQE/airgun/pull/1611 
- Add Robottelo tests to verify that the documentation links on Satellite pages are working.

### Related Issues
- See SAT-27552
- Depends on https://github.com/SatelliteQE/airgun/pull/1611 

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->