### PR TITLE
Make container and flatpak hosts ipv6 aware

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -221,6 +221,7 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
         "rhel_version": "8",
         "distro": "rhel",
         "no_containers": True,
+        "network": "ipv6" if settings.server.is_ipv6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
@@ -245,6 +246,7 @@ def module_flatpak_contenthost(request):
         "rhel_version": "9",
         "distro": "rhel",
         "no_containers": True,
+        "network": "ipv6" if settings.server.is_ipv6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()


### PR DESCRIPTION
### Problem Statement
Several tests fail in host setup in IPv6 pipeline since they are unaware of IPV context and spawn on IPv4 infra.
```
pytest_fixtures/core/contenthosts.py:235: in module_flatpak_contenthost
    with Broker(**host_conf(request), host_class=ContentHost) as host:
    ...
    sock.connect((host, port))
E   socket.gaierror: [Errno -5] No address associated with hostname
```


### Solution
Deploy them properly per IPV settings.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_flatpak.py -k sync_consume_flatpak_repo_via_library
network_type: ipv6
```
