### PR TITLE
[CustomerCase] Test Errata type "Other", with inclusive CV Filter, verify content counts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v0.9.6
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--fix, --exit-non-zero-on-fix, --target-version=py310]
       - id: ruff-format
   - repo: local
     hooks:


### PR DESCRIPTION
### Purpose:
Covers CustomerCase: SAT-24725 ([BZ: 2160804](https://bugzilla.redhat.com/show_bug.cgi?id=2160804))
- We use the EPEL 10 repository to sync real Erratum of types that fall under 'Other' (ie newpackage , unspecified)
- We need to fetch a dynamically created PGP key from https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10
- Syncing EPEL version 10, because it matches the newest RHEL version from supportability

Closely following DEV Testing Steps from Katello MR: https://github.com/Katello/katello/pull/11188
### Steps (condensed):
GET request to receive a new PGP key from FedoraProject.
Create a GPG key on satellite from the PGP key received, create product with the GPG assigned.
Use the GPG key to create and sync, large EPEL 10 (x86_64 - everything) as a custom repository.
Publish the 1st CV version with EPEL repo contents added.
Add inclusive Erratum (by Date) CV filter with rules:
- `'start_date'` left unspecified (None)
- `'end_date'` Today (UTC)
- `'allow-other-types'` True

Add inclusive RPM CV filter (All)
Publish the 2nd CV Version with filtering (~10 minutes).

### Expected Results:
- Erratum and RPM counts are the same between the filtered and unfiltered versions.
- Inclusive filtering of all Errata (by date), including 'Other' types, does not affect RPM filtering or package counts 
for the next published version. 
- The EPEL repository's Erratum are overwhelmingly types that are 'Other' , we can verify this in the content counts.


### PRT Case:
```
trigger: test-robottelo
pytest: tests/foreman/api/test_errata.py::test_positive_filter_errata_type_other
```