### PR TITLE
[6.16.z] Stub out the ostree tests

### DIFF
--- a/tests/foreman/cli/test_ostreebranch.py
+++ b/tests/foreman/cli/test_ostreebranch.py
@@ -24,6 +24,7 @@ pytestmark = [
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     ),
     pytest.mark.tier3,
+    pytest.mark.stubbed,
 ]
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16922

### Problem Statement
Ostree content type is not supported in downstream since 6.10. Ostree tests used to be been skipped based on the BZ status (CLOSED_WONTFIX) until #16347 was merged and now they are failing with validation error.


### Solution
Stub the tests until the ostree is supported again.
