### PR TITLE
[6.17.z] Add a negative test for JWT invalidate through hammer

### DIFF
--- a/tests/foreman/api/test_registration.py
+++ b/tests/foreman/api/test_registration.py
@@ -450,7 +450,6 @@ def test_positive_katello_ca_crt_refresh(
     assert ca_cert_file == ca_file_after_refresh
 
 
-@pytest.mark.no_containers
 @pytest.mark.rhel_ver_list([settings.content_host.default_rhel_version])
 def test_positive_invalidate_users_tokens(
     target_sat, request, module_org, module_location, rhel_contenthost, module_activation_key


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17525

### Problem Statement
Negative test to verify users permission for JWT invalidate

### Solution
Negative test added to for users permission
Update tests to use containers
### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->