### PR TITLE
[6.15.z] Add tests for python content type

### DIFF
--- a/conf/repos.yaml.template
+++ b/conf/repos.yaml.template
@@ -190,3 +190,7 @@ REPOS:
   GR_YUM_REPO:
     URL:
     GPG_URL:
+
+  PYTHON:
+    PYPI:
+      URL: 'https://pypi.org/project/pytest'

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -322,6 +322,12 @@ VALIDATORS = dict(
             must_exist=True,
             is_type_of=str,
         ),
+        Validator(
+            'repos.python.pypi.url',
+            must_exist=True,
+            is_type_of=str,
+            default='https://pypi.org/project/pytest',
+        ),
     ],
     rhev=[
         Validator(

--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -215,6 +215,7 @@ REPO_TYPE = {
     'docker': "docker",
     'ansible_collection': "ansible_collection",
     'file': "file",
+    'python': 'python',
 }
 
 DOWNLOAD_POLICIES = {

--- a/tests/foreman/api/test_repository.py
+++ b/tests/foreman/api/test_repository.py
@@ -2450,3 +2450,33 @@ class TestTokenAuthContainerRepository:
             synced_repo = repo.read()
             assert synced_repo.content_counts['docker_manifest'] >= 1
             assert synced_repo.content_counts['docker_tag'] == 1
+
+
+class TestPythonRepository:
+    """Specific tests for Python Repositories"""
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize(
+        'repo_options',
+        **parametrized(
+            [{'content_type': constants.REPO_TYPE['python'], 'url': settings.repos.python.pypi.url}]
+        ),
+        indirect=True,
+    )
+    def test_positive_sync(self, repo, target_sat):
+        """Check python repository can be synced.
+
+        :id: e521a7a4-2502-4fe2-b297-a13fc99e679f
+
+        :BlockedBy: SAT-23430
+
+        :steps:
+            1. Sync python repo
+
+        :expectedresults: Pyhton repo is synced
+
+        :CaseImportance: Critical
+
+        :CaseAutomation: Automated
+        """
+        repo.sync()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17704

### Problem Statement

Missing python content type

### Solution

Add python as content type and add simple happy flow test for sync

### Related Issues

tests/foreman/api/test_repository.py::TestPythonRepository::test_positive_sync
-->