### PR TITLE
[6.16.z] remove user to prevent ForeignKeyViolation

### DIFF
--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -283,7 +283,7 @@ class TestAnsibleCfgMgmt:
     @pytest.mark.rhel_ver_match('[78]')
     @pytest.mark.tier2
     def test_positive_read_facts_with_filter(
-        self, target_sat, rex_contenthost, filtered_user, module_org, module_location
+        self, request, target_sat, rex_contenthost, filtered_user, module_org, module_location
     ):
         """Read host's Ansible facts as a user with a role that has host filter
 
@@ -304,6 +304,9 @@ class TestAnsibleCfgMgmt:
         host.organization = module_org
         host.location = module_location
         host.update(['organization', 'location'])
+        request.addfinalizer(
+            user.delete
+        )  # Adding a temporary workaround until the issue 'SAT-18656' is resolved.
 
         # gather ansible facts by running ansible roles on the host
         host.play_ansible_roles()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17024

**Problem -** 
When creating another user with a specific role and adding resources in the filter with the 'view_facts' permission, an error occurred ('PG::ForeignKeyViolation: ERROR:  update or delete on table "hosts" violates foreign key constraint "fact_values_host_id_fk" on table "fact_values"') during the teardown process while deleting the host. This happened because a user with only view permissions existed for the host and making it impossible to update or delete the user associated with the fact.

**Solution -**
To prevent this error, the user was removed before the teardown process.