### PR TITLE
Fix long failing reporting API tests

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -82,24 +82,6 @@ def setup_content(module_sca_manifest_org, module_target_sat):
     return ak, org
 
 
-@pytest.fixture
-def setup_ak_with_cve(target_sat, function_lce, function_org):
-    """
-    This fixture sets up an activation key with LCE that has CV promoted to it.
-
-    :return: activation_key, cv, function_lce, function_org
-    """
-    cv = target_sat.api.ContentView(organization=function_org).create()
-    cv.publish()
-    cvv = cv.read().version[0].read()
-    cvv.promote(data={'environment_ids': function_lce.id})
-    activation_key = target_sat.api.ActivationKey(
-        environment=function_lce, organization=function_org, content_view=cv
-    ).create()
-
-    return activation_key, cv, function_lce, function_org
-
-
 # Tests for ``katello/api/v2/report_templates``.
 
 
@@ -377,7 +359,7 @@ def test_negative_create_report_without_name(module_target_sat):
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 def test_positive_applied_errata(
-    function_location, rhel_contenthost, target_sat, setup_ak_with_cve
+    rhel_contenthost, target_sat, function_location, function_org, function_lce
 ):
     """Generate an Applied Errata report
 
@@ -393,18 +375,16 @@ def test_positive_applied_errata(
 
     :CaseImportance: Medium
     """
-    activation_key, cv, function_lce, function_org = setup_ak_with_cve
 
     ERRATUM_ID = str(settings.repos.yum_6.errata[2])
-    target_sat.cli_factory.setup_org_for_a_custom_repo(
+    created_vals = target_sat.cli_factory.setup_org_for_a_custom_repo(
         {
             'url': settings.repos.yum_9.url,
             'organization-id': function_org.id,
-            'content-view-id': cv.id,
             'lifecycle-environment-id': function_lce.id,
-            'activationkey-id': activation_key.id,
         }
     )
+    activation_key = target_sat.api.ActivationKey(id=created_vals['activationkey-id']).read()
     result = rhel_contenthost.register(
         function_org, function_location, activation_key.name, target_sat
     )
@@ -451,7 +431,11 @@ def test_positive_applied_errata(
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
 def test_positive_applied_errata_report_with_invalid_errata(
-    function_location, rhel_contenthost, target_sat, setup_ak_with_cve
+    rhel_contenthost,
+    target_sat,
+    function_location,
+    function_org,
+    function_lce,
 ):
     """Generate an Applied Errata report after an invalid errata has been applied
 
@@ -470,17 +454,16 @@ def test_positive_applied_errata_report_with_invalid_errata(
 
     :customerscenario: true
     """
-    activation_key, cv, function_lce, function_org = setup_ak_with_cve
 
-    target_sat.cli_factory.setup_org_for_a_custom_repo(
+    created_vals = target_sat.cli_factory.setup_org_for_a_custom_repo(
         {
             'url': settings.repos.yum_6.url,
             'organization-id': function_org.id,
-            'content-view-id': cv.id,
             'lifecycle-environment-id': function_lce.id,
-            'activationkey-id': activation_key.id,
         }
     )
+    activation_key = target_sat.api.ActivationKey(id=created_vals['activationkey-id']).read()
+
     result = rhel_contenthost.register(
         function_org, function_location, activation_key.name, target_sat
     )
@@ -524,7 +507,9 @@ def test_positive_applied_errata_report_with_invalid_errata(
 @pytest.mark.tier2
 @pytest.mark.rhel_ver_match('[^6]')
 @pytest.mark.no_containers
-def test_positive_applied_errata_by_search(rhel_contenthost, target_sat, setup_ak_with_cve):
+def test_positive_applied_errata_by_search(
+    rhel_contenthost, target_sat, function_org, function_lce
+):
     """Generate an Applied Errata report
 
     :id: 0f7d2772-47a4-4215-b555-dd8ee675372f
@@ -539,17 +524,16 @@ def test_positive_applied_errata_by_search(rhel_contenthost, target_sat, setup_a
 
     :CaseImportance: Medium
     """
-    activation_key, cv, function_lce, function_org = setup_ak_with_cve
+
     ERRATUM_ID = str(settings.repos.yum_6.errata[2])
-    target_sat.cli_factory.setup_org_for_a_custom_repo(
+    created_vals = target_sat.cli_factory.setup_org_for_a_custom_repo(
         {
             'url': settings.repos.yum_6.url,
             'organization-id': function_org.id,
-            'content-view-id': cv.id,
             'lifecycle-environment-id': function_lce.id,
-            'activationkey-id': activation_key.id,
         }
     )
+    activation_key = target_sat.api.ActivationKey(id=created_vals['activationkey-id']).read()
     errata_name = (
         target_sat.api.Errata()
         .search(query={'search': f'errata_id="{ERRATUM_ID}"'})[0]


### PR DESCRIPTION
### Problem Statement
Some API reporting tests did not work in the stream due to multi-CV changes.
The main goal is to get rid of `Environment ID and content view ID must be provided together` errors which appear due to outdated test composition.

### Solution
Let the `setup_org_for_a_custom_repo` function create and promote CV and create AK

<img width="321" alt="image" src="https://github.com/user-attachments/assets/39c18f8b-f2e1-4737-9953-9d81883e05a3" />


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_reporttemplates.py -k "test_positive_applied_errata or test_positive_applied_errata_report_with_invalid_errata or test_positive_applied_errata_by_search"
```