### PR TITLE
vmware provision test, missing customerscenario tag

### DIFF
--- a/tests/foreman/cli/test_computeresource_vmware.py
+++ b/tests/foreman/cli/test_computeresource_vmware.py
@@ -111,6 +111,8 @@ def test_positive_provision_end_to_end(
     :expectedresults: Host is provisioned succesfully with hostgroup
 
     :Verifies: SAT-25810
+
+    :customerscenario: true
     """
     sat = module_provisioning_sat.sat
     hostname = gen_string('alpha').lower()


### PR DESCRIPTION
### Problem Statement
automation reported this, closes 
https://github.com/SatelliteQE/robottelo/issues/17554
https://github.com/SatelliteQE/robottelo/issues/17603
### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->