### PR TITLE
[6.15.z] Fix expected user name

### DIFF
--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -266,7 +266,7 @@ def test_positive_add_katello_role(
         session.activationkey.create({'name': ak_name})
         assert session.activationkey.search(ak_name)[0]['Name'] == ak_name
         current_user = session.activationkey.read(ak_name, 'current_user')['current_user']
-        assert f"{auth_source.attr_firstname} {auth_source.attr_lastname}" in current_user
+        assert ldap_data['ldap_user_shown_name'] in current_user
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17161

### Problem Statement
Test `tests/foreman/ui/test_ldap_authentication.py::test_positive_add_katello_role` fails with the following error message:
```
AssertionError: assert 'givenName sn' in 'Foreman User'
```
The reason is that instead of comparing expected value of the name field, verbatim _names of those fields_ are used instead - `givenName` and `sn` of course aren't names of the user but names of the fields where that info is stored.

### Solution
Use `user shown name` config field that is meant specifically for this, it specifies the expected display name of the user in config file.
This is consistent with changes in other similar tests as per https://github.com/SatelliteQE/robottelo/pull/16382

### Related Issues
Similar failures fixed in https://github.com/SatelliteQE/robottelo/pull/16382