### PR TITLE
cherry-picks of FAM test fixes for 6.15.z

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -190,7 +190,7 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
 
     # Execute test_playbook
     result = module_target_sat.execute(
-        f'export NO_COLOR=True && export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 && cd {FAM_ROOT_DIR} && make livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.11"'
+        f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.11"'
     )
     assert 'PASSED' in result.stdout
     assert result.status == 0

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -190,7 +190,7 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
 
     # Execute test_playbook
     result = module_target_sat.execute(
-        f'export NO_COLOR=True && cd {FAM_ROOT_DIR} && make livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.11"'
+        f'export NO_COLOR=True && export PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 && cd {FAM_ROOT_DIR} && make livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.11"'
     )
     assert 'PASSED' in result.stdout
     assert result.status == 0

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -194,5 +194,4 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
     result = module_target_sat.execute(
         f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.11"'
     )
-    assert 'PASSED' in result.stdout
-    assert result.status == 0
+    assert result.status == 0, f"{result.status=}\n{result.stdout=}\n{result.stderr=}"

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -101,26 +101,28 @@ def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_rol
         f'''sed -i 's|subscription_manifest_path:.*|subscription_manifest_path: "data/{module_sca_manifest.name}"|g' {config_file}'''
     )
 
-    repo_path = '/fake_puppet1/system/releases/p/puppetlabs/'
-    module_tarball = 'puppetlabs-ntp-3.0.3.tar.gz'
-    local_path = '/tmp'
-    module_target_sat.execute(
-        f'curl --output {local_path}/{module_tarball} {settings.robottelo.repos_hosting_url}{repo_path}{module_tarball}',
-    )
-    module_target_sat.execute(
-        f'puppet module install --ignore-dependencies {local_path}/{module_tarball}'
-    )
-
     def create_fake_module(module_target_sat, module_name, module_classes):
         base_dir = '/etc/puppetlabs/code/environments/production/modules'
         module_dir = f'{base_dir}/{module_name}'
         manifest_dir = f'{module_dir}/manifests'
         module_target_sat.execute(f'mkdir -p {manifest_dir}')
         for module_class in module_classes:
+            if isinstance(module_class, str):
+                module_code = '(){}'
+            else:
+                module_class, module_code = module_class
             full_class = module_name if module_class == 'init' else f'{module_name}::{module_class}'
-            module_target_sat.execute(
-                f'echo "class {full_class}(){{}}" > {manifest_dir}/{module_class}.pp'
+            module_target_sat.put(
+                f'class {full_class}{module_code}',
+                f'{manifest_dir}/{module_class}.pp',
+                temp_file=True,
             )
+
+    create_fake_module(
+        module_target_sat,
+        'ntp',
+        [('init', '($logfile, $config_dir, $servers, $burst, $stepout){}'), 'config'],
+    )
 
     create_fake_module(
         module_target_sat,


### PR DESCRIPTION
### Problem Statement

Fixes happened for 6.16.z and master, but were not backported to 6.15.z, even tho they are applicable

### Solution

Cherry pick things :)

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->