### PR TITLE
[6.15.z Cherrypick]Fix assertion for installing katello-ca cert and updating rhel_contenthost fixture to test default rhel version

### DIFF
--- a/tests/foreman/cli/test_registration.py
+++ b/tests/foreman/cli/test_registration.py
@@ -107,9 +107,8 @@ def test_host_registration_end_to_end(
     assert rhel_contenthost.subscription_config['server']['port'] == CLIENT_PORT
 
 
-def test_upgrade_katello_ca_consumer_rpm(
-    module_org, module_location, target_sat, rhel7_contenthost
-):
+@pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
+def test_upgrade_katello_ca_consumer_rpm(module_org, module_location, target_sat, rhel_contenthost):
     """After updating the consumer cert the rhsm.conf file still points to Satellite host name
     and not Red Hat CDN for subscription.
 
@@ -135,11 +134,12 @@ def test_upgrade_katello_ca_consumer_rpm(
     consumer_cert_src = f'{consumer_cert_name}-1.0-1.src.rpm'
     new_consumer_cert_rpm = f'{consumer_cert_name}-1.0-2.noarch.rpm'
     spec_file = f'{consumer_cert_name}.spec'
-    vm = rhel7_contenthost
+    vm = rhel_contenthost
     # Install consumer cert and check server URL in /etc/rhsm/rhsm.conf
-    assert vm.execute(
+    result = vm.execute(
         f'rpm -Uvh "http://{target_sat.hostname}/pub/{consumer_cert_name}-1.0-1.noarch.rpm"'
     )
+    assert result.status == 0
     # Check server URL is not Red Hat CDN's "subscription.rhsm.redhat.com"
     assert vm.subscription_config['server']['hostname'] != 'subscription.rhsm.redhat.com'
     assert target_sat.hostname == vm.subscription_config['server']['hostname']


### PR DESCRIPTION
…updating rhel_contenthost fixture to test default rhel version]

### Problem Statement
Failed auto-cherrypick https://github.com/SatelliteQE/robottelo/issues/17626

### Solution
Manually cherrypicked.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->