### PR TITLE
ignore warnings from Ansible when a host can't be found

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -221,7 +221,7 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
 
     # Execute test_playbook
     result = module_target_sat.execute(
-        f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.12"'
+        f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ANSIBLE_HOST_PATTERN_MISMATCH=ignore make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.12"'
     )
     assert result.status == 0, f"{result.status=}\n{result.stdout=}\n{result.stderr=}"
 


### PR DESCRIPTION
### Problem Statement

some test playbook have a "foreman" host defined, but that's not in the
inventory and thus generates warnings

### Solution

tell ansible to ignore this

### Related Issues


### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/sys/test_fam.py::test_positive_run_modules_and_roles[host]
