### PR TITLE
[6.16.z] Fix typo in SCA-only upgrade scenario

### DIFF
--- a/tests/upgrades/test_repository.py
+++ b/tests/upgrades/test_repository.py
@@ -511,7 +511,7 @@ class TestSimpleContentAccessOnly:
         sca_access = target_sat.execute(
             f'echo "Organization.find({org_id}).simple_content_access?" | foreman-rake console'
         )
-        assert 'True' in sca_access.stdout
+        assert 'true' in sca_access.stdout
         sca_mode = target_sat.execute(
             f'echo "Organization.find({org_id}).content_access_mode" | foreman-rake console'
         )


### PR DESCRIPTION
### Problem Statement
The `test_post_simple_content_access_only` fails in 6.16.z due to typo.
```
AssertionError: assert 'True' in 'Loading production environment (Rails 6.1.7.8)\nSwitch to inspect mode.\nOrganization.find(21).simple_content_access?\ntrue\n\n'
 +  where 'Loading production environment (Rails 6.1.7.8)\nSwitch to inspect mode.\nOrganization.find(21).simple_content_access?\ntrue\n\n' = stdout:\nLoading production environment (Rails 6.1.7.8)\nSwitch to inspect mode.\nOrganization.find(21).simple_content_access?\ntrue\n\n\nstderr:\n\nstatus: 0.stdout
```

The rake console always returns bool value with lowercase
```
[root@sat ~]# foreman-rake console
Loading production environment (Rails 6.1.7.8)
irb(main):001:0> Organization.find(1).simple_content_access?
=> true
irb(main):002:0> Organization.find(1).content_access_mode
=> "org_environment"
irb(main):003:0> Organization.find(1).content_access_mode_list
=> ["org_environment"]
```

### Solution
Lowercase the assertion.