### PR TITLE
pull mode rex survives leapp upgrade

### DIFF
--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -2,15 +2,11 @@ from broker import Broker
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import PRDS
+from robottelo.constants import PRDS, RHEL7_VER, RHEL8_VER, RHEL9_VER
 from robottelo.hosts import ContentHost
 from robottelo.logging import logger
 
 synced_repos = pytest.StashKey[dict]
-
-RHEL7_VER = '7.9'
-RHEL8_VER = '8.10'
-RHEL9_VER = '9.5'
 
 RHEL_REPOS = {
     'rhel7_server': {

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -208,18 +208,20 @@ def module_capsule_configured(request, module_capsule_host, module_target_sat):
 
 
 @pytest.fixture(scope='module')
-def module_capsule_configured_mqtt(request, module_capsule_configured):
+def module_capsule_configured_mqtt(request, module_capsule_configured_ansible):
     """Configure the capsule instance with the satellite from settings.server.hostname,
     enable MQTT broker"""
-    module_capsule_configured.set_rex_script_mode_provider('pull-mqtt')
+    module_capsule_configured_ansible.set_rex_script_mode_provider('pull-mqtt')
     # lower the mqtt_resend_interval interval
-    module_capsule_configured.set_mqtt_resend_interval('30')
-    result = module_capsule_configured.execute('systemctl status mosquitto')
+    module_capsule_configured_ansible.set_mqtt_resend_interval('30')
+    result = module_capsule_configured_ansible.execute('systemctl status mosquitto')
     assert result.status == 0, 'MQTT broker is not running'
-    result = module_capsule_configured.execute('firewall-cmd --permanent --add-port="1883/tcp"')
+    result = module_capsule_configured_ansible.execute(
+        'firewall-cmd --permanent --add-port="1883/tcp"'
+    )
     assert result.status == 0, 'Failed to open mqtt port on capsule'
-    module_capsule_configured.execute('firewall-cmd --reload')
-    yield module_capsule_configured
+    module_capsule_configured_ansible.execute('firewall-cmd --reload')
+    yield module_capsule_configured_ansible
     if request.config.option.n_minus:
         raise TypeError('The teardown is missed for MQTT configuration undo for nminus testing')
 

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -728,6 +728,11 @@ REPOS = {
     },
 }
 
+# RHEL versions for LEAPP testing
+RHEL7_VER = '7.9'
+RHEL8_VER = '8.10'
+RHEL9_VER = '9.5'
+
 BULK_REPO_LIST = [
     REPOS['rhel7_optional'],
     REPOS['rhel7_sup'],

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -16,10 +16,19 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
+from robottelo.constants import RHEL8_VER, RHEL9_VER
+from robottelo.utils import ohsnap
 
-RHEL7_VER = '7.9'
-RHEL8_VER = '8.10'
-RHEL9_VER = '9.5'
+
+def get_yggdrasil_service_name(rhel_contenthost):
+    return (
+        'yggdrasil'
+        if (
+            rhel_contenthost.os_version.major > 9
+            or (rhel_contenthost.os_version.major == 9 and rhel_contenthost.os_version.minor > 5)
+        )
+        else 'yggdrasild'
+    )
 
 
 @pytest.mark.e2e
@@ -105,3 +114,165 @@ def test_positive_leapp_upgrade_rhel(
 
     custom_leapp_host.clean_cached_properties()
     assert str(custom_leapp_host.os_version) == upgrade_path['target_version']
+
+
+@pytest.mark.no_containers
+@pytest.mark.parametrize(
+    'upgrade_path',
+    [
+        {'source_version': RHEL8_VER, 'target_version': RHEL9_VER},
+    ],
+    ids=lambda upgrade_path: f'{upgrade_path["source_version"]}'
+    f'_to_{upgrade_path["target_version"]}',
+)
+@pytest.mark.parametrize(
+    'setting_update',
+    ['remote_execution_global_proxy=False'],
+    ids=["no_global_proxy"],
+    indirect=True,
+)
+def test_positive_ygdrassil_client_after_leapp_upgrade(
+    request,
+    module_target_sat,
+    custom_leapp_host,
+    upgrade_path,
+    verify_target_repo_on_satellite,
+    precondition_check_upgrade_and_install_leapp_tool,
+    module_sca_manifest_org,
+    module_capsule_configured_mqtt,
+    smart_proxy_location,
+    setting_update,
+    function_leapp_ak,
+    module_leapp_lce,
+):
+    """Test to upgrade a RHEL host to next major RHEL release using leapp while maintaining a working pull-mqtt rex setup
+
+    :id: ba3a0eb6-779f-46b5-b4b9-c10fc182e974
+
+    :steps:
+        1. Import a subscription manifest and enable, sync source & target repositories
+        2. Create LCE, Create CV, add repositories to it, publish and promote CV, Create AK, etc.
+        3. Register content host with AK
+        4. Verify that target rhel repositories are enabled on Satellite
+        5. Update all packages, install leapp tool and fix inhibitors
+        6. Set up mqtt capsule, sync content to it, re-register host to it
+        7. Run Leapp Preupgrade and Leapp Upgrade job template
+
+    :expectedresults:
+        1. Update RHEL OS major version to another major version
+        2. Check that pull mode rex is working after upgrade
+
+    :CaseComponent: RemoteExecution
+    """
+    login = settings.server.admin_username
+    password = settings.server.admin_password
+    org = module_sca_manifest_org
+
+    client_repo = ohsnap.dogfood_repository(
+        settings.ohsnap,
+        product='client',
+        repo='client',
+        release='client',
+        os_release=custom_leapp_host.os_version.major,
+    )
+
+    # Update module_capsule_configured_mqtt to include org/loc
+    module_target_sat.cli.Capsule.update(
+        {
+            'name': module_capsule_configured_mqtt.hostname,
+            'organization-ids': module_sca_manifest_org.id,
+            'location-ids': smart_proxy_location.id,
+        }
+    )
+    # Associated LCE with pull provider capsule and sync
+    module_capsule_configured_mqtt.nailgun_capsule.content_add_lifecycle_environment(
+        data={'environment_id': module_leapp_lce.id}
+    )
+    # Update capsule's download policy to on_demand
+    module_capsule_configured_mqtt.update_download_policy('on_demand')
+    # Sync repo metatdata
+    sync_status = module_capsule_configured_mqtt.nailgun_capsule.content_sync(timeout=800)
+    assert sync_status['result'] == 'success', 'Capsule sync task failed.'
+
+    # set releasever for activation key so that global registration can access the version-specific rhel repo
+    module_target_sat.cli.ActivationKey.update(
+        {
+            'id': function_leapp_ak.id,
+            'organization-id': module_sca_manifest_org.id,
+            'release-version': RHEL8_VER,
+        }
+    )
+
+    # re-register host with pull provider capsule
+    result = custom_leapp_host.register(
+        module_sca_manifest_org,
+        smart_proxy_location,
+        function_leapp_ak.name,
+        module_capsule_configured_mqtt,
+        setup_remote_execution_pull=True,
+        repo_data=f'repo={client_repo.baseurl}',
+        ignore_subman_errors=True,
+        force=True,
+    )
+    assert result.status == 0, f'Failed to register host: {result.stderr}'
+
+    service_name = get_yggdrasil_service_name(custom_leapp_host)
+    result = custom_leapp_host.execute(f'systemctl status {service_name}')
+    assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+
+    # unset releasever in AK
+    module_target_sat.cli.ActivationKey.update(
+        {
+            'id': function_leapp_ak.id,
+            'organization-id': module_sca_manifest_org.id,
+            'release-version': '',
+        }
+    )
+
+    # Workaround for https://issues.redhat.com/browse/RHEL-55871
+    assert custom_leapp_host.execute('echo \'ulimit -n 16384\' > /root/.bashrc').status == 0
+    # Run leapp preupgrade job
+    invocation_command = module_target_sat.cli_factory.job_invocation_with_credentials(
+        {
+            'job-template': 'Run preupgrade via Leapp',
+            'search-query': f'name = {custom_leapp_host.hostname}',
+            'organization-id': org.id,
+        },
+        (login, password),
+    )
+    result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
+    assert result['success'] == '1'
+
+    # Run leapp upgrade job
+    invocation_command = module_target_sat.cli_factory.job_invocation_with_credentials(
+        {
+            'job-template': 'Run upgrade via Leapp',
+            'search-query': f'name = {custom_leapp_host.hostname}',
+            'organization-id': org.id,
+            'inputs': 'Reboot=false',
+        },
+        (login, password),
+    )
+
+    custom_leapp_host.power_control(state='reboot')
+    result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
+    assert result['success'] == '1'
+
+    custom_leapp_host.clean_cached_properties()
+    assert str(custom_leapp_host.os_version) == upgrade_path['target_version']
+
+    # check mqtt still works after upgrade
+    service_name = get_yggdrasil_service_name(custom_leapp_host)
+    result = custom_leapp_host.execute(f'systemctl status {service_name}')
+    assert result.status == 0, f'Failed to start yggdrasil on client: {result.stderr}'
+
+    invocation_command = module_target_sat.cli_factory.job_invocation_with_credentials(
+        {
+            'job-template': 'Run Command - Script Default',
+            'inputs': "command=ls",
+            'search-query': f"name ~ {custom_leapp_host.hostname}",
+        },
+        (login, password),
+    )
+    result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
+    assert result['success'] == '1'

--- a/tests/foreman/ui/test_leapp_client.py
+++ b/tests/foreman/ui/test_leapp_client.py
@@ -14,9 +14,7 @@
 
 import pytest
 
-RHEL7_VER = '7.9'
-RHEL8_VER = '8.10'
-RHEL9_VER = '9.5'
+from robottelo.constants import RHEL8_VER, RHEL9_VER
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
### Problem Statement
check that pull-rex mode setup survives leapp upgrade, preparation for SAT-28315, SAT-27476

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->