### PR TITLE
Fix provisioning tests

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -309,7 +309,7 @@ def pxeless_discovery_host(provisioning_host, module_discovery_sat, pxe_loader):
     """Fixture for returning a pxe-less discovery host for provisioning"""
     sat = module_discovery_sat.sat
     image_name = f"{gen_string('alpha')}-{module_discovery_sat.iso}"
-    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    mac = provisioning_host.provisioning_nic_mac_addr
     # Remaster and upload discovery image to automatically input values
     result = sat.execute(
         'cd /var/www/html/pub && '

--- a/tests/foreman/api/test_discoveredhost.py
+++ b/tests/foreman/api/test_discoveredhost.py
@@ -198,7 +198,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+        mac = provisioning_host.provisioning_nic_mac_addr
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
@@ -383,7 +383,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+        mac = provisioning_host.provisioning_nic_mac_addr
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,
@@ -430,7 +430,7 @@ class TestDiscoveredHost:
         """
         sat = module_discovery_sat.sat
         provisioning_host.power_control(ensure=False)
-        mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+        mac = provisioning_host.provisioning_nic_mac_addr
         wait_for(
             lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
             timeout=1500,

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -98,7 +98,7 @@ def test_rhel_pxe_provisioning(
 
     :parametrized: yes
     """
-    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
@@ -238,7 +238,7 @@ def test_rhel_ipxe_provisioning(
         )
     )
     assert ipxe_http_url.status == 0
-    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
         organization=module_sca_manifest_org,
@@ -366,8 +366,7 @@ def test_rhel_httpboot_provisioning(
     sat = module_provisioning_sat.sat
     # update grub2-efi package
     sat.cli.Packages.update(packages='grub2-efi', options={'assumeyes': True})
-
-    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,
         organization=module_sca_manifest_org,
@@ -492,7 +491,7 @@ def test_rhel_pxe_provisioning_fips_enabled(
     :Verifies: SAT-26071
     """
     sat = module_provisioning_sat.sat
-    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     # Verify password hashing algorithm SHA512 is set in OS used for provisioning
     assert module_provisioning_rhel_content.os.password_hash == 'SHA512'
 
@@ -736,7 +735,7 @@ def test_capsule_pxe_provisioning(
 
     :parametrized: yes
     """
-    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = capsule_provisioning_sat.sat
     cap = module_capsule_configured
     host = sat.api.Host(

--- a/tests/foreman/api/test_provisioning_puppet.py
+++ b/tests/foreman/api/test_provisioning_puppet.py
@@ -133,7 +133,7 @@ def test_host_provisioning_with_external_puppetserver(
     :customerscenario: true
     """
     puppet_env = 'production'
-    host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
     host = sat.api.Host(
         hostgroup=provisioning_hostgroup,

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -924,7 +924,7 @@ class TestAnsibleAAPIntegration:
             1. All hosts managed by Satellite are added to Satellite inventory.
             2. Starting ansible-callback systemd service, starts a job_template execution in AAP
         """
-        host_mac_addr = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+        host_mac_addr = provisioning_host.provisioning_nic_mac_addr
         sat = module_provisioning_sat.sat
         aap_fqdn = settings.AAP_INTEGRATION.AAP_FQDN
         job_template = settings.AAP_INTEGRATION.callback_job_template

--- a/tests/foreman/cli/test_discoveredhost.py
+++ b/tests/foreman/cli/test_discoveredhost.py
@@ -50,8 +50,7 @@ def test_rhel_pxe_discovery_provisioning(
     """
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
-    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
-
+    mac = provisioning_host.provisioning_nic_mac_addr
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,

--- a/tests/foreman/ui/test_discoveredhost.py
+++ b/tests/foreman/ui/test_discoveredhost.py
@@ -81,7 +81,7 @@ def test_positive_provision_pxe_host(
     """
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
-    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    mac = provisioning_host.provisioning_nic_mac_addr
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,
@@ -164,7 +164,7 @@ def test_positive_custom_provision_pxe_host(
     """
     sat = module_discovery_sat.sat
     provisioning_host.power_control(ensure=False)
-    mac = provisioning_host._broker_facts['provisioning_nic_mac_addr']
+    mac = provisioning_host.provisioning_nic_mac_addr
     wait_for(
         lambda: sat.api.DiscoveredHost().search(query={'mac': mac}) != [],
         timeout=1500,


### PR DESCRIPTION
### Problem Statement
Provisioning tests are failing with `AttributeError: 'ContentHost' object has no attribute '_broker_facts'. Did you mean: '_broker_args'?` 

### Solution
Fix the test