### PR TITLE
[6.14.z] assertion fix for rex time expressions test

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -344,7 +344,7 @@ class TestRemoteExecution:
         """
         client = rex_contenthost
         today = datetime.today()
-        hour = datetime.utcnow().hour
+        hour = datetime.now().hour
         last_day_of_month = monthrange(today.year, today.month)[1]
         days_to = (2 - today.weekday()) % 7
         # cronline uses https://github.com/floraison/fugit


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17059

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->