### PR TITLE
Add permission tests for snapshot management plugin

### DIFF
--- a/pytest_fixtures/component/permissions.py
+++ b/pytest_fixtures/component/permissions.py
@@ -39,6 +39,12 @@ def expected_permissions(session_target_sat):
     if 'rubygem-foreman_scc_manager' not in rpm_packages:
         permissions.pop('SccAccount')
         permissions.pop('SccProduct')
+    if 'rubygem-foreman_snapshot_management' not in rpm_packages:
+        permissions['Host'].remove('view_snapshots')
+        permissions['Host'].remove('create_snapshots')
+        permissions[None].remove('destroy_snapshots')
+        permissions[None].remove('revert_snapshots')
+        permissions[None].remove('edit_snapshots')
     if 'gem-foreman_salt' not in rpm_packages:
         permissions['Host'].remove('saltrun_hosts')
         permissions['SmartProxy'].remove('destroy_smart_proxies_salt_autosign')

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1056,6 +1056,9 @@ PERMISSIONS = {
         'import_ansible_playbooks',
         'dispatch_cloud_requests',
         'control_organization_insights',
+        'destroy_snapshots',
+        'revert_snapshots',
+        'edit_snapshots',
     ],
     'AnsibleRole': ['view_ansible_roles', 'destroy_ansible_roles', 'import_ansible_roles'],
     'AnsibleVariable': [
@@ -1384,6 +1387,8 @@ PERMISSIONS = {
         'view_hosts',
         'forget_status_hosts',
         'saltrun_hosts',
+        'view_snapshots',
+        'create_snapshots',
     ],
     'Katello::ActivationKey': [
         'view_activation_keys',


### PR DESCRIPTION
### Problem Statement

Missing permissions for snapshot management plugin

### Solution

see code

### Tests to run

tests/foreman/api/test_permission.py::TestPermission


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->