### PR TITLE
populate future date subscription in satellite

### DIFF
--- a/pytest_fixtures/component/taxonomy.py
+++ b/pytest_fixtures/component/taxonomy.py
@@ -225,3 +225,11 @@ def sca_manifest_for_upgrade():
     """Returns a manifest in sca mode. Used only for upgrade scenarios"""
     manifester = Manifester(manifest_category=settings.manifest.golden_ticket)
     return manifester.get_manifest(), manifester
+
+
+@pytest.fixture
+def func_future_dated_subscription_manifest(target_sat, function_org):
+    """Create and upload future date subscription manifest into org"""
+    with Manifester(manifest_category=settings.manifest.future_date_subscription) as manifest:
+        target_sat.upload_manifest(function_org.id, manifest.content)
+    return manifest

--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -20,6 +20,7 @@ from zoneinfo import ZoneInfo
 from fauxfactory import gen_string
 from manifester import Manifester
 import pytest
+from tzlocal import get_localzone_name
 
 from robottelo.config import settings
 from robottelo.constants import (
@@ -556,7 +557,7 @@ def test_positive_populate_future_date_subcription(
         assert session.subscription.has_manifest, 'Manifest not uploaded'
 
         # Get current date time and convert into date
-        current_datetime = datetime.now(ZoneInfo('Asia/Kolkata'))
+        current_datetime = datetime.now(ZoneInfo(get_localzone_name()))
         current_date = current_datetime.date()
 
         # Get subscription Start Date


### PR DESCRIPTION
### Problem Statement
Future date subscription doesn't populated on Subscription page
https://issues.redhat.com/browse/SAT-29203

### Solution
1. Add subscription with custom validity period to stage account
2. in `robottelo/conf/manifest.yaml`, add a new manifest block
3. New fixture to create manifest with future date subscription

### Related Issues
https://gitlab.cee.redhat.com/satelliteqe/satellite-jenkins/-/merge_requests/1612

 ### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_positive_populate_future_date_subcription'
```

<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->