### PR TITLE
Add workaround for SAT-30807 to use proxy for connecting to ansible-galaxy

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -888,6 +888,13 @@ class ContentHost(Host, ContentHostMixins):
             url = urlparse(settings.http_proxy.http_proxy_ipv6_url)
             self.enable_dnf_proxy(url.hostname, url.scheme, url.port)
 
+    def enable_ipv6_system_proxy(self):
+        """Execute procedures for enabling IPv6 HTTP Proxy on system"""
+        if self.ipv6:
+            self.execute(
+                f'echo "export HTTPS_PROXY={settings.http_proxy.http_proxy_ipv6_url}" >> ~/.bashrc'
+            )
+
     def disable_rhsm_proxy(self):
         """Disables HTTP proxy for subscription manager"""
         self.execute('subscription-manager remove server.proxy_hostname server.proxy_port')

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -602,10 +602,14 @@ class TestAnsibleREX:
             5. Run REX job to install Ansible collection on content host.
 
         :expectedresults: Ansible collection can be installed on content host via REX.
+
+        :verifies: SAT-30807
         """
         client = rhel_contenthost
         # Adding IPv6 proxy for IPv6 communication
         client.enable_ipv6_dnf_and_rhsm_proxy()
+        if is_open('SAT-30807'):
+            rhel_contenthost.enable_ipv6_system_proxy()
         # Enable Ansible repository and Install ansible or ansible-core package
         client.register(module_org, None, module_ak_with_cv.name, target_sat)
         rhel_repo_urls = getattr(settings.repos, f'rhel{client.os_version.major}_os', None)

--- a/tests/foreman/ui/test_ansible.py
+++ b/tests/foreman/ui/test_ansible.py
@@ -787,9 +787,13 @@ class TestAnsibleREX:
             6. Click "Submit"
 
         :expectedresults: The Ansible collection is successfully installed on the host
+
+        :verifies: SAT-30807
         """
         # Adding IPv6 proxy for IPv6 communication
         rhel_contenthost.enable_ipv6_dnf_and_rhsm_proxy()
+        if is_open('SAT-30807'):
+            rhel_contenthost.enable_ipv6_system_proxy()
         client = rhel_contenthost
         # Enable Ansible repository and Install ansible or ansible-core package
         client.register(module_org, None, module_ak_with_cv.name, target_sat)


### PR DESCRIPTION
### Problem Statement
In SAT-30807, "Ansible Collection - Install from Galaxy" job times out when run on IPv6 host

### Solution
Add workaround for SAT-30807 to use proxy for connecting to ansible-galaxy

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->