### PR TITLE
Fix datetime.utcnow deprecation warning

### DIFF
--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -165,7 +165,7 @@ def pytest_collection_modifyitems(items, config):
     logger.info('Processing test items to add testimony token markers')
     for item in items:
         item.user_properties.append(
-            ("start_time", datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME))
+            ("start_time", datetime.datetime.now(datetime.UTC).strftime(FMT_XUNIT_TIME))
         )
         if item.nodeid.startswith('tests/robottelo/') and 'test_junit' not in item.nodeid:
             # Unit test, no testimony markers


### PR DESCRIPTION


### Problem Statement

DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version
### Solution

see diff

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->