### PR TITLE
delete subscription manifest so it can re imported again

### DIFF
--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -80,8 +80,13 @@ def test_positive_create(module_sca_manifest, module_target_sat):
 
     :CaseImportance: Critical
     """
-    org = module_target_sat.api.Organization().create()
-    module_target_sat.upload_manifest(org.id, module_sca_manifest.content)
+    try:
+        org = module_target_sat.api.Organization().create()
+        module_target_sat.upload_manifest(org.id, module_sca_manifest.content)
+    finally:
+        module_target_sat.api.Subscription(organization=org).delete_manifest(
+            data={'organization_id': org.id}
+        )
 
 
 @pytest.mark.tier1

--- a/tests/foreman/api/test_subscription.py
+++ b/tests/foreman/api/test_subscription.py
@@ -70,26 +70,6 @@ def module_ak(module_sca_manifest_org, rh_repo, custom_repo, module_target_sat):
 
 
 @pytest.mark.tier1
-@pytest.mark.pit_server
-def test_positive_create(module_sca_manifest, module_target_sat):
-    """Upload a manifest.
-
-    :id: 6faf9d96-9b45-4bdc-afa9-ec3fbae83d41
-
-    :expectedresults: Manifest is uploaded successfully
-
-    :CaseImportance: Critical
-    """
-    try:
-        org = module_target_sat.api.Organization().create()
-        module_target_sat.upload_manifest(org.id, module_sca_manifest.content)
-    finally:
-        module_target_sat.api.Subscription(organization=org).delete_manifest(
-            data={'organization_id': org.id}
-        )
-
-
-@pytest.mark.tier1
 def test_positive_refresh(function_sca_manifest_org, request, target_sat):
     """Upload a manifest and refresh it afterwards.
 


### PR DESCRIPTION
### Problem Statement

- `test_sca_end_to_end` and `test_positive_expired_SCA_cert_handling` tests are failing imported manifest issue.
- **Error:** This subscription management application has already been imported by another owner
- I guess `test_positive_create` test uses mdoule_manifest_org fixture and it is creating issue while importing manifest

### Solution
Delete `test_positive_create` test, as it uses `module_sca_manifest` fixture and which is used inside any `*_sca_manifest_org fixture` that executed on so many places.

### Local test execution
```
============================= test session starts ==============================
collecting ... 2024-12-10 22:29:23 - robottelo.collection - INFO - Processing test items to add testimony token markers
collected 11 items / 8 deselected / 3 selected

tests/foreman/api/test_subscription.py::test_positive_create 
tests/foreman/api/test_subscription.py::test_sca_end_to_end[rhel7-ipv4] 
tests/foreman/api/test_subscription.py::test_positive_expired_SCA_cert_handling[rhel7-ipv4] 

=========== 3 passed, 8 deselected, 58 warnings in 697.74s (0:11:37) ===========
```

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_subscription.py

```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->