### PR TITLE
permission read test skipped

### DIFF
--- a/tests/foreman/api/test_multiple_paths.py
+++ b/tests/foreman/api/test_multiple_paths.py
@@ -471,10 +471,15 @@ class TestEntityRead:
             class and name and resource_type fields are populated
 
         :CaseImportance: Critical
+
+        :Verifies: SAT-29957
+
+        :BlockedBy: SAT-29957
         """
-        perm = target_sat.api.Permission().search(query={'per_page': '1'})[0]
-        assert perm.name
-        assert perm.resource_type
+        perms = target_sat.api.Permission().search(query={'per_page': '1'})
+        for perm in perms:
+            assert perm.name
+            assert perm.resource_type
 
     @pytest.mark.tier1
     def test_positive_media_read(self, target_sat):


### PR DESCRIPTION
### Problem Statement


### Solution
Changed the test so it doesn't just check the first perm, associated a related JIRA

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->