### PR TITLE
Verify the content type of flatpak manifests

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -832,18 +832,15 @@ CONTAINER_MANIFEST_LABELS = {'annotations', 'labels', 'is_bootable', 'is_flatpak
 FLATPAK_REMOTES = {
     'Fedora': {
         'url': 'https://registry.fedoraproject.org',
-        'index_url': 'https://registry.fedoraproject.org/index/static?label:org.flatpak.ref:exists=1&tag=latest',
         'authenticated': False,
     },
     'RedHat': {
         'url': 'https://flatpaks.redhat.io/rhel/',
-        'index_url': 'https://flatpaks.redhat.io/rhel/index/static?label:org.flatpak.ref:exists=1&tag=latest',
         'authenticated': True,
     },
 }
-PULPCORE_FLATPAK_ENDPOINT = (
-    'https://{}/pulpcore_registry/index/static?label:org.flatpak.ref:exists=1'
-)
+FLATPAK_INDEX_SUFFIX = 'index/static?label:org.flatpak.ref:exists=1&tag=latest'
+PULPCORE_FLATPAK_ENDPOINT = 'https://{}/pulpcore_registry/' + FLATPAK_INDEX_SUFFIX
 
 CONTAINER_CLIENTS = ['docker', 'podman']
 CUSTOM_LOCAL_FOLDER = '/var/lib/pulp/imports/myrepo/'


### PR DESCRIPTION
### Problem Statement
New `content_type` field has been added to the container manifests and container manifests list so that users can differentiate between flatpaks and other container images. We should check the field is set properly for the flatpak manifests.


### Solution
This PR extends `test_sync_consume_flatpak_repo_via_library` with this assertion.
Apart from that it also leverages the `function_flatpak_remote` fixture.


### Related Issues
https://issues.redhat.com/browse/SAT-21691


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py -k 'test_scan_flatpak_remote or test_flatpak_pulpcore_endpoint or test_sync_consume_flatpak_repo_via_library'
Katello:
  katello: 11300
```