### PR TITLE
[6.14.z] Use _broker_facts instead of _broker_args for provisioning t…

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -297,7 +297,7 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
     """Fixture for returning a pxe-less discovery host for provisioning"""
     sat = module_discovery_sat.sat
     image_name = f"{gen_string('alpha')}-{module_discovery_sat.iso}"
-    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     # Remaster and upload discovery image to automatically input values
     result = sat.execute(
         'cd /var/www/html/pub && '

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -198,7 +198,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
@@ -249,7 +249,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         pxeless_discovery_host.power_control(ensure=False)
-        mac = pxeless_discovery_host._broker_args['provisioning_nic_mac_addr']
+        mac = pxeless_discovery_host._broker_facts['provisioning_nic_mac_addr']
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
@@ -383,7 +383,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
@@ -428,7 +428,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -97,7 +97,7 @@ def test_rhel_pxe_provisioning(
 
     :parametrized: yes
     """
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     sat = module_provisioning_sat.sat
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
@@ -232,7 +232,7 @@ def test_rhel_ipxe_provisioning(
         )
     )
     assert ipxe_http_url.status == 0
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
         organization=module_sca_manifest_org,
@@ -361,7 +361,7 @@ def test_rhel_httpboot_provisioning(
     # update grub2-efi package
     sat.cli.Packages.update(packages='grub2-efi', options={'assumeyes': True})
 
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
         organization=module_sca_manifest_org,
@@ -484,7 +484,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
     :BZ: 2240076
     """
     sat = module_provisioning_sat.sat
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     # Verify password hashing algorithm SHA256 is set in OS used for provisioning
     assert module_provisioning_rhel_content.os.password_hash == 'SHA256'
 
@@ -622,7 +622,7 @@ def test_capsule_pxe_provisioning(
 
     :parametrized: yes
     """
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     sat = capsule_provisioning_sat.sat
     cap = module_capsule_configured
     host = sat.api.Host(

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -133,7 +133,7 @@ def test_host_provisioning_with_external_puppetserver(
     :customerscenario: true
     """
     puppet_env = 'production'
-    host_mac_addr = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     sat = module_provisioning_sat.sat
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -48,7 +48,7 @@ def test_rhel_pxe_discovery_provisioning(
     """
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
-    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
 
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
@@ -109,7 +109,7 @@ def test_rhel_pxeless_discovery_provisioning(
     """
     sat = module_discovery_sat.sat
     pxeless_discovery_host.power_control(ensure=False)
-    mac = pxeless_discovery_host._broker_args['provisioning_nic_mac_addr']
+    mac = pxeless_discovery_host._broker_facts['provisioning_nic_mac_addr']
 
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -79,7 +79,7 @@ def test_positive_provision_pxe_host(
     """
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
-    mac = provisioning_host._broker_args['provisioning_nic_mac_addr']
+    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
@@ -182,7 +182,7 @@ def test_positive_auto_provision_host_with_rule(
     """
     sat = module_discovery_sat.sat
     pxeless_discovery_host.power_control(ensure=False)
-    mac = pxeless_discovery_host._broker_args['provisioning_nic_mac_addr']
+    mac = pxeless_discovery_host._broker_facts['provisioning_nic_mac_addr']
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17492

### Problem Statement
_broker_facts is used to fetch the host-specific facts in broker v0.6.x, and we're still using _broker_args

### Solution
Use _broker_facts instead of _broker_args for provisioning tests

### Related Issues
MR: satlab-tower#1237