### PR TITLE
[6.16.z] CP: rhel_ver_match(N-x) Optional Format

### DIFF
--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -20,7 +20,7 @@ def pytest_configure(config):
         "run_in_one_thread: Sequential tests",
         "build_sanity: Fast, basic tests that confirm build is ready for full test suite",
         "rhel_ver_list: Filter rhel_contenthost versions by list",
-        "rhel_ver_match: Filter rhel_contenthost versions by regexp",
+        "rhel_ver_match: Filter rhel_contenthost versions by regexp, or format 'N-x'",
         "no_containers: Disable container hosts from being used in favor of VMs",
         "include_capsule: For satellite-maintain tests to run on Satellite and Capsule both",
         "capsule_only: For satellite-maintain tests to run only on Capsules",


### PR DESCRIPTION
### Problem Statement
Partial cherry-pick of #16807 , adding ('N-x') format to parametrize marker `rhel_ver_match` for rhel contenthosts/clients.
Just CPing the fixture changes, as some new tests are also being CP'd to 6.16/6.15.z, with the N-x marker format.
Otherwise, the format is invalid for regex, so all distros are picked including fips.

_Note_: In 6.15.z and 6.16.z , RHEL9 is N (newest) in `supportability.yaml`. RHEL10 is only in Stream (6.17)

Example: 
```
@pytest.mark.rhel_ver_match('N-2') # rhel9, 8, and 7  in 6.16 and 6.15
def test_case(rhel_contenthost, target_sat, ...):
```


### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_inventory.py -k 'test_positive_register_insights_client_host'

or tests/foreman/api/test_rhcloud_inventory.py -k 'test_rhcloud_scheduled_insights_sync'
```