### PR TITLE
Fix test_negative_ipv6_update_check

### DIFF
--- a/tests/foreman/destructive/test_fm_upgrade.py
+++ b/tests/foreman/destructive/test_fm_upgrade.py
@@ -50,6 +50,6 @@ def test_negative_ipv6_update_check(sat_maintain):
     )
     assert result.status != 0
     assert (
-        'The kernel contains ipv6.disable=1 which is known to break installation and upgrade, remove and reboot before continuining.'
+        'The kernel contains ipv6.disable=1 which is known to break installation and upgrade, remove and reboot before continuing.'
         in result.stdout
     )


### PR DESCRIPTION
### Problem Statement
- test_negative_ipv6_update_check is failing because of change in assertion message.

### Solution
- Update assertion

### Related Issues
- SAT-30972
- SAT-30154

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->