### PR TITLE
Fix failing IPv6 puppet tests for RHEL7 host

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -868,7 +868,10 @@ class ContentHost(Host, ContentHostMixins):
         cmd = f"echo -e 'proxy = {scheme}://{hostname}"
         if port:
             cmd += f':{port}'
-        cmd += "' >> /etc/dnf/dnf.conf"
+        if self.execute('test -f /etc/dnf/dnf.conf').status == 0:
+            cmd += "' >> /etc/dnf/dnf.conf"
+        else:
+            cmd += "' >> /etc/yum.conf"
         logger.info(f'Configuring {hostname} HTTP proxy for dnf.')
         self.execute(cmd)
 


### PR DESCRIPTION
### Problem Statement
Tests using enable_ipv6_dnf_and_rhsm_proxy for RHEL 7 content host fails ar it configures proxy for dnf.conf whereas RHEL7 recognizes yum.conf

### Solution
Update the function to configure proxy for yum.conf