### PR TITLE
[6.14.z] Update RHEL9 version for Leapp client

### DIFF
--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -10,7 +10,7 @@ synced_repos = pytest.StashKey[dict]
 
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.4'
+RHEL9_VER = '9.5'
 
 RHEL_REPOS = {
     'rhel7_server': {

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -25,7 +25,7 @@ synced_repos = pytest.StashKey[dict]
 
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.4'
+RHEL9_VER = '9.5'
 
 RHEL_REPOS = {
     'rhel7_server': {

--- a/tests/foreman/ui/test_leapp_client.py
+++ b/tests/foreman/ui/test_leapp_client.py
@@ -16,7 +16,7 @@ import pytest
 
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.4'
+RHEL9_VER = '9.5'
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17010

### Problem Statement
RHEL 9.5 is released but leapp tests were still using RHEL9.4 

### Solution
RHEL 9 is updated to 9.5

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->