### PR TITLE
use wait_for_tasks after generate metadata for repos

### DIFF
--- a/robottelo/host_helpers/repository_mixins.py
+++ b/robottelo/host_helpers/repository_mixins.py
@@ -636,6 +636,13 @@ class RepositoryCollection:
             repos_info.append(repo_info)
         self._custom_product_info = custom_product
         self._repos_info = repos_info
+        # Wait for metadata generation for repository creation for specific org
+        task_query = f'Metadata generate "{custom_product.organization}"'
+        self.satellite.wait_for_tasks(
+            search_query=task_query,
+            max_tries=6,
+            search_rate=10,
+        )
         return custom_product, repos_info
 
     def setup_content_view(self, org_id, lce_id=None):


### PR DESCRIPTION
### Problem Statement
Build says it's regression. Few tests were failing due to below error, it is failing in `robottelo/host_helpers/repository_mixins.py` 
Back trace-
`robottelo/host_helpers/repository_mixins.py:769: in setup_content`

**Error** 
```
Pending tasks detected in repositories of this content view. Please wait for the tasks
```
**Stack Trace** 
```
pytest_fixtures/component/repository.py:246: in module_repos_collection_with_manifest
    _repos_collection.setup_content(module_sca_manifest_org.id, module_lce.id)
robottelo/host_helpers/repository_mixins.py:769: in setup_content
    content_view, lce = self.setup_content_view(org_id, lce_id)
robottelo/host_helpers/repository_mixins.py:656: in setup_content_view
    self.satellite.cli.ContentView.publish({'id': content_view['id']})
robottelo/cli/contentview.py:115: in publish
    return cls.execute(cls._construct_command(options), ignore_stderr=True, timeout=timeout)
robottelo/cli/base.py:211: in execute
    return cls._handle_response(response, ignore_stderr=ignore_stderr)
robottelo/cli/base.py:60: in _handle_response
    raise CLIReturnCodeError(*error_data)
E   robottelo.exceptions.CLIReturnCodeError: CLIReturnCodeError(status=70, stderr='Could not publish the content view:\n  Pending tasks detected in repositories of this content view. Please wait for the tasks: - https://sat.example.com/foreman_tasks/tasks/45c46d79-75b0-455d-a471-cea5bf9f8b17 before publishing.\n', msg='Command "content-view publish" finished with status 70\nstderr contains:\nCould not publish the content view:\n  Pending tasks detected in repositories of this content view. Please wait for the tasks: - https://sat.example.com/foreman_tasks/tasks/45c46d79-75b0-455d-a471-cea5bf9f8b17 before publishing.\n'
```

### Solution
Add `wait_for_tasks` in repository_mixins.py after repository setup.

### Related Issues
N/A

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_positive_end_to_end_bulk_update'
```

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->