### PR TITLE
[6.15.z] Mark one RHSSO test for PIT server

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -289,7 +289,8 @@ def auth_data(request, ad_data, ipa_data):
 @pytest.fixture(scope='module')
 def enroll_configure_rhsso_external_auth(module_target_sat):
     """Enroll the Satellite6 Server to an RHSSO Server."""
-    module_target_sat.register_to_cdn()
+    if settings.robottelo.rhel_source == "ga":
+        module_target_sat.register_to_cdn()
     # keycloak-httpd-client-install needs lxml but it's not an rpm dependency + is not documented
     assert (
         module_target_sat.execute(

--- a/tests/foreman/destructive/test_ldapauthsource.py
+++ b/tests/foreman/destructive/test_ldapauthsource.py
@@ -42,6 +42,7 @@ def rh_sso_hammer_auth_setup(module_target_sat, default_sso_host, request):
     default_sso_host.update_client_configuration(client_config)
 
 
+@pytest.mark.pit_server
 def test_rhsso_login_using_hammer(
     module_target_sat,
     enable_external_auth_rhsso,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17204

RHSSO needs some packages shipped by RHEL that we expect to change, we should interop test it. The test will probably never run in older z-streams without it. The test is destructive though, it runs an installer. Debate on allowing destructive tests in PIT is in the corresponding PR in our config repo.