### PR TITLE
Add Python 3.13 for PR checks in GHA

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -193,7 +193,7 @@ jobs:
           PROTECTION_PAYLOAD='{
             "required_status_checks": {
                 "strict": true,
-                "contexts": ["Code Quality (3.10)", "Code Quality (3.11)", "Code Quality (3.12)", "Enforcing cherrypick labels"]
+                "contexts": ["Code Quality (3.10)", "Code Quality (3.11)", "Code Quality (3.12)", "Code Quality (3.13)", "Enforcing cherrypick labels"]
             },
             "required_linear_history": true,
             "enforce_admins": null,

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       UV_CACHE_DIR: /tmp/.uv-cache
       UV_SYSTEM_PYTHON: 1


### PR DESCRIPTION
### Problem Statement
Python 3.13 was released on October 7, 2024, and we're not covering this in the PR checks in GHA yet

### Solution
Add Python 3.13 for PR checks in GHA

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->