### PR TITLE
[6.16.z] [CC Automation] Test for Scheduled insights sync job

### DIFF
--- a/tests/foreman/api/test_rhcloud_inventory.py
+++ b/tests/foreman/api/test_rhcloud_inventory.py
@@ -289,3 +289,45 @@ def test_include_parameter_tags_setting(
                 if tag['key'] == 'host_collection':
                     assert tag['value'] == f'"{host_col_name}"'
                     break
+
+
+@pytest.mark.e2e
+@pytest.mark.tier3
+def test_rhcloud_scheduled_insights_sync(
+    rhcloud_manifest_org,
+    rhcloud_registered_hosts,
+    module_target_sat,
+):
+    """Verify that triggering the InsightsScheduledSync job in Satellite succeeds with no errors
+
+    :id: 59f66062-2865-4cca-82bb-8d0501fd40f1
+
+    :steps:
+        1. Prepare machine and upload its data to Insights
+        2. Sync inventory status using RH Cloud plugin api
+        3. Trigger the InsightsScheduledSync job manually
+        4. Assert job succeeds
+
+    :expectedresults:
+        1. Manually triggering the InsightsScheduledSync job succeeds with no errors.
+
+    :Verifies: SAT-22626
+
+    :CaseAutomation: Automated
+    """
+    org = rhcloud_manifest_org
+    virtual_host, baremetal_host = rhcloud_registered_hosts
+    # Generate report
+    module_target_sat.generate_inventory_report(org)
+    # Sync inventory status
+    inventory_sync = module_target_sat.sync_inventory_status(org)
+    task_output = module_target_sat.api.ForemanTask().search(
+        query={'search': f'id = {inventory_sync["task"]["id"]}'}
+    )
+    # Assert that both hosts are synced successfully
+    assert task_output[0].output['host_statuses']['sync'] == 2
+    result = module_target_sat.execute(
+        "foreman-rake console SATELLITE_RH_CLOUD_REQUESTS_DELAY=0 <<< 'ForemanTasks.sync_task(InsightsCloud::Async::InsightsScheduledSync)'"
+    )
+    assert 'success' in result.stdout
+    assert result.status == 0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16913

David: Since RHEL10 clients are only in stream, we do not expect a RHEL10 param in 6.16.z. 
All prior RHEL distros (up to rhel9) should pass PRT