### PR TITLE
success > Succeeded status change in host table

### DIFF
--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -783,7 +783,7 @@ class TestAnsibleREX:
             status = session.jobinvocation.read(
                 entity_name=job_description, host_name=client.hostname
             )
-            assert status['overview']['hosts_table'][0]['Status'] == 'success'
+            assert status['overview']['hosts_table'][0]['Status'] == 'Succeeded'
 
             collection_path = client.execute('ls ~/ansible_collections').stdout
             assert 'oasis_roles' in collection_path

--- a/tests/foreman/ui/test_leapp_client.py
+++ b/tests/foreman/ui/test_leapp_client.py
@@ -74,4 +74,4 @@ def test_leapp_preupgrade_report(
         status = session.jobinvocation.read(
             entity_name='Upgradeability check for rhel host', host_name=hostname
         )
-        assert status['overview']['hosts_table'][0]['Status'] == 'success'
+        assert status['overview']['hosts_table'][0]['Status'] == 'Succeeded'

--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -141,7 +141,7 @@ def test_positive_run_default_job_template(
         )
         session.jobinvocation.wait_job_invocation_state(entity_name='Run ls', host_name=hostname)
         status = session.jobinvocation.read(entity_name='Run ls', host_name=hostname)
-        assert status['overview']['hosts_table'][0]['Status'] == 'success'
+        assert status['overview']['hosts_table'][0]['Status'] == 'Succeeded'
 
         # check status also on the job dashboard
         job_name = f'Run {command}'
@@ -250,7 +250,7 @@ def test_positive_run_custom_job_template(
             entity_name=job_description, host_name=hostname
         )
         status = session.jobinvocation.read(entity_name=job_description, host_name=hostname)
-        assert status['overview']['hosts_table'][0]['Status'] == 'success'
+        assert status['overview']['hosts_table'][0]['Status'] == 'Succeeded'
 
 
 @pytest.mark.upgrade
@@ -364,7 +364,7 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
         assert job_status['overview']['hosts_table'][0]['Status'] in (
             'Awaiting start',
             'N/A',
-            'success',
+            'Succeeded',
         )
         # recalculate the job left time to be more accurate
         job_left_time = (plan_time - session.browser.get_client_datetime()).total_seconds()
@@ -383,14 +383,14 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
             lambda: session.jobinvocation.read(
                 f'Run {command_to_run}', hostname, 'overview.hosts_table'
             )['overview']['hosts_table'][0]['Status']
-            == 'success',
+            == 'Succeeded',
             timeout=30,
             delay=1,
         )
         job_status = session.jobinvocation.read(f'Run {command_to_run}', hostname, 'overview')
         assert job_status['overview']['job_status'] == 'Success'
         assert job_status['overview']['hosts_table'][0]['Host'] == hostname
-        assert job_status['overview']['hosts_table'][0]['Status'] == 'success'
+        assert job_status['overview']['hosts_table'][0]['Status'] == 'Succeeded'
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
### Problem Statement
since snap 78
```
AssertionError: assert 'Succeeded' == 'success'
  
  - success
  + Succeeded
```

### Solution
this PR

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->