### PR TITLE
Add tests for VMware secureboot provisioning

### DIFF
--- a/pytest_fixtures/component/provision_vmware.py
+++ b/pytest_fixtures/component/provision_vmware.py
@@ -72,6 +72,11 @@ def module_vmware_hostgroup(
         subnet=module_provisioning_sat.subnet,
         pxe_loader=pxe_loader.pxe_loader,
         group_parameters_attributes=[
+            {
+                'name': 'remote_execution_connect_by_ip',
+                'parameter_type': 'boolean',
+                'value': 'true',
+            },
             # assign AK in order the hosts to be subscribed
             {
                 'name': 'kt_activation_keys',

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -58,7 +58,7 @@ def test_positive_provision_end_to_end(
 
     :CaseImportance: Critical
 
-    :Verifies: SAT-18721, SAT-23558, SAT-25810
+    :Verifies: SAT-18721, SAT-23558, SAT-25810, SAT-25339
 
     :customerscenario: true
 
@@ -128,9 +128,15 @@ def test_positive_provision_end_to_end(
 
     request.addfinalizer(lambda: sat.provisioning_cleanup(host.name))
     assert host.name == f'{name}.{module_provisioning_sat.domain.name}'
-    # check if vm is created on vmware
+    # Check if VM is created on VMware
     assert vmwareclient.does_vm_exist(host.name) is True
-    # check the build status
+
+    # Check if virtual TPM device is added to created VM (only for UEFI)
+    if pxe_loader.vm_firmware != 'bios':
+        vm = vmwareclient.get_vm(host.name)
+        assert 'VirtualTPM' in vm.get_virtual_device_type_names()
+
+    # Check the build status
     wait_for(
         lambda: host.read().build_status_label != 'Pending installation',
         timeout=1500,

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -66,6 +66,18 @@ def test_positive_provision_end_to_end(
     """
     sat = module_provisioning_sat.sat
     name = gen_string('alpha').lower()
+
+    # Add remote_execution_ssh_keys parameter in hostgroup for ssh connection to EL9/EL10 host
+    existing_params = module_vmware_hostgroup.group_parameters_attributes
+    module_vmware_hostgroup.group_parameters_attributes = [
+        {
+            'name': 'remote_execution_ssh_keys',
+            'value': settings.provisioning.host_ssh_key_pub,
+            'parameter_type': 'string',
+        },
+    ] + existing_params
+    module_vmware_hostgroup.update(['group_parameters_attributes'])
+
     host = sat.api.Host(
         hostgroup=module_vmware_hostgroup,
         organization=module_sca_manifest_org,
@@ -97,6 +109,7 @@ def test_positive_provision_end_to_end(
                     'controller_key': 1001,
                 },
             },
+            'virtual_tpm': 'false' if pxe_loader.vm_firmware == 'bios' else 'true',
         },
         interfaces_attributes={
             '0': {

--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -81,7 +81,7 @@ def test_positive_vmware_cr_end_to_end(target_sat, module_org, module_location, 
 @pytest.mark.parametrize('vmware', ['vmware7', 'vmware8'], indirect=True)
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 @pytest.mark.parametrize('provision_method', ['build', 'bootdisk'])
-@pytest.mark.rhel_ver_match('[8]')
+@pytest.mark.rhel_ver_match('[7]')
 @pytest.mark.tier3
 def test_positive_provision_end_to_end(
     request,
@@ -126,7 +126,7 @@ def test_positive_provision_end_to_end(
             'compute-attributes': f'cluster={settings.vmware.cluster},'
             f'path=/Datacenters/{settings.vmware.datacenter}/vm/,'
             'scsi_controller_type=VirtualLsiLogicController,'
-            f'guest_id=rhel8_64Guest,firmware={pxe_loader.vm_firmware},'
+            f'guest_id=rhel7_64Guest,firmware={pxe_loader.vm_firmware},'
             'cpus=1,memory_mb=6000, start=1',
             'interface': f'compute_type=VirtualVmxnet3,'
             f'compute_network=VLAN {settings.provisioning.vlan_id}',

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -557,12 +557,11 @@ def test_positive_virt_card(session, target_sat, module_location, module_org, vm
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 @pytest.mark.parametrize('provision_method', ['build'])
-@pytest.mark.rhel_ver_list('[9, 10]')
+@pytest.mark.rhel_ver_match('[8]')
 @pytest.mark.tier3
 def test_positive_provision_end_to_end(
     request,
     module_sca_manifest_org,
-    module_location,
     pxe_loader,
     module_vmware_cr,
     module_vmware_hostgroup,
@@ -572,7 +571,6 @@ def test_positive_provision_end_to_end(
     vmwareclient,
     target_sat,
     module_provisioning_rhel_content,
-    module_ssh_key_file,
     get_vmware_datastore_summary_string,
 ):
     """Assign Ansible role to a Hostgroup and verify ansible role execution job is scheduled after a host is provisioned
@@ -606,7 +604,6 @@ def test_positive_provision_end_to_end(
     }
     with target_sat.ui_session() as session:
         session.organization.select(module_sca_manifest_org.name)
-        session.location.select(module_location.name)
         session.ansibleroles.import_all_roles()
         session.hostgroup.assign_role_to_hostgroup(
             module_vmware_hostgroup.name, {'ansible_roles.resources': SELECTED_ROLE}
@@ -652,17 +649,9 @@ def test_positive_provision_end_to_end(
         # Verify SecureBoot is enabled on host after provisioning is completed sucessfully
         if pxe_loader.vm_firmware == 'uefi_secure_boot':
             host = target_sat.api.Host().search(query={'host': host_name})[0].read()
-            provisioning_host = ContentHost(host.ip, auth=module_ssh_key_file)
+            provisioning_host = ContentHost(host.ip)
             # Wait for the host to be rebooted and SSH daemon to be started.
             provisioning_host.wait_for_connection()
-            # Enable Root Login
-            if int(host.operatingsystem.read().major) >= 9:
-                assert (
-                    provisioning_host.execute(
-                        'echo -e "\nPermitRootLogin yes" >> /etc/ssh/sshd_config; systemctl restart sshd'
-                    ).status
-                    == 0
-                )
             assert 'SecureBoot enabled' in provisioning_host.execute('mokutil --sb-state').stdout
 
         # Verify if assigned role is executed on the host, and correct host passwd is set

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -562,6 +562,7 @@ def test_positive_virt_card(session, target_sat, module_location, module_org, vm
 def test_positive_provision_end_to_end(
     request,
     module_sca_manifest_org,
+    module_location,
     pxe_loader,
     module_vmware_cr,
     module_vmware_hostgroup,
@@ -594,7 +595,7 @@ def test_positive_provision_end_to_end(
     """
     SELECTED_ROLE = 'theforeman.foreman_scap_client'
     host_name = gen_string('alpha').lower()
-    guest_os_names = 'Red Hat Enterprise Linux 9 (64 bit)'
+    guest_os_names = 'Red Hat Enterprise Linux 8 (64 bit)'
     storage_data = {'storage': {'disks': [{'data_store': get_vmware_datastore_summary_string}]}}
     network_data = {
         'network_interfaces': {
@@ -603,8 +604,10 @@ def test_positive_provision_end_to_end(
         }
     }
     with target_sat.ui_session() as session:
-        session.organization.select(module_sca_manifest_org.name)
         session.ansibleroles.import_all_roles()
+        assert session.ansibleroles.import_all_roles() == session.ansibleroles.imported_roles_count
+        session.location.select(module_location.name)
+        session.organization.select(module_sca_manifest_org.name)
         session.hostgroup.assign_role_to_hostgroup(
             module_vmware_hostgroup.name, {'ansible_roles.resources': SELECTED_ROLE}
         )

--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -557,7 +557,7 @@ def test_positive_virt_card(session, target_sat, module_location, module_org, vm
 @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
 @pytest.mark.parametrize('pxe_loader', ['bios', 'uefi', 'secureboot'], indirect=True)
 @pytest.mark.parametrize('provision_method', ['build'])
-@pytest.mark.rhel_ver_match('[9]')
+@pytest.mark.rhel_ver_list('[9, 10]')
 @pytest.mark.tier3
 def test_positive_provision_end_to_end(
     request,
@@ -607,7 +607,7 @@ def test_positive_provision_end_to_end(
     with target_sat.ui_session() as session:
         session.organization.select(module_sca_manifest_org.name)
         session.location.select(module_location.name)
-        assert session.ansibleroles.import_all_roles() == session.ansibleroles.imported_roles_count
+        session.ansibleroles.import_all_roles()
         session.hostgroup.assign_role_to_hostgroup(
             module_vmware_hostgroup.name, {'ansible_roles.resources': SELECTED_ROLE}
         )


### PR DESCRIPTION
### Problem Statement
Missing test coverage for new feature of VMware secureboot provisioning

### Solution
Update existing tests to include VMware UEFI secureboot provisioning

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->