### PR TITLE
Auto branching: Add randomness to branch name

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout from ${{ github.event.inputs.target_branch }} branch for auto-branching changes
         id: checkout-to-auto-branch
         run: |
-            branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s')"
+            branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s.%N')"
             git checkout -b "$branch_name"
             echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
 
@@ -269,7 +269,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s')"
+          branch_name="auto-branching-${{ github.event.inputs.target_branch }}-$(date '+%s.%N')"
           git checkout -b "$branch_name"
           git add setup.py ./tests/foreman ./robottelo/* ./requirements.txt ./.github/* ./conf/robottelo.yaml.template
           git commit -m "Changes for new ${{ github.event.inputs.target_branch }} branch"


### PR DESCRIPTION
### Problem Statement
`date '+%n` was not random enough. When two jobs run in parallel, they create a branch with the same name.

### Solution
Adding `%N` to add microseconds to add a bit of _random_ to it.

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->