### PR TITLE
[6.15.z] less fragile string comparison in negative domain test

### DIFF
--- a/tests/foreman/cli/test_domain.py
+++ b/tests/foreman/cli/test_domain.py
@@ -196,7 +196,9 @@ def test_negative_create_with_invalid_dns_id(module_target_sat):
         module_target_sat.cli_factory.make_domain({'name': gen_string('alpha'), 'dns-id': -1})
     valid_messages = ['Invalid smart-proxy id', 'Invalid capsule id']
     exception_string = str(context.value)
-    messages = [message for message in valid_messages if message in exception_string]
+    messages = [
+        message for message in valid_messages if message.lower() in exception_string.lower()
+    ]
     assert len(messages) > 0
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17511

### Problem Statement
Change in case in error message causes test failure 

### Solution
this PR

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->