### PR TITLE
fixed subscription list test case

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -214,6 +214,7 @@ def test_positive_access_with_non_admin_user_with_manifest(
             session.subscription.search(f'name = "{DEFAULT_SUBSCRIPTION_NAME}"')[0]['Name']
             == DEFAULT_SUBSCRIPTION_NAME
         )
+    pass
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
### Problem Statement
Test case `test_positive_access_with_non_admin_user_with_manifest` was failing due to Error
`TypeError: 'NoneType' object is not subscriptable`

### Solution
Collect the list of all available scriptions from the page and iterate over each till matches default subscription name

### Airgun PR
https://github.com/SatelliteQE/airgun/pull/1702

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_access_with_non_admin_user_with_manifest'
airgun: 1702
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->