### PR TITLE
On demand download policy is supported for deb

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -479,7 +479,7 @@ class TestRepository:
         [
             {'content_type': content_type, 'download_policy': 'on_demand'}
             for content_type in constants.REPO_TYPE
-            if content_type not in ['yum', 'docker']
+            if content_type not in ['yum', 'docker', 'deb']
         ],
         indirect=True,
         ids=lambda x: x['content_type'],


### PR DESCRIPTION
### Problem Statement

deb repos allow on_deman download policy

### Solution

Exclude deb repo from negative test
This was alread fixed in cli tests https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/cli/test_repository.py#L662

### Related Issues

relevant tests tests/foreman/api/test_repository.py::TestRepository::test_negative_create_repos_with_download_policy

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->