### PR TITLE
remove port 8443

### DIFF
--- a/tests/foreman/data/haproxy.cfg
+++ b/tests/foreman/data/haproxy.cfg
@@ -29,7 +29,7 @@ defaults
     timeout check           10s
     maxconn                 3000
 
-#https
+#https + rhsm
 frontend https
    bind *:443
    mode tcp
@@ -84,20 +84,6 @@ backend f-proxy-anaconda
    balance roundrobin
    server f-proxy-anaconda-2 CAPSULE_1:8000 check
    server f-proxy-anaconda-3 CAPSULE_2:8000 check
-
-#rhsm
-frontend rhsm
-   bind *:8443
-   mode tcp
-   option              	tcplog
-   default_backend f-proxy-rhsm
-
-backend f-proxy-rhsm
-   option tcp-check
-   mode tcp
-   balance roundrobin
-   server f-proxy-rhsm-2 CAPSULE_1:8443 check
-   server f-proxy-rhsm-3 CAPSULE_2:8443 check
 
 #scap
 frontend scap


### PR DESCRIPTION
Port 8443 was removed as reverse proxy from capsule. Clients should use port 443 for RHSM and others.

The modified haproxy.cfg is being used in tests of Load Balancer