### PR TITLE
Revert "Bump cryptography from 43.0.3 to 44.0.0 (#17004)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       - "6.15.z"
       - "6.14.z"
       - "6.13.z"
+    ignore:
+      - dependency-name: "cryptography"
+        update-types: ["version-update:semver-minor"]
 
   # Maintain dependencies for our GitHub Actions
   - package-ecosystem: "github-actions"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 apypie==0.5.0
 betelgeuse==1.11.0
 broker[docker,podman,hussh]==0.5.7
-cryptography==44.0.0
+cryptography==43.0.3
 deepdiff==8.0.1
 dynaconf[vault]==3.2.6
 fauxfactory==3.1.1


### PR DESCRIPTION
This reverts commit cfce89a7f496405837d0514fe2cc3f4e806a5424.

### Problem Statement

Updating cryptography to 44.0.0 causes the following error:

```
11:03:30  _ ERROR at setup of TestGCEHostProvisioningTestCase.test_positive_gce_host_provisioned[sat] _
11:03:30  pytest_fixtures/component/provision_gce.py:92: in gce_latest_rhel_uuid
11:03:30      templates = googleclient.find_templates(
11:03:30  ../../lib64/python3.12/site-packages/wrapanapi/systems/google.py:721: in find_templates
11:03:30      return self._list_templates(
11:03:30  ../../lib64/python3.12/site-packages/wrapanapi/systems/google.py:664: in _list_templates
11:03:30      .execute()
11:03:30  ../../lib64/python3.12/site-packages/googleapiclient/_helpers.py:130: in positional_wrapper
11:03:30      return wrapped(*args, **kwargs)
11:03:30  ../../lib64/python3.12/site-packages/googleapiclient/http.py:923: in execute
11:03:30      resp, content = _retry_request(
11:03:30  ../../lib64/python3.12/site-packages/googleapiclient/http.py:191: in _retry_request
11:03:30      resp, content = http.request(uri, method, *args, **kwargs)
11:03:30  ../../lib64/python3.12/site-packages/oauth2client/transport.py:159: in new_request
11:03:30      credentials._refresh(orig_request_method)
11:03:30  ../../lib64/python3.12/site-packages/oauth2client/client.py:749: in _refresh
11:03:30      self._do_refresh_request(http)
11:03:30  ../../lib64/python3.12/site-packages/oauth2client/client.py:774: in _do_refresh_request
11:03:30      body = self._generate_refresh_request_body()
11:03:30  ../../lib64/python3.12/site-packages/oauth2client/client.py:1484: in _generate_refresh_request_body
11:03:30      assertion = self._generate_assertion()
11:03:30  ../../lib64/python3.12/site-packages/oauth2client/service_account.py:384: in _generate_assertion
11:03:30      return crypt.make_signed_jwt(self._signer, payload,
11:03:30  ../../lib64/python3.12/site-packages/oauth2client/crypt.py:97: in make_signed_jwt
11:03:30      signature = signer.sign(signing_input)
11:03:30  ../../lib64/python3.12/site-packages/oauth2client/_openssl_crypt.py:97: in sign
11:03:30      return crypto.sign(self._key, message, 'sha256')
11:03:30  ../../lib64/python3.12/site-packages/cryptography/utils.py:68: in __getattr__
11:03:30      obj = getattr(self._module, attr)
11:03:30  E   AttributeError: module 'OpenSSL.crypto' has no attribute 'sign'
```

### Solution

Reverting to 43.0.3 makes sanity jobs work again.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->