### PR TITLE
AK UI test fix

### DIFF
--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -960,7 +960,7 @@ def test_negative_usage_limit(
     assert vm1.subscribed
     result = vm2.register(module_org, None, name, target_sat)
     assert not vm2.subscribed
-    assert len(result.stderr)
+    assert result.status
     assert f'Max Hosts ({hosts_limit}) reached for activation key' in str(result.stderr)
 
 

--- a/tests/foreman/ui/test_activationkey.py
+++ b/tests/foreman/ui/test_activationkey.py
@@ -1147,10 +1147,3 @@ def test_positive_new_ak_lce_cv_assignment(target_sat):
         assert (
             ak_values['details']['lce']['Library']['Library'] == True  # noqa: E712, explicit comparison fits this case
         ), 'Library view is not assigned to newly created AK'
-
-
-def test_dummy(target_sat):
-    with target_sat.ui_session() as session:
-        # name = gen_string('alpha')
-        # print(name)
-        session.activationkey.update_ak_host_limit("testKey", 'unlimitedAAAA')


### PR DESCRIPTION
### Problem Statement
One AK UI test was failing due to outdated airgun and test composition

### Solution
This PR and Related Airgun PR fixes this test

### Related issues
This PR needs https://github.com/SatelliteQE/airgun/pull/1744

<img width="146" alt="image" src="https://github.com/user-attachments/assets/eda6156b-9fee-412b-9333-3fdbcd05ac7d" />

RHEL9 test fails with, 

`500 Server Error: Internal Server Error (can only create exec sessions on running containers: container state improper)`

thus not related to this PR.

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_activationkey.py -k 'test_negative_usage_limit'
airgun: 1744
```