### PR TITLE
[6.16.z] Fix pulp tasks purge test case

### DIFF
--- a/tests/foreman/cli/test_repositories.py
+++ b/tests/foreman/cli/test_repositories.py
@@ -194,15 +194,16 @@ def test_purge_pulp_tasks(module_target_sat, module_org, module_repository, sett
     :customerscenario: true
 
     """
-    original_ptc = int(module_target_sat.execute('pulp task list | jq length').stdout)
+    cmd = 'pulp task list --limit 99999 | jq length'
+    original_ptc = int(module_target_sat.execute(cmd).stdout)
     module_target_sat.run_orphan_cleanup(smart_proxy_id=1)
-    new_ptc = int(module_target_sat.execute('pulp task list | jq length').stdout)
+    new_ptc = int(module_target_sat.execute(cmd).stdout)
     assert new_ptc > original_ptc, 'Pulp tasks were unexpectedly purged'
 
     setting_update.value = 0
     setting_update.update({'value'})
 
-    original_ptc = int(module_target_sat.execute('pulp task list | jq length').stdout)
+    original_ptc = int(module_target_sat.execute(cmd).stdout)
     module_target_sat.run_orphan_cleanup(smart_proxy_id=1)
-    new_ptc = int(module_target_sat.execute('pulp task list | jq length').stdout)
+    new_ptc = int(module_target_sat.execute(cmd).stdout)
     assert new_ptc < original_ptc, 'Pulp tasks were not purged'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17190

### Problem Statement
The `test_purge_pulp_tasks` fails with
```
AssertionError: Pulp tasks were unexpectedly purged
assert 25 > 25
```
because `pulp task list` command uses pagination, so it returns only 25 tasks event when there are more tasks to be listed.


### Solution
The command offers `--limit` option for pagination control. Let's use it.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_repositories.py -k test_purge_pulp_tasks
```