### PR TITLE
Rely on dynaconf to render the config based on is_ipv6 setting

### DIFF
--- a/conf/dynaconf_hooks.py
+++ b/conf/dynaconf_hooks.py
@@ -7,7 +7,7 @@ from box import Box
 
 from robottelo.logging import logger
 from robottelo.utils.ohsnap import dogfood_repository
-from robottelo.utils.url import ipv6_hostname_translation, is_url
+from robottelo.utils.url import is_url
 
 
 def post(settings):
@@ -30,7 +30,6 @@ def post(settings):
             )
             data = get_repos_config(settings)
             write_cache(settings_cache_path, data)
-    ipv6_hostname_translation(settings, data)
     config_migrations(settings, data)
     data['dynaconf_merge'] = True
     return data

--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -37,7 +37,6 @@ def get_settings():
             load_dotenv=True,
         )
         settings.validators.register(**VALIDATORS)
-
         try:
             settings.validators.validate()
         except ValidationError as err:

--- a/robottelo/utils/url.py
+++ b/robottelo/utils/url.py
@@ -1,7 +1,5 @@
 from urllib.parse import urlparse
 
-from robottelo.logging import logger
-
 
 def is_url(url):
     try:
@@ -9,43 +7,3 @@ def is_url(url):
         return all([result.scheme, result.netloc])
     except (ValueError, AttributeError):
         return False
-
-
-def is_ipv4_url(text):
-    """Verify if the URL is IPv4 url"""
-    return isinstance(text, str) and 'ipv4' in text and 'redhat.com' in text
-
-
-def ipv6_translator(settings_list, setting_major, data):
-    """Translates the hostname containing IPv4 to IPv6 and updates the settings object"""
-    setting_major = list(map(str, setting_major))
-    dotted_settings = '.'.join(setting_major)
-    for _key, _val in settings_list.items():
-        if is_ipv4_url(_val):
-            data[f'{dotted_settings}.{_key}'] = str(_val).replace('ipv4', 'ipv6')
-            logger.debug(f'Setting translated to IPv6, Path: {dotted_settings}.{_key}')
-        elif isinstance(_val, list):
-            updated = False
-            new_list = _val
-            for i in range(len(new_list)):
-                if is_ipv4_url(new_list[i]):
-                    new_list[i] = new_list[i].replace('ipv4', 'ipv6')
-                    updated = True
-            if updated:
-                data[f'{dotted_settings}.{_key}'] = new_list
-                logger.debug(f'Setting translated to IPv6, Path: {dotted_settings}.{_key}')
-        elif isinstance(_val, dict):
-            new_setting_major = setting_major + [_key]
-            ipv6_translator(settings_list=_val, setting_major=new_setting_major, data=data)
-
-
-def ipv6_hostname_translation(settings, data):
-    """Migrates any IPv4 containing hostname in conf to IPv6 hostname"""
-    settings_path = []
-    if settings.server.is_ipv6:
-        all_settings = settings.loaded_by_loaders.items()
-        for loader_name, loader_settings in tuple(all_settings):
-            if loader_name.loader == 'yaml':
-                ipv6_translator(loader_settings, settings_path, data)
-    else:
-        logger.debug('IPv6 Hostname dynaconf migration hook is skipped for IPv4 testing')


### PR DESCRIPTION
### Problem Statement

The REPOS section of the config contains `-ipv4` hostnames despite the `is_ipv6` setting being set to `True`. This happens because we are looping through the non-templatized/non-formatted configuration loaded by the dynaconf YAML loader: https://github.com/SatelliteQE/robottelo/blob/a79da44f45e7ebfa53c49d9d8a20cfd538a51e82/robottelo/utils/url.py#L46

Since the `REPOS` config section contains several templates, either `@format` or `@jinja`, injecting a string containing `-ipv4`, and since our algorithm uses the raw config file value loaded by the YAML loader, we are not able to detect this case and change these URLs and hostnames to `-ipv6`.


### Solution
The proposed solution is to shift to a different approach - from mutating settings by an algorithm in robottelo to creating a self-contained configuration structure and including IPv4 and IPv6 URLs and hostnames in the config. Based on the `IS_IPV6` setting, templatize the value of the actual hostname/URL config field.

### Related Issues
https://issues.redhat.com/browse/SAT-29304
satellite-jenkins!1545

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->