### PR TITLE
[6.16.z] Add Python 3.13 for PR checks in GHA

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
     env:
       UV_CACHE_DIR: /tmp/.uv-cache
       UV_SYSTEM_PYTHON: 1


### PR DESCRIPTION
(cherry picked from commit e2d0259660c64faeef6c4206c38c8a7f846da3c8)

### Problem Statement
Cherrypick failed for https://github.com/SatelliteQE/robottelo/pull/17405 because of auto-branching GHA changes 

### Solution
Remove auto-branching GHA changes , and cherrypick only Py3.13 related changes

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->