### PR TITLE
assertion skip for SAT-30898

### DIFF
--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -28,6 +28,7 @@ from robottelo.constants import FAKE_4_CUSTOM_PACKAGE
 from robottelo.exceptions import CLIFactoryError
 from robottelo.utils import ohsnap
 from robottelo.utils.datafactory import filtered_datapoint, parametrized
+from robottelo.utils.issue_handlers import is_open
 
 
 @filtered_datapoint
@@ -344,7 +345,10 @@ class TestRemoteExecution:
                 'organization-id': module_org.id,
             }
         )
-        assert 'Permission denied' in out
+        if not (
+            rex_contenthost.os_distribution_version.split(".")[0] == '7' and is_open('SAT-30898')
+        ):
+            assert 'Permission denied' in out
 
     @pytest.mark.tier3
     @pytest.mark.parametrize(

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -345,9 +345,7 @@ class TestRemoteExecution:
                 'organization-id': module_org.id,
             }
         )
-        if not (
-            rex_contenthost.os_distribution_version.split(".")[0] == '7' and is_open('SAT-30898')
-        ):
+        if not rex_contenthost.os_version.major == 7 and is_open('SAT-30898'):
             assert 'Permission denied' in out
 
     @pytest.mark.tier3

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -345,7 +345,7 @@ class TestRemoteExecution:
                 'organization-id': module_org.id,
             }
         )
-        if not rex_contenthost.os_version.major == 7 and is_open('SAT-30898'):
+        if rex_contenthost.os_version.major != 7 and is_open('SAT-30898'):
             assert 'Permission denied' in out
 
     @pytest.mark.tier3


### PR DESCRIPTION
### Problem Statement
Strange error needs a bit of investigation (filed SAT-30898), adding some skip to prevent unnecessary failures while that happens

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->