### PR TITLE
[6.14.z] Prevent satellite-installer false negative (#17384)

### DIFF
--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -1367,8 +1367,8 @@ def install_satellite(satellite, installer_args):
     satellite.execute(
         'firewall-cmd --permanent --add-service RH-Satellite-6 && firewall-cmd --reload'
     )
-    # Install Satellite
-    satellite.execute(
+    # Install Satellite and return result
+    return satellite.execute(
         InstallerCommand(installer_args=installer_args).get_command(),
         timeout='30m',
     )
@@ -1382,7 +1382,9 @@ def sat_default_install(module_sat_ready_rhels):
         f'foreman-initial-admin-password {settings.server.admin_password}',
     ]
     sat = module_sat_ready_rhels.pop()
-    install_satellite(sat, installer_args)
+    assert install_satellite(sat, installer_args).status == 0, (
+        "Satellite installation failed (non-zero return code)"
+    )
     return sat
 
 
@@ -1396,7 +1398,9 @@ def sat_non_default_install(module_sat_ready_rhels):
         'foreman-proxy-content-pulpcore-hide-guarded-distributions false',
     ]
     sat = module_sat_ready_rhels.pop()
-    install_satellite(sat, installer_args)
+    assert install_satellite(sat, installer_args).status == 0, (
+        "Satellite installation failed (non-zero return code)"
+    )
     return sat
 
 


### PR DESCRIPTION
cherrypick of #17384

fix false negative

(cherry picked from commit https://github.com/SatelliteQE/robottelo/commit/c251f4678dc06401046a66aa5d8c16b7d3fe55e9)

closes #17386