### PR TITLE
[6.15.z] Refactor ipv6 http_proxy code

### DIFF
--- a/conf/http_proxy.yaml.template
+++ b/conf/http_proxy.yaml.template
@@ -1,5 +1,6 @@
 HTTP_PROXY:
   UN_AUTH_PROXY_URL:  # http://proxy-01.example.com:3423
+  HTTP_PROXY_IPV6_URL:  # http://proxy-01.ipv6.example.com:3423
   AUTH_PROXY_URL:  # http://proxy-02.example.com:3423
   USERNAME: auth-proxy-user
   PASSWORD: auth-proxy-password

--- a/conf/migrations.py
+++ b/conf/migrations.py
@@ -35,3 +35,15 @@ def migration_231129_deploy_workflow(settings, data):
             logger.info(
                 f'Migrated {product_type}.DEPLOY_WORKFLOW to {product_type}.DEPLOY_WORKFLOWS'
             )
+
+
+def migration_241120_http_proxy_ipv6_url(settings, data):
+    """Migrates server.http_proxy_ipv6_url to http_proxy.http_proxy_ipv6_url"""
+    if (
+        settings.server.get('http_proxy_ipv6_url')
+        and isinstance(settings.server.http_proxy_ipv6_url, str)
+        and not settings.http_proxy.get('http_proxy_ipv6_url')
+    ):
+        data.http_proxy = {}
+        data.http_proxy.http_proxy_ipv6_url = settings.server.http_proxy_ipv6_url
+        logger.info('Migrated SERVER.HTTP_PROXY_IPv6_URL to HTTP_PROXY.HTTP_PROXY_IPV6_URL')

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -15,8 +15,6 @@ SERVER:
     RHEL_VERSION: '8'
   # If the the satellite server is IPv6 server
   IS_IPV6: False
-  # HTTP Proxy url for IPv6 satellite to connect for outer world access
-  HTTP_PROXY_IPv6_URL:
   # run-on-one - All xdist runners default to the first satellite
   # balance - xdist runners will be split between available satellites
   # on-demand - any xdist runner without a satellite will have a new one provisioned.

--- a/pytest_fixtures/component/maintain.py
+++ b/pytest_fixtures/component/maintain.py
@@ -25,7 +25,7 @@ def module_stash(request):
 def sat_maintain(request, module_target_sat, module_capsule_configured):
     if settings.remotedb.server:
         sat = Satellite(settings.remotedb.server)
-        sat.enable_ipv6_http_proxy()
+        sat.enable_satellite_ipv6_http_proxy()
         yield sat
     else:
         module_target_sat.register_to_cdn(pool_ids=settings.subscription.fm_rhn_poolid.split())

--- a/pytest_fixtures/core/broker.py
+++ b/pytest_fixtures/core/broker.py
@@ -24,7 +24,7 @@ def _target_sat_imp(request, _default_sat, satellite_factory):
     """This is the actual working part of the following target_sat fixtures"""
     if request.node.get_closest_marker(name='destructive'):
         new_sat = satellite_factory()
-        new_sat.enable_ipv6_http_proxy()
+        new_sat.enable_satellite_ipv6_http_proxy()
         yield new_sat
         new_sat.teardown()
         Broker(hosts=[new_sat]).checkin()
@@ -34,7 +34,7 @@ def _target_sat_imp(request, _default_sat, satellite_factory):
         yield installer_sat
     else:
         if _default_sat:
-            _default_sat.enable_ipv6_http_proxy()
+            _default_sat.enable_satellite_ipv6_http_proxy()
         yield _default_sat
 
 

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -31,7 +31,7 @@ def resolve_deploy_args(args_dict):
 def _target_satellite_host(request, satellite_factory):
     if 'sanity' not in request.config.option.markexpr:
         new_sat = satellite_factory()
-        new_sat.enable_ipv6_http_proxy()
+        new_sat.enable_satellite_ipv6_http_proxy()
         yield new_sat
         new_sat.teardown()
         Broker(hosts=[new_sat]).checkin()
@@ -49,7 +49,7 @@ def cached_capsule_cdn_register(hostname=None):
 def _target_capsule_host(request, capsule_factory):
     if 'sanity' not in request.config.option.markexpr and not request.config.option.n_minus:
         new_cap = capsule_factory()
-        new_cap.enable_ipv6_http_proxy()
+        new_cap.enable_ipv6_dnf_and_rhsm_proxy()
         yield new_cap
         new_cap.teardown()
         Broker(hosts=[new_cap]).checkin()
@@ -96,7 +96,7 @@ def satellite_factory():
 def large_capsule_host(capsule_factory):
     """A fixture that provides a Capsule based on config settings"""
     new_cap = capsule_factory(deploy_flavor=settings.flavors.custom_db)
-    new_cap.enable_ipv6_http_proxy()
+    new_cap.enable_ipv6_dnf_and_rhsm_proxy()
     yield new_cap
     new_cap.teardown()
     Broker(hosts=[new_cap]).checkin()
@@ -250,7 +250,7 @@ def module_lb_capsule(retry_limit=3, delay=300, **broker_args):
         )
         cap_hosts = wait_for(hosts.checkout, timeout=timeout, delay=delay)
 
-    [cap.enable_ipv6_http_proxy() for cap in cap_hosts.out]
+    [cap.enable_ipv6_dnf_and_rhsm_proxy() for cap in cap_hosts.out]
     yield cap_hosts.out
 
     [cap.teardown() for cap in cap_hosts.out]
@@ -285,7 +285,7 @@ def parametrized_enrolled_sat(
 ):
     """Yields a Satellite enrolled into [IDM, AD] as parameter."""
     new_sat = satellite_factory()
-    new_sat.enable_ipv6_http_proxy()
+    new_sat.enable_satellite_ipv6_http_proxy()
     ipa_host = IPAHost(new_sat)
     new_sat.register_to_cdn()
     if 'IDM' in request.param:
@@ -345,7 +345,7 @@ def cap_ready_rhel():
         'workflow': settings.capsule.deploy_workflows.os,
     }
     with Broker(**deploy_args, host_class=Capsule) as host:
-        host.enable_ipv6_http_proxy()
+        host.enable_ipv6_dnf_and_rhsm_proxy()
         yield host
 
 
@@ -403,7 +403,7 @@ def installer_satellite(request):
         ).get_command(),
         timeout='30m',
     )
-    sat.enable_ipv6_http_proxy()
+    sat.enable_satellite_ipv6_http_proxy()
     if 'sanity' in request.config.option.markexpr:
         configure_nailgun()
         configure_airgun()

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -36,12 +36,6 @@ VALIDATORS = dict(
         Validator('server.ssh_password', default=None),
         Validator('server.verify_ca', default=False),
         Validator('server.is_ipv6', is_type_of=bool, default=False),
-        # validate http_proxy_ipv6_url only if is_ipv6 is True
-        Validator(
-            'server.http_proxy_ipv6_url',
-            is_type_of=str,
-            when=Validator('server.is_ipv6', eq=True),
-        ),
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),
@@ -160,6 +154,12 @@ VALIDATORS = dict(
             'http_proxy.username',
             'http_proxy.password',
             must_exist=True,
+        ),
+        # validate http_proxy_ipv6_url only if server.is_ipv6 is True
+        Validator(
+            'http_proxy.http_proxy_ipv6_url',
+            is_type_of=str,
+            when=Validator('server.is_ipv6', eq=True),
         ),
     ],
     ipa=[

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -110,11 +110,11 @@ class VersionedContent:
         """Downloads the tools/client, capsule, or satellite repos on the machine"""
         product, release, v_major, _ = self._dogfood_helper(product, release)
         if not proxy and settings.server.is_ipv6:
-            proxy = settings.server.http_proxy_ipv6_url
+            proxy = settings.http_proxy.http_proxy_ipv6_url
         url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap, proxy=proxy)
         command = f'curl -o /etc/yum.repos.d/{product}.repo -L {url}'
         if settings.server.is_ipv6:
-            command += f' -x {settings.server.http_proxy_ipv6_url}'
+            command += f' -x {settings.http_proxy.http_proxy_ipv6_url}'
         self.execute(command)
 
     def dogfood_repository(self, repo=None, product=None, release=None, snap=''):

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -60,7 +60,7 @@ from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
 def test_positive_end_to_end(
     setup_http_proxy, module_target_sat, module_org, module_repos_collection_with_manifest
 ):
-    """End-to-end test for HTTP Proxy related scenarios.
+    """End-to-end test for HTTP proxy related scenarios.
 
     :id: 38df5479-9127-49f3-a30e-26b33655971a
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1509,7 +1509,7 @@ def sat_default_install(module_sat_ready_rhels):
     ]
     sat = module_sat_ready_rhels.pop()
     install_satellite(sat, installer_args)
-    sat.enable_ipv6_http_proxy()
+    sat.enable_satellite_ipv6_http_proxy()
     return sat
 
 
@@ -1522,7 +1522,8 @@ def sat_fapolicyd_install(module_sat_ready_rhels):
     ]
     sat = module_sat_ready_rhels.pop()
     install_satellite(sat, installer_args, enable_fapolicyd=True)
-    sat.enable_ipv6_http_proxy()
+    sat.enable_ipv6_dnf_and_rhsm_proxy()
+    sat.enable_satellite_http_proxy()
     return sat
 
 
@@ -1539,7 +1540,7 @@ def sat_non_default_install(module_sat_ready_rhels):
     ]
     sat = module_sat_ready_rhels.pop()
     install_satellite(sat, installer_args, enable_fapolicyd=True)
-    sat.enable_ipv6_http_proxy()
+    sat.enable_satellite_ipv6_http_proxy()
     sat.execute('dnf -y --disableplugin=foreman-protector install foreman-discovery-image')
     return sat
 
@@ -1548,14 +1549,8 @@ def sat_non_default_install(module_sat_ready_rhels):
 @pytest.mark.tier1
 @pytest.mark.pit_server
 @pytest.mark.build_sanity
-@pytest.mark.parametrize(
-    'setting_update',
-    [f'http_proxy={settings.http_proxy.un_auth_proxy_url}'],
-    indirect=True,
-    ids=["un_auth_proxy"],
-)
 def test_capsule_installation(
-    pytestconfig, sat_fapolicyd_install, cap_ready_rhel, module_sca_manifest, setting_update
+    pytestconfig, sat_fapolicyd_install, cap_ready_rhel, module_sca_manifest
 ):
     """Run a basic Capsule installation with fapolicyd
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16928

### Problem Statement
- The current design of `enable_ipv6_http_proxy` and `disable_ipv6_http_proxy` is incorrect and confusing. 
- `Satellite` and `Capsule` classes of `robottelo/hosts.py` have `enable_ipv6_http_proxy`. The one present in Satellite is for setting HTTP proxy in Satellite settings(content and general HTTP proxy). And the one in Capsule is for enabling HTTP proxy for dnf and rhsm.
- This design doesn't allow Satellite to set dnf and rhsm proxies.

### Solution
- Remove`enable_ipv6_http_proxy` and `disable_ipv6_http_proxy` from `Satellite` and `Capsule` classes.
- Add `enable_satellite_http_proxy` and `disable_satellite_http_proxy` to enable/disable ipv4/ipv6 HTTP proxy.  
- Add `enable_satellite_ipv6_http_proxy` in `Satellite` class to set Ipv6 HTTP proxy in Satellite settings, rhsm, and dnf.
- Add `enable_ipv6_dnf_and_rhsm_proxy` to `ContenHost` class so all the three kind of hosts can use it (Satellite, Capsule, Client).
- This PR also removes `test_installer_modules_check` and covers it in `test_satellite_installation`.
- It also remove http_proxy test parameterization for `test_capsule_installation` as it'll be covered by default (Satellite will have HTTP proxy enabled)

### Related Issues
- SAT-29467
- Depends on satellite-jenkins#1556

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->