### PR TITLE
[6.17.z] ci: do not fail running backports fast

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -37,6 +37,7 @@ jobs:
     needs: find-the-parent-prt-comment
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         label: ${{ github.event.pull_request.labels.*.name }}
 

--- a/.github/workflows/auto_cherry_pick_merged.yaml
+++ b/.github/workflows/auto_cherry_pick_merged.yaml
@@ -89,6 +89,7 @@ jobs:
     needs: [arrayconversion, get-parentPR-details]
     if: ${{ needs.arrayconversion.outputs.branches != '' }}
     strategy:
+      fail-fast: false
       matrix:
         branch: ${{ fromJson(needs.arrayconversion.outputs.branches) }}
     steps:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/robottelo/pull/17929

### Problem Statement
The process around a PR backport - `git cherry-pick` is set up in as a job matrix.
The [fail-fast](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) param
is set to `true` by default. That causes jobs from the same matrix, that are still running, to fail in case any job in the matrix fails.

As a result of this, a PR with the backported patch gets created, same as an GitHub Issue stating that `git cherry-pick` failed.

### Solution
* Set `fail-fast` to `false`


### Related Issues


