### PR TITLE
allow applying a scap policy after manual hardening

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -468,6 +468,10 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
         f'/usr/share/xml/scap/ssg/content/ssg-{distro}-ds.xml',
     )
 
+    # disable gpgcheck enabled by the above security policy
+    contenthost.run(
+        "sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/yum.repos.d/foreman_registration1.repo "
+    )
     # Apply policy
     job_id = target_sat.cli.Host.ansible_roles_play({'name': contenthost.hostname.lower()})[0].get(
         'id'


### PR DESCRIPTION
### Problem Statement
SAT-19505 now in testing, the test failed on scap installation from client repo.  The scenario precludes using non-signed repo which is what we have.

### Solution
Revert the effect of manual policy run for the one specific repo

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->