### PR TITLE
Fix capsule pub url for IPv6

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -777,14 +777,11 @@ class TestCapsuleContentManagement:
 
         :BZ: 1463810, 2122780
         """
-        https_pub_url = f'https://{module_capsule_configured.ip_addr}/pub'
-        http_pub_url = f'http://{module_capsule_configured.ip_addr}/pub'
+        https_pub_url = f'https://{module_capsule_configured.hostname}/pub'
+        http_pub_url = f'http://{module_capsule_configured.hostname}/pub'
         for url in [http_pub_url, https_pub_url]:
             response = client.get(url, verify=False)
-
-            assert response.status_code == 200
-
-            # check that one of the files is in the content
+            assert response.ok
             assert b'katello-server-ca.crt' in response.content
 
     @pytest.mark.upgrade


### PR DESCRIPTION
### Problem Statement
The `test_positive_capsule_pub_url_accessible` fails on IPv6 network 


### Solution
Use the FQDN instead, DNS should resolve it.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k capsule_pub_url_accessible
network_type: ipv6
```
