### PR TITLE
Remove Python 3.10 support

### DIFF
--- a/.github/workflows/auto_branching.yml
+++ b/.github/workflows/auto_branching.yml
@@ -193,7 +193,7 @@ jobs:
           PROTECTION_PAYLOAD='{
             "required_status_checks": {
                 "strict": true,
-                "contexts": ["Code Quality (3.10)", "Code Quality (3.11)", "Code Quality (3.12)", "Code Quality (3.13)", "Enforcing cherrypick labels"]
+                "contexts": ["Code Quality (3.11)", "Code Quality (3.12)", "Code Quality (3.13)", "Enforcing cherrypick labels"]
             },
             "required_linear_history": true,
             "enforce_admins": null,

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
     env:
       UV_CACHE_DIR: /tmp/.uv-cache
       UV_SYSTEM_PYTHON: 1

--- a/scripts/config_helpers.py
+++ b/scripts/config_helpers.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "click",
 #     "deepdiff",

--- a/scripts/customer_scenarios.py
+++ b/scripts/customer_scenarios.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "click",
 #     "requests",

--- a/scripts/fixture_cli.py
+++ b/scripts/fixture_cli.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "click",
 #     "pytest",

--- a/scripts/tokenize_customer_scenario.py
+++ b/scripts/tokenize_customer_scenario.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "codemod",
 # ]

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -1,5 +1,5 @@
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.11"
 # dependencies = [
 #     "dynaconf",
 # ]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
     license='GNU GPL v3.0',
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
-    python_requires="~=3.10",
+    python_requires="~=3.11",
     classifiers=(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
### Problem Statement
We can not update the Sphinx library without dropping Python 3.10 - SatelliteQE/robottelo#17638.

### Solution
Drop Python 3.10 suport.


### Related Issues
SatelliteQE/robottelo#17638
SatelliteQE/robottelo#17666
SatelliteQE/robottelo#17557

