### PR TITLE
fixture to get expected permissions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -53,6 +53,7 @@ pytest_plugins = [
     'pytest_fixtures.component.os',
     'pytest_fixtures.component.oscap',
     'pytest_fixtures.component.partition_table',
+    'pytest_fixtures.component.permissions',
     'pytest_fixtures.component.provision_azure',
     'pytest_fixtures.component.provision_gce',
     'pytest_fixtures.component.provision_libvirt',

--- a/pytest_fixtures/component/permissions.py
+++ b/pytest_fixtures/component/permissions.py
@@ -1,0 +1,55 @@
+import pytest
+
+from robottelo.constants import PERMISSIONS
+
+
+@pytest.fixture(scope="session")
+def expected_permissions(session_target_sat):
+    """Return the list of permissions valid for current instance."""
+
+    permissions = PERMISSIONS.copy()
+    rpm_packages = session_target_sat.execute('rpm -qa').stdout
+    if 'rubygem-foreman_rh_cloud' not in rpm_packages:
+        permissions.pop('InsightsHit')
+        permissions[None].remove('generate_foreman_rh_cloud')
+        permissions[None].remove('view_foreman_rh_cloud')
+        permissions[None].remove('dispatch_cloud_requests')
+        permissions[None].remove('control_organization_insights')
+    if 'rubygem-foreman_bootdisk' not in rpm_packages:
+        permissions[None].remove('download_bootdisk')
+    if 'gem-foreman_virt_who_configure' not in rpm_packages:
+        permissions.pop('ForemanVirtWhoConfigure::Config')
+    if 'gem-foreman_openscap' not in rpm_packages:
+        permissions.pop('ForemanOpenscap::Policy')
+        permissions.pop('ForemanOpenscap::ScapContent')
+        permissions[None].remove('destroy_arf_reports')
+        permissions[None].remove('view_arf_reports')
+        permissions[None].remove('create_arf_reports')
+    if 'gem-foreman_remote_execution' not in rpm_packages:
+        permissions.pop('JobInvocation')
+        permissions.pop('JobTemplate')
+        permissions.pop('RemoteExecutionFeature')
+        permissions.pop('TemplateInvocation')
+    if 'gem-foreman_puppet' not in rpm_packages:
+        permissions.pop('ForemanPuppet::ConfigGroup')
+        permissions.pop('ForemanPuppet::Environment')
+        permissions.pop('ForemanPuppet::HostClass')
+        permissions.pop('ForemanPuppet::Puppetclass')
+        permissions.pop('ForemanPuppet::PuppetclassLookupKey')
+    if 'rubygem-foreman_scc_manager' not in rpm_packages:
+        permissions.pop('SccAccount')
+        permissions.pop('SccProduct')
+    if 'gem-foreman_salt' not in rpm_packages:
+        permissions['Host'].remove('saltrun_hosts')
+        permissions['SmartProxy'].remove('destroy_smart_proxies_salt_autosign')
+        permissions['SmartProxy'].remove('view_smart_proxies_salt_autosign')
+        permissions['SmartProxy'].remove('destroy_smart_proxies_salt_keys')
+        permissions['SmartProxy'].remove('view_smart_proxies_salt_keys')
+        permissions['SmartProxy'].remove('edit_smart_proxies_salt_keys')
+        permissions['SmartProxy'].remove('auth_smart_proxies_salt_autosign')
+        permissions['SmartProxy'].remove('create_smart_proxies_salt_autosign')
+        permissions.pop('ForemanSalt::SaltVariable')
+        permissions.pop('ForemanSalt::SaltEnvironment')
+        permissions.pop('ForemanSalt::SaltModule')
+
+    return permissions

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -35,59 +35,14 @@ class TestPermission:
     """Tests for the ``permissions`` path."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def create_permissions(self, class_target_sat):
+    def create_permissions(self, expected_permissions):
         # workaround for setting class variables
         cls = type(self)
-        cls.permissions = PERMISSIONS.copy()
-
-        rpm_packages = class_target_sat.execute('rpm -qa').stdout
-        if 'rubygem-foreman_rh_cloud' not in rpm_packages:
-            cls.permissions.pop('InsightsHit')
-            cls.permissions[None].remove('generate_foreman_rh_cloud')
-            cls.permissions[None].remove('view_foreman_rh_cloud')
-            cls.permissions[None].remove('dispatch_cloud_requests')
-            cls.permissions[None].remove('control_organization_insights')
-        if 'rubygem-foreman_bootdisk' not in rpm_packages:
-            cls.permissions[None].remove('download_bootdisk')
-        if 'rubygem-foreman_virt_who_configure' not in rpm_packages:
-            cls.permissions.pop('ForemanVirtWhoConfigure::Config')
-        if 'rubygem-foreman_openscap' not in rpm_packages:
-            cls.permissions.pop('ForemanOpenscap::Policy')
-            cls.permissions.pop('ForemanOpenscap::ScapContent')
-            cls.permissions[None].remove('destroy_arf_reports')
-            cls.permissions[None].remove('view_arf_reports')
-            cls.permissions[None].remove('create_arf_reports')
-        if 'rubygem-foreman_remote_execution' not in rpm_packages:
-            cls.permissions.pop('JobInvocation')
-            cls.permissions.pop('JobTemplate')
-            cls.permissions.pop('RemoteExecutionFeature')
-            cls.permissions.pop('TemplateInvocation')
-        if 'rubygem-foreman_puppet' not in rpm_packages:
-            cls.permissions.pop('ForemanPuppet::ConfigGroup')
-            cls.permissions.pop('ForemanPuppet::Environment')
-            cls.permissions.pop('ForemanPuppet::HostClass')
-            cls.permissions.pop('ForemanPuppet::Puppetclass')
-            cls.permissions.pop('ForemanPuppet::PuppetclassLookupKey')
-        if 'rubygem-foreman_scc_manager' not in rpm_packages:
-            cls.permissions.pop('SccAccount')
-            cls.permissions.pop('SccProduct')
-        if 'rubygem-foreman_salt' not in rpm_packages:
-            cls.permissions['Host'].remove('saltrun_hosts')
-            cls.permissions['SmartProxy'].remove('destroy_smart_proxies_salt_autosign')
-            cls.permissions['SmartProxy'].remove('view_smart_proxies_salt_autosign')
-            cls.permissions['SmartProxy'].remove('destroy_smart_proxies_salt_keys')
-            cls.permissions['SmartProxy'].remove('view_smart_proxies_salt_keys')
-            cls.permissions['SmartProxy'].remove('edit_smart_proxies_salt_keys')
-            cls.permissions['SmartProxy'].remove('auth_smart_proxies_salt_autosign')
-            cls.permissions['SmartProxy'].remove('create_smart_proxies_salt_autosign')
-            cls.permissions.pop('ForemanSalt::SaltVariable')
-            cls.permissions.pop('ForemanSalt::SaltEnvironment')
-            cls.permissions.pop('ForemanSalt::SaltModule')
-
+        cls.permissions = expected_permissions
         #: e.g. ['Architecture', 'Audit', 'AuthSourceLdap', …]
-        cls.permission_resource_types = list(cls.permissions.keys())
+        cls.permission_resource_types = list(expected_permissions.keys())
         #: e.g. ['view_architectures', 'create_architectures', …]
-        cls.permission_names = list(chain.from_iterable(cls.permissions.values()))
+        cls.permission_names = list(chain.from_iterable(expected_permissions.values()))
 
     @pytest.mark.tier1
     def test_positive_search_by_name(self, target_sat):

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -36,7 +36,6 @@ from robottelo.constants import (
     FAKE_8_CUSTOM_PACKAGE_NAME,
     OSCAP_PERIOD,
     OSCAP_WEEKDAY,
-    PERMISSIONS,
     REPO_TYPE,
     ROLES,
 )
@@ -649,7 +648,7 @@ def test_positive_view_hosts_with_non_admin_user(
 
 @pytest.mark.tier3
 def test_positive_remove_parameter_non_admin_user(
-    test_name, module_org, smart_proxy_location, target_sat
+    test_name, module_org, smart_proxy_location, target_sat, expected_permissions
 ):
     """Remove a host parameter as a non-admin user with enough permissions
 
@@ -666,8 +665,8 @@ def test_positive_remove_parameter_non_admin_user(
     target_sat.api_factory.create_role_permissions(
         role,
         {
-            'Parameter': PERMISSIONS['Parameter'],
-            'Host': PERMISSIONS['Host'],
+            'Parameter': expected_permissions['Parameter'],
+            'Host': expected_permissions['Host'],
             'Operatingsystem': ['view_operatingsystems'],
         },
     )
@@ -699,7 +698,7 @@ def test_positive_remove_parameter_non_admin_user(
 
 @pytest.mark.tier3
 def test_negative_remove_parameter_non_admin_user(
-    test_name, module_org, smart_proxy_location, target_sat
+    test_name, module_org, smart_proxy_location, target_sat, expected_permissions
 ):
     """Attempt to remove host parameter as a non-admin user with
     insufficient permissions
@@ -721,7 +720,7 @@ def test_negative_remove_parameter_non_admin_user(
         role,
         {
             'Parameter': ['view_params'],
-            'Host': PERMISSIONS['Host'],
+            'Host': expected_permissions['Host'],
             'Operatingsystem': ['view_operatingsystems'],
         },
     )
@@ -753,7 +752,7 @@ def test_negative_remove_parameter_non_admin_user(
 
 @pytest.mark.tier3
 def test_positive_check_permissions_affect_create_procedure(
-    test_name, smart_proxy_location, target_sat, function_org, function_role
+    test_name, smart_proxy_location, target_sat, function_org, function_role, expected_permissions
 ):
     """Verify whether user permissions affect what entities can be selected
     when host is created
@@ -824,7 +823,10 @@ def test_positive_check_permissions_affect_create_procedure(
     # Add permissions for Organization and Location
     target_sat.api_factory.create_role_permissions(
         function_role,
-        {'Organization': PERMISSIONS['Organization'], 'Location': PERMISSIONS['Location']},
+        {
+            'Organization': expected_permissions['Organization'],
+            'Location': expected_permissions['Location'],
+        },
     )
     # Create new user with a configured role
     user_password = gen_string('alpha')


### PR DESCRIPTION
### Problem Statement
Some permission comparison happens also outside of the test_permission module. With https://github.com/SatelliteQE/robottelo/pull/16962 not all perms are sat specific, which caused failures in host module as the context-based permission filtering was not done there

### Solution
moving the permission filtering part to a separate fixture to make it reusable across modules

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->