### PR TITLE
Fix container path pattern

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -225,7 +225,7 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
-        for client in constants.CONTAINER_CLIENTS:
+        for client in settings.container.clients:
             assert host.execute(f'yum -y install {client}').status == 0, (
                 f'{client} installation failed'
             )

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -397,7 +397,7 @@ class TestDockerClient:
 
         podman_pull_command = (
             f"podman pull --tls-verify=false {target_sat.hostname}/{module_org.label}"
-            f"-{lce['label']}-{cv['label']}-{product['label']}-{repo_name}".lower()
+            f"/{lce['label']}/{cv['label']}/{product['label']}/{repo_name}".lower()
         )
 
         # 4. Pull in docker image

--- a/tests/foreman/cli/test_container_management.py
+++ b/tests/foreman/cli/test_container_management.py
@@ -332,7 +332,7 @@ class TestDockerClient:
         result = module_container_contenthost.execute(docker_pull_command)
         assert result.status == 0
 
-    def test_negative_pull_content_with_longer_name(
+    def test_positive_pull_content_with_longer_name(
         self, request, target_sat, module_container_contenthost, module_org
     ):
         """Verify that long name CV publishes when CV & docker repo both have a larger name.


### PR DESCRIPTION
### Problem Statement
The default registry name pattern has been changed from `-` to `/` in 6.17.0 and `test_negative_pull_content_with_longer_name` seems to be the last left forgotten.


### Solution
Update the pattern.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/cli/test_container_management.py -k test_negative_pull_content_with_longer_name
```