### PR TITLE
 [6.15.z]Unpin wrapanapi version from requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 apypie==0.5.0
 betelgeuse==1.11.0
 broker[docker,podman,hussh]==0.5.7
-cryptography==44.0.0
+cryptography==43.0.3
 deepdiff==8.0.1
 dynaconf[vault]==3.2.6
 fauxfactory==3.1.1
@@ -26,7 +26,7 @@ requests==2.32.3
 tenacity==9.0.0
 testimony==2.4.0
 wait-for==1.2.0
-wrapanapi==3.6.1
+wrapanapi
 
 # Get airgun, nailgun and upgrade from 6.15.z
 airgun @ git+https://github.com/SatelliteQE/airgun.git@6.15.z#egg=airgun


### PR DESCRIPTION
Manual cherrypick of https://github.com/SatelliteQE/robottelo/pull/17023

### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->