### PR TITLE
create a fake ntp module for FAM tests

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -101,16 +101,6 @@ def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_rol
         f'''sed -i 's|subscription_manifest_path:.*|subscription_manifest_path: "data/{module_sca_manifest.name}"|g' {config_file}'''
     )
 
-    repo_path = '/fake_puppet1/system/releases/p/puppetlabs/'
-    module_tarball = 'puppetlabs-ntp-3.0.3.tar.gz'
-    local_path = '/tmp'
-    module_target_sat.execute(
-        f'curl --output {local_path}/{module_tarball} {settings.robottelo.repos_hosting_url}{repo_path}{module_tarball}',
-    )
-    module_target_sat.execute(
-        f'puppet module install --ignore-dependencies {local_path}/{module_tarball}'
-    )
-
     def create_fake_module(module_target_sat, module_name, module_classes):
         base_dir = '/etc/puppetlabs/code/environments/production/modules'
         module_dir = f'{base_dir}/{module_name}'
@@ -127,6 +117,12 @@ def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_rol
                 f'{manifest_dir}/{module_class}.pp',
                 temp_file=True,
             )
+
+    create_fake_module(
+        module_target_sat,
+        'ntp',
+        [('init', '($logfile, $config_dir, $servers, $burst, $stepout){}'), 'config'],
+    )
 
     create_fake_module(
         module_target_sat,

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -118,8 +118,10 @@ def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_rol
         module_target_sat.execute(f'mkdir -p {manifest_dir}')
         for module_class in module_classes:
             full_class = module_name if module_class == 'init' else f'{module_name}::{module_class}'
-            module_target_sat.execute(
-                f'echo "class {full_class}(){{}}" > {manifest_dir}/{module_class}.pp'
+            module_target_sat.put(
+                f'class {full_class}(){{}}',
+                f'{manifest_dir}/{module_class}.pp',
+                temp_file=True,
             )
 
     create_fake_module(

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -117,9 +117,13 @@ def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_rol
         manifest_dir = f'{module_dir}/manifests'
         module_target_sat.execute(f'mkdir -p {manifest_dir}')
         for module_class in module_classes:
+            if isinstance(module_class, str):
+                module_code = '(){}'
+            else:
+                module_class, module_code = module_class
             full_class = module_name if module_class == 'init' else f'{module_name}::{module_class}'
             module_target_sat.put(
-                f'class {full_class}(){{}}',
+                f'class {full_class}{module_code}',
                 f'{manifest_dir}/{module_class}.pp',
                 temp_file=True,
             )


### PR DESCRIPTION
### Problem Statement

The ntp module in the fixtures is too old, but we also only need a few params from it.

### Solution

Drop the install code and use the fake code to create a module as the tests expect

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->
