### PR TITLE
ReportTemplates Coverage for RHEL10 hosts

### DIFF
--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -356,7 +356,7 @@ def test_negative_create_report_without_name(module_target_sat):
 
 
 @pytest.mark.tier2
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.no_containers
 def test_positive_applied_errata(
     rhel_contenthost, target_sat, function_location, function_org, function_lce
@@ -428,7 +428,7 @@ def test_positive_applied_errata(
 
 
 @pytest.mark.tier2
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.no_containers
 def test_positive_applied_errata_report_with_invalid_errata(
     rhel_contenthost,
@@ -505,7 +505,7 @@ def test_positive_applied_errata_report_with_invalid_errata(
 
 
 @pytest.mark.tier2
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.no_containers
 def test_positive_applied_errata_by_search(
     rhel_contenthost, target_sat, function_org, function_lce
@@ -765,7 +765,7 @@ def test_positive_generate_job_report(setup_content, module_target_sat, content_
 
 @pytest.mark.tier2
 @pytest.mark.no_containers
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match('N-2')
 def test_positive_installable_errata(
     target_sat, function_org, function_lce, function_location, rhel_contenthost
 ):
@@ -879,7 +879,7 @@ def test_positive_installable_errata(
 
 
 @pytest.mark.tier2
-@pytest.mark.rhel_ver_match('[^6]')
+@pytest.mark.rhel_ver_match('N-2')
 def test_positive_installed_products(
     target_sat,
     rhel_contenthost,

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -924,14 +924,14 @@ def test_negative_generate_hostpkgcompare_nonexistent_host(module_target_sat):
     assert "At least one of the hosts couldn't be found" in cm.value.stderr
 
 
-@pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.tier3
+@pytest.mark.rhel_ver_match('N-2')
 def test_positive_generate_installed_packages_report(
     module_sca_manifest_org,
-    local_ak,
+    rhel_contenthost,
     local_content_view,
     local_environment,
-    rhel_contenthost,
+    local_ak,
     target_sat,
 ):
     """Generate an report using the 'Host - All Installed Packages' Report template

--- a/tests/foreman/cli/test_reporttemplates.py
+++ b/tests/foreman/cli/test_reporttemplates.py
@@ -924,7 +924,7 @@ def test_negative_generate_hostpkgcompare_nonexistent_host(module_target_sat):
     assert "At least one of the hosts couldn't be found" in cm.value.stderr
 
 
-@pytest.mark.rhel_ver_list([7, 8, 9])
+@pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.tier3
 def test_positive_generate_installed_packages_report(
     module_sca_manifest_org,

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -228,7 +228,7 @@ def test_positive_end_to_end(session, module_org, module_location):
         assert not session.reporttemplate.search(new_name)
 
 
-@pytest.mark.rhel_ver_match('N-2')
+@pytest.mark.rhel_ver_list([7, 8, 9])
 @pytest.mark.upgrade
 @pytest.mark.tier2
 def test_positive_generate_registered_hosts_report(
@@ -480,7 +480,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
     """
 
 
-@pytest.mark.rhel_ver_match('N-2')
+@pytest.mark.rhel_ver_list([7, 8, 9])
 @pytest.mark.tier3
 def test_positive_generate_all_installed_packages_report(
     session, module_setup_content, rhel_contenthost, target_sat

--- a/tests/foreman/ui/test_reporttemplates.py
+++ b/tests/foreman/ui/test_reporttemplates.py
@@ -228,7 +228,7 @@ def test_positive_end_to_end(session, module_org, module_location):
         assert not session.reporttemplate.search(new_name)
 
 
-@pytest.mark.rhel_ver_list([7, 8, 9])
+@pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.upgrade
 @pytest.mark.tier2
 def test_positive_generate_registered_hosts_report(
@@ -480,7 +480,7 @@ def test_negative_nonauthor_of_report_cant_download_it(session):
     """
 
 
-@pytest.mark.rhel_ver_list([7, 8, 9])
+@pytest.mark.rhel_ver_match('N-2')
 @pytest.mark.tier3
 def test_positive_generate_all_installed_packages_report(
     session, module_setup_content, rhel_contenthost, target_sat


### PR DESCRIPTION
### Problem Statement
Add parametrization for RHEL10, for the `rhel_contenthost`'s in these ReportTemplates cases.
Some RT tests are already running with a RHEL10 contenthost param, but found a few more we would want also covered.
Also fix AK creation issue seen locally and in Stream, for `api/test_reporttemplates.py::test_positive_installable_errata`

### PRT Case
```
trigger: test-robottelo
pytest: tests/foreman/api/test_reporttemplates.py tests/foreman/cli/test_reporttemplates.py -k 'rhel10'
```