### PR TITLE
Remove 6.13.z branch from dependabot to not auto-cherrypick

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,6 @@ updates:
       - "dependencies"
       - "6.15.z"
       - "6.14.z"
-      - "6.13.z"
     ignore:
       - dependency-name: "cryptography"
         update-types: ["version-update:semver-minor"]
@@ -31,4 +30,3 @@ updates:
       - "dependencies"
       - "6.15.z"
       - "6.14.z"
-      - "6.13.z"


### PR DESCRIPTION
Removing 6.13.z label from dependabot for not to auto-cherrypick by ACP GHA.