### PR TITLE
Fix VMware compute profile test

### DIFF
--- a/tests/foreman/ui/test_computeresource_vmware.py
+++ b/tests/foreman/ui/test_computeresource_vmware.py
@@ -326,7 +326,7 @@ def test_positive_vmware_custom_profile_end_to_end(
     cpus = ['2', '4', '6']
     vm_memory = ['4000', '6000', '8000']
     annotation_notes = gen_string('alpha')
-    firmware_type = ['Automatic', 'BIOS', 'EFI']
+    firmware_type = ['Automatic', 'BIOS', 'UEFI']
     resource_pool = VMWARE_CONSTANTS['pool']
     folder = VMWARE_CONSTANTS['folder']
     virtual_hw_version = VMWARE_CONSTANTS['virtualhw_version']


### PR DESCRIPTION
### Problem Statement
The VMware test is failing due to a recent change of secure boot in stream. Radio button `EFI` has been changed to `UEFI`

### Solution
Update the test to fix above issue

