### PR TITLE
Add rhel10 support in registration tests

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -29,7 +29,7 @@ pytestmark = pytest.mark.tier1
 
 @pytest.mark.e2e
 @pytest.mark.pit_client
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 @pytest.mark.no_containers
 def test_host_registration_end_to_end(
     module_sca_manifest_org,
@@ -89,7 +89,7 @@ def test_host_registration_end_to_end(
 
 @pytest.mark.tier3
 @pytest.mark.pit_client
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 def test_positive_allow_reregistration_when_dmi_uuid_changed(
     module_sca_manifest_org,
     rhel_contenthost,
@@ -133,7 +133,7 @@ def test_positive_allow_reregistration_when_dmi_uuid_changed(
     assert result.status == 0, f'Failed to register host: {result.stderr}'
 
 
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match('N-1')
 def test_positive_update_packages_registration(
     module_target_sat,
     module_sca_manifest_org,
@@ -166,7 +166,7 @@ def test_positive_update_packages_registration(
     assert result.status == 0
 
 
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 @pytest.mark.no_containers
 def test_positive_rex_interface_for_global_registration(
     module_target_sat,
@@ -272,7 +272,7 @@ def test_negative_capsule_without_registration_enabled(
     )
 
 
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 def test_positive_host_registration_with_non_admin_user_with_setup_false(
     module_org,
     module_location,
@@ -333,7 +333,7 @@ def test_positive_host_registration_with_non_admin_user_with_setup_false(
     assert rhel_contenthost.execute('cat ~/.ssh/authorized_keys | grep foreman-proxy').status == 1
 
 
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 def test_negative_verify_bash_exit_status_failing_host_registration(
     module_sca_manifest_org,
     module_location,

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -75,7 +75,7 @@ def test_negative_list_by_name(module_target_sat):
 @pytest.mark.e2e
 @pytest.mark.no_containers
 @pytest.mark.pit_client
-@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+@pytest.mark.rhel_ver_match('N-1')
 def test_positive_facts_end_to_end(
     module_target_sat, rhel_contenthost, module_org, module_location, module_activation_key
 ):
@@ -140,7 +140,7 @@ def test_positive_facts_end_to_end(
         ), f'Assertion failed: {fact} (expected: {expected_value}, actual: {actual_value})'
 
 
-@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+@pytest.mark.rhel_ver_match('N-1')
 def test_positive_custom_facts_and_clean_orphaned_facts(
     module_target_sat, module_org, module_location, module_activation_key, rhel_contenthost
 ):

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -172,7 +172,7 @@ def test_upgrade_katello_ca_consumer_rpm(
     assert result.status == 0
 
 
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 @pytest.mark.tier3
 def test_negative_register_twice(module_ak_with_cv, module_org, rhel_contenthost, target_sat):
     """Attempt to register a host twice to Satellite
@@ -193,7 +193,7 @@ def test_negative_register_twice(module_ak_with_cv, module_org, rhel_contenthost
     assert 'This system is already registered' in str(result.stderr)
 
 
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 @pytest.mark.tier3
 def test_positive_force_register_twice(module_ak_with_cv, module_org, rhel_contenthost, target_sat):
     """Register a host twice to Satellite, with force=true

--- a/tests/foreman/ui/test_fact.py
+++ b/tests/foreman/ui/test_fact.py
@@ -14,10 +14,8 @@
 
 import pytest
 
-from robottelo.config import settings
 
-
-@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+@pytest.mark.rhel_ver_match('N-1')
 def test_positive_upload_host_facts(
     module_target_sat,
     rhel_contenthost,

--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -137,7 +137,7 @@ def test_negative_global_registration_without_ak(
 @pytest.mark.no_containers
 @pytest.mark.pit_client
 @pytest.mark.tier3
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match(r'^(?!.*fips).*$')
 def test_positive_global_registration_end_to_end(
     module_activation_key,
     module_org,
@@ -434,7 +434,7 @@ def test_global_registration_with_gpg_repo_and_default_package(
 
 
 @pytest.mark.tier3
-@pytest.mark.rhel_ver_match('9')
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_global_re_registration_host_with_force_ignore_error_options(
     module_activation_key, rhel_contenthost, module_target_sat, module_org
 ):
@@ -475,7 +475,7 @@ def test_global_re_registration_host_with_force_ignore_error_options(
 
 
 @pytest.mark.tier2
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_global_registration_token_restriction(
     module_activation_key, rhel_contenthost, module_target_sat, module_org
 ):
@@ -515,7 +515,7 @@ def test_global_registration_token_restriction(
         assert 'Unable to authenticate user' in result.stdout
 
 
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_positive_host_registration_with_non_admin_user(
     test_name,
     module_sca_manifest_org,
@@ -635,7 +635,7 @@ def test_positive_global_registration_form(
 
 
 @pytest.mark.tier2
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_global_registration_with_capsule_host(
     capsule_configured,
     rhel_contenthost,


### PR DESCRIPTION
### Problem Statement
Missing support for RHEL10 for Registration and Facts

### Solution
Added support of RHEL10

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->