### PR TITLE
Remove the MultiCV hack since it's become available

### DIFF
--- a/pytest_fixtures/component/contentview.py
+++ b/pytest_fixtures/component/contentview.py
@@ -73,7 +73,6 @@ def module_cv_repo(module_org, module_repository, module_lce, module_target_sat)
 @pytest.fixture(scope='session')
 def session_multicv_sat(session_satellite_host):
     """Satellite with multi-CV enabled"""
-    session_satellite_host.enable_multicv_setting()
     session_satellite_host.update_setting('allow_multiple_content_views', 'True')
     return session_satellite_host
 

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -39,23 +39,6 @@ class EnablePluginsSatellite:
         assert 'Success!' in result.stdout
         return self
 
-    def enable_multicv_setting(self):
-        """Makes multi-CV setting available in the downstream Satellite"""
-        if len(
-            self.api.Setting().search(query={'search': 'name={"allow_multiple_content_views"}'})
-        ):
-            return  # Setting is already exposed
-        cfg_file = 'upstream_only_settings.rb'
-        cfg_path = self.execute(f'find /usr/share/gems/gems/ -name {cfg_file}').stdout.strip()
-        assert cfg_file in cfg_path, 'Config file not found'
-        self.execute(
-            f'sed -i "s/allow_multiple_content_views/#allow_multiple_content_views/g" {cfg_path}'
-        )
-        self.cli.Service.restart()
-        assert len(
-            self.api.Setting().search(query={'search': f'name={"allow_multiple_content_views"}'})
-        ), 'Multi-CV enablement failed'
-
 
 class ContentInfo:
     """Miscellaneous content helper methods"""

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2035,9 +2035,8 @@ def test_negative_multi_cv_registration(
     :steps:
         1. Register a host with global reg, just to get the sub-man config and certs right
         2. Unregister the host
-        3. Verify that allow_multiple_content_views setting is not exposed
-        4. Attempt to register the host with subscription-manager, passing multiple environments
-        5. Confirm that registration fails
+        3. Attempt to register the host with subscription-manager, passing multiple environments
+        4. Confirm that registration fails
 
     :expectedresults: allow_multiple_content_views setting is not exposed, and defaults to false.
         So registration fails because multiple environments are not allowed.
@@ -2059,10 +2058,6 @@ def test_negative_multi_cv_registration(
     # Unregister the host
     unregister_result = rhel_contenthost.unregister()
     assert unregister_result.status == 0
-
-    # Verify that allow_multiple_content_views setting is not exposed
-    with pytest.raises(CLIReturnCodeError):
-        target_sat.cli.Settings.info({'name': 'allow_multiple_content_views'})
 
     env_names = f"{module_lce_library.name}/{module_published_cv.name},{module_lce.name}/{module_promoted_cv.name}"
 


### PR DESCRIPTION
### Problem Statement
MultiCV has become available in 6.17 via setting, no hacks are needed anymore.


### Solution
Just remove the helper from mixins and fixture.


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/cli/test_host.py -k _multi_cv_