### PR TITLE
Fix legacy errata upgrade scenario tests

### DIFF
--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -5,6 +5,7 @@ import os
 import random
 import re
 
+from fauxfactory import gen_string
 import requests
 from wait_for import TimedOutError, wait_for
 
@@ -184,15 +185,17 @@ class ContentInfo:
         """
         return self.api.Organization(id=org_id).read().simple_content_access
 
-    def publish_content_view(self, org, repo_list, name):
+    def publish_content_view(self, org, repo_list, name=None):
         """This method publishes the content view for a given organization and repository list.
 
         :param str org: The name of the organization to which the content view belongs
         :param list or str repo_list:  A list of repositories or a single repository
+        :param str name: Name of the Content View to create. Defaults to random string.
 
         :return: A dictionary containing the details of the published content view.
         """
         repo = repo_list if isinstance(repo_list, list) else [repo_list]
+        name = name or gen_string('alpha')
         content_view = self.api.ContentView(organization=org, repository=repo, name=name).create()
         content_view.publish()
         return content_view.read()

--- a/tests/upgrades/test_errata.py
+++ b/tests/upgrades/test_errata.py
@@ -195,7 +195,9 @@ class TestScenarioErrataCount(TestScenarioErrataAbstract):
             }
         )
 
-    @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
+    @pytest.mark.parametrize(
+        'pre_upgrade_data', ['rhel7-ipv4', 'rhel8-ipv4', 'rhel9-ipv4'], indirect=True
+    )
     @pytest.mark.post_upgrade(depend_on=test_pre_scenario_generate_errata_for_client)
     def test_post_scenario_errata_count_installation(self, target_sat, pre_upgrade_data):
         """Post-upgrade scenario that applies errata on the RHEL client that was set up

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -493,7 +493,9 @@ class TestSimpleContentAccessOnly:
             }
         )
 
-    @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
+    @pytest.mark.parametrize(
+        'pre_upgrade_data', ['rhel7-ipv4', 'rhel8-ipv4', 'rhel9-ipv4'], indirect=True
+    )
     @pytest.mark.post_upgrade(depend_on=test_pre_simple_content_access_only)
     def test_post_simple_content_access_only(self, target_sat, pre_upgrade_data):
         """Check that both the custom repository and the red hat repository are enabled

--- a/tests/upgrades/test_subscription.py
+++ b/tests/upgrades/test_subscription.py
@@ -141,7 +141,9 @@ class TestSubscriptionAutoAttach:
             }
         )
 
-    @pytest.mark.parametrize('pre_upgrade_data', ['rhel7', 'rhel8', 'rhel9'], indirect=True)
+    @pytest.mark.parametrize(
+        'pre_upgrade_data', ['rhel7-ipv4', 'rhel8-ipv4', 'rhel9-ipv4'], indirect=True
+    )
     @pytest.mark.post_upgrade(depend_on=test_pre_subscription_scenario_auto_attach)
     @pytest.mark.manifester
     def test_post_subscription_scenario_auto_attach(self, request, target_sat, pre_upgrade_data):


### PR DESCRIPTION
### Problem Statement
1. We have seen several `post_upgrade` failures for "`rhel_contenthost`-parametrized" upgrade scenario tests where the pre-data could not be fetched from the `scenario_entities` file:
```
failed on setup with "Failed: Invalid test parameter: rhel7. Test data not found."
```
The reason is that the pre-upgrade test names are now suffixed with `-ipv4` so the `scenario_entities` hold items like this:

```
{"tests/upgrades/test_repository.py::TestSimpleContentAccessOnly::test_pre_simple_content_access_only[rhel7-ipv4]": {...}}
```

2. #14111 extended the `ContentInfo.publish_content_view()` method of with the `name` parameter without updating tests in the legacy upgrade scenarios, so now they cry:
```
TypeError: ContentInfo.publish_content_view() missing 1 required positional argument: 'name'
```


### Solution
1. Pick the test names from `scenario_entities` including their suffix.
2. Make the `name` parameter optional.


### Local run results
```
(venv) [vsedmik@fedora robottelo]$ pytest tests/upgrades/test_errata.py -m pre_upgrade -k test_pre_scenario_generate_errata_for_client
========================================================== test session starts =========================================================
...
collected 6 items / 3 deselected / 3 selected

tests/upgrades/test_errata.py ...                                                                                                [100%]

====================================== 3 passed, 3 deselected, 283 warnings in 1859.47s (0:30:59) ======================================



(venv) [vsedmik@fedora robottelo]$ pytest tests/upgrades/test_errata.py -m post_upgrade -k test_post_scenario_errata_count_installation
========================================================== test session starts =========================================================
...
collected 6 items / 3 deselected / 3 selected

tests/upgrades/test_errata.py ...                                                                                                [100%]

======================================= 3 passed, 3 deselected, 99 warnings in 353.67s (0:05:53) =======================================
```
