### PR TITLE
Add issue SAT-26076 to convert2rhel tests

### DIFF
--- a/tests/foreman/api/test_convert2rhel.py
+++ b/tests/foreman/api/test_convert2rhel.py
@@ -255,7 +255,7 @@ def test_convert2rhel_oracle_with_pre_conversion_template_check(
 
     :parametrized: yes
 
-    :Verifies: SAT-24654, SAT-24655
+    :Verifies: SAT-24654, SAT-24655, SAT-26076
     """
     major = version.split('.')[0]
     assert oracle.execute('yum -y update').status == 0
@@ -359,7 +359,7 @@ def test_convert2rhel_centos_with_pre_conversion_template_check(
 
     :parametrized: yes
 
-    :Verifies: SAT-24654, SAT-24655
+    :Verifies: SAT-24654, SAT-24655, SAT-26076
     """
     host_content = module_target_sat.api.Host(id=centos.hostname).read_json()
     major = version.split('.')[0]


### PR DESCRIPTION
### Problem Statement
We missed adding related issue in convert2rhel tests in https://github.com/SatelliteQE/robottelo/pull/17143

### Solution
Add issue SAT-26076 to convert2rhel tests

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->