### PR TITLE
[6.17.z] Add Cli/API/UI tests for bootc

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -270,6 +270,23 @@ def oracle_host(request, version):
         yield host
 
 
+@pytest.fixture
+def bootc_host():
+    """Fixture to check out boot-c host"""
+    with Broker(
+        workflow='deploy-bootc',
+        host_class=ContentHost,
+        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
+    ) as host:
+        assert (
+            host.execute(
+                f"echo '{constants.DUMMY_BOOTC_FACTS}' > /etc/rhsm/facts/bootc.facts"
+            ).status
+            == 0
+        )
+        yield host
+
+
 @pytest.fixture(scope='module', params=[{'rhel_version': 8, 'no_containers': True}])
 def external_puppet_server(request):
     deploy_args = host_conf(request)

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -2271,6 +2271,21 @@ DNF_RECOMMENDATION = (
 EXPIRED_MANIFEST = 'expired-manifest.zip'
 EXPIRED_MANIFEST_DATE = 'Fri Dec 03 2021'
 
+DUMMY_BOOTC_FACTS = """{
+  "bootc.booted.image": "quay.io/centos-bootc/centos-bootc:stream10",
+  "bootc.booted.version": "stream10.20241202.0",
+  "bootc.booted.digest": "sha256:54256a998f0c62e16f3927c82b570f90bd8449a52e03daabd5fd16d6419fd572",
+  "bootc.staged.image": null,
+  "bootc.staged.version": null,
+  "bootc.staged.digest": null,
+  "bootc.rollback.image": "quay.io/centos-bootc/centos-bootc:stream10",
+  "bootc.rollback.version": "stream10.20241107.0",
+  "bootc.rollback.digest": "sha256:9ed49e9b189f5dae5a01ea9abdcef0884616300b565d32061aea619f2e916be3",
+  "bootc.available.image": null,
+  "bootc.available.version": null,
+  "bootc.available.digest": null
+}"""
+
 
 # Data File Paths
 class DataFile(Box):

--- a/tests/foreman/cli/test_host.py
+++ b/tests/foreman/cli/test_host.py
@@ -12,6 +12,7 @@
 
 """
 
+import json
 from random import choice
 import re
 
@@ -23,6 +24,7 @@ import yaml
 from robottelo.config import settings
 from robottelo.constants import (
     DEFAULT_SUBSCRIPTION_NAME,
+    DUMMY_BOOTC_FACTS,
     FAKE_1_CUSTOM_PACKAGE,
     FAKE_1_CUSTOM_PACKAGE_NAME,
     FAKE_2_CUSTOM_PACKAGE,
@@ -2039,6 +2041,30 @@ def test_syspurpose_end_to_end(
                 'host-id': host['id'],
             }
         )
+
+
+@pytest.mark.e2e
+def test_positive_register_read_bootc(target_sat, bootc_host, function_ak_with_cv, function_org):
+    """Register a bootc host and validate the information
+
+    :id: d9557843-4cc7-4e70-a035-7b2c4008dd5e
+
+    :expectedresults: Upon registering a Bootc host, the facts are attached to the host, and are accurate.
+
+    :CaseComponent:Hosts-Content
+
+    :Verifies:SAT-27168, SAT-27170
+
+    :CaseImportance: Critical
+    """
+    bootc_dummy_info = json.loads(DUMMY_BOOTC_FACTS)
+    assert bootc_host.register(function_org, None, function_ak_with_cv.name, target_sat).status == 0
+    assert bootc_host.subscribed
+    bootc_info = target_sat.cli.Host.info({'name': bootc_host.hostname})['bootc-image-information']
+    assert bootc_info['running-image'] == bootc_dummy_info['bootc.booted.image']
+    assert bootc_info['running-image-digest'] == bootc_dummy_info['bootc.booted.digest']
+    assert bootc_info['rollback-image'] == bootc_dummy_info['bootc.rollback.image']
+    assert bootc_info['rollback-image-digest'] == bootc_dummy_info['bootc.rollback.digest']
 
 
 # -------------------------- MULTI-CV SCENARIOS -------------------------


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17634

### Problem Statement
Adds tests for CLI/UI/API for bootc, using dummy facts

### Related Issues
Relies on: https://github.com/SatelliteQE/airgun/pull/1745 and https://github.com/SatelliteQE/nailgun/pull/1277

