### PR TITLE
[6.16.z] more future-proof scap profile selected

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1678,7 +1678,7 @@ OSCAP_PROFILE = {
     'ppgpo': 'Protection Profile for General Purpose Operating Systems',
     'acscee': 'Australian Cyber Security Centre (ACSC) Essential Eight',
     'ospp7': 'OSPP - Protection Profile for General Purpose Operating Systems v4.2.1',
-    'ospp8': 'Protection Profile for General Purpose Operating Systems',
+    'ospp8+': 'Protection Profile for General Purpose Operating Systems',
     'usgcb': 'United States Government Configuration Baseline (USGCB)',
     'pcidss6': 'PCI-DSS v3 Control Baseline for Red Hat Enterprise Linux 6',
     'pcidss7': 'PCI-DSS v3.2.1 Control Baseline for Red Hat Enterprise Linux 7',

--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -38,8 +38,8 @@ cv_name = {
     'rhel7': f'cv_{gen_string("alpha")}_rhel7',
 }
 profiles = {
-    'rhel9': OSCAP_PROFILE['cbrhel9'],
-    'rhel8': OSCAP_PROFILE['ospp8'],
+    'rhel9': OSCAP_PROFILE['ospp8+'],
+    'rhel8': OSCAP_PROFILE['ospp8+'],
     'rhel7': OSCAP_PROFILE['security7'],
 }
 rhel_repos = {


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17419

### Problem Statement
The "PCI-DSS v4.0 Control Baseline for Red Hat Enterprise Linux 9" scap profile contains the version number in its title, once it is updated, cause test failure with a need of a constant update

### Solution
Changing from "PCI-DSS v4.0 Control Baseline for Red Hat Enterprise Linux 9" to "Protection Profile for General Purpose Operating Systems", both are present in rhel9 default content. 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->