### PR TITLE
Revert "Skip /var/log/foreman-proxy/ log assertion for capsule installation"

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -429,10 +429,9 @@ def test_capsule_installation(
     # no errors/failures in /var/log/httpd/*
     result = cap_ready_rhel.execute(r'grep -iR "error" /var/log/httpd/*')
     assert len(result.stdout) == 0
-    if not is_open('SAT-29982'):
-        # no errors/failures in /var/log/foreman-proxy/*
-        result = cap_ready_rhel.execute(r'grep -iR "error" /var/log/foreman-proxy/*')
-        assert len(result.stdout) == 0
+    # no errors/failures in /var/log/foreman-proxy/*
+    result = cap_ready_rhel.execute(r'grep -iR "error" /var/log/foreman-proxy/*')
+    assert len(result.stdout) == 0
 
     # Enabling firewall
     cap_ready_rhel.execute('firewall-cmd --add-service RH-Satellite-6-capsule')


### PR DESCRIPTION
This reverts commit b8890f951682019b1de38ae4b19571fd16bc4905.
It's not required once gitlab MR satellite-packaging/#8552 is merged

Note: Do not merge before