### PR TITLE
added wait for tasks for repo creation

### DIFF
--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -53,7 +53,15 @@ def _create_repository(module_target_sat, product, name=None, upstream_name=None
 @pytest.fixture
 def repo(module_product, module_target_sat):
     """Create a single repository."""
-    return _create_repository(module_target_sat, module_product)
+    repo = _create_repository(module_target_sat, module_product)
+    module_target_sat.wait_for_tasks(
+        search_query='Actions::Katello::Repository::MetadataGenerate'
+        f' and resource_id = {repo.id}'
+        ' and resource_type = Katello::Repository',
+        max_tries=6,
+        search_rate=10,
+    )
+    return repo
 
 
 @pytest.fixture

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -545,8 +545,8 @@ class TestDockerActivationKey:
             content_view=content_view, environment=module_lce, organization=module_org
         ).create()
         assert ak.content_view.id == content_view.id
-        ak.content_view = None
-        assert ak.update(['content_view']).content_view is None
+        ak.content_view_environments = None
+        assert ak.update(['content_view_environments']).content_view is None
 
     @pytest.mark.tier2
     def test_positive_add_docker_repo_ccv(
@@ -610,8 +610,8 @@ class TestDockerActivationKey:
             content_view=comp_content_view, environment=module_lce, organization=module_org
         ).create()
         assert ak.content_view.id == comp_content_view.id
-        ak.content_view = None
-        assert ak.update(['content_view']).content_view is None
+        ak.content_view_environments = None
+        assert ak.update(['content_view_environments']).content_view is None
 
 
 class TestPodman:


### PR DESCRIPTION
### Problem Statement
Few tests from `tests/foreman/api/test_docker.py` are failing due to pending tasks issue in repositories of cv.
**Error:** 
`"errors":["Pending tasks detected in repositories of this content view. Please wait for the tasks: - https://satellite-ip.redhat.com/foreman_tasks/tasks/207e977b-d3df-4daa-94ba-27a7b7cbdc69 before publishing." `

Affected test cases:
```
TestDockerActivationKey::test_positive_add_docker_repo_cv
TestDockerActivationKey::test_positive_remove_docker_repo_cv
TestDockerActivationKey::test_positive_add_docker_repo_ccv
TestDockerActivationKey::test_positive_remove_docker_repo_ccv
```


### Solution
add wait_for_tasks to wait for resource type  Katello::Repository while repo creating. 

### Related Issues
N/A

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_docker.py::TestDockerActivationKey
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->