### PR TITLE
[6.17.z] Check RHCloud auto-sync setting

### DIFF
--- a/tests/foreman/cli/test_rhcloud_inventory.py
+++ b/tests/foreman/cli/test_rhcloud_inventory.py
@@ -405,3 +405,24 @@ def test_positive_register_insights_client_host(module_target_sat, rhel_insights
     output = rhel_insights_vm.execute(f'insights-client --ansible-host={rhel_insights_vm.hostname}')
     assert output.status == 0
     assert 'Ansible hostname updated' in output.stdout
+
+
+def test_positive_check_report_autosync_setting(target_sat):
+    """Verify that the Insights report autosync setting is enabled by default.
+
+    :id: 137dffe6-50a4-4327-8e93-79e128bee63b
+
+    :steps:
+        1. Check the Insights report autosync setting.
+
+    :expectedresults:
+        1. The Insights setting "Synchronize recommendations Automatically" should have value "true"
+
+    :Verifies: SAT-30227
+    """
+    assert (
+        target_sat.cli.Settings.list({'search': 'Synchronize recommendations Automatically'})[0][
+            'value'
+        ]
+        == 'true'
+    ), 'Setting is not enabled by default!'


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17790

### Problem Statement
Automation for SAT-30227 was needed.
It needs to check that the RHCloud auto-sync setting is set to true by default

### Solution
This PR
![image](https://github.com/user-attachments/assets/8eec03ed-babb-4be6-89f1-24c1e9225b14)

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_rhcloud_inventory.py::test_positive_check_report_autosync_setting
```
