### PR TITLE
Adapt robottelo to dualstack deployments

### DIFF
--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -11,7 +11,7 @@ CAPSULE:
     SOURCE: "internal"
     # The base os rhel version where the capsule installed
     # RHEL_VERSION:
-  # Network type on which the Satellite Capsule is deployed
+  # Network type on which the Satellite Capsule server is deployed
   # could be one of ["ipv4", "ipv6", "dualstack"]
   NETWORK_TYPE: '@jinja {{ this.server.network_type }}'
   # The Ansible Tower workflow used to deploy a capsule

--- a/conf/capsule.yaml.template
+++ b/conf/capsule.yaml.template
@@ -11,10 +11,13 @@ CAPSULE:
     SOURCE: "internal"
     # The base os rhel version where the capsule installed
     # RHEL_VERSION:
+  # Network type on which the Satellite Capsule is deployed
+  # could be one of ["ipv4", "ipv6", "dualstack"]
+  NETWORK_TYPE: '@jinja {{ this.server.network_type }}'
   # The Ansible Tower workflow used to deploy a capsule
   DEPLOY_WORKFLOWS:
     PRODUCT: deploy-capsule  # workflow to deploy OS with product running on top of it
     OS: deploy-rhel  # workflow to deploy OS that is ready to run the product
   # Dictionary of arguments which should be passed along to the deploy workflow
   DEPLOY_ARGUMENTS:
-    deploy_network_type: '@jinja {{"ipv6" if this.server.is_ipv6 else "ipv4"}}'
+    deploy_network_type: '@format {this.capsule.network_type}'

--- a/conf/content_host.yaml.template
+++ b/conf/content_host.yaml.template
@@ -1,4 +1,6 @@
 content_host:
+  attributes:
+    network_type: dualstack  # could be one of ["ipv4", "ipv6", "dualstack"]
   default_rhel_version: 9
   rhel6:
     vm:

--- a/conf/migrations.py
+++ b/conf/migrations.py
@@ -11,7 +11,7 @@ import warnings
 
 from packaging.version import Version
 
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.logging import logger
 
 
@@ -60,7 +60,7 @@ def migration_250404_network_type(settings, data):
             DeprecationWarning,
             stacklevel=2,
         )
-        n_type = HostNetworkType.IPV6 if settings.server.is_ipv6 else HostNetworkType.IPV4
+        n_type = NetworkType.IPV6 if settings.server.is_ipv6 else NetworkType.IPV4
         if not hasattr(data, 'server'):
             data.server = {}
         data.server.network_type = str(n_type)

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -15,8 +15,6 @@ SERVER:
     RHEL_VERSION: '9'
   # Network type on which the Satellite server deployed
   NETWORK_TYPE: ipv4  # could be one of ["ipv4", "ipv6", "dualstack"]
-  # If the Satellite server is IPv6 server
-  IS_IPV6: '@jinja {{ this.server.network_type == "ipv6" }}'
   # run-on-one - All xdist runners default to the first satellite
   # balance - xdist runners will be split between available satellites
   # on-demand - any xdist runner without a satellite will have a new one provisioned.

--- a/conf/server.yaml.template
+++ b/conf/server.yaml.template
@@ -13,8 +13,10 @@ SERVER:
     SOURCE: "internal"
     # The RHEL Base OS Version(x.y) where the Satellite is installed
     RHEL_VERSION: '9'
-  # If the the satellite server is IPv6 server
-  IS_IPV6: False
+  # Network type on which the Satellite server deployed
+  NETWORK_TYPE: ipv4  # could be one of ["ipv4", "ipv6", "dualstack"]
+  # If the Satellite server is IPv6 server
+  IS_IPV6: '@jinja {{ this.server.network_type == "ipv6" }}'
   # run-on-one - All xdist runners default to the first satellite
   # balance - xdist runners will be split between available satellites
   # on-demand - any xdist runner without a satellite will have a new one provisioned.
@@ -34,7 +36,7 @@ SERVER:
     OS: deploy-rhel  # workflow to deploy OS that is ready to run the product
   # Dictionary of arguments which should be passed along to the deploy workflow
   # DEPLOY_ARGUMENTS:
-  #  deploy_network_type: '@jinja {{"ipv6" if this.server.is_ipv6 else "ipv4"}}'
+  #  deploy_network_type: '@format { this.server.network_type }'
   # HTTP scheme when building the server URL
   # Suggested values for "scheme" are "http" and "https".
   SCHEME: https

--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -163,8 +163,6 @@ def custom_leapp_host(upgrade_path, module_target_sat, module_sca_manifest_org, 
         host_class=ContentHost,
         deploy_rhel_version=upgrade_path['source_version'],
         deploy_flavor=settings.flavors.default,
-        # TODO(shwsingh): Check whether this is valid for dualstack scenaro. Ideally, we should
-        # parametrize this fixture by fixture_markers plugin
         deploy_network_type=settings.content_host.attributes.network_type,
     ) as chost:
         result = chost.register(

--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -163,7 +163,7 @@ def custom_leapp_host(upgrade_path, module_target_sat, module_sca_manifest_org, 
         host_class=ContentHost,
         deploy_rhel_version=upgrade_path['source_version'],
         deploy_flavor=settings.flavors.default,
-        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',  # fix ipv6
+        deploy_network_type=settings.content_host.attributes.network_type,
     ) as chost:
         result = chost.register(
             module_sca_manifest_org, None, function_leapp_ak.name, module_target_sat

--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -163,6 +163,8 @@ def custom_leapp_host(upgrade_path, module_target_sat, module_sca_manifest_org, 
         host_class=ContentHost,
         deploy_rhel_version=upgrade_path['source_version'],
         deploy_flavor=settings.flavors.default,
+        # TODO(shwsingh): Check whether this is valid for dualstack scenaro. Ideally, we should
+        # parametrize this fixture by fixture_markers plugin
         deploy_network_type=settings.content_host.attributes.network_type,
     ) as chost:
         result = chost.register(

--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -163,7 +163,7 @@ def custom_leapp_host(upgrade_path, module_target_sat, module_sca_manifest_org, 
         host_class=ContentHost,
         deploy_rhel_version=upgrade_path['source_version'],
         deploy_flavor=settings.flavors.default,
-        deploy_network_type=settings.content_host.attributes.network_type,
+        deploy_network_type=settings.content_host.network_type,
     ) as chost:
         result = chost.register(
             module_sca_manifest_org, None, function_leapp_ak.name, module_target_sat

--- a/pytest_fixtures/component/leapp_client.py
+++ b/pytest_fixtures/component/leapp_client.py
@@ -163,7 +163,7 @@ def custom_leapp_host(upgrade_path, module_target_sat, module_sca_manifest_org, 
         host_class=ContentHost,
         deploy_rhel_version=upgrade_path['source_version'],
         deploy_flavor=settings.flavors.default,
-        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
+        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',  # fix ipv6
     ) as chost:
         result = chost.register(
             module_sca_manifest_org, None, function_leapp_ak.name, module_target_sat

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -11,6 +11,7 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
+from robottelo.enums import HostNetworkType
 from robottelo.hosts import ContentHost
 
 
@@ -150,6 +151,7 @@ def module_provisioning_sat(
     provisioning_type = getattr(request, 'param', '')
     sat = module_target_sat
     provisioning_domain_name = f"{gen_string('alpha').lower()}.foo"
+    sat_ipv6 = sat.network_type == HostNetworkType.IPV6
 
     broker_data_out = Broker().execute(
         workflow=settings.provisioning.provisioning_sat_workflow,
@@ -167,19 +169,19 @@ def module_provisioning_sat(
     # we might need to set up Sat's DNS server as the primary one on the Sat host
     provisioning_upstream_dns_primary = (
         broker_data_out.provisioning_upstream_dns
-        if settings.server.is_ipv6
+        if sat_ipv6
         else broker_data_out.provisioning_upstream_dns.pop()
     )  # There should always be at least one upstream DNS
     provisioning_upstream_dns_secondary = (
         broker_data_out.provisioning_upstream_dns.pop()
-        if len(broker_data_out.provisioning_upstream_dns) and not settings.server.is_ipv6
+        if len(broker_data_out.provisioning_upstream_dns) and not sat_ipv6
         else None
     )
 
     domain = sat.api.Domain(
         location=[module_location],
         organization=[module_sca_manifest_org],
-        dns=None if settings.server.is_ipv6 else module_provisioning_capsule.id,
+        dns=None if sat_ipv6 else module_provisioning_capsule.id,
         name=provisioning_domain_name,
     ).create()
 
@@ -187,7 +189,10 @@ def module_provisioning_sat(
         location=[module_location],
         organization=[module_sca_manifest_org],
         network=str(provisioning_network.network_address),
-        network_type='IPv6' if settings.server.is_ipv6 else 'IPv4',
+        # TODO(sganar): Is this correct for dualstack?
+        network_type=sat.network_type.formatted
+        if sat.network_type == HostNetworkType.IPV4
+        else HostNetworkType.IPV6.formatted,
         vlanid=settings.provisioning.vlan_id,
         mask=str(provisioning_network.netmask),
         gateway=broker_data_out.provisioning_gw_ip,
@@ -196,11 +201,11 @@ def module_provisioning_sat(
         dns_primary=provisioning_upstream_dns_primary,
         dns_secondary=provisioning_upstream_dns_secondary,
         boot_mode='DHCP',
-        ipam='None' if settings.server.is_ipv6 else 'DHCP',
-        dhcp=None if settings.server.is_ipv6 else module_provisioning_capsule.id,
+        ipam='None' if sat_ipv6 else 'DHCP',
+        dhcp=None if sat_ipv6 else module_provisioning_capsule.id,
         tftp=module_provisioning_capsule.id,
         template=module_provisioning_capsule.id,
-        dns=None if settings.server.is_ipv6 else module_provisioning_capsule.id,
+        dns=None if sat_ipv6 else module_provisioning_capsule.id,
         httpboot=module_provisioning_capsule.id,
         discovery=module_provisioning_capsule.id,
         remote_execution_proxy=[module_provisioning_capsule.id],
@@ -221,7 +226,10 @@ def module_ssh_key_file():
 @pytest.fixture
 def provisioning_host(module_ssh_key_file, pxe_loader, module_provisioning_sat):
     """Fixture to check out blank VM"""
-    if pxe_loader.vm_firmware == 'bios' and settings.server.is_ipv6:
+    if (
+        pxe_loader.vm_firmware == 'bios'
+        and module_provisioning_sat.network_type == HostNetworkType.IPV6
+    ):
         pytest.skip('BIOS is not supported with IPv6')
     vlan_id = settings.provisioning.vlan_id
     cd_iso = (
@@ -239,14 +247,15 @@ def provisioning_host(module_ssh_key_file, pxe_loader, module_provisioning_sat):
     ) as prov_host:
         yield prov_host
         # Set host as non-blank to run teardown of the host
-        if not settings.server.is_ipv6:
+        if settings.server.network_type != HostNetworkType.IPV6:
             assert module_provisioning_sat.sat.execute('systemctl restart dhcpd').status == 0
         prov_host.blank = getattr(prov_host, 'blank', False)
 
 
 @pytest.fixture(scope='module')
 def configure_kea_dhcp6_server():
-    if settings.server.is_ipv6:
+    # TODO(sganar): How should we handle this fixture for dualstack?
+    if settings.server.network_type == HostNetworkType.IPV6:
         kea_host = Broker(
             workflow=settings.provisioning.provisioning_kea_workflow,
             artifacts='last',
@@ -272,6 +281,7 @@ def provisioning_hostgroup(
     module_provisioning_capsule,
     pxe_loader,
 ):
+    sat_ipv6 = module_provisioning_sat.network_type == HostNetworkType.IPV6
     return module_provisioning_sat.sat.api.HostGroup(
         organization=[module_sca_manifest_org],
         location=[module_location],
@@ -284,8 +294,8 @@ def provisioning_hostgroup(
         root_pass=settings.provisioning.host_root_password,
         operatingsystem=module_provisioning_rhel_content.os,
         ptable=default_partitiontable,
-        subnet=module_provisioning_sat.subnet if not settings.server.is_ipv6 else None,
-        subnet6=module_provisioning_sat.subnet if settings.server.is_ipv6 else None,
+        subnet=module_provisioning_sat.subnet if not sat_ipv6 else None,
+        subnet6=module_provisioning_sat.subnet if sat_ipv6 else None,
         pxe_loader=pxe_loader.pxe_loader,
         group_parameters_attributes=[
             {

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -189,9 +189,7 @@ def module_provisioning_sat(
         location=[module_location],
         organization=[module_sca_manifest_org],
         network=str(provisioning_network.network_address),
-        network_type=NetworkType.IPV4.formatted
-        if sat.network_type == NetworkType.IPV4
-        else NetworkType.IPV6.formatted,
+        network_type='IPv6' if provisioning_network.version == 6 else 'IPv4',
         vlanid=settings.provisioning.vlan_id,
         mask=str(provisioning_network.netmask),
         gateway=broker_data_out.provisioning_gw_ip,
@@ -200,10 +198,8 @@ def module_provisioning_sat(
         dns_primary=provisioning_upstream_dns_primary,
         dns_secondary=provisioning_upstream_dns_secondary,
         boot_mode='DHCP',
-        ipam='None' if sat_ipv6 else 'DHCP',
-        dhcp=None if sat_ipv6 else module_provisioning_capsule.id,
-        tftp=module_provisioning_capsule.id,
-        template=module_provisioning_capsule.id,
+        ipam='None' if provisioning_network.version == 6 else 'DHCP',
+        dhcp=None if provisioning_network.version == 6 else module_provisioning_capsule.id,
         dns=None if sat_ipv6 else module_provisioning_capsule.id,
         httpboot=module_provisioning_capsule.id,
         discovery=module_provisioning_capsule.id,

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -189,8 +189,7 @@ def module_provisioning_sat(
         location=[module_location],
         organization=[module_sca_manifest_org],
         network=str(provisioning_network.network_address),
-        # TODO(sganar): Is this correct for dualstack?
-        network_type=sat.network_type.formatted
+        network_type=NetworkType.IPV4.formatted
         if sat.network_type == NetworkType.IPV4
         else NetworkType.IPV6.formatted,
         vlanid=settings.provisioning.vlan_id,
@@ -247,14 +246,13 @@ def provisioning_host(module_ssh_key_file, pxe_loader, module_provisioning_sat):
     ) as prov_host:
         yield prov_host
         # Set host as non-blank to run teardown of the host
-        if settings.server.network_type != NetworkType.IPV6:
+        if settings.server.network_type == NetworkType.IPV4:
             assert module_provisioning_sat.sat.execute('systemctl restart dhcpd').status == 0
         prov_host.blank = getattr(prov_host, 'blank', False)
 
 
 @pytest.fixture(scope='module')
 def configure_kea_dhcp6_server():
-    # TODO(sganar): How should we handle this fixture for dualstack?
     if settings.server.network_type == NetworkType.IPV6:
         kea_host = Broker(
             workflow=settings.provisioning.provisioning_kea_workflow,

--- a/pytest_fixtures/component/provision_pxe.py
+++ b/pytest_fixtures/component/provision_pxe.py
@@ -363,7 +363,7 @@ def configure_secureboot_provisioning(
     if (
         int(rhel_ver) > sat.os_version.major
         and pxe_loader.vm_firmware == 'uefi_secure_boot'
-        and not settings.server.is_ipv6
+        and module_provisioning_sat.network_type != NetworkType.IPV6
     ):
         # Set the path for the shim and GRUB2 binaries for the OS of host
         bootloader_path = '/var/lib/tftpboot/bootloader-universe/pxegrub2/redhat/default/x86_64'

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -220,7 +220,6 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
         "rhel_version": "8",
         "distro": "rhel",
         "no_containers": True,
-        # TODO(vsedmik): Check whether this is valid for dualstack scenaro
         "network": "ipv6" if module_target_sat.network_type == NetworkType.IPV6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
@@ -245,7 +244,6 @@ def module_flatpak_contenthost(request):
         "rhel_version": "9",
         "distro": "rhel",
         "no_containers": True,
-        # TODO(vsedmik): Check whether this is valid for dualstack scenaro
         "network": "ipv6" if settings.server.network_type == NetworkType.IPV6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -20,7 +20,9 @@ def host_conf(request):
     if hasattr(request, 'param'):
         params = request.param
     distro = params.get('distro', 'rhel')
+    network = params.get('network')
     _rhelver = f"{distro}{params.get('rhel_version', settings.content_host.default_rhel_version)}"
+
     # check to see if no-containers is passed as an argument to pytest
     deploy_kwargs = {}
     if not any(
@@ -31,15 +33,16 @@ def host_conf(request):
         ]
     ):
         deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('container', {})
-        if deploy_kwargs and (network := params.get('network')):
+        if deploy_kwargs and network:
             deploy_kwargs.update({'Container': network})
     # if we're not using containers or a container isn't available, use a VM
     if not deploy_kwargs:
         deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('vm', {})
-        if network := params.get('network'):
+        if network:
             deploy_kwargs.update({'deploy_network_type': network})
-    if network := params.get('network'):  # TODO(ogajduse) optimize multiple calls
-        conf.update({'net_type': network})
+    if network:
+        # pass the network type to the deploy kwargs, so the host class can use it
+        deploy_kwargs.update({'net_type': network})
     conf.update(deploy_kwargs)
     return conf
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -10,7 +10,7 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.hosts import ContentHost, Satellite
 
 
@@ -200,7 +200,7 @@ def rhel_contenthost_with_repos(request, target_sat):
     repositories on the host"""
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         # add IPv6 proxy for IPv6 communication
-        if host.network_type == HostNetworkType.IPV6:
+        if host.network_type == NetworkType.IPV6:
             host.enable_ipv6_dnf_and_rhsm_proxy()
             host.enable_ipv6_system_proxy()
 
@@ -221,7 +221,7 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
         "distro": "rhel",
         "no_containers": True,
         # TODO(vsedmik): Check whether this is valid for dualstack scenaro
-        "network": "ipv6" if module_target_sat.network_type == HostNetworkType.IPV6 else "ipv4",
+        "network": "ipv6" if module_target_sat.network_type == NetworkType.IPV6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
@@ -246,7 +246,7 @@ def module_flatpak_contenthost(request):
         "distro": "rhel",
         "no_containers": True,
         # TODO(vsedmik): Check whether this is valid for dualstack scenaro
-        "network": "ipv6" if settings.server.network_type == HostNetworkType.IPV6 else "ipv4",
+        "network": "ipv6" if settings.server.network_type == NetworkType.IPV6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
@@ -267,9 +267,7 @@ def centos_host(request, version):
         **host_conf(request),
         host_class=ContentHost,
         # TODO(shwsingh): Check whether this is valid for dualstack scenaro
-        deploy_network_type='ipv6'
-        if settings.server.network_type == HostNetworkType.IPV6
-        else 'ipv4',
+        deploy_network_type='ipv6' if settings.server.network_type == NetworkType.IPV6 else 'ipv4',
     ) as host:
         yield host
 
@@ -285,9 +283,7 @@ def oracle_host(request, version):
         **host_conf(request),
         host_class=ContentHost,
         # TODO(shwsingh): Check whether this is valid for dualstack scenaro
-        deploy_network_type='ipv6'
-        if settings.server.network_type == HostNetworkType.IPV6
-        else 'ipv4',
+        deploy_network_type='ipv6' if settings.server.network_type == NetworkType.IPV6 else 'ipv4',
     ) as host:
         yield host
 
@@ -300,9 +296,7 @@ def bootc_host():
         host_class=ContentHost,
         target_template='tpl-bootc-rhel-10.0',
         # TODO(sbible): Check whether this is valid for dualstack scenaro
-        deploy_network_type='ipv6'
-        if settings.server.network_type == HostNetworkType.IPV6
-        else 'ipv4',
+        deploy_network_type='ipv6' if settings.server.network_type == NetworkType.IPV6 else 'ipv4',
     ) as host:
         assert (
             host.execute(

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -200,7 +200,7 @@ def rhel_contenthost_with_repos(request, target_sat):
     repositories on the host"""
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         # add IPv6 proxy for IPv6 communication
-        if host.network_type == NetworkType.IPV6:
+        if not host.network_type.has_ipv6:
             host.enable_ipv6_dnf_and_rhsm_proxy()
             host.enable_ipv6_system_proxy()
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -10,6 +10,7 @@ import pytest
 
 from robottelo import constants
 from robottelo.config import settings
+from robottelo.enums import HostNetworkType
 from robottelo.hosts import ContentHost, Satellite
 
 
@@ -196,7 +197,7 @@ def rhel_contenthost_with_repos(request, target_sat):
     repositories on the host"""
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         # add IPv6 proxy for IPv6 communication
-        if settings.server.is_ipv6:
+        if host.network_type == HostNetworkType.IPV6:
             host.enable_ipv6_dnf_and_rhsm_proxy()
             host.enable_ipv6_system_proxy()
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -200,7 +200,7 @@ def rhel_contenthost_with_repos(request, target_sat):
     repositories on the host"""
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         # add IPv6 proxy for IPv6 communication
-        if not host.network_type.has_ipv6:
+        if not host.network_type.has_ipv4:
             host.enable_ipv6_dnf_and_rhsm_proxy()
             host.enable_ipv6_system_proxy()
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -266,7 +266,7 @@ def centos_host(request, version):
     with Broker(
         **host_conf(request),
         host_class=ContentHost,
-        deploy_network_type=settings.content_host.attributes.network_type,
+        deploy_network_type=settings.content_host.network_type,
     ) as host:
         yield host
 
@@ -281,7 +281,7 @@ def oracle_host(request, version):
     with Broker(
         **host_conf(request),
         host_class=ContentHost,
-        deploy_network_type=settings.content_host.attributes.network_type,
+        deploy_network_type=settings.content_host.network_type,
     ) as host:
         yield host
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -220,7 +220,8 @@ def module_container_contenthost(request, module_target_sat, module_org, module_
         "rhel_version": "8",
         "distro": "rhel",
         "no_containers": True,
-        "network": "ipv6" if settings.server.is_ipv6 else "ipv4",
+        # TODO(vsedmik): Check whether this is valid for dualstack scenaro
+        "network": "ipv6" if module_target_sat.network_type == HostNetworkType.IPV6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
@@ -244,7 +245,8 @@ def module_flatpak_contenthost(request):
         "rhel_version": "9",
         "distro": "rhel",
         "no_containers": True,
-        "network": "ipv6" if settings.server.is_ipv6 else "ipv4",
+        # TODO(vsedmik): Check whether this is valid for dualstack scenaro
+        "network": "ipv6" if settings.server.network_type == HostNetworkType.IPV6 else "ipv4",
     }
     with Broker(**host_conf(request), host_class=ContentHost) as host:
         host.register_to_cdn()
@@ -264,7 +266,10 @@ def centos_host(request, version):
     with Broker(
         **host_conf(request),
         host_class=ContentHost,
-        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
+        # TODO(shwsingh): Check whether this is valid for dualstack scenaro
+        deploy_network_type='ipv6'
+        if settings.server.network_type == HostNetworkType.IPV6
+        else 'ipv4',
     ) as host:
         yield host
 
@@ -279,7 +284,10 @@ def oracle_host(request, version):
     with Broker(
         **host_conf(request),
         host_class=ContentHost,
-        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
+        # TODO(shwsingh): Check whether this is valid for dualstack scenaro
+        deploy_network_type='ipv6'
+        if settings.server.network_type == HostNetworkType.IPV6
+        else 'ipv4',
     ) as host:
         yield host
 
@@ -291,7 +299,10 @@ def bootc_host():
         workflow='deploy-bootc',
         host_class=ContentHost,
         target_template='tpl-bootc-rhel-10.0',
-        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
+        # TODO(sbible): Check whether this is valid for dualstack scenaro
+        deploy_network_type='ipv6'
+        if settings.server.network_type == HostNetworkType.IPV6
+        else 'ipv4',
     ) as host:
         assert (
             host.execute(

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -37,6 +37,8 @@ def host_conf(request):
         deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('vm', {})
         if network := params.get('network'):
             deploy_kwargs.update({'deploy_network_type': network})
+    if network := params.get('network'):  # TODO(ogajduse) optimize multiple calls
+        conf.update({'net_type': network})
     conf.update(deploy_kwargs)
     return conf
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -266,8 +266,7 @@ def centos_host(request, version):
     with Broker(
         **host_conf(request),
         host_class=ContentHost,
-        # TODO(shwsingh): Check whether this is valid for dualstack scenaro
-        deploy_network_type='ipv6' if settings.server.network_type == NetworkType.IPV6 else 'ipv4',
+        deploy_network_type=settings.content_host.attributes.network_type,
     ) as host:
         yield host
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -281,8 +281,7 @@ def oracle_host(request, version):
     with Broker(
         **host_conf(request),
         host_class=ContentHost,
-        # TODO(shwsingh): Check whether this is valid for dualstack scenaro
-        deploy_network_type='ipv6' if settings.server.network_type == NetworkType.IPV6 else 'ipv4',
+        deploy_network_type=settings.content_host.attributes.network_type,
     ) as host:
         yield host
 

--- a/pytest_fixtures/core/contenthosts.py
+++ b/pytest_fixtures/core/contenthosts.py
@@ -34,7 +34,7 @@ def host_conf(request):
     ):
         deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('container', {})
         if deploy_kwargs and network:
-            deploy_kwargs.update({'Container': network})
+            deploy_kwargs.update({'Container': str(network)})
     # if we're not using containers or a container isn't available, use a VM
     if not deploy_kwargs:
         deploy_kwargs = settings.content_host.get(_rhelver).to_dict().get('vm', {})

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -304,7 +304,6 @@ def get_sat_deploy_args(request):
         | settings.server.deploy_arguments
         | {
             'deploy_rhel_version': rhel_version.base_version,
-            'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',  # fix ipv6
             'deploy_flavor': settings.flavors.default,
             'workflow': settings.server.deploy_workflows.os,
         }
@@ -325,7 +324,6 @@ def get_cap_deploy_args():
         | settings.capsule.deploy_arguments
         | {
             'deploy_rhel_version': rhel_version.base_version,
-            'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',  # fix ipv6
             'deploy_flavor': settings.flavors.default,
             'workflow': settings.capsule.deploy_workflows.os,
         }

--- a/pytest_fixtures/core/sat_cap_factory.py
+++ b/pytest_fixtures/core/sat_cap_factory.py
@@ -304,7 +304,7 @@ def get_sat_deploy_args(request):
         | settings.server.deploy_arguments
         | {
             'deploy_rhel_version': rhel_version.base_version,
-            'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+            'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',  # fix ipv6
             'deploy_flavor': settings.flavors.default,
             'workflow': settings.server.deploy_workflows.os,
         }
@@ -325,7 +325,7 @@ def get_cap_deploy_args():
         | settings.capsule.deploy_arguments
         | {
             'deploy_rhel_version': rhel_version.base_version,
-            'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+            'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',  # fix ipv6
             'deploy_flavor': settings.flavors.default,
             'workflow': settings.capsule.deploy_workflows.os,
         }

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -67,10 +67,10 @@ def pytest_generate_tests(metafunc):
             rhel_params.append(dict(rhel_version=ver, no_containers=no_containers))
 
         # Determine the default network type based on settings
-        if settings.content_host.attributes.network_type == 'dualstack':
+        if settings.content_host.network_type == 'dualstack':
             network_params = ['ipv4', 'ipv6']
         else:  # rely on network_type setting to be either ipv4 or ipv6
-            network_params = [settings.content_host.attributes.network_type]
+            network_params = [settings.content_host.network_type]
 
         # Check for the network marker
         network_marker = metafunc.definition.get_closest_marker("network")
@@ -164,18 +164,18 @@ def pytest_collection_modifyitems(session, items, config):
         if network_marker := item.get_closest_marker("network"):
             marker_network_types = network_marker.args[0] if network_marker.args else []
             # Skip the test if network_type setting is not set to ipv4 and network marker is set to ipv6
-            if (
-                'ipv6' in marker_network_types
-                and settings.content_host.attributes.network_type not in ['ipv6', 'dualstack']
-            ):
+            if 'ipv6' in marker_network_types and settings.content_host.network_type not in [
+                'ipv6',
+                'dualstack',
+            ]:
                 item.add_marker(
                     pytest.mark.skip(reason=f"Skipping {item.name} due to network type mismatch")
                 )
             # Skip the test if network_type setting is not set to ipv6 and network marker is set to ipv4
-            if (
-                'ipv4' in marker_network_types
-                and settings.content_host.attributes.network_type not in ['ipv4', 'dualstack']
-            ):
+            if 'ipv4' in marker_network_types and settings.content_host.network_type not in [
+                'ipv4',
+                'dualstack',
+            ]:
                 item.add_marker(
                     pytest.mark.skip(reason=f"Skipping {item.name} due to network type mismatch")
                 )

--- a/pytest_plugins/fixture_markers.py
+++ b/pytest_plugins/fixture_markers.py
@@ -69,7 +69,7 @@ def pytest_generate_tests(metafunc):
 
         # Determine the default network type based on settings
         if settings.content_host.network_type == NetworkType.DUALSTACK:
-            network_params = [NetworkType.IPV4, NetworkType.IPV6]
+            network_params = [NetworkType.IPV4.value, NetworkType.IPV6.value]
         else:  # rely on network_type setting to be either ipv4 or ipv6
             network_params = [settings.content_host.network_type]
 

--- a/pytest_plugins/markers.py
+++ b/pytest_plugins/markers.py
@@ -22,6 +22,7 @@ def pytest_configure(config):
         "manifester: Tests that require manifester",
         "ldap: Tests related to ldap authentication",
         "no_compose : Skip the marked sanity test for nightly compose",
+        "network: Restrict test to specific network environments",
     ]
     markers.extend(module_markers())
     for marker in markers:

--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -152,9 +152,6 @@ def pytest_collection_modifyitems(items, config):
     sat_version = settings.server.version.get('release')
     snap_version = settings.server.version.get('snap', '')
 
-    # Satellite Network Type on which tests are running on
-    satellite_network_type = 'ipv6' if settings.server.is_ipv6 else 'ipv4'  # fix ipv6
-
     # split the option string and handle no option, single option, multiple
     # config.getoption(default) doesn't work like you think it does, hence or ''
     importance = [i.lower() for i in (config.getoption('importance') or '').split(',') if i != '']
@@ -228,7 +225,7 @@ def pytest_collection_modifyitems(items, config):
         item.user_properties.append(("SnapVersion", snap_version))
 
         # Network Type user property
-        item.user_properties.append(("SatelliteNetworkType", satellite_network_type))
+        item.user_properties.append(("SatelliteNetworkType", settings.server.network_type))
 
         # exit early if no filters were passed
         if importance or component or team:

--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -153,7 +153,7 @@ def pytest_collection_modifyitems(items, config):
     snap_version = settings.server.version.get('snap', '')
 
     # Satellite Network Type on which tests are running on
-    satellite_network_type = 'ipv6' if settings.server.is_ipv6 else 'ipv4'
+    satellite_network_type = 'ipv6' if settings.server.is_ipv6 else 'ipv4'  # fix ipv6
 
     # split the option string and handle no option, single option, multiple
     # config.getoption(default) doesn't work like you think it does, hence or ''

--- a/pytest_plugins/metadata_markers.py
+++ b/pytest_plugins/metadata_markers.py
@@ -225,7 +225,12 @@ def pytest_collection_modifyitems(items, config):
         item.user_properties.append(("SnapVersion", snap_version))
 
         # Network Type user property
-        item.user_properties.append(("SatelliteNetworkType", settings.server.network_type))
+        # Note:
+        # We must convert the network type to a string
+        # because the network type is a class object
+        # and execnet/xdist will not serialize it
+        # properly when running in parallel
+        item.user_properties.append(("SatelliteNetworkType", str(settings.server.network_type)))
 
         # exit early if no filters were passed
         if importance or component or team:

--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -22,7 +22,7 @@ def _clean_video(session_id, test):
 
         if settings.ui.grid_url and session_id:
             grid = urlparse(url=settings.ui.grid_url)
-            infra_grid = Host(hostname=grid.hostname, ipv6=settings.server.is_ipv6)  # fix ipv6
+            infra_grid = Host(hostname=grid.hostname)
             infra_grid.execute(command=f'rm -rf /var/www/html/videos/{session_id}')
             logger.info(f"video cleanup for session {session_id} is complete")
         else:

--- a/pytest_plugins/video_cleanup.py
+++ b/pytest_plugins/video_cleanup.py
@@ -22,7 +22,7 @@ def _clean_video(session_id, test):
 
         if settings.ui.grid_url and session_id:
             grid = urlparse(url=settings.ui.grid_url)
-            infra_grid = Host(hostname=grid.hostname, ipv6=settings.server.is_ipv6)
+            infra_grid = Host(hostname=grid.hostname, ipv6=settings.server.is_ipv6)  # fix ipv6
             infra_grid.execute(command=f'rm -rf /var/www/html/videos/{session_id}')
             logger.info(f"video cleanup for session {session_id} is complete")
         else:

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -45,10 +45,8 @@ VALIDATORS = dict(
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),
-        Validator('content_host.attributes', must_exist=True, is_type_of=dict),
         Validator(
-            'content_host.attributes.network_type',
-            must_exist=True,
+            'content_host.network_type',
             is_in=NetworkType.list_values(),
             default=NetworkType.IPV4.value,
         ),

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -36,8 +36,11 @@ VALIDATORS = dict(
         Validator('server.ssh_username', default='root'),
         Validator('server.ssh_password', default=None),
         Validator('server.verify_ca', default=False),
-        # TODO(ogajduse): should we have a default value for network_type?
-        Validator('server.network_type', must_exist=True, is_in=NetworkType.list_values()),
+        Validator(
+            'server.network_type',
+            is_in=NetworkType.list_values(),
+            default=NetworkType.IPV4.value,
+        ),
         # Validator('server.is_ipv6', is_type_of=bool, must_exist=False),  # TODO(ogajduse): uncomment
     ],
     content_host=[

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -1,7 +1,7 @@
 from dynaconf import Validator
 
 from robottelo.constants import AZURERM_VALID_REGIONS, VALID_GCE_ZONES
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 
 VALIDATORS = dict(
     supportability=[
@@ -37,7 +37,7 @@ VALIDATORS = dict(
         Validator('server.ssh_password', default=None),
         Validator('server.verify_ca', default=False),
         # TODO(ogajduse): should we have a default value for network_type?
-        Validator('server.network_type', must_exist=True, is_in=HostNetworkType.list_values()),
+        Validator('server.network_type', must_exist=True, is_in=NetworkType.list_values()),
         # Validator('server.is_ipv6', is_type_of=bool, must_exist=False),  # TODO(ogajduse): uncomment
     ],
     content_host=[
@@ -46,9 +46,9 @@ VALIDATORS = dict(
         Validator(
             'content_host.attributes.network_type',
             must_exist=True,
-            is_in=HostNetworkType.list_values(),
+            is_in=NetworkType.list_values(),
             # TODO(ogajduse): should we have a default value for network_type?
-            default=HostNetworkType.DUALSTACK.value,
+            default=NetworkType.DUALSTACK.value,
         ),
     ],
     subscription=[
@@ -212,7 +212,7 @@ VALIDATORS = dict(
         Validator(
             'http_proxy.http_proxy_ipv6_url',
             is_type_of=str,
-            when=Validator('server.network_type', eq=HostNetworkType.IPV6.value),
+            when=Validator('server.network_type', eq=NetworkType.IPV6.value),
         ),
     ],
     ipa=[

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -38,7 +38,7 @@ VALIDATORS = dict(
         Validator('server.verify_ca', default=False),
         Validator(
             'server.network_type',
-            is_in=NetworkType.list_values(),
+            cast=NetworkType,
             default=NetworkType.IPV4.value,
         ),
         Validator('server.is_ipv6', is_type_of=bool, must_exist=False),
@@ -47,7 +47,7 @@ VALIDATORS = dict(
         Validator('content_host.default_rhel_version', must_exist=True),
         Validator(
             'content_host.network_type',
-            is_in=NetworkType.list_values(),
+            cast=NetworkType,
             default=NetworkType.IPV4.value,
         ),
     ],

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -208,11 +208,11 @@ VALIDATORS = dict(
             'http_proxy.password',
             must_exist=True,
         ),
-        # validate http_proxy_ipv6_url only if server.network_type is ipv6
+        # validate http_proxy_ipv6_url only if server.network_type does not have ipv4
         Validator(
             'http_proxy.http_proxy_ipv6_url',
             is_type_of=str,
-            when=Validator('server.network_type', eq=NetworkType.IPV6.value),
+            when=Validator('server.network_type', condition=lambda v: not v.has_ipv4),
         ),
     ],
     ipa=[

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -35,10 +35,19 @@ VALIDATORS = dict(
         Validator('server.ssh_username', default='root'),
         Validator('server.ssh_password', default=None),
         Validator('server.verify_ca', default=False),
+        Validator('server.network_type', default='ipv4', is_in=['ipv4', 'ipv6', 'dualstack']),
         Validator('server.is_ipv6', is_type_of=bool, default=False),
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),
+        Validator('content_host.attributes', must_exist=True, is_type_of=dict),
+        # TODO(ogajduse): is_in from the enum, need to solve circular imports
+        Validator(
+            'content_host.attributes.network_type',
+            must_exist=True,
+            is_in=['ipv4', 'ipv6', 'dualstack'],
+            default='dualstack',
+        ),
     ],
     subscription=[
         Validator('subscription.rhn_username', must_exist=True),

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -38,7 +38,7 @@ VALIDATORS = dict(
         Validator('server.verify_ca', default=False),
         # TODO(ogajduse): should we have a default value for network_type?
         Validator('server.network_type', must_exist=True, is_in=HostNetworkType.list_values()),
-        Validator('server.is_ipv6', is_type_of=bool, must_exist=False),
+        # Validator('server.is_ipv6', is_type_of=bool, must_exist=False),  # TODO(ogajduse): uncomment
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),

--- a/robottelo/config/validators.py
+++ b/robottelo/config/validators.py
@@ -41,7 +41,7 @@ VALIDATORS = dict(
             is_in=NetworkType.list_values(),
             default=NetworkType.IPV4.value,
         ),
-        # Validator('server.is_ipv6', is_type_of=bool, must_exist=False),  # TODO(ogajduse): uncomment
+        Validator('server.is_ipv6', is_type_of=bool, must_exist=False),
     ],
     content_host=[
         Validator('content_host.default_rhel_version', must_exist=True),
@@ -50,8 +50,7 @@ VALIDATORS = dict(
             'content_host.attributes.network_type',
             must_exist=True,
             is_in=NetworkType.list_values(),
-            # TODO(ogajduse): should we have a default value for network_type?
-            default=NetworkType.DUALSTACK.value,
+            default=NetworkType.IPV4.value,
         ),
     ],
     subscription=[

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -20,6 +20,14 @@ class NetworkType(StrEnum):
     DUALSTACK = 'dualstack'
 
     @property
+    def has_ipv4(self):
+        return self in (self.IPV4, self.DUALSTACK)
+
+    @property
+    def has_ipv6(self):
+        return self in (self.IPV6, self.DUALSTACK)
+
+    @property
     def formatted(self):
         """
         Returns the properly formatted version of the network type (e.g., 'IPv4', 'IPv6')

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -7,7 +7,7 @@ and configurations used in Robottelo tests and utilities.
 from enum import StrEnum
 
 
-class HostNetworkType(StrEnum):
+class NetworkType(StrEnum):
     """
     Enumeration of host network addressing types.
 
@@ -48,7 +48,7 @@ class HostNetworkType(StrEnum):
         Implements equality comparison between enum members and strings.
 
         This allows direct comparison of enum members with their string values:
-        HostNetworkType.IPV4 == 'ipv4'  # True
+        NetworkType.IPV4 == 'ipv4'  # True
 
         :param other: The object to compare with
         :return: True if equal, False otherwise

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -26,18 +26,3 @@ class NetworkType(StrEnum):
     @property
     def has_ipv6(self):
         return self in (self.IPV6, self.DUALSTACK)
-
-    @property
-    def formatted(self):
-        """
-        Returns the properly formatted version of the network type (e.g., 'IPv4', 'IPv6')
-
-        :returns: The formatted network type as a string.
-        :rtype: str
-        :raises ValueError: If called on DUALSTACK
-        """
-        if self.value == 'dualstack':
-            raise ValueError(f'Formatted property not supported for {self.name}')
-        if self.value in (self.IPV4, self.IPV6):
-            return self.value.replace('ipv', 'IPv')
-        raise ValueError(f'Invalid network type: {self.value}')

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -33,13 +33,3 @@ class NetworkType(StrEnum):
         if self.value in (self.IPV4, self.IPV6):
             return self.value.replace('ipv', 'IPv')
         raise ValueError(f'Invalid network type: {self.value}')
-
-    @classmethod
-    def list_values(cls):
-        """
-        Return a set of all enum values.
-
-        :returns: A set containing all the string values of the enum members.
-        :rtype: set
-        """
-        return {nt.value for nt in cls}

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -6,7 +6,12 @@ and configurations used in Robottelo tests and utilities.
 
 from enum import StrEnum
 
+import ruamel.yaml
 
+yaml = ruamel.yaml.YAML()
+
+
+@yaml.register_class
 class NetworkType(StrEnum):
     """
     Enumeration of host network addressing types.
@@ -26,3 +31,12 @@ class NetworkType(StrEnum):
     @property
     def has_ipv6(self):
         return self in (self.IPV6, self.DUALSTACK)
+
+    @classmethod
+    def to_yaml(cls, representer, node):
+        return representer.represent_scalar('!NetworkType', node.value)
+
+    @classmethod
+    def from_yaml(cls, constructor, node):
+        value = constructor.construct_scalar(node)
+        return cls(value)

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -34,30 +34,6 @@ class NetworkType(StrEnum):
             return self.value.replace('ipv', 'IPv')
         raise ValueError(f'Invalid network type: {self.value}')
 
-    def __str__(self):
-        """
-        Returns the string representation of the enum member.
-
-        :returns: The string value of the enum member.
-        :rtype: str
-        """
-        return self.value
-
-    def __eq__(self, other):
-        """
-        Implements equality comparison between enum members and strings.
-
-        This allows direct comparison of enum members with their string values:
-        NetworkType.IPV4 == 'ipv4'  # True
-
-        :param other: The object to compare with
-        :return: True if equal, False otherwise
-        :rtype: bool
-        """
-        if isinstance(other, str):
-            return self.value == other
-        return super().__eq__(other)
-
     @classmethod
     def list_values(cls):
         """

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -4,12 +4,10 @@ This module provides standardized enumerations for various types, statuses,
 and configurations used in Robottelo tests and utilities.
 """
 
-from enum import Enum
-
-# TODO: change double quotes to single quotes bcs of consistency
+from enum import StrEnum
 
 
-class HostNetworkType(Enum):
+class HostNetworkType(StrEnum):
     """
     Enumeration of host network addressing types.
 
@@ -32,7 +30,7 @@ class HostNetworkType(Enum):
         """
         if self.value == 'dualstack':
             raise ValueError(f'Formatted property not supported for {self.name}')
-        if self.value in (self.IVP4):
+        if self.value in (self.IPV4, self.IPV6):
             return self.value.replace('ipv', 'IPv')
         raise ValueError(f'Invalid network type: {self.value}')
 

--- a/robottelo/enums.py
+++ b/robottelo/enums.py
@@ -1,0 +1,71 @@
+"""Module containing enumeration classes used throughout Robottelo.
+
+This module provides standardized enumerations for various types, statuses,
+and configurations used in Robottelo tests and utilities.
+"""
+
+from enum import Enum
+
+# TODO: change double quotes to single quotes bcs of consistency
+
+
+class HostNetworkType(Enum):
+    """
+    Enumeration of host network addressing types.
+
+    This enum represents the different network addressing modes that can be
+    configured for a host.
+    """
+
+    IPV4 = 'ipv4'
+    IPV6 = 'ipv6'
+    DUALSTACK = 'dualstack'
+
+    @property
+    def formatted(self):
+        """
+        Returns the properly formatted version of the network type (e.g., 'IPv4', 'IPv6')
+
+        :returns: The formatted network type as a string.
+        :rtype: str
+        :raises ValueError: If called on DUALSTACK
+        """
+        if self.value == 'dualstack':
+            raise ValueError(f'Formatted property not supported for {self.name}')
+        if self.value in (self.IVP4):
+            return self.value.replace('ipv', 'IPv')
+        raise ValueError(f'Invalid network type: {self.value}')
+
+    def __str__(self):
+        """
+        Returns the string representation of the enum member.
+
+        :returns: The string value of the enum member.
+        :rtype: str
+        """
+        return self.value
+
+    def __eq__(self, other):
+        """
+        Implements equality comparison between enum members and strings.
+
+        This allows direct comparison of enum members with their string values:
+        HostNetworkType.IPV4 == 'ipv4'  # True
+
+        :param other: The object to compare with
+        :return: True if equal, False otherwise
+        :rtype: bool
+        """
+        if isinstance(other, str):
+            return self.value == other
+        return super().__eq__(other)
+
+    @classmethod
+    def list_values(cls):
+        """
+        Return a set of all enum values.
+
+        :returns: A set containing all the string values of the enum members.
+        :rtype: set
+        """
+        return {nt.value for nt in cls}

--- a/robottelo/host_helpers/__init__.py
+++ b/robottelo/host_helpers/__init__.py
@@ -1,3 +1,5 @@
+from enum import Enum, auto
+
 from robottelo.host_helpers.capsule_mixins import CapsuleInfo, EnablePluginsCapsule
 from robottelo.host_helpers.contenthost_mixins import (
     HostInfo,
@@ -25,3 +27,13 @@ class SatelliteMixins(
     ContentInfo, Factories, SystemInfo, EnablePluginsSatellite, ProvisioningSetup
 ):
     pass
+
+
+class HostNetworkType(Enum):
+    IPV4 = 'ipv4'
+    IPV6 = 'ipv6'
+    DUALSTACK = 'dualstack'
+
+    @classmethod
+    def list_values(cls):
+        return {nt.value for nt in cls}

--- a/robottelo/host_helpers/__init__.py
+++ b/robottelo/host_helpers/__init__.py
@@ -1,5 +1,3 @@
-from enum import Enum, auto
-
 from robottelo.host_helpers.capsule_mixins import CapsuleInfo, EnablePluginsCapsule
 from robottelo.host_helpers.contenthost_mixins import (
     HostInfo,
@@ -27,13 +25,3 @@ class SatelliteMixins(
     ContentInfo, Factories, SystemInfo, EnablePluginsSatellite, ProvisioningSetup
 ):
     pass
-
-
-class HostNetworkType(Enum):
-    IPV4 = 'ipv4'
-    IPV6 = 'ipv6'
-    DUALSTACK = 'dualstack'
-
-    @classmethod
-    def list_values(cls):
-        return {nt.value for nt in cls}

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -6,7 +6,6 @@ from tempfile import NamedTemporaryFile
 
 from robottelo import constants
 from robottelo.config import robottelo_tmp_dir, settings
-from robottelo.enums import NetworkType
 from robottelo.logging import logger
 from robottelo.utils.ohsnap import dogfood_repofile_url, dogfood_repository
 
@@ -112,7 +111,7 @@ class VersionedContent:
         product, release, v_major, _ = self._dogfood_helper(product, release)
         url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap, proxy=proxy)
         command = f'curl -o /etc/yum.repos.d/{product}.repo -L {url}'
-        if self.network_type == NetworkType.IPV6:
+        if not self.network_type.has_ipv4:
             command += f' -x {settings.http_proxy.http_proxy_ipv6_url}'
         self.execute(command)
 

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -6,7 +6,7 @@ from tempfile import NamedTemporaryFile
 
 from robottelo import constants
 from robottelo.config import robottelo_tmp_dir, settings
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.logging import logger
 from robottelo.utils.ohsnap import dogfood_repofile_url, dogfood_repository
 
@@ -112,7 +112,7 @@ class VersionedContent:
         product, release, v_major, _ = self._dogfood_helper(product, release)
         url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap, proxy=proxy)
         command = f'curl -o /etc/yum.repos.d/{product}.repo -L {url}'
-        if self.network_type == HostNetworkType.IPV6:
+        if self.network_type == NetworkType.IPV6:
             command += f' -x {settings.http_proxy.http_proxy_ipv6_url}'
         self.execute(command)
 

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -6,6 +6,7 @@ from tempfile import NamedTemporaryFile
 
 from robottelo import constants
 from robottelo.config import robottelo_tmp_dir, settings
+from robottelo.enums import HostNetworkType
 from robottelo.logging import logger
 from robottelo.utils.ohsnap import dogfood_repofile_url, dogfood_repository
 
@@ -109,11 +110,9 @@ class VersionedContent:
     def download_repofile(self, product=None, release=None, snap='', proxy=None):
         """Downloads the tools/client, capsule, or satellite repos on the machine"""
         product, release, v_major, _ = self._dogfood_helper(product, release)
-        if not proxy and settings.server.is_ipv6:
-            proxy = settings.http_proxy.http_proxy_ipv6_url
         url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap, proxy=proxy)
         command = f'curl -o /etc/yum.repos.d/{product}.repo -L {url}'
-        if settings.server.is_ipv6:
+        if self.network_type == HostNetworkType.IPV6:
             command += f' -x {settings.http_proxy.http_proxy_ipv6_url}'
         self.execute(command)
 

--- a/robottelo/host_helpers/contenthost_mixins.py
+++ b/robottelo/host_helpers/contenthost_mixins.py
@@ -106,10 +106,10 @@ class VersionedContent:
             )
         return product, release, v_major, repo
 
-    def download_repofile(self, product=None, release=None, snap='', proxy=None):
+    def download_repofile(self, product=None, release=None, snap=''):
         """Downloads the tools/client, capsule, or satellite repos on the machine"""
         product, release, v_major, _ = self._dogfood_helper(product, release)
-        url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap, proxy=proxy)
+        url = dogfood_repofile_url(settings.ohsnap, product, release, v_major, snap)
         command = f'curl -o /etc/yum.repos.d/{product}.repo -L {url}'
         if not self.network_type.has_ipv4:
             command += f' -x {settings.http_proxy.http_proxy_ipv6_url}'

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -19,6 +19,7 @@ from robottelo.constants import (
     PUPPET_COMMON_INSTALLER_OPTS,
     PUPPET_SATELLITE_INSTALLER,
 )
+from robottelo.enums import HostNetworkType
 from robottelo.exceptions import CLIReturnCodeError, NoManifestProvidedError
 from robottelo.host_helpers.api_factory import APIFactory
 from robottelo.host_helpers.cli_factory import CLIFactory
@@ -299,7 +300,7 @@ class SystemInfo:
             pre_ncat_procs = self.execute('pgrep ncat').stdout.splitlines()
             with self.session.shell() as channel:
                 # if ncat isn't backgrounded, it prevents the channel from closing
-                nwtype = '6' if self.ipv6 else ''
+                nwtype = '6' if self.network_type == HostNetworkType.IPV6 else ''
                 command = f'ncat -{nwtype}kl -p {newport} -c "ncat {self.hostname} {oldport}" &'
                 logger.debug(f'Creating tunnel: {command}')
                 channel.send(command)
@@ -374,7 +375,9 @@ class ProvisioningSetup:
                 host[0].delete()
             assert not self.api.Host().search(query={'search': f'name={hostname}'})
         # Workaround SAT-28381
-        if not settings.server.is_ipv6:
+        if (
+            self.network_type != HostNetworkType.IPV6
+        ):  # TODO(sganar): What should we do in case of dualstack?
             assert self.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
             assert self.execute('systemctl restart dhcpd').status == 0
             # Workaround BZ: 2207698

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -375,7 +375,7 @@ class ProvisioningSetup:
                 host[0].delete()
             assert not self.api.Host().search(query={'search': f'name={hostname}'})
         # Workaround SAT-28381
-        if self.network_type != NetworkType.IPV6:
+        if self.network_type == NetworkType.IPV4:
             assert self.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
             assert self.execute('systemctl restart dhcpd').status == 0
             # Workaround BZ: 2207698

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -375,9 +375,7 @@ class ProvisioningSetup:
                 host[0].delete()
             assert not self.api.Host().search(query={'search': f'name={hostname}'})
         # Workaround SAT-28381
-        if (
-            self.network_type != NetworkType.IPV6
-        ):  # TODO(sganar): What should we do in case of dualstack?
+        if self.network_type != NetworkType.IPV6:
             assert self.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
             assert self.execute('systemctl restart dhcpd').status == 0
             # Workaround BZ: 2207698

--- a/robottelo/host_helpers/satellite_mixins.py
+++ b/robottelo/host_helpers/satellite_mixins.py
@@ -19,7 +19,7 @@ from robottelo.constants import (
     PUPPET_COMMON_INSTALLER_OPTS,
     PUPPET_SATELLITE_INSTALLER,
 )
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.exceptions import CLIReturnCodeError, NoManifestProvidedError
 from robottelo.host_helpers.api_factory import APIFactory
 from robottelo.host_helpers.cli_factory import CLIFactory
@@ -300,7 +300,7 @@ class SystemInfo:
             pre_ncat_procs = self.execute('pgrep ncat').stdout.splitlines()
             with self.session.shell() as channel:
                 # if ncat isn't backgrounded, it prevents the channel from closing
-                nwtype = '6' if self.network_type == HostNetworkType.IPV6 else ''
+                nwtype = '6' if self.network_type == NetworkType.IPV6 else ''
                 command = f'ncat -{nwtype}kl -p {newport} -c "ncat {self.hostname} {oldport}" &'
                 logger.debug(f'Creating tunnel: {command}')
                 channel.send(command)
@@ -376,7 +376,7 @@ class ProvisioningSetup:
             assert not self.api.Host().search(query={'search': f'name={hostname}'})
         # Workaround SAT-28381
         if (
-            self.network_type != HostNetworkType.IPV6
+            self.network_type != NetworkType.IPV6
         ):  # TODO(sganar): What should we do in case of dualstack?
             assert self.execute('cat /dev/null > /var/lib/dhcpd/dhcpd.leases').status == 0
             assert self.execute('systemctl restart dhcpd').status == 0

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2428,7 +2428,7 @@ class Satellite(Capsule, SatelliteMixins):
         # if this is an IPv6 machine, we'll probably get a hostname
         # that is TOOOO LOOOONG for Active Directory which can only count to 15
         hostname_changed = False
-        if settings.server.is_ipv6:
+        if self.network_type == HostNetworkType.IPV6:
             original_shortname = self.execute('hostname -s').stdout.strip()
             if len(original_shortname) > 15:
                 hostname_changed = True
@@ -2478,7 +2478,7 @@ class Satellite(Capsule, SatelliteMixins):
         )
         # if this is an IPv6 only machine, also add
         # a line that fixes: https://github.com/SSSD/sssd/issues/3057
-        if settings.server.is_ipv6:
+        if self.network_type == HostNetworkType.IPV6:
             assert (
                 self.execute(
                     f'sed -i "{line_number + 1}i lookup_family_order = ipv6_only" /etc/sssd/sssd.conf'
@@ -2871,7 +2871,7 @@ class IPAHost(Host):
 
         # if this is an IPv6 only machine, also add
         # a line that fixes: https://github.com/SSSD/sssd/issues/3057
-        if settings.server.is_ipv6:
+        if self.satellite.network_type == HostNetworkType.IPV6:
             line_number = int(
                 self.satellite.execute(
                     "awk -v search='domain/' '$0~search{print NR; exit}' /etc/sssd/sssd.conf"

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -151,6 +151,7 @@ class ContentHost(Host, ContentHostMixins):
             # key file based authentication
             kwargs.update({'key_filename': auth})
         self._satellite = kwargs.get('satellite')
+        # TODO(ogajduse): what should be the default net_type? Should there be a default at all?
         self._net_type = HostNetworkType(kwargs.pop('net_type', None))
         self.blank = kwargs.get('blank', False)
         super().__init__(hostname=hostname, **kwargs)

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -158,7 +158,7 @@ class ContentHost(Host, ContentHostMixins):
 
     @property
     def network_type(self):
-        if not self._net_type:
+        if not hasattr(self, '_net_type'):
             self._net_type = NetworkType(settings.content_host.network_type)
         return self._net_type
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -134,6 +134,8 @@ class ProxyHostError(Exception):
 class ContentHost(Host, ContentHostMixins):
     run = Host.execute
     default_timeout = settings.server.ssh_client.command_timeout
+    # Extend the keep_keys tuple from the parent class
+    keep_keys = (*Host.keep_keys, 'net_type', 'blank')
 
     def __init__(self, hostname, auth=None, **kwargs):
         """ContentHost object with optional ssh connection

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -1648,13 +1648,6 @@ class Capsule(ContentHost, CapsuleMixins):
         super().__init__(hostname=hostname, **kwargs)
 
     @property
-    def network_type(self):
-        """Get the network type of the host"""
-        if not self._net_type:
-            self._net_type = NetworkType(settings.capsule.network_type)
-        return self._net_type
-
-    @property
     def nailgun_capsule(self):
         return self.satellite.api.Capsule().search(query={'search': f'name={self.hostname}'})[0]
 
@@ -2002,13 +1995,6 @@ class Satellite(Capsule, SatelliteMixins):
                         pass
         self._cli._configured = True
         return self._cli
-
-    @property
-    def network_type(self):
-        """Get the network type of the host"""
-        if not self._net_type:
-            self._net_type = NetworkType(settings.server.network_type)
-        return self._net_type
 
     @contextmanager
     def omit_credentials(self):

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -919,19 +919,19 @@ class ContentHost(Host, ContentHostMixins):
 
     def enable_ipv6_rhsm_proxy(self):
         """Execute procedures for enabling rhsm IPv6 HTTP Proxy"""
-        if self.network_type == NetworkType.IPV6:
+        if not self.network_type.has_ipv4:
             url = urlparse(settings.http_proxy.http_proxy_ipv6_url)
             self.enable_rhsm_proxy(url.hostname, url.port)
 
     def enable_ipv6_dnf_proxy(self):
         """Execute procedures for enabling dnf IPv6 HTTP Proxy"""
-        if self.network_type == NetworkType.IPV6:
+        if not self.network_type.has_ipv4:
             url = urlparse(settings.http_proxy.http_proxy_ipv6_url)
             self.enable_dnf_proxy(url.hostname, url.scheme, url.port)
 
     def enable_ipv6_system_proxy(self):
         """Execute procedures for enabling IPv6 HTTP Proxy on system"""
-        if self.network_type == NetworkType.IPV6:
+        if not self.network_type.has_ipv4:
             self.execute(
                 f'echo "export HTTPS_PROXY={settings.http_proxy.http_proxy_ipv6_url}" >> ~/.bashrc'
             )
@@ -946,7 +946,7 @@ class ContentHost(Host, ContentHostMixins):
 
     def enable_ipv6_dnf_and_rhsm_proxy(self):
         """Execute procedures for enabling rhsm and dnf IPv6 HTTP Proxy"""
-        if self.network_type == NetworkType.IPV6:
+        if not self.network_type.has_ipv4:
             self.enable_ipv6_rhsm_proxy()
             self.enable_ipv6_dnf_proxy()
 
@@ -1527,7 +1527,7 @@ class ContentHost(Host, ContentHostMixins):
         self.reset_rhsm()
 
         # Enabling proxy for IPv6
-        if self.network_type == NetworkType.IPV6:
+        if not self.network_type.has_ipv4:
             url = urlparse(settings.http_proxy.http_proxy_ipv6_url)
             self.enable_rhsm_proxy(url.hostname, url.port)
             self.enable_dnf_proxy(url.hostname, url.scheme, url.port)
@@ -2066,7 +2066,7 @@ class Satellite(Capsule, SatelliteMixins):
         """
         http_proxy_name = 'IPv4 HTTP Proxy for Content sync'
         http_proxy_url = settings.http_proxy.un_auth_proxy_url
-        if self.network_type == NetworkType.IPV6:
+        if not self.network_type.has_ipv4:
             http_proxy_name = 'IPv6 HTTP Proxy for Content sync'
             http_proxy_url = settings.http_proxy.http_proxy_ipv6_url
         if not self.cli.HttpProxy.exists(search=('name', http_proxy_name)):
@@ -2114,7 +2114,7 @@ class Satellite(Capsule, SatelliteMixins):
 
     def enable_satellite_ipv6_http_proxy(self):
         """Execute procedures for setting ipv6 HTTP Proxy in Satellite settings, rhsm and dnf."""
-        if self.network_type == NetworkType.IPV6:
+        if not self.network_type.has_ipv4:
             self.enable_satellite_http_proxy()
             self.enable_ipv6_dnf_and_rhsm_proxy()
 
@@ -2206,7 +2206,7 @@ class Satellite(Capsule, SatelliteMixins):
         )
         http_proxy = (
             f'HTTP_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
-            if self.network_type == NetworkType.IPV6
+            if not self.network_type.has_ipv4
             else ''
         )
         self.execute(

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -159,7 +159,7 @@ class ContentHost(Host, ContentHostMixins):
     @property
     def network_type(self):
         if not self._net_type:
-            self._net_type = NetworkType(settings.content_host.attributes.network_type)
+            self._net_type = NetworkType(settings.content_host.network_type)
         return self._net_type
 
     @classmethod

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -151,10 +151,8 @@ class ContentHost(Host, ContentHostMixins):
             # key file based authentication
             kwargs.update({'key_filename': auth})
         self._satellite = kwargs.get('satellite')
-        if not self._net_type:
-            self._net_type = HostNetworkType(
-                kwargs.get('net_type', settings.content_host.attributes.network_type)
-            )
+        if nt := kwargs.get('net_type'):
+            self._net_type = HostNetworkType(nt)
         self.blank = kwargs.get('blank', False)
         super().__init__(hostname=hostname, **kwargs)
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -151,10 +151,10 @@ class ContentHost(Host, ContentHostMixins):
             # key file based authentication
             kwargs.update({'key_filename': auth})
         self._satellite = kwargs.get('satellite')
-        self._net_type = HostNetworkType(
-            # TODO(ogajduse): should we get instead of pop to propagate the attr to inventory?
-            kwargs.pop('net_type', settings.content_host.attributes.network_type)
-        )
+        if not self._net_type:
+            self._net_type = HostNetworkType(
+                kwargs.get('net_type', settings.content_host.attributes.network_type)
+            )
         self.blank = kwargs.get('blank', False)
         super().__init__(hostname=hostname, **kwargs)
 

--- a/robottelo/hosts.py
+++ b/robottelo/hosts.py
@@ -2622,12 +2622,6 @@ class SSOHost(Host):
 
     def __init__(self, sat_obj, **kwargs):
         self.satellite = sat_obj
-
-        # TODO(ogajduse) handle the condition more properly
-        if kwargs.get('net_type') == HostNetworkType.IPV6.value:
-            kwargs['ipv6'] = True
-        else:
-            kwargs['ipv6'] = settings.server.network_type
         super().__init__(**kwargs)
 
     def get_sso_client_id(self):

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -1,6 +1,7 @@
 """Utility module to handle the shared ssh connection."""
 
 from robottelo.cli import hammer
+from robottelo.enums import HostNetworkType
 
 
 def get_client(
@@ -23,7 +24,8 @@ def get_client(
         username=username or settings.server.ssh_username,
         password=password or settings.server.ssh_password,
         port=port or settings.server.ssh_client.port,
-        ipv6=ipv6 or settings.server.is_ipv6,
+        #TODO(ogajduse): we better ger rid of the ssh module entirely
+        ipv6=ipv6 or settings.server.network_type == HostNetworkType.IPV6,
     )
 
 

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -1,7 +1,6 @@
 """Utility module to handle the shared ssh connection."""
 
 from robottelo.cli import hammer
-from robottelo.enums import HostNetworkType
 
 
 def get_client(
@@ -9,7 +8,7 @@ def get_client(
     username=None,
     password=None,
     port=22,
-    ipv6=None,
+    net_type=None,
 ):
     """Returns a host object that provides an ssh connection
 
@@ -25,7 +24,7 @@ def get_client(
         password=password or settings.server.ssh_password,
         port=port or settings.server.ssh_client.port,
         # TODO(ogajduse): we better ger rid of the ssh module entirely
-        ipv6=ipv6 or settings.server.network_type == HostNetworkType.IPV6,
+        net_type=net_type or settings.server.network_type,
     )
 
 
@@ -37,7 +36,7 @@ def command(
     password=None,
     timeout=None,
     port=22,
-    ipv6=None,
+    net_type=None,
 ):
     """Executes SSH command(s) on remote hostname.
 
@@ -53,7 +52,7 @@ def command(
         username=username,
         password=password,
         port=port,
-        ipv6=ipv6,
+        net_type=net_type,
     )
     result = client.execute(cmd, timeout=timeout)
 

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -23,7 +23,7 @@ def get_client(
         username=username or settings.server.ssh_username,
         password=password or settings.server.ssh_password,
         port=port or settings.server.ssh_client.port,
-        # TODO(ogajduse): we better ger rid of the ssh module entirely
+        # TODO(ogajduse): we better get rid of the ssh module entirely
         net_type=net_type or settings.server.network_type,
     )
 

--- a/robottelo/ssh.py
+++ b/robottelo/ssh.py
@@ -24,7 +24,7 @@ def get_client(
         username=username or settings.server.ssh_username,
         password=password or settings.server.ssh_password,
         port=port or settings.server.ssh_client.port,
-        #TODO(ogajduse): we better ger rid of the ssh module entirely
+        # TODO(ogajduse): we better ger rid of the ssh module entirely
         ipv6=ipv6 or settings.server.network_type == HostNetworkType.IPV6,
     )
 

--- a/robottelo/utils/ohsnap.py
+++ b/robottelo/utils/ohsnap.py
@@ -21,7 +21,7 @@ def ohsnap_response_hook(r, *args, **kwargs):
     r.raise_for_status()
 
 
-def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap='', proxy=None):
+def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap=''):
     """Returns a URL pointing to Ohsnap "repo_file" or "repositories" API endpoint"""
     if request_type not in ['repo_file', 'repositories']:
         raise InvalidArgumentError('Type must be one of "repo_file" or "repositories"')
@@ -46,8 +46,6 @@ def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap='',
                 'url': f'{ohsnap.host}/api/streams',
                 'hooks': {'response': ohsnap_response_hook},
             }
-            if proxy:
-                request_query['proxies'] = {'http': proxy}
             res, _ = wait_for(
                 lambda: requests.get(**request_query),
                 handle_exception=True,
@@ -72,8 +70,8 @@ def ohsnap_repo_url(ohsnap, request_type, product, release, os_release, snap='',
     )
 
 
-def dogfood_repofile_url(ohsnap, product, release, os_release, snap='', proxy=None):
-    return ohsnap_repo_url(ohsnap, 'repo_file', product, release, os_release, snap, proxy)
+def dogfood_repofile_url(ohsnap, product, release, os_release, snap=''):
+    return ohsnap_repo_url(ohsnap, 'repo_file', product, release, os_release, snap)
 
 
 def dogfood_repository(

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -19,6 +19,7 @@ from wait_for import wait_for
 
 from robottelo.config import settings, user_nailgun_config
 from robottelo.hosts import ContentHost
+from robottelo.enums import HostNetworkType
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -84,7 +85,7 @@ class TestAnsibleCfgMgmt:
         """
         http_proxy = (
             f'HTTPS_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
-            if settings.server.is_ipv6
+            if target_sat.network_type == HostNetworkType.IPV6
             else ''
         )
         assert (

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -18,7 +18,6 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings, user_nailgun_config
-from robottelo.enums import NetworkType
 from robottelo.hosts import ContentHost
 from robottelo.utils.issue_handlers import is_open
 
@@ -85,7 +84,7 @@ class TestAnsibleCfgMgmt:
         """
         http_proxy = (
             f'HTTPS_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
-            if target_sat.network_type == NetworkType.IPV6
+            if not target_sat.network_type.has_ipv4
             else ''
         )
         assert (
@@ -439,19 +438,19 @@ class TestAnsibleREX:
                 'host_class': ContentHost,
                 'workflow': settings.server.deploy_workflows.os,
                 'deploy_rhel_version': '9',
-                'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+                'deploy_network_type': settings.server.network_type,
             },
             rhel8={
                 'host_class': ContentHost,
                 'workflow': settings.server.deploy_workflows.os,
                 'deploy_rhel_version': '8',
-                'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+                'deploy_network_type': settings.server.network_type,
             },
             rhel7={
                 'host_class': ContentHost,
                 'workflow': settings.server.deploy_workflows.os,
                 'deploy_rhel_version': '7',
-                'deploy_network_type': 'ipv6' if settings.server.is_ipv6 else 'ipv4',
+                'deploy_network_type': settings.server.network_type,
             },
         ) as multi_hosts:
             hosts = [multi_hosts['rhel9'][0], multi_hosts['rhel8'][0], multi_hosts['rhel7'][0]]

--- a/tests/foreman/api/test_ansible.py
+++ b/tests/foreman/api/test_ansible.py
@@ -18,8 +18,8 @@ import pytest
 from wait_for import wait_for
 
 from robottelo.config import settings, user_nailgun_config
+from robottelo.enums import NetworkType
 from robottelo.hosts import ContentHost
-from robottelo.enums import HostNetworkType
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -85,7 +85,7 @@ class TestAnsibleCfgMgmt:
         """
         http_proxy = (
             f'HTTPS_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
-            if target_sat.network_type == HostNetworkType.IPV6
+            if target_sat.network_type == NetworkType.IPV6
             else ''
         )
         assert (

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -20,7 +20,7 @@ from wait_for import TimedOutError, wait_for
 from wrapanapi.systems.virtualcenter import VMWareVirtualMachine
 
 from robottelo.config import settings
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.logging import logger
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
@@ -106,13 +106,13 @@ def test_rhel_pxe_provisioning(
     # TODO(sganar) does the following also apply to dualstack?
     if (
         pxe_loader.vm_firmware == 'bios'
-        and module_provisioning_sat.network_type == HostNetworkType.IPV6
+        and module_provisioning_sat.network_type == NetworkType.IPV6
     ):
         pytest.skip('Test cannot be run on BIOS as its not supported')
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
     # Configure the grubx64.efi image to setup the interface and use TFTP to load the configuration
-    if module_provisioning_sat.network_type == HostNetworkType.IPV6:
+    if module_provisioning_sat.network_type == NetworkType.IPV6:
         sat.execute("echo -e 'net_bootp6\nset root=tftp\nset prefix=(tftp)/grub2' > pre.cfg")
         sat.execute(
             'grub2-mkimage -c pre.cfg -o /var/lib/tftpboot/grub2/grubx64.efi -p /grub2/ -O x86_64-efi efinet efi_netfs efienv efifwsetup efi_gop tftp net normal chain configfile loadenv procfs romfs'
@@ -159,7 +159,7 @@ def test_rhel_pxe_provisioning(
     # Change the hostname of the host as we know it already.
     # In the current infra environment we do not support
     # addressing hosts using FQDNs, falling back to IP.
-    if is_open('SAT-30601') and module_provisioning_sat.network_type != HostNetworkType.IPV6:
+    if is_open('SAT-30601') and module_provisioning_sat.network_type != NetworkType.IPV6:
         provisioning_host.hostname = host.ip
         # Host is not blank anymore
         provisioning_host.blank = False

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -20,6 +20,7 @@ from wait_for import TimedOutError, wait_for
 from wrapanapi.systems.virtualcenter import VMWareVirtualMachine
 
 from robottelo.config import settings
+from robottelo.enums import HostNetworkType
 from robottelo.logging import logger
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
@@ -102,12 +103,16 @@ def test_rhel_pxe_provisioning(
 
     :parametrized: yes
     """
-    if pxe_loader.vm_firmware == 'bios' and settings.server.is_ipv6:
+    # TODO(sganar) does the following also apply to dualstack?
+    if (
+        pxe_loader.vm_firmware == 'bios'
+        and module_provisioning_sat.network_type == HostNetworkType.IPV6
+    ):
         pytest.skip('Test cannot be run on BIOS as its not supported')
     host_mac_addr = provisioning_host.provisioning_nic_mac_addr
     sat = module_provisioning_sat.sat
     # Configure the grubx64.efi image to setup the interface and use TFTP to load the configuration
-    if settings.server.is_ipv6:
+    if module_provisioning_sat.network_type == HostNetworkType.IPV6:
         sat.execute("echo -e 'net_bootp6\nset root=tftp\nset prefix=(tftp)/grub2' > pre.cfg")
         sat.execute(
             'grub2-mkimage -c pre.cfg -o /var/lib/tftpboot/grub2/grubx64.efi -p /grub2/ -O x86_64-efi efinet efi_netfs efienv efifwsetup efi_gop tftp net normal chain configfile loadenv procfs romfs'
@@ -154,7 +159,7 @@ def test_rhel_pxe_provisioning(
     # Change the hostname of the host as we know it already.
     # In the current infra environment we do not support
     # addressing hosts using FQDNs, falling back to IP.
-    if is_open('SAT-30601') and not settings.server.is_ipv6:
+    if is_open('SAT-30601') and module_provisioning_sat.network_type != HostNetworkType.IPV6:
         provisioning_host.hostname = host.ip
         # Host is not blank anymore
         provisioning_host.blank = False

--- a/tests/foreman/api/test_provisioning.py
+++ b/tests/foreman/api/test_provisioning.py
@@ -103,7 +103,6 @@ def test_rhel_pxe_provisioning(
 
     :parametrized: yes
     """
-    # TODO(sganar) does the following also apply to dualstack?
     if (
         pxe_loader.vm_firmware == 'bios'
         and module_provisioning_sat.network_type == NetworkType.IPV6
@@ -159,7 +158,7 @@ def test_rhel_pxe_provisioning(
     # Change the hostname of the host as we know it already.
     # In the current infra environment we do not support
     # addressing hosts using FQDNs, falling back to IP.
-    if is_open('SAT-30601') and module_provisioning_sat.network_type != NetworkType.IPV6:
+    if is_open('SAT-30601') and module_provisioning_sat.network_type == NetworkType.IPV4:
         provisioning_host.hostname = host.ip
         # Host is not blank anymore
         provisioning_host.blank = False

--- a/tests/foreman/api/test_templatesync.py
+++ b/tests/foreman/api/test_templatesync.py
@@ -58,7 +58,7 @@ class TestTemplateSyncTestCase:
         # Download the Test Template in test running folder
         proxy_options = (
             f"-e use_proxy=yes -e https_proxy={settings.http_proxy.http_proxy_ipv6_url}"
-            if settings.server.is_ipv6
+            if not module_target_sat.network_type.has_ipv4
             else ""
         )
         module_target_sat.execute(

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -21,7 +21,6 @@ from robottelo.config import (
     robottelo_tmp_dir,
     settings,
 )
-from robottelo.enums import NetworkType
 from robottelo.exceptions import CLIFactoryError
 from robottelo.utils.issue_handlers import is_open
 
@@ -236,7 +235,7 @@ class TestAnsibleCfgMgmt:
         for path in ['/etc/ansible/collections', '/usr/share/ansible/collections']:
             http_proxy = (
                 f'HTTPS_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
-                if target_sat.network_type == NetworkType.IPV6
+                if not target_sat.network_type.has_ipv4
                 else ''
             )
             assert (

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -21,6 +21,7 @@ from robottelo.config import (
     robottelo_tmp_dir,
     settings,
 )
+from robottelo.enums import HostNetworkType
 from robottelo.exceptions import CLIFactoryError
 from robottelo.utils.issue_handlers import is_open
 
@@ -235,7 +236,7 @@ class TestAnsibleCfgMgmt:
         for path in ['/etc/ansible/collections', '/usr/share/ansible/collections']:
             http_proxy = (
                 f'HTTPS_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
-                if settings.server.is_ipv6
+                if target_sat.network_type == HostNetworkType.IPV6
                 else ''
             )
             assert (

--- a/tests/foreman/cli/test_ansible.py
+++ b/tests/foreman/cli/test_ansible.py
@@ -21,7 +21,7 @@ from robottelo.config import (
     robottelo_tmp_dir,
     settings,
 )
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.exceptions import CLIFactoryError
 from robottelo.utils.issue_handlers import is_open
 
@@ -236,7 +236,7 @@ class TestAnsibleCfgMgmt:
         for path in ['/etc/ansible/collections', '/usr/share/ansible/collections']:
             http_proxy = (
                 f'HTTPS_PROXY={settings.http_proxy.HTTP_PROXY_IPv6_URL} '
-                if target_sat.network_type == HostNetworkType.IPV6
+                if target_sat.network_type == NetworkType.IPV6
                 else ''
             )
             assert (

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -29,7 +29,9 @@ from robottelo.utils.issue_handlers import is_open
         'system_uptime::seconds',
         'memory::system::total',
         # TODO(gtalreja): How should we handle dualstack here?
-        'networking::ip6' if settings.server.network_type == HostNetworkType.IPV6 else 'networking::ip',
+        'networking::ip6'
+        if settings.server.network_type == HostNetworkType.IPV6
+        else 'networking::ip',
     ],
 )
 def test_positive_list_by_name(fact, module_target_sat):

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -16,6 +16,7 @@ from fauxfactory import gen_ipaddr, gen_mac, gen_string
 import pytest
 
 from robottelo.config import settings
+from robottelo.enums import HostNetworkType
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -27,7 +28,8 @@ from robottelo.utils.issue_handlers import is_open
         'os::family',
         'system_uptime::seconds',
         'memory::system::total',
-        'networking::ip6' if settings.server.is_ipv6 else 'networking::ip',
+        # TODO(gtalreja): How should we handle dualstack here?
+        'networking::ip6' if settings.server.network_type == HostNetworkType.IPV6 else 'networking::ip',
     ],
 )
 def test_positive_list_by_name(fact, module_target_sat):

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -16,7 +16,7 @@ from fauxfactory import gen_ipaddr, gen_mac, gen_string
 import pytest
 
 from robottelo.config import settings
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.utils.issue_handlers import is_open
 
 
@@ -29,9 +29,7 @@ from robottelo.utils.issue_handlers import is_open
         'system_uptime::seconds',
         'memory::system::total',
         # TODO(gtalreja): How should we handle dualstack here?
-        'networking::ip6'
-        if settings.server.network_type == HostNetworkType.IPV6
-        else 'networking::ip',
+        'networking::ip6' if settings.server.network_type == NetworkType.IPV6 else 'networking::ip',
     ],
 )
 def test_positive_list_by_name(fact, module_target_sat):

--- a/tests/foreman/cli/test_fact.py
+++ b/tests/foreman/cli/test_fact.py
@@ -28,7 +28,6 @@ from robottelo.utils.issue_handlers import is_open
         'os::family',
         'system_uptime::seconds',
         'memory::system::total',
-        # TODO(gtalreja): How should we handle dualstack here?
         'networking::ip6' if settings.server.network_type == NetworkType.IPV6 else 'networking::ip',
     ],
 )

--- a/tests/foreman/cli/test_templatesync.py
+++ b/tests/foreman/cli/test_templatesync.py
@@ -51,7 +51,7 @@ class TestTemplateSyncTestCase:
         # Download the Test Template in test running folder
         proxy_options = (
             f"-e use_proxy=yes -e https_proxy={settings.http_proxy.http_proxy_ipv6_url}"
-            if settings.server.is_ipv6
+            if not module_target_sat.network_type.has_ipv4
             else ""
         )
         module_target_sat.execute(

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -16,7 +16,7 @@ import requests
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
 
 pytestmark = pytest.mark.destructive
@@ -176,7 +176,7 @@ def test_infoblox_end_to_end(
     assert f'current: "{settings.infoblox.hostname}"' in installer.stdout
 
     macaddress = gen_mac(multicast=False)
-    is_ipv6 = module_target_sat.network_type == HostNetworkType.IPV6
+    is_ipv6 = module_target_sat.network_type == NetworkType.IPV6
     # using the domain name as defined in Infoblox DNS
     domain = module_target_sat.api.Domain(
         name=settings.infoblox.domain,

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -187,7 +187,9 @@ def test_infoblox_end_to_end(
         location=[module_location],
         organization=[module_sca_manifest_org],
         network=settings.infoblox.network,
-        network_type='IPv6' if is_ipv6 else 'IPv4',  # TODO(sganar): What should we set here in case of dualstack?
+        network_type='IPv6'
+        if is_ipv6
+        else 'IPv4',  # TODO(sganar): What should we set here in case of dualstack?
         cidr=settings.infoblox.network_prefix,
         mask=settings.infoblox.netmask,
         from_=None if is_ipv6 else settings.infoblox.start_range,

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -187,9 +187,7 @@ def test_infoblox_end_to_end(
         location=[module_location],
         organization=[module_sca_manifest_org],
         network=settings.infoblox.network,
-        network_type='IPv6'
-        if is_ipv6
-        else 'IPv4',  # TODO(sganar): What should we set here in case of dualstack?
+        network_type='IPv6' if is_ipv6 else 'IPv4',
         cidr=settings.infoblox.network_prefix,
         mask=settings.infoblox.netmask,
         from_=None if is_ipv6 else settings.infoblox.start_range,

--- a/tests/foreman/destructive/test_infoblox.py
+++ b/tests/foreman/destructive/test_infoblox.py
@@ -16,6 +16,7 @@ import requests
 from requests.exceptions import HTTPError
 
 from robottelo.config import settings
+from robottelo.enums import HostNetworkType
 from robottelo.utils.installer import InstallerCommand
 
 pytestmark = pytest.mark.destructive
@@ -175,7 +176,7 @@ def test_infoblox_end_to_end(
     assert f'current: "{settings.infoblox.hostname}"' in installer.stdout
 
     macaddress = gen_mac(multicast=False)
-    is_ipv6 = settings.server.is_ipv6
+    is_ipv6 = module_target_sat.network_type == HostNetworkType.IPV6
     # using the domain name as defined in Infoblox DNS
     domain = module_target_sat.api.Domain(
         name=settings.infoblox.domain,
@@ -186,7 +187,7 @@ def test_infoblox_end_to_end(
         location=[module_location],
         organization=[module_sca_manifest_org],
         network=settings.infoblox.network,
-        network_type='IPv6' if is_ipv6 else 'IPv4',
+        network_type='IPv6' if is_ipv6 else 'IPv4',  # TODO(sganar): What should we set here in case of dualstack?
         cidr=settings.infoblox.network_prefix,
         mask=settings.infoblox.netmask,
         from_=None if is_ipv6 else settings.infoblox.start_range,

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -317,7 +317,6 @@ def sat_fapolicyd_install(module_sat_ready_rhels):
     assert install_satellite(sat, installer_args, enable_fapolicyd=True).status == 0, (
         "Satellite installation failed (non-zero return code)"
     )
-    # TODO(jpathan): Check whether this is valid for dualstack
     if settings.server.network_type == NetworkType.IPV6:
         sat.enable_satellite_http_proxy()
     return sat
@@ -337,7 +336,6 @@ def sat_non_default_install(module_sat_ready_rhels):
     assert install_satellite(sat, installer_args, enable_fapolicyd=True).status == 0, (
         "Satellite installation failed (non-zero return code)"
     )
-    # TODO(jpathan): Check whether this is valid for dualstack
     if settings.server.network_type == NetworkType.IPV6:
         sat.enable_satellite_http_proxy()
     return sat

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -19,6 +19,7 @@ import yaml
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE, FOREMAN_SETTINGS_YML, PRDS, REPOS, REPOSET
+from robottelo.enums import HostNetworkType
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
 from robottelo.utils.ohsnap import dogfood_repository
@@ -316,7 +317,8 @@ def sat_fapolicyd_install(module_sat_ready_rhels):
     assert install_satellite(sat, installer_args, enable_fapolicyd=True).status == 0, (
         "Satellite installation failed (non-zero return code)"
     )
-    if settings.server.is_ipv6:
+    # TODO(jpathan): Check whether this is valid for dualstack
+    if settings.server.network_type == HostNetworkType.IPV6:
         sat.enable_satellite_http_proxy()
     return sat
 
@@ -335,7 +337,8 @@ def sat_non_default_install(module_sat_ready_rhels):
     assert install_satellite(sat, installer_args, enable_fapolicyd=True).status == 0, (
         "Satellite installation failed (non-zero return code)"
     )
-    if settings.server.is_ipv6:
+    # TODO(jpathan): Check whether this is valid for dualstack
+    if settings.server.network_type == HostNetworkType.IPV6:
         sat.enable_satellite_http_proxy()
     return sat
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -19,7 +19,6 @@ import yaml
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE, FOREMAN_SETTINGS_YML, PRDS, REPOS, REPOSET
-from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
 from robottelo.utils.ohsnap import dogfood_repository
@@ -317,7 +316,7 @@ def sat_fapolicyd_install(module_sat_ready_rhels):
     assert install_satellite(sat, installer_args, enable_fapolicyd=True).status == 0, (
         "Satellite installation failed (non-zero return code)"
     )
-    if settings.server.network_type == NetworkType.IPV6:
+    if not settings.server.network_type.has_ipv4:
         sat.enable_satellite_http_proxy()
     return sat
 
@@ -336,7 +335,7 @@ def sat_non_default_install(module_sat_ready_rhels):
     assert install_satellite(sat, installer_args, enable_fapolicyd=True).status == 0, (
         "Satellite installation failed (non-zero return code)"
     )
-    if settings.server.network_type == NetworkType.IPV6:
+    if not settings.server.network_type.has_ipv4:
         sat.enable_satellite_http_proxy()
     return sat
 

--- a/tests/foreman/installer/test_installer.py
+++ b/tests/foreman/installer/test_installer.py
@@ -19,7 +19,7 @@ import yaml
 from robottelo import ssh
 from robottelo.config import settings
 from robottelo.constants import DEFAULT_ARCHITECTURE, FOREMAN_SETTINGS_YML, PRDS, REPOS, REPOSET
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 from robottelo.utils.installer import InstallerCommand
 from robottelo.utils.issue_handlers import is_open
 from robottelo.utils.ohsnap import dogfood_repository
@@ -318,7 +318,7 @@ def sat_fapolicyd_install(module_sat_ready_rhels):
         "Satellite installation failed (non-zero return code)"
     )
     # TODO(jpathan): Check whether this is valid for dualstack
-    if settings.server.network_type == HostNetworkType.IPV6:
+    if settings.server.network_type == NetworkType.IPV6:
         sat.enable_satellite_http_proxy()
     return sat
 
@@ -338,7 +338,7 @@ def sat_non_default_install(module_sat_ready_rhels):
         "Satellite installation failed (non-zero return code)"
     )
     # TODO(jpathan): Check whether this is valid for dualstack
-    if settings.server.network_type == HostNetworkType.IPV6:
+    if settings.server.network_type == NetworkType.IPV6:
         sat.enable_satellite_http_proxy()
     return sat
 

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -244,7 +244,7 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
         'ANSIBLE_HOST_PATTERN_MISMATCH=ignore',
     ]
 
-    if module_target_sat.network_type == NetworkType.IPV6 and ansible_module in ['redhat_manifest']:
+    if not module_target_sat.network_type.has_ipv4 and ansible_module in ['redhat_manifest']:
         env.append(f'HTTPS_PROXY={settings.http_proxy.http_proxy_ipv6_url}')
 
     # Execute test_playbook

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -25,7 +25,7 @@ from robottelo.constants import (
     FOREMAN_ANSIBLE_MODULES,
     RH_SAT_ROLES,
 )
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 
 
 @pytest.fixture
@@ -229,7 +229,7 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
     :expectedresults: All modules and roles run successfully
     """
     # Skip oVirt/RHV tests on IPv6 setups
-    if module_target_sat.network_type == HostNetworkType.IPV6 and ansible_module in [
+    if module_target_sat.network_type == NetworkType.IPV6 and ansible_module in [
         'compute_profile_ovirt'
     ]:
         pytest.skip("oVirt/RHV is not properly set up in IPv6 environment")
@@ -244,9 +244,7 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
         'ANSIBLE_HOST_PATTERN_MISMATCH=ignore',
     ]
 
-    if module_target_sat.network_type == HostNetworkType.IPV6 and ansible_module in [
-        'redhat_manifest'
-    ]:
+    if module_target_sat.network_type == NetworkType.IPV6 and ansible_module in ['redhat_manifest']:
         env.append(f'HTTPS_PROXY={settings.http_proxy.http_proxy_ipv6_url}')
 
     # Execute test_playbook

--- a/tests/foreman/sys/test_fam.py
+++ b/tests/foreman/sys/test_fam.py
@@ -25,6 +25,7 @@ from robottelo.constants import (
     FOREMAN_ANSIBLE_MODULES,
     RH_SAT_ROLES,
 )
+from robottelo.enums import HostNetworkType
 
 
 @pytest.fixture
@@ -228,7 +229,9 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
     :expectedresults: All modules and roles run successfully
     """
     # Skip oVirt/RHV tests on IPv6 setups
-    if settings.server.is_ipv6 and ansible_module in ['compute_profile_ovirt']:
+    if module_target_sat.network_type == HostNetworkType.IPV6 and ansible_module in [
+        'compute_profile_ovirt'
+    ]:
         pytest.skip("oVirt/RHV is not properly set up in IPv6 environment")
 
     # Setup provisioning resources
@@ -241,7 +244,9 @@ def test_positive_run_modules_and_roles(module_target_sat, setup_fam, ansible_mo
         'ANSIBLE_HOST_PATTERN_MISMATCH=ignore',
     ]
 
-    if settings.server.is_ipv6 and ansible_module in ['redhat_manifest']:
+    if module_target_sat.network_type == HostNetworkType.IPV6 and ansible_module in [
+        'redhat_manifest'
+    ]:
         env.append(f'HTTPS_PROXY={settings.http_proxy.http_proxy_ipv6_url}')
 
     # Execute test_playbook

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -194,7 +194,7 @@ def test_positive_list_host_based_on_rule_search_query(
 
     :BZ: 1731112
     """
-    ip_address = gen_ipaddr(ipv6=target_sat.network_type == NetworkType.IPV6)
+    ip_address = gen_ipaddr(ipv6=target_sat.network_type.has_ipv6)
     cpu_count = gen_integer(2, 10)
     rule_name = gen_string('alpha')
     rule_search = f'cpu_count = {cpu_count}'
@@ -240,7 +240,7 @@ def test_positive_list_host_based_on_rule_search_query(
         values = session.discoveryrule.read_discovered_hosts(discovery_rule.name)
         assert values['searchbox'] == rule_search
         assert len(values['table']) == 1
-        if target_sat.network_type in [NetworkType.IPV6, NetworkType.DUALSTACK]:
+        if not target_sat.network_type.has_ipv4:
             lookup = NetworkType.IPV6.formatted
         else:
             lookup = NetworkType.IPV4.formatted

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -194,7 +194,6 @@ def test_positive_list_host_based_on_rule_search_query(
 
     :BZ: 1731112
     """
-    # TODO(sganar): How should this test case look like for dualstack?
     ip_address = gen_ipaddr(ipv6=target_sat.network_type == NetworkType.IPV6)
     cpu_count = gen_integer(2, 10)
     rule_name = gen_string('alpha')

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -15,7 +15,7 @@
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
 import pytest
 
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 
 
 @pytest.fixture
@@ -195,7 +195,7 @@ def test_positive_list_host_based_on_rule_search_query(
     :BZ: 1731112
     """
     # TODO(sganar): How should this test case look like for dualstack?
-    ip_address = gen_ipaddr(ipv6=target_sat.network_type == HostNetworkType.IPV6)
+    ip_address = gen_ipaddr(ipv6=target_sat.network_type == NetworkType.IPV6)
     cpu_count = gen_integer(2, 10)
     rule_name = gen_string('alpha')
     rule_search = f'cpu_count = {cpu_count}'
@@ -241,10 +241,10 @@ def test_positive_list_host_based_on_rule_search_query(
         values = session.discoveryrule.read_discovered_hosts(discovery_rule.name)
         assert values['searchbox'] == rule_search
         assert len(values['table']) == 1
-        if target_sat.network_type in [HostNetworkType.IPV6, HostNetworkType.DUALSTACK]:
-            lookup = HostNetworkType.IPV6.formatted
+        if target_sat.network_type in [NetworkType.IPV6, NetworkType.DUALSTACK]:
+            lookup = NetworkType.IPV6.formatted
         else:
-            lookup = HostNetworkType.IPV4.formatted
+            lookup = NetworkType.IPV4.formatted
         assert values['table'][0][lookup] == ip_address
         assert values['table'][0]['CPUs'] == str(cpu_count)
         # auto provision the discovered host

--- a/tests/foreman/ui/test_discoveryrule.py
+++ b/tests/foreman/ui/test_discoveryrule.py
@@ -15,8 +15,6 @@
 from fauxfactory import gen_integer, gen_ipaddr, gen_string
 import pytest
 
-from robottelo.enums import NetworkType
-
 
 @pytest.fixture
 def module_discovery_env(module_org, module_location, module_target_sat):
@@ -240,10 +238,7 @@ def test_positive_list_host_based_on_rule_search_query(
         values = session.discoveryrule.read_discovered_hosts(discovery_rule.name)
         assert values['searchbox'] == rule_search
         assert len(values['table']) == 1
-        if not target_sat.network_type.has_ipv4:
-            lookup = NetworkType.IPV6.formatted
-        else:
-            lookup = NetworkType.IPV4.formatted
+        lookup = "IPv6" if not target_sat.network_type.has_ipv4 else "IPv4"
         assert values['table'][0][lookup] == ip_address
         assert values['table'][0]['CPUs'] == str(cpu_count)
         # auto provision the discovered host

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -880,7 +880,7 @@ def test_positive_apply_for_all_hosts(
         workflow='deploy-template',
         host_class=ContentHost,
         _count=num_hosts,
-        deploy_network_type='ipv6' if settings.server.is_ipv6 else 'ipv4',
+        deploy_network_type=settings.content_host.attibutes.network_type,
     ) as hosts:
         if not isinstance(hosts, list) or len(hosts) != num_hosts:
             pytest.fail('Failed to provision the expected number of hosts.')

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -882,7 +882,7 @@ def test_positive_apply_for_all_hosts(
         _count=num_hosts,
         # TODO(shwsingh): this is best effor for dualstack. This host deployment
         # should be a part of a fixture
-        deploy_network_type=settings.content_host.attibutes.network_type,
+        deploy_network_type=settings.content_host.network_type,
     ) as hosts:
         if not isinstance(hosts, list) or len(hosts) != num_hosts:
             pytest.fail('Failed to provision the expected number of hosts.')

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -880,7 +880,7 @@ def test_positive_apply_for_all_hosts(
         workflow='deploy-template',
         host_class=ContentHost,
         _count=num_hosts,
-        # TODO(shwsingh): this is best effor for dualstack. This host deployment
+        # TODO(@SatelliteQE/team-phoenix): this is best effort for dualstack. This host deployment
         # should be a part of a fixture
         deploy_network_type=settings.content_host.network_type,
     ) as hosts:

--- a/tests/foreman/ui/test_errata.py
+++ b/tests/foreman/ui/test_errata.py
@@ -880,6 +880,8 @@ def test_positive_apply_for_all_hosts(
         workflow='deploy-template',
         host_class=ContentHost,
         _count=num_hosts,
+        # TODO(shwsingh): this is best effor for dualstack. This host deployment
+        # should be a part of a fixture
         deploy_network_type=settings.content_host.attibutes.network_type,
     ) as hosts:
         if not isinstance(hosts, list) or len(hosts) != num_hosts:

--- a/tests/robottelo/test_enum.py
+++ b/tests/robottelo/test_enum.py
@@ -44,8 +44,3 @@ class TestNetworkType:
         assert NetworkType.IPV4 == NetworkType.IPV4
         assert NetworkType.IPV4 != NetworkType.IPV6
         assert NetworkType.IPV6 != NetworkType.DUALSTACK
-
-    def test_list_values(self):
-        """Test the list_values class method."""
-        expected = {'ipv4', 'ipv6', 'dualstack'}
-        assert NetworkType.list_values() == expected

--- a/tests/robottelo/test_enum.py
+++ b/tests/robottelo/test_enum.py
@@ -2,50 +2,50 @@
 
 import pytest
 
-from robottelo.enums import HostNetworkType
+from robottelo.enums import NetworkType
 
 
-class TestHostNetworkType:
-    """Tests for the HostNetworkType enum class."""
+class TestNetworkType:
+    """Tests for the NetworkType enum class."""
 
     def test_enum_values(self):
         """Test that the enum has the expected values."""
-        assert HostNetworkType.IPV4 == 'ipv4'
-        assert HostNetworkType.IPV6 == 'ipv6'
-        assert HostNetworkType.DUALSTACK == 'dualstack'
+        assert NetworkType.IPV4 == 'ipv4'
+        assert NetworkType.IPV6 == 'ipv6'
+        assert NetworkType.DUALSTACK == 'dualstack'
 
     def test_formatted_property_ipv4(self):
         """Test the formatted property for IPV4."""
-        assert HostNetworkType.IPV4.formatted == 'IPv4'
+        assert NetworkType.IPV4.formatted == 'IPv4'
 
     def test_formatted_property_dualstack(self):
         """Test that formatted property raises ValueError for DUALSTACK."""
         error_msg = 'Formatted property not supported for DUALSTACK'
         with pytest.raises(ValueError, match=error_msg) as excinfo:
-            _ = HostNetworkType.DUALSTACK.formatted
+            _ = NetworkType.DUALSTACK.formatted
         assert 'not supported for DUALSTACK' in str(excinfo.value)
 
     def test_str_representation(self):
         """Test the string representation of enum members."""
-        assert str(HostNetworkType.IPV4) == 'ipv4'
-        assert str(HostNetworkType.IPV6) == 'ipv6'
-        assert str(HostNetworkType.DUALSTACK) == 'dualstack'
+        assert str(NetworkType.IPV4) == 'ipv4'
+        assert str(NetworkType.IPV6) == 'ipv6'
+        assert str(NetworkType.DUALSTACK) == 'dualstack'
 
     def test_equality_with_string(self):
         """Test equality comparison between enum members and strings."""
-        assert HostNetworkType.IPV4 == 'ipv4'
-        assert HostNetworkType.IPV6 == 'ipv6'
-        assert HostNetworkType.DUALSTACK == 'dualstack'
-        assert HostNetworkType.IPV4 != 'ipv6'
-        assert HostNetworkType.IPV6 != 'ipv4'
+        assert NetworkType.IPV4 == 'ipv4'
+        assert NetworkType.IPV6 == 'ipv6'
+        assert NetworkType.DUALSTACK == 'dualstack'
+        assert NetworkType.IPV4 != 'ipv6'
+        assert NetworkType.IPV6 != 'ipv4'
 
     def test_equality_with_enum(self):
         """Test equality comparison between enum members."""
-        assert HostNetworkType.IPV4 == HostNetworkType.IPV4
-        assert HostNetworkType.IPV4 != HostNetworkType.IPV6
-        assert HostNetworkType.IPV6 != HostNetworkType.DUALSTACK
+        assert NetworkType.IPV4 == NetworkType.IPV4
+        assert NetworkType.IPV4 != NetworkType.IPV6
+        assert NetworkType.IPV6 != NetworkType.DUALSTACK
 
     def test_list_values(self):
         """Test the list_values class method."""
         expected = {'ipv4', 'ipv6', 'dualstack'}
-        assert HostNetworkType.list_values() == expected
+        assert NetworkType.list_values() == expected

--- a/tests/robottelo/test_enum.py
+++ b/tests/robottelo/test_enum.py
@@ -44,3 +44,15 @@ class TestNetworkType:
         assert NetworkType.IPV4 == NetworkType.IPV4
         assert NetworkType.IPV4 != NetworkType.IPV6
         assert NetworkType.IPV6 != NetworkType.DUALSTACK
+
+    def test_has_ipv4_property(self):
+        """Test the has_ipv4 property for all network types."""
+        assert NetworkType.IPV4.has_ipv4 is True
+        assert NetworkType.IPV6.has_ipv4 is False
+        assert NetworkType.DUALSTACK.has_ipv4 is True
+
+    def test_has_ipv6_property(self):
+        """Test the has_ipv6 property for all network types."""
+        assert NetworkType.IPV4.has_ipv6 is False
+        assert NetworkType.IPV6.has_ipv6 is True
+        assert NetworkType.DUALSTACK.has_ipv6 is True

--- a/tests/robottelo/test_enum.py
+++ b/tests/robottelo/test_enum.py
@@ -1,0 +1,51 @@
+"""Tests for Robottelo's enumeration classes."""
+
+import pytest
+
+from robottelo.enums import HostNetworkType
+
+
+class TestHostNetworkType:
+    """Tests for the HostNetworkType enum class."""
+
+    def test_enum_values(self):
+        """Test that the enum has the expected values."""
+        assert HostNetworkType.IPV4 == 'ipv4'
+        assert HostNetworkType.IPV6 == 'ipv6'
+        assert HostNetworkType.DUALSTACK == 'dualstack'
+
+    def test_formatted_property_ipv4(self):
+        """Test the formatted property for IPV4."""
+        assert HostNetworkType.IPV4.formatted == 'IPv4'
+
+    def test_formatted_property_dualstack(self):
+        """Test that formatted property raises ValueError for DUALSTACK."""
+        error_msg = 'Formatted property not supported for DUALSTACK'
+        with pytest.raises(ValueError, match=error_msg) as excinfo:
+            _ = HostNetworkType.DUALSTACK.formatted
+        assert 'not supported for DUALSTACK' in str(excinfo.value)
+
+    def test_str_representation(self):
+        """Test the string representation of enum members."""
+        assert str(HostNetworkType.IPV4) == 'ipv4'
+        assert str(HostNetworkType.IPV6) == 'ipv6'
+        assert str(HostNetworkType.DUALSTACK) == 'dualstack'
+
+    def test_equality_with_string(self):
+        """Test equality comparison between enum members and strings."""
+        assert HostNetworkType.IPV4 == 'ipv4'
+        assert HostNetworkType.IPV6 == 'ipv6'
+        assert HostNetworkType.DUALSTACK == 'dualstack'
+        assert HostNetworkType.IPV4 != 'ipv6'
+        assert HostNetworkType.IPV6 != 'ipv4'
+
+    def test_equality_with_enum(self):
+        """Test equality comparison between enum members."""
+        assert HostNetworkType.IPV4 == HostNetworkType.IPV4
+        assert HostNetworkType.IPV4 != HostNetworkType.IPV6
+        assert HostNetworkType.IPV6 != HostNetworkType.DUALSTACK
+
+    def test_list_values(self):
+        """Test the list_values class method."""
+        expected = {'ipv4', 'ipv6', 'dualstack'}
+        assert HostNetworkType.list_values() == expected

--- a/tests/robottelo/test_enum.py
+++ b/tests/robottelo/test_enum.py
@@ -1,7 +1,5 @@
 """Tests for Robottelo's enumeration classes."""
 
-import pytest
-
 from robottelo.enums import NetworkType
 
 
@@ -13,17 +11,6 @@ class TestNetworkType:
         assert NetworkType.IPV4 == 'ipv4'
         assert NetworkType.IPV6 == 'ipv6'
         assert NetworkType.DUALSTACK == 'dualstack'
-
-    def test_formatted_property_ipv4(self):
-        """Test the formatted property for IPV4."""
-        assert NetworkType.IPV4.formatted == 'IPv4'
-
-    def test_formatted_property_dualstack(self):
-        """Test that formatted property raises ValueError for DUALSTACK."""
-        error_msg = 'Formatted property not supported for DUALSTACK'
-        with pytest.raises(ValueError, match=error_msg) as excinfo:
-            _ = NetworkType.DUALSTACK.formatted
-        assert 'not supported for DUALSTACK' in str(excinfo.value)
 
     def test_str_representation(self):
         """Test the string representation of enum members."""


### PR DESCRIPTION
# Add HostNetworkType enum and improve network type handling in Robottelo

This pull request introduces a new `HostNetworkType` enumeration class to standardize network type handling throughout the codebase. Instead of relying on boolean flags like `settings.server.is_ipv6`, the new enum provides a more expressive and extensible approach for handling different network configurations including IPv4, IPv6, and DualStack.

## Changes

- Added a new `HostNetworkType` enum class with values:
  - `IPV4` - for IPv4-only networks
  - `IPV6` - for IPv6-only networks 
  - `DUALSTACK` - for dual-stack (IPv4 + IPv6) networks

- Added a new `settings.content_host.attributes.network_type` setting to specify the network type to use during host deployment

- Modified the `fixture_markers.py` plugin to properly parametrize tests for either 'ipv4' or 'ipv6' based on configuration

- Refactored network-related code to use the new enum instead of boolean flags:
  - Updated Satellite and Capsule code to use `enable_ipv6_http_proxy()` method
  - Updated ContentHost methods that handle network configuration
  - Updated test fixtures that deploy hosts with network parameters

## Benefits

- Proper support for dual-stack network environments in the testing framework
- More expressive and self-documenting code with named network types
- Better preparation for hosts that need to operate in mixed network environments
- Consistent network type handling across the codebase
- Improved test parametrization based on network configuration

## Patch backport

This patch will partially be backported to the older branches only on the configuration level. Meaning, robottelo in the other branches should be able to set `settings.server.is_ipv6` according to what `settings.server.network_type` is set to.

## Testing

All existing tests run successfully with the network configuration specified in settings without errors, whether using IPv4-only, IPv6-only, or dual-stack configurations.

The only problem that persists is that `ipv6` ContentHosts are connecting to the test-session-wide `settings.robottelo.repos_hosting_url`, which, in our internal infra, is either IPv4-only or IPv6-only.

## TODOs

- [x] rename the enumerator to `NetworkType`
- [x] rebase onto master
- [x] rewrite the newly added `is_ipv6` references in master
- [x] raise a configuration patch in the internal repository - MR 1673
- [x] have a strategy on how to use single settings without `server.is_ipv6` across all currently active robottelo branches