### PR TITLE
Add tests for Libvirt secureboot provisioning

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -299,7 +299,7 @@ def pxe_loader(request):
         'uefi': {'vm_firmware': 'uefi', 'pxe_loader': 'Grub2 UEFI'},
         'ipxe': {'vm_firmware': 'bios', 'pxe_loader': 'iPXE Embedded'},
         'http_uefi': {'vm_firmware': 'uefi', 'pxe_loader': 'Grub2 UEFI HTTP'},
-        'secureboot': {'vm_firmware': 'uefi_secureboot', 'pxe_loader': 'Grub2 UEFI SecureBoot'},
+        'secureboot': {'vm_firmware': 'uefi_secure_boot', 'pxe_loader': 'Grub2 UEFI SecureBoot'},
     }
     return Box(PXE_LOADER_MAP[getattr(request, 'param', 'uefi')])
 

--- a/pytest_fixtures/component/provision_vmware.py
+++ b/pytest_fixtures/component/provision_vmware.py
@@ -116,7 +116,7 @@ def module_vmware_image(
 def provisioning_vmware_host(pxe_loader, vmwareclient, module_ssh_key_file):
     """Fixture to check out blank VM on VMware"""
     vm_boot_firmware = 'efi' if pxe_loader.vm_firmware.startswith('uefi') else 'bios'
-    vm_secure_boot = 'true' if pxe_loader.vm_firmware == 'uefi_secureboot' else 'false'
+    vm_secure_boot = 'true' if pxe_loader.vm_firmware == 'uefi_secure_boot' else 'false'
     vlan_id = settings.provisioning.vlan_id
     with Broker(
         workflow='deploy-blank-vm-vcenter',

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -380,7 +380,7 @@ def test_positive_update_console_password(libvirt_url, set_console_password, mod
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
-@pytest.mark.rhel_ver_match('[8]')
+@pytest.mark.rhel_ver_match('[7]')
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_end_to_end(

--- a/tests/foreman/cli/test_computeresource_libvirt.py
+++ b/tests/foreman/cli/test_computeresource_libvirt.py
@@ -38,6 +38,7 @@ from wait_for import wait_for
 from robottelo.config import settings
 from robottelo.constants import FOREMAN_PROVIDERS, LIBVIRT_RESOURCE_URL
 from robottelo.exceptions import CLIReturnCodeError
+from robottelo.hosts import ContentHost
 from robottelo.utils.datafactory import parametrized
 
 LIBVIRT_URL = LIBVIRT_RESOURCE_URL % settings.libvirt.libvirt_hostname
@@ -379,11 +380,12 @@ def test_positive_update_console_password(libvirt_url, set_console_password, mod
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
-@pytest.mark.tier3
-@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
+@pytest.mark.rhel_ver_match('[8]')
+@pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 def test_positive_provision_end_to_end(
     request,
+    pxe_loader,
     setting_update,
     module_libvirt_provisioning_sat,
     module_sca_manifest_org,
@@ -410,7 +412,7 @@ def test_positive_provision_end_to_end(
 
     :BZ: 2236693
 
-    :Verifies: SAT-22491
+    :Verifies: SAT-22491, SAT-25808
 
     :customerscenario: true
     """
@@ -427,6 +429,7 @@ def test_positive_provision_end_to_end(
         }
     )
     assert libvirt_cr['name'] == cr_name
+
     host = sat.cli.Host.create(
         {
             'name': hostname,
@@ -436,9 +439,10 @@ def test_positive_provision_end_to_end(
             'compute-resource-id': libvirt_cr['id'],
             'ip': None,
             'mac': None,
-            'compute-attributes': 'cpus=1, memory=6442450944, start=1',
+            'compute-attributes': f'cpus=1, memory=6442450944, start=1, firmware={pxe_loader.vm_firmware}',
             'interface': f'compute_type=bridge,compute_bridge=br-{settings.provisioning.vlan_id}',
             'volume': 'capacity=10',
+            'parameters': 'name=remote_execution_connect_by_ip,' 'type=boolean,' 'value=true',
             'provision-method': 'build',
         }
     )
@@ -463,3 +467,10 @@ def test_positive_provision_end_to_end(
     )
     host_info = sat.cli.Host.info({'id': host['id']})
     assert host_info['status']['build-status'] == 'Installed'
+
+    # Verify SecureBoot is enabled on host after provisioning is completed sucessfully
+    if pxe_loader.vm_firmware == 'uefi_secure_boot':
+        provisioning_host = ContentHost(host_info['network']['ipv4-address'])
+        # Wait for the host to be rebooted and SSH daemon to be started.
+        provisioning_host.wait_for_connection()
+        assert 'SecureBoot enabled' in provisioning_host.execute('mokutil --sb-state').stdout

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -120,7 +120,7 @@ def test_positive_end_to_end(session, module_target_sat, module_org, module_loca
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
-@pytest.mark.rhel_ver_match('[9]')
+@pytest.mark.rhel_ver_list('[9, 10]')
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 def test_positive_provision_end_to_end(

--- a/tests/foreman/ui/test_computeresource_libvirt.py
+++ b/tests/foreman/ui/test_computeresource_libvirt.py
@@ -24,6 +24,7 @@ from robottelo.constants import (
     FOREMAN_PROVIDERS,
     LIBVIRT_RESOURCE_URL,
 )
+from robottelo.hosts import ContentHost
 
 pytestmark = [pytest.mark.skip_if_not_set('libvirt')]
 
@@ -119,17 +120,19 @@ def test_positive_end_to_end(session, module_target_sat, module_org, module_loca
 
 @pytest.mark.e2e
 @pytest.mark.on_premises_provisioning
-@pytest.mark.tier4
-@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
+@pytest.mark.rhel_ver_match('[9]')
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
+@pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 def test_positive_provision_end_to_end(
     request,
+    pxe_loader,
     setting_update,
     module_sca_manifest_org,
     module_location,
     provisioning_hostgroup,
     module_libvirt_provisioning_sat,
     module_provisioning_rhel_content,
+    module_ssh_key_file,
 ):
     """Provision Host on libvirt compute resource, and delete it afterwards
 
@@ -141,7 +144,7 @@ def test_positive_provision_end_to_end(
 
     :BZ: 1243223, 2236693
 
-    :Verifies: SAT-22491
+    :Verifies: SAT-22491, SAT-25808
 
     :parametrized: yes
     """
@@ -154,6 +157,13 @@ def test_positive_provision_end_to_end(
         location=[module_location],
         organization=[module_sca_manifest_org],
     ).create()
+
+    existing_params = provisioning_hostgroup.group_parameters_attributes
+    provisioning_hostgroup.group_parameters_attributes = [
+        {'name': 'remote_execution_connect_by_ip', 'value': 'true', 'parameter_type': 'boolean'},
+    ] + existing_params
+    provisioning_hostgroup.update(['group_parameters_attributes'])
+
     with sat.ui_session() as session:
         session.organization.select(module_sca_manifest_org.name)
         session.location.select(module_location.name)
@@ -182,17 +192,32 @@ def test_positive_provision_end_to_end(
         assert hostname in result.stdout
         # Wait for provisioning to complete and report status back to Satellite
         wait_for(
-            lambda: session.host.get_details(name)['properties']['properties_table']['Build']
-            != 'Pending installation clear',
+            lambda: session.host_new.get_host_statuses(name)['Build']['Status']
+            != 'Pending installation',
             timeout=1800,
             delay=30,
             fail_func=session.browser.refresh,
             silent_failure=True,
             handle_exception=True,
         )
-        assert (
-            session.host.get_details(name)['properties']['properties_table']['Build']
-            == 'Installed clear'
-        )
+        values = session.host_new.get_host_statuses(name)
+        assert values['Build']['Status'] == 'Installed'
+
+        # Verify SecureBoot is enabled on host after provisioning is completed sucessfully
+        if pxe_loader.vm_firmware == 'uefi_secure_boot':
+            host = sat.api.Host().search(query={'host': hostname})[0].read()
+            provisioning_host = ContentHost(host.ip, auth=module_ssh_key_file)
+            # Wait for the host to be rebooted and SSH daemon to be started.
+            provisioning_host.wait_for_connection()
+            # Enable Root Login
+            if int(host.operatingsystem.read().major) >= 9:
+                assert (
+                    provisioning_host.execute(
+                        'echo -e "\nPermitRootLogin yes" >> /etc/ssh/sshd_config; systemctl restart sshd'
+                    ).status
+                    == 0
+                )
+            assert 'SecureBoot enabled' in provisioning_host.execute('mokutil --sb-state').stdout
+
         session.host.delete(name)
         assert not sat.api.Host().search(query={'search': f'name="{name}"'})


### PR DESCRIPTION
### Problem Statement
Missing test coverage for new feature of Libvirt UEFI and secureboot provisioning

### Solution
Add and update existing tests to include Libvirt UEFI and secureboot provisioning

### Related Issues
https://issues.redhat.com/browse/SAT-25808

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->