### PR TITLE
[6.16.z] Add test for baremetal secureboot provisioning

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -287,6 +287,7 @@ def pxe_loader(request):
         'uefi': {'vm_firmware': 'uefi', 'pxe_loader': 'Grub2 UEFI'},
         'ipxe': {'vm_firmware': 'bios', 'pxe_loader': 'iPXE Embedded'},
         'http_uefi': {'vm_firmware': 'uefi', 'pxe_loader': 'Grub2 UEFI HTTP'},
+        'secureboot': {'vm_firmware': 'uefi_secureboot', 'pxe_loader': 'Grub2 UEFI SecureBoot'},
     }
     return Box(PXE_LOADER_MAP[getattr(request, 'param', 'bios')])
 

--- a/pytest_fixtures/component/provision_vmware.py
+++ b/pytest_fixtures/component/provision_vmware.py
@@ -5,6 +5,7 @@ from wrapanapi import VMWareSystem
 from wrapanapi.systems.virtualcenter import VMWareVirtualMachine
 
 from robottelo.config import settings
+from robottelo.hosts import ContentHost
 
 
 @pytest.fixture(scope='module')
@@ -112,18 +113,24 @@ def module_vmware_image(
 
 
 @pytest.fixture
-def provisioning_vmware_host(pxe_loader, vmwareclient):
+def provisioning_vmware_host(pxe_loader, vmwareclient, module_ssh_key_file):
     """Fixture to check out blank VM on VMware"""
-    vm_boot_firmware = 'efi' if pxe_loader.vm_firmware == 'uefi' else 'bios'
-    provisioning_host = Broker(
+    vm_boot_firmware = 'efi' if pxe_loader.vm_firmware.startswith('uefi') else 'bios'
+    vm_secure_boot = 'true' if pxe_loader.vm_firmware == 'uefi_secureboot' else 'false'
+    vlan_id = settings.provisioning.vlan_id
+    with Broker(
         workflow='deploy-blank-vm-vcenter',
-        artifacts='last',
-        vm_network=settings.provisioning.vlan_id,
+        host_class=ContentHost,
+        vm_network=vlan_id,
         vm_boot_firmware=vm_boot_firmware,
-    ).execute()
-    yield provisioning_host
-    # delete the host
-    vmware_host = VMWareVirtualMachine(vmwareclient, name=provisioning_host['name'])
-    vmware_host.delete()
-    # check if vm is deleted from VMware
-    assert vmwareclient.does_vm_exist(provisioning_host['name']) is False
+        vm_secure_boot=vm_secure_boot,
+        auth=module_ssh_key_file,
+        blank=True,
+        _skip_context_checkin=True,
+    ) as provisioning_host:
+        yield provisioning_host
+        # Delete the host
+        vmware_host = VMWareVirtualMachine(vmwareclient, name=provisioning_host.name)
+        vmware_host.delete()
+        # Verify host is deleted from VMware
+        assert vmwareclient.does_vm_exist(provisioning_host.name) is False

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -154,12 +154,13 @@ def test_positive_provision_vmware_pxe_discovery(
         2. Provision the host
 
     :expectedresults: Host should be provisioned successfully
-
     """
-    mac = provisioning_vmware_host['provisioning_nic_mac_addr']
+    mac = provisioning_vmware_host._broker_args['provisioning_nic_mac_addr']
     sat = module_discovery_sat.sat
     # start the provisioning host
-    vmware_host = VMWareVirtualMachine(vmwareclient, name=provisioning_vmware_host['name'])
+    vmware_host = VMWareVirtualMachine(
+        vmwareclient, name=provisioning_vmware_host._broker_args['name']
+    )
     vmware_host.start()
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/15735

### Problem Statement
Missing test for baremetal secureboot provisioning

### Solution
Add test for baremetal secureboot provisioning

