### PR TITLE
[Customer Case]Reregister Host with removed consumer certs

### DIFF
--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2855,3 +2855,6 @@ def test_positive_reregister_rhel(
     )
     assert reregister.status == 0
     assert rhel_contenthost.subscribed
+    certs = rhel_contenthost.execute("ls /etc/pki/consumer").stdout
+    assert 'cert.pem' in certs
+    assert 'key.pem' in certs

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -284,7 +284,6 @@ def test_positive_search_all_field_sets(module_target_sat):
         assert field in list(output_field_sets[host_idx].keys())
 
 
-@pytest.mark.no_containers
 @pytest.mark.rhel_ver_match('8')
 @pytest.mark.cli_host_subscription
 @pytest.mark.tier3

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2833,7 +2833,7 @@ def test_positive_reregister_rhel(
     :steps:
         1. Register a Host
         2. Remove consumer certs from Host
-        3. Attempt to reregister the Host 
+        3. Attempt to reregister the Host
 
     :expectedresults: Host is reregisterd with no errors
 
@@ -2850,6 +2850,8 @@ def test_positive_reregister_rhel(
     status = rhel_contenthost.execute("subscription-manager status")
     assert "Overall Status: Unknown" in status.stdout
     # reregister host with force
-    reregister = rhel_contenthost.register(function_org, None, function_ak_with_cv.name, target_sat, force=True)
+    reregister = rhel_contenthost.register(
+        function_org, None, function_ak_with_cv.name, target_sat, force=True
+    )
     assert reregister.status == 0
     assert rhel_contenthost.subscribed

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -2826,7 +2826,7 @@ def test_positive_reregister_rhel(
     function_ak_with_cv,
     function_org,
 ):
-    """Reregister a Host after cusumer certs have been removed
+    """Reregister a Host after consumer certs have been removed
 
     :id: 23d1ddba-256f-43a9-bd25-797f6a66942d
 


### PR DESCRIPTION
Test for re-registering a host once consumer certs are removed 

Customer Case for SAT-27875