### PR TITLE
[6.16.z] Fix assertion for test_katello_certs_check_output_invalid_input

### DIFF
--- a/tests/foreman/sys/test_katello_certs_check.py
+++ b/tests/foreman/sys/test_katello_certs_check.py
@@ -73,11 +73,12 @@ class TestKatelloCertsCheck:
     CA cert (a.k.a cacert.crt or rootCA.pem) can be used as bundle file.
     """
 
+    error_message = f"error 26 at 0 depth lookup: {'unsupported' if settings.repos.rhel_major_version == '8' else 'unsuitable'} certificate purpose"
     invalid_inputs = [
         (
             {
                 'check': 'Checking CA bundle against the certificate file',
-                'message': 'error 26 at 0 depth lookup: unsupported certificate purpose',
+                'message': error_message,
             },
             'certs/invalid.crt',
             'certs/invalid.key',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17002

### Problem Statement
-  `test_katello_certs_check_output_invalid_input[error0-certs/invalid.crt-certs/invalid.key-certs/ca.crt]` is failing with AssertionError because the error message has changed.

### Solution
- Fix assertion

### Related Issues
- SAT-29725

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->