### PR TITLE
[6.16.z] Fix puppet tests by using proxy for connecting to puppet forgeapis

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2085,8 +2085,13 @@ class Satellite(Capsule, SatelliteMixins):
             f'curl -O {settings.robottelo.repos_hosting_url}{CUSTOM_PUPPET_MODULE_REPOS_PATH}'
             f'{custom_puppet_module_repo}',
         )
+        http_proxy = (
+            f'HTTP_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
+            if settings.server.is_ipv6
+            else ''
+        )
         self.execute(
-            f'puppet module install {custom_puppet_module_repo} '
+            f'{http_proxy}puppet module install {custom_puppet_module_repo} '
             f'--target-dir /etc/puppetlabs/code/environments/{env_name}/modules/'
         )
         smart_proxy = (


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17613

### Problem Statement
puppet forgeapis FQDN is unreachable from IPv6 sat

### Solution
Fix puppet tests by using proxy for connecting to puppet forgeapis

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->