### PR TITLE
[6.14.z] adding blocked-by for negative host test

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -546,6 +546,8 @@ def test_negative_create_with_unpublished_cv(module_lce, module_org, module_cv, 
     :expectedresults: Host is not created using new unpublished cv
 
     :CaseImportance: Critical
+
+    :BlockedBy: SAT-30848
     """
     with pytest.raises(CLIFactoryError):
         module_target_sat.cli_factory.make_fake_host(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17481

### Problem Statement
Skipping on a reported Jira 

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->