### PR TITLE
Make container content related settings configurable

### DIFF
--- a/conf/container.yaml.template
+++ b/conf/container.yaml.template
@@ -1,0 +1,15 @@
+---
+CONTAINER:
+  CLIENTS:
+    - docker
+    - podman
+  REGISTRY_HUB: https://mirror.gcr.io
+  UPSTREAM_NAME: 'library/busybox'
+  DOCKER:
+    REPO_UPSTREAM_NAME: 'openshift3/logging-elasticsearch'
+  PULP:
+    REGISTRY_HUB: 'https://ghcr.io'
+  RH:
+    REGISTRY_HUB: 'https://registry.redhat.io/'
+    UPSTREAM_NAME: 'openshift3/ose-metrics-hawkular-openshift-agent'
+...

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -85,6 +85,47 @@ VALIDATORS = dict(
         Validator('libvirt.libvirt_hostname', must_exist=True),
         Validator('libvirt.libvirt_image_dir', default='/var/lib/libvirt/images'),
     ],
+    container=[
+        Validator(
+            'container.clients', must_exist=True, is_type_of=list, default=['docker', 'podman']
+        ),
+        Validator(
+            'container.registry_hub',
+            must_exist=True,
+            is_type_of=str,
+            default='https://mirror.gcr.io',
+        ),
+        Validator(
+            'container.upstream_name',
+            must_exist=True,
+            is_type_of=str,
+            default='library/busybox',
+        ),
+        Validator(
+            'container.docker.repo_upstream_name',
+            must_exist=True,
+            is_type_of=str,
+            default='openshift3/logging-elasticsearch',
+        ),
+        Validator(
+            'container.pulp.registry_hub',
+            must_exist=True,
+            is_type_of=str,
+            default='https://ghcr.io',
+        ),
+        Validator(
+            'container.rh.registry_hub',
+            must_exist=True,
+            is_type_of=str,
+            default='https://registry.redhat.io/',
+        ),
+        Validator(
+            'container.rh.upstream_name',
+            must_exist=True,
+            is_type_of=str,
+            default='openshift3/ose-metrics-hawkular-openshift-agent',
+        ),
+    ],
     container_repo=[
         Validator(
             'container_repo.registries.redhat.url',

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -792,12 +792,7 @@ FILTER_ERRATA_TYPE = {
 FILTER_ERRATA_DATE = {'updated': "updated", 'issued': "issued"}
 
 REPORT_TEMPLATE_FILE = 'report_template.txt'
-CONTAINER_REGISTRY_HUB = 'https://mirror.gcr.io'
-RH_CONTAINER_REGISTRY_HUB = 'https://registry.redhat.io/'
-PULP_CONTAINER_REGISTRY_HUB = 'https://ghcr.io'
-CONTAINER_UPSTREAM_NAME = 'library/busybox'
-DOCKER_REPO_UPSTREAM_NAME = 'openshift3/logging-elasticsearch'
-CONTAINER_RH_REGISTRY_UPSTREAM_NAME = 'openshift3/ose-metrics-hawkular-openshift-agent'
+
 BOOTABLE_REPO = {
     'upstream_name': 'pulp/bootc-labeled',
     'manifest': {
@@ -851,7 +846,6 @@ FLATPAK_ENDPOINTS = {
     'katello': 'https://{}/' + FLATPAK_INDEX_SUFFIX,
 }
 
-CONTAINER_CLIENTS = ['docker', 'podman']
 CUSTOM_LOCAL_FOLDER = '/var/lib/pulp/imports/myrepo/'
 CUSTOM_LOCAL_FILE = '/var/lib/pulp/imports/myrepo/test.txt'
 CUSTOM_FILE_REPO_FILES_COUNT = 3

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -26,9 +26,6 @@ from requests.exceptions import HTTPError
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_CLIENTS,
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     ENVIRONMENT,
     FAKE_1_YUM_REPOS_COUNT,
     FAKE_3_YUM_REPO_RPMS,
@@ -42,7 +39,6 @@ from robottelo.constants import (
     PULP_ARTIFACT_DIR,
     REPOS,
     REPOSET,
-    RH_CONTAINER_REGISTRY_HUB,
     RPM_TO_UPLOAD,
     DataFile,
 )
@@ -981,7 +977,7 @@ class TestCapsuleContentManagement:
             for repo in repos
         ]
 
-        for con_client in CONTAINER_CLIENTS:
+        for con_client in settings.container.clients:
             result = module_container_contenthost.execute(
                 f'{con_client} login -u {settings.server.admin_username}'
                 f' -p {settings.server.admin_password} {module_capsule_configured.hostname}'
@@ -1609,7 +1605,7 @@ class TestCapsuleContentManagement:
                 content_type='docker',
                 docker_upstream_name=ups_name,
                 product=function_product,
-                url=RH_CONTAINER_REGISTRY_HUB,
+                url=settings.container.rh.registry_hub,
                 upstream_username=settings.subscription.rhn_username,
                 upstream_password=settings.subscription.rhn_password,
             ).create()
@@ -1647,8 +1643,8 @@ class TestCapsuleContentManagement:
                 'YumRepository': {'url': settings.repos.module_stream_1.url},
                 'FileRepository': {'url': CUSTOM_FILE_REPO},
                 'DockerRepository': {
-                    'url': CONTAINER_REGISTRY_HUB,
-                    'upstream_name': CONTAINER_UPSTREAM_NAME,
+                    'url': settings.container.registry_hub,
+                    'upstream_name': settings.container.upstream_name,
                 },
                 'AnsibleRepository': {
                     'url': ANSIBLE_GALAXY,

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -21,7 +21,6 @@ from requests.exceptions import HTTPError
 
 from robottelo.config import settings, user_nailgun_config
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
     CUSTOM_RPM_SHA_512_FEED_COUNT,
     DEFAULT_ARCHITECTURE,
     PERMISSIONS,
@@ -1258,7 +1257,7 @@ class TestOstreeContentView:
             content_type='docker',
             docker_upstream_name='busybox',
             product=module_product,
-            url=CONTAINER_REGISTRY_HUB,
+            url=settings.container.registry_hub,
         ).create()
         self.docker_repo.sync()
 

--- a/tests/foreman/api/test_contentviewfilter.py
+++ b/tests/foreman/api/test_contentviewfilter.py
@@ -23,7 +23,6 @@ import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB
 from robottelo.utils.datafactory import (
     parametrized,
     valid_data_list,
@@ -217,7 +216,7 @@ class TestContentViewFilter:
             content_type='docker',
             docker_upstream_name='busybox',
             product=module_product.id,
-            url=CONTAINER_REGISTRY_HUB,
+            url=settings.container.registry_hub,
         ).create()
         content_view.repository = [sync_repo, docker_repository]
         content_view.update(['repository'])
@@ -428,7 +427,7 @@ class TestContentViewFilter:
             content_type='docker',
             docker_upstream_name='busybox',
             product=module_product.id,
-            url=CONTAINER_REGISTRY_HUB,
+            url=settings.container.registry_hub,
         ).create()
         content_view.repository = [sync_repo, docker_repository]
         content_view = content_view.update(['repository'])

--- a/tests/foreman/api/test_docker.py
+++ b/tests/foreman/api/test_docker.py
@@ -15,7 +15,6 @@ import pytest
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
-from robottelo.constants import CONTAINER_REGISTRY_HUB, CONTAINER_UPSTREAM_NAME
 from robottelo.utils.datafactory import (
     generate_strings_list,
     invalid_docker_upstream_names,
@@ -34,19 +33,19 @@ def _create_repository(module_target_sat, product, name=None, upstream_name=None
     :param str name: Name for the repository. If ``None`` then a random
         value will be generated.
     :param str upstream_name: A valid name of an existing upstream repository.
-        If ``None`` then defaults to CONTAINER_UPSTREAM_NAME.
+        If ``None`` then defaults to settings.container.upstream_name.
     :return: A ``Repository`` object.
     """
     if name is None:
         name = choice(generate_strings_list(15, ['numeric', 'html']))
     if upstream_name is None:
-        upstream_name = CONTAINER_UPSTREAM_NAME
+        upstream_name = settings.container.upstream_name
     return module_target_sat.api.Repository(
         content_type='docker',
         docker_upstream_name=upstream_name,
         name=name,
         product=product,
-        url=CONTAINER_REGISTRY_HUB,
+        url=settings.container.registry_hub,
     ).create()
 
 
@@ -125,7 +124,7 @@ class TestDockerRepository:
         """
         repo = _create_repository(module_target_sat, module_product, name)
         assert repo.name == name
-        assert repo.docker_upstream_name == CONTAINER_UPSTREAM_NAME
+        assert repo.docker_upstream_name == settings.container.upstream_name
         assert repo.content_type == 'docker'
 
     @pytest.mark.tier1
@@ -230,7 +229,7 @@ class TestDockerRepository:
 
         :CaseImportance: Critical
         """
-        assert repo.docker_upstream_name == CONTAINER_UPSTREAM_NAME
+        assert repo.docker_upstream_name == settings.container.upstream_name
 
         # Update the repository upstream name
         new_upstream_name = 'fedora/ssh'
@@ -249,14 +248,14 @@ class TestDockerRepository:
 
         :BZ: 1489322
         """
-        assert repo.url == CONTAINER_REGISTRY_HUB
+        assert repo.url == settings.container.registry_hub
 
         # Update the repository URL
         new_url = gen_url()
         repo.url = new_url
         repo = repo.update()
         assert repo.url == new_url
-        assert repo.url != CONTAINER_REGISTRY_HUB
+        assert repo.url != settings.container.registry_hub
 
     @pytest.mark.tier1
     def test_positive_delete(self, repo):

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -17,10 +17,6 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
-)
 from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
 
 
@@ -43,8 +39,8 @@ from robottelo.constants.repos import ANSIBLE_GALAXY, CUSTOM_FILE_REPO
             'YumRepository': {'url': settings.repos.module_stream_1.url},
             'FileRepository': {'url': CUSTOM_FILE_REPO},
             'DockerRepository': {
-                'url': CONTAINER_REGISTRY_HUB,
-                'upstream_name': CONTAINER_UPSTREAM_NAME,
+                'url': settings.container.registry_hub,
+                'upstream_name': settings.container.upstream_name,
             },
             'AnsibleRepository': {
                 'url': ANSIBLE_GALAXY,

--- a/tests/foreman/api/test_product.py
+++ b/tests/foreman/api/test_product.py
@@ -21,8 +21,6 @@ from requests.exceptions import HTTPError
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     REPO_TYPE,
     DataFile,
 )
@@ -180,9 +178,9 @@ def test_positive_sync_several_repos(module_org, module_target_sat):
     ).create()
     docker_repo = module_target_sat.api.Repository(
         content_type=REPO_TYPE['docker'],
-        docker_upstream_name=CONTAINER_UPSTREAM_NAME,
+        docker_upstream_name=settings.container.upstream_name,
         product=product,
-        url=CONTAINER_REGISTRY_HUB,
+        url=settings.container.registry_hub,
     ).create()
     assert rpm_repo.read().content_counts['rpm'] == 0
     assert docker_repo.read().content_counts['docker_tag'] == 0

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1549,9 +1549,9 @@ class TestDockerRepository:
             [
                 {
                     'content_type': 'docker',
-                    'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
+                    'docker_upstream_name': settings.container.upstream_name,
                     'name': name,
-                    'url': constants.CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
                 for name in datafactory.valid_docker_repository_names()
             ]
@@ -1579,9 +1579,9 @@ class TestDockerRepository:
             {
                 'large_repo': {
                     'content_type': 'docker',
-                    'docker_upstream_name': constants.DOCKER_REPO_UPSTREAM_NAME,
+                    'docker_upstream_name': settings.container.docker.repo_upstream_name,
                     'name': gen_string('alphanumeric', 10),
-                    'url': constants.RH_CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.rh.registry_hub,
                     'upstream_username': settings.subscription.rhn_username,
                     'upstream_password': settings.subscription.rhn_password,
                 }
@@ -1622,11 +1622,11 @@ class TestDockerRepository:
         'repo_options_custom_product',
         **datafactory.parametrized(
             {
-                constants.CONTAINER_UPSTREAM_NAME: {
+                settings.container.upstream_name: {
                     'content_type': 'docker',
-                    'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
+                    'docker_upstream_name': settings.container.upstream_name,
                     'name': gen_string('alphanumeric', 10),
-                    'url': constants.CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
             }
         ),
@@ -1801,12 +1801,12 @@ class TestDockerRepository:
         'repo_options',
         **datafactory.parametrized(
             {
-                constants.CONTAINER_UPSTREAM_NAME: {
+                settings.container.upstream_name: {
                     'content_type': 'docker',
                     'include_tags': ['latest'],
-                    'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
+                    'docker_upstream_name': settings.container.upstream_name,
                     'name': gen_string('alphanumeric', 10),
-                    'url': constants.CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
             }
         ),
@@ -1836,7 +1836,7 @@ class TestDockerRepository:
                     'content_type': 'docker',
                     'docker_upstream_name': item['upstream_name'],
                     'name': gen_string('alpha'),
-                    'url': constants.PULP_CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.pulp.registry_hub,
                 }
                 for item in LABELLED_REPOS
             ]
@@ -1908,11 +1908,11 @@ class TestDockerRepository:
         'repo_options',
         **datafactory.parametrized(
             {
-                constants.CONTAINER_UPSTREAM_NAME: {
+                settings.container.upstream_name: {
                     'content_type': 'docker',
-                    'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
+                    'docker_upstream_name': settings.container.upstream_name,
                     'name': gen_string('alphanumeric', 10),
-                    'url': constants.CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
             }
         ),
@@ -1949,12 +1949,12 @@ class TestDockerRepository:
         'repo_options',
         **datafactory.parametrized(
             {
-                constants.CONTAINER_UPSTREAM_NAME: {
+                settings.container.upstream_name: {
                     'content_type': 'docker',
                     'include_tags': ['latest', gen_string('alpha')],
-                    'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
+                    'docker_upstream_name': settings.container.upstream_name,
                     'name': gen_string('alphanumeric', 10),
-                    'url': constants.CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
             }
         ),
@@ -1980,12 +1980,12 @@ class TestDockerRepository:
         'repo_options',
         **datafactory.parametrized(
             {
-                constants.CONTAINER_UPSTREAM_NAME: {
+                settings.container.upstream_name: {
                     'content_type': 'docker',
                     'include_tags': [gen_string('alpha') for _ in range(3)],
-                    'docker_upstream_name': constants.CONTAINER_UPSTREAM_NAME,
+                    'docker_upstream_name': settings.container.upstream_name,
                     'name': gen_string('alphanumeric', 10),
-                    'url': constants.CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
             }
         ),

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -20,8 +20,6 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     FAKE_0_CUSTOM_PACKAGE_NAME,
     PULP_EXPORT_DIR,
 )
@@ -160,8 +158,8 @@ def _dictionarize_counts(data):
             'YumRepository': {'url': settings.repos.module_stream_1.url},
             'FileRepository': {'url': CUSTOM_FILE_REPO},
             'DockerRepository': {
-                'url': CONTAINER_REGISTRY_HUB,
-                'upstream_name': CONTAINER_UPSTREAM_NAME,
+                'url': settings.container.registry_hub,
+                'upstream_name': settings.container.upstream_name,
             },
             'AnsibleRepository': {
                 'url': ANSIBLE_GALAXY,
@@ -668,8 +666,8 @@ def test_positive_exported_imported_content_sync(
         {'content_type': 'file', 'url': CUSTOM_FILE_REPO},
         {
             'content_type': 'docker',
-            'docker_upstream_name': CONTAINER_UPSTREAM_NAME,
-            'url': CONTAINER_REGISTRY_HUB,
+            'docker_upstream_name': settings.container.upstream_name,
+            'url': settings.container.registry_hub,
         },
         {
             'content_type': 'ansible_collection',

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -16,8 +16,6 @@ from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     REPO_TYPE,
 )
 from robottelo.logging import logger
@@ -30,18 +28,18 @@ def _repo(sat, product_id, name=None, upstream_name=None, url=None):
     :param str name: Name for the repository. If ``None`` then a random
         value will be generated.
     :param str upstream_name: A valid name of an existing upstream repository.
-        If ``None`` then defaults to CONTAINER_UPSTREAM_NAME constant.
+        If ``None`` then defaults to settings.container.upstream_name constant.
     :param str url: URL of repository. If ``None`` then defaults to
-        CONTAINER_REGISTRY_HUB constant.
+        settings.container.registry_hub constant.
     :return: A ``Repository`` object.
     """
     return sat.cli_factory.make_repository(
         {
             'content-type': REPO_TYPE['docker'],
-            'docker-upstream-name': upstream_name or CONTAINER_UPSTREAM_NAME,
+            'docker-upstream-name': upstream_name or settings.container.upstream_name,
             'name': name or gen_string('alpha', 5),
             'product-id': product_id,
-            'url': url or CONTAINER_REGISTRY_HUB,
+            'url': url or settings.container.registry_hub,
         }
     )
 
@@ -149,7 +147,7 @@ class TestDockerClient:
         # create lifecycle environment and promote content view to it
         lce = target_sat.cli_factory.make_lifecycle_environment({'organization-id': module_org.id})
         product = target_sat.cli_factory.make_product_wait({'organization-id': module_org.id})
-        repo = _repo(target_sat, product['id'], upstream_name=CONTAINER_UPSTREAM_NAME)
+        repo = _repo(target_sat, product['id'], upstream_name=settings.container.upstream_name)
         target_sat.cli.Repository.synchronize({'id': repo['id']})
         content_view = target_sat.cli_factory.make_content_view(
             {'composite': False, 'organization-id': module_org.id}
@@ -172,11 +170,13 @@ class TestDockerClient:
         )
         docker_repo_uri = (
             f'{target_sat.hostname}/{pattern_prefix}-{content_view["label"]}/'
-            f'{CONTAINER_UPSTREAM_NAME}'
+            f'{settings.container.upstream_name}'
         ).lower()
 
         # 3. Try to search for docker images on Satellite
-        remote_search_command = f'docker search {target_sat.hostname}/{CONTAINER_UPSTREAM_NAME}'
+        remote_search_command = (
+            f'docker search {target_sat.hostname}/{settings.container.upstream_name}'
+        )
         result = module_container_contenthost.execute(remote_search_command)
         assert result.status == 0
         assert docker_repo_uri not in result.stdout
@@ -250,7 +250,7 @@ class TestDockerClient:
         :parametrized: yes
         """
         pattern_prefix = gen_string('alpha', 5)
-        docker_upstream_name = CONTAINER_UPSTREAM_NAME
+        docker_upstream_name = settings.container.upstream_name
         registry_name_pattern = (
             f'{pattern_prefix}-<%= content_view.label %>/<%= repository.docker_upstream_name %>'
         )
@@ -370,7 +370,10 @@ class TestDockerClient:
         )
 
         repo = _repo(
-            target_sat, product['id'], name=repo_name, upstream_name=CONTAINER_UPSTREAM_NAME
+            target_sat,
+            product['id'],
+            name=repo_name,
+            upstream_name=settings.container.upstream_name,
         )
 
         # 2. Sync the repos

--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1537,7 +1537,7 @@ class TestContentView:
                 'content-type': 'docker',
                 'docker-upstream-name': 'quay/busybox',
                 'product-id': module_product.id,
-                'url': constants.CONTAINER_REGISTRY_HUB,
+                'url': settings.container.registry_hub,
             }
         )
         # Sync all three repos
@@ -2546,10 +2546,10 @@ class TestContentView:
         docker_repository = module_target_sat.cli_factory.make_repository(
             {
                 'content-type': 'docker',
-                'docker-upstream-name': constants.CONTAINER_UPSTREAM_NAME,
+                'docker-upstream-name': settings.container.upstream_name,
                 'name': gen_string('alpha', 20),
                 'product-id': docker_product['id'],
-                'url': constants.CONTAINER_REGISTRY_HUB,
+                'url': settings.container.registry_hub,
             }
         )
         module_target_sat.cli.Repository.synchronize({'id': docker_repository['id']})
@@ -2776,10 +2776,10 @@ class TestContentView:
         docker_repository = module_target_sat.cli_factory.make_repository(
             {
                 'content-type': 'docker',
-                'docker-upstream-name': constants.CONTAINER_UPSTREAM_NAME,
+                'docker-upstream-name': settings.container.upstream_name,
                 'name': gen_string('alpha', 20),
                 'product-id': docker_product['id'],
-                'url': constants.CONTAINER_REGISTRY_HUB,
+                'url': settings.container.registry_hub,
             }
         )
         module_target_sat.cli.Repository.synchronize({'id': docker_repository['id']})
@@ -3644,10 +3644,10 @@ class TestContentViewFileRepo:
         repo = module_target_sat.cli_factory.make_repository(
             {
                 'content-type': 'docker',
-                'docker-upstream-name': constants.CONTAINER_UPSTREAM_NAME,
+                'docker-upstream-name': settings.container.upstream_name,
                 'name': gen_string('alpha', 20),
                 'product-id': module_product.id,
-                'url': constants.CONTAINER_REGISTRY_HUB,
+                'url': settings.container.registry_hub,
             }
         )
         module_target_sat.cli.Repository.synchronize({'id': repo['id']})

--- a/tests/foreman/cli/test_contentviewfilter.py
+++ b/tests/foreman/cli/test_contentviewfilter.py
@@ -18,7 +18,7 @@ from fauxfactory import gen_string
 import pytest
 
 from robottelo.cli.defaults import Defaults
-from robottelo.constants import CONTAINER_REGISTRY_HUB
+from robottelo.config import settings
 from robottelo.exceptions import CLIReturnCodeError
 from robottelo.utils.datafactory import (
     invalid_values_list,
@@ -435,7 +435,7 @@ class TestContentViewFilter:
                 'docker-upstream-name': 'busybox',
                 'organization-id': module_org.id,
                 'product-id': module_product.id,
-                'url': CONTAINER_REGISTRY_HUB,
+                'url': settings.container.registry_hub,
             },
         )
 
@@ -699,7 +699,7 @@ class TestContentViewFilter:
                 'docker-upstream-name': 'busybox',
                 'organization-id': module_org.id,
                 'product-id': module_product.id,
-                'url': CONTAINER_REGISTRY_HUB,
+                'url': settings.container.registry_hub,
             },
         )
         module_target_sat.cli.ContentView.add_repository(

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -15,9 +15,6 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_RH_REGISTRY_UPSTREAM_NAME,
-    CONTAINER_UPSTREAM_NAME,
     EXPIRED_MANIFEST,
     REPO_TYPE,
     DataFile,
@@ -38,18 +35,18 @@ def _repo(sat, product_id, name=None, upstream_name=None, url=None):
     :param str name: Name for the repository. If ``None`` then a random
         value will be generated.
     :param str upstream_name: A valid name of an existing upstream repository.
-        If ``None`` then defaults to CONTAINER_UPSTREAM_NAME constant.
+        If ``None`` then defaults to settings.container.upstream_name constant.
     :param str url: URL of repository. If ``None`` then defaults to
-        CONTAINER_REGISTRY_HUB constant.
+        settings.container.registry_hub constant.
     :return: A ``Repository`` object.
     """
     return sat.cli_factory.make_repository(
         {
             'content-type': REPO_TYPE['docker'],
-            'docker-upstream-name': upstream_name or CONTAINER_UPSTREAM_NAME,
+            'docker-upstream-name': upstream_name or settings.container.upstream_name,
             'name': name or gen_string('alpha', 5),
             'product-id': product_id,
-            'url': url or CONTAINER_REGISTRY_HUB,
+            'url': url or settings.container.registry_hub,
         }
     )
 
@@ -153,7 +150,7 @@ class TestDockerRepository:
         """
         repo = _repo(module_target_sat, module_product.id, name)
         assert repo['name'] == name
-        assert repo['upstream-repository-name'] == CONTAINER_UPSTREAM_NAME
+        assert repo['upstream-repository-name'] == settings.container.upstream_name
         assert repo['content-type'] == REPO_TYPE['docker']
 
     @pytest.mark.tier2
@@ -305,10 +302,10 @@ class TestDockerRepository:
         repo = _repo(
             module_target_sat,
             module_product.id,
-            upstream_name=CONTAINER_RH_REGISTRY_UPSTREAM_NAME,
+            upstream_name=settings.container.rh.upstream_name,
             url=settings.docker.external_registry_1,
         )
-        assert repo['upstream-repository-name'] == CONTAINER_RH_REGISTRY_UPSTREAM_NAME
+        assert repo['upstream-repository-name'] == settings.container.rh.upstream_name
 
     @pytest.mark.skip_if_not_set('docker')
     @pytest.mark.tier1
@@ -326,13 +323,13 @@ class TestDockerRepository:
         """
         module_target_sat.cli.Repository.update(
             {
-                'docker-upstream-name': CONTAINER_RH_REGISTRY_UPSTREAM_NAME,
+                'docker-upstream-name': settings.container.rh.upstream_name,
                 'id': repo['id'],
                 'url': settings.docker.external_registry_1,
             }
         )
         repo = module_target_sat.cli.Repository.info({'id': repo['id']})
-        assert repo['upstream-repository-name'] == CONTAINER_RH_REGISTRY_UPSTREAM_NAME
+        assert repo['upstream-repository-name'] == settings.container.rh.upstream_name
 
     @pytest.mark.tier2
     def test_positive_update_url(self, repo, module_target_sat):

--- a/tests/foreman/cli/test_repository.py
+++ b/tests/foreman/cli/test_repository.py
@@ -22,8 +22,6 @@ from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     CUSTOM_FILE_REPO_FILES_COUNT,
     CUSTOM_LOCAL_FOLDER,
     DOWNLOAD_POLICIES,
@@ -475,9 +473,9 @@ class TestRepository:
             [
                 {
                     'content-type': 'docker',
-                    'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
+                    'docker-upstream-name': settings.container.upstream_name,
                     'name': valid_docker_repository_names()[0],
-                    'url': CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
             ]
         ),
@@ -505,9 +503,9 @@ class TestRepository:
             [
                 {
                     'content-type': 'docker',
-                    'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
+                    'docker-upstream-name': settings.container.upstream_name,
                     'name': name,
-                    'url': CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
                 for name in valid_docker_repository_names()
             ]
@@ -756,9 +754,9 @@ class TestRepository:
             [
                 {
                     'content-type': 'docker',
-                    'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
+                    'docker-upstream-name': settings.container.upstream_name,
                     'name': valid_docker_repository_names()[0],
-                    'url': CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
             ]
         ),
@@ -803,9 +801,9 @@ class TestRepository:
             [
                 {
                     'content-type': 'docker',
-                    'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
+                    'docker-upstream-name': settings.container.upstream_name,
                     'name': valid_docker_repository_names()[0],
-                    'url': CONTAINER_REGISTRY_HUB,
+                    'url': settings.container.registry_hub,
                 }
             ]
         ),
@@ -837,8 +835,8 @@ class TestRepository:
             [
                 {
                     'content-type': 'docker',
-                    'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
-                    'url': CONTAINER_REGISTRY_HUB,
+                    'docker-upstream-name': settings.container.upstream_name,
+                    'url': settings.container.registry_hub,
                     'mirroring-policy': 'additive',
                 }
             ]
@@ -878,8 +876,8 @@ class TestRepository:
             [
                 {
                     'content-type': 'docker',
-                    'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
-                    'url': CONTAINER_REGISTRY_HUB,
+                    'docker-upstream-name': settings.container.upstream_name,
+                    'url': settings.container.registry_hub,
                     'mirroring-policy': 'mirror_content_only',
                 }
             ]
@@ -921,8 +919,8 @@ class TestRepository:
             [
                 {
                     'content-type': 'docker',
-                    'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
-                    'url': CONTAINER_REGISTRY_HUB,
+                    'docker-upstream-name': settings.container.upstream_name,
+                    'url': settings.container.registry_hub,
                     'include-tags': f"latest,{gen_string('alpha')}",
                 }
             ]

--- a/tests/foreman/cli/test_satellitesync.py
+++ b/tests/foreman/cli/test_satellitesync.py
@@ -22,8 +22,6 @@ from wait_for import wait_for
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     DEFAULT_ARCHITECTURE,
     DEFAULT_CV,
     ENVIRONMENT,
@@ -197,8 +195,8 @@ def function_synced_docker_repo(target_sat, function_org, function_product):
             'product-id': function_product.id,
             'content-type': REPO_TYPE['docker'],
             'download-policy': 'immediate',
-            'url': CONTAINER_REGISTRY_HUB,
-            'docker-upstream-name': CONTAINER_UPSTREAM_NAME,
+            'url': settings.container.registry_hub,
+            'docker-upstream-name': settings.container.upstream_name,
         }
     )
     target_sat.cli.Repository.synchronize({'id': repo['id']})

--- a/tests/foreman/cli/test_vm_install_products_package.py
+++ b/tests/foreman/cli/test_vm_install_products_package.py
@@ -17,8 +17,6 @@ import pytest
 
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     DISTROS_SUPPORTED,
     FAKE_0_CUSTOM_PACKAGE,
 )
@@ -43,8 +41,8 @@ def lce(function_sca_manifest_org, target_sat):
             'SatelliteToolsRepository': {'cdn': 'cdn', 'distro': 'distro'},
             'YumRepository': {'url': settings.repos.yum_0.url},
             'DockerRepository': {
-                'url': CONTAINER_REGISTRY_HUB,
-                'upstream_name': CONTAINER_UPSTREAM_NAME,
+                'url': settings.container.registry_hub,
+                'upstream_name': settings.container.upstream_name,
             },
         }
     ],

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -786,7 +786,7 @@ def test_positive_add_docker_repo_cv(session, module_org, module_target_sat):
     repo = module_target_sat.api.Repository(
         content_type=constants.REPO_TYPE['docker'],
         product=module_target_sat.api.Product(organization=module_org).create(),
-        url=constants.CONTAINER_REGISTRY_HUB,
+        url=settings.container.registry_hub,
     ).create()
     content_view = module_target_sat.api.ContentView(
         composite=False, organization=module_org, repository=[repo]
@@ -827,7 +827,7 @@ def test_positive_add_docker_repo_ccv(session, module_org, module_target_sat):
     repo = module_target_sat.api.Repository(
         content_type=constants.REPO_TYPE['docker'],
         product=module_target_sat.api.Product(organization=module_org).create(),
-        url=constants.CONTAINER_REGISTRY_HUB,
+        url=settings.container.registry_hub,
     ).create()
     content_view = module_target_sat.api.ContentView(
         composite=False, organization=module_org, repository=[repo]

--- a/tests/foreman/ui/test_containerimagetag.py
+++ b/tests/foreman/ui/test_containerimagetag.py
@@ -14,9 +14,8 @@
 
 import pytest
 
+from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     DEFAULT_CV,
     ENVIRONMENT,
     REPO_TYPE,
@@ -37,9 +36,9 @@ def module_product(module_org, module_target_sat):
 def module_repository(module_product, module_target_sat):
     repo = module_target_sat.api.Repository(
         content_type=REPO_TYPE['docker'],
-        docker_upstream_name=CONTAINER_UPSTREAM_NAME,
+        docker_upstream_name=settings.container.upstream_name,
         product=module_product,
-        url=CONTAINER_REGISTRY_HUB,
+        url=settings.container.registry_hub,
     ).create()
     repo.sync(timeout=1440)
     return repo

--- a/tests/foreman/ui/test_contentview_old.py
+++ b/tests/foreman/ui/test_contentview_old.py
@@ -28,8 +28,6 @@ from robottelo import constants
 from robottelo.cli.contentview import ContentView
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
-    CONTAINER_UPSTREAM_NAME,
     DEFAULT_ARCHITECTURE,
     DEFAULT_CV,
     DEFAULT_OS_SEARCH_QUERY,
@@ -255,7 +253,7 @@ def test_positive_create_composite(
         'releasever': None,
     }
     docker_repo = target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
 
     target_sat.api_factory.enable_sync_redhat_repo(rh_repo, org.id)
@@ -332,7 +330,7 @@ def test_positive_add_docker_repo(session, module_target_sat, module_org, module
         composite=False, organization=module_org
     ).create()
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     with session:
         session.contentview.add_docker_repo(content_view.name, repo.name)
@@ -357,7 +355,9 @@ def test_positive_add_docker_repos(session, module_target_sat, module_org, modul
     ).create()
     repos = [
         module_target_sat.api.Repository(
-            url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+            url=settings.container.registry_hub,
+            product=module_prod,
+            content_type=REPO_TYPE['docker'],
         ).create()
         for _ in range(randint(2, 3))
     ]
@@ -385,7 +385,7 @@ def test_positive_add_synced_docker_repo(session, module_target_sat, module_org,
         composite=False, organization=module_org
     ).create()
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     with session:
         result = session.sync_status.synchronize([(module_prod.name, repo.name)])
@@ -414,7 +414,7 @@ def test_positive_add_docker_repo_to_ccv(session, module_target_sat, module_org,
         composite=True, organization=module_org
     ).create()
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     with session:
         session.contentview.add_docker_repo(content_view.name, repo.name)
@@ -440,7 +440,9 @@ def test_positive_add_docker_repos_to_ccv(session, module_target_sat, module_org
     cvs = []
     for _ in range(randint(2, 3)):
         repo = module_target_sat.api.Repository(
-            url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+            url=settings.container.registry_hub,
+            product=module_prod,
+            content_type=REPO_TYPE['docker'],
         ).create()
         content_view = module_target_sat.api.ContentView(
             composite=False, organization=module_org, repository=[repo]
@@ -476,7 +478,7 @@ def test_positive_publish_with_docker_repo(session, module_target_sat, module_or
         composite=False, organization=module_org
     ).create()
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     with session:
         session.contentview.add_docker_repo(content_view.name, repo.name)
@@ -501,7 +503,7 @@ def test_positive_publish_with_docker_repo_composite(
     :CaseImportance: High
     """
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     content_view = module_target_sat.api.ContentView(
         composite=False, organization=module_org, repository=[repo]
@@ -532,7 +534,7 @@ def test_positive_publish_multiple_with_docker_repo(
     :CaseImportance: Low
     """
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     content_view = module_target_sat.api.ContentView(
         composite=False, organization=module_org, repository=[repo]
@@ -557,7 +559,7 @@ def test_positive_publish_multiple_with_docker_repo_composite(
     :CaseImportance: Low
     """
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     content_view = module_target_sat.api.ContentView(
         composite=False, organization=module_org, repository=[repo]
@@ -587,7 +589,7 @@ def test_positive_promote_with_docker_repo(session, module_target_sat, module_or
     """
     lce = module_target_sat.api.LifecycleEnvironment(organization=module_org).create()
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     content_view = module_target_sat.api.ContentView(
         composite=False, organization=module_org, repository=[repo]
@@ -614,7 +616,7 @@ def test_positive_promote_multiple_with_docker_repo(
     :CaseImportance: Low
     """
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     content_view = module_target_sat.api.ContentView(
         composite=False, organization=module_org, repository=[repo]
@@ -642,7 +644,7 @@ def test_positive_promote_multiple_with_docker_repo_composite(
         is promoted to multiple lifecycle-environments.
     """
     repo = module_target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     content_view = module_target_sat.api.ContentView(
         composite=False, organization=module_org, repository=[repo]
@@ -934,10 +936,10 @@ def test_positive_publish_composite_with_custom_content(
     }
     # Create docker repos and sync
     docker_repo1 = target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=product, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=product, content_type=REPO_TYPE['docker']
     ).create()
     docker_repo2 = target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=product, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=product, content_type=REPO_TYPE['docker']
     ).create()
     docker_repo1.sync()
     docker_repo2.sync()
@@ -1172,10 +1174,10 @@ def test_positive_promote_composite_with_custom_content(
         target_sat.api_factory.create_sync_custom_repo(repo_name=name, repo_url=url, org_id=org.id)
     # Create docker repo and sync
     docker_repo1 = target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=product, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=product, content_type=REPO_TYPE['docker']
     ).create()
     docker_repo2 = target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB,
+        url=settings.container.registry_hub,
         product=product,
         content_type=REPO_TYPE['docker'],
         docker_upstream_name='quay/busybox',
@@ -1418,7 +1420,7 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(
     repo = target_sat.cli_factory.RepositoryCollection(
         repositories=[
             target_sat.cli_factory.DockerRepository(
-                url=CONTAINER_REGISTRY_HUB, upstream_name=CONTAINER_UPSTREAM_NAME
+                url=settings.container.registry_hub, upstream_name=settings.container.upstream_name
             )
         ]
     )
@@ -1454,8 +1456,8 @@ def test_positive_remove_qe_promoted_cv_version_from_default_env(
             'distro': 'rhel7',
             'YumRepository': {'url': settings.repos.yum_0.url},
             'DockerRepository': {
-                'url': CONTAINER_REGISTRY_HUB,
-                'upstream_name': CONTAINER_UPSTREAM_NAME,
+                'url': settings.container.registry_hub,
+                'upstream_name': settings.container.upstream_name,
             },
         }
     ],
@@ -2635,7 +2637,7 @@ def test_positive_rh_mixed_content_end_to_end(
     """
     cv_name = gen_string('alpha')
     docker_repo = target_sat.api.Repository(
-        url=CONTAINER_REGISTRY_HUB, product=module_prod, content_type=REPO_TYPE['docker']
+        url=settings.container.registry_hub, product=module_prod, content_type=REPO_TYPE['docker']
     ).create()
     rh_st_repo = {
         'name': REPOS['rhst7']['name'],

--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -17,7 +17,7 @@ from fauxfactory import gen_integer, gen_string, gen_url
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import DOCKER_REPO_UPSTREAM_NAME, REPO_TYPE, REPOS
+from robottelo.constants import REPO_TYPE, REPOS
 from robottelo.hosts import ProxyHostError
 
 
@@ -499,15 +499,17 @@ def test_positive_repo_discovery(setup_http_proxy, module_target_sat, module_org
                 'repo_type': 'Container Images',
                 'create_repo.product_type': 'New Product',
                 'create_repo.product_content.product_name': product_name,
-                'registry_search': DOCKER_REPO_UPSTREAM_NAME,
+                'registry_search': settings.container.docker.repo_upstream_name,
                 'name': gen_string('alphanumeric', 10),
                 'username': settings.subscription.rhn_username,
                 'password': settings.subscription.rhn_password,
-                'discovered_repos.repos': DOCKER_REPO_UPSTREAM_NAME,
+                'discovered_repos.repos': settings.container.docker.repo_upstream_name,
             }
         )
         assert session.product.search(product_name)[0]['Name'] == product_name
         assert (
-            DOCKER_REPO_UPSTREAM_NAME
-            in session.repository.search(product_name, DOCKER_REPO_UPSTREAM_NAME)[0]['Name']
+            settings.container.docker.repo_upstream_name
+            in session.repository.search(
+                product_name, settings.container.docker.repo_upstream_name
+            )[0]['Name']
         )

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -21,7 +21,6 @@ import pytest
 from robottelo import constants
 from robottelo.config import settings
 from robottelo.constants import (
-    CONTAINER_REGISTRY_HUB,
     DOWNLOAD_POLICIES,
     INVALID_URL,
     PRDS,
@@ -765,7 +764,7 @@ def test_positive_delete_random_docker_repo(session, module_org, module_target_s
     ]
     for product in products:
         repo = module_target_sat.api.Repository(
-            url=CONTAINER_REGISTRY_HUB, product=product, content_type=REPO_TYPE['docker']
+            url=settings.container.registry_hub, product=product, content_type=REPO_TYPE['docker']
         ).create()
         entities_list.append((product.name, repo.name))
     with session:

--- a/tests/foreman/ui/test_sync.py
+++ b/tests/foreman/ui/test_sync.py
@@ -18,12 +18,10 @@ import pytest
 from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_ARCHITECTURE,
-    DOCKER_REPO_UPSTREAM_NAME,
     PRDS,
     REPO_TYPE,
     REPOS,
     REPOSET,
-    RH_CONTAINER_REGISTRY_HUB,
 )
 from robottelo.constants.repos import FEDORA_OSTREE_REPO
 
@@ -154,8 +152,8 @@ def test_positive_sync_docker_via_sync_status(session, module_org, module_target
             {
                 'name': repo_name,
                 'repo_type': REPO_TYPE['docker'],
-                'repo_content.upstream_url': RH_CONTAINER_REGISTRY_HUB,
-                'repo_content.upstream_repo_name': DOCKER_REPO_UPSTREAM_NAME,
+                'repo_content.upstream_url': settings.container.rh.registry_hub,
+                'repo_content.upstream_repo_name': settings.container.docker.repo_upstream_name,
                 'repo_content.upstream_username': settings.subscription.rhn_username,
                 'repo_content.upstream_password': settings.subscription.rhn_password,
             },

--- a/tests/new_upgrades/test_repository.py
+++ b/tests/new_upgrades/test_repository.py
@@ -22,7 +22,6 @@ from robottelo.constants import (
     FAKE_0_CUSTOM_PACKAGE_NAME,
     FAKE_4_CUSTOM_PACKAGE_NAME,
     LABELLED_REPOS,
-    PULP_CONTAINER_REGISTRY_HUB,
 )
 from robottelo.hosts import ContentHost
 from robottelo.utils.shared_resource import SharedResource
@@ -163,7 +162,7 @@ def container_repo_sync_setup(content_upgrade_shared_satellite, upgrade_action):
                 content_type='docker',
                 docker_upstream_name=item['upstream_name'],
                 product=product,
-                url=PULP_CONTAINER_REGISTRY_HUB,
+                url=settings.container.pulp.registry_hub,
             ).create()
             repo.sync()
             repo = repo.read()

--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -22,7 +22,6 @@ from robottelo.constants import (
     FAKE_0_CUSTOM_PACKAGE_NAME,
     FAKE_4_CUSTOM_PACKAGE_NAME,
     LABELLED_REPOS,
-    PULP_CONTAINER_REGISTRY_HUB,
     REPOS,
 )
 from robottelo.hosts import ContentHost
@@ -324,7 +323,7 @@ class TestScenarioContainerRepoSync:
                 content_type='docker',
                 docker_upstream_name=item['upstream_name'],
                 product=module_product,
-                url=PULP_CONTAINER_REGISTRY_HUB,
+                url=settings.container.pulp.registry_hub,
             ).create()
             repo.sync()
             repo = repo.read()


### PR DESCRIPTION
### Problem Statement

container related settings cannot be configured via settings file

### Solution

Move container related settings to yaml settings file

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->