### PR TITLE
Fix intermittent connection timeout on host reboot

### DIFF
--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -184,6 +184,7 @@ def precondition_check_upgrade_and_install_leapp_tool(custom_leapp_host):
     assert custom_leapp_host.run('yum install leapp-upgrade -y').status == 0
     if custom_leapp_host.run('needs-restarting -r').status == 1:
         custom_leapp_host.power_control(state='reboot', ensure=True)
+        custom_leapp_host.wait_for_connection()
 
     # Fixing known inhibitors for source rhel version 8
     if custom_leapp_host.os_version.major == 8:

--- a/tests/foreman/cli/test_leapp_client.py
+++ b/tests/foreman/cli/test_leapp_client.py
@@ -98,6 +98,7 @@ def test_positive_leapp_upgrade_rhel(
         (login, password),
     )
     custom_leapp_host.power_control(state='reboot')
+    custom_leapp_host.wait_for_connection()
     result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
     assert result['success'] == '1'
 
@@ -244,6 +245,7 @@ def test_positive_ygdrassil_client_after_leapp_upgrade(
     )
 
     custom_leapp_host.power_control(state='reboot')
+    custom_leapp_host.wait_for_connection()
     result = module_target_sat.cli.JobInvocation.info({'id': invocation_command['id']})
     assert result['success'] == '1'
 


### PR DESCRIPTION
### Problem Statement
Leapp tests were failing intermittently due to connection error with host.

### Solution
Added wait_for_connection() to ensure it doesn't fail. 

### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->