### PR TITLE
Skip GCE test

### DIFF
--- a/tests/foreman/api/test_computeresource_gce.py
+++ b/tests/foreman/api/test_computeresource_gce.py
@@ -230,8 +230,8 @@ class TestGCEHostProvisioningTestCase:
     @pytest.mark.pit_server
     @pytest.mark.build_sanity
     @pytest.mark.skipif(
-        ((settings.server.is_ipv6) and is_open('SAT-27997')),
-        reason='Google CR APIs failing for IPv6',
+        (is_open('SAT-27997')),
+        reason='Google CR APIs failing',
     )
     @pytest.mark.parametrize('sat_gce', ['sat', 'puppet_sat'], indirect=True)
     def test_positive_gce_host_provisioned(self, class_host, google_host):


### PR DESCRIPTION
### Problem Statement
VPC network created in Google cloud causing tests for GCE to fail. 

### Solution


### Related Issues
Skipping the test until we fix the issue either on automation end or on Google Cloud.

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->