### PR TITLE
multi cv ak displays content view environments information

### DIFF
--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1603,19 +1603,23 @@ def test_positive_multi_cv_info(
     :Verifies: SAT-27863
     """
     # Create two lifecycle environments
-    lce1 = session_multicv_sat.api.LifecycleEnvironment(organization=session_multicv_org).create()
-    lce2 = session_multicv_sat.api.LifecycleEnvironment(organization=session_multicv_org).create()
-
+    lces_list = [
+        session_multicv_sat.api.LifecycleEnvironment(organization=session_multicv_org).create()
+        for i in range(2)
+    ]
+    lce1 = lces_list[0]
+    lce2 = lces_list[1]
     # Create two content views
-    cv1 = session_multicv_sat.api.ContentView(organization=session_multicv_org).create()
-    cv1.publish()
-    cv1 = cv1.read()
-    cv1.version[0].promote(data={'environment_ids': lce1.id})
-
-    cv2 = session_multicv_sat.api.ContentView(organization=session_multicv_org).create()
-    cv2.publish()
-    cv2 = cv2.read()
-    cv2.version[0].promote(data={'environment_ids': lce2.id})
+    cvs_list = [
+        session_multicv_sat.api.ContentView(organization=session_multicv_org).create()
+        for i in range(2)
+    ]
+    for i in range(2):
+        cvs_list[i].publish()
+        cvs_list[i] = cvs_list[i].read()
+        cvs_list[i].version[0].promote(data={'environment_ids': lces_list[i].id})
+    cv1 = cvs_list[0]
+    cv2 = cvs_list[1]
 
     # Update ak with multiple content view environments
     ak = session_multicv_default_ak

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1605,6 +1605,8 @@ def test_positive_multi_cv_info(
     :team: Phoenix-subscriptions
 
     :parametrized: No
+
+    :Verifies: SAT-27863
     """
     # Create two lifecycle environments
     lce1 = session_multicv_sat.api.LifecycleEnvironment(organization=session_multicv_org).create()

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1607,8 +1607,7 @@ def test_positive_multi_cv_info(
         session_multicv_sat.api.LifecycleEnvironment(organization=session_multicv_org).create()
         for i in range(2)
     ]
-    lce1 = lces_list[0]
-    lce2 = lces_list[1]
+    lce1, lce2 = lces_list
     # Create two content views
     cvs_list = [
         session_multicv_sat.api.ContentView(organization=session_multicv_org).create()

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1587,24 +1587,18 @@ def test_positive_invalid_release_version(module_sca_manifest_org, module_target
 def test_positive_multi_cv_info(
     session_multicv_sat, session_multicv_org, session_multicv_default_ak
 ):
-    """Verify that multi-env AK display into hammer activation-key info commands output
+    """Verify that multi content view environment details displays into hammer activation-key info commands output
 
     :id: 6a1c3189-74f9-4a54-8579-f3b045870cd9
 
     :steps:
         1. Create two lifecycle environments and two content views, publish/promote to respective lce
         2. Create activation key and update ak with multiple content view environments
-        3. Check ak info displays 'Multi Content View Environment' and 'Content View Environments'
+        3. Check that ak info displays 'Multi Content View Environment' and 'Content View Environments'
 
     :expectedresults: AK info displays 'Multi Content View Environment' and 'Content View Environments'
 
     :CaseImportance: Medium
-
-    :CaseComponent: ActivationKeys
-
-    :team: Phoenix-subscriptions
-
-    :parametrized: No
 
     :Verifies: SAT-27863
     """

--- a/tests/foreman/cli/test_activationkey.py
+++ b/tests/foreman/cli/test_activationkey.py
@@ -1617,8 +1617,7 @@ def test_positive_multi_cv_info(
         cvs_list[i].publish()
         cvs_list[i] = cvs_list[i].read()
         cvs_list[i].version[0].promote(data={'environment_ids': lces_list[i].id})
-    cv1 = cvs_list[0]
-    cv2 = cvs_list[1]
+    cv1, cv2 = cvs_list
 
     # Update ak with multiple content view environments
     ak = session_multicv_default_ak


### PR DESCRIPTION
### Problem Statement
Automation coverage for SAT-27863
Adds support for multi environment activation keys.

### Solution
new test case "test_positive_multi_cv_info"

### Related Issues
No

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_activationkey.py -k 'test_positive_multi_cv_info'
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->