### PR TITLE
[6.15.z] Fix Discovery Tests

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -216,7 +216,7 @@ def module_ssh_key_file():
 
 
 @pytest.fixture
-def provisioning_host(module_ssh_key_file, pxe_loader):
+def provisioning_host(module_ssh_key_file, pxe_loader, module_provisioning_sat):
     """Fixture to check out blank VM"""
     vlan_id = settings.provisioning.vlan_id
     cd_iso = (
@@ -234,6 +234,7 @@ def provisioning_host(module_ssh_key_file, pxe_loader):
     ) as prov_host:
         yield prov_host
         # Set host as non-blank to run teardown of the host
+        assert module_provisioning_sat.sat.execute('systemctl restart dhcpd').status == 0
         prov_host.blank = getattr(prov_host, 'blank', False)
 
 

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -27,7 +27,7 @@ from robottelo.utils.issue_handlers import is_open
 def _read_log(ch, pattern):
     """Read the first line from the given channel buffer and return the matching line"""
     # read lines until the buffer is empty
-    for log_line in ch.stdout().splitlines():
+    for log_line in ch.result.stdout.splitlines():
         logger.debug(f'foreman-tail: {log_line}')
         if re.search(pattern, log_line):
             return log_line
@@ -389,6 +389,7 @@ def test_rhel_httpboot_provisioning(
     # check for proper HTTP requests
     shell = module_provisioning_sat.session.shell()
     shell.send('foreman-tail')
+    shell.close()
     assert_host_logs(shell, f'GET /httpboot/grub2/grub.cfg-{host_mac_addr} with 200')
     # Host should do call back to the Satellite reporting
     # the result of the installation. Wait until Satellite reports that the host is installed.


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16605

### Problem Statement
Discovery tests were failing with hussh backend as the shell didn't have stdout attribute and also because of a bug in hussh: https://github.com/JacobCallahan/Hussh/issues/26 

### Solution
Updated the tests to exit the shell contextmanager and read shell.result.stdout. Also, because of the bug, we need to explicitly close the shell before exiting contextmanager.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->