### PR TITLE
[6.15.z] Fix some long failing subscription tests

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -294,7 +294,10 @@ def test_sca_end_to_end(
     content_view.publish()
     assert len(content_view.repository) == 2
     host = rhel_contenthost.nailgun_host
-    host.content_facet_attributes = {'content_view_id': content_view.id}
+    host.content_facet_attributes = {
+        'content_view_id': content_view.id,
+        'lifecycle_environment_id': module_ak.environment.id,
+    }
     host.update(['content_facet_attributes'])
     rhel_contenthost.run('subscription-manager repos --enable *')
     repos = rhel_contenthost.run('subscription-manager refresh && yum repolist')

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -32,9 +32,9 @@ from robottelo.utils.manifest import clone
 pytestmark = [pytest.mark.run_in_one_thread, pytest.mark.skip_if_not_set('fake_manifest')]
 
 
-@pytest.fixture(scope='module')
-def golden_ticket_host_setup(function_entitlement_manifest_org, module_target_sat):
-    org = function_entitlement_manifest_org
+@pytest.fixture
+def golden_ticket_host_setup(function_sca_manifest_org, module_target_sat):
+    org = function_sca_manifest_org
     rh_repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
         basearch='x86_64',
         org_id=org.id,
@@ -474,12 +474,12 @@ def test_positive_subscription_status_disabled_golden_ticket(
     result = rhel_contenthost.register(org, None, ak.name, target_sat)
     assert result.status == 0, f'Failed to register host: {result.stderr}'
     assert rhel_contenthost.subscribed
-    with session:
+    with target_sat.ui_session() as session:
         session.organization.select(org_name=org.name)
-        host = session.contenthost.read(rhel_contenthost.hostname, widget_names='details')[
-            'details'
-        ]['subscription_status']
-        assert 'Simple Content Access' in host
+        read_host_subs_status = session.contenthost.read_legacy_ui(
+            rhel_contenthost.hostname, widget_names='details'
+        )['details']['subscription_status']
+        assert 'Simple Content Access' in read_host_subs_status
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
This PR fixes 2 long failing subscription tests.
One of them was missing the required function parameter (lce_id) thus was failing.
For second UI test I have upgraded the fixture and UI test logic to used legacy content host's UI.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py::test_positive_subscription_status_disabled_golden_ticket  tests/foreman/api/test_subscription.py::test_sca_end_to_end
```
