### PR TITLE
[6.14.z] Rely on dynaconf to render the config based on is_ipv6 setting

### DIFF
--- a/robottelo/config/__init__.py
+++ b/robottelo/config/__init__.py
@@ -37,7 +37,6 @@ def get_settings():
             load_dotenv=True,
         )
         settings.validators.register(**VALIDATORS)
-
         try:
             settings.validators.validate()
         except ValidationError as err:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16886

### Problem Statement

The REPOS section of the config contains `-ipv4` hostnames despite the `is_ipv6` setting being set to `True`. This happens because we are looping through the non-templatized/non-formatted configuration loaded by the dynaconf YAML loader: https://github.com/SatelliteQE/robottelo/blob/a79da44f45e7ebfa53c49d9d8a20cfd538a51e82/robottelo/utils/url.py#L46

Since the `REPOS` config section contains several templates, either `@format` or `@jinja`, injecting a string containing `-ipv4`, and since our algorithm uses the raw config file value loaded by the YAML loader, we are not able to detect this case and change these URLs and hostnames to `-ipv6`.


### Solution
The proposed solution is to shift to a different approach - from mutating settings by an algorithm in robottelo to creating a self-contained configuration structure and including IPv4 and IPv6 URLs and hostnames in the config. Based on the `IS_IPV6` setting, templatize the value of the actual hostname/URL config field.

### Related Issues
https://issues.redhat.com/browse/SAT-29304
satellite-jenkins!1545

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->