### PR TITLE
[6.16.z] assert fapolicyd is running after setup finished

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -165,6 +165,7 @@ def install_satellite(satellite, installer_args, enable_fapolicyd=False):
     if enable_fapolicyd:
         assert satellite.execute('rpm -q foreman-fapolicyd').status == 0
         assert satellite.execute('rpm -q foreman-proxy-fapolicyd').status == 0
+        assert satellite.execute('systemctl is-active fapolicyd').status == 0
     # Configure Satellite firewall to open communication
     satellite.execute(
         'firewall-cmd --permanent --add-service RH-Satellite-6 && firewall-cmd --reload'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16895

### Problem Statement

There is a bug (https://issues.redhat.com/browse/SAT-29311) in fapolicyd, which freezes the machine and our tests didn't catch it. While this change will probably not surface that bug (we are still unsure how to reliably trigger it), it should at least assert fapolicyd is actually running (and didn't crash, which it sometimes does!) after policy loading.

### Solution

assert systemd things fapolicyd is running

### Related Issues

https://issues.redhat.com/browse/SAT-29311

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->