### PR TITLE
[6.15.z] Enable IPv6 proxy when settings.server.is_ipv6=True in IPv6 runs

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -362,7 +362,7 @@ def installer_satellite(request):
     sat.setup_firewall()
 
     # register to cdn (also enables rhel repos from cdn)
-    sat.register_to_cdn(enable_proxy=True)
+    sat.register_to_cdn()
 
     # setup source repositories
     if settings.server.version.source == "ga":


### PR DESCRIPTION
Manual cherrypick of #16795 
Fixes https://github.com/SatelliteQE/robottelo/issues/16881

### **Problem Statement**
IPv6 proxy isn't configured for subscription manager and DNF, causing tests to fail where we register or with installer when run for IPv6

### **Solution**
Enable IPv6 proxy when settings.server.is_ipv6=True in IPv6 runs