### PR TITLE
Enable IPv6 rhsm proxy for test_positive_register bootstrap test

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -872,6 +872,18 @@ class ContentHost(Host, ContentHostMixins):
         logger.info(f'Configuring {hostname} HTTP proxy for dnf.')
         self.execute(cmd)
 
+    def enable_ipv6_rhsm_proxy(self):
+        """Execute procedures for enabling rhsm IPv6 HTTP Proxy"""
+        if self.ipv6:
+            url = urlparse(settings.http_proxy.http_proxy_ipv6_url)
+            self.enable_rhsm_proxy(url.hostname, url.port)
+
+    def enable_ipv6_dnf_proxy(self):
+        """Execute procedures for enabling dnf IPv6 HTTP Proxy"""
+        if self.ipv6:
+            url = urlparse(settings.http_proxy.http_proxy_ipv6_url)
+            self.enable_dnf_proxy(url.hostname, url.scheme, url.port)
+
     def disable_rhsm_proxy(self):
         """Disables HTTP proxy for subscription manager"""
         self.execute('subscription-manager remove server.proxy_hostname server.proxy_port')
@@ -883,9 +895,8 @@ class ContentHost(Host, ContentHostMixins):
     def enable_ipv6_dnf_and_rhsm_proxy(self):
         """Execute procedures for enabling rhsm and dnf IPv6 HTTP Proxy"""
         if self.ipv6:
-            url = urlparse(settings.http_proxy.http_proxy_ipv6_url)
-            self.enable_rhsm_proxy(url.hostname, url.port)
-            self.enable_dnf_proxy(url.hostname, url.scheme, url.port)
+            self.enable_ipv6_rhsm_proxy()
+            self.enable_ipv6_dnf_proxy()
 
     def add_authorized_key(self, pub_key):
         """Inject a public key into the authorized keys file

--- a/tests/foreman/cli/test_bootstrap_script.py
+++ b/tests/foreman/cli/test_bootstrap_script.py
@@ -53,6 +53,10 @@ def test_positive_register(
 
     :BZ: 2001476
     """
+    # Workaround for a bug in bootstrap.py https://github.com/Katello/katello-client-bootstrap/pull/373
+    # rhel_contenthost has internet-based repos enabled, which it can't reach in IPv6-only setups,
+    # but also shouldn't have configured to begin with.
+    rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
     if rhel_contenthost.os_version.major == 7:
         python_cmd = 'python'
     elif rhel_contenthost.os_version.major == 8:


### PR DESCRIPTION
### Problem Statement
test_positive_register bootstrap test is failing because the subscription manager is unable to connect to cdn-ubi.redhat.com

### Solution
- Enable IPv6 rhsm proxy for the host

### Related Issues
SAT-30100

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->