### PR TITLE
[6.16.z] Fix Capsule test case for non-admin user

### DIFF
--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1912,6 +1912,7 @@ class TestCapsuleContentManagement:
         target_sat,
         module_capsule_configured,
         default_org,
+        default_location,
         default_non_admin_user,
     ):
         """Try to list and read Capsules with a non-admin user with and without permissions.
@@ -1923,8 +1924,9 @@ class TestCapsuleContentManagement:
             2. Non-admin user without any roles/permissions.
 
         :steps:
-            1. Using the non-admin user try to list all or particular Capsule.
-            2. Add Viewer role to the user and try again.
+            1. Assign the capsule to the default org/loc so it can be searched and found.
+            2. Using the non-admin user try to list all or particular Capsule.
+            3. Add Viewer role to the user and try again.
 
         :expectedresults:
             1. Read should fail without Viewer role.
@@ -1934,6 +1936,12 @@ class TestCapsuleContentManagement:
 
         :customerscenario: true
         """
+        # Assign the capsule to the default org/loc so it can be searched and found.
+        nc = module_capsule_configured.nailgun_smart_proxy
+        target_sat.api.SmartProxy(
+            id=nc.id, organization=[default_org], location=[default_location]
+        ).update(['organization', 'location'])
+
         # Using the non-admin user try to list all or particular Capsule
         user = default_non_admin_user
         sc = ServerConfig(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17422

### Problem Statement
The `test_positive_read_with_non_admin_user` fails when run before the Default org/loc is assigned to the Capsule (search won't find it in that case).
```
tests/foreman/api/test_capsulecontent.py:1983: in test_positive_read_with_non_admin_user
    assert len(res) >= 2, 'Expected at least one internal and one or more external Capsule(s).'
E   AssertionError: Expected at least one internal and one or more external Capsule(s).
E   assert 1 >= 2
```

### Solution
Assign it to defaults before we try to search.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_capsulecontent.py -k test_positive_read_with_non_admin_user
```