### PR TITLE
Fix _broker_args for target_vm_firmware fact

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -329,7 +329,7 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
         job_template='configure-pxe-boot',
         target_host=provisioning_host.name,
         target_vlan_id=settings.provisioning.vlan_id,
-        target_vm_firmware=provisioning_host._broker_facts['target_vm_firmware'],
+        target_vm_firmware=provisioning_host._broker_args['target_vm_firmware'],
         target_pxeless_image=image_name,
         target_boot_scenario='pxeless_pre',
     ).execute()


### PR DESCRIPTION
### Problem Statement
_broker_args for target_vm_firmware fact was replaced with _broker_facts mistakenly in PR: https://github.com/SatelliteQE/robottelo/pull/17492

### Solution
Fix _broker_args for target_vm_firmware fact (Already fixed in the cherrypick PRs)
### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->