### PR TITLE
Extend manifest labels test case with manifest_lists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -98,6 +98,8 @@ tests/foreman/ui/test_subscription.py @SatelliteQE/team-phoenix
 tests/foreman/ui/test_sync.py @SatelliteQE/team-phoenix
 tests/foreman/ui/test_syncplan.py @SatelliteQE/team-phoenix
 tests/foreman/virtwho/ @SatelliteQE/team-phoenix
+tests/new_upgrades/test_repository.py @SatelliteQE/team-phoenix
+tests/new_upgrades/test_contentview.py @SatelliteQE/team-phoenix
 tests/upgrades/test_activation_key.py @SatelliteQE/team-phoenix
 tests/upgrades/test_client.py @SatelliteQE/team-phoenix
 tests/upgrades/test_contentview.py @SatelliteQE/team-phoenix

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -721,7 +721,7 @@ BOOTABLE_REPO = {
     },
     'manifest_list': {
         'count': 1,
-        'bootable': False,
+        'bootable': True,
         'flatpak': False,
         'labels_count': 0,
         'annotations_count': 0,

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -712,19 +712,37 @@ DOCKER_REPO_UPSTREAM_NAME = 'openshift3/logging-elasticsearch'
 CONTAINER_RH_REGISTRY_UPSTREAM_NAME = 'openshift3/ose-metrics-hawkular-openshift-agent'
 BOOTABLE_REPO = {
     'upstream_name': 'pulp/bootc-labeled',
-    'manifests_count': 1,
-    'bootable': True,
-    'flatpak': False,
-    'labels_count': 2,
-    'annotations_count': 2,
+    'manifest': {
+        'count': 1,
+        'bootable': True,
+        'flatpak': False,
+        'labels_count': 2,
+        'annotations_count': 2,
+    },
+    'manifest_list': {
+        'count': 1,
+        'bootable': False,
+        'flatpak': False,
+        'labels_count': 0,
+        'annotations_count': 0,
+    },
 }
 FLATPAK_REPO = {
     'upstream_name': 'pulp/oci-net.fishsoup.hello',
-    'manifests_count': 2,
-    'bootable': False,
-    'flatpak': True,
-    'labels_count': 10,
-    'annotations_count': 0,
+    'manifest': {
+        'count': 2,
+        'bootable': False,
+        'flatpak': True,
+        'labels_count': 10,
+        'annotations_count': 0,
+    },
+    'manifest_list': {
+        'count': 1,
+        'bootable': False,
+        'flatpak': True,
+        'labels_count': 0,
+        'annotations_count': 0,
+    },
 }
 LABELLED_REPOS = [BOOTABLE_REPO, FLATPAK_REPO]
 CONTAINER_MANIFEST_LABELS = {'annotations', 'labels', 'is_bootable', 'is_flatpak'}

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1846,7 +1846,8 @@ class TestDockerRepository:
     def test_positive_synchronize_docker_repo_with_manifest_labels(
         self, target_sat, repo_options, repo
     ):
-        """Verify the container manifest labels were indexed properly during the repo sync.
+        """Verify the container manifests and manifest_lists labels were indexed properly during
+            the repo sync.
 
         :id: c865d350-fd19-43fb-b9fd-5ef86cbe3e09
 
@@ -1855,40 +1856,49 @@ class TestDockerRepository:
         :steps:
             1. Sync container-type repositories with some labels, annotations
                and bootable and flatpak flags.
-            2. Verify all manifests in each repo contain the expected keys.
-            3. Verify the manifests count matches the repository content counts and the expectation.
+            2. Verify all manifests and manifest_lists in each repo contain the expected keys.
+            3. Verify the manifests and manifest_lists count matches the repository content counts
+               and the expectation.
             4. Verify the values meet the expectations specific for each repo.
 
         :expectedresults: Container labels were indexed properly.
         """
         repo.sync()
         repo = repo.read()
-        dms = target_sat.api.Repository(id=repo.id).docker_manifests()['results']
-        assert all(
-            [CONTAINER_MANIFEST_LABELS.issubset(m.keys()) for m in dms]
-        ), 'Some expected key is missing in the repository manifests'
-        expected_values = next(
-            (i for i in LABELLED_REPOS if i['upstream_name'] == repo.docker_upstream_name), None
-        )
-        assert expected_values, f'{repo.docker_upstream_name} not found in {LABELLED_REPOS}'
-        assert (
-            len(dms) == repo.content_counts['docker_manifest']
-        ), 'Manifests count does not match the repository content counts'
-        assert (
-            len(dms) == expected_values['manifests_count']
-        ), 'Manifests count does not meet the expectation'
-        assert all(
-            [m['is_bootable'] == expected_values['bootable'] for m in dms]
-        ), 'Unexpected is_bootable flag'
-        assert all(
-            [m['is_flatpak'] == expected_values['flatpak'] for m in dms]
-        ), 'Unexpected is_flatpak flag'
-        assert all(
-            [len(m['labels']) == expected_values['labels_count'] for m in dms]
-        ), 'Unexpected lables count'
-        assert all(
-            [len(m['annotations']) == expected_values['annotations_count'] for m in dms]
-        ), 'Unexpected annotations count'
+
+        for entity_type in ['manifest', 'manifest_list']:
+            entity_data = (
+                target_sat.api.Repository(id=repo.id).docker_manifests()['results']
+                if entity_type == 'manifest'
+                else target_sat.api.Repository(id=repo.id).docker_manifest_lists()['results']
+            )
+
+            assert all(
+                [CONTAINER_MANIFEST_LABELS.issubset(m.keys()) for m in entity_data]
+            ), f'Some expected key is missing in the repository {entity_type}s'
+            expected_values = next(
+                (i for i in LABELLED_REPOS if i['upstream_name'] == repo.docker_upstream_name), None
+            )
+            assert expected_values, f'{repo.docker_upstream_name} not found in {LABELLED_REPOS}'
+            expected_values = expected_values[entity_type]
+            assert (
+                len(entity_data) == repo.content_counts[f'docker_{entity_type}']
+            ), f'{entity_type}s count does not match the repository content counts'
+            assert (
+                len(entity_data) == expected_values['count']
+            ), f'{entity_type}s count does not meet the expectation'
+            assert all(
+                [m['is_bootable'] == expected_values['bootable'] for m in entity_data]
+            ), 'Unexpected is_bootable flag'
+            assert all(
+                [m['is_flatpak'] == expected_values['flatpak'] for m in entity_data]
+            ), 'Unexpected is_flatpak flag'
+            assert all(
+                [len(m['labels']) == expected_values['labels_count'] for m in entity_data]
+            ), 'Unexpected lables count'
+            assert all(
+                [len(m['annotations']) == expected_values['annotations_count'] for m in entity_data]
+            ), 'Unexpected annotations count'
 
     @pytest.mark.skip(
         reason="Tests behavior that is no longer present in the same way, needs refactor"

--- a/tests/new_upgrades/test_repository.py
+++ b/tests/new_upgrades/test_repository.py
@@ -18,8 +18,11 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import (
+    CONTAINER_MANIFEST_LABELS,
     FAKE_0_CUSTOM_PACKAGE_NAME,
     FAKE_4_CUSTOM_PACKAGE_NAME,
+    LABELLED_REPOS,
+    PULP_CONTAINER_REGISTRY_HUB,
 )
 from robottelo.hosts import ContentHost
 from robottelo.utils.shared_resource import SharedResource
@@ -127,3 +130,99 @@ def test_scenario_custom_repo_check(custom_repo_check_setup):
     rhel_client = ContentHost.get_host_by_hostname(test_data.rhel_client.hostname)
     result = rhel_client.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE_NAME}')
     assert result.status == 0
+
+
+@pytest.fixture
+def container_repo_sync_setup(content_upgrade_shared_satellite, upgrade_action):
+    """This is a pre-upgrade fixture to sync container repositories
+    with some labels, annotations and bootable and flatpak flags.
+
+    :id: preupgrade-55b82217-7fd0-4b98-bd38-2a08a36f77db
+
+    :steps:
+        1. Create bootable container repository with some labels and flags.
+        2. Sync the repository and assert sync succeeds.
+        3. Create flatpak container repository with some labels and flags.
+        4. Sync the repository and assert sync succeeds.
+
+    :expectedresults: Container repositories are synced and ready for upgrade.
+    """
+    target_sat = content_upgrade_shared_satellite
+    with SharedResource(target_sat.hostname, upgrade_action, target_sat=target_sat) as sat_upgrade:
+        test_data = Box(
+            {
+                'target_sat': target_sat,
+                'repos': [],
+            }
+        )
+        org = target_sat.api.Organization(name=gen_alpha()).create()
+        product = target_sat.api.Product(name=gen_alpha(), organization=org).create()
+        for item in LABELLED_REPOS:
+            repo = target_sat.api.Repository(
+                name=gen_alpha(),
+                content_type='docker',
+                docker_upstream_name=item['upstream_name'],
+                product=product,
+                url=PULP_CONTAINER_REGISTRY_HUB,
+            ).create()
+            repo.sync()
+            repo = repo.read()
+            assert repo.content_counts['docker_manifest'] > 0
+            test_data.repos.append(repo.id)
+        sat_upgrade.ready()
+        target_sat._session = None
+        yield test_data
+
+
+@pytest.mark.content_upgrades
+def test_container_repo_sync(container_repo_sync_setup):
+    """This is a post-upgrade test to verify the container labels
+    were indexed properly in the post-upgrade task.
+
+    :id: postupgrade-1e8f2f4a-6232-4671-9d6f-2ada1b70bc59
+
+    :steps:
+        1. Verify all manifests and manifest_lists in each repo contain the expected keys.
+        2. Verify the manifests and manifest_lists count matches the repository content counts
+           and the expectation.
+        3. Verify the values meet the expectations specific for each repo.
+
+    :expectedresults: Container labels were indexed properly.
+    """
+    test_data = container_repo_sync_setup
+    target_sat = test_data.target_sat
+    for repo_id in test_data.repos:
+        repo = target_sat.api.Repository(id=repo_id).read()
+        for entity_type in ['manifest', 'manifest_list']:
+            entity_data = (
+                target_sat.api.Repository(id=repo.id).docker_manifests()['results']
+                if entity_type == 'manifest'
+                else target_sat.api.Repository(id=repo.id).docker_manifest_lists()['results']
+            )
+
+            assert all(
+                [CONTAINER_MANIFEST_LABELS.issubset(m.keys()) for m in entity_data]
+            ), f'Some expected key is missing in the repository {entity_type}s'
+            expected_values = next(
+                (i for i in LABELLED_REPOS if i['upstream_name'] == repo.docker_upstream_name), None
+            )
+            assert expected_values, f'{repo.docker_upstream_name} not found in {LABELLED_REPOS}'
+            expected_values = expected_values[entity_type]
+            assert (
+                len(entity_data) == repo.content_counts[f'docker_{entity_type}']
+            ), f'{entity_type}s count does not match the repository content counts'
+            assert (
+                len(entity_data) == expected_values['count']
+            ), f'{entity_type}s count does not meet the expectation'
+            assert all(
+                [m['is_bootable'] == expected_values['bootable'] for m in entity_data]
+            ), 'Unexpected is_bootable flag'
+            assert all(
+                [m['is_flatpak'] == expected_values['flatpak'] for m in entity_data]
+            ), 'Unexpected is_flatpak flag'
+            assert all(
+                [len(m['labels']) == expected_values['labels_count'] for m in entity_data]
+            ), 'Unexpected lables count'
+            assert all(
+                [len(m['annotations']) == expected_values['annotations_count'] for m in entity_data]
+            ), 'Unexpected annotations count'

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -348,32 +348,43 @@ class TestScenarioContainerRepoSync:
         """
         for repo_id in pre_upgrade_data.values():
             repo = target_sat.api.Repository(id=repo_id).read()
-            dms = target_sat.api.Repository(id=repo_id).docker_manifests()['results']
-            assert all(
-                [CONTAINER_MANIFEST_LABELS.issubset(m.keys()) for m in dms]
-            ), 'Some expected key is missing in the repository manifests'
-            expected_values = next(
-                (i for i in LABELLED_REPOS if i['upstream_name'] == repo.docker_upstream_name), None
-            )
-            assert expected_values, f'{repo.docker_upstream_name} not found in {LABELLED_REPOS}'
-            assert (
-                len(dms) == repo.content_counts['docker_manifest']
-            ), 'Manifests count does not match the repository content counts'
-            assert (
-                len(dms) == expected_values['manifests_count']
-            ), 'Manifests count does not meet the expectation'
-            assert all(
-                [m['is_bootable'] == expected_values['bootable'] for m in dms]
-            ), 'Unexpected is_bootable flag'
-            assert all(
-                [m['is_flatpak'] == expected_values['flatpak'] for m in dms]
-            ), 'Unexpected is_flatpak flag'
-            assert all(
-                [len(m['labels']) == expected_values['labels_count'] for m in dms]
-            ), 'Unexpected lables count'
-            assert all(
-                [len(m['annotations']) == expected_values['annotations_count'] for m in dms]
-            ), 'Unexpected annotations count'
+            for entity_type in ['manifest', 'manifest_list']:
+                entity_data = (
+                    target_sat.api.Repository(id=repo.id).docker_manifests()['results']
+                    if entity_type == 'manifest'
+                    else target_sat.api.Repository(id=repo.id).docker_manifest_lists()['results']
+                )
+
+                assert all(
+                    [CONTAINER_MANIFEST_LABELS.issubset(m.keys()) for m in entity_data]
+                ), f'Some expected key is missing in the repository {entity_type}s'
+                expected_values = next(
+                    (i for i in LABELLED_REPOS if i['upstream_name'] == repo.docker_upstream_name),
+                    None,
+                )
+                assert expected_values, f'{repo.docker_upstream_name} not found in {LABELLED_REPOS}'
+                expected_values = expected_values[entity_type]
+                assert (
+                    len(entity_data) == repo.content_counts[f'docker_{entity_type}']
+                ), f'{entity_type}s count does not match the repository content counts'
+                assert (
+                    len(entity_data) == expected_values['count']
+                ), f'{entity_type}s count does not meet the expectation'
+                assert all(
+                    [m['is_bootable'] == expected_values['bootable'] for m in entity_data]
+                ), 'Unexpected is_bootable flag'
+                assert all(
+                    [m['is_flatpak'] == expected_values['flatpak'] for m in entity_data]
+                ), 'Unexpected is_flatpak flag'
+                assert all(
+                    [len(m['labels']) == expected_values['labels_count'] for m in entity_data]
+                ), 'Unexpected lables count'
+                assert all(
+                    [
+                        len(m['annotations']) == expected_values['annotations_count']
+                        for m in entity_data
+                    ]
+                ), 'Unexpected annotations count'
 
 
 class TestSimpleContentAccessOnly:


### PR DESCRIPTION
### Problem Statement
1. Manifest labels, annotations and other flags were added to manifest lists too (previously they were added to manifests only). After container-type repo sync they should be indexed and returned by API.
2. Also the labels and flags should be indexed during upgrade from 6.16 to 6.17.
3. We are going to have a new-style approach to the upgrade scenarios.


### Solution
1. We already have a test case to check the fields in manifests. This PR extends the test case to check the same in manifest lists too.
2. We already have similar test case in upgrade scenarios. This PR extends the test case, and
3. adds new one as an upgrade new-styler using the `share_resource` approach.
4. Here we also update the `CODEOWNERS` file with the new upgrade files.


### Related Issues
https://issues.redhat.com/browse/SAT-27490


### PRT test Cases example
Requires
https://github.com/Katello/katello/pull/11172
https://github.com/SatelliteQE/nailgun/pull/1240 (merged)
```
trigger: test-robottelo
pytest: tests/foreman/api/test_repository.py -k synchronize_docker_repo_with_manifest_labels
Katello:
  katello: 11172
```
For the new-style upgrade scenario we need to wait for the 11172 being packed in next snap.
```
trigger: test-robottelo
pytest: tests/new_upgrades/test_repository.py -k test_container_repo_sync
env:
  BROKER_SSH_BACKEND: hussh
```