### PR TITLE
[6.17.z] Fix CV perm restricted tests

### DIFF
--- a/tests/foreman/cli/test_contentview.py
+++ b/tests/foreman/cli/test_contentview.py
@@ -1910,8 +1910,9 @@ class TestContentView:
     @pytest.mark.skipif(
         (not settings.robottelo.REPOS_HOSTING_URL), reason='Missing repos_hosting_url'
     )
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_sub_host_with_restricted_user_perm_at_custom_loc(
-        self, module_org, rhel7_contenthost, target_sat
+        self, module_org, rhel_contenthost, target_sat
     ):
         """Attempt to subscribe a host with restricted user permissions and
         custom location.
@@ -2064,16 +2065,17 @@ class TestContentView:
             }
         )
         # create a client host and register it with the created user
-        rhel7_contenthost.register(org, loc, ak_name, target_sat)
-        assert rhel7_contenthost.subscribed
+        rhel_contenthost.register(org, loc, ak_name, target_sat)
+        assert rhel_contenthost.subscribed
         # check that the client host exist in the system
         org_hosts = target_sat.cli.Host.list({'organization-id': org['id']})
         assert len(org_hosts) == 1
-        assert org_hosts[0]['name'] == rhel7_contenthost.hostname
+        assert org_hosts[0]['name'] == rhel_contenthost.hostname
 
     @pytest.mark.tier3
+    @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
     def test_positive_sub_host_with_restricted_user_perm_at_default_loc(
-        self, module_org, rhel7_contenthost, target_sat
+        self, module_org, rhel_contenthost, target_sat
     ):
         """Attempt to subscribe a host with restricted user permissions and
         default location.
@@ -2180,7 +2182,7 @@ class TestContentView:
         # role info (note: view_roles is not in the required permissions)
         with pytest.raises(CLIReturnCodeError) as context:
             target_sat.cli.Role.with_user(user_name, user_password).info({'id': role['id']})
-        assert '403 Forbidden' in str(context)
+        assert 'Access denied' in str(context)
         # Create a lifecycle environment
         env = target_sat.cli_factory.make_lifecycle_environment({'organization-id': org['id']})
         # Create a product
@@ -2211,14 +2213,16 @@ class TestContentView:
         )
         # assert that this is the same content view
         assert content_view['name'] == user_content_view['name']
-        ak = target_sat.api.ActivationKey(content_view=user_content_view, organization=org).create()
+        ak = target_sat.api.ActivationKey(
+            content_view=user_content_view['id'], environment=env['id'], organization=org['id']
+        ).create()
         # create a client host and register it with the created user
-        rhel7_contenthost.register(org, loc, ak.name, target_sat)
-        assert rhel7_contenthost.subscribed
+        rhel_contenthost.register(org, loc, ak.name, target_sat)
+        assert rhel_contenthost.subscribed
         # check that the client host exist in the system
         org_hosts = target_sat.cli.Host.list({'organization-id': org['id']})
         assert len(org_hosts) == 1
-        assert org_hosts[0]['name'] == rhel7_contenthost.hostname
+        assert org_hosts[0]['name'] == rhel_contenthost.hostname
 
     @pytest.mark.tier1
     def test_positive_clone_by_name(self, module_org, module_target_sat):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17727

### Problem Statement
The `test_positive_sub_host_with_restricted_user_perm_at_default_loc` fails due to improved error message and needs a small fix.
```
tests/foreman/cli/test_contentview.py:2183: in test_positive_sub_host_with_restricted_user_perm_at_default_loc
    assert '403 Forbidden' in str(context)
E   assert '403 Forbidden' in '<ExceptionInfo CLIReturnCodeError(status=77, stderr=\'Access denied\\nMissing one of the required permissions: view_roles\\n\', msg=\'Comm... info" finished with status 77\\nstderr contains:\\nAccess denied\\nMissing one of the required permissions: view_roles\\n\' tblen=4>'
```


### Solution
This PR updates the message but it turned out it needed also `AK.create` update and also I used this opportunity to replace `rhel7_contenthost` with default `rhel_contenthost`.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_contentview.py -k restricted_user_perm
```