### PR TITLE
Update flatpak REX templates names

### DIFF
--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -876,7 +876,7 @@ def test_sync_consume_flatpak_repo_via_library(
     job = module_target_sat.cli_factory.job_invocation(
         {
             'organization': function_org.name,
-            'job-template': 'Set up Flatpak remote on host',
+            'job-template': 'Flatpak - Set up remote on host',
             'inputs': (
                 f'Remote Name={remote_name}, '
                 f'Flatpak registry URL=https://{caps.hostname}/pulpcore_registry/, '
@@ -901,7 +901,7 @@ def test_sync_consume_flatpak_repo_via_library(
     job = module_target_sat.cli_factory.job_invocation(
         {
             'organization': function_org.name,
-            'job-template': 'Install Flatpak application on host',
+            'job-template': 'Flatpak - Install application on host',
             'inputs': f'Flatpak remote name={remote_name}, Application name={app_name}',
             'search-query': f"name ~ {host.hostname}",
         }

--- a/tests/foreman/cli/test_flatpak.py
+++ b/tests/foreman/cli/test_flatpak.py
@@ -302,7 +302,7 @@ def test_sync_consume_flatpak_repo_via_library(
     job = module_target_sat.cli_factory.job_invocation(
         {
             'organization': function_org.name,
-            'job-template': 'Set up Flatpak remote on host',
+            'job-template': 'Flatpak - Set up remote on host',
             'inputs': (
                 f'Remote Name={remote_name}, '
                 f'Flatpak registry URL=https://{sat.hostname}/pulpcore_registry/, '
@@ -327,7 +327,7 @@ def test_sync_consume_flatpak_repo_via_library(
     job = module_target_sat.cli_factory.job_invocation(
         {
             'organization': function_org.name,
-            'job-template': 'Install Flatpak application on host',
+            'job-template': 'Flatpak - Install application on host',
             'inputs': f'Flatpak remote name={remote_name}, Application name={app_name}',
             'search-query': f"name ~ {host.hostname}",
         }


### PR DESCRIPTION
### Problem Statement
Flatpak REX templates names have been changed in https://github.com/Katello/katello/pull/11297 and https://github.com/Katello/katello/pull/11300, so we need to update them too.


### Solution
This PR.


### Related Issues
https://issues.redhat.com/browse/SAT-30815


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py -k test_sync_consume_flatpak_repo_via_library
Katello:
  katello: 11300
```
