### PR TITLE
Add issue SAT-5118 to test_positive_set_default_http_proxy

### DIFF
--- a/tests/foreman/ui/test_http_proxy.py
+++ b/tests/foreman/ui/test_http_proxy.py
@@ -263,10 +263,12 @@ def test_positive_set_default_http_proxy(
         4. Verify the "Default HTTP Proxy" setting with created above.
         5. Update "Default HTTP Proxy" to "no global default".
 
-    :Verifies: SAT-28860
-
     :expectedresults: Creating Http Proxy with option "Default content HTTP proxy",
         updates setting "Default HTTP Proxy" succesfully.
+
+    :verifies: SAT-5118, SAT-28860
+
+    :customerscenario: true
     """
     property_name = setting_update.name
     http_proxy_name = gen_string('alpha', 15)


### PR DESCRIPTION
### Problem Statement
We missed adding related issue in `test_positive_set_default_http_proxy` in PR https://github.com/SatelliteQE/robottelo/pull/17153

### Solution
Add issue SAT-5118 in test_positive_set_default_http_proxy


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->