### PR TITLE
Update rhc tests to use manifest with satqe prefix

### DIFF
--- a/conf/rh_cloud.yaml.template
+++ b/conf/rh_cloud.yaml.template
@@ -1,6 +1,6 @@
 RH_CLOUD:
   TOKEN: this-isnt-the-token
   INSTALL_RHC: false
-  ORGANIZATION: org_name
+  ORGANIZATION:
   ACTIVATION_KEY: ak_name
   CRC_ENV: prod

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -42,7 +42,7 @@ def module_rhc_org(module_target_sat):
     """Module level fixture for creating organization"""
     if settings.rh_cloud.crc_env == 'prod':
         org = module_target_sat.api.Organization(
-            name=settings.rh_cloud.organization or gen_string('alpha')
+            name=settings.rh_cloud.organization or 'satqe-rhc-org-' + gen_string('alpha')
         ).create()
     else:
         org = (


### PR DESCRIPTION
### Problem Statement
- Satellite RH Cloud tests uses name of `module_rhc_org` as manifest name. This works fine with automation but if someone runs the test manually and has not set `settings.rh_cloud.organization`, a manifest with a random name gets created.

### Solution
- Add `satqe-rhc-org` prefix to the code that sets random name and update `conf/rh_cloud.yaml.template`.

### Related Issues
- SAT-30336

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->