### PR TITLE
[6.16.z] Fix test_positive_mismatched_satellite_fqdn

### DIFF
--- a/tests/foreman/destructive/test_installer.py
+++ b/tests/foreman/destructive/test_installer.py
@@ -28,10 +28,15 @@ def set_random_fqdn(target_sat):
     shortname = gen_string('alpha')
     new_domain = gen_domain()
     target_sat.execute(
-        f'echo "search {new_domain}" >> /etc/resolv.conf; hostnamectl set-hostname {shortname}'
+        'mv -f /etc/resolv.conf /etc/resolv.conf.bak; '
+        f'echo "search {new_domain}" > /etc/resolv.conf; '
+        f'hostnamectl set-hostname {shortname}'
     )
     yield shortname, new_domain
-    target_sat.execute(f'hostnamectl set-hostname {target_sat.hostname}')
+    target_sat.execute(
+        'mv -f /etc/resolv.conf.bak /etc/resolv.conf; '
+        f'hostnamectl set-hostname {target_sat.hostname}'
+    )
 
 
 def test_installer_sat_pub_directory_accessibility(target_sat):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16796

Test seemed to randomly fail on assertion at https://github.com/SatelliteQE/robottelo/blob/952b960381ce5817ffdd5598c3d9fc4ef8b9fff0/tests/foreman/destructive/test_installer.py#L109

After some investigation I found out that the domain is being generated randomly and for some domains (e.g. _test.com_, _test.biz_) the output of `hostname --fqdn` returns FQDN, not just "shortname" as we expected.

Removing nameservers from /etc/resolv.conf solves the issue.

```
> hostnamectl set-hostname testname # set test hostname
> echo "search example.info" > /etc/resolv.conf # set search domain to example.info
> hostname --fqdn # hostname prints only hostname without domain name
testname
> sed -i "s/^search.*/search test.biz/" /etc/resolv.conf # set search domain to test.biz
> hostname --fqdn # for some reason the fqdn is printed
testname.test.biz
> sed -i "/nameserver.*/d" /etc/resolv.conf # remove nameservers
> hostname --fqdn # only hostname without domain name is printed
testname
```
