### PR TITLE
Add Hammer support for invalidating users JWTs

### DIFF
--- a/robottelo/cli/user.py
+++ b/robottelo/cli/user.py
@@ -132,3 +132,15 @@ class User(Base):
         """
         cls.command_sub = 'mail-notification add'
         return cls.execute(cls._construct_command(options), output_format='csv')
+
+    @classmethod
+    def invalidate(cls, options=None):
+        """Invalidate JWTs for a single user"""
+        cls.command_sub = 'registration-tokens invalidate'
+        return cls.execute(cls._construct_command(options))
+
+    @classmethod
+    def invalidate_multiple(cls, options=None):
+        """Invalidate JWTs for multiple users"""
+        cls.command_sub = 'registration-tokens invalidate-multiple'
+        return cls.execute(cls._construct_command(options))


### PR DESCRIPTION
### Problem Statement
Hammer support for invalidating JWTs : SAT-30385

### Solution
Added support for JWT invalidate in CLI

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->