### PR TITLE
Fix IPv6 ansible and registration tests

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -351,6 +351,7 @@ class TestAnsibleREX:
         :BZ: 2164400
         """
         SELECTED_ROLE = 'RedHatInsights.insights-client'
+        rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
         if rhel_contenthost.os_version.major <= 7:
             rhel_contenthost.create_custom_repos(rhel7=settings.repos.rhel7_os)
             assert rhel_contenthost.execute('yum install -y insights-client').status == 0

--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -147,6 +147,8 @@ def test_positive_update_packages_registration(
 
     :expectedresults: Package update is successful on host post registration.
     """
+    # Adding IPv6 proxy for IPv6 communication
+    rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
     org = module_sca_manifest_org
     result = rhel_contenthost.api_register(
         module_target_sat,

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -86,6 +86,7 @@ class TestAnsibleCfgMgmt:
         SELECTED_ROLE_1 = 'theforeman.foreman_scap_client'
         SELECTED_VAR = gen_string('alpha')
         proxy_id = target_sat.nailgun_smart_proxy.id
+        rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
         # disable batch tasks to test BZ#2154184
         target_sat.cli.Settings.set({'name': 'foreman_tasks_proxy_batch_trigger', 'value': 'false'})
         result = rhel_contenthost.register(
@@ -593,6 +594,8 @@ class TestAnsibleREX:
         :expectedresults: Ansible collection can be installed on content host via REX.
         """
         client = rhel_contenthost
+        # Adding IPv6 proxy for IPv6 communication
+        client.enable_ipv6_dnf_and_rhsm_proxy()
         # Enable Ansible repository and Install ansible or ansible-core package
         client.register(module_org, None, module_ak_with_cv.name, target_sat)
         rhel_repo_urls = getattr(settings.repos, f'rhel{client.os_version.major}_os', None)

--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -129,6 +129,8 @@ def test_upgrade_katello_ca_consumer_rpm(
 
     :BZ: 1791503
     """
+    # Adding IPv6 proxy for IPv6 communication
+    rhel7_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
     consumer_cert_name = f'katello-ca-consumer-{target_sat.hostname}'
     consumer_cert_src = f'{consumer_cert_name}-1.0-1.src.rpm'
     new_consumer_cert_rpm = f'{consumer_cert_name}-1.0-2.noarch.rpm'

--- a/tests/foreman/cli/test_report.py
+++ b/tests/foreman/cli/test_report.py
@@ -85,6 +85,8 @@ def test_positive_install_configure_host(
     """
     puppet_infra_host = [session_puppet_enabled_sat, session_puppet_enabled_capsule]
     for client, puppet_proxy in zip(content_hosts, puppet_infra_host, strict=True):
+        # Adding IPv6 proxy for IPv6 communication
+        client.enable_ipv6_dnf_and_rhsm_proxy()
         client.configure_puppet(
             proxy_hostname=puppet_proxy.hostname, install_puppet_agent7=(client_repo_ver == '1')
         )
@@ -137,6 +139,8 @@ def test_positive_run_puppet_agent_generate_report_when_no_message(
     :parametrized: yes
     """
     sat = session_puppet_enabled_sat
+    # Adding IPv6 proxy for IPv6 communication
+    rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
     client = rhel_contenthost
     client.configure_puppet(
         proxy_hostname=sat.hostname,

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -592,6 +592,7 @@ class TestAnsibleREX:
             2. Job report should be created.
         """
         SELECTED_ROLE = 'RedHatInsights.insights-client'
+        rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
         if rhel_contenthost.os_version.major <= 7:
             rhel_contenthost.create_custom_repos(rhel7=settings.repos.rhel7_os)
             assert rhel_contenthost.execute('yum install -y insights-client').status == 0
@@ -787,6 +788,8 @@ class TestAnsibleREX:
 
         :expectedresults: The Ansible collection is successfully installed on the host
         """
+        # Adding IPv6 proxy for IPv6 communication
+        rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
         client = rhel_contenthost
         # Enable Ansible repository and Install ansible or ansible-core package
         client.register(module_org, None, module_ak_with_cv.name, target_sat)

--- a/tests/foreman/ui/test_registration.py
+++ b/tests/foreman/ui/test_registration.py
@@ -161,6 +161,8 @@ def test_positive_global_registration_end_to_end(
 
     :parametrized: yes
     """
+    # Adding IPv6 proxy for IPv6 communication
+    rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
     # make sure global parameters for rex and insights are set to true
     insights_cp = (
         module_target_sat.api.CommonParameter()
@@ -204,6 +206,7 @@ def test_positive_global_registration_end_to_end(
     ]
     for pair in expected_pairs:
         assert pair in cmd
+
     # rhel repo required for insights client installation,
     # syncing it to the satellite would take too long
     rhelver = rhel_contenthost.os_version.major
@@ -387,6 +390,8 @@ def test_global_registration_with_gpg_repo_and_default_package(
 
     :parametrized: yes
     """
+    # Adding IPv6 proxy for IPv6 communication
+    rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
     client = rhel_contenthost
     repo_name = 'foreman_register'
     repo_url = settings.repos.gr_yum_repo.url
@@ -752,6 +757,8 @@ def test_subscription_manager_install_from_repository(
 
     :BZ: 1923320
     """
+    # Adding IPv6 proxy for IPv6 communication
+    rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
     client = rhel_contenthost
     repo_name = 'foreman_register'
     rhel_ver = rhel_contenthost.os_version.major


### PR DESCRIPTION
Fix failing IPv6 ansible and registration tests.
The test is failing because the custom repos are created with download.devel url to download packages which can't be reached over IPv6