### PR TITLE
Fix deployment in Interop testing

### DIFF
--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -292,15 +292,19 @@ def parametrized_enrolled_sat(
     Broker(hosts=[new_sat]).checkin()
 
 
-def get_deploy_args(request):
-    """Get deploy arguments for Satellite base OS deployment. Should not be used for Capsule."""
+def get_sat_deploy_args(request):
+    """Get deploy arguments for Satellite base OS deployment."""
     rhel_version = get_sat_rhel_version()
-    deploy_args = settings.content_host[f'rhel{rhel_version.major}'].vm | {
-        'deploy_rhel_version': rhel_version.base_version,
-        'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
-        'deploy_flavor': settings.flavors.default,
-        'workflow': settings.server.deploy_workflows.os,
-    }
+    deploy_args = (
+        settings.content_host[f'rhel{rhel_version.major}'].vm
+        | settings.server.deploy_arguments
+        | {
+            'deploy_rhel_version': rhel_version.base_version,
+            'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+            'deploy_flavor': settings.flavors.default,
+            'workflow': settings.server.deploy_workflows.os,
+        }
+    )
     if hasattr(request, 'param'):
         if isinstance(request.param, dict):
             deploy_args.update(request.param)
@@ -309,16 +313,31 @@ def get_deploy_args(request):
     return deploy_args
 
 
+def get_cap_deploy_args():
+    """Get deploy arguments for Capsule base OS deployment."""
+    rhel_version = Version(settings.capsule.version.rhel_version)
+    return (
+        settings.content_host[f'rhel{rhel_version.major}'].vm
+        | settings.capsule.deploy_arguments
+        | {
+            'deploy_rhel_version': rhel_version.base_version,
+            'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+            'deploy_flavor': settings.flavors.default,
+            'workflow': settings.capsule.deploy_workflows.os,
+        }
+    )
+
+
 @pytest.fixture
 def sat_ready_rhel(request):
-    deploy_args = get_deploy_args(request)
+    deploy_args = get_sat_deploy_args(request)
     with Broker(**deploy_args, host_class=Satellite) as host:
         yield host
 
 
 @pytest.fixture(scope='module')
 def module_sat_ready_rhels(request, module_target_sat):
-    deploy_args = get_deploy_args(request)
+    deploy_args = get_sat_deploy_args(request)
     if 'build_sanity' not in request.config.option.markexpr:
         with Broker(**deploy_args, host_class=Satellite, _count=3) as hosts:
             yield hosts
@@ -329,13 +348,8 @@ def module_sat_ready_rhels(request, module_target_sat):
 @pytest.fixture
 def cap_ready_rhel():
     """Deploy bare RHEL system ready for Capsule installation."""
-    rhel_version = Version(settings.capsule.version.rhel_version)
-    deploy_args = settings.capsule.deploy_arguments | {
-        'deploy_rhel_version': rhel_version.base_version,
-        'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
-        'deploy_flavor': settings.flavors.default,
-        'workflow': settings.capsule.deploy_workflows.os,
-    }
+    deploy_args = get_cap_deploy_args()
+
     with Broker(**deploy_args, host_class=Capsule) as host:
         host.enable_ipv6_dnf_and_rhsm_proxy()
         yield host
@@ -354,7 +368,6 @@ def installer_satellite(request):
         sat = Satellite(settings.server.hostname)
     else:
         sat = lru_sat_ready_rhel(getattr(request, 'param', None))
-    sat.setup_firewall()
 
     # register to cdn (also enables rhel repos from cdn)
     sat.register_to_cdn()
@@ -383,6 +396,7 @@ def installer_satellite(request):
         # add internal rhel repos
         sat.create_custom_repos(**settings.repos.get(f'rhel{sat.os_version.major}_os'))
 
+    sat.setup_firewall()
     sat.install_satellite_or_capsule_package()
     # Install Satellite
     installer_result = sat.execute(

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1655,24 +1655,35 @@ class Capsule(ContentHost, CapsuleMixins):
         """Prepare the host and run the capsule installer"""
         self._satellite = sat_host or Satellite()
 
-        # Register capsule host to CDN and enable repos
-        result = self.register_contenthost(
-            org=None,
-            lce=None,
-            username=settings.subscription.rhn_username,
-            password=settings.subscription.rhn_password,
-            auto_attach=True,
-        )
-        if result.status:
-            raise CapsuleHostError(f'Capsule CDN registration failed\n{result.stderr}')
-
-        for repo in getattr(constants, f"OHSNAP_RHEL{self.os_version.major}_REPOS"):
-            result = self.enable_repo(repo, force=True)
+        if settings.robottelo.rhelsource == "ga":
+            # Register capsule host to CDN and enable repos
+            result = self.register_contenthost(
+                org=None,
+                lce=None,
+                username=settings.subscription.rhn_username,
+                password=settings.subscription.rhn_password,
+                auto_attach=True,
+            )
             if result.status:
-                raise CapsuleHostError(f'Repo enable at capsule host failed\n{result.stdout}')
+                raise CapsuleHostError(f'Capsule CDN registration failed\n{result.stderr}')
+
+            for repo in getattr(constants, f"OHSNAP_RHEL{self.os_version.major}_REPOS"):
+                result = self.enable_repo(repo, force=True)
+                if result.status:
+                    raise CapsuleHostError(f'Repo enable at capsule host failed\n{result.stdout}')
+        elif settings.robottelo.rhel_source == "internal":
+            # add internal rhel repos
+            self.create_custom_repos(**settings.repos.get(f'rhel{self.os_version.major}_os'))
 
         # Update system, firewall services and check capsule is already installed from template
-        self.execute('yum -y update', timeout=0)
+        # Setups firewall on Capsule
+        self.execute('dnf -y update', timeout=0)
+        assert (
+            self.execute(
+                "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
+            ).status
+            == 0
+        ), "firewalld is not present and can't be installed"
         self.execute('firewall-cmd --add-service RH-Satellite-6-capsule')
         self.execute('firewall-cmd --runtime-to-permanent')
         result = self.execute('rpm -q satellite-capsule')
@@ -2027,6 +2038,12 @@ class Satellite(Capsule, SatelliteMixins):
 
     def setup_firewall(self):
         # Setups firewall on Satellite
+        assert (
+            self.execute(
+                "which firewall-cmd || dnf -y install firewalld && systemctl enable --now firewalld"
+            ).status
+            == 0
+        ), "firewalld is not present and can't be installed"
         assert (
             self.execute(
                 command='firewall-cmd --add-port="53/udp" --add-port="53/tcp" --add-port="67/udp" '

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -141,7 +141,7 @@ def common_sat_install_assertions(satellite):
 
 
 def install_satellite(satellite, installer_args, enable_fapolicyd=False):
-    # Register for RHEL8 repos, get Ohsnap repofile, and enable and download satellite
+    # Register for RHEL repos, get Ohsnap repofile, and enable and download satellite
     satellite.register_to_cdn()
     if settings.server.version.source == 'nightly':
         satellite.create_custom_repos(
@@ -154,6 +154,11 @@ def install_satellite(satellite, installer_args, enable_fapolicyd=False):
             release=settings.server.version.release,
             snap=settings.server.version.snap,
         )
+    if settings.robottelo.rhel_source == "internal":
+        # disable rhel repos from cdn
+        satellite.disable_repo("rhel-*")
+        # add internal rhel repos
+        satellite.create_custom_repos(**settings.repos.get(f'rhel{satellite.os_version.major}_os'))
     if enable_fapolicyd:
         if satellite.execute('rpm -q satellite-maintain').status == 0:
             # Installing the rpm on existing sat needs sat-maintain perms


### PR DESCRIPTION
Various fixes of Installer tests that were failing during Interop testing
- using server deploy arguments (instead of content_host)
- ensuring that firewall is installed before it's configuration (firewalld is not installed on compose rhel images)
- setting up rhel and satellite repositories