### PR TITLE
Add end-to-end test for EC2 Compute Resource

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -58,6 +58,7 @@ pytest_plugins = [
     'pytest_fixtures.component.permissions',
     'pytest_fixtures.component.provision_azure',
     'pytest_fixtures.component.provision_gce',
+    'pytest_fixtures.component.provision_ec2',
     'pytest_fixtures.component.provision_libvirt',
     'pytest_fixtures.component.provision_pxe',
     'pytest_fixtures.component.provision_capsule_pxe',

--- a/pytest_fixtures/component/provision_ec2.py
+++ b/pytest_fixtures/component/provision_ec2.py
@@ -1,0 +1,135 @@
+# EC2 CR Fixtures
+from fauxfactory import gen_string
+import pytest
+from wrapanapi import EC2System
+
+from robottelo.config import settings
+from robottelo.constants import (
+    DEFAULT_ARCHITECTURE,
+    DEFAULT_OS_SEARCH_QUERY,
+    DEFAULT_PTABLE,
+)
+
+
+@pytest.fixture(scope='module')
+def sat_ec2(request, session_target_sat):
+    hosts = {'sat': session_target_sat}
+    return hosts[request.param]
+
+
+@pytest.fixture(scope='module')
+def sat_ec2_org(sat_ec2):
+    return sat_ec2.api.Organization().create()
+
+
+@pytest.fixture(scope='module')
+def sat_ec2_loc(sat_ec2):
+    return sat_ec2.api.Location().create()
+
+
+@pytest.fixture(scope='module')
+def sat_ec2_domain(sat_ec2, sat_ec2_loc, sat_ec2_org):
+    return sat_ec2.api.Domain(location=[sat_ec2_loc], organization=[sat_ec2_org]).create()
+
+
+@pytest.fixture(scope='module')
+def sat_ec2_default_os(sat_ec2):
+    """Default OS on the Satellite"""
+    return sat_ec2.api.OperatingSystem().search(query={'search': DEFAULT_OS_SEARCH_QUERY})[0].read()
+
+
+@pytest.fixture(scope='module')
+def sat_ec2_default_architecture(sat_ec2):
+    return (
+        sat_ec2.api.Architecture()
+        .search(query={'search': f'name="{DEFAULT_ARCHITECTURE}"'})[0]
+        .read()
+    )
+
+
+@pytest.fixture(scope='module')
+def sat_ec2_default_partition_table(sat_ec2):
+    # Get the Partition table ID
+    return sat_ec2.api.PartitionTable().search(query={'search': f'name="{DEFAULT_PTABLE}"'})[0]
+
+
+@pytest.fixture(scope='module')
+def ec2_settings():
+    return dict(
+        access_key=settings.ec2.access_key,
+        secret_key=settings.ec2.secret_key,
+        region=settings.ec2.region,
+        image=settings.ec2.image,
+        availability_zone=settings.ec2.availability_zone,
+        subnet=settings.ec2.subnet,
+        security_groups=settings.ec2.security_groups,
+        managed_ip=settings.ec2.managed_ip,
+    )
+
+
+@pytest.fixture(scope='module')
+def ec2client(ec2_settings):
+    """Connect to EC2 using wrapanapi EC2System"""
+    ec2client = EC2System(
+        username=ec2_settings['access_key'],
+        password=ec2_settings['secret_key'],
+        region=ec2_settings['region'],
+    )
+    yield ec2client
+    ec2client.disconnect()
+
+
+@pytest.fixture(scope='module')
+def module_ec2_cr(ec2_settings, sat_ec2_org, sat_ec2_loc, sat_ec2):
+    """Create EC2 Compute Resource"""
+    return sat_ec2.api.EC2ComputeResource(
+        name=gen_string('alpha'),
+        provider='EC2',
+        user=ec2_settings['access_key'],
+        password=ec2_settings['secret_key'],
+        region=ec2_settings['region'],
+        organization=[sat_ec2_org],
+        location=[sat_ec2_loc],
+    ).create()
+
+
+@pytest.fixture(scope='module')
+def ec2_hostgroup(
+    sat_ec2,
+    sat_ec2_default_architecture,
+    module_ec2_cr,
+    sat_ec2_domain,
+    sat_ec2_loc,
+    sat_ec2_default_os,
+    sat_ec2_org,
+    sat_ec2_default_partition_table,
+):
+    """Sets Hostgroup for EC2 Host Provisioning"""
+    return sat_ec2.api.HostGroup(
+        architecture=sat_ec2_default_architecture,
+        compute_resource=module_ec2_cr,
+        domain=sat_ec2_domain,
+        location=[sat_ec2_loc],
+        root_pass="dog8code",
+        operatingsystem=sat_ec2_default_os,
+        organization=[sat_ec2_org],
+        ptable=sat_ec2_default_partition_table,
+    ).create()
+
+
+@pytest.fixture(scope='module')
+def module_ec2_finishimg(
+    sat_ec2_default_architecture,
+    sat_ec2_default_os,
+    sat_ec2,
+    module_ec2_cr,
+):
+    """Creates Finish Template image on EC2 Compute Resource"""
+    return sat_ec2.api.Image(
+        architecture=sat_ec2_default_architecture,
+        compute_resource=module_ec2_cr,
+        name=gen_string('alpha'),
+        operatingsystem=sat_ec2_default_os,
+        username="root",
+        uuid=settings.ec2.image,
+    ).create()

--- a/tests/foreman/api/test_computeresource_ec2.py
+++ b/tests/foreman/api/test_computeresource_ec2.py
@@ -1,0 +1,105 @@
+"""Test class for EC2 Compute Resource
+
+:Requirement: Computeresource EC2
+
+:CaseAutomation: Automated
+
+:CaseComponent: ComputeResources-EC2
+
+:Team: Rocket
+
+:CaseImportance: High
+
+"""
+
+from fauxfactory import gen_string
+import pytest
+
+from robottelo.config import settings
+
+
+@pytest.mark.run_in_one_thread
+class TestEC2CustomImageFinishTemplateProvisioning:
+    """EC2 Host Provisioning Tests with Custom Image"""
+
+    @pytest.fixture(scope='class', autouse=True)
+    def class_setup(
+        self,
+        request,
+        sat_ec2_domain,
+        module_ec2_cr,
+    ):
+        """
+        Sets Constants for all the Tests, fixtures which will be later used for assertions
+        """
+        request.cls.region = settings.ec2.region
+        request.cls.hostname = f'test{gen_string("alpha")}'
+        request.cls.fullhostname = f'{self.hostname}.{sat_ec2_domain.name}'.lower()
+
+    @pytest.fixture(scope='class')
+    def class_host_custom_ft(
+        self,
+        sat_ec2,
+        module_ec2_finishimg,
+        sat_ec2_default_architecture,
+        sat_ec2_domain,
+        sat_ec2_loc,
+        sat_ec2_org,
+        sat_ec2_default_os,
+        ec2_hostgroup,
+    ):
+        """
+        Provisions the host on EC2 using Finish template
+        Later in tests this host will be used to perform assertions
+        """
+        with sat_ec2.skip_yum_update_during_provisioning(template='Kickstart default finish'):
+            host = sat_ec2.api.Host(
+                architecture=sat_ec2_default_architecture,
+                domain=sat_ec2_domain,
+                hostgroup=ec2_hostgroup,
+                organization=sat_ec2_org,
+                operatingsystem=sat_ec2_default_os,
+                location=sat_ec2_loc,
+                name=self.hostname,
+                provision_method='image',
+                image=module_ec2_finishimg,
+                root_pass=gen_string('alphanumeric'),
+            ).create()
+            yield host
+
+    @pytest.fixture(scope='class')
+    def ec2client_host(self, ec2client, class_host_custom_ft):
+        """Returns the EC2 Client Host object to perform the assertions"""
+
+        return ec2client.get_vm(name=class_host_custom_ft.name.split('.')[0])
+
+    @pytest.mark.upgrade
+    @pytest.mark.parametrize('sat_ec2', ['sat'], indirect=True)
+    @pytest.mark.parametrize('setting_update', ['destroy_vm_on_host_delete=True'], indirect=True)
+    def test_positive_ec2_custom_image_host_provisioned(
+        self, class_host_custom_ft, ec2client_host, setting_update
+    ):
+        """Host can be provisioned on EC2 using Custom Image
+
+        :id: ba056978-f563-4836-8336-e1d1de97ff08
+
+        :CaseImportance: Critical
+
+        :steps:
+            1. Create an EC2 Compute Resource with Custom Image and provision host.
+
+        :expectedresults:
+            1. The host should be provisioned on EC2 using Custom Image
+            2. The host name should be the same as given in data to provision the host
+            3. The host should show Installed status for provisioned host
+            4. The provisioned host should be assigned with external IP
+            5. The host Name and Platform should be same on ec2 Cloud as provided during
+               provisioned
+
+        """
+        assert class_host_custom_ft.name == self.fullhostname
+        assert class_host_custom_ft.build_status_label == "Installed"
+        assert class_host_custom_ft.ip == ec2client_host.ip
+
+        # ec2 cloud
+        assert self.hostname.lower() == ec2client_host.name


### PR DESCRIPTION
### Problem Statement
Provisioning host on EC2 was not covered.

### Solution
Added Provisioning host on EC2.

### Related Issues
https://github.com/SatelliteQE/nailgun/pull/1301

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->