### PR TITLE
Use custom content for RHEL10 until SAT-29721 is resolved

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -44,6 +44,7 @@ REPOS:
     RHEL7: replace-with-rhel7-http-link
     RHEL8: replace-with-rhel8-http-link
     RHEL9: replace-with-rhel9-http-link
+    RHEL10: replace-with-rhel10-http-link
   # Downstream Satellite-maintain repo
   SATMAINTENANCE_REPO: replace-with-sat-maintain-repo
   # Software Collection Repo

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -118,7 +118,7 @@ def module_provisioning_rhel_content(
     rhel_xy = Version(
         constants.REPOS['kickstart'][f'rhel{rhel_ver}']['version']
         if rhel_ver == 7
-        else '10.1'  # EL10 pre-release version
+        else constants.RHEL10_VER
         if rhel_ver == 10
         else constants.REPOS['kickstart'][f'rhel{rhel_ver}_bos']['version']
     )

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -12,7 +12,6 @@ import pytest
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.hosts import ContentHost
-from robottelo.utils.issue_handlers import is_open
 
 
 @pytest.fixture(scope='module')
@@ -39,11 +38,7 @@ def module_provisioning_rhel_content(
     repo_names = []
     if int(rhel_ver) <= 7:
         repo_names.append(f'rhel{rhel_ver}')
-    # Provision using RHEL10 Beta repos until its GA
-    elif int(rhel_ver) == 10:
-        repo_names.append(f'rhel{rhel_ver}_bos_beta')
-        repo_names.append(f'rhel{rhel_ver}_aps_beta')
-    else:
+    elif int(rhel_ver) < 10:
         repo_names.append(f'rhel{rhel_ver}_bos')
         repo_names.append(f'rhel{rhel_ver}_aps')
     rh_repos = []
@@ -51,8 +46,8 @@ def module_provisioning_rhel_content(
     rh_repo_id = ""
     content_view = sat.api.ContentView(organization=module_sca_manifest_org).create()
 
-    # Custom Content for Client repo
-    if is_open('SAT-27193') and int(rhel_ver) != 10:
+    if int(rhel_ver) < 10:
+        # Custom Content for Client repo
         custom_product = sat.api.Product(
             organization=module_sca_manifest_org, name=f'rhel{rhel_ver}_{gen_string("alpha")}'
         ).create()
@@ -66,35 +61,53 @@ def module_provisioning_rhel_content(
         tasks.append(task)
         content_view.repository = [client_repo]
 
-    for name in repo_names:
-        rh_kickstart_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
-            basearch=constants.DEFAULT_ARCHITECTURE,
-            org_id=module_sca_manifest_org.id,
-            product=constants.REPOS['kickstart'][name]['product'],
-            repo=constants.REPOS['kickstart'][name]['name'],
-            reposet=constants.REPOS['kickstart'][name]['reposet'],
-            releasever=constants.REPOS['kickstart'][name]['version'],
-        )
-        # do not sync content repos for discovery based provisioning.
-        if module_provisioning_sat.provisioning_type != 'discovery':
-            rh_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
+        for name in repo_names:
+            rh_kickstart_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
                 basearch=constants.DEFAULT_ARCHITECTURE,
                 org_id=module_sca_manifest_org.id,
-                product=constants.REPOS[name]['product'],
-                repo=constants.REPOS[name]['name'],
-                reposet=constants.REPOS[name]['reposet'],
-                releasever=constants.REPOS[name]['releasever'],
+                product=constants.REPOS['kickstart'][name]['product'],
+                repo=constants.REPOS['kickstart'][name]['name'],
+                reposet=constants.REPOS['kickstart'][name]['reposet'],
+                releasever=constants.REPOS['kickstart'][name]['version'],
             )
+            # do not sync content repos for discovery based provisioning.
+            if module_provisioning_sat.provisioning_type != 'discovery':
+                rh_repo_id = sat.api_factory.enable_rhrepo_and_fetchid(
+                    basearch=constants.DEFAULT_ARCHITECTURE,
+                    org_id=module_sca_manifest_org.id,
+                    product=constants.REPOS[name]['product'],
+                    repo=constants.REPOS[name]['name'],
+                    reposet=constants.REPOS[name]['reposet'],
+                    releasever=constants.REPOS[name]['releasever'],
+                )
 
-        # Sync step because repo is not synced by default
-        for repo_id in [rh_kickstart_repo_id, rh_repo_id]:
-            if repo_id:
-                rh_repo = sat.api.Repository(id=repo_id).read()
-                task = rh_repo.sync(synchronous=False)
-                tasks.append(task)
-                rh_repos.append(rh_repo)
-                content_view.repository.append(rh_repo)
-                content_view.update(['repository'])
+            # Sync step because repo is not synced by default
+            for repo_id in [rh_kickstart_repo_id, rh_repo_id]:
+                if repo_id:
+                    rh_repo = sat.api.Repository(id=repo_id).read()
+                    task = rh_repo.sync(synchronous=False)
+                    tasks.append(task)
+                    rh_repos.append(rh_repo)
+                    content_view.repository.append(rh_repo)
+                    content_view.update(['repository'])
+    else:
+        # Use custom Content for RHEL10 until SAT-29721 is resolved
+        custom_product = sat.api.Product(
+            organization=module_sca_manifest_org, name=f'rhel{rhel_ver}_{gen_string("alpha")}'
+        ).create()
+        for repo in settings.repos.rhel10_os.values():
+            rh_repo = sat.api.Repository(
+                organization=module_sca_manifest_org,
+                product=custom_product,
+                content_type='yum',
+                url=repo,
+            ).create()
+            task = rh_repo.sync(synchronous=False)
+            tasks.append(task)
+            rh_repos.append(rh_repo)
+            content_view.repository.append(rh_repo)
+            content_view.update(['repository'])
+
     for task in tasks:
         sat.wait_for_tasks(
             search_query=(f'id = {task["id"]}'),
@@ -105,7 +118,7 @@ def module_provisioning_rhel_content(
     rhel_xy = Version(
         constants.REPOS['kickstart'][f'rhel{rhel_ver}']['version']
         if rhel_ver == 7
-        else constants.REPOS['kickstart'][f'rhel{rhel_ver}_bos_beta']['version']
+        else '10.0'
         if rhel_ver == 10
         else constants.REPOS['kickstart'][f'rhel{rhel_ver}_bos']['version']
     )
@@ -116,6 +129,7 @@ def module_provisioning_rhel_content(
     os = o_systems[0].read()
     # return only the first kickstart repo - RHEL X KS or RHEL X BaseOS KS
     ksrepo = rh_repos[0]
+
     publish = content_view.publish()
     task_status = sat.wait_for_tasks(
         search_query=(f'Actions::Katello::ContentView::Publish and id = {publish["id"]}'),
@@ -133,7 +147,7 @@ def module_provisioning_rhel_content(
     ).create()
 
     # Ensure client repo is enabled in the activation key
-    if is_open('SAT-27193') and int(rhel_ver) != 10:
+    if int(rhel_ver) < 10:
         content = ak.product_content(data={'content_access_mode_all': '1'})['results']
         client_repo_label = [repo['label'] for repo in content if repo['name'] == client_repo.name][
             0

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -734,6 +734,7 @@ REPOS = {
 RHEL7_VER = '7.9'
 RHEL8_VER = '8.10'
 RHEL9_VER = '9.5'
+RHEL10_VER = '10.1'  # EL10 pre-release version
 
 BULK_REPO_LIST = [
     REPOS['rhel7_optional'],


### PR DESCRIPTION
### Problem Statement
With RHEL10 beta repos, provisioning fails because of SAT-29721, and it will be fixed when it becomes GA

### Solution
Use custom content for RHEL10 until SAT-29721 is resolved

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->