### PR TITLE
[6.16.z] Remove rhsc7 check from robottelo

### DIFF
--- a/robottelo/host_helpers/cli_factory.py
+++ b/robottelo/host_helpers/cli_factory.py
@@ -912,53 +912,6 @@ class CLIFactory:
                 )
         return result
 
-    @staticmethod
-    def _get_capsule_vm_distro_repos(distro):
-        """Return the right RH repos info for the capsule setup"""
-        rh_repos = []
-        if distro == 'rhel7':
-            # Red Hat Enterprise Linux 7 Server
-            rh_product_arch = constants.REPOS['rhel7']['arch']
-            rh_product_releasever = constants.REPOS['rhel7']['releasever']
-            rh_repos.append(
-                {
-                    'product': constants.PRDS['rhel'],
-                    'repository-set': constants.REPOSET['rhel7'],
-                    'repository': constants.REPOS['rhel7']['name'],
-                    'repository-id': constants.REPOS['rhel7']['id'],
-                    'releasever': rh_product_releasever,
-                    'arch': rh_product_arch,
-                    'cdn': True,
-                }
-            )
-            # Red Hat Software Collections (for 7 Server)
-            rh_repos.append(
-                {
-                    'product': constants.PRDS['rhscl'],
-                    'repository-set': constants.REPOSET['rhscl7'],
-                    'repository': constants.REPOS['rhscl7']['name'],
-                    'repository-id': constants.REPOS['rhscl7']['id'],
-                    'releasever': rh_product_releasever,
-                    'arch': rh_product_arch,
-                    'cdn': True,
-                }
-            )
-            # Red Hat Satellite Capsule 6.2 (for RHEL 7 Server)
-            rh_repos.append(
-                {
-                    'product': constants.PRDS['rhsc'],
-                    'repository-set': constants.REPOSET['rhsc7'],
-                    'repository': constants.REPOS['rhsc7']['name'],
-                    'repository-id': constants.REPOS['rhsc7']['id'],
-                    'url': settings.repos.capsule_repo,
-                    'cdn': settings.robottelo.cdn or not settings.repos.capsule_repo,
-                }
-            )
-        else:
-            raise CLIFactoryError(f'distro "{distro}" not supported')
-
-        return rh_product_arch, rh_product_releasever, rh_repos
-
     def add_role_permissions(self, role_id, resource_permissions):
         """Create role permissions found in resource permissions dict
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -474,7 +474,7 @@ class ContentHost(Host, ContentHostMixins):
             downstream_repo = settings.repos.sattools_repo['rhel7']
         elif repo == constants.REPOS['rhst8']['id']:
             downstream_repo = settings.repos.sattools_repo['rhel8']
-        elif repo in (constants.REPOS['rhsc7']['id'], constants.REPOS['rhsc8']['id']):
+        elif repo in (constants.REPOS['rhsc8']['id'], constants.REPOS['rhsc9']['id']):
             downstream_repo = settings.repos.capsule_repo
         if force or settings.robottelo.cdn or not downstream_repo:
             return self.execute(f'subscription-manager repos --enable {repo}')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17443

### Problem Statement
rhsc7 repo is removed from constants.py as it is no longer supported in [PR](https://github.com/SatelliteQE/robottelo/pull/17421) but missed removing its check from code.

### Solution
Removed the check for rhsc7 and added for rhsc9.

### Related Issues
https://github.com/SatelliteQE/robottelo/pull/17421 

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->