### PR TITLE
Add a default location to the non-admin user to support Ansible role synchronization.

### DIFF
--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -642,7 +642,14 @@ class TestAnsibleREX:
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.parametrize('auth_type', ['admin', 'non-admin'])
     def test_positive_ansible_variables_imported_with_roles(
-        self, request, auth_type, target_sat, module_org, module_ak_with_cv, rhel_contenthost
+        self,
+        request,
+        auth_type,
+        target_sat,
+        module_org,
+        default_location,
+        module_ak_with_cv,
+        rhel_contenthost,
     ):
         """Verify that when Ansible roles are imported, their variables are imported simultaneously
 
@@ -671,6 +678,7 @@ class TestAnsibleREX:
                     'login': username,
                     'password': password,
                     'organization-ids': module_org.id,
+                    'default-location': default_location.id,
                 }
             )
             target_sat.cli.User.add_role(


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->