### PR TITLE
fix type error in contenthost fixture

### DIFF
--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -206,7 +206,7 @@ def rhel_contenthost_with_repos(request, target_sat):
     repositories on the host"""
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         # create a custom, rhel version-specific OS repo
-        rhelver = request.param['rhel_version']
+        rhelver = host.os_version.major
         if rhelver > 7:
             host.create_custom_repos(**settings.repos[f'rhel{rhelver}_os'])
         else:


### PR DESCRIPTION
### Problem Statement
introduced in https://github.com/SatelliteQE/robottelo/pull/17551, request param version can be a string (oddly, this is the case for fips variants only), hence type error

### Solution


### Related Issues


<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->