### PR TITLE
Add possibility to specify download-utility

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -634,6 +634,7 @@ class ContentHost(Host, ContentHostMixins):
         hostgroup=None,
         auth_username=None,
         auth_password=None,
+        download_utility=None,
     ):
         """Registers content host to the Satellite or Capsule server
         using a global registration template.
@@ -704,6 +705,8 @@ class ContentHost(Host, ContentHostMixins):
             options['ignore-subman-errors'] = str(ignore_subman_errors).lower()
         if force:
             options['force'] = str(force).lower()
+        if download_utility is not None:
+            options['download-utility'] = download_utility
 
         self._satellite = target.satellite
         if auth_username and auth_password:

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -338,6 +338,39 @@ def test_positive_global_registration_with_gpg_repo(
         assert rhel_contenthost.execute('dnf install -y bear').status == 0
 
 
+@pytest.mark.upgrade
+@pytest.mark.no_containers
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+@pytest.mark.parametrize('download_utility', ['wget', 'curl'])
+def test_positive_register_download_utility(
+    module_sca_manifest_org,
+    module_location,
+    module_activation_key,
+    module_target_sat,
+    rhel_contenthost,
+    download_utility,
+):
+    """Verify host registration command gets generated and host is registered successfully with all supported download utilities.
+
+    :id: 80c3204a-7923-4c70-b7c1-7b368c61d4b8
+
+    :steps:
+        1. Register host with global registration template using different download utilities.
+
+    :expectedresults: Host is successfully registered.
+    """
+    org = module_sca_manifest_org
+    result = rhel_contenthost.register(
+        org,
+        module_location,
+        module_activation_key.name,
+        module_target_sat,
+        download_utility=download_utility,
+    )
+    assert result.status == 0
+    assert rhel_contenthost.subscribed
+
+
 @pytest.mark.parametrize('setting_update', ['default_location_subscribed_hosts'], indirect=True)
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_positive_verify_default_location_for_registered_host(


### PR DESCRIPTION
### Problem Statement

newly added download utility option missing https://github.com/theforeman/foreman/pull/9808


### Solution

Add field

### Related Issues

dependency https://github.com/SatelliteQE/nailgun/pull/1257

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->