### PR TITLE
RHEL10 OS repository for Insights Client

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -22,6 +22,9 @@ REPOS:
   RHEL9_OS:
     BASEOS: replace-with-rhel9-os-baseos-http-link
     APPSTREAM: replace-with-rhel9-os-appstream-http-link
+  RHEL10_OS:
+    BASEOS: replace-with-rhel10-os-baseos-http-link
+    APPSTREAM: replace-with-rhel10-os-appstream-http-link
   RHEL7_OPTIONAL: replace-with-rhel7-optional-url
   RHEL7_EXTRAS: replace-with-rhel7-extras-url
   # If capsule and satellite tools repositories available related packages will

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1105,13 +1105,14 @@ class ContentHost(Host, ContentHostMixins):
         :param register: Whether to register client to insights
         :return: None
         """
-        # Red Hat Insights requires RHEL 6/7/8/9 repo and it is not
+        # Red Hat Insights requires RHEL OS repos and it is not
         # possible to sync the repo during the tests, Adding repo file.
         distro_repo_map = {
             'rhel6': settings.repos.rhel6_os,
             'rhel7': settings.repos.rhel7_os,
             'rhel8': settings.repos.rhel8_os,
             'rhel9': settings.repos.rhel9_os,
+            'rhel10': settings.repos.rhel10_os,
         }
         rhel_repo = distro_repo_map.get(rhel_distro)
 


### PR DESCRIPTION
Repo addition requested for insights client to work using RHEL10: https://github.com/SatelliteQE/robottelo/pull/17044#issuecomment-2514429160 
Also to get RHEL10 param working for Stream testing of MR #16913 

Also needs ~Satellite-Jenkins MR 1568~ (merged) , adding RHEL10 BASEOS and APPSTREAM to `repos.yaml`