### PR TITLE
Add IPv6 support in  Centos/Oracle Host checkout

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -247,7 +247,11 @@ def centos_host(request, version):
         "distro": "centos",
         "no_containers": True,
     }
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with Broker(
+        **host_conf(request),
+        host_class=ContentHost,
+        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
+    ) as host:
         yield host
 
 
@@ -258,7 +262,11 @@ def oracle_host(request, version):
         "distro": "oracle",
         "no_containers": True,
     }
-    with Broker(**host_conf(request), host_class=ContentHost) as host:
+    with Broker(
+        **host_conf(request),
+        host_class=ContentHost,
+        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
+    ) as host:
         yield host
 
 

--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -124,6 +124,7 @@ def centos(
 ):
     """Deploy and register Centos host"""
     major = version.split('.')[0]
+    centos_host.enable_ipv6_dnf_proxy()
     assert centos_host.execute('yum -y update').status == 0
     repo_url = settings.repos.convert2rhel.convert_to_rhel_repo.format(major)
     repo = create_repo(module_target_sat, module_els_sca_manifest_org, repo_url)
@@ -171,6 +172,7 @@ def oracle(
 ):
     """Deploy and register Oracle host"""
     major = version.split('.')[0]
+    oracle_host.enable_ipv6_dnf_proxy()
     # disable rhn-client-tools because it obsoletes the subscription manager package
     oracle_host.execute('echo "exclude=rhn-client-tools" >> /etc/yum.conf')
     # Install and set correct RHEL compatible kernel and using non-UEK kernel, based on C2R docs


### PR DESCRIPTION
### Problem Statement
Centos/Oracle Host checkout for IPv6 failing due to no option for ipv6.

### Solution
Update Centos/Oracle Host checkout for IPv6.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->