### PR TITLE
Revert "[6.16.z] Bump cryptography from 43.0.3 to 44.0.0 (#17008)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 apypie==0.5.0
 betelgeuse==1.11.0
 broker[docker,podman,hussh]==0.5.7
-cryptography==44.0.0
+cryptography==43.0.3
 deepdiff==8.0.1
 dynaconf[vault]==3.2.6
 fauxfactory==3.1.1


### PR DESCRIPTION
This reverts commit 3f8eb05a7c977f032e7a41c217fb97ec2d6d399e.

### Problem Statement

Apply the same fix that we did for #17011

### Solution

Reverting to 43.0.3 makes sanity jobs work again.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->