### PR TITLE
Fix assertion error for test_positive_self_update_maintain_package

### DIFF
--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -140,7 +140,10 @@ def test_positive_self_update_maintain_package(sat_maintain):
         options={'whitelist': 'repositories-validate, non-rh-packages'}
     )
     assert result.status == 0
-    assert 'Checking for new version of satellite-maintain...' in result.stdout
+    assert (
+        'Checking for new version of satellite-maintain, rubygem-foreman_maintain...'
+        in result.stdout
+    )
     result = sat_maintain.cli.Update.check(
         options={
             'whitelist': 'repositories-validate, non-rh-packages',
@@ -148,7 +151,10 @@ def test_positive_self_update_maintain_package(sat_maintain):
         }
     )
     assert result.status == 0
-    assert 'Checking for new version of satellite-maintain...' not in result.stdout
+    assert (
+        'Checking for new version of satellite-maintain, rubygem-foreman_maintain...'
+        not in result.stdout
+    )
 
 
 @pytest.mark.stubbed


### PR DESCRIPTION
### Problem Statement
- `satellite-maintain update` command's output has changed because of https://github.com/theforeman/foreman_maintain/pull/944 causing `test_positive_self_update_maintain_package` to fail with assertion error.

### Solution
- Updated the assertion

### Related Issues
- SAT-29668

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->