### PR TITLE
[6.16.z] Update API e2e test to use RegistrationCommand entity to register

### DIFF
--- a/tests/foreman/endtoend/test_api_endtoend.py
+++ b/tests/foreman/endtoend/test_api_endtoend.py
@@ -1032,7 +1032,7 @@ class TestEndToEnd:
     @pytest.mark.skip_if_not_set('libvirt')
     @pytest.mark.tier4
     @pytest.mark.no_containers
-    @pytest.mark.rhel_ver_match('7')
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.e2e
     @pytest.mark.upgrade
     @pytest.mark.skipif(
@@ -1097,13 +1097,14 @@ class TestEndToEnd:
         repositories.append(custom_repo)
 
         # step 2.6: Enable a Red Hat repository
+        repo_key = f'{constants.PRODUCT_KEY_SAT_CLIENT}{rhel_contenthost.os_version.major}'
         rhel_repo = target_sat.api.Repository(
             id=target_sat.api_factory.enable_rhrepo_and_fetchid(
-                basearch='x86_64',
+                basearch=constants.DEFAULT_ARCHITECTURE,
                 org_id=org.id,
-                product=constants.PRDS['rhel'],
-                repo=constants.REPOS['rhst7']['name'],
-                reposet=constants.REPOSET['rhst7'],
+                product=constants.REPOS[repo_key]['product'],
+                repo=constants.REPOS[repo_key]['name'],
+                reposet=constants.REPOS[repo_key]['reposet'],
             )
         )
         repositories.append(rhel_repo)
@@ -1143,11 +1144,10 @@ class TestEndToEnd:
         activation_key.content_override(
             data={
                 'content_overrides': [
-                    {'content_label': constants.REPOS['rhst7']['id'], 'value': '1'}
+                    {'content_label': constants.REPOS[repo_key]['id'], 'value': '1'}
                 ]
             }
         )
-
         # BONUS: Create a content host and associate it with promoted
         # content view and last lifecycle where it exists
         content_host = target_sat.api.Host(
@@ -1190,13 +1190,16 @@ class TestEndToEnd:
         # step 2.18: Provision a client
         # TODO this isn't provisioning through satellite as intended
         # Note it wasn't well before the change that added this todo
-        # Register client with foreman server using act keys
-        rhel_contenthost.register(org, None, activation_key.name, target_sat)
+        # Register client with foreman server using act keys and install packages
+        packages = 'katello-host-tools puppet-agent'
+        result = rhel_contenthost.api_register(
+            target_sat,
+            organization=org,
+            activation_keys=[activation_key.name],
+            packages=packages,
+        )
+        assert result.status == 0, f'Failed to register host: {result.stderr}'
         assert rhel_contenthost.subscribed
-        # Install rpm on client
-        package_name = 'katello-agent'
-        result = rhel_contenthost.execute(f'yum install -y {package_name}')
-        assert result.status == 0
-        # Verify that the package is installed by querying it
-        result = rhel_contenthost.run(f'rpm -q {package_name}')
-        assert result.status == 0
+        # Verify that the packages are installed by querying it
+        for package in packages.split(' '):
+            assert rhel_contenthost.execute(f'rpm -q {package}').status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16914

### Problem Statement
API e2e test to use hammer to register instead of API/nailgun

### Solution
- Update API e2e test to use RegistrationCommand entity to register
- Also cover the package install during registration process with RegistrationCommand entity

### Related Issues
https://github.com/SatelliteQE/nailgun/pull/1225