### PR TITLE
[6.17.z] Multiple PhoenixSubs test fixes

### DIFF
--- a/tests/foreman/api/test_activationkey.py
+++ b/tests/foreman/api/test_activationkey.py
@@ -461,7 +461,13 @@ def test_positive_fetch_product_content(
         organization=module_org, repository=[rh_repo_id, custom_repo.id]
     ).create()
     cv.publish()
-    ak = module_target_sat.api.ActivationKey(content_view=cv, organization=module_org).create()
+    cv = cv.read()
+    cvv = cv.version[0]
+    cvv.promote(data={'environment_ids': module_lce.id})
+
+    ak = module_target_sat.api.ActivationKey(
+        content_view=cv, organization=module_org, environment=module_lce.name
+    ).create()
     ak_content = ak.product_content()['results']
     assert {custom_repo.product.id, rh_repo.product.id} == {
         repos['product']['id'] for repos in ak_content

--- a/tests/foreman/api/test_reporttemplates.py
+++ b/tests/foreman/api/test_reporttemplates.py
@@ -947,11 +947,13 @@ def test_positive_installed_products(
         .read()
         .generate(data=input_data)
     )
+
     assert report, 'No report generated.'
     assert report[0]['Host Name'] == rhel_contenthost.hostname, 'Incorrect host was reported.'
     assert report[0]['Organization'] == org.name, 'Incorrect org was reported.'
-    assert report[0]['Lifecycle Environment'] == lce_name, 'Incorrect LCE was reported.'
-    assert report[0]['Content View'] == cv_name, 'Incorrect CV was reported.'
+    assert report[0]['Content View Environments'] == f'{lce_name}/{cv_name}', (
+        'Incorrect content view environment(s) reported.'
+    )
     assert report[0]['Role'] == sys_tags['role'], 'Incorrect role was reported.'
     assert report[0]['Usage'] == sys_tags['usage'], 'Incorrect usage was reported.'
 

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -925,7 +925,10 @@ class TestDockerActivationKey:
                 'organization-id': module_org.id,
             }
         )
-        assert activation_key['content-view'] == comp_content_view['name']
+        assert (
+            activation_key['content-view-environments'][0]['label']
+            == f'{module_lce.name}/{comp_content_view["name"]}'
+        )
 
     @pytest.mark.tier2
     def test_positive_remove_docker_repo_ccv(
@@ -973,7 +976,10 @@ class TestDockerActivationKey:
                 'organization-id': module_org.id,
             }
         )
-        assert activation_key['content-view'] == comp_content_view['name']
+        assert (
+            activation_key['content-view-environments'][0]['label']
+            == f'{module_lce.name}/{comp_content_view["name"]}'
+        )
 
         # Create another content view replace with
         another_cv = module_target_sat.cli_factory.make_content_view(
@@ -994,4 +1000,7 @@ class TestDockerActivationKey:
             }
         )
         activation_key = module_target_sat.cli.ActivationKey.info({'id': activation_key['id']})
-        assert activation_key['content-view'] != comp_content_view['name']
+        assert (
+            activation_key['content-view-environments'][0]['label']
+            != f'{module_lce.name}/{comp_content_view["name"]}'
+        )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17705

### Problem Statement
There were still some outdated tests in our test framework which were failing for a while

### Solution
This PR fixes some of those tests

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_docker.py::TestDockerActivationKey::test_positive_add_docker_repo_ccv tests/foreman/cli/test_docker.py::TestDockerActivationKey::test_positive_remove_docker_repo_ccv tests/foreman/cli/test_activationkey.py::test_positive_update_cv  tests/foreman/api/test_reporttemplates.py::test_positive_installed_products
```

Tests passed locally
```
collected 6 items
tests/foreman/cli/test_docker.py ..                                          [ 33%]
tests/foreman/cli/test_activationkey.py .                                [ 50%]
tests/foreman/api/test_reporttemplates.py ...                          [100%]
...
6 passed
```
