### PR TITLE
fixed subscription list test case for stream branch

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -210,10 +210,13 @@ def test_positive_access_with_non_admin_user_with_manifest(
         default_organization=org,
     ).create()
     with target_sat.ui_session(test_name, user=user.login, password=user_password) as session:
-        assert (
-            session.subscription.search(f'name = "{DEFAULT_SUBSCRIPTION_NAME}"')[0]['Name']
-            == DEFAULT_SUBSCRIPTION_NAME
-        )
+        all_subscriptions = session.subscription.search('name ~ "Red Hat"')
+        for subscription in all_subscriptions:
+            if subscription['Name'] == DEFAULT_SUBSCRIPTION_NAME:
+                assert True
+                break
+        else:
+            pytest.fail(f"{DEFAULT_SUBSCRIPTION_NAME} not found..!")
 
 
 @pytest.mark.tier2


### PR DESCRIPTION
### Problem Statement
Test case `test_positive_access_with_non_admin_user_with_manifest` was failing due to Error
`TypeError: 'NoneType' object is not subscriptable`

### Solution
Collect the list of all available scriptions from the page and iterate over each till matches default subscription name
Note: This fix is for Stream Branch

### Airgun PR
https://github.com/SatelliteQE/airgun/pull/1702

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_access_with_non_admin_user_with_manifest'
airgun: 1702
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->