### PR TITLE
missing customerscenario tag for rex

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -373,6 +373,8 @@ class TestRemoteExecution:
 
         :verifies: SAT-28443
 
+        :customerscenario: true
+
         :steps:
             1. set global parameters for rex
             2. re-register the client to check that sudo setup was performed based on parameters


### PR DESCRIPTION
### Problem Statement

closes https://github.com/SatelliteQE/robottelo/issues/17477



### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->