### PR TITLE
[6.14.z] Add a default location to the non-admin user to support Ansible role synchronization.

### DIFF
--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -595,7 +595,14 @@ class TestAnsibleREX:
     @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     @pytest.mark.parametrize('auth_type', ['admin', 'non-admin'])
     def test_positive_ansible_variables_imported_with_roles(
-        self, request, auth_type, target_sat, module_org, module_ak_with_cv, rhel_contenthost
+        self,
+        request,
+        auth_type,
+        target_sat,
+        module_org,
+        default_location,
+        module_ak_with_cv,
+        rhel_contenthost,
     ):
         """Verify that when Ansible roles are imported, their variables are imported simultaneously
 
@@ -624,6 +631,7 @@ class TestAnsibleREX:
                     'login': username,
                     'password': password,
                     'organization-ids': module_org.id,
+                    'location-ids': default_location.id,
                 }
             )
             target_sat.cli.User.add_role(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17556

When a non-admin user is created with only an organization, and we set Satellite to a specific organization the host registers successfully but does not appears on Satellite. 
To resolve this issue, a non-admin user was created with both an organization and a default location. This ensures that when the host is registered with the user, it remains visible. Additionally, when we select only the organization in Satellite, the host becomes visible, allowing it to identify the proxy ID and execute the Ansible sync role. This fix prevents post-upgrade failure.