### PR TITLE
Fix ansible tests by using proxy for connecting to ansible-galaxy

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -80,9 +80,17 @@ class TestAnsibleCfgMgmt:
 
         :customerscenario: true
         """
-        target_sat.execute(
-            "ansible-galaxy collection install -p /usr/share/ansible/collections "
-            "xprazak2.forklift_collection"
+        http_proxy = (
+            f'HTTPS_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
+            if settings.server.is_ipv6
+            else ''
+        )
+        assert (
+            target_sat.execute(
+                f'{http_proxy}ansible-galaxy collection install -p /usr/share/ansible/collections '
+                'xprazak2.forklift_collection'
+            ).status
+            == 0
         )
         proxy_id = target_sat.nailgun_smart_proxy.id
         playbook_fetch = target_sat.api.AnsiblePlaybooks().fetch(data={'proxy_id': proxy_id})

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -235,7 +235,17 @@ class TestAnsibleCfgMgmt:
         proxy_id = target_sat.nailgun_smart_proxy.id
 
         for path in ['/etc/ansible/collections', '/usr/share/ansible/collections']:
-            target_sat.execute(f'ansible-galaxy collection install -p {path} {SELECTED_COLLECTION}')
+            http_proxy = (
+                f'HTTPS_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
+                if settings.server.is_ipv6
+                else ''
+            )
+            assert (
+                target_sat.execute(
+                    f'{http_proxy}ansible-galaxy collection install -p {path} {SELECTED_COLLECTION}'
+                ).status
+                == 0
+            )
             target_sat.cli.Ansible.roles_sync({'role-names': SELECTED_ROLE, 'proxy-id': proxy_id})
             result = target_sat.cli.Host.ansible_roles_assign(
                 {'id': target_host.id, 'ansible-roles': f'{SELECTED_ROLE}'}


### PR DESCRIPTION
### Problem Statement
ansible-galaxy is unreachable from IPv6 sat

### Solution
Fix ansible tests by using proxy for connecting to ansible-galaxy

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->