### PR TITLE
[6.15.z] [6.16.z] CP: rhel_ver_match(N-x) Optional Format

### DIFF
--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -34,14 +34,27 @@ def pytest_generate_tests(metafunc):
         # process eventual rhel_version_match markers
         matchers = [i.args for i in function_marks if i.name == 'rhel_ver_match']
         match_params = []
-        for matcher in matchers:
-            match_params.extend(
-                [
-                    setting_rhel_ver
-                    for setting_rhel_ver in settings.supportability.content_hosts.rhel.versions
-                    if re.fullmatch(str(matcher[0]), str(setting_rhel_ver))
-                ]
-            )
+        # check if param matches format 'N-x'
+        if matchers and len(matchers[0][0]) == 3 and matchers[0][0].startswith('N-'):
+            # num of desired prior versions
+            num_versions = int(matchers[0][0].split('-')[1])
+            # grab major versions, excluding fips, from tail of supportability list
+            filtered_versions = [
+                setting_rhel_ver
+                for setting_rhel_ver in settings.supportability.content_hosts.rhel.versions
+                if 'fips' not in str(setting_rhel_ver)
+            ][-(num_versions + 1) :]  # inclusive (+1) to collect N as well
+            match_params.extend(filtered_versions)
+        # match versions with existing regex markers
+        else:
+            for matcher in matchers:
+                match_params.extend(
+                    [
+                        setting_rhel_ver
+                        for setting_rhel_ver in settings.supportability.content_hosts.rhel.versions
+                        if re.fullmatch(str(matcher[0]), str(setting_rhel_ver))
+                    ]
+                )
         network_params = ['ipv6' if settings.server.is_ipv6 else 'ipv4']
         rhel_params = []
         ids = []

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -20,7 +20,7 @@ def pytest_configure(config):
         "run_in_one_thread: Sequential tests",
         "build_sanity: Fast, basic tests that confirm build is ready for full test suite",
         "rhel_ver_list: Filter rhel_contenthost versions by list",
-        "rhel_ver_match: Filter rhel_contenthost versions by regexp",
+        "rhel_ver_match: Filter rhel_contenthost versions by regexp, or format 'N-x'",
         "no_containers: Disable container hosts from being used in favor of VMs",
         "include_capsule: For satellite-maintain tests to run on Satellite and Capsule both",
         "capsule_only: For satellite-maintain tests to run only on Capsules",


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17090

### Problem Statement
Partial cherry-pick of #16807 , adding ('N-x') format to parametrize marker `rhel_ver_match` for rhel contenthosts/clients.
Just CPing the fixture changes, as some new tests are also being CP'd to 6.16/6.15.z, with the N-x marker format.
Otherwise, the format is invalid for regex, so all distros are picked including fips.

_Note_: In 6.15.z and 6.16.z , RHEL9 is N (newest) in `supportability.yaml`. RHEL10 is only in Stream (6.17)

Example: 
```
@pytest.mark.rhel_ver_match('N-2') # rhel9, 8, and 7  in 6.16 and 6.15
def test_case(rhel_contenthost, target_sat, ...):
```


### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_inventory.py -k 'test_positive_register_insights_client_host'

or tests/foreman/api/test_rhcloud_inventory.py -k 'test_rhcloud_scheduled_insights_sync'
```