### PR TITLE
Fix ProvisioningTemplate test for RHEL10

### DIFF
--- a/tests/foreman/api/test_provisioningtemplate.py
+++ b/tests/foreman/api/test_provisioningtemplate.py
@@ -744,7 +744,7 @@ class TestProvisioningTemplate:
         # Check chronyd is getting installed in place of ntpdate which is deprecated.
         assert 'systemctl enable --now chronyd' in render
         assert 'yum -y install ntpdate' not in render
-        if module_sync_kickstart_content.os.major >= '9':
+        if int(module_sync_kickstart_content.os.major) >= 9:
             assert f'timesource --ntp-server {ntp_server_value}' in render
             assert f'timezone --utc {timezone}' in render
         else:


### PR DESCRIPTION
### Problem Statement
Provisioning Template test was failing due to incorrect comparison for RHEL10.

### Solution
Fixed the test.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->