### PR TITLE
Remove rhsc7 check from robottelo

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -283,7 +283,6 @@ REPOSET = {
     'rhva6': ('Red Hat Enterprise Virtualization Agents for RHEL 6 Server (RPMs)'),
     'rhs7': 'Red Hat Satellite 6.11 (for RHEL 7 Server) (RPMs)',
     'rhs8': 'Red Hat Satellite 6.13 for RHEL 8 x86_64 (RPMs)',
-    'rhsc7': 'Red Hat Satellite Capsule 6.16 (for RHEL 7 Server) (RPMs)',
     'rhsc8': 'Red Hat Satellite Capsule 6.16 for RHEL 8 x86_64 (RPMs)',
     'rhsc9': 'Red Hat Satellite Capsule 6.16 for RHEL 9 x86_64 (RPMs)',
     'rhsc7_iso': 'Red Hat Satellite Capsule 6.4 (for RHEL 7 Server) (ISOs)',
@@ -410,15 +409,6 @@ REPOS = {
         'product': PRDS['rhs'],
         'distro': 'rhel7',
         'key': 'rhs',
-    },
-    'rhsc7': {
-        'id': 'rhel-7-server-satellite-capsule-6.16-rpms',
-        'name': ('Red Hat Satellite Capsule 6.16 for RHEL 7 Server RPMs x86_64'),
-        'version': '6.16',
-        'reposet': REPOSET['rhsc7'],
-        'product': PRDS['rhsc'],
-        'distro': 'rhel7',
-        'key': 'rhsc',
     },
     'rhsc8': {
         'id': 'satellite-capsule-6.16-for-rhel-8-x86_64-rpms',

--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -922,53 +922,6 @@ class CLIFactory:
                 )
         return result
 
-    @staticmethod
-    def _get_capsule_vm_distro_repos(distro):
-        """Return the right RH repos info for the capsule setup"""
-        rh_repos = []
-        if distro == 'rhel7':
-            # Red Hat Enterprise Linux 7 Server
-            rh_product_arch = constants.REPOS['rhel7']['arch']
-            rh_product_releasever = constants.REPOS['rhel7']['releasever']
-            rh_repos.append(
-                {
-                    'product': constants.PRDS['rhel'],
-                    'repository-set': constants.REPOSET['rhel7'],
-                    'repository': constants.REPOS['rhel7']['name'],
-                    'repository-id': constants.REPOS['rhel7']['id'],
-                    'releasever': rh_product_releasever,
-                    'arch': rh_product_arch,
-                    'cdn': True,
-                }
-            )
-            # Red Hat Software Collections (for 7 Server)
-            rh_repos.append(
-                {
-                    'product': constants.PRDS['rhscl'],
-                    'repository-set': constants.REPOSET['rhscl7'],
-                    'repository': constants.REPOS['rhscl7']['name'],
-                    'repository-id': constants.REPOS['rhscl7']['id'],
-                    'releasever': rh_product_releasever,
-                    'arch': rh_product_arch,
-                    'cdn': True,
-                }
-            )
-            # Red Hat Satellite Capsule 6.2 (for RHEL 7 Server)
-            rh_repos.append(
-                {
-                    'product': constants.PRDS['rhsc'],
-                    'repository-set': constants.REPOSET['rhsc7'],
-                    'repository': constants.REPOS['rhsc7']['name'],
-                    'repository-id': constants.REPOS['rhsc7']['id'],
-                    'url': settings.repos.capsule_repo,
-                    'cdn': settings.robottelo.cdn or not settings.repos.capsule_repo,
-                }
-            )
-        else:
-            raise CLIFactoryError(f'distro "{distro}" not supported')
-
-        return rh_product_arch, rh_product_releasever, rh_repos
-
     def add_role_permissions(self, role_id, resource_permissions):
         """Create role permissions found in resource permissions dict
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -475,7 +475,7 @@ class ContentHost(Host, ContentHostMixins):
             downstream_repo = settings.repos.sattools_repo['rhel7']
         elif repo == constants.REPOS['rhst8']['id']:
             downstream_repo = settings.repos.sattools_repo['rhel8']
-        elif repo in (constants.REPOS['rhsc7']['id'], constants.REPOS['rhsc8']['id']):
+        elif repo in (constants.REPOS['rhsc8']['id'], constants.REPOS['rhsc9']['id']):
             downstream_repo = settings.repos.capsule_repo
         if force or settings.robottelo.cdn or not downstream_repo:
             return self.execute(f'subscription-manager repos --enable {repo}')

--- a/tests/foreman/ui/test_package.py
+++ b/tests/foreman/ui/test_package.py
@@ -16,7 +16,15 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_LOC, PRDS, REPOS, REPOSET, RPM_TO_UPLOAD, DataFile
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_LOC,
+    PRDS,
+    REPOS,
+    REPOSET,
+    RPM_TO_UPLOAD,
+    DataFile,
+)
 
 
 @pytest.fixture(scope='module')
@@ -55,14 +63,13 @@ def module_yum_repo2(module_product, module_target_sat):
 
 @pytest.fixture(scope='module')
 def module_rh_repo(module_sca_manifest_org, module_target_sat):
-    rhsc = module_target_sat.cli_factory.SatelliteCapsuleRepository(cdn=True)
     repo_id = module_target_sat.api_factory.enable_rhrepo_and_fetchid(
-        basearch=rhsc.data['arch'],
+        basearch=DEFAULT_ARCHITECTURE,
         org_id=module_sca_manifest_org.id,
-        product=rhsc.data['product'],
-        repo=rhsc.data['repository'],
-        reposet=rhsc.data['repository-set'],
-        releasever=rhsc.data['releasever'],
+        product=REPOS['rhsc9']['product'],
+        repo=REPOS['rhsc9']['name'],
+        reposet=REPOSET['rhsc9'],
+        releasever=REPOS['rhsc9']['version'],
     )
     module_target_sat.api.Repository(id=repo_id).sync()
     return module_target_sat.api.Repository(id=repo_id).read()


### PR DESCRIPTION
### Problem Statement
rhsc7 repo is removed from constants.py as it is no longer supported in [PR](https://github.com/SatelliteQE/robottelo/pull/17421) but missed removing its check from code.

### Solution
Removed the check for rhsc7 and added for rhsc9.

### Related Issues
https://github.com/SatelliteQE/robottelo/pull/17421 

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->