### PR TITLE
[6.15.z] reboot not working for discovery host, added workaround

### DIFF
--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -422,6 +422,8 @@ class TestDiscoveredHost:
 
         :expectedresults: All discovered hosst should be rebooted successfully
 
+        :BlockedBy: SAT-30395
+
         :verifies: SAT-23279
 
         :CaseImportance: Medium


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17296

Reboot functionality is not working for the discovery host and is throwing an error. Therefore, the reboot step is being skipped for now until a fix is available.






