### PR TITLE
[6.14.z] Update fact name for fetching fqdn fact

### DIFF
--- a/tests/foreman/ui/test_fact.py
+++ b/tests/foreman/ui/test_fact.py
@@ -53,7 +53,7 @@ def test_positive_upload_host_facts(
         assert result.status == 0, f'Failed to register host: {result.stderr}'
 
         rhel_contenthost.execute('subscription-manager facts --update')
-        host_facts = session.host_new.get_host_facts(rhel_contenthost.hostname, fact='network')
+        host_facts = session.host_new.get_host_facts(rhel_contenthost.hostname, fact='fqdn')
         assert host_facts is not None
         assert rhel_contenthost.hostname in [
             var['Value'] for var in host_facts if var['Name'] == 'networkfqdn'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17308

### Problem Statement
Assertion failing on host fqdn while fetching the fact.

### Solution
Updated the fact name .

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->