### PR TITLE
[6.15.z] Fix failing provisioning tests due to the sat workflow update

### DIFF
--- a/pytest_fixtures/component/provision_capsule_pxe.py
+++ b/pytest_fixtures/component/provision_capsule_pxe.py
@@ -45,7 +45,7 @@ def capsule_provisioning_sat(
     )
 
     broker_data_out = Box(**broker_data_out['data_out'])
-    provisioning_interface = ipaddress.ip_interface(broker_data_out.provisioning_addr_ipv4)
+    provisioning_interface = ipaddress.ip_interface(broker_data_out.provisioning_addr_ip)
     provisioning_network = provisioning_interface.network
     # TODO: investigate DNS setup issue on Satellite,
     # we might need to set up Sat's DNS server as the primary one on the Sat host
@@ -69,7 +69,7 @@ def capsule_provisioning_sat(
         organization=[module_sca_manifest_org],
         network=str(provisioning_network.network_address),
         mask=str(provisioning_network.netmask),
-        gateway=broker_data_out.provisioning_gw_ipv4,
+        gateway=broker_data_out.provisioning_gw_ip,
         from_=broker_data_out.provisioning_host_range_start,
         to=broker_data_out.provisioning_host_range_end,
         dns_primary=provisioning_upstream_dns_primary,
@@ -119,7 +119,7 @@ def capsule_provisioning_hostgroup(
     module_capsule_configured,
 ):
     capsule = module_capsule_configured.nailgun_smart_proxy
-    provisioning_ip = capsule_provisioning_sat.broker_data.provisioning_addr_ipv4
+    provisioning_ip = capsule_provisioning_sat.broker_data.provisioning_addr_ip
     provisioning_ip = ipaddress.ip_interface(provisioning_ip).ip
     return capsule_provisioning_sat.sat.api.HostGroup(
         organization=[module_sca_manifest_org],

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -161,7 +161,7 @@ def module_provisioning_sat(
     )
 
     broker_data_out = Box(**broker_data_out['data_out'])
-    provisioning_interface = ipaddress.ip_interface(broker_data_out.provisioning_addr_ipv4)
+    provisioning_interface = ipaddress.ip_interface(broker_data_out.provisioning_addr_ip)
     provisioning_network = provisioning_interface.network
     # TODO: investigate DNS setup issue on Satellite,
     # we might need to set up Sat's DNS server as the primary one on the Sat host
@@ -186,7 +186,7 @@ def module_provisioning_sat(
         organization=[module_sca_manifest_org],
         network=str(provisioning_network.network_address),
         mask=str(provisioning_network.netmask),
-        gateway=broker_data_out.provisioning_gw_ipv4,
+        gateway=broker_data_out.provisioning_gw_ip,
         from_=broker_data_out.provisioning_host_range_start,
         to=broker_data_out.provisioning_host_range_end,
         dns_primary=provisioning_upstream_dns_primary,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17595

### Problem Statement
The provisioning tests are failing due to the recent sat workflow update

### Solution
Fix/update the tests 