### PR TITLE
test without recursive variables

### DIFF
--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -87,6 +87,9 @@ def setup_fam(module_target_sat, module_sca_manifest, install_import_ansible_rol
         f'{FAM_ROOT_DIR}/tests/test_playbooks/vars/server.yml',
         temp_file=True,
     )
+    # HACK! let's drop those recursive variable definitions
+    module_target_sat.execute(f"sed -i '/{{/d' {FAM_ROOT_DIR}/tests/test_playbooks/vars/server.yml")
+
     module_target_sat.put(
         settings.fam.compute_profile.to_yaml(),
         f'{FAM_ROOT_DIR}/tests/test_playbooks/vars/compute_profile.yml',

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -224,7 +224,8 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
 
     # Execute test_playbook
     result = module_target_sat.execute(
-        f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ANSIBLE_HOST_PATTERN_MISMATCH=ignore make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.12"'
+        f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ANSIBLE_HOST_PATTERN_MISMATCH=ignore make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.12"',
+        timeout="12h",
     )
     assert result.status == 0, f"{result.status=}\n{result.stdout=}\n{result.stderr=}"
 

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -223,6 +223,7 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
         module_target_sat.configure_libvirt_cr()
 
     # Execute test_playbook
+    assert false, f"the default_timeout is {module_target_sat.default_timeout}, the session timeout is {module_target_sat.session.get_timeout()}"
     result = module_target_sat.execute(
         f'NO_COLOR=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ANSIBLE_HOST_PATTERN_MISMATCH=ignore make --directory {FAM_ROOT_DIR} livetest_{ansible_module} PYTHON_COMMAND="python3" PYTEST_COMMAND="pytest-3.12"',
         timeout="12h",


### PR DESCRIPTION
### Problem Statement


### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->