### PR TITLE
[master]: Changes for new 6.17.z branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.17.z'
       - '6.16.z'
       - "CherryPick"
       - "dependencies"
@@ -25,6 +26,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.17.z'
       - '6.16.z'
       - "CherryPick"
       - "dependencies"

--- a/conf/robottelo.yaml.template
+++ b/conf/robottelo.yaml.template
@@ -15,7 +15,7 @@ ROBOTTELO:
   RUN_ONE_DATAPOINT: false
   # Satellite version supported by this branch
   # UNDR version is used for some URL composition
-  SATELLITE_VERSION: "6.17"
+  SATELLITE_VERSION: "6.18"
   # Update non-ga versions with each release
   SAT_NON_GA_VERSIONS:
     - '6.16'

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -6,7 +6,7 @@ from box import Box
 from nailgun import entities
 
 # This should be updated after each version branch
-SATELLITE_VERSION = "6.17"
+SATELLITE_VERSION = "6.18"
 SATELLITE_OS_VERSION = "9"
 
 # Default system ports


### PR DESCRIPTION

  ### Problem Statement
  New 6.17.z downstream and master points to stream that is 6.18
  ### Solution
  - Dependabot.yaml cherrypicks to 6.17.z
  - Robottelo conf and constants now uses 6.18 and 6.17.z satellite versions
