### PR TITLE
[6.17.z] Fix subscriptions UI test

### DIFF
--- a/tests/foreman/ui/test_subscription.py
+++ b/tests/foreman/ui/test_subscription.py
@@ -436,6 +436,7 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(
         'Type': False,
         'Consumed': False,
         'Entitlements': False,
+        'Product Host Count': False,
     }
     org = function_org
     with session:
@@ -446,7 +447,6 @@ def test_select_customizable_columns_uncheck_and_checks_all_checkboxes(
         )
         headers = session.subscription.filter_columns(checkbox_dict)
         assert headers == ('Select all rows',)
-        assert len(checkbox_dict) == 9
         time.sleep(3)
         checkbox_dict.update((k, True) for k in checkbox_dict)
         col = session.subscription.filter_columns(checkbox_dict)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17862

### Problem Statement
The test was failing due to a missing column that needed to be managed.

This easy fix adds a missing column and removes one not-ideal assert.

<img width="423" alt="image" src="https://github.com/user-attachments/assets/2aa77bf6-a37d-458c-bb47-71a1b31c6f80" />

### PRT test Cases example
```
trigger: test-robottelo
pytest: tests/foreman/ui/test_subscription.py -k 'test_select_customizable_columns_uncheck_and_checks_all_checkboxes'
```
