### PR TITLE
[6.17.z] Read leftover container upstream names from settings

### DIFF
--- a/conf/container.yaml.template
+++ b/conf/container.yaml.template
@@ -5,6 +5,9 @@ CONTAINER:
     - podman
   REGISTRY_HUB: https://mirror.gcr.io
   UPSTREAM_NAME: 'library/busybox'
+  ALTERNATIVE_UPSTREAM_NAMES:
+    - hello-world
+    - alpine
   DOCKER:
     REPO_UPSTREAM_NAME: 'openshift3/logging-elasticsearch'
   PULP:

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -102,6 +102,12 @@ VALIDATORS = dict(
             default='library/busybox',
         ),
         Validator(
+            'container.alternative_upstream_names',
+            must_exist=True,
+            is_type_of=list,
+            default=['hello-world', 'alpine'],
+        ),
+        Validator(
             'container.docker.repo_upstream_name',
             must_exist=True,
             is_type_of=str,

--- a/tests/foreman/cli/test_docker.py
+++ b/tests/foreman/cli/test_docker.py
@@ -565,7 +565,7 @@ class TestDockerContentView:
         """
         old_prod_name = gen_string('alpha', 5)
         new_prod_name = gen_string('alpha', 5)
-        docker_upstream_name = 'hello-world'
+        docker_upstream_name = settings.container.alternative_upstream_names[0]
         new_pattern = '<%= content_view.label %>/<%= product.name %>'
 
         lce = module_target_sat.cli_factory.make_lifecycle_environment(
@@ -650,7 +650,7 @@ class TestDockerContentView:
         """
         old_repo_name = gen_string('alpha', 5)
         new_repo_name = gen_string('alpha', 5)
-        docker_upstream_name = 'hello-world'
+        docker_upstream_name = settings.container.alternative_upstream_names[0]
         new_pattern = '<%= content_view.label %>/<%= repository.name %>'
 
         lce = module_target_sat.cli_factory.make_lifecycle_environment(
@@ -728,7 +728,7 @@ class TestDockerContentView:
 
         :expectedresults: Content view is not promoted
         """
-        docker_upstream_names = ['hello-world', 'alpine']
+        docker_upstream_names = settings.container.alternative_upstream_names
         new_pattern = '<%= organization.label %>'
 
         lce = module_target_sat.cli_factory.make_lifecycle_environment(
@@ -766,7 +766,7 @@ class TestDockerContentView:
 
         :expectedresults: Registry name pattern is not changed
         """
-        docker_upstream_names = ['hello-world', 'alpine']
+        docker_upstream_names = settings.container.alternative_upstream_names
         new_pattern = '<%= organization.label %>'
 
         content_view = module_target_sat.cli_factory.make_content_view(


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17729

### Problem Statement

Some docker upstream names were still ahrdcoded

### Solution

Make them configurable

### Tests to run

pytest -s -vvv tests/foreman/cli/test_docker.py::TestDockerContentView
<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->