### PR TITLE
Skip /var/log/foreman-proxy/ log assertion for capsule installation

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -429,9 +429,10 @@ def test_capsule_installation(
     # no errors/failures in /var/log/httpd/*
     result = cap_ready_rhel.execute(r'grep -iR "error" /var/log/httpd/*')
     assert len(result.stdout) == 0
-    # no errors/failures in /var/log/foreman-proxy/*
-    result = cap_ready_rhel.execute(r'grep -iR "error" /var/log/foreman-proxy/*')
-    assert len(result.stdout) == 0
+    if not is_open('SAT-29982'):
+        # no errors/failures in /var/log/foreman-proxy/*
+        result = cap_ready_rhel.execute(r'grep -iR "error" /var/log/foreman-proxy/*')
+        assert len(result.stdout) == 0
 
     # Enabling firewall
     cap_ready_rhel.execute('firewall-cmd --add-service RH-Satellite-6-capsule')


### PR DESCRIPTION
### Problem Statement
test_capsule_installation is failing because of SAT-29982

### Solution
- Skip the assertion till the issue is resolved as it shouldn't affect other functionalities and continue with the rest of the code.

### Related Issues
- SAT-29982
- SAT-29984

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->