### PR TITLE
test rex using values from global parameters

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -43,6 +43,7 @@ pytest_plugins = [
     'pytest_fixtures.component.contentview',
     'pytest_fixtures.component.domain',
     'pytest_fixtures.component.discovery',
+    'pytest_fixtures.component.global_params',
     'pytest_fixtures.component.host',
     'pytest_fixtures.component.hostgroup',
     'pytest_fixtures.component.http_proxy',

--- a/pytest_fixtures/component/global_params.py
+++ b/pytest_fixtures/component/global_params.py
@@ -1,0 +1,33 @@
+# Settings Fixtures
+import pytest
+
+
+@pytest.fixture
+def multi_global_param_update(request, target_sat):
+    """
+    This fixture is used to alter multiple global parameters in one batch.
+    """
+    key_vals = request.param
+    param_objects = []
+    for key_val in key_vals:
+        param, new_value = tuple(key_val.split('=')) if '=' in key_val else (key_val, None)
+        existing_params = target_sat.api.CommonParameter().search(query={'search': f'name={param}'})
+        if len(existing_params) > 0:
+            assert len(existing_params) == 1, 'Unexpected number of parameters returned'
+            param_object = existing_params[0]
+            cleanup = False
+            default_param_value = param_object.value
+        else:
+            param_object = target_sat.api.CommonParameter(name=param, value=new_value).create()
+            cleanup = True
+            default_param_value = new_value
+        param_objects.append(
+            {'object': param_object, 'default': default_param_value, 'cleanup': cleanup}
+        )
+    yield [item['object'] for item in param_objects]
+    for item in param_objects:
+        if item['cleanup']:
+            item['object'].delete()
+        else:
+            item['object'].value = item['default']
+            item['object'].update({'value'})

--- a/pytest_fixtures/component/settings.py
+++ b/pytest_fixtures/component/settings.py
@@ -19,3 +19,26 @@ def setting_update(request, target_sat):
     yield setting_object
     setting_object.value = default_setting_value
     setting_object.update({'value'})
+
+
+@pytest.fixture
+def multi_setting_update(request, target_sat):
+    """
+    This fixture is used to alter multiple settings in one batch.
+    """
+    key_vals = request.param
+    setting_objects = []
+    for key_val in key_vals:
+        setting, new_value = tuple(key_val.split('=')) if '=' in key_val else (key_val, None)
+        setting_object = target_sat.api.Setting().search(query={'search': f'name={setting}'})[0]
+        default_setting_value = (
+            '' if setting_object.value in [None, '*****'] else setting_object.value
+        )
+        if new_value is not None:
+            setting_object.value = new_value
+            setting_object.update({'value'})
+        setting_objects.append({'object': setting_object, 'original': default_setting_value})
+    yield [item['object'] for item in setting_objects]
+    for item in setting_objects:
+        item['object'].value = item['original']
+        item['object'].update({'value'})


### PR DESCRIPTION
### Problem Statement
mostly to cover SAT-28443, but also to check global params usage

### Solution
~~note: It turned out the scenario needs global params and not global settings, but since I already wrote the  multi_setting_update fixture, I left it there for potential future use 
also stream has hickups with AKs, so holding of prt for now~~
update: I added another test, so both global parameters and global settings are used, but the glob settings version is blocked by SAT-30443

### Related Issues
SAT-28443

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->