### PR TITLE
Set Capsule autosync explicitly

### DIFF
--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -787,10 +787,12 @@ def test_positive_repair_artifacts(
 
 @pytest.mark.e2e
 @pytest.mark.parametrize('function_flatpak_remote', ['RedHat'], indirect=True)
+@pytest.mark.parametrize('setting_update', ['foreman_proxy_content_auto_sync=True'], indirect=True)
 def test_sync_consume_flatpak_repo_via_library(
     request,
     module_target_sat,
     module_capsule_configured,
+    setting_update,
     module_flatpak_contenthost,
     function_org,
     function_product,
@@ -800,6 +802,8 @@ def test_sync_consume_flatpak_repo_via_library(
     """Verify flatpak repository workflow via capsule end to end.
 
     :id: 8871b695-18fd-45a8-bb40-664c384996a0
+
+    :parametrized: yes
 
     :setup:
         1. Registered external capsule.


### PR DESCRIPTION
### Problem Statement
Test fails in CI in `wait_for_sync`
```
tests/foreman/cli/test_capsulecontent.py:855: in test_sync_consume_flatpak_repo_via_library
    module_capsule_configured.wait_for_sync(start_time=timestamp)
robottelo/host_helpers/capsule_mixins.py:105: in wait_for_sync
    assert len(sync_status['active_sync_tasks']) or (
E   AssertionError: No active or recent sync found for capsule ...
```
It looks like the autosync was turned OFF.


### Solution
For now turn the autosync ON explicitly and see what happens.
Optionally we could trigger the sync from test.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_capsulecontent.py -k test_sync_consume_flatpak_repo_via_library
```
