### PR TITLE
Add test coverage for SAT-28860

### DIFF
--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -13,19 +13,28 @@ def session_auth_proxy(session_target_sat):
 @pytest.fixture
 def setup_http_proxy(request, module_manifest_org, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
+    content_proxy_value = target_sat.api.Setting().search(
+        query={'search': 'name=content_default_http_proxy'}
+    )[0]
+    general_proxy_value = target_sat.api.Setting().search(query={'search': 'name=http_proxy'})[0]
+
     http_proxy = target_sat.api_factory.make_http_proxy(module_manifest_org, request.param)
-    general_proxy = http_proxy.url if request.param is False else ''
-    if request.param:
+    content_proxy = target_sat.api.Setting().search(
+        query={'search': 'name=content_default_http_proxy'}
+    )[0]
+    assert content_proxy.value == http_proxy.name
+
+    if request.param is not None:
         general_proxy = (
-            f'http://{settings.http_proxy.username}:'
-            f'{settings.http_proxy.password}@{http_proxy.url[7:]}'
+            f'http://{settings.http_proxy.username}:{settings.http_proxy.password}@{http_proxy.url[7:]}'
+            if request.param
+            else http_proxy.url
         )
-    content_proxy_value = target_sat.update_setting(
-        'content_default_http_proxy', http_proxy.name if request.param is not None else ''
-    )
-    general_proxy_value = target_sat.update_setting(
-        'http_proxy', general_proxy if request.param is not None else ''
-    )
+        target_sat.update_setting('http_proxy', general_proxy)
+    else:
+        target_sat.update_setting('content_default_http_proxy', '')
+        target_sat.update_setting('http_proxy', '')
+
     yield http_proxy, request.param
     target_sat.update_setting('content_default_http_proxy', content_proxy_value)
     target_sat.update_setting('http_proxy', general_proxy_value)

--- a/pytest_fixtures/component/http_proxy.py
+++ b/pytest_fixtures/component/http_proxy.py
@@ -13,16 +13,18 @@ def session_auth_proxy(session_target_sat):
 @pytest.fixture
 def setup_http_proxy(request, module_manifest_org, target_sat):
     """Create a new HTTP proxy and set related settings based on proxy"""
-    content_proxy_value = target_sat.api.Setting().search(
+    content_proxy = target_sat.api.Setting().search(
         query={'search': 'name=content_default_http_proxy'}
     )[0]
-    general_proxy_value = target_sat.api.Setting().search(query={'search': 'name=http_proxy'})[0]
+    content_proxy_value = '' if content_proxy.value is None else content_proxy.value
+    general_proxy = target_sat.api.Setting().search(query={'search': 'name=http_proxy'})[0]
+    general_proxy_value = '' if general_proxy.value is None else general_proxy.value
 
     http_proxy = target_sat.api_factory.make_http_proxy(module_manifest_org, request.param)
     content_proxy = target_sat.api.Setting().search(
         query={'search': 'name=content_default_http_proxy'}
     )[0]
-    assert content_proxy.value == http_proxy.name
+    assert content_proxy.value == (http_proxy.name if request.param is not None else '')
 
     if request.param is not None:
         general_proxy = (

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -39,7 +39,7 @@ class APIFactory:
                 name=gen_string('alpha', 15),
                 url=settings.http_proxy.un_auth_proxy_url,
                 organization=[org.id],
-                default_content_http_proxy=True,
+                content_default_http_proxy=True,
             ).create()
         if http_proxy_type:
             return self._satellite.api.HTTPProxy(
@@ -48,7 +48,7 @@ class APIFactory:
                 username=settings.http_proxy.username,
                 password=settings.http_proxy.password,
                 organization=[org.id],
-                default_content_http_proxy=True,
+                content_default_http_proxy=True,
             ).create()
         return None
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -39,6 +39,7 @@ class APIFactory:
                 name=gen_string('alpha', 15),
                 url=settings.http_proxy.un_auth_proxy_url,
                 organization=[org.id],
+                default_content_http_proxy=True,
             ).create()
         if http_proxy_type:
             return self._satellite.api.HTTPProxy(
@@ -47,6 +48,7 @@ class APIFactory:
                 username=settings.http_proxy.username,
                 password=settings.http_proxy.password,
                 organization=[org.id],
+                default_content_http_proxy=True,
             ).create()
         return None
 

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -201,7 +201,9 @@ def test_positive_assign_http_proxy_to_products_repositories(
 @pytest.mark.tier1
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize('setting_update', ['content_default_http_proxy'], indirect=True)
-def test_set_default_http_proxy(module_org, module_location, setting_update, target_sat):
+def test_set_default_http_proxy_no_global_default(
+    module_org, module_location, setting_update, target_sat
+):
     """Setting "Default HTTP proxy" to "no global default".
 
     :id: e93733e1-5c05-4b7f-89e4-253b9ce55a5a
@@ -242,6 +244,51 @@ def test_set_default_http_proxy(module_org, module_location, setting_update, tar
         session.settings.update(f'name = {property_name}', "no global default")
         result = session.settings.read(f'name = {property_name}')
         assert result['table'][0]['Value'] == "Empty"
+
+
+@pytest.mark.tier1
+@pytest.mark.run_in_one_thread
+@pytest.mark.parametrize('setting_update', ['content_default_http_proxy'], indirect=True)
+def test_positive_set_default_http_proxy(
+    request, module_org, module_location, setting_update, target_sat
+):
+    """Setting "Default HTTP proxy" when new HTTP proxy is created.
+
+    :id: e93733e1-5c05-4b7f-89e4-253b9ce55a5b
+
+    :steps:
+        1. Navigate to Infrastructure > Http Proxies
+        2. Create a Http Proxy and set "Default content HTTP proxy"
+        3. Navigate to Administer > Settings > Content tab
+        4. Verify the "Default HTTP Proxy" setting with created above.
+        5. Update "Default HTTP Proxy" to "no global default".
+
+    :Verifies: SAT-28860
+
+    :expectedresults: Creating Http Proxy with option "Default content HTTP proxy",
+        updates setting "Default HTTP Proxy" succesfully.
+    """
+    property_name = setting_update.name
+    http_proxy_name = gen_string('alpha', 15)
+    http_proxy_url = settings.http_proxy.un_auth_proxy_url
+
+    with target_sat.ui_session() as session:
+        session.http_proxy.create(
+            {
+                'http_proxy.name': http_proxy_name,
+                'http_proxy.url': http_proxy_url,
+                'http_proxy.default_content_http_proxy': 'true',
+                'locations.resources.assigned': [module_location.name],
+                'organizations.resources.assigned': [module_org.name],
+            }
+        )
+        request.addfinalizer(
+            lambda: target_sat.api.HTTPProxy()
+            .search(query={'search': f'name={http_proxy_name}'})[0]
+            .delete()
+        )
+        result = session.settings.read(f'name = {property_name}')
+        assert result['table'][0]['Value'] == f'{http_proxy_name} ({http_proxy_url})'
 
 
 @pytest.mark.tier1


### PR DESCRIPTION
### Problem Statement
Missing test coverage for new feature SAT-28860

### Solution
Add test coverage for new feature SAT-28860

### Related Issues
https://github.com/SatelliteQE/airgun/pull/1636
https://github.com/SatelliteQE/nailgun/pull/1254

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->