### PR TITLE
[cp 6.15] Extend search time for discoveryhost mac6.15

### DIFF
--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -203,6 +203,7 @@ class TestDiscoveredHost:
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
+            retries=2,
             delay=40,
         )
         discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -55,6 +55,7 @@ def test_rhel_pxe_discovery_provisioning(
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
+        retries=2,
         delay=40,
     )
     discovered_host = sat.api.DiscoveredHost().search(query={'mac': mac})[0]


### PR DESCRIPTION
The Lambda timeout was insufficient to fetch the discovered host's MAC address.Added retries to allow additional time for execution, ensuring better handling of delays and transient issues.

Fixes - https://github.com/SatelliteQE/robottelo/issues/17336