### PR TITLE
[6.16.z] Correction in yaml value

### DIFF
--- a/tests/foreman/api/test_classparameters.py
+++ b/tests/foreman/api/test_classparameters.py
@@ -47,7 +47,7 @@ def invalid_sc_parameters_data():
         {'sc_type': 'real', 'value': gen_string('alpha')},
         {'sc_type': 'array', 'value': '0'},
         {'sc_type': 'hash', 'value': 'a:test'},
-        {'sc_type': 'yaml', 'value': '{a:test}'},
+        {'sc_type': 'yaml', 'value': '@test'},
         {'sc_type': 'json', 'value': gen_string('alpha')},
     ]
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17229

### Problem Statement
When we provide a string value as input in YAML, it is accepting the value. Ideally, it should not accept an invalid value. The value provided in the YAML is incorrect and should be rejected.

### Solution
Updated the value for yaml parameter to ensure it works for the negative test case.






