### PR TITLE
Update test_positive_documentation_links to test stage doc links

### DIFF
--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -29,3 +29,5 @@ ROBOTTELO:
   SETTINGS:
     GET_FRESH: true
     IGNORE_VALIDATION_ERRORS: false
+  # Stage docs url
+  STAGE_DOCS_URL: https://docs.redhat.com

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -321,6 +321,7 @@ VALIDATORS = dict(
         Validator('remotedb.port', default=5432),
     ],
     robottelo=[
+        Validator('robottelo.stage_docs_url', default='https://docs.redhat.com'),
         Validator('robottelo.settings.ignore_validation_errors', is_type_of=bool, default=False),
         Validator('robottelo.rhel_source', default='ga', is_in=['ga', 'internal']),
         Validator(


### PR DESCRIPTION
### Problem Statement
Currently `test_positive_documentation_links` doesn't check the links for unreleased Satellite doc links.

### Solution
- Update `test_positive_documentation_links` to make it work with stage docs

### Related Issues
- SAT-27552


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->