### PR TITLE
[6.15.z] update WrapanAPI dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ requests==2.32.3
 tenacity==9.0.0
 testimony==2.4.0
 wait-for==1.2.0
-wrapanapi==3.6.1
+wrapanapi==3.6.4
 
 # Get airgun, nailgun and upgrade from 6.15.z
 airgun @ git+https://github.com/SatelliteQE/airgun.git@6.15.z#egg=airgun


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17019

### Problem Statement
Sanity GCE Test is failing with depreciated sign function in pyopenssl new version.


### Solution
The wrapanAPI version 3.6.3 has pinned pyopenssl. So pin the package to 3.6.3

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->