### PR TITLE
[6.14] fixture to get expected permissions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -54,6 +54,7 @@ pytest_plugins = [
     'pytest_fixtures.component.os',
     'pytest_fixtures.component.oscap',
     'pytest_fixtures.component.partition_table',
+    'pytest_fixtures.component.permissions',
     'pytest_fixtures.component.provision_azure',
     'pytest_fixtures.component.provision_gce',
     'pytest_fixtures.component.provision_libvirt',

--- a/pytest_fixtures/component/permissions.py
+++ b/pytest_fixtures/component/permissions.py
@@ -1,0 +1,34 @@
+import pytest
+
+from robottelo.constants import PERMISSIONS
+
+
+@pytest.fixture(scope="session")
+def expected_permissions(session_target_sat):
+    """Return the list of permissions valid for current instance."""
+
+    permissions = PERMISSIONS.copy()
+    if session_target_sat.is_upstream:
+        permissions[None].extend(permissions.pop('DiscoveryRule'))
+        permissions[None].remove('app_root')
+        permissions[None].remove('attachments')
+        permissions[None].remove('configuration')
+        permissions[None].remove('logs')
+        permissions[None].remove('view_cases')
+        permissions[None].remove('view_log_viewer')
+
+    result = session_target_sat.execute('rpm -qa | grep rubygem-foreman_openscap')
+    if result.status != 0:
+        permissions.pop('ForemanOpenscap::Policy')
+        permissions.pop('ForemanOpenscap::ScapContent')
+        permissions[None].remove('destroy_arf_reports')
+        permissions[None].remove('view_arf_reports')
+        permissions[None].remove('create_arf_reports')
+    result = session_target_sat.execute('rpm -qa | grep rubygem-foreman_remote_execution')
+    if result.status != 0:
+        permissions.pop('JobInvocation')
+        permissions.pop('JobTemplate')
+        permissions.pop('RemoteExecutionFeature')
+        permissions.pop('TemplateInvocation')
+
+    return permissions

--- a/tests/foreman/api/test_permission.py
+++ b/tests/foreman/api/test_permission.py
@@ -35,37 +35,14 @@ class TestPermission:
     """Tests for the ``permissions`` path."""
 
     @pytest.fixture(scope='class', autouse=True)
-    def create_permissions(self, class_target_sat):
+    def create_permissions(self, expected_permissions):
         # workaround for setting class variables
         cls = type(self)
-        cls.permissions = PERMISSIONS.copy()
-        if class_target_sat.is_upstream:
-            cls.permissions[None].extend(cls.permissions.pop('DiscoveryRule'))
-            cls.permissions[None].remove('app_root')
-            cls.permissions[None].remove('attachments')
-            cls.permissions[None].remove('configuration')
-            cls.permissions[None].remove('logs')
-            cls.permissions[None].remove('view_cases')
-            cls.permissions[None].remove('view_log_viewer')
-
-        result = class_target_sat.execute('rpm -qa | grep rubygem-foreman_openscap')
-        if result.status != 0:
-            cls.permissions.pop('ForemanOpenscap::Policy')
-            cls.permissions.pop('ForemanOpenscap::ScapContent')
-            cls.permissions[None].remove('destroy_arf_reports')
-            cls.permissions[None].remove('view_arf_reports')
-            cls.permissions[None].remove('create_arf_reports')
-        result = class_target_sat.execute('rpm -qa | grep rubygem-foreman_remote_execution')
-        if result.status != 0:
-            cls.permissions.pop('JobInvocation')
-            cls.permissions.pop('JobTemplate')
-            cls.permissions.pop('RemoteExecutionFeature')
-            cls.permissions.pop('TemplateInvocation')
-
+        cls.permissions = expected_permissions
         #: e.g. ['Architecture', 'Audit', 'AuthSourceLdap', …]
-        cls.permission_resource_types = list(cls.permissions.keys())
+        cls.permission_resource_types = list(expected_permissions.keys())
         #: e.g. ['view_architectures', 'create_architectures', …]
-        cls.permission_names = list(chain.from_iterable(cls.permissions.values()))
+        cls.permission_names = list(chain.from_iterable(expected_permissions.values()))
 
     @pytest.mark.tier1
     def test_positive_search_by_name(self, target_sat):

--- a/tests/foreman/ui/test_host.py
+++ b/tests/foreman/ui/test_host.py
@@ -34,7 +34,6 @@ from robottelo.constants import (
     FAKE_8_CUSTOM_PACKAGE_NAME,
     OSCAP_PERIOD,
     OSCAP_WEEKDAY,
-    PERMISSIONS,
     REPO_TYPE,
 )
 from robottelo.constants.repos import CUSTOM_FILE_REPO
@@ -564,7 +563,7 @@ def test_positive_view_hosts_with_non_admin_user(
 
 @pytest.mark.tier3
 def test_positive_remove_parameter_non_admin_user(
-    test_name, module_org, smart_proxy_location, target_sat
+    test_name, module_org, smart_proxy_location, target_sat, expected_permissions
 ):
     """Remove a host parameter as a non-admin user with enough permissions
 
@@ -581,8 +580,8 @@ def test_positive_remove_parameter_non_admin_user(
     target_sat.api_factory.create_role_permissions(
         role,
         {
-            'Parameter': PERMISSIONS['Parameter'],
-            'Host': PERMISSIONS['Host'],
+            'Parameter': expected_permissions['Parameter'],
+            'Host': expected_permissions['Host'],
             'Operatingsystem': ['view_operatingsystems'],
         },
     )
@@ -614,7 +613,7 @@ def test_positive_remove_parameter_non_admin_user(
 
 @pytest.mark.tier3
 def test_negative_remove_parameter_non_admin_user(
-    test_name, module_org, smart_proxy_location, target_sat
+    test_name, module_org, smart_proxy_location, target_sat, expected_permissions
 ):
     """Attempt to remove host parameter as a non-admin user with
     insufficient permissions
@@ -636,7 +635,7 @@ def test_negative_remove_parameter_non_admin_user(
         role,
         {
             'Parameter': ['view_params'],
-            'Host': PERMISSIONS['Host'],
+            'Host': expected_permissions['Host'],
             'Operatingsystem': ['view_operatingsystems'],
         },
     )
@@ -668,7 +667,7 @@ def test_negative_remove_parameter_non_admin_user(
 
 @pytest.mark.tier3
 def test_positive_check_permissions_affect_create_procedure(
-    test_name, smart_proxy_location, target_sat, function_org, function_role
+    test_name, smart_proxy_location, target_sat, function_org, function_role, expected_permissions
 ):
     """Verify whether user permissions affect what entities can be selected
     when host is created
@@ -739,7 +738,10 @@ def test_positive_check_permissions_affect_create_procedure(
     # Add permissions for Organization and Location
     target_sat.api_factory.create_role_permissions(
         function_role,
-        {'Organization': PERMISSIONS['Organization'], 'Location': PERMISSIONS['Location']},
+        {
+            'Organization': expected_permissions['Organization'],
+            'Location': expected_permissions['Location'],
+        },
     )
     # Create new user with a configured role
     user_password = gen_string('alpha')


### PR DESCRIPTION
### Problem Statement
closes https://github.com/SatelliteQE/robottelo/issues/17416

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->