### PR TITLE
[6.14] Fix expected user name

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -54,6 +54,7 @@ def ad_data():
         if version in supported_server_versions:
             ad_server_details = {
                 'ldap_user_name': settings.ldap.username,
+                'ldap_user_shown_name': settings.ldap.user_shown_name,
                 'ldap_user_cn': settings.ldap.username,
                 'ldap_user_passwd': settings.ldap.password,
                 'base_dn': settings.ldap.basedn,
@@ -78,6 +79,7 @@ def ad_data():
 def ipa_data():
     return {
         'ldap_user_name': settings.ipa.user,
+        'ldap_user_shown_name': settings.ipa.user_shown_name,
         'ldap_user_cn': settings.ipa.username,
         'ipa_otp_username': settings.ipa.otp_user,
         'ldap_user_passwd': settings.ipa.password,
@@ -95,6 +97,7 @@ def ipa_data():
 def open_ldap_data():
     return {
         'ldap_user_name': settings.open_ldap.open_ldap_user,
+        'ldap_user_shown_name': settings.open_ldap.user_shown_name,
         'ldap_user_cn': settings.open_ldap.username,
         'ldap_hostname': settings.open_ldap.hostname,
         'ldap_user_passwd': settings.open_ldap.password,

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -335,7 +335,7 @@ def test_positive_update_external_roles(
         session.activationkey.create({'name': ak_name})
         assert session.activationkey.search(ak_name)[0]['Name'] == ak_name
         current_user = session.activationkey.read(ak_name, 'current_user')['current_user']
-        assert ldap_data['ldap_user_name'] in current_user
+        assert ldap_data['ldap_user_shown_name'] == current_user
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)
@@ -531,7 +531,7 @@ def test_positive_add_admin_role_with_org_loc(
         session.location.create({'name': location_name})
         assert session.location.search(location_name)[0]['Name'] == location_name
         location = session.location.read(location_name, ['current_user', 'primary'])
-        assert ldap_data['ldap_user_name'] in location['current_user']
+        assert ldap_data['ldap_user_shown_name'] in location['current_user']
         assert location['primary']['name'] == location_name
         session.organization.select(module_org.name)
         session.activationkey.create({'name': ak_name})

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -266,7 +266,7 @@ def test_positive_add_katello_role(
         session.activationkey.create({'name': ak_name})
         assert session.activationkey.search(ak_name)[0]['Name'] == ak_name
         current_user = session.activationkey.read(ak_name, 'current_user')['current_user']
-        assert ldap_data['ldap_user_name'] in current_user
+        assert ldap_data['ldap_user_shown_name'] in current_user
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)

--- a/tests/foreman/ui/test_ldap_authentication.py
+++ b/tests/foreman/ui/test_ldap_authentication.py
@@ -470,13 +470,13 @@ def test_positive_update_external_user_roles(
         )
     with target_sat.ui_session(
         test_name, ldap_data['ldap_user_name'], ldap_data['ldap_user_passwd']
-    ) as session:
+    ) as ldapsession:
         with pytest.raises(NavigationTriesExceeded):
             ldapsession.architecture.search('')
-        session.activationkey.create({'name': ak_name})
-        assert session.activationkey.search(ak_name)[0]['Name'] == ak_name
-        current_user = session.activationkey.read(ak_name, 'current_user')['current_user']
-        assert ldap_data['ldap_user_name'] in current_user
+        ldapsession.activationkey.create({'name': ak_name})
+        assert ldapsession.activationkey.search(ak_name)[0]['Name'] == ak_name
+        current_user = ldapsession.activationkey.read(ak_name, 'current_user')['current_user']
+        assert ldap_data['ldap_user_shown_name'] == current_user
 
 
 @pytest.mark.parametrize('ldap_auth_source', ['AD', 'IPA'], indirect=True)


### PR DESCRIPTION
Cherrypick of https://github.com/SatelliteQE/robottelo/pull/17161 and also of https://github.com/SatelliteQE/robottelo/pull/16382 because it hasn't been previously cherrypicked to 6.14.