### PR TITLE
Add permission tests for foreman_scc_manager

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1153,6 +1153,19 @@ PERMISSIONS = {
         'lock_report_templates',
     ],
     'Role': ['view_roles', 'create_roles', 'edit_roles', 'destroy_roles'],
+    'SccAccount': [
+        "delete_scc_accounts",
+        "edit_scc_accounts",
+        "new_scc_accounts",
+        "sync_scc_accounts",
+        "test_connection_scc_accounts",
+        "use_scc_accounts",
+        "view_scc_accounts",
+    ],
+    'SccProduct': [
+        "subscribe_scc_products",
+        "view_scc_products",
+    ],
     'Setting': ['view_settings', 'edit_settings'],
     'SmartProxy': [
         'view_smart_proxies',

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -68,6 +68,9 @@ class TestPermission:
             cls.permissions.pop('ForemanPuppet::HostClass')
             cls.permissions.pop('ForemanPuppet::Puppetclass')
             cls.permissions.pop('ForemanPuppet::PuppetclassLookupKey')
+        if 'rubygem-foreman_scc_manager' not in rpm_packages:
+            cls.permissions.pop('SccAccount')
+            cls.permissions.pop('SccProduct')
 
         #: e.g. ['Architecture', 'Audit', 'AuthSourceLdap', …]
         cls.permission_resource_types = list(cls.permissions.keys())


### PR DESCRIPTION
### Problem Statement

permission tests are failing with foreman_scc_manager plugin installed

### Solution

adapt permission tests

### Related Issues

relevant tests: tests/foreman/api/test_permission.py


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->