### PR TITLE
FAM: set a password for LDAP Auth sources at creation

### DIFF
--- a/conf/fam.yaml.template
+++ b/conf/fam.yaml.template
@@ -36,6 +36,7 @@ FAM:
     auth_source_ldap_attr_login: uid
     auth_source_ldap_groups_base: cn=groups,cn=accounts,dc=example,dc=com
     external_usergroup_name: "admins"
+    default_auth_source_ldap_account_password: password
 
   COMPUTE_PROFILE:
     libvirt:


### PR DESCRIPTION
This was originally removed in c390a27ea411b8701383f2214b6848b6c287f71e
as always setting the password broke idempotency.
But with https://github.com/theforeman/foreman-ansible-modules/pull/1806
we can now set the password for creation, but avoid trying to update it.

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->