### PR TITLE
Add test cases for pulpcore flatpak endpoint

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -759,6 +759,9 @@ FLATPAK_REMOTES = {
         'authenticated': True,
     },
 }
+PULPCORE_FLATPAK_ENDPOINT = (
+    'https://{}/pulpcore_registry/index/static?label:org.flatpak.ref:exists=1'
+)
 
 CONTAINER_CLIENTS = ['docker', 'podman']
 CUSTOM_LOCAL_FOLDER = '/var/lib/pulp/imports/myrepo/'

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -21,6 +21,7 @@ from nailgun import client
 from nailgun.config import ServerConfig
 from nailgun.entity_mixins import call_entity_method_with_timeout
 import pytest
+import requests
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
@@ -38,6 +39,7 @@ from robottelo.constants import (
     KICKSTART_CONTENT,
     PRDS,
     PULP_ARTIFACT_DIR,
+    PULPCORE_FLATPAK_ENDPOINT,
     REPOS,
     REPOSET,
     RH_CONTAINER_REGISTRY_HUB,
@@ -784,6 +786,23 @@ class TestCapsuleContentManagement:
 
             # check that one of the files is in the content
             assert b'katello-server-ca.crt' in response.content
+
+    @pytest.mark.upgrade
+    def test_flatpak_pulpcore_enpoint(self, target_sat, module_capsule_configured):
+        """Ensure the Capsules's flatpak pulpcore endpoint is up after install or upgrade.
+
+        :id: 5676fbbb-75be-4660-a09e-65cafdfb221a
+
+        :steps:
+            1. Hit Capsule's pulpcore_registry endpoint.
+
+        :expectedresults:
+            1. HTTP 200
+        """
+        rq = requests.get(
+            PULPCORE_FLATPAK_ENDPOINT.format(module_capsule_configured.hostname), verify=False
+        )
+        assert rq.ok, f'Expected 200 but got {rq.status_code} from pulpcore registry index'
 
     @pytest.mark.e2e
     @pytest.mark.tier4

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -16,7 +16,7 @@ import pytest
 import requests
 
 from robottelo.config import settings
-from robottelo.constants import FLATPAK_REMOTES
+from robottelo.constants import FLATPAK_REMOTES, PULPCORE_FLATPAK_ENDPOINT
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.utils.datafactory import gen_string
 
@@ -205,3 +205,19 @@ def test_scan_flatpak_remote(target_sat, function_org, function_product, remote)
 
     # 3. Compare the scanned repos match the repos in the remote index.
     assert sorted(scanned_repo_names) == sorted(index_repo_names)
+
+
+@pytest.mark.upgrade
+def test_flatpak_pulpcore_enpoint(target_sat):
+    """Ensure the Satellite's flatpak pulpcore endpoint is up after install or upgrade.
+
+    :id: 3593ac46-4e5d-495e-95eb-d9609cb46a15
+
+    :steps:
+        1. Hit Satellite's pulpcore_registry endpoint.
+
+    :expectedresults:
+        1. HTTP 200
+    """
+    rq = requests.get(PULPCORE_FLATPAK_ENDPOINT.format(target_sat.hostname), verify=False)
+    assert rq.ok, f'Expected 200 but got {rq.status_code} from pulpcore registry index'


### PR DESCRIPTION
### Problem Statement
After 6.17.0 install (or upgrade) the pulpcore flatpak endpoint should be up at the Satellite and/or Capsule and we should verify it.


### Solution
This PR adds a test case for both.


### PRT test Cases example
Needs https://github.com/theforeman/puppet-pulpcore/pull/363 in stream snap.

```
trigger: test-robottelo
pytest: tests/foreman -k test_flatpak_pulpcore_enpoint
```