### PR TITLE
Provide better error output for test_satellite_installation

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -385,7 +385,7 @@ def installer_satellite(request):
 
     sat.install_satellite_or_capsule_package()
     # Install Satellite
-    sat.execute(
+    installer_result = sat.execute(
         InstallerCommand(
             installer_args=[
                 'scenario satellite',
@@ -394,6 +394,9 @@ def installer_satellite(request):
         ).get_command(),
         timeout='30m',
     )
+    # exit code 0 means no changes, 2 means changes were applied succesfully
+    assert installer_result.status in (0, 2), installer_result.stdout
+
     sat.enable_satellite_ipv6_http_proxy()
     if 'sanity' in request.config.option.markexpr:
         configure_nailgun()

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -364,19 +364,18 @@ def installer_satellite(request):
         # enable satellite repos
         for repo in sat.SATELLITE_CDN_REPOS.values():
             sat.enable_repo(repo, force=True)
+    elif settings.server.version.source == 'nightly':
+        sat.create_custom_repos(
+            satellite_repo=settings.repos.satellite_repo,
+            satmaintenance_repo=settings.repos.satmaintenance_repo,
+        )
     else:
-        if settings.server.version.source == 'nightly':
-            sat.create_custom_repos(
-                satellite_repo=settings.repos.satellite_repo,
-                satmaintenance_repo=settings.repos.satmaintenance_repo,
-            )
-        else:
-            # get ohsnap repofile
-            sat.download_repofile(
-                product='satellite',
-                release=settings.server.version.release,
-                snap=settings.server.version.snap,
-            )
+        # get ohsnap repofile
+        sat.download_repofile(
+            product='satellite',
+            release=settings.server.version.release,
+            snap=settings.server.version.snap,
+        )
 
     if settings.robottelo.rhel_source == "internal":
         # disable rhel repos from cdn

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -116,22 +116,22 @@ def common_sat_install_assertions(satellite):
     result = satellite.execute(
         r'journalctl --quiet --no-pager --boot --priority err -u "dynflow-sidekiq*" -u "foreman-proxy" -u "foreman" -u "httpd" -u "postgresql" -u "pulpcore-api" -u "pulpcore-content" -u "pulpcore-worker*" -u "redis" -u "tomcat"'
     )
-    assert len(result.stdout) == 0
+    assert not result.stdout
     # no errors in /var/log/foreman/production.log
     result = satellite.execute(r'grep --context=100 -E "\[E\|" /var/log/foreman/production.log')
     if not is_open('SAT-21086'):
-        assert len(result.stdout) == 0
+        assert not result.stdout
     # no errors/failures in /var/log/foreman-installer/satellite.log
     result = satellite.execute(
         r'grep "\[ERROR" --context=100 /var/log/foreman-installer/satellite.log'
     )
-    assert len(result.stdout) == 0
+    assert not result.stdout
     # no errors/failures in /var/log/httpd/*
     result = satellite.execute(r'grep -iR "error" /var/log/httpd/*')
-    assert len(result.stdout) == 0
+    assert not result.stdout
     # no errors/failures in /var/log/candlepin/*
     result = satellite.execute(r'grep -iR "error" /var/log/candlepin/*')
-    assert len(result.stdout) == 0
+    assert not result.stdout
 
     httpd_log = satellite.execute('journalctl --unit=httpd')
     assert "WARNING" not in httpd_log.stdout


### PR DESCRIPTION
### Problem Statement

The current output of `test_satellite_installation` is useless. Because the output is so long, pytest truncates it which hides the relevant error.

### Solution

As a first step, it does a trivial cleanup for readability. The next commit stops using `len(x) == 0` and instead uses `not x` to assert there is no output. I haven't tested this, but I believe this allows pytest to skip a layer of output and hopefully also provide better output.

The real change is that it asserts the exit code of the installer to be 0 or 2. In practice I'd always expect 2, but 0 is also valid. See https://github.com/theforeman/kafo?tab=readme-ov-file#exit-code for more information. Since foreman-installer 3.8.0 (https://github.com/theforeman/foreman-installer/commit/0d2fb671ea579bf1f44b93dded089c0db159b536) it also displays structured output on the exact failure.

### Related Issues

trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_satellite_installation'