### PR TITLE
Fix DeprecationWarning: datetime.datetime.utcnow() is deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ fixable = ["ALL"]
 select = [
     "B",  # bugbear
     # "C90", # mccabe
+    "DTZ003", # call-datetime-utcnow
     "E",  # pycodestyle
     "F",  # flake8
     "I", # isort

--- a/pytest_fixtures/core/reporting.py
+++ b/pytest_fixtures/core/reporting.py
@@ -40,11 +40,11 @@ def pytest_sessionstart(session):
         xml = session.config._store.get(xml_key, None)
         if xml:
             xml.add_global_property(
-                'start_time', datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME)
+                'start_time', datetime.datetime.now(datetime.UTC).strftime(FMT_XUNIT_TIME)
             )
 
 
 @pytest.fixture(autouse=False, scope='session')
 def record_testsuite_timestamp_xml(record_testsuite_property):
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.UTC)
     record_testsuite_property('start_time', now.strftime(FMT_XUNIT_TIME))

--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -165,7 +165,7 @@ def pytest_collection_modifyitems(items, config):
     logger.info('Processing test items to add testimony token markers')
     for item in items:
         item.user_properties.append(
-            ("start_time", datetime.datetime.utcnow().strftime(FMT_XUNIT_TIME))
+            ("start_time", datetime.datetime.now(datetime.UTC).strftime(FMT_XUNIT_TIME))
         )
         if item.nodeid.startswith('tests/robottelo/') and 'test_junit' not in item.nodeid:
             # Unit test, no testimony markers

--- a/robottelo/host_helpers/capsule_mixins.py
+++ b/robottelo/host_helpers/capsule_mixins.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import time
 
 from box import Box
@@ -92,7 +92,7 @@ class CapsuleInfo:
         sync_status = self.nailgun_capsule.content_get_sync(timeout=timeout, synchronous=True)
         # Current UTC time for start_time, if not provided
         if start_time is None:
-            start_time = datetime.utcnow().replace(microsecond=0)
+            start_time = datetime.now(UTC).replace(microsecond=0)
         # 1s margin of safety for rounding
         start_time = (
             (start_time - timedelta(seconds=1))

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1,7 +1,7 @@
 from configparser import ConfigParser
 import contextlib
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import cached_property, lru_cache
 import importlib
 import io
@@ -2409,7 +2409,7 @@ class Satellite(Capsule, SatelliteMixins):
     def generate_inventory_report(self, org, disconnected='false'):
         """Function to perform inventory upload."""
         generate_report_task = 'ForemanInventoryUpload::Async::GenerateReportJob'
-        timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+        timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         self.api.Organization(id=org.id).rh_cloud_generate_report(
             data={'disconnected': disconnected}
         )
@@ -2441,7 +2441,7 @@ class Satellite(Capsule, SatelliteMixins):
 
     def run_orphan_cleanup(self, smart_proxy_id=None):
         """Run orphan cleanup task for all or given smart proxy."""
-        timestamp = datetime.utcnow().replace(microsecond=0)
+        timestamp = datetime.now(UTC).replace(microsecond=0)
         rake_command = 'foreman-rake katello:delete_orphaned_content RAILS_ENV=production'
         if smart_proxy_id:
             rake_command = f'{rake_command} SMART_PROXY_ID={smart_proxy_id}'

--- a/robottelo/utils/decorators/func_shared/shared.py
+++ b/robottelo/utils/decorators/func_shared/shared.py
@@ -313,7 +313,7 @@ class _SharedFunction:
                 pid = value['pid']
                 creation_datetime = datetime.datetime.strptime(
                     value['creation_datetime'], _DATETIME_FORMAT
-                )
+                ).replace(tzinfo=datetime.UTC)
 
                 if state in [_STATE_READY, _STATE_FAILED] and not self._has_result_expired(
                     creation_datetime

--- a/robottelo/utils/decorators/func_shared/shared.py
+++ b/robottelo/utils/decorators/func_shared/shared.py
@@ -285,7 +285,7 @@ class _SharedFunction:
 
     def _has_result_expired(self, creation_datetime):
         expire_datetime = creation_datetime + datetime.timedelta(seconds=self._share_timeout)
-        return datetime.datetime.utcnow() >= expire_datetime
+        return datetime.datetime.now(datetime.UTC) >= expire_datetime
 
     def __call__(self):
         # this lock prevent any other process to run the function,
@@ -324,7 +324,7 @@ class _SharedFunction:
 
             if call_function is True:
                 result, exp, traceback_text = self._call_function()
-                creation_datetime = datetime.datetime.utcnow().strftime(_DATETIME_FORMAT)
+                creation_datetime = datetime.datetime.now(datetime.UTC).strftime(_DATETIME_FORMAT)
                 if exp:
                     error = str(exp) or 'error occurred'
                     error_class_name = f'{exp.__class__.__module__}.{exp.__class__.__name__}'

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -13,7 +13,7 @@ interactions and use capsule.
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import re
 from time import sleep
 
@@ -128,7 +128,7 @@ class TestCapsuleContentManagement:
 
         assert repo.read().content_counts['rpm'] == 1
 
-        timestamp = datetime.utcnow().replace(microsecond=0)
+        timestamp = datetime.now(UTC).replace(microsecond=0)
         # Publish new version of the content view
         cv.publish()
         # query sync status as publish invokes sync, task succeeds
@@ -196,7 +196,7 @@ class TestCapsuleContentManagement:
         assert len(cv.version) == 1
 
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
         module_capsule_configured.wait_for_sync(start_time=timestamp)
 
@@ -229,7 +229,7 @@ class TestCapsuleContentManagement:
 
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -304,7 +304,7 @@ class TestCapsuleContentManagement:
         assert len(cv.version) == 1
 
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -324,7 +324,7 @@ class TestCapsuleContentManagement:
 
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -414,7 +414,7 @@ class TestCapsuleContentManagement:
         assert len(active_tasks) == 0
         # Promote content view to lifecycle environment,
         # invoking capsule sync task(s)
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -462,7 +462,7 @@ class TestCapsuleContentManagement:
         cvv = cv.version[-1].read()
         # Promote new content view version to lifecycle environment,
         # capsule sync task(s) invoked and succeed
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -484,7 +484,7 @@ class TestCapsuleContentManagement:
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
 
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -551,7 +551,7 @@ class TestCapsuleContentManagement:
             organization=module_sca_manifest_org, repository=[rh_repo]
         ).create()
         # Publish new version of the content view
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cv.publish()
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -632,7 +632,7 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -714,7 +714,7 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -742,7 +742,7 @@ class TestCapsuleContentManagement:
         cv.version.sort(key=lambda version: version.id)
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -860,7 +860,7 @@ class TestCapsuleContentManagement:
 
         cvv = cv.version[-1].read()
         # Promote content view to lifecycle environment
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -964,7 +964,7 @@ class TestCapsuleContentManagement:
 
         # Promote the latest CV version into capsule's LCE
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -1083,7 +1083,7 @@ class TestCapsuleContentManagement:
         assert function_lce_library.id in [capsule_lce['id'] for capsule_lce in result['results']]
 
         # Sync the repo
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         repo.sync(timeout=600)
         repo = repo.read()
         assert repo.content_counts['ansible_collection'] == 2
@@ -1167,7 +1167,7 @@ class TestCapsuleContentManagement:
 
         # Promote the latest CV version into capsule's LCE
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -1265,13 +1265,13 @@ class TestCapsuleContentManagement:
         # Promote the CV to both Capsule's LCEs without waiting for Capsule sync task completion.
         cvv = cv.version[-1].read()
         assert len(cvv.environment) == 1
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': lce1.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
         cvv = cvv.read()
         assert len(cvv.environment) == 2
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': lce2.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -1318,7 +1318,7 @@ class TestCapsuleContentManagement:
         cv = cv.read()
 
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -1497,7 +1497,7 @@ class TestCapsuleContentManagement:
         assert function_lce.id in [capsule_lce['id'] for capsule_lce in result['results']]
 
         # Sync a yum repo, publish and promote it to a CVE, sync the Capsule and wait for it.
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         repos_collection.setup_content(function_org.id, function_lce.id, override=True)
         module_capsule_configured.wait_for_sync(start_time=timestamp)
 
@@ -1628,7 +1628,7 @@ class TestCapsuleContentManagement:
 
         # Promote the latest CV version into capsule's LCE
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)
@@ -1869,7 +1869,7 @@ class TestCapsuleContentManagement:
         cv = cv.read()
 
         cvv = cv.version[-1].read()
-        timestamp = datetime.utcnow()
+        timestamp = datetime.now(UTC)
         cvv.promote(data={'environment_ids': function_lce.id})
 
         module_capsule_configured.wait_for_sync(start_time=timestamp)

--- a/tests/foreman/api/test_capsulecontent.py
+++ b/tests/foreman/api/test_capsulecontent.py
@@ -1341,7 +1341,10 @@ class TestCapsuleContentManagement:
         # Check sync status again, and ensure last_sync_time is still correct
         sync_status = module_capsule_configured.nailgun_capsule.content_get_sync()
         assert (
-            datetime.strptime(sync_status['last_sync_time'], '%Y-%m-%d %H:%M:%S UTC') >= timestamp
+            datetime.strptime(sync_status['last_sync_time'], '%Y-%m-%d %H:%M:%S UTC').replace(
+                tzinfo=UTC
+            )
+            >= timestamp
         )
 
     @pytest.mark.tier4

--- a/tests/foreman/api/test_contentview.py
+++ b/tests/foreman/api/test_contentview.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import random
 
 from fauxfactory import gen_integer, gen_string, gen_utf8
@@ -543,7 +543,7 @@ class TestContentViewPublishPromote:
         content_view.update(['repository'])
         content_view = content_view.read()
         existing_versions = content_view.version
-        timestamp = (datetime.utcnow() - timedelta(seconds=1)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(seconds=1)).strftime('%Y-%m-%d %H:%M')
 
         # perform async repository sync, while still in progress-
         # attempt to publish a new version of the content view.

--- a/tests/foreman/api/test_syncplan.py
+++ b/tests/foreman/api/test_syncplan.py
@@ -16,7 +16,7 @@ API reference for sync plans can be found on your Satellite:
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from time import sleep
 
 from fauxfactory import gen_choice, gen_string
@@ -618,7 +618,7 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request,
     validate_repo_content(repo, ['erratum', 'rpm', 'package_group'], after_sync=False)
     # Create and Associate sync plan with product
     sync_plan = target_sat.api.SyncPlan(
-        organization=module_org, enabled=True, sync_date=datetime.utcnow().replace(second=0)
+        organization=module_org, enabled=True, sync_date=datetime.now(UTC).replace(second=0)
     ).create()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     sync_plan.add_products(data={'product_ids': [product.id]})
@@ -649,7 +649,7 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request,
         organization=module_org,
         enabled=True,
         interval='hourly',
-        sync_date=datetime.utcnow().replace(second=0) - timedelta(seconds=interval - delay),
+        sync_date=datetime.now(UTC).replace(second=0) - timedelta(seconds=interval - delay),
     ).create()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     sync_plan.add_products(data={'product_ids': [product.id]})
@@ -695,7 +695,7 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     # Create and Associate sync plan with product
     # BZ:1695733 is closed WONTFIX so apply this workaround
     logger.info('Need to set seconds to zero because BZ#1695733')
-    sync_date = datetime.utcnow().replace(second=0) + timedelta(seconds=delay)
+    sync_date = datetime.now(UTC).replace(second=0) + timedelta(seconds=delay)
     sync_plan = target_sat.api.SyncPlan(
         organization=module_org, enabled=True, sync_date=sync_date
     ).create()
@@ -753,7 +753,7 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
     # Create and Associate sync plan with products
     # BZ:1695733 is closed WONTFIX so apply this workaround
     logger.info('Need to set seconds to zero because BZ#1695733')
-    sync_date = datetime.utcnow().replace(second=0) + timedelta(seconds=delay)
+    sync_date = datetime.now(UTC).replace(second=0) + timedelta(seconds=delay)
     sync_plan = target_sat.api.SyncPlan(
         organization=module_org, enabled=True, sync_date=sync_date
     ).create()
@@ -815,7 +815,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
         organization=org,
         enabled=True,
         interval='hourly',
-        sync_date=datetime.utcnow() - timedelta(seconds=interval - delay),
+        sync_date=datetime.now(UTC) - timedelta(seconds=interval - delay),
     ).create()
     request.addfinalizer(lambda: target_sat.api_factory.disable_syncplan(sync_plan))
     # Associate sync plan with product
@@ -875,7 +875,7 @@ def test_positive_synchronize_rh_product_future_sync_date(
     repo = target_sat.api.Repository(id=repo_id).read()
     # BZ:1695733 is closed WONTFIX so apply this workaround
     logger.info('Need to set seconds to zero because BZ#1695733')
-    sync_date = datetime.utcnow().replace(second=0) + timedelta(seconds=delay)
+    sync_date = datetime.now(UTC).replace(second=0) + timedelta(seconds=delay)
     sync_plan = target_sat.api.SyncPlan(
         organization=org, enabled=True, interval='hourly', sync_date=sync_date
     ).create()
@@ -920,7 +920,7 @@ def test_positive_synchronize_custom_product_daily_recurrence(module_org, reques
     delay = 2 * 60
     product = target_sat.api.Product(organization=module_org).create()
     repo = target_sat.api.Repository(product=product).create()
-    start_date = datetime.utcnow().replace(second=0) - timedelta(days=1) + timedelta(seconds=delay)
+    start_date = datetime.now(UTC).replace(second=0) - timedelta(days=1) + timedelta(seconds=delay)
     # Create and Associate sync plan with product
     sync_plan = target_sat.api.SyncPlan(
         organization=module_org, enabled=True, interval='daily', sync_date=start_date
@@ -963,7 +963,7 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
     delay = 2 * 60
     product = target_sat.api.Product(organization=module_org).create()
     repo = target_sat.api.Repository(product=product).create()
-    start_date = datetime.utcnow().replace(second=0) - timedelta(weeks=1) + timedelta(seconds=delay)
+    start_date = datetime.now(UTC).replace(second=0) - timedelta(weeks=1) + timedelta(seconds=delay)
     # Create and Associate sync plan with product
     sync_plan = target_sat.api.SyncPlan(
         organization=module_org, enabled=True, interval='weekly', sync_date=start_date

--- a/tests/foreman/cli/test_artifacts.py
+++ b/tests/foreman/cli/test_artifacts.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 import random
 
 from box import Box
@@ -38,7 +38,7 @@ def module_synced_content(
     :return: Box with created instances and Repository sync time.
     """
     repo = module_target_sat.api.Repository(product=module_product, **request.param).create()
-    sync_time = datetime.utcnow().replace(microsecond=0)
+    sync_time = datetime.now(UTC).replace(microsecond=0)
     repo.sync()
 
     cv = module_target_sat.api.ContentView(organization=module_org, repository=[repo]).create()

--- a/tests/foreman/cli/test_capsulecontent.py
+++ b/tests/foreman/cli/test_capsulecontent.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 import random
 
 from box import Box
@@ -67,7 +67,7 @@ def module_synced_content(
         module_capsule_configured.nailgun_capsule.content_add_lifecycle_environment(
             data={'environment_id': [module_lce.id, module_lce_library.id]}
         )
-    sync_time = datetime.utcnow().replace(microsecond=0)
+    sync_time = datetime.now(UTC).replace(microsecond=0)
     module_target_sat.cli.Capsule.content_synchronize(
         {'id': module_capsule_configured.nailgun_capsule.id, 'organization-id': module_org.id}
     )
@@ -109,7 +109,7 @@ def module_capsule_artifact_cleanup(
             data={'environment_id': lce['id']}
         )
     # Run orphan cleanup for the capsule.
-    timestamp = datetime.utcnow().replace(microsecond=0)
+    timestamp = datetime.now(UTC).replace(microsecond=0)
     module_target_sat.execute(
         'foreman-rake katello:delete_orphaned_content RAILS_ENV=production '
         f'SMART_PROXY_ID={module_capsule_configured.nailgun_capsule.id}'
@@ -406,7 +406,7 @@ def test_positive_content_counts_granularity(
         cvs.append(cv.read())
     cv1, cv2 = cvs
     module_target_sat.wait_for_tasks(
-        search_query=wait_query.format(datetime.utcnow().replace(microsecond=0)),
+        search_query=wait_query.format(datetime.now(UTC).replace(microsecond=0)),
         search_rate=5,
         max_tries=5,
     )
@@ -456,7 +456,7 @@ def test_positive_content_counts_granularity(
         cv.version[0].promote(data={'environment_ids': [lce1.id, lce2.id]})
         cv = cv.read()
     module_target_sat.wait_for_tasks(
-        search_query=wait_query.format(datetime.utcnow().replace(microsecond=0)),
+        search_query=wait_query.format(datetime.now(UTC).replace(microsecond=0)),
         search_rate=5,
         max_tries=5,
     )
@@ -478,7 +478,7 @@ def test_positive_content_counts_granularity(
     cv1.version[0].promote(data={'environment_ids': lce1.id})
     cv1 = cv1.read()
     module_target_sat.wait_for_tasks(
-        search_query=wait_query.format(datetime.utcnow().replace(microsecond=0)),
+        search_query=wait_query.format(datetime.now(UTC).replace(microsecond=0)),
         search_rate=5,
         max_tries=5,
     )
@@ -503,7 +503,7 @@ def test_positive_content_counts_granularity(
     cv1.version[0].promote(data={'environment_ids': lce2.id})
     cv1 = cv1.read()
     module_target_sat.wait_for_tasks(
-        search_query=wait_query.format(datetime.utcnow().replace(microsecond=0)),
+        search_query=wait_query.format(datetime.now(UTC).replace(microsecond=0)),
         search_rate=5,
         max_tries=5,
     )
@@ -851,7 +851,7 @@ def test_sync_consume_flatpak_repo_via_library(
     local_repos = sat.cli.Repository.list({'product-id': function_product.id})
     assert set([r['name'] for r in local_repos]) == set(repo_names)
 
-    timestamp = datetime.utcnow()
+    timestamp = datetime.now(UTC)
     for repo in local_repos:
         sat.cli.Repository.synchronize({'id': repo['id']})
     module_capsule_configured.wait_for_sync(start_time=timestamp)

--- a/tests/foreman/cli/test_errata.py
+++ b/tests/foreman/cli/test_errata.py
@@ -11,7 +11,7 @@
 :CaseImportance: High
 """
 
-from datetime import date, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from operator import itemgetter
 import re
 
@@ -267,7 +267,7 @@ def start_and_wait_errata_recalculate(sat, host):
         sat.cli.Host.errata_recalculate({'host-id': host.nailgun_host.id})
         host.run('subscription-manager repos')
     # Note time check for later wait_for_tasks include 30s margin of safety
-    timestamp = (datetime.utcnow() - timedelta(seconds=30)).strftime(TIMESTAMP_FMT_S)
+    timestamp = (datetime.now(UTC) - timedelta(seconds=30)).strftime(TIMESTAMP_FMT_S)
     # Wait for upload profile event (in case Satellite system is slow)
     sat.wait_for_tasks(
         search_query=(

--- a/tests/foreman/cli/test_remoteexecution.py
+++ b/tests/foreman/cli/test_remoteexecution.py
@@ -13,7 +13,7 @@
 """
 
 from calendar import monthrange
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import random
 from time import sleep
 
@@ -835,7 +835,7 @@ class TestRemoteExecution:
             ],
             [
                 '@hourly',
-                f'{(datetime.utcnow() + timedelta(hours=1)).strftime("%Y/%m/%d %H")}:00:00',
+                f'{(datetime.now(UTC) + timedelta(hours=1)).strftime("%Y/%m/%d %H")}:00:00',
             ],
             # last day of month
             [

--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 import time
 
 import pytest
@@ -122,7 +122,7 @@ def test_positive_inventory_recommendation_sync(
     """
     org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_insights:sync'
-    timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
     result = module_target_sat.execute(cmd)
     wait_for(
         lambda: module_target_sat.api.ForemanTask()
@@ -168,7 +168,7 @@ def test_positive_sync_inventory_status(
     org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:sync'
     success_msg = f"Synchronized inventory for organization '{org.name}'"
-    timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
     result = module_target_sat.execute(cmd)
     assert result.status == 0
     assert success_msg in result.stdout
@@ -218,7 +218,7 @@ def test_positive_sync_inventory_status_missing_host_ip(
     org = rhcloud_manifest_org
     cmd = f'organization_id={org.id} foreman-rake rh_cloud_inventory:sync'
     success_msg = f"Synchronized inventory for organization '{org.name}'"
-    timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+    timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
     rhcloud_host = module_target_sat.cli.Host.info({'name': rhcloud_registered_hosts[0].hostname})[
         'id'
     ]
@@ -354,7 +354,7 @@ def test_positive_generate_all_reports_job(target_sat):
             time.sleep(30)  # sleep to allow time for console to open
             sh.send(f'ForemanTasks.async_task({generate_report_jobs})')
             time.sleep(3)  # sleep for the cmd execution
-        timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+        timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         wait_for(
             lambda: target_sat.api.ForemanTask()
             .search(query={'search': f'{generate_report_jobs} and started_at >= "{timestamp}"'})[0]

--- a/tests/foreman/cli/test_syncplan.py
+++ b/tests/foreman/cli/test_syncplan.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from time import sleep
 
 from fauxfactory import gen_string
@@ -383,7 +383,7 @@ def test_positive_info_with_assigned_product(module_org, module_target_sat):
         {
             'enabled': 'false',
             'organization-id': module_org.id,
-            'sync-date': datetime.utcnow().strftime(SYNC_DATE_FMT),
+            'sync-date': datetime.now(UTC).strftime(SYNC_DATE_FMT),
         }
     )
     for prod_name in [prod1, prod2]:
@@ -414,7 +414,7 @@ def test_negative_synchronize_custom_product_past_sync_date(module_org, request,
         {
             'enabled': 'true',
             'organization-id': module_org.id,
-            'sync-date': datetime.utcnow().strftime(SYNC_DATE_FMT),
+            'sync-date': datetime.now(UTC).strftime(SYNC_DATE_FMT),
         }
     )
     sync_plan = target_sat.api.SyncPlan(organization=module_org.id, id=new_sync_plan['id']).read()
@@ -448,7 +448,7 @@ def test_positive_synchronize_custom_product_past_sync_date(module_org, request,
             'enabled': 'true',
             'interval': 'hourly',
             'organization-id': module_org.id,
-            'sync-date': (datetime.utcnow() - timedelta(seconds=interval - delay)).strftime(
+            'sync-date': (datetime.now(UTC) - timedelta(seconds=interval - delay)).strftime(
                 SYNC_DATE_FMT
             ),
         }
@@ -496,13 +496,13 @@ def test_positive_synchronize_custom_product_future_sync_date(module_org, reques
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
     repo = target_sat.cli_factory.make_repository({'product-id': product['id']})
     # if < 3 mins before the target event rather wait 3 mins for the next test window
-    if int(datetime.utcnow().strftime('%M')) % (cron_multiple) > int(guardtime / 60):
+    if int(datetime.now(UTC).strftime('%M')) % (cron_multiple) > int(guardtime / 60):
         sleep(guardtime)
     new_sync_plan = target_sat.cli_factory.sync_plan(
         {
             'enabled': 'true',
             'organization-id': module_org.id,
-            'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay)).strftime(
+            'sync-date': (datetime.now(UTC).replace(second=0) + timedelta(seconds=delay)).strftime(
                 SYNC_DATE_FMT
             ),
             'cron-expression': [f'*/{cron_multiple} * * * *'],
@@ -559,13 +559,13 @@ def test_positive_synchronize_custom_products_future_sync_date(module_org, reque
         for _ in range(2)
     ]
     # if < 3 mins before the target event rather wait 3 mins for the next test window
-    if int(datetime.utcnow().strftime('%M')) % (cron_multiple) > int(guardtime / 60):
+    if int(datetime.now(UTC).strftime('%M')) % (cron_multiple) > int(guardtime / 60):
         sleep(guardtime)
     new_sync_plan = target_sat.cli_factory.sync_plan(
         {
             'enabled': 'true',
             'organization-id': module_org.id,
-            'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay)).strftime(
+            'sync-date': (datetime.now(UTC).replace(second=0) + timedelta(seconds=delay)).strftime(
                 SYNC_DATE_FMT
             ),
             'cron-expression': [f'*/{cron_multiple} * * * *'],
@@ -645,7 +645,7 @@ def test_positive_synchronize_rh_product_past_sync_date(
             'enabled': 'true',
             'interval': 'hourly',
             'organization-id': org.id,
-            'sync-date': (datetime.utcnow() - timedelta(seconds=interval - delay)).strftime(
+            'sync-date': (datetime.now(UTC) - timedelta(seconds=interval - delay)).strftime(
                 SYNC_DATE_FMT
             ),
         }
@@ -708,13 +708,13 @@ def test_positive_synchronize_rh_product_future_sync_date(
         {'name': REPOS['rhva6']['name'], 'product': product['name'], 'organization-id': org.id}
     )
     # if < 3 mins before the target event rather wait 3 mins for the next test window
-    if int(datetime.utcnow().strftime('%M')) % (cron_multiple) > int(guardtime / 60):
+    if int(datetime.now(UTC).strftime('%M')) % (cron_multiple) > int(guardtime / 60):
         sleep(guardtime)
     new_sync_plan = target_sat.cli_factory.sync_plan(
         {
             'enabled': 'true',
             'organization-id': org.id,
-            'sync-date': (datetime.utcnow().replace(second=0) + timedelta(seconds=delay)).strftime(
+            'sync-date': (datetime.now(UTC).replace(second=0) + timedelta(seconds=delay)).strftime(
                 SYNC_DATE_FMT
             ),
             'cron-expression': [f'*/{cron_multiple} * * * *'],
@@ -764,7 +764,7 @@ def test_positive_synchronize_custom_product_weekly_recurrence(module_org, reque
     delay = 2 * 60
     product = target_sat.cli_factory.make_product({'organization-id': module_org.id})
     repo = target_sat.cli_factory.make_repository({'product-id': product['id']})
-    start_date = datetime.utcnow() - timedelta(weeks=1) + timedelta(seconds=delay)
+    start_date = datetime.now(UTC) - timedelta(weeks=1) + timedelta(seconds=delay)
     new_sync_plan = target_sat.cli_factory.sync_plan(
         {
             'enabled': 'true',

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -251,7 +251,7 @@ class TestUser:
         result_before_login = module_target_sat.cli.User.list({'search': f'login = {login}'})
 
         # this is because satellite uses the UTC timezone
-        before_login_time = datetime.datetime.utcnow()
+        before_login_time = datetime.datetime.now(datetime.UTC)
         assert result_before_login[0]['login'] == login
         assert result_before_login[0]['last-login'] == ""
 
@@ -480,7 +480,7 @@ class TestPersonalAccessToken:
         user = target_sat.cli_factory.user()
         target_sat.cli.User.add_role({'login': user['login'], 'role': 'Viewer'})
         token_name = gen_alphanumeric()
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         datetime_expire = datetime_now + datetime.timedelta(seconds=20)
         datetime_expire = datetime_expire.strftime("%Y-%m-%d %H:%M:%S")
         result = target_sat.cli.User.access_token(
@@ -579,7 +579,7 @@ class TestPersonalAccessToken:
                     },
                 )
         # check for past datetime
-        datetime_now = datetime.datetime.utcnow()
+        datetime_now = datetime.datetime.now(datetime.UTC)
         datetime_expire = datetime_now - datetime.timedelta(seconds=20)
         datetime_expire = datetime_expire.strftime("%Y-%m-%d %H:%M:%S")
         with pytest.raises(CLIReturnCodeError):

--- a/tests/foreman/cli/test_user.py
+++ b/tests/foreman/cli/test_user.py
@@ -264,7 +264,7 @@ class TestUser:
         assert result_after_login[0]['last-login'] != ""
         after_login_time = datetime.datetime.strptime(
             result_after_login[0]['last-login'], "%Y/%m/%d %H:%M:%S"
-        )
+        ).replace(tzinfo=datetime.UTC)
         assert after_login_time > before_login_time
 
     @pytest.mark.tier1

--- a/tests/foreman/destructive/test_capsulecontent.py
+++ b/tests/foreman/destructive/test_capsulecontent.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from box import Box
 from fauxfactory import gen_alpha
@@ -109,7 +109,7 @@ def test_positive_sync_without_deadlock(
     )
     # timestamp: to check capsule task(s) began, exclude priors
     # within 120 seconds of end of repo_sync
-    timestamp = datetime.utcnow().replace(microsecond=0) - timedelta(seconds=120)
+    timestamp = datetime.now(UTC).replace(microsecond=0) - timedelta(seconds=120)
     repo_to_capsule_task = target_sat.wait_for_tasks(
         search_query=(
             f'label=Actions::Katello::Repository::CapsuleSync and started_at >= {timestamp}'

--- a/tests/foreman/longrun/test_inc_updates.py
+++ b/tests/foreman/longrun/test_inc_updates.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -142,7 +142,7 @@ def host(
     )
     rhel7_contenthost_module.enable_repo(REPOS['rhsclient7']['id'])
     # make a note of time for later wait_for_tasks, and include 4 mins margin of safety.
-    timestamp = (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
+    timestamp = (datetime.now(UTC) - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
     # AK added custom repo for errata package, just install it.
     rhel7_contenthost_module.execute(f'yum install -y {FAKE_4_CUSTOM_PACKAGE}')
     rhel7_contenthost_module.execute('subscription-manager repos')
@@ -244,7 +244,7 @@ def test_positive_incremental_update_time(module_target_sat, module_sca_manifest
         {'organization-id': module_sca_manifest_org.id}
     )
     repo_sync_timestamp = (
-        datetime.utcnow().replace(microsecond=0) - timedelta(seconds=1)
+        datetime.now(UTC).replace(microsecond=0) - timedelta(seconds=1)
     ).strftime('%Y-%m-%d %H:%M')
     # setup rh repositories, add to cv, begin sync
     for _repo in ['rhel8_bos', 'rhst8', 'rhsclient8']:
@@ -281,21 +281,21 @@ def test_positive_incremental_update_time(module_target_sat, module_sca_manifest
 
     # update incremental version via hammer, using one errata.
     # expect: incr. "version-1.1" is created
-    update_start_time = datetime.utcnow()
+    update_start_time = datetime.now(UTC)
     result = module_target_sat.cli.ContentView.version_incremental_update(
         options={'content-view-version-id': cvv['id'], 'errata-ids': REAL_RHEL8_1_ERRATA_ID},
         output_format='base',
     )
     assert f'Content View: {cv.name} version 1.1' in result
-    update_duration = (datetime.utcnow() - update_start_time).total_seconds()
+    update_duration = (datetime.now(UTC) - update_start_time).total_seconds()
     logger.info(
         f'Update of incremental version-1.1, for CV id: {content_view["id"]},'
         f' took {update_duration} seconds.'
     )
     # publish the full CV, containing the added version-1.1
-    publish_start_time = datetime.utcnow()
+    publish_start_time = datetime.now(UTC)
     result = module_target_sat.cli.ContentView.publish({'id': cv['id']})
-    publish_duration = (datetime.utcnow() - publish_start_time).total_seconds()
+    publish_duration = (datetime.now(UTC) - publish_start_time).total_seconds()
     logger.info(f'Publish for CV id: {content_view["id"]}, took {publish_duration} seconds.')
     # Per BZs: expect update duration was quicker than publish duration,
     # if instead, update took longer, check that they were close,

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -122,14 +122,14 @@ def test_pulp_status(target_sat):
     assert status['redis_connection']['connected']
 
     workers_beats = [
-        datetime.strptime(worker['last_heartbeat'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        datetime.strptime(worker['last_heartbeat'], '%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=UTC)
         for worker in status['online_workers']
     ]
     assert all((now - beat).seconds < 20 for beat in workers_beats), (
         'Some pulp workers seem to me dead!'
     )
     apps_beats = [
-        datetime.strptime(app['last_heartbeat'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        datetime.strptime(app['last_heartbeat'], '%Y-%m-%dT%H:%M:%S.%fZ').replace(tzinfo=UTC)
         for app in status['online_content_apps']
     ]
     assert all((now - beat).seconds < 20 for beat in apps_beats), (

--- a/tests/foreman/sys/test_pulp3_filesystem.py
+++ b/tests/foreman/sys/test_pulp3_filesystem.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 import json
 
 import pytest
@@ -115,7 +115,7 @@ def test_pulp_status(target_sat):
         2. The pulp components are alive according to provided status.
     """
     result = target_sat.execute('pulp status')
-    now = datetime.utcnow()
+    now = datetime.now(UTC)
     assert not result.status
     status = json.loads(result.stdout)
     assert status['database_connection']['connected']

--- a/tests/foreman/ui/test_capsulecontent.py
+++ b/tests/foreman/ui/test_capsulecontent.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -327,7 +327,7 @@ def test_positive_content_counts_granular_update(
         session.capsule.refresh_lce_counts(
             module_capsule_configured.hostname, lce_name=lce1.name, cv_name=cv1.name
         )
-        timestamp = (datetime.utcnow() - timedelta(seconds=1)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(seconds=1)).strftime('%Y-%m-%d %H:%M')
         task = module_target_sat.api.ForemanTask().search(
             query={
                 'search': f'label=Actions::Katello::CapsuleContent::UpdateContentCounts and started_at>="{timestamp}"'
@@ -349,7 +349,7 @@ def test_positive_content_counts_granular_update(
 
         # 6. Refresh counts for the second LCE, check entity IDs in the Update task.
         session.capsule.refresh_lce_counts(module_capsule_configured.hostname, lce_name=lce2.name)
-        timestamp = (datetime.utcnow() - timedelta(seconds=1)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(seconds=1)).strftime('%Y-%m-%d %H:%M')
         task = module_target_sat.api.ForemanTask().search(
             query={
                 'search': f'label=Actions::Katello::CapsuleContent::UpdateContentCounts and started_at>="{timestamp}"'

--- a/tests/foreman/ui/test_contenthost.py
+++ b/tests/foreman/ui/test_contenthost.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import re
 from urllib.parse import urlparse
 
@@ -305,7 +305,7 @@ def test_positive_end_to_end_bulk_update(session, default_location, vm, target_s
         assert p.path == '/content_hosts'
         assert p.query == query
         # Note time for later wait_for_tasks, and include 4 mins margin of safety.
-        timestamp = (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
         # Update the package by name
         session.hostcollection.manage_packages(
             hc_name,
@@ -1143,7 +1143,7 @@ def test_module_status_update_without_force_upload_package_profile(
     # reset walrus module streams
     run_remote_command_on_content_host(f'dnf module reset {module_name} -y', vm_module_streams)
     # make a note of time for later wait_for_tasks, and include 4 mins margin of safety.
-    timestamp = (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
+    timestamp = (datetime.now(UTC) - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
     # install walrus module stream with flipper profile
     run_remote_command_on_content_host(
         f'dnf module install {module_name}:{stream_version}/{profile} -y',

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import re
 
 from broker import Broker
@@ -364,7 +364,7 @@ def test_end_to_end(
     )
 
     with session:
-        datetime_utc_start = datetime.utcnow().replace(microsecond=0)
+        datetime_utc_start = datetime.now(UTC).replace(microsecond=0)
         # Check selection box function for BZ#1688636
         session.location.select(loc_name=DEFAULT_LOC)
         results = session.errata.search_content_hosts(
@@ -902,7 +902,7 @@ def test_positive_apply_for_all_hosts(
             assert client.applicable_package_count > 0
 
         with session:
-            timestamp = datetime.utcnow().replace(microsecond=0) - timedelta(seconds=1)
+            timestamp = datetime.now(UTC).replace(microsecond=0) - timedelta(seconds=1)
             session.location.select(loc_name=DEFAULT_LOC)
             # for first errata, apply to all chosts at once,
             # from ContentTypes > Errata > info > ContentHosts tab
@@ -1479,7 +1479,7 @@ def test_positive_check_errata_counts_by_type_on_host_details_page(
         assert int(len(read_errata['Content']['Errata']['pagination'])) == 0
 
         pkgs = ' '.join(FAKE_9_YUM_OUTDATED_PACKAGES)
-        install_timestamp = datetime.utcnow().replace(microsecond=0) - timedelta(seconds=1)
+        install_timestamp = datetime.now(UTC).replace(microsecond=0) - timedelta(seconds=1)
         assert vm.execute(f'yum install -y {pkgs}').status == 0
 
         # applicability task(s) found and succeed

--- a/tests/foreman/ui/test_repository.py
+++ b/tests/foreman/ui/test_repository.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from random import choice, randint, shuffle
 
 from navmazing import NavigationTriesExceeded
@@ -991,7 +991,7 @@ def test_sync_status_persists_after_task_delete(session, module_prod, module_org
     :expectedresults: Displayed Sync Status is still "Synced" after task deleted.
     """
     # make a note of time for later API wait_for_tasks, and include 4 mins margin of safety.
-    timestamp = (datetime.utcnow() - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
+    timestamp = (datetime.now(UTC) - timedelta(minutes=4)).strftime('%Y-%m-%d %H:%M')
     repo = target_sat.api.Repository(url=settings.repos.yum_1.url, product=module_prod).create()
     with session:
         result = session.sync_status.read()

--- a/tests/foreman/ui/test_rhc.py
+++ b/tests/foreman/ui/test_rhc.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from fauxfactory import gen_string
 from manifester import Manifester
@@ -142,7 +142,7 @@ def test_positive_configure_cloud_connector(
     parameters = [{'name': 'source_display_name', 'value': gen_string('alpha')}]
     host.host_parameters_attributes = parameters
     host.update(['host_parameters_attributes'])
-    timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
+    timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
     with module_target_sat.ui_session() as session:
         session.organization.select(org_name=module_rhc_org.name)
         if session.cloudinventory.is_cloud_connector_configured():

--- a/tests/foreman/ui/test_rhcloud_insights.py
+++ b/tests/foreman/ui/test_rhcloud_insights.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pytest
 from wait_for import wait_for
@@ -37,7 +37,7 @@ def sync_recommendations(satellite, org_name=DEFAULT_ORG, loc_name=DEFAULT_LOC):
         session.organization.select(org_name=org_name)
         session.location.select(loc_name=DEFAULT_LOC)
 
-        timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+        timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.sync_hits()
 
     wait_for(
@@ -119,7 +119,7 @@ def test_rhcloud_insights_e2e(
         assert result['Recommendation'] == OPENSSH_RECOMMENDATION
 
         # Run the remediation.
-        timestamp = datetime.utcnow().strftime('%Y-%m-%d %H:%M')
+        timestamp = datetime.now(UTC).strftime('%Y-%m-%d %H:%M')
         session.cloudinsights.remediate(OPENSSH_RECOMMENDATION)
 
     # Wait for the remediation task to complete.

--- a/tests/foreman/ui/test_rhcloud_inventory.py
+++ b/tests/foreman/ui/test_rhcloud_inventory.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from wait_for import wait_for
@@ -88,7 +88,7 @@ def test_rhcloud_inventory_e2e(
     with module_target_sat.ui_session() as session:
         session.organization.select(org_name=org.name)
         session.location.select(loc_name=DEFAULT_LOC)
-        timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
@@ -186,7 +186,7 @@ def test_rh_cloud_inventory_settings(
         session.cloudinventory.update({'obfuscate_hostnames': True})
         session.cloudinventory.update({'obfuscate_ips': True})
         session.cloudinventory.update({'exclude_packages': True})
-        timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
@@ -240,7 +240,7 @@ def test_rh_cloud_inventory_settings(
         module_target_sat.update_setting('obfuscate_inventory_hostnames', True)
         module_target_sat.update_setting('obfuscate_inventory_ips', True)
         module_target_sat.update_setting('exclude_installed_packages', True)
-        timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(org.name)
         # wait_for_tasks report generation task to finish.
         wait_for(
@@ -332,7 +332,7 @@ def test_rhcloud_inventory_without_manifest(session, module_org, target_sat):
     """
     with session:
         session.organization.select(org_name=module_org.name)
-        timestamp = (datetime.utcnow() - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
+        timestamp = (datetime.now(UTC) - timedelta(minutes=2)).strftime('%Y-%m-%d %H:%M')
         session.cloudinventory.generate_report(module_org.name)
         wait_for(
             lambda: target_sat.api.ForemanTask()

--- a/tests/foreman/ui/test_syncplan.py
+++ b/tests/foreman/ui/test_syncplan.py
@@ -12,7 +12,7 @@
 
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from fauxfactory import gen_choice
 import pytest
@@ -160,7 +160,7 @@ def test_positive_search_scoped(session, request, target_sat):
     :CaseImportance: High
     """
     name = gen_string('alpha')
-    start_date = datetime.utcnow() + timedelta(days=10)
+    start_date = datetime.now(UTC) + timedelta(days=10)
     org = target_sat.api.Organization().create()
     sync_plan = target_sat.api.SyncPlan(
         name=name,

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -10,7 +10,7 @@
 
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 from airgun.session import Session
 from fauxfactory import gen_string
@@ -290,7 +290,7 @@ class TestVirtwhoConfigforEsx:
         assert (
             abs(
                 datetime.strptime(checkin_time, "%B %d, %Y at %I:%M %p")
-                .replace(year=datetime.utcnow().year)
+                .replace(year=datetime.now(UTC).year)
                 .timestamp()
                 - time_now.timestamp()
             )

--- a/tests/foreman/virtwho/ui/test_esx_sca.py
+++ b/tests/foreman/virtwho/ui/test_esx_sca.py
@@ -10,7 +10,7 @@
 
 """
 
-from datetime import UTC, datetime
+from datetime import datetime
 
 from airgun.session import Session
 from fauxfactory import gen_string
@@ -289,9 +289,7 @@ class TestVirtwhoConfigforEsx:
         # 10 mins margin to check the Last Checkin time
         assert (
             abs(
-                datetime.strptime(checkin_time, "%B %d, %Y at %I:%M %p")
-                .replace(year=datetime.now(UTC).year)
-                .timestamp()
+                datetime.strptime(checkin_time, "%B %d, %Y at %I:%M %p").timestamp()
                 - time_now.timestamp()
             )
             <= 300


### PR DESCRIPTION
### Problem Statement
There are numerous `DeprecationWarning: datetime.datetime.utcnow() is deprecated ...`

### Solution
Fix `DeprecationWarning` by replacing `.utcnow()` with `.now( [ datetime. ] UTC)`

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->