### PR TITLE
[6.17.z] Fix container contenthost

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -225,7 +225,7 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
-        for client in constants.CONTAINER_CLIENTS:
+        for client in settings.container.clients:
             assert host.execute(f'yum -y install {client}').status == 0, (
                 f'{client} installation failed'
             )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17825

### Problem Statement
In #17690 we moved container constants to settings but forgot about `container_contentohst`, so we get these failures
```
pytest_fixtures/core/contenthosts.py:234: in module_container_contenthost
    for client in constants.CONTAINER_CLIENTS:
E   AttributeError: module 'robottelo.constants' has no attribute 'CONTAINER_CLIENTS'
```


### Solution
Update the fixture.


### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman -k test_negative_pull_content_with_longer_name
```