### PR TITLE
[6.17.z] update assertion for discovery plugin test as per IPv4/Ipv6 ip address

### DIFF
--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -15,6 +15,8 @@
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
 import pytest
 
+from robottelo.config import settings
+
 
 @pytest.fixture
 def module_discovery_env(module_org, module_location, module_target_sat):
@@ -169,7 +171,12 @@ def test_negative_delete_rule_with_non_admin_user(
 @pytest.mark.run_in_one_thread
 @pytest.mark.tier3
 def test_positive_list_host_based_on_rule_search_query(
-    request, session, module_org, module_location, module_discovery_env, target_sat
+    request,
+    session,
+    module_org,
+    module_location,
+    module_discovery_env,
+    target_sat,
 ):
     """List all the discovered hosts resolved by given rule's search query
     e.g. all discovered hosts with cpu_count = 2, and list rule's associated
@@ -190,7 +197,7 @@ def test_positive_list_host_based_on_rule_search_query(
 
     :BZ: 1731112
     """
-    ip_address = gen_ipaddr()
+    ip_address = gen_ipaddr(ipv6=settings.server.is_ipv6)
     cpu_count = gen_integer(2, 10)
     rule_name = gen_string('alpha')
     rule_search = f'cpu_count = {cpu_count}'
@@ -236,7 +243,7 @@ def test_positive_list_host_based_on_rule_search_query(
         values = session.discoveryrule.read_discovered_hosts(discovery_rule.name)
         assert values['searchbox'] == rule_search
         assert len(values['table']) == 1
-        assert values['table'][0]['IP Address'] == ip_address
+        assert values['table'][0]['IPv6' if settings.server.is_ipv6 else 'IPv4'] == ip_address
         assert values['table'][0]['CPUs'] == str(cpu_count)
         # auto provision the discovered host
         result = target_sat.api.DiscoveredHost(id=discovered_host['id']).auto_provision()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17633

Previously, there was only one column for `IP Address`. However, starting from `version 6.17`, both `IPv4` and `IPv6` networks are used. When a discovery host is created, two separate columns are displayed for `IPv4` and `IPv6`. To prevent assertion failures, the IP address will be fetched based on the respective network.

`Prior -
`![image](https://github.com/user-attachments/assets/21525a7e-431f-4f2e-9409-a955832e5952)

`Latest - 
`![image](https://github.com/user-attachments/assets/0374a8ec-9994-4318-bcca-3bde9f26f488)
