### PR TITLE
Unpin wrapanapi version from requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ requests==2.32.3
 tenacity==9.0.0
 testimony==2.4.0
 wait-for==1.2.0
-wrapanapi==3.6.4
+wrapanapi
 
 # Get airgun, nailgun and upgrade from master
 airgun @ git+https://github.com/SatelliteQE/airgun.git@master#egg=airgun


### PR DESCRIPTION
### Problem Statement
Robottelo uses wrapanapi and currently it is pinned to version 3.6.4. Since we are always using latest version of wrapanapi so pinning to version needs to be updated whenever wrapanapi releases a new version.  

### Solution
Unpinned wrapanapi to always use the latest version in robottelo.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->