### PR TITLE
[6.16.z] org/loc create with all users tests adjusted

### DIFF
--- a/tests/foreman/ui/test_location.py
+++ b/tests/foreman/ui/test_location.py
@@ -104,17 +104,15 @@ def test_positive_end_to_end(session, target_sat):
 
 
 @pytest.mark.tier2
-def test_positive_update_with_all_users(session, target_sat):
-    """Create location and do not add user to it. Check and uncheck
-    'all users' setting. Verify that for both operation expected location
-    is assigned to user. Then add user to location and retry.
+def test_positive_create_with_all_users(session, target_sat):
+    """Create location and do not add user to it. Check
+    'all users' setting.
 
     :id: 6596962b-8fd0-4a82-bf54-fa6a31147311
 
     :customerscenario: true
 
-    :expectedresults: Location entity is assigned to user after checkbox
-        was enabled and then disabled afterwards
+    :expectedresults: User is visible in selected location
 
     :BZ: 1479736
 
@@ -128,22 +126,11 @@ def test_positive_update_with_all_users(session, target_sat):
         session.organization.select(org_name=ANY_CONTEXT['org'])
         session.location.select(loc_name=loc.name)
         session.location.update(loc.name, {'users.all_users': True})
-        user_values = session.user.read(user.login)
-        assert loc.name in user_values['locations']['resources']['assigned']
-        session.location.update(loc.name, {'users.all_users': False})
-        user_values = session.user.read(user.login)
-        assert loc.name in user_values['locations']['resources']['unassigned']
-        session.location.update(loc.name, {'users.resources.assigned': [user.login]})
-        loc_values = session.location.read(loc.name)
-        user_values = session.user.read(user.login)
-        assert loc_values['users']['resources']['assigned'][0] == user.login
-        assert user_values['locations']['resources']['assigned'][0] == loc.name
-        session.location.update(loc.name, {'users.all_users': True})
-        user_values = session.user.read(user.login)
-        assert loc.name in user_values['locations']['resources']['assigned']
-        session.location.update(loc.name, {'users.all_users': False})
-        user_values = session.user.read(user.login)
-        assert loc.name in user_values['locations']['resources']['unassigned']
+        found_users = session.user.search(user.login)
+        assert user.login in [user['Username'] for user in found_users]
+        # SAT-25386 closed wontdo
+        # user_values = session.user.read(user.login)
+        # assert loc.name in user_values['locations']['resources']['assigned']
 
 
 @pytest.mark.tier2

--- a/tests/foreman/ui/test_organization.py
+++ b/tests/foreman/ui/test_organization.py
@@ -16,7 +16,7 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DEFAULT_ORG, INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
+from robottelo.constants import ANY_CONTEXT, DEFAULT_ORG, INSTALL_MEDIUM_URL, LIBVIRT_RESOURCE_URL
 from robottelo.logging import logger
 
 CUSTOM_REPO_ERRATA_ID = settings.repos.yum_0.errata[0]
@@ -196,14 +196,13 @@ def test_positive_search_scoped(session):
 @pytest.mark.tier2
 def test_positive_create_with_all_users(session, module_target_sat):
     """Create organization and new user. Check 'all users' setting for
-    organization. Verify that user is assigned to organization and
-    vice versa organization is assigned to user
+    organization.
 
     :id: 6032be70-00a0-4ccd-ad01-391546074879
 
     :customerscenario: true
 
-    :expectedresults: Organization and user entities assigned to each other
+    :expectedresults: User is visible in selected org
 
     :verifies: SAT-25386
 
@@ -217,10 +216,12 @@ def test_positive_create_with_all_users(session, module_target_sat):
         assert user.login in org_values['users']['resources']['assigned']
         session.organization.search(org.name)
         session.organization.select(org_name=org.name)
+        session.location.select(loc_name=ANY_CONTEXT['location'])
         found_users = session.user.search(user.login)
         assert user.login in [user['Username'] for user in found_users]
-        user_values = session.user.read(user.login)
-        assert org.name in user_values['organizations']['resources']['assigned']
+        # SAT-25386 closed wontdo
+        # user_values = session.user.read(user.login)
+        # assert org.name in user_values['organizations']['resources']['assigned']
 
 
 @pytest.mark.skip_if_not_set('libvirt')


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17437

### Problem Statement

SAT-25386 won't be fixed, but its still valuable that the user appears under the org/loc context even if that org/loc isn't written to its params

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->