### PR TITLE
[6.14.z] non existent APIResponseError

### DIFF
--- a/robottelo/exceptions.py
+++ b/robottelo/exceptions.py
@@ -1,6 +1,10 @@
 """Custom Errors for Robottelo"""
 
 
+class APIResponseError(Exception):
+    """Indicates wrong API response"""
+
+
 class GCECertNotFoundError(Exception):
     """An exception to raise when GCE Cert json is not available for creating GCE CR"""
 

--- a/robottelo/host_helpers/api_factory.py
+++ b/robottelo/host_helpers/api_factory.py
@@ -17,6 +17,7 @@ from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
     REPO_TYPE,
 )
+from robottelo.exceptions import APIResponseError
 from robottelo.host_helpers.repository_mixins import initiate_repo_helpers
 
 
@@ -206,14 +207,14 @@ class APIFactory:
                         query={'search': f'name="{name}"'}
                     )
                     if not result:
-                        raise self._satellite.api.APIResponseError(f'permission "{name}" not found')
+                        raise APIResponseError(f'permission "{name}" not found')
                     if len(result) > 1:
-                        raise self._satellite.api.APIResponseError(
+                        raise APIResponseError(
                             f'found more than one entity for permission "{name}"'
                         )
                     entity_permission = result[0]
                     if entity_permission.name != name:
-                        raise self._satellite.api.APIResponseError(
+                        raise APIResponseError(
                             'the returned permission is different from the'
                             f' requested one "{entity_permission.name} != {name}"'
                         )
@@ -229,9 +230,7 @@ class APIFactory:
                     query={'per_page': '350', 'search': f'resource_type="{resource_type}"'}
                 )
                 if not resource_type_permissions_entities:
-                    raise self._satellite.api.APIResponseError(
-                        f'resource type "{resource_type}" permissions not found'
-                    )
+                    raise APIResponseError(f'resource type "{resource_type}" permissions not found')
 
                 permissions_entities = [
                     entity
@@ -243,7 +242,7 @@ class APIFactory:
                 permissions_entities_names = {entity.name for entity in permissions_entities}
                 not_found_names = set(permissions_name).difference(permissions_entities_names)
                 if not_found_names:
-                    raise self._satellite.api.APIResponseError(
+                    raise APIResponseError(
                         f'permissions names entities not found "{not_found_names}"'
                     )
             self._satellite.api.Filter(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17406

### Problem Statement
create_role_permissions factory function started to fail as a side-effect of https://github.com/SatelliteQE/robottelo/pull/16962 (I'll be posting a fix in a separate PR). This uncovered that satellite.api.APIResponseError is no longer around (not sure how long)

### Solution
creating our own error class

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->