### PR TITLE
Create fake galaxy.yml to make the FAM Makefile happy

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -14,6 +14,7 @@
 
 from broker import Broker
 import pytest
+import yaml
 
 from robottelo.config import settings
 from robottelo.constants import (
@@ -68,6 +69,15 @@ def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_rol
     module_target_sat.put(
         settings.fam.compute_profile.to_yaml(),
         f'{FAM_ROOT_DIR}/tests/test_playbooks/vars/compute_profile.yml',
+        temp_file=True,
+    )
+
+    # Create fake galaxy.yml to make Makefile happy.
+    # The data in the file is unused, but not being able to load it produces errors in the
+    # logs and is confusing when searching for an actual problem during testing.
+    module_target_sat.put(
+        yaml.safe_dump({'name': 'satellite', 'namespace': 'redhat', 'version': '1.0.0'}),
+        f'{FAM_ROOT_DIR}/galaxy.yml',
         temp_file=True,
     )
 


### PR DESCRIPTION
### Problem Statement

The upstream FAM Makefile expects a `galaxy.yml` to read some data from it, as it exists in git.
A release doesn't include `galaxy.yml` (it's the input to the release process).
But we call the Makefile on a released version, and this produces irritating output on stderr (without being an actual error).

### Solution

The data in the file is unused, but not being able to load it produces
errors in the logs and is confusing when searching for an actual problem
during testing. Fake a file to silence the errors.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->