### PR TITLE
Customer case automation - satellite installation in ipv6 disabled environment.

### DIFF
--- a/tests/foreman/destructive/test_fm_upgrade.py
+++ b/tests/foreman/destructive/test_fm_upgrade.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.destructive
 
 @pytest.mark.include_capsule
 def test_negative_ipv6_update_check(sat_maintain):
-    """Ensure update check fails when ipv6.disable=1 in boot options
+    """Ensure update check and satellite-installer fails when ipv6.disable=1 in boot options
 
     :id: 7b3e017f-443a-4204-99be-e39fa04c89f6
 
@@ -29,12 +29,13 @@ def test_negative_ipv6_update_check(sat_maintain):
         1. Add ipv6.disable to grub boot options
         2. Reboot
         3. Run update check
+        4. Run satellite-installer
 
     :customerscenario: true
 
-    :verifies: SAT-24811
+    :verifies: SAT-24811, SAT-26758
 
-    :expectedresults: Update check fails due to ipv6.disable=1 in boot options
+    :expectedresults: Update check and satellite-installer fails due to ipv6.disable=1 in boot options
     """
     result = sat_maintain.execute('grubby --args="ipv6.disable=1" --update-kernel=ALL')
     assert result.status == 0
@@ -53,3 +54,9 @@ def test_negative_ipv6_update_check(sat_maintain):
         'The kernel contains ipv6.disable=1 which is known to break installation and upgrade, remove and reboot before continuing.'
         in result.stdout
     )
+    result = sat_maintain.execute('satellite-installer')
+    assert (
+        'The kernel contains ipv6.disable=1 which is known to break installation and upgrade.\nRemove and reboot before continuining.\n'
+        in result.stderr
+    )
+    assert result.status != 0


### PR DESCRIPTION
### Problem Statement
- Add Customer case automation for SAT-26758 - satellite installation in ipv6 disabled environment.

### Solution
- Update `test_negative_ipv6_update_check` and add scenario to test that satellite-installer will fail when kernel contains ipv6.disable=1.

### Related Issues
- SAT-26758
- SAT-31232

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->