### PR TITLE
better logging of fam failures

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -192,5 +192,4 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
     result = module_target_sat.execute(
         f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.11"'
     )
-    assert 'PASSED' in result.stdout
-    assert result.status == 0
+    assert result.status == 0, f"{result.status=}\n{result.stdout=}\n{result.stderr=}"


### PR DESCRIPTION
### Problem Statement

The output of FAM tests is mangled due to how pytest tries to print the big `result` object.
There are no linebreaks and it's super hard to find the failure.

Additionally the double assert is pointless, as it asserts twice the same thing: the result is successful.

### Solution

Stop asserting `PASSED` in stdout (additionally saves the case where there is the string `PASSED` in the output for some reason, but the test actually failed).
Pass a custom error output to the `status == 0` assertion, including stdout, stderr and the status code.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->