### PR TITLE
[6.13.z] Update Jira ON_QA status for Jira issue handler

### DIFF
--- a/conf/jira.yaml.template
+++ b/conf/jira.yaml.template
@@ -7,4 +7,4 @@ JIRA:
   COMMENT_VISIBILITY: "Red Hat Employee"
   ENABLE_COMMENT: false
   # Comment only if jira is in one of the following state
-  ISSUE_STATUS: ["Review", "Release Pending"]
+  ISSUE_STATUS: ["Testing", "Release Pending"]

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -189,7 +189,7 @@ VALIDATORS = dict(
         Validator('jira.comment_type', default="group"),
         Validator('jira.comment_visibility', default="Red Hat Employee"),
         Validator('jira.enable_comment', default=False),
-        Validator('jira.issue_status', default=["Review", "Release Pending"]),
+        Validator('jira.issue_status', default=["Testing", "Release Pending"]),
     ],
     ldap=[
         Validator(

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1723,8 +1723,16 @@ WONTFIX_RESOLUTIONS = ("WONTFIX", "CANTFIX", "DEFERRED")
 # Jira statuses used by Robottelo issue handler.
 JIRA_TESTS_PASSED_LABEL = "tests-passed"
 JIRA_TESTS_FAILED_LABEL = "tests-failed"
-JIRA_OPEN_STATUSES = ("New", "Backlog", "Refinement", "To Do", "In Progress")
-JIRA_ONQA_STATUS = "Review"
+JIRA_OPEN_STATUSES = (
+    "New",
+    "Backlog",
+    "Refinement",
+    "To Do",
+    "In Progress",
+    "Review",
+    "Release Pending - Upstream",
+)
+JIRA_ONQA_STATUS = "Testing"
 JIRA_CLOSED_STATUSES = ("Release Pending", "Closed")
 JIRA_WONTFIX_RESOLUTIONS = "Obsolete"
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/16721

### Problem Statement
We'll be adding a new Jira status, breaking the Jira issue handler for Robottelo. 

### Solution
Update the statuses with the new ones.