### PR TITLE
Update provisioning tests for IPv6 provisoning

### DIFF
--- a/pytest_plugins/infra_dependent_markers.py
+++ b/pytest_plugins/infra_dependent_markers.py
@@ -5,6 +5,7 @@ def pytest_configure(config):
     """Register custom markers to avoid warnings."""
     markers = [
         "on_premises_provisioning: Tests that runs on on_premises Providers",
+        "ipv6_provisioning: Tests for IPv6 provisioning"
         "libvirt_discovery: Tests depends on Libvirt Provider for discovery",
         "external_auth: External Authentication tests",
         "vlan_networking: Tests depends on static predefined vlan networking etc",

--- a/pytest_plugins/marker_deselection.py
+++ b/pytest_plugins/marker_deselection.py
@@ -9,6 +9,7 @@ def pytest_addoption(parser):
     """Add options for pytest to collect tests than can run on SatLab infra"""
     infra_options = [
         '--include-onprem-provisioning',
+        '--include-ipv6-provisioning',
         '--include-libvirt',
         '--include-external-auth',
         '--include-vlan-networking',
@@ -34,6 +35,7 @@ def pytest_collection_modifyitems(items, config):
     Collects and modifies tests collection based on pytest option to deselect tests for new infra
     """
     include_onprem_provision = config.getoption('include_onprem_provisioning', False)
+    include_ipv6_provisioning = config.getoption('include_ipv6_provisioning', False)
     include_libvirt = config.getoption('include_libvirt', False)
     include_eauth = config.getoption('include_external_auth', False)
     include_vlan = config.getoption('include_vlan_networking', False)
@@ -53,11 +55,14 @@ def pytest_collection_modifyitems(items, config):
             else:
                 deselected.append(item)
             continue
-
         item_marks = [m.name for m in item.iter_markers()]
         # Include / Exclude On Premises Provisioning Tests
         if 'on_premises_provisioning' in item_marks:
             selected.append(item) if include_onprem_provision else deselected.append(item)
+            continue
+        # Include / Exclude IPv6 Provisioning Tests
+        if 'ipv6_provisioning' in item_marks:
+            selected.append(item) if include_ipv6_provisioning else deselected.append(item)
             continue
         # Include / Exclude External Libvirt based Tests
         if 'libvirt_discovery' in item_marks:
@@ -67,7 +72,7 @@ def pytest_collection_modifyitems(items, config):
         if 'external_auth' in item_marks:
             selected.append(item) if include_eauth else deselected.append(item)
             continue
-        # Include / Exclude VLAN networking based based Tests
+        # Include / Exclude VLAN networking based Tests
         if 'vlan_networking' in item_marks:
             selected.append(item) if include_vlan else deselected.append(item)
             continue

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -383,10 +383,11 @@ class ProvisioningSetup:
                 host[0].delete()
             assert not self.api.Host().search(query={'search': f'name={hostname}'})
         # Workaround SAT-28381
-        assert self.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
-        assert self.execute('systemctl restart dhcpd').status == 0
-        # Workaround BZ: 2207698
-        assert self.cli.Service.restart().status == 0
+        if not settings.server.is_ipv6:
+            assert self.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
+            assert self.execute('systemctl restart dhcpd').status == 0
+            # Workaround BZ: 2207698
+            assert self.cli.Service.restart().status == 0
 
 
 class Factories:


### PR DESCRIPTION
### Problem Statement
Provisioning tests are not updated to run on IPv6 satellite

### Solution
Update the tests to run on IPv6 satellite

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->