### PR TITLE
6.14 allow applying a scap policy after manual hardening

### DIFF
--- a/tests/foreman/longrun/test_oscap.py
+++ b/tests/foreman/longrun/test_oscap.py
@@ -309,6 +309,7 @@ def test_positive_oscap_run_via_ansible_bz_1814988(
                 'ansible-role-ids': role_id,
             }
         )
+        vm.run("sed -i 's/gpgcheck=1/gpgcheck=0/' /etc/yum.repos.d/foreman_registration1.repo")
         job_id = target_sat.cli.Host.ansible_roles_play({'name': vm.hostname.lower()})[0].get('id')
         target_sat.wait_for_tasks(
             f'resource_type = JobInvocation and resource_id = {job_id} and action ~ "hosts job"'


### PR DESCRIPTION
### Problem Statement

manual cherrypick of https://github.com/SatelliteQE/robottelo/pull/17681
closes https://github.com/SatelliteQE/robottelo/issues/17732

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->