### PR TITLE
[6.15.z] pin wrapnapi to force dependency errors to become more visible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ requests==2.32.3
 tenacity==9.0.0
 testimony==2.4.0
 wait-for==1.2.0
-wrapanapi
+wrapanapi==3.6.6
 
 # Get airgun, nailgun and upgrade from 6.15.z
 airgun @ git+https://github.com/SatelliteQE/airgun.git@6.15.z#egg=airgun


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17166

### Problem Statement

[airgun bumped the selenium dep](https://github.com/SatelliteQE/airgun/commit/d5285d4c56a26aebe21118433f62c285a5001cc2), which updates [websocket-client](https://github.com/SeleniumHQ/selenium/blob/selenium-4.27.1-python/py/pyproject.toml#L35) to a version that's not compatible with the [ancient openshift/kubernetes used by wrapanapi](https://github.com/RedHatQE/wrapanapi/blob/3.6.6/pyproject.toml#L57) (https://github.com/openshift/openshift-restclient-python/blob/release-0.3.4/requirements.txt#L3, https://github.com/kubernetes-client/python/blob/release-3.0/requirements.txt#L9).

as we don't pin wrapanapi, the depsolver tries to find a version that works, and picks one that has azure unpinned (2.7.0!).

this gets us azure 5.0.0, but azure 5.0.0 deprecated the `azure` meta package in favor of service specific packages prefixed by `azure-` and errors out when you try to install it.

### Solution

- pin wrapanapi, so we see clearly when it can't be installed
- fix airgun

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->