### PR TITLE
update rh satellite capsule version to rhel9 from rhel7

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -280,7 +280,6 @@ REPOSET = {
     'rhva6': ('Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)'),
     'rhs7': 'Red Hat Satellite 6.11 (for RHEL 7 Server) (RPMs)',
     'rhs8': 'Red Hat Satellite 6.13 for RHEL 8 x86_64 (RPMs)',
-    'rhsc7': 'Red Hat Satellite Capsule 6.16 (for RHEL 7 Server) (RPMs)',
     'rhsc8': 'Red Hat Satellite Capsule 6.16 for RHEL 8 x86_64 (RPMs)',
     'rhsc9': 'Red Hat Satellite Capsule 6.16 for RHEL 9 x86_64 (RPMs)',
     'rhsc7_iso': 'Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (ISOs)',
@@ -389,15 +388,6 @@ REPOS = {
         'product': PRDS['rhs'],
         'distro': 'rhel7',
         'key': 'rhs',
-    },
-    'rhsc7': {
-        'id': 'rhel-7-server-satellite-capsule-6.16-rpms',
-        'name': ('Red Hat Satellite Capsule 6.16 for RHEL 7 Server RPMs x86_64'),
-        'version': '6.16',
-        'reposet': REPOSET['rhsc7'],
-        'product': PRDS['rhsc'],
-        'distro': 'rhel7',
-        'key': 'rhsc',
     },
     'rhsc8': {
         'id': 'satellite-capsule-6.16-for-rhel-8-x86_64-rpms',

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -16,7 +16,15 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC, PRDS, REPOS, REPOSET, RPM_TO_UPLOAD, DataFile
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_LOC,
+    PRDS,
+    REPOS,
+    REPOSET,
+    RPM_TO_UPLOAD,
+    DataFile,
+)
 
 
 @pytest.fixture(scope='module')
@@ -55,14 +63,13 @@ def module_yum_repo2(module_product, module_target_sat):
 
 @pytest.fixture(scope='module')
 def module_rh_repo(module_sca_manifest_org, module_target_sat):
-    rhsc = module_target_sat.cli_factory.SatelliteCapsuleRepository(cdn=True)
     repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
-        basearch=rhsc.data['arch'],
+        basearch=DEFAULT_ARCHITECTURE,
         org_id=module_sca_manifest_org.id,
-        product=rhsc.data['product'],
-        repo=rhsc.data['repository'],
-        reposet=rhsc.data['repository-set'],
-        releasever=rhsc.data['releasever'],
+        product=REPOS['rhsc9']['product'],
+        repo=REPOS['rhsc9']['name'],
+        reposet=REPOSET['rhsc9'],
+        releasever=REPOS['rhsc9']['version'],
     )
     module_target_sat.api.Repository(id=repo_id).sync()
     return module_target_sat.api.Repository(id=repo_id).read()


### PR DESCRIPTION
### Problem Statement
Upgrade test was failing due to unavailability of `Red Hat Satellite Capsule 6.16 for RHEL 7 Server RPMs x86_64` repository, as Satellite is running on RHEL8 & RHEL9, no RHSC RHEL7 repo present in reposet

### Solution
Update test case and pass rhsc rhel9 details to fetch correct details.

### Related Issues
No

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_package.py -k 'test_positive_rh_repo_search_and_check_file_list'

```
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->