### PR TITLE
Update RHEL9 version for Leapp client

### DIFF
--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -10,7 +10,7 @@ synced_repos = pytest.StashKey[dict]
 
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.4'
+RHEL9_VER = '9.5'
 
 RHEL_REPOS = {
     'rhel7_server': {

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -23,8 +23,8 @@ from robottelo.logging import logger
 synced_repos = pytest.StashKey[dict]
 
 RHEL7_VER = '7.9'
-RHEL8_VER = '8.9'
-RHEL9_VER = '9.4'
+RHEL8_VER = '8.10'
+RHEL9_VER = '9.5'
 
 RHEL_REPOS = {
     'rhel7_server': {

--- a/tests/foreman/ui/test_leapp_client.py
+++ b/tests/foreman/ui/test_leapp_client.py
@@ -16,7 +16,7 @@ import pytest
 
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
-RHEL9_VER = '9.4'
+RHEL9_VER = '9.5'
 
 
 @pytest.mark.tier3


### PR DESCRIPTION
### Problem Statement
Failed cp  https://github.com/SatelliteQE/robottelo/issues/17031 

### Solution
Manually cherrypicked

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->