### PR TITLE
[6.14] Mark one RHSSO test for PIT server

### DIFF
--- a/pytest_fixtures/component/satellite_auth.py
+++ b/pytest_fixtures/component/satellite_auth.py
@@ -290,9 +290,15 @@ def auth_data(request, ad_data, ipa_data):
 @pytest.fixture(scope='module')
 def enroll_configure_rhsso_external_auth(module_target_sat):
     """Enroll the Satellite6 Server to an RHSSO Server."""
-    module_target_sat.execute(
-        'yum -y --disableplugin=foreman-protector install '
-        'mod_auth_openidc keycloak-httpd-client-install'
+    if settings.robottelo.rhel_source == "ga":
+        module_target_sat.register_to_cdn()
+    # keycloak-httpd-client-install needs lxml but it's not an rpm dependency + is not documented
+    assert (
+        module_target_sat.execute(
+            'yum -y --disableplugin=foreman-protector install '
+            'mod_auth_openidc keycloak-httpd-client-install python3-lxml '
+        ).status
+        == 0
     )
     # if target directory not given it is installing in /usr/local/lib64
     module_target_sat.execute('python3 -m pip install lxml -t /usr/lib64/python3.6/site-packages')

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -322,6 +322,7 @@ VALIDATORS = dict(
     ],
     robottelo=[
         Validator('robottelo.settings.ignore_validation_errors', is_type_of=bool, default=False),
+        Validator('robottelo.rhel_source', default='ga', is_in=['ga', 'internal']),
         Validator(
             'robottelo.sat_non_ga_versions',
             is_type_of=list,

--- a/tests/foreman/destructive/test_ldapauthsource.py
+++ b/tests/foreman/destructive/test_ldapauthsource.py
@@ -42,6 +42,7 @@ def rh_sso_hammer_auth_setup(module_target_sat, default_sso_host, request):
     default_sso_host.update_client_configuration(client_config)
 
 
+@pytest.mark.pit_server
 def test_rhsso_login_using_hammer(
     module_target_sat,
     enable_external_auth_rhsso,


### PR DESCRIPTION
6.14.z cherrypick of https://github.com/SatelliteQE/robottelo/pull/17204

Note that I've had to add validator:
```
Validator('robottelo.rhel_source', default='ga', is_in=['ga', 'internal']),
```