### PR TITLE
Add e2e test case for flatpak

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -232,6 +232,22 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
         yield host
 
 
+@pytest.fixture(scope='module')
+def module_flatpak_contenthost(request):
+    request.param = {
+        "rhel_version": "9",
+        "distro": "rhel",
+        "no_containers": True,
+    }
+    with Broker(**host_conf(request), host_class=ContentHost) as host:
+        host.register_to_cdn()
+        for pkg in ['podman', 'flatpak', 'dbus-x11']:
+            res = host.execute(f'dnf -y install {pkg}')
+            assert res.status == 0, f'{pkg} installation failed: {res.stderr}'
+        host.unregister()
+        yield host
+
+
 @pytest.fixture
 def centos_host(request, version):
     request.param = {

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -241,9 +241,8 @@ def module_flatpak_contenthost(request):
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
-        for pkg in ['podman', 'flatpak', 'dbus-x11']:
-            res = host.execute(f'dnf -y install {pkg}')
-            assert res.status == 0, f'{pkg} installation failed: {res.stderr}'
+        res = host.execute('dnf -y install podman flatpak dbus-x11')
+        assert res.status == 0, f'Initial installation failed: {res.stderr}'
         host.unregister()
         yield host
 

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -785,7 +785,7 @@ class TestCapsuleContentManagement:
             assert b'katello-server-ca.crt' in response.content
 
     @pytest.mark.upgrade
-    def test_flatpak_pulpcore_enpoint(self, target_sat, module_capsule_configured):
+    def test_flatpak_pulpcore_endpoint(self, target_sat, module_capsule_configured):
         """Ensure the Capsules's flatpak pulpcore endpoint is up after install or upgrade.
 
         :id: 5676fbbb-75be-4660-a09e-65cafdfb221a

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -316,7 +316,7 @@ def test_sync_consume_flatpak_repo_via_library(
     assert 'succeeded' in res['status']
     request.addfinalizer(lambda: host.execute(f'flatpak remote-delete {remote_name}'))
 
-    # 7. Install flatpak app from the repo via REX on the contenthost.
+    # 6. Install flatpak app from the repo via REX on the contenthost.
     res = host.execute('flatpak remotes')
     assert remote_name in res.stdout
 

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -208,7 +208,7 @@ def test_scan_flatpak_remote(target_sat, function_org, function_product, remote)
 
 
 @pytest.mark.upgrade
-def test_flatpak_pulpcore_enpoint(target_sat):
+def test_flatpak_pulpcore_endpoint(target_sat):
     """Ensure the Satellite's flatpak pulpcore endpoint is up after install or upgrade.
 
     :id: 3593ac46-4e5d-495e-95eb-d9609cb46a15

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -221,3 +221,123 @@ def test_flatpak_pulpcore_enpoint(target_sat):
     """
     rq = requests.get(PULPCORE_FLATPAK_ENDPOINT.format(target_sat.hostname), verify=False)
     assert rq.ok, f'Expected 200 but got {rq.status_code} from pulpcore registry index'
+
+
+@pytest.mark.e2e
+@pytest.mark.upgrade
+def test_sync_consume_flatpak_repo_via_library(
+    request, module_target_sat, module_flatpak_contenthost, function_org, function_product
+):
+    """Verify flatpak repository workflow end to end.
+
+    :id: 06043b3e-be9b-4444-96b1-d3d15b7e3d8c
+
+    :steps:
+        1. Create a flatpak remote and scan it.
+        2. Mirror a flatpak repository and sync it.
+        3. Create an AK assigned to the Library.
+        4. Register a content host using the AK.
+        5. Configure the contenthost via REX to use Satellite's flatpak index.
+        6. Install flatpak app from the repo via REX on the contenthost.
+        7. Ensure the app has been installed successfully.
+
+    :expectedresults:
+        1. Entire workflow works and allows user to install a flatpak app at the registered
+           contenthost.
+
+    """
+    sat, host = module_target_sat, module_flatpak_contenthost
+    # 1. Create a flatpak remote and scan it.
+    fr = sat.cli.FlatpakRemote().create(
+        {
+            'organization-id': function_org.id,
+            'url': FLATPAK_REMOTES['RedHat']['url'],
+            'name': gen_string('alpha'),
+            'username': settings.container_repo.registries.redhat.username,
+            'token': settings.container_repo.registries.redhat.password,
+        }
+    )
+    sat.cli.FlatpakRemote().scan({'id': fr['id']})
+    repos = sat.cli.FlatpakRemote().repository_list({'flatpak-remote-id': fr['id']})
+    assert len(repos), 'No repositories scanned'
+
+    # 2. Mirror a flatpak repository and sync it.
+    repo_names = ['rhel9/firefox-flatpak', 'rhel9/flatpak-runtime']  # runtime is dependency
+    remote_repos = [r for r in repos if r['name'] in repo_names]
+    for repo in remote_repos:
+        sat.cli.FlatpakRemote().repository_mirror(
+            {
+                'flatpak-remote-id': fr['id'],
+                'id': repo['id'],  # or by name
+                'product-id': function_product.id,
+            }
+        )
+        local_repo = sat.cli.Repository.list(
+            {'product-id': function_product.id, 'name': repo['name']}
+        )[0]
+        sat.cli.Repository.synchronize({'id': local_repo['id']})
+        assert 'latest' in sat.api.Repository(id=local_repo['id']).read().include_tags
+    local_repos = sat.cli.Repository.list({'product-id': function_product.id})
+    assert set([r['name'] for r in local_repos]) == set(repo_names)
+
+    # 3. Create an AK assigned to the Library.
+    ak_lib = sat.cli.ActivationKey.create(
+        {
+            'name': gen_string('alpha'),
+            'organization-id': function_org.id,
+            'lifecycle-environment': 'Library',
+            'content-view': 'Default Organization View',
+        }
+    )
+
+    # 4. Register a content host using the AK.
+    res = host.register(function_org, None, ak_lib['name'], sat, force=True)
+    assert res.status == 0, (
+        f'Failed to register host: {host.hostname}\n' f'StdOut: {res.stdout}\nStdErr: {res.stderr}'
+    )
+    assert host.subscribed
+
+    # 5. Configure the contenthost via REX to use Satellite's flatpak index.
+    remote_name = f'SAT-remote-{gen_string("alpha")}'
+    job = module_target_sat.cli_factory.job_invocation(
+        {
+            'organization': function_org.name,
+            'job-template': 'Set up Flatpak remote on host',
+            'inputs': (
+                f'Remote Name={remote_name}, '
+                f'Flatpak registry URL=https://{sat.hostname}/pulpcore_registry/, '
+                f'Username={settings.server.admin_username}, '
+                f'Password={settings.server.admin_password}'
+            ),
+            'search-query': f"name ~ {host.hostname}",
+        }
+    )
+    res = module_target_sat.cli.JobInvocation.info({'id': job.id})
+    assert 'succeeded' in res['status']
+    request.addfinalizer(lambda: host.execute(f'flatpak remote-delete {remote_name}'))
+
+    # 7. Install flatpak app from the repo via REX on the contenthost.
+    res = host.execute('flatpak remotes')
+    assert remote_name in res.stdout
+
+    app_name = 'Firefox'  # or 'org.mozilla.Firefox'
+    res = host.execute('flatpak remote-ls')
+    assert app_name in res.stdout
+
+    job = module_target_sat.cli_factory.job_invocation(
+        {
+            'organization': function_org.name,
+            'job-template': 'Install Flatpak application on host',
+            'inputs': f'Flatpak remote name={remote_name}, Application name={app_name}',
+            'search-query': f"name ~ {host.hostname}",
+        }
+    )
+    res = module_target_sat.cli.JobInvocation.info({'id': job.id})
+    assert 'succeeded' in res['status']
+    request.addfinalizer(
+        lambda: host.execute(f'flatpak uninstall {remote_name} {app_name} com.redhat.Platform -y')
+    )
+
+    # 7. Ensure the app has been installed successfully.
+    res = host.execute('flatpak list')
+    assert app_name in res.stdout


### PR DESCRIPTION
### Problem Statement
In Satellite 6.17 we are going to support full path for host setup and flatpak app installation on a content host, including REX templates to make it more user-friendly. We should have an E2E test case to cover all of that too.


### Solution
This PR adds such a test case (and fixes two typos).


### Related Issues
https://issues.redhat.com/browse/SAT-28557
https://issues.redhat.com/browse/SAT-4420


### Requires
https://github.com/Katello/katello/pull/11223 (in snap)
https://github.com/Katello/hammer-cli-katello/pull/971 (in snap)
https://github.com/Katello/katello/pull/11264

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py -k test_sync_consume_flatpak_repo_via_library
Katello:
    katello: 11264
```