### PR TITLE
Update SATELLITE_OS_VERSION for Stream/6.17

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -7,7 +7,7 @@ from nailgun import entities
 
 # This should be updated after each version branch
 SATELLITE_VERSION = "6.17"
-SATELLITE_OS_VERSION = "8"
+SATELLITE_OS_VERSION = "9"
 
 # Default system ports
 HTTPS_PORT = '443'


### PR DESCRIPTION
### Problem Statement
There is no 6.17 RHEL8 support

### Solution
Update `SATELLITE_OS_VERSION` for Stream/6.17 to `"9"`

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->