### PR TITLE
[6.16.z] Prevent satellite-installer false negative

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -170,8 +170,8 @@ def install_satellite(satellite, installer_args, enable_fapolicyd=False):
     satellite.execute(
         'firewall-cmd --permanent --add-service RH-Satellite-6 && firewall-cmd --reload'
     )
-    # Install Satellite
-    satellite.execute(
+    # Install Satellite and return result
+    return satellite.execute(
         InstallerCommand(installer_args=installer_args).get_command(),
         timeout='30m',
     )
@@ -300,7 +300,9 @@ def sat_default_install(module_sat_ready_rhels):
         f'foreman-initial-admin-password {settings.server.admin_password}',
     ]
     sat = module_sat_ready_rhels.pop()
-    install_satellite(sat, installer_args)
+    assert install_satellite(sat, installer_args).status == 0, (
+        "Satellite installation failed (non-zero return code)"
+    )
     sat.enable_satellite_ipv6_http_proxy()
     return sat
 
@@ -313,7 +315,9 @@ def sat_fapolicyd_install(module_sat_ready_rhels):
         f'foreman-initial-admin-password {settings.server.admin_password}',
     ]
     sat = module_sat_ready_rhels.pop()
-    install_satellite(sat, installer_args, enable_fapolicyd=True)
+    assert install_satellite(sat, installer_args, enable_fapolicyd=True).status == 0, (
+        "Satellite installation failed (non-zero return code)"
+    )
     sat.enable_ipv6_dnf_and_rhsm_proxy()
     sat.enable_satellite_http_proxy()
     return sat
@@ -331,7 +335,9 @@ def sat_non_default_install(module_sat_ready_rhels):
         'foreman-proxy-plugin-discovery-install-images true',
     ]
     sat = module_sat_ready_rhels.pop()
-    install_satellite(sat, installer_args, enable_fapolicyd=True)
+    assert install_satellite(sat, installer_args, enable_fapolicyd=True).status == 0, (
+        "Satellite installation failed (non-zero return code)"
+    )
     sat.enable_satellite_ipv6_http_proxy()
     sat.execute('dnf -y --disableplugin=foreman-protector install foreman-discovery-image')
     return sat


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17384

Prevent false negative (There is a bug but test does not detect it) of installer by checking its return code.