### PR TITLE
[6.16.z] removing cloned_from_id key from template object

### DIFF
--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -187,7 +187,7 @@ class TestProvisioningTemplate:
         # clone
         template_origin = template.read_json()
         # remove unique keys
-        unique_keys = ('updated_at', 'created_at', 'id', 'name')
+        unique_keys = ('updated_at', 'created_at', 'id', 'name', 'cloned_from_id')
         template_origin = {
             key: value for key, value in template_origin.items() if key not in unique_keys
         }


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16813

### Problem Statement
The value of `cloned_from_id` differs between the two instances, while the rest of the data matches. Since `dupe_json` is cloned from `template`, it inherits the id from `template`, whereas the template object itself was created directly and does not have a clone id . And it causes an assertion error. I remove `cloned_from_id` to prevent the assertion from failing.

### Solution
I remove `cloned_from_id` key to prevent the assertion from failing and removing `cloned_from_id` does not impact the test.