### PR TITLE
Donwload policy on_demand supported for file type repository

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -479,13 +479,13 @@ class TestRepository:
         [
             {'content_type': content_type, 'download_policy': 'on_demand'}
             for content_type in constants.REPO_TYPE
-            if content_type not in ['yum', 'docker', 'deb']
+            if content_type not in ['yum', 'docker', 'deb', 'file']
         ],
         indirect=True,
         ids=lambda x: x['content_type'],
     )
     def test_negative_create_repos_with_download_policy(self, repo_options, target_sat):
-        """Verify that non-YUM & non-docker repositories cannot be created with
+        """Verify that non-YUM, non-docker, non-debian, and non-file repositories cannot be created with
         download policy
 
         :id: 8a59cb31-164d-49df-b3c6-9b90634919ce

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -659,13 +659,13 @@ class TestRepository:
             [
                 {'content-type': content_type, 'download-policy': 'on_demand'}
                 for content_type in REPO_TYPE
-                if content_type not in ['yum', 'docker', 'deb']
+                if content_type not in ['yum', 'docker', 'deb', 'file']
             ]
         ),
         indirect=True,
     )
     def test_negative_create_repos_with_download_policy(self, repo_options, module_target_sat):
-        """Verify that non-YUM & non-docker repositories cannot be created with download
+        """Verify that non-YUM, non-docker, non-debian, and non-file repositories cannot be created with download
         policy
 
         :id: 71388973-50ea-4a20-9406-0aca142014ca


### PR DESCRIPTION
see https://github.com/Katello/katello/pull/11184

### Problem Statement

see title

### Solution

adapt tests

### Related Issues

relevant tests
tests/foreman/cli/test_repository.py::TestRepository::test_negative_create_repos_with_download_policy

tests/foreman/api/test_repository.py::TestRepository::test_negative_create_repos_with_download_policy


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->