### PR TITLE
Use k-h-t from client repo for http proxy testing

### DIFF
--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -149,9 +149,9 @@ def test_positive_end_to_end(
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize(
     'setup_http_proxy',
-    [None, True, False],
+    [True, False],
     indirect=True,
-    ids=['no_http_proxy', 'auth_http_proxy', 'unauth_http_proxy'],
+    ids=['auth_http_proxy', 'unauth_http_proxy'],
 )
 @pytest.mark.tier3
 def test_positive_install_content_with_http_proxy(

--- a/tests/foreman/api/test_http_proxy.py
+++ b/tests/foreman/api/test_http_proxy.py
@@ -145,7 +145,7 @@ def test_positive_end_to_end(
 
 @pytest.mark.e2e
 @pytest.mark.upgrade
-@pytest.mark.rhel_ver_match('8')
+@pytest.mark.rhel_ver_match('9')
 @pytest.mark.run_in_one_thread
 @pytest.mark.parametrize(
     'setup_http_proxy',
@@ -181,8 +181,8 @@ def test_positive_install_content_with_http_proxy(
 
     :parametrized: yes
     """
-    repo_to_use = 'rhae2.9_el8'
-    pkg_name = 'ansible'
+    repo_to_use = 'rhsclient9'
+    pkg_name = 'katello-host-tools'
     org = function_sca_manifest_org
     lce = module_target_sat.api.LifecycleEnvironment(organization=org).create()
     content_view = module_target_sat.api.ContentView(organization=org).create()


### PR DESCRIPTION
### Problem Statement
The `test_positive_install_content_with_http_proxy` fails to install ansible due to changed dependency.
```
AssertionError: ansible installation failed with: Error: 
   Problem: cannot install the best candidate for the job
    - nothing provides python3-PyYAML needed by ansible-2.9.27-1.el8ae.noarch from ansible-2.9-for-rhel-8-x86_64-rpms
    - nothing provides python3-cryptography needed by ansible-2.9.27-1.el8ae.noarch from ansible-2.9-for-rhel-8-x86_64-rpms
    - nothing provides python3-jinja2 needed by ansible-2.9.27-1.el8ae.noarch from ansible-2.9-for-rhel-8-x86_64-rpms
```


### Solution
Use some different repo/pkg without dependency.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/api/test_http_proxy.py -k test_positive_install_content_with_http_proxy
```