### PR TITLE
[6.17.z] Fix typo in capsule_setup helper

### DIFF
--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1663,7 +1663,7 @@ class Capsule(ContentHost, CapsuleMixins):
         """Prepare the host and run the capsule installer"""
         self._satellite = sat_host or Satellite()
 
-        if settings.robottelo.rhelsource == "ga":
+        if settings.robottelo.rhel_source == "ga":
             # Register capsule host to CDN and enable repos
             result = self.register_contenthost(
                 org=None,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17657

### Problem Statement
Recent change in PR https://github.com/SatelliteQE/robottelo/pull/17489 updated `capsule_setup` helper, which now fails with below error
```
failed on setup with "dynaconf.vendor.box.exceptions.BoxKeyError: "'DynaBox' object has no attribute 'rhelsource'". Did you mean: 'rhel_source'?"
```

### Solution
Fix typo in capsule_setup helper

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->