### PR TITLE
Add customer case automation for SAT-25949

### DIFF
--- a/robottelo/constants/__init__.py
+++ b/robottelo/constants/__init__.py
@@ -1905,7 +1905,8 @@ VMWARE_CONSTANTS = {
 HAMMER_CONFIG = "~/.hammer/cli.modules.d/foreman.yml"
 HAMMER_SESSIONS = "~/.hammer/sessions"
 
-INSTALLER_CONFIG_FILE = '/etc/foreman-installer/scenarios.d/satellite.yaml'
+SATELLITE_INSTALLER_CONFIG = '/etc/foreman-installer/scenarios.d/satellite.yaml'
+CAPSULE_INSTALLER_CONFIG = '/etc/foreman-installer/scenarios.d/capsule.yaml'
 SATELLITE_ANSWER_FILE = "/etc/foreman-installer/scenarios.d/satellite-answers.yaml"
 CAPSULE_ANSWER_FILE = "/etc/foreman-installer/scenarios.d/capsule-answers.yaml"
 MAINTAIN_HAMMER_YML = "/etc/foreman-maintain/foreman-maintain-hammer.yml"

--- a/tests/foreman/maintain/test_backup_restore.py
+++ b/tests/foreman/maintain/test_backup_restore.py
@@ -430,7 +430,7 @@ def test_positive_backup_restore(
 
     :customerscenario: true
 
-    :Verifies: SAT-23093
+    :Verifies: SAT-23093, SAT-19933
 
     :BZ: 2172540, 1978764, 1979045
     """
@@ -452,13 +452,14 @@ def test_positive_backup_restore(
 
     expected_files = get_exp_files(sat_maintain, skip_pulp)
     assert set(files).issuperset(expected_files), assert_msg
-
+    config_files = sat_maintain.execute(
+        f"tar -tf {backup_dir}/config_files.tar.gz"
+    ).stdout.splitlines()
     # Check if certificate tar file is present in Capsule backup.
     if instance == 'capsule':
-        cert_file = sat_maintain.execute(
-            f'tar -tvf {backup_dir}/config_files.tar.gz | grep {sat_maintain.hostname}'
-        ).stdout
-        assert f'{sat_maintain.hostname}-certs.tar' in cert_file
+        assert f'root/{sat_maintain.hostname}-certs.tar' in config_files
+    # Check Ansible configuration file under /etc/ansible is present
+    assert 'etc/ansible/ansible.cfg' in config_files
 
     # Run restore
     if not skip_pulp:

--- a/tests/foreman/maintain/test_upgrade.py
+++ b/tests/foreman/maintain/test_upgrade.py
@@ -15,7 +15,7 @@
 import pytest
 
 from robottelo.config import settings
-from robottelo.constants import INSTALLER_CONFIG_FILE
+from robottelo.constants import SATELLITE_INSTALLER_CONFIG
 
 
 def last_y_stream_version(release):
@@ -101,7 +101,7 @@ def test_negative_pre_update_tuning_profile_check(request, custom_host):
     )
     # Change to correct tuning profile (default or medium)
     custom_host.execute(
-        f'sed -i "s/tuning: development/tuning: {profile}/g" {INSTALLER_CONFIG_FILE};'
+        f'sed -i "s/tuning: development/tuning: {profile}/g" {SATELLITE_INSTALLER_CONFIG};'
         f'satellite-installer'
     )
     # Check that the update check fails due to system requirements


### PR DESCRIPTION
### Problem Statement
Add customer case automation for SAT-25949 - satellite-maintain backup command does not include custom answers file in the backup archieve.

### Related Issues
- SAT-25949
- SAT-31861

<!-- ### PRT test Cases example
trigger: test-robottelo
pytest: tests/foreman/ui/test_contenthost.py -k 'test_syspurpose_mismatched'
-->
<!--
PRT usage reference link: https://github.com/SatelliteQE/robottelo/wiki/Robottelo-Pull-Request-Testing-(PRT)-Process#usage-examples
-->