### PR TITLE
RFE: extended test for new job_invocations detail page, vol. 2

### DIFF
--- a/tests/foreman/ui/test_remoteexecution.py
+++ b/tests/foreman/ui/test_remoteexecution.py
@@ -20,6 +20,7 @@ from inflection import camelize
 import pytest
 from wait_for import wait_for
 
+from robottelo.constants import ANY_CONTEXT
 from robottelo.utils.datafactory import (
     gen_string,
     valid_hostgroups_list_short,
@@ -397,7 +398,7 @@ def test_positive_run_scheduled_job_template_by_ip(session, module_org, rex_cont
 @pytest.mark.rhel_ver_list('8')
 @pytest.mark.usefixtures('setting_update')
 @pytest.mark.parametrize('setting_update', ['lab_features=true'], indirect=True)
-def test_positive_check_job_invocation_details_page(target_sat, module_org, rex_contenthost):
+def test_positive_check_job_invocation_details_page(target_sat, rex_contenthost):
     """
     Run a remote job and check the job invocations detail page for correct values.
 
@@ -410,11 +411,12 @@ def test_positive_check_job_invocation_details_page(target_sat, module_org, rex_
     :expectedresults:
         1. It should report the job name in the title.
         2. It should report the correct numbers in Succeeded, Failed, In Progres and Cancelled fields.
-        3. It should report the correct template name that was used.
+        3. It should report correct information, like, template name that was used, host search query,
+            organization, location and command.
 
     :CaseImportance: High
 
-    :Verifies: SAT-18427
+    :Verifies: SAT-18427, SAT-26605
 
     :parametrized: yes
     """
@@ -424,6 +426,7 @@ def test_positive_check_job_invocation_details_page(target_sat, module_org, rex_
     command = f'echo {correlation_id}'
     job_name = f'Run {command}'
     template_name = 'Run Command - Script Default'
+    host_search_query = f'name = {client.hostname}'
     jobs_succeeded = 1
     total_hosts = 1
 
@@ -434,12 +437,13 @@ def test_positive_check_job_invocation_details_page(target_sat, module_org, rex_
         synchronous=False,
         data={
             'job_template_id': template_id,
-            'organization': module_org.name,
+            'organization': ANY_CONTEXT['org'],
+            'location': ANY_CONTEXT['location'],
             'inputs': {
                 'command': command,
             },
             'targeting_type': 'static_query',
-            'search_query': f'name = {client.hostname}',
+            'search_query': host_search_query,
         },
     )
     target_sat.wait_for_tasks(f'resource_type = JobInvocation and resource_id = {job["id"]}')
@@ -456,5 +460,9 @@ def test_positive_check_job_invocation_details_page(target_sat, module_org, rex_
         assert status['status']['Succeeded'] == jobs_succeeded
         assert status['status']['Failed'] == 0
         assert status['status']['In Progress'] == 0
-        assert status['status']['Canceled'] == 0
+        assert status['status']['Cancelled'] == 0
         assert status['overview']['Template'] == template_name
+        assert status['target_hosts']['search_query'] == host_search_query
+        assert status['target_hosts']['data']['Organization'] == ANY_CONTEXT['org']
+        assert status['target_hosts']['data']['Location'] == ANY_CONTEXT['location']
+        assert status['user_inputs']['data']['command'] == command


### PR DESCRIPTION
### RFE SAT-26605: new job_invocations detail page, vol. 2 ###

Requires https://github.com/SatelliteQE/airgun/pull/1743

This PR extends the new job invocations detail page testing
with new widgets that have been added as part of SAT-26605 RFE.
Namely the expandable sections `Target Hosts` and `User Inputs`.

The expandable hosts table will be added in a separate PR,
see more details why in the linked airgun PR above.
