### PR TITLE
Post deployments for content hosts, starting with FIPS

### DIFF
--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -2,7 +2,7 @@ content_host:
   default_rhel_version: 7
   rhel6:
     vm:
-      workflow: deploy-base-rhel
+      workflow: deploy-rhel
       deploy_rhel_version: '6'
       target_memory: 1GiB
       target_cores: 1
@@ -10,7 +10,7 @@ content_host:
       container_host: rhel6:latest
   rhel7:
     vm:
-      workflow: deploy-base-rhel
+      workflow: deploy-rhel
       deploy_rhel_version: '7'
       target_memory: 1GiB
       target_cores: 1
@@ -18,13 +18,13 @@ content_host:
       container_host: ubi7:latest
   rhel7_fips:
     vm:
-      workflow: deploy-base-rhel-fips
+      workflow: deploy-rhel
       deploy_rhel_version: '7'
       target_memory: 1GiB
       target_cores: 1
   rhel8:
     vm:
-      workflow: deploy-base-rhel
+      workflow: deploy-rhel
       deploy_rhel_version: '8'
       target_memory: 1536 MiB
       target_cores: 1
@@ -32,13 +32,13 @@ content_host:
       container_host: ubi8:latest
   rhel8_fips:
     vm:
-      workflow: deploy-base-rhel-fips
+      workflow: deploy-rhel
       deploy_rhel_version: '8'
       target_memory: 1536 MiB
       target_cores: 1
   rhel9:
     vm:
-      workflow: deploy-base-rhel
+      workflow: deploy-rhel
       deploy_rhel_version: '9'
       target_memory: 1536 MiB
       target_cores: 1
@@ -46,7 +46,7 @@ content_host:
       container_host: ubi9:latest
   rhel9_fips:
     vm:
-      workflow: deploy-base-rhel-fips
+      workflow: deploy-rhel
       deploy_rhel_version: '9'
       target_memory: 1536 MiB
       target_cores: 1

--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -50,6 +50,12 @@ content_host:
       deploy_rhel_version: '9'
       target_memory: 1536 MiB
       target_cores: 1
+  rhel10_fips:
+    vm:
+      workflow: deploy-template
+      deploy_rhel_version: '10'
+      target_memory: 1536 MiB
+      target_cores: 1
   centos7:
     vm:
       workflow: deploy-centos

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -41,12 +41,22 @@ def host_conf(request):
     return conf
 
 
+def run_post_deployments(request, host):
+    """Execute post deploy"""
+    params = {}
+    if hasattr(request, 'param'):
+        params = request.param
+    if 'fips' in params.get('rhel_version'):
+        Broker().execute(workflow='enable-fips', target_host=host.name)
+
+
 @pytest.fixture
 def rhel_contenthost(request):
     """A function-level fixture that provides a content host object parametrized"""
     # Request should be parametrized through pytest_fixtures.fixture_markers
     # unpack params dict
     with Broker(**host_conf(request), host_class=ContentHost) as host:
+        run_post_deployments(request, host)
         yield host
 
 
@@ -56,6 +66,7 @@ def module_rhel_contenthost(request):
     # Request should be parametrized through pytest_fixtures.fixture_markers
     # unpack params dict
     with Broker(**host_conf(request), host_class=ContentHost) as host:
+        run_post_deployments(request, host)
         yield host
 
 
@@ -112,6 +123,8 @@ def rhel9_contenthost(request):
 def content_hosts(request):
     """A function-level fixture that provides two rhel content hosts object"""
     with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
+        for host in hosts:
+            run_post_deployments(request, host)
         hosts[0].set_infrastructure_type('physical')
         yield hosts
 
@@ -120,6 +133,8 @@ def content_hosts(request):
 def mod_content_hosts(request):
     """A module-level fixture that provides two rhel content hosts object"""
     with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
+        for host in hosts:
+            run_post_deployments(request, host)
         hosts[0].set_infrastructure_type('physical')
         yield hosts
 
@@ -172,6 +187,7 @@ def cockpit_host(class_target_sat, class_org, rhel_contenthost):
 def rex_contenthost(request, module_org, target_sat, module_ak_with_cv):
     request.param['no_containers'] = True
     with Broker(**host_conf(request), host_class=ContentHost) as host:
+        run_post_deployments(request, host)
         repo = settings.repos['SATCLIENT_REPO'][f'RHEL{host.os_version.major}']
         host.register(
             module_org, None, module_ak_with_cv.name, target_sat, repo_data=f'repo={repo}'
@@ -184,6 +200,7 @@ def rex_contenthosts(request, module_org, target_sat, module_ak_with_cv):
     request.param['no_containers'] = True
     with Broker(**host_conf(request), host_class=ContentHost, _count=2) as hosts:
         for host in hosts:
+            run_post_deployments(request, host)
             repo = settings.repos['SATCLIENT_REPO'][f'RHEL{host.os_version.major}']
             host.register(
                 module_org, None, module_ak_with_cv.name, target_sat, repo_data=f'repo={repo}'

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -147,6 +147,7 @@ class ContentHost(Host, ContentHostMixins):
         self._satellite = kwargs.get('satellite')
         self.ipv6 = kwargs.get('ipv6', settings.server.is_ipv6)
         self.blank = kwargs.get('blank', False)
+        self.fips = kwargs.get('fips', False)
         super().__init__(hostname=hostname, **kwargs)
 
     @classmethod
@@ -336,10 +337,17 @@ class ContentHost(Host, ContentHostMixins):
             with contextlib.suppress(KeyError):  # ignore if property is not cached
                 del self.__dict__[name]
 
+    def enable_fips(self):
+        logger.debug(f'Enabling FIPS on the host {self.name}')
+        Broker().execute(workflow='enable-fips', target_host=self.name)
+        logger.debug(f'Enabling FIPS on the host {self.name} finished.')
+
     def setup(self):
         logger.debug('START: setting up host %s', self)
         if not self.blank:
             self.reset_rhsm()
+        if self.fips:
+            self.enable_fips()
 
         logger.debug('END: setting up host %s', self)
 


### PR DESCRIPTION
### Problem Statement
- The existing FIPS WF is going to be deleted as RHEL10 demands the enablement of FIPS as a separate task
- Resulting the WF to be deleted from Lab and introduce new `enable-fips` WF for any RHEL
- Currently, robottelo does not support 2 steps installation of FIPS and hence that needs to handle in robottelo

### Solution
- Introducing the post deployments for content hosts which should run procedures on content host based on conditions
- Starting with FIPS, when the content host is entitled for FIPS the `enable_fips` WF should run on the given host hence supporting 2 steps FIPS Content host
- Also, the existing content host template is updated for FIPS to deploy_rhel instead of the previous (To be Removed) WF.


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->