### PR TITLE
Fix configure_kea_dhcp6_server fixture for IPv4

### DIFF
--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -278,6 +278,8 @@ def configure_kea_dhcp6_server():
         ).execute()
         yield kea_host
         Broker(workflow='remove-vm', source_vm=kea_host.name).execute()
+    else:
+        yield None
 
 
 @pytest.fixture


### PR DESCRIPTION
### Problem Statement
When setup `configure_kea_dhcp6_server` fixture is run for IPv4, it fails with "failed on setup with "ValueError: configure_kea_dhcp6_server did not yield a value"

### Solution
Fix configure_kea_dhcp6_server fixture for IPv4 by yielding None value since this fixture intended for IPv6 only

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->