### PR TITLE
[6.16.z] Fix assertion in docker test

### DIFF
--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -1790,8 +1790,8 @@ class TestDockerRepository:
         """
         with pytest.raises(
             HTTPError,
-            match='422 Client Error: Unprocessable Entity for url: '
-            f'{target_sat.url}:443/katello/api/v2/repositories',
+            match='422 Client Error: Unprocessable Content for url: '
+            f'{target_sat.url}/katello/api/v2/repositories',
         ):
             target_sat.api.Repository(**repo_options).create()
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17728

### Problem Statement

Downstream tests were failing due to wrong assertion message. I'm not sure if this also happens on upstream.
If PRT fails I would close the PR.

### Solution

Fix assertion message

### Tests to run

tests/foreman/api/test_repository.py::TestDockerRepository::test_negative_synchronize_private_registry_no_passwd