### PR TITLE
[6.16.z] Use _broker_facts instead of _broker_args for provisioning tests

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -298,7 +298,7 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
     """Fixture for returning a pxe-less discovery host for provisioning"""
     sat = module_discovery_sat.sat
     image_name = f"{gen_string('alpha')}-{module_discovery_sat.iso}"
-    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     # Remaster and upload discovery image to automatically input values
     result = sat.execute(
         'cd /var/www/html/pub && '
@@ -318,7 +318,7 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
         job_template='configure-pxe-boot',
         target_host=provisioning_host.name,
         target_vlan_id=settings.provisioning.vlan_id,
-        target_vm_firmware=provisioning_host._broker_args['target_vm_firmware'],
+        target_vm_firmware=provisioning_host._broker_facts['target_vm_firmware'],
         target_pxeless_image=image_name,
         target_boot_scenario='pxeless_pre',
     ).execute()

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -318,7 +318,7 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
         job_template='configure-pxe-boot',
         target_host=provisioning_host.name,
         target_vlan_id=settings.provisioning.vlan_id,
-        target_vm_firmware=provisioning_host._broker_facts['target_vm_firmware'],
+        target_vm_firmware=provisioning_host._broker_args['target_vm_firmware'],
         target_pxeless_image=image_name,
         target_boot_scenario='pxeless_pre',
     ).execute()

--- a/tests/foreman/api/test_computeresource_vmware.py
+++ b/tests/foreman/api/test_computeresource_vmware.py
@@ -155,11 +155,11 @@ def test_positive_provision_vmware_pxe_discovery(
 
     :expectedresults: Host should be provisioned successfully
     """
-    mac = provisioning_vmware_host._broker_args['provisioning_nic_mac_addr']
+    mac = provisioning_vmware_host._broker_facts['provisioning_nic_mac_addr']
     sat = module_discovery_sat.sat
     # start the provisioning host
     vmware_host = VMWareVirtualMachine(
-        vmwareclient, name=provisioning_vmware_host._broker_args['name']
+        vmwareclient, name=provisioning_vmware_host._broker_facts['name']
     )
     vmware_host.start()
     wait_for(

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -198,7 +198,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
@@ -249,7 +249,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         pxeless_discovery_host.power_control(ensure=False)
-        mac = pxeless_discovery_host._broker_args['provisioning_nic_mac_addr']
+        mac = pxeless_discovery_host._broker_facts['provisioning_nic_mac_addr']
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
@@ -383,7 +383,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
@@ -430,7 +430,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -99,7 +99,7 @@ def test_rhel_pxe_provisioning(
 
     :parametrized: yes
     """
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     sat = module_provisioning_sat.sat
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
@@ -239,7 +239,7 @@ def test_rhel_ipxe_provisioning(
         )
     )
     assert ipxe_http_url.status == 0
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
         organization=module_sca_manifest_org,
@@ -368,7 +368,7 @@ def test_rhel_httpboot_provisioning(
     # update grub2-efi package
     sat.cli.Packages.update(packages='grub2-efi', options={'assumeyes': True})
 
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
         organization=module_sca_manifest_org,
@@ -493,7 +493,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
     :Verifies: SAT-26071
     """
     sat = module_provisioning_sat.sat
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     # Verify password hashing algorithm SHA512 is set in OS used for provisioning
     assert module_provisioning_rhel_content.os.password_hash == 'SHA512'
 
@@ -631,7 +631,7 @@ def test_rhel_pxe_provisioning_secureboot_enabled(
 
     :parametrized: yes
     """
-    host_mac_addr = provisioning_vmware_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_vmware_host._broker_facts['provisioning_nic_mac_addr']
     sat = module_provisioning_sat.sat
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
@@ -647,7 +647,7 @@ def test_rhel_pxe_provisioning_secureboot_enabled(
 
     # start the provisioning host on VMware, do not ensure that we can connect to SSHD
     vmware_host = VMWareVirtualMachine(
-        vmwareclient, name=provisioning_vmware_host._broker_args['name']
+        vmwareclient, name=provisioning_vmware_host._broker_facts['name']
     )
     vmware_host.start()
 
@@ -737,7 +737,7 @@ def test_capsule_pxe_provisioning(
 
     :parametrized: yes
     """
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     sat = capsule_provisioning_sat.sat
     cap = module_capsule_configured
     host = sat.api.Host(

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -133,7 +133,7 @@ def test_host_provisioning_with_external_puppetserver(
     :customerscenario: true
     """
     puppet_env = 'production'
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     sat = module_provisioning_sat.sat
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -905,7 +905,7 @@ class TestAnsibleAAPIntegration:
             1. All hosts managed by Satellite are added to Satellite inventory.
             2. Starting ansible-callback systemd service, starts a job_template execution in AAP
         """
-        host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+        host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
         sat = module_provisioning_sat.sat
         aap_fqdn = settings.AAP_INTEGRATION.AAP_FQDN
         job_template = settings.AAP_INTEGRATION.callback_job_template

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -50,7 +50,7 @@ def test_rhel_pxe_discovery_provisioning(
     """
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
-    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
 
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
@@ -111,7 +111,7 @@ def test_rhel_pxeless_discovery_provisioning(
     """
     sat = module_discovery_sat.sat
     pxeless_discovery_host.power_control(ensure=False)
-    mac = pxeless_discovery_host._broker_args['provisioning_nic_mac_addr']
+    mac = pxeless_discovery_host._broker_facts['provisioning_nic_mac_addr']
 
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -81,7 +81,7 @@ def test_positive_provision_pxe_host(
     """
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
-    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
@@ -164,7 +164,7 @@ def test_positive_custom_provision_pxe_host(
     """
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
-    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
@@ -320,7 +320,7 @@ def test_positive_auto_provision_host_with_rule(
     """
     sat = module_discovery_sat.sat
     pxeless_discovery_host.power_control(ensure=False)
-    mac = pxeless_discovery_host._broker_args['provisioning_nic_mac_addr']
+    mac = pxeless_discovery_host._broker_facts['provisioning_nic_mac_addr']
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17492

### Problem Statement
`_broker_facts` is used to fetch the host-specific facts in broker v0.6.x, and we're still using `_broker_args` 

### Solution
Use _broker_facts instead of _broker_args for provisioning tests

### Related Issues
MR: satlab-tower#1237